### PR TITLE
Fix inconsistent dialog width

### DIFF
--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -20,7 +20,7 @@
       }
 
       paper-dialog[data-domain=camera] {
-        min-width: auto;
+        width: auto;
       }
 
       state-history-charts {

--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -18,8 +18,11 @@
         font-size: 14px;
       }
 
+      paper-dialog[data-domain=climate] {
+        width: 450px;
+      }
+
       state-history-charts {
-        width: 100%;
         position: relative;
         z-index: 1;
       }
@@ -42,10 +45,11 @@
           overflow: scroll;
         }
       }
+
     </style>
 
     <!-- entry-animation='slide-up-animation' exit-animation='slide-down-animation' -->
-    <paper-dialog id="dialog" with-backdrop opened='{{dialogOpen}}'>
+    <paper-dialog id="dialog" with-backdrop opened='{{dialogOpen}}' data-domain$='[[stateObj.domain]]'>
       <h2>
         <state-card-content
           state-obj="[[stateObj]]"

--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -16,6 +16,11 @@
     <style>
       paper-dialog {
         font-size: 14px;
+        width: 450px;
+      }
+
+      paper-dialog[data-domain=camera] {
+        min-width: 450px;
       }
 
       state-history-charts {
@@ -26,25 +31,6 @@
       state-card-content {
         margin-bottom: 24px;
         font-size: 14px;
-      }
-
-      @@media all and (min-width: 451px){
-        paper-dialog[data-domain=alarm_control_panel],
-        paper-dialog[data-domain=automation],
-        paper-dialog[data-domain=climate],
-        paper-dialog[data-domain=configurator],
-        paper-dialog[data-domain=cover],
-        paper-dialog[data-domain=group],
-        paper-dialog[data-domain=hvac],
-        paper-dialog[data-domain=light],
-        paper-dialog[data-domain=lock],
-        paper-dialog[data-domain=media_player],
-        paper-dialog[data-domain=script],
-        paper-dialog[data-domain=sun],
-        paper-dialog[data-domain=thermostat],
-        paper-dialog[data-domain=updater], {
-          width: 450px;
-        }
       }
 
       @media all and (max-width: 450px), all and (max-height: 500px) {

--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -19,6 +19,7 @@
       }
 
       state-history-charts {
+        width: 100%;
         position: relative;
         z-index: 1;
       }

--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -18,19 +18,33 @@
         font-size: 14px;
       }
 
-      paper-dialog[data-domain=climate] {
-        width: 450px;
-      }
-
       state-history-charts {
         position: relative;
         z-index: 1;
-        max-width: 100%;
       }
 
       state-card-content {
         margin-bottom: 24px;
         font-size: 14px;
+      }
+
+      @@media all and (min-width: 451px){
+        paper-dialog[data-domain=alarm_control_panel],
+        paper-dialog[data-domain=automation],
+        paper-dialog[data-domain=climate],
+        paper-dialog[data-domain=configurator],
+        paper-dialog[data-domain=cover],
+        paper-dialog[data-domain=group],
+        paper-dialog[data-domain=hvac],
+        paper-dialog[data-domain=light],
+        paper-dialog[data-domain=lock],
+        paper-dialog[data-domain=media_player],
+        paper-dialog[data-domain=script],
+        paper-dialog[data-domain=sun],
+        paper-dialog[data-domain=thermostat],
+        paper-dialog[data-domain=updater], {
+          width: 450px;
+        }
       }
 
       @media all and (max-width: 450px), all and (max-height: 500px) {

--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -16,7 +16,7 @@
     <style>
       paper-dialog {
         font-size: 14px;
-        width: 450px;
+        width: 365px;
       }
 
       paper-dialog[data-domain=camera] {
@@ -26,6 +26,7 @@
       state-history-charts {
         position: relative;
         z-index: 1;
+        max-width: 365px;
       }
 
       state-card-content {

--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -25,6 +25,7 @@
       state-history-charts {
         position: relative;
         z-index: 1;
+        max-width: 100%;
       }
 
       state-card-content {

--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -20,7 +20,7 @@
       }
 
       paper-dialog[data-domain=camera] {
-        min-width: 450px;
+        min-width: auto;
       }
 
       state-history-charts {


### PR DESCRIPTION
Dialog width is inconsistent when it is presented with history charts.

**Related Issue**
https://github.com/home-assistant/home-assistant-polymer/issues/60
