### PR TITLE
Promise polyfill for outdated browsers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "iron-flex-layout": "^1.3.1",
     "paper-scroll-header-panel": "1.0.16",
     "app-layout": "^0.10.1",
-    "fecha": "^2.2.0"
+    "fecha": "^2.2.0",
+    "promise-polyfill": "^6.0.1"
   },
   "_comment": "specify iron-flex-layout for higher version than iron elements"
 }

--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -1,3 +1,4 @@
+<script src="../bower_components/promise-polyfill/promise.js"></script>
 <link rel='import' href='../bower_components/polymer/polymer.html'>
 <link rel='import' href='../bower_components/paper-spinner/paper-spinner.html'>
 <link rel='import' href='./util/roboto.html'>


### PR DESCRIPTION
Promise polyfill for outdated browsers like Safari iOS 7 (iPhone 4) and probably others.
