### PR TITLE
Added a translate: rotateZ(360) to force GPU scrolling

### DIFF
--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -9,6 +9,7 @@
     :host {
       display: block;
       padding-right: 8px;
+      transform: rotateZ(360deg)
     }
 
     .no-badges {


### PR DESCRIPTION
Before this was added the scrolling on my LG G3 was really jerky. Now it silky smooth. 
This hack will only affect rendering in webkit browsers. The downside is that more GPU memory could be consumed. 
When I inspected it, it did no difference in memory consumption which I think is because the font antialiasing which also puts everything in GPU context.
