### PR TITLE
Fix rollershutter fully open/closed state

### DIFF
--- a/src/state-summary/state-card-rollershutter.html
+++ b/src/state-summary/state-card-rollershutter.html
@@ -25,10 +25,10 @@
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
       <div class='state'>
         <paper-icon-button icon="mdi:arrow-up" on-tap='onMoveUpTap'
-          disabled='[[computeIsFullyClosed(stateObj)]]'></paper-icon-button>
+          disabled='[[computeIsFullyOpen(stateObj)]]'></paper-icon-button>
         <paper-icon-button icon="mdi:stop" on-tap='onStopTap'></paper-icon-button>
         <paper-icon-button icon="mdi:arrow-down" on-tap='onMoveDownTap'
-          disabled='[[computeIsFullyOpen(stateObj)]]'></paper-icon-button>
+          disabled='[[computeIsFullyClosed(stateObj)]]'></paper-icon-button>
       </div>
     </div>
   </template>


### PR DESCRIPTION
See https://github.com/home-assistant/home-assistant/issues/2486#issuecomment-233071373 for problem description.

It is my understanding that the Rollershutter and Garagedoor will be combined to a "Cover" component, but in the meantime it does no harm to fix this, since roller shutter users cannot open or close their shutters when in the `0` or `100` positions.
