### PR TITLE
Set initial history date value based on local time

### DIFF
--- a/src/layouts/partial-history.js
+++ b/src/layouts/partial-history.js
@@ -64,10 +64,13 @@ export default new Polymer({
   },
 
   attached() {
+    Date.prototype.toLocaleStringShort = function(){
+        return [(1900 + this.getYear()), (this.getMonth() + 1), this.getDate()].join('-');
+    };
     this.datePicker = new window.Pikaday({
       field: this.$.datePicker.inputElement,
       onSelect: entityHistoryActions.changeCurrentDate,
-    });
+    }).setDate((new Date()).toLocaleStringShort());
   },
 
   detached() {


### PR DESCRIPTION
The back end to history assumes localtime, but the front end supplies UTC.

In New Zealand (+12/13) this means that history is broken for half the time.

Here's a quick fix. I'd prefer it if the Date prototype lived somewhere else.

BTW. I tried using the defaultDate: parameter first, but this didn't appear to work.
