### PR TITLE
Update state icons for binary sensors

### DIFF
--- a/src/util/state-icon.js
+++ b/src/util/state-icon.js
@@ -14,11 +14,11 @@ function binarySensorIcon(state) {
     case 'safety':
     case 'gas':
     case 'light':
-      return activated ? 'mdi:brightness-5' : 'mdi:brightness-7'
+      return activated ? 'mdi:brightness-5' : 'mdi:brightness-7';
     case 'sound':
-      return activated ? 'mdi:bell-off' : 'mdi:bell-ring'
+      return activated ? 'mdi:bell-off' : 'mdi:bell-ring';
     case 'vibration':
-      return activated ? 'mdi:crop-portrait' : 'mdi:vibrate'
+      return activated ? 'mdi:crop-portrait' : 'mdi:vibrate';
     case 'smoke':
     case 'power':
       return activated ? 'mdi:verified' : 'mdi:alert';

--- a/src/util/state-icon.js
+++ b/src/util/state-icon.js
@@ -13,6 +13,12 @@ function binarySensorIcon(state) {
       return activated ? 'mdi:water-off' : 'mdi:water';
     case 'safety':
     case 'gas':
+    case 'light':
+      return activated ? 'mdi:brightness-5' : 'mdi:brightness-7'
+    case 'sound':
+      return activated ? 'mdi:bell-off' : 'mdi:bell-ring'
+    case 'vibration':
+      return activated ? 'mdi:crop-portrait' : 'mdi:vibrate'
     case 'smoke':
     case 'power':
       return activated ? 'mdi:verified' : 'mdi:alert';

--- a/src/util/state-icon.js
+++ b/src/util/state-icon.js
@@ -16,7 +16,7 @@ function binarySensorIcon(state) {
     case 'light':
       return activated ? 'mdi:brightness-5' : 'mdi:brightness-7';
     case 'sound':
-      return activated ? 'mdi:bell-off' : 'mdi:bell-ring';
+      return activated ? 'mdi:music-note-off' : 'mdi:music-note';
     case 'vibration':
       return activated ? 'mdi:crop-portrait' : 'mdi:vibrate';
     case 'smoke':


### PR DESCRIPTION
Updates to the icons used for binary sensors.

https://github.com/balloob/home-assistant/pull/1380 implements these new types.

Current icons I think thinking of using...

I am wondering if we should add in new icons for vibration, sound, and light? I also added sound to the base binary sensor type dictionary. These are what I am thinking for the icons. Thoughts?

sound: mdi-bell or mdi-bell-ring
no sound: mdi-bell-off

noticed that the bell is used in the alarm component, so maybe it would be better to use volume-high and volume-low/volume-off?

light: mdi-brightness-5
no light: mdi-brightness-7

vibration: mdi-vibrate
no vibration: mdi-crop-portrait (not too sure on this)
