### PR TITLE
Remove improper capitalization in state display

### DIFF
--- a/src/state-summary/state-card-display.html
+++ b/src/state-summary/state-card-display.html
@@ -10,7 +10,6 @@
     color: var(--primary-text-color);
 
     margin-left: 16px;
-    text-transform: capitalize;
     text-align: right;
     line-height: 40px;
   }


### PR DESCRIPTION
This fixes issue https://github.com/home-assistant/home-assistant-polymer/issues/59 in home-assistant-polymer and https://github.com/home-assistant/home-assistant/issues/938 in home-assistant.
