### PR TITLE
Fix link for changed "Update" instructions

### DIFF
--- a/src/more-infos/more-info-updater.html
+++ b/src/more-infos/more-info-updater.html
@@ -10,7 +10,7 @@
   <template>
     <div class='layout vertical'>
 
-      <a class='link' href='https://home-assistant.io/getting-started/#updating' target='_blank'>Update Instructions</a>
+      <a class='link' href='https://home-assistant.io/getting-started/updating/' target='_blank'>Update Instructions</a>
 
     </div>
   </template>


### PR DESCRIPTION
As per: https://github.com/home-assistant/home-assistant.io/commit/b7de714d6c65c719db641aedfe748323810167a0
