### PR TITLE
Fix the safety-related sensor class icons

### DIFF
--- a/src/util/state-icon.js
+++ b/src/util/state-icon.js
@@ -11,14 +11,14 @@ function binarySensorIcon(state) {
       return activated ? 'mdi:crop-square' : 'mdi:exit-to-app';
     case 'moisture':
       return activated ? 'mdi:water-off' : 'mdi:water';
-    case 'safety':
-    case 'gas':
     case 'light':
       return activated ? 'mdi:brightness-5' : 'mdi:brightness-7';
     case 'sound':
       return activated ? 'mdi:music-note-off' : 'mdi:music-note';
     case 'vibration':
       return activated ? 'mdi:crop-portrait' : 'mdi:vibrate';
+    case 'safety':
+    case 'gas':
     case 'smoke':
     case 'power':
       return activated ? 'mdi:verified' : 'mdi:alert';


### PR DESCRIPTION
Commit 3ad5b9acb2c4b9388af8861b4efdbba3302b7908 added some new icons
in the middle of the safety-related ones so that some things like
'safety' and 'gas' now resolve to a brightness icon. This moves them
down in the list to match up with the original peers 'smoke' and 'power'.
