### PR TITLE
Use state as a fallback if current_position == undefined

### DIFF
--- a/src/state-summary/state-card-cover.html
+++ b/src/state-summary/state-card-cover.html
@@ -56,17 +56,15 @@ Polymer({
   computeIsFullyOpen: function (stateObj) {
     if (stateObj.attributes.current_position !== undefined) {
       return stateObj.attributes.current_position === 100;
-    } else {
-      return stateObj.state === "open";
     }
+    return stateObj.state === 'open';
   },
 
   computeIsFullyClosed: function (stateObj) {
     if (stateObj.attributes.current_position !== undefined) {
       return stateObj.attributes.current_position === 0;
-    } else {
-      return stateObj.state === "closed";
     }
+    return stateObj.state === 'closed';
   },
 
   onOpenTap: function () {

--- a/src/state-summary/state-card-cover.html
+++ b/src/state-summary/state-card-cover.html
@@ -54,11 +54,19 @@ Polymer({
   },
 
   computeIsFullyOpen: function (stateObj) {
-    return stateObj.attributes.current_position === 100;
+    if (stateObj.attributes.current_position !== undefined) {
+      return stateObj.attributes.current_position === 100;
+    } else {
+      return stateObj.state === "open";
+    }
   },
 
   computeIsFullyClosed: function (stateObj) {
-    return stateObj.attributes.current_position === 0;
+    if (stateObj.attributes.current_position !== undefined) {
+      return stateObj.attributes.current_position === 0;
+    } else {
+      return stateObj.state === "closed";
+    }
   },
 
   onOpenTap: function () {


### PR DESCRIPTION
Fixes issue mentioned [here](https://community.home-assistant.io/t/frontend-status-feedback-for-cover-component/3934/15) about cover not disabling up/down when it's already up/down if `current_position` is null. Replaces my PR at https://github.com/home-assistant/home-assistant/pull/3662 because this should be a better way to accomplish it
