### PR TITLE
Honor the icon from state.attributes, if set

### DIFF
--- a/src/components/entity/ha-state-label-badge.js
+++ b/src/components/entity/ha-state-label-badge.js
@@ -52,6 +52,10 @@ export default new Polymer({
   },
 
   computeValue(state) {
+    // If an icon was provided, don't render the value
+    if (state.attributes.icon) {
+      return null;
+    }
     switch (state.domain) {
       case 'binary_sensor':
       case 'device_tracker':
@@ -68,6 +72,10 @@ export default new Polymer({
   },
 
   computeIcon(state) {
+    // Render the icon, if set
+    if (state.attributes.icon) {
+      return state.attributes.icon;
+    }
     switch (state.domain) {
       case 'alarm_control_panel':
         if (state.state === 'pending') {


### PR DESCRIPTION
I assume there is some reason this was not already done, but just in case:

This makes the frontend honor the icon that was set on the entity in the
backend, if any. This lets things like sensors able to control their own
destiny in terms of what is displayed on the frontend with respect to
their icon.
