### PR TITLE
Use material UI color for light icon

### DIFF
--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -26,7 +26,7 @@
     ha-state-icon[data-domain=switch][data-state=on],
     ha-state-icon[data-domain=binary_sensor][data-state=on],
     ha-state-icon[data-domain=sun][data-state=above_horizon] {
-      color: #DCC91F;
+      color: #FDD835;
     }
 
     /* Color the icon if unavailable */


### PR DESCRIPTION
This is purely subjective, but in my view, the current frontend color for light icons is pretty dark/brownish, especially when seen next to a hue bulb that changes based on the color. In this PR I used a color from the material design template: https://www.materialui.co/colors/yellow/600

Shown below is a comparison between the current color and the new one in this PR. Also shown is a hue bulb at 330 mired for comparison.

![Color Comparison](http://i.imgur.com/R3VKblt.png)
