### PR TITLE
Correct URL's for the hass repo's

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A frontend for Home Assistant using the Polymer framework",
   "repository": {
     "type": "git",
-    "url": "https://github.com/balloob/home-assistant-polymer"
+    "url": "https://github.com/home-assistant/home-assistant-polymer"
   },
   "scripts": {
     "setup_js_dev": "git submodule init && git submodule update && cd home-assistant-js && npm install",

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -84,9 +84,9 @@
           <p>
             Published under the MIT license<br />
             Source:
-            <a href='https://github.com/balloob/home-assistant' target='_blank'>server</a> &mdash;
-            <a href='https://github.com/balloob/home-assistant-polymer' target='_blank'>frontend-ui</a> &mdash;
-            <a href='https://github.com/balloob/home-assistant-js' target='_blank'>frontend-core</a>
+            <a href='https://github.com/home-assistant/home-assistant' target='_blank'>server</a> &mdash;
+            <a href='https://github.com/home-assistant/home-assistant-polymer' target='_blank'>frontend-ui</a> &mdash;
+            <a href='https://github.com/home-assistant/home-assistant-js' target='_blank'>frontend-core</a>
           </p>
           <p>
             Built using


### PR DESCRIPTION
I noticed that the URL's in the info panel still refer to the old repo's before they were renamed/moved.
This is just a very minor PR, but fixes that.
