### PR TITLE
Make dev-state panel more readable

### DIFF
--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -31,6 +31,14 @@
         text-align: left;
       }
 
+      .entities tr {
+        vertical-align: top;
+      }
+
+      .entities tr:nth-child(even) {
+        background-color: #eee;
+      }
+
       .entities td:nth-child(3) {
         white-space: pre-wrap;
         word-break: break-word;


### PR DESCRIPTION
With a lot dev-states, especially ones that have large 3rd column
content, the visual display of what col #1 goes with which col #3 is
not always clear. This does 2 things.

Vertical align all rows, so the top alignment is a clear guide.

Color all even rows to #eee, so we get a stipple effect which makes it
clear which things group together.
