### PR TITLE
Add color_temp slider if supported by light platform

### DIFF
--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -40,9 +40,19 @@
           on-change='brightnessSliderChanged' class='flex'>
         </paper-slider>
       </div>
+      <template is="dom-if" if="{{ctSliderValue}}">
+        <div class='brightness center horizontal layout'>
+          <div>Color temperature</div>
+          <paper-slider min="154" max="500"
+            id='ct' value='{{ctSliderValue}}'
+            on-change='ctSliderChanged' class='flex'>
+          </paper-slider>
+        </div>
+      </template>
 
       <ha-color-picker on-colorselected='colorPicked' width='350' height='200'>
-      </color-picker>
+      </ha-color-picker>
+
     </div>
   </template>
 </dom-module>

--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -5,15 +5,7 @@
 
 <dom-module id='more-info-light'>
   <style>
-    .brightness {
-      margin-bottom: 8px;
-
-      max-height: 0px;
-      overflow: hidden;
-      transition: max-height .5s ease-in;
-    }
-
-    .color_temp {
+    .brightness, .color_temp {
       margin-bottom: 8px;
 
       max-height: 0px;

--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -13,6 +13,14 @@
       transition: max-height .5s ease-in;
     }
 
+    .color_temp {
+      margin-bottom: 8px;
+
+      max-height: 0px;
+      overflow: hidden;
+      transition: max-height .5s ease-in;
+    }
+
     ha-color-picker {
       display: block;
       width: 350px;
@@ -24,6 +32,10 @@
     }
 
     .has-brightness .brightness {
+      max-height: 40px;
+    }
+
+    .has-color_temp .color_temp {
       max-height: 40px;
     }
 
@@ -40,15 +52,13 @@
           on-change='brightnessSliderChanged' class='flex'>
         </paper-slider>
       </div>
-      <template is="dom-if" if="{{ctSliderValue}}">
-        <div class='brightness center horizontal layout'>
-          <div>Color temperature</div>
-          <paper-slider min="154" max="500"
-            id='ct' value='{{ctSliderValue}}'
-            on-change='ctSliderChanged' class='flex'>
-          </paper-slider>
-        </div>
-      </template>
+      <div class='color_temp center horizontal layout'>
+        <div>Color temperature</div>
+        <paper-slider min="154" max="500"
+          id='color_temp' value='{{ctSliderValue}}'
+          on-change='ctSliderChanged' class='flex'>
+        </paper-slider>
+      </div>
 
       <ha-color-picker on-colorselected='colorPicked' width='350' height='200'>
       </ha-color-picker>

--- a/src/more-infos/more-info-light.js
+++ b/src/more-infos/more-info-light.js
@@ -5,7 +5,7 @@ import attributeClassNames from '../util/attribute-class-names';
 
 require('../components/ha-color-picker');
 
-const ATTRIBUTE_CLASSES = ['brightness', 'xy_color'];
+const ATTRIBUTE_CLASSES = ['brightness', 'xy_color', 'ct_color'];
 
 export default new Polymer({
   is: 'more-info-light',
@@ -20,11 +20,17 @@ export default new Polymer({
       type: Number,
       value: 0,
     },
+
+    ctSliderValue: {
+      type: Number,
+      value: 0,
+    },
   },
 
   stateObjChanged(newVal) {
     if (newVal && newVal.state === 'on') {
       this.brightnessSliderValue = newVal.attributes.brightness;
+      this.ctSliderValue = newVal.attributes.ct_color;
     }
 
     this.async(() => this.fire('iron-resize'), 500);
@@ -47,6 +53,17 @@ export default new Polymer({
         brightness: bri,
       });
     }
+  },
+
+  ctSliderChanged(ev) {
+    const ct = parseInt(ev.target.value, 10);
+
+    if (isNaN(ct)) return;
+
+    serviceActions.callService('light', 'turn_on', {
+      entity_id: this.stateObj.entityId,
+      ct_color: ct,
+    });
   },
 
   colorPicked(ev) {

--- a/src/more-infos/more-info-light.js
+++ b/src/more-infos/more-info-light.js
@@ -5,7 +5,7 @@ import attributeClassNames from '../util/attribute-class-names';
 
 require('../components/ha-color-picker');
 
-const ATTRIBUTE_CLASSES = ['brightness', 'xy_color', 'ct_color'];
+const ATTRIBUTE_CLASSES = ['brightness', 'xy_color', 'color_temp'];
 
 export default new Polymer({
   is: 'more-info-light',
@@ -30,7 +30,7 @@ export default new Polymer({
   stateObjChanged(newVal) {
     if (newVal && newVal.state === 'on') {
       this.brightnessSliderValue = newVal.attributes.brightness;
-      this.ctSliderValue = newVal.attributes.ct_color;
+      this.ctSliderValue = newVal.attributes.color_temp;
     }
 
     this.async(() => this.fire('iron-resize'), 500);
@@ -62,7 +62,7 @@ export default new Polymer({
 
     serviceActions.callService('light', 'turn_on', {
       entity_id: this.stateObj.entityId,
-      ct_color: ct,
+      color_temp: ct,
     });
   },
 


### PR DESCRIPTION
Color temperature slider

Only shows if color_temp property is set.

Slider values are based on mired (https://en.wikipedia.org/wiki/Mired)
min/max value based on Hue. These may need to be dynamic if other lights support a wider range.
