### PR TITLE
Added title attributes to dev buttons

### DIFF
--- a/src/components/ha-sidebar.html
+++ b/src/components/ha-sidebar.html
@@ -142,23 +142,23 @@
       <div class='dev-tools layout horizontal justified'>
         <paper-icon-button
           icon='mdi:remote' data-panel='dev-service'
-          alt="Services"
+          alt="Services" title="Services"
           on-tap='menuClicked'></paper-icon-button>
         <paper-icon-button
           icon='mdi:code-tags' data-panel='dev-state'
-          alt="States"
+          alt="States" title="States"
           on-tap='menuClicked'></paper-icon-button>
         <paper-icon-button
           icon='mdi:radio-tower' data-panel='dev-event'
-          alt="Events"
+          alt="Events" title="Events"
           on-tap='menuClicked'></paper-icon-button>
         <paper-icon-button
           icon='mdi:file-xml' data-panel='dev-template'
-          alt="Templates"
+          alt="Templates" title="Templates"
           on-tap='menuClicked'></paper-icon-button>
         <paper-icon-button
           icon='mdi:information-outline' data-panel='dev-info'
-          alt="Info"
+          alt="Info" title="Info"
           on-tap='menuClicked'></paper-icon-button>
       </div>
     </div>


### PR DESCRIPTION
The title attribute doesn't aid in accessibility, but it can give a visual cue to what those buttons do. It took me a while before I got the hang of what was under each since icons can be Rorsachs.
