### PR TITLE
Display a different entity icon if device is unavailable

### DIFF
--- a/src/components/entity/ha-entity-toggle.js
+++ b/src/components/entity/ha-entity-toggle.js
@@ -59,7 +59,8 @@ export default new Polymer({
 
   computeIsOn(stateObj) {
     return stateObj && stateObj.state !== 'off' &&
-      stateObj.state !== 'unlocked' && stateObj.state !== 'closed';
+      stateObj.state !== 'unlocked' && stateObj.state !== 'closed' &&
+      stateObj.state !== 'unavailable';
   },
 
   // We call updateToggle after a successful call to re-sync the toggle

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -27,6 +27,14 @@
   ha-state-icon[data-domain=sun][data-state=above_horizon] {
     color: #DCC91F;
   }
+
+  /* Color the icon if unavailable */
+  ha-state-icon[data-domain=light][data-state=unavailable],
+  ha-state-icon[data-domain=switch][data-state=unavailable],
+  ha-state-icon[data-domain=binary_sensor][data-state=unavailable],
+  ha-state-icon[data-domain=sensor][data-state=unavailable] {
+    color: #D3D3D3;
+  }
   </style>
 
   <template>

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -27,7 +27,6 @@
   ha-state-icon[data-domain=sun][data-state=above_horizon] {
     color: #DCC91F;
   }
-
   </style>
 
   <template>

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -27,11 +27,18 @@
   ha-state-icon[data-domain=sun][data-state=above_horizon] {
     color: #DCC91F;
   }
+
+  /* Color the icon if entity is offline */
+  ha-state-icon[data-domain=light][data-online=offline],
+  ha-state-icon[data-domain=switch][data-online=offline],
+  ha-state-icon[data-domain=binary_sensor][data-online=offline] {
+    color: #D3D3D3;
+  }
   </style>
 
   <template>
     <ha-state-icon id='icon' state-obj='[[stateObj]]'
-      data-domain$='[[stateObj.domain]]' data-state$='[[stateObj.state]]'>
+      data-domain$='[[stateObj.domain]]' data-state$='[[stateObj.state]]' data-online$='[[stateObj.online]]'>
     </ha-state-icon>
   </template>
 </dom-module>

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -28,17 +28,11 @@
     color: #DCC91F;
   }
 
-  /* Color the icon if entity is offline */
-  ha-state-icon[data-domain=light][data-online=offline],
-  ha-state-icon[data-domain=switch][data-online=offline],
-  ha-state-icon[data-domain=binary_sensor][data-online=offline] {
-    color: #D3D3D3;
-  }
   </style>
 
   <template>
     <ha-state-icon id='icon' state-obj='[[stateObj]]'
-      data-domain$='[[stateObj.domain]]' data-state$='[[stateObj.state]]' data-online$='[[stateObj.online]]'>
+      data-domain$='[[stateObj.domain]]' data-state$='[[stateObj.state]]'>
     </ha-state-icon>
   </template>
 </dom-module>

--- a/src/util/state-icon.js
+++ b/src/util/state-icon.js
@@ -33,8 +33,6 @@ function binarySensorIcon(state) {
 export default function stateIcon(state) {
   if (!state) {
     return defaultIcon;
-  } else if (state.state && state.state === 'unavailable') {
-    return 'mdi:alert-circle-outline';
   } else if (state.attributes.icon) {
     return state.attributes.icon;
   }

--- a/src/util/state-icon.js
+++ b/src/util/state-icon.js
@@ -6,6 +6,9 @@ const { util: { temperatureUnits } } = hass;
 
 function binarySensorIcon(state) {
   const activated = state.state && state.state === 'off';
+  if (state.state && state.state === 'unavailable') {
+    return 'mdi:alert-circle-outline';
+  }
   switch (state.attributes.sensor_class) {
     case 'opening':
       return activated ? 'mdi:crop-square' : 'mdi:exit-to-app';
@@ -33,6 +36,8 @@ function binarySensorIcon(state) {
 export default function stateIcon(state) {
   if (!state) {
     return defaultIcon;
+  } else if (state.state && state.state === 'unavailable') {
+    return 'mdi:alert-circle-outline';
   } else if (state.attributes.icon) {
     return state.attributes.icon;
   }

--- a/src/util/state-icon.js
+++ b/src/util/state-icon.js
@@ -6,9 +6,6 @@ const { util: { temperatureUnits } } = hass;
 
 function binarySensorIcon(state) {
   const activated = state.state && state.state === 'off';
-  if (state.state && state.state === 'unavailable') {
-    return 'mdi:alert-circle-outline';
-  }
   switch (state.attributes.sensor_class) {
     case 'opening':
       return activated ? 'mdi:crop-square' : 'mdi:exit-to-app';


### PR DESCRIPTION
@balloob You mentioned in https://github.com/balloob/home-assistant/issues/861

"Add it to the state icon badge (exclamation mark or fade out?) / state icon label badge (exclamation mark as icon?)"

This PR changes the state icon to mdi:alert-circle-outline if the device is unavailable. I am not sure if this is the only place changes need made?
