### PR TITLE
Filter external attributes

### DIFF
--- a/src/more-infos/more-info-default.html
+++ b/src/more-infos/more-info-default.html
@@ -25,7 +25,7 @@
 <script>
 (function () {
   'use strict';
-  var FILTER_KEYS = ['entity_picture', 'friendly_name', 'icon', 'unit_of_measurement', 'emulated_hue', 'emulated_hue_name'];
+  var FILTER_KEYS = ['entity_picture', 'friendly_name', 'icon', 'unit_of_measurement', 'emulated_hue', 'emulated_hue_name', 'haaska_name', 'haaska_hidden'];
 
   Polymer({
     is: 'more-info-default',

--- a/src/more-infos/more-info-default.html
+++ b/src/more-infos/more-info-default.html
@@ -25,7 +25,10 @@
 <script>
 (function () {
   'use strict';
-  var FILTER_KEYS = ['entity_picture', 'friendly_name', 'icon', 'unit_of_measurement', 'emulated_hue', 'emulated_hue_name', 'haaska_name', 'haaska_hidden', 'homebridge_hidden', 'homebridge_name'];
+  var FILTER_KEYS = ['entity_picture', 'friendly_name', 'icon', 'unit_of_measurement',
+                     'emulated_hue', 'emulated_hue_name',
+                     'haaska_hidden', 'haaska_name',
+                     'homebridge_hidden', 'homebridge_name'];
 
   Polymer({
     is: 'more-info-default',

--- a/src/more-infos/more-info-default.html
+++ b/src/more-infos/more-info-default.html
@@ -25,7 +25,7 @@
 <script>
 (function () {
   'use strict';
-  var FILTER_KEYS = ['entity_picture', 'friendly_name', 'icon', 'unit_of_measurement', 'emulated_hue', 'emulated_hue_name', 'haaska_name', 'haaska_hidden'];
+  var FILTER_KEYS = ['entity_picture', 'friendly_name', 'icon', 'unit_of_measurement', 'emulated_hue', 'emulated_hue_name', 'haaska_name', 'haaska_hidden', 'homebridge_hidden', 'homebridge_name'];
 
   Polymer({
     is: 'more-info-default',

--- a/src/more-infos/more-info-default.html
+++ b/src/more-infos/more-info-default.html
@@ -25,7 +25,7 @@
 <script>
 (function () {
   'use strict';
-  var FILTER_KEYS = ['entity_picture', 'friendly_name', 'icon', 'unit_of_measurement'];
+  var FILTER_KEYS = ['entity_picture', 'friendly_name', 'icon', 'unit_of_measurement', 'emulated_hue', 'emulated_hue_name'];
 
   Polymer({
     is: 'more-info-default',


### PR DESCRIPTION
This pull adds the following keys to the default more info `FILTER_KEYS`:
- [emulated_hue](https://home-assistant.io/components/emulated_hue/)
- [emulated_hue_name](https://home-assistant.io/components/emulated_hue/)
- [haaska_hidden](https://github.com/auchter/haaska#customization)
- [haaska_name](https://github.com/auchter/haaska#customization)
- [homebridge_hidden](https://github.com/home-assistant/homebridge-homeassistant#customization)
- [homebridge_name](https://github.com/home-assistant/homebridge-homeassistant#customization)

I did this because @arsaboo pointed out that the card looks a bit squished with these attributes, and they don't provide any value to the frontend.

Here's the screenshot that convinced me
![blob](https://cloud.githubusercontent.com/assets/18516/18218469/c2c579f6-7117-11e6-84cf-14a96cd604a1.png)

I made this a PR instead of pushing direct to master because I am unsure if we want to make this a precedent, especially for a totally external tool (Haaska). @balloob, can I get your thoughts?
