### PR TITLE
Display path to configuration.yaml

### DIFF
--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -138,7 +138,7 @@ Polymer({
       type: String,
       bindNuclear: function (hass) {
         return hass.configGetters.configDir;
-      }
+      },
     },
 
     polymerVersion: {

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -74,7 +74,7 @@
             [[hassVersion]]
           </p>
           <p>
-            Configuration.yaml path: [[hassConfigDir]]
+            Path to configuration.yaml: [[hassConfigDir]]
           </p>
           <p class='develop'>
             <a href='https://home-assistant.io/developers/credits/' target='_blank'>

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -73,6 +73,9 @@
             Home Assistant<br />
             [[hassVersion]]
           </p>
+          <p>
+            Configuration.yaml path: [[hassConfigDir]]
+          </p>
           <p class='develop'>
             <a href='https://home-assistant.io/developers/credits/' target='_blank'>
               Developed by a bunch of awesome people.
@@ -129,6 +132,13 @@ Polymer({
       bindNuclear: function (hass) {
         return hass.configGetters.serverVersion;
       },
+    },
+
+    hassConfigDir: {
+      type: String,
+      bindNuclear: function (hass) {
+        return hass.configGetters.configDir;
+      }
     },
 
     polymerVersion: {


### PR DESCRIPTION
Displays configuration.yaml path on the dev-info screen.

Related Issue:
https://github.com/home-assistant/home-assistant/issues/3556

Related PR's:
https://github.com/home-assistant/home-assistant/pull/3660
https://github.com/home-assistant/home-assistant-js/pull/23
