### PR TITLE
Fix minimal length for state label

### DIFF
--- a/src/components/state-info.html
+++ b/src/components/state-info.html
@@ -7,7 +7,7 @@
   <style>
   :host {
     line-height: 1.5;
-    min-width: 150px;
+    min-width: 175px;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
The state label "a few seconds ago" is truncated - this fixes it 

![s7](https://cloud.githubusercontent.com/assets/2315617/12441292/c5d256fc-bf45-11e5-9cf8-cb02d946c846.png)
