### PR TITLE
Add caching to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: node_js
+cache:
+  directories:
+    - node_modules
+    - bower_components
 install:
   - npm install
   - bower install


### PR DESCRIPTION
This makes sure that Travis caches the output of NPM and Bower, speeding up test runs by 2 minutes 👍 
