### PR TITLE
Fix hidden tooltip on history chart

### DIFF
--- a/src/components/state-history-chart-timeline.html
+++ b/src/components/state-history-chart-timeline.html
@@ -1,5 +1,11 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 
+<style>
+  .charts-tooltip {
+    z-index: 200 !important;
+  }
+</style>
+
 <script>
 Polymer({
   is: 'state-history-chart-timeline',

--- a/src/components/state-history-chart-timeline.html
+++ b/src/components/state-history-chart-timeline.html
@@ -1,12 +1,13 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 
 <style>
-  .charts-tooltip {
+  div.charts-tooltip {
     z-index: 200 !important;
   }
 </style>
 
 <script>
+
 Polymer({
   is: 'state-history-chart-timeline',
 


### PR DESCRIPTION
Fixes tooltip on history charts that is hidden behind the more-infos modal.

**Related Issues**
https://github.com/home-assistant/home-assistant-polymer/issues/27
