### PR TITLE
adjusting alignment of entity states to improve readability

### DIFF
--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -34,6 +34,7 @@
       .entities td:nth-child(3) {
         white-space: pre-wrap;
         word-break: break-word;
+        vertical-align: top;
       }
 
       .entities a {


### PR DESCRIPTION
Currently the entity status table is vertically aligned to the center of each cell.

When you have "attributes" ticked, this makes it hard to distguish one entity's attributes from another.

This PR simply set's "vertical-align: top" to the attributes table, so that the name of an entity lines up with its first attribute. Without changing the overall style of the page it makes it easier to read.

See example screenshots (red box added for example emphasis):

**Before:**
![selection_006](https://cloud.githubusercontent.com/assets/131580/19503747/8924db70-956a-11e6-86ea-a93630462172.png)

**After:**
![selection_005](https://cloud.githubusercontent.com/assets/131580/19503751/8d23ea4a-956a-11e6-9f8c-a0ff55a49dbe.png)
