### PR TITLE
Allow entities to specify icons as entity_pictures

### DIFF
--- a/src/components/entity/ha-state-label-badge.html
+++ b/src/components/entity/ha-state-label-badge.html
@@ -82,6 +82,9 @@ Polymer({
         return null;
       case 'sensor':
       default:
+        if (window.hassUtil.computeIconImage(state)) {
+          return null;
+        }
         return state.state === 'unknown' ? '-' : state.state;
     }
   },
@@ -109,12 +112,12 @@ Polymer({
         return state.state === 'above_horizon' ?
         window.hassUtil.domainIcon(state.domain) : 'mdi:brightness-3';
       default:
-        return null;
+        return window.hassUtil.computeIconImage(state) || null;
     }
   },
 
   computeImage: function (state) {
-    return state.attributes.entity_picture || null;
+    return (!window.hassUtil.computeIconImage(state) && state.attributes.entity_picture) || null;
   },
 
   computeLabel: function (state) {

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -60,7 +60,7 @@ Polymer({
    */
   updateIconColor: function (newVal) {
     // hide icon if we have entity picture
-    if (newVal.attributes.entity_picture) {
+    if (newVal.attributes.entity_picture && !window.hassUtil.computeIconImage(newVal)) {
       this.style.backgroundImage = 'url(' + newVal.attributes.entity_picture + ')';
       this.$.icon.style.display = 'none';
       return;

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -164,6 +164,11 @@ window.hassUtil.relativeTime.tests = [
   7, 'day',
 ];
 
+window.hassUtil.computeIconImage = function (state) {
+  return state.attributes.entity_picture &&
+    state.attributes.entity_picture.substring(0, 4) === 'mdi:' ?
+    state.attributes.entity_picture : null;
+};
 
 window.hassUtil.stateCardType = function (hass, state) {
   if (state.state === 'unavailable') {
@@ -318,6 +323,8 @@ window.hassUtil.stateIcon = function (state) {
 
   if (!state) {
     return window.hassUtil.DEFAULT_ICON;
+  } else if (window.hassUtil.computeIconImage(state)) {
+    return window.hassUtil.computeIconImage(state);
   } else if (state.attributes.icon) {
     return state.attributes.icon;
   }


### PR DESCRIPTION
The badges will display one of entity_image, state value, or icon, in that priority. Allowing home assistant polymer to accept icon uris as the entity_image allows an entity to specify an icon that should be displayed instead of the state value.

There's definitely multiple ways this could be accomplished, but to me this seemed the cleanest from the python perspective. I'm open to feedback here though, and I'd be willing to implement this differently if there's a better idea.

See: https://github.com/home-assistant/home-assistant/pull/2795
