### PR TITLE
Rollershutter state logic backwards

### DIFF
--- a/src/state-summary/state-card-rollershutter.html
+++ b/src/state-summary/state-card-rollershutter.html
@@ -22,10 +22,10 @@
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
       <div class='state'>
         <paper-icon-button icon="mdi:arrow-up" on-tap='onMoveUpTap'
-          disabled='[[computeIsFullyClosed(stateObj)]]'></paper-icon-button>
+          disabled='[[computeIsFullyOpen(stateObj)]]'></paper-icon-button>
         <paper-icon-button icon="mdi:stop" on-tap='onStopTap'></paper-icon-button>
         <paper-icon-button icon="mdi:arrow-down" on-tap='onMoveDownTap'
-          disabled='[[computeIsFullyOpen(stateObj)]]'></paper-icon-button>
+          disabled='[[computeIsFullyClosed(stateObj)]]'></paper-icon-button>
       </div>
     </div>
   </template>


### PR DESCRIPTION
We want to disable the down/close button when the blinds are fully closed, not fully open (and vise-versa). Without this change, the UI locks you from being able to open the blinds once fully closed or close the blinds once fully open.
