### PR TITLE
Update styling on climate sliders

### DIFF
--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -50,32 +50,31 @@
         width: 100%;
       }
 
-      #temp-slider,
-      #humidity-slider {
+      paper-slider {
         width: 100%;
       }
 
-      .auto #temp-slider {
+      .auto paper-slider {
         --paper-slider-active-color: var(--paper-orange-400);
         --paper-slider-secondary-color: var(--paper-blue-400);
       }
 
-      .heat #temp-slider {
+      .heat paper-slider {
         --paper-slider-active-color: var(--paper-orange-400);
         --paper-slider-secondary-color: var(--paper-green-400);
       }
 
-      .cool #temp-slider {
+      .cool paper-slider {
         --paper-slider-active-color: var(--paper-green-400);
         --paper-slider-secondary-color: var(--paper-blue-400);
       }
 
-      #humidity-slider {
+      .humidity {
         --paper-slider-active-color: var(--paper-blue-400);
         --paper-slider-secondary-color: var(--paper-blue-400);
       }
 
-      #temp-range-slider {
+      paper-range-slider {
         --paper-range-slider-lower-color: var(--paper-orange-400);
         --paper-range-slider-active-color: var(--paper-green-400);
         --paper-range-slider-higher-color: var(--paper-blue-400);
@@ -98,7 +97,6 @@
         <div class$='single-row, [[stateObj.attributes.operation_mode]]'>
           <div hidden$='[[computeTargetTempHidden(stateObj)]]'>Target Temperature</div>
           <paper-slider
-            id='temp-slider'
             min='[[stateObj.attributes.min_temp]]'
             max='[[stateObj.attributes.max_temp]]'
             secondary-progress='[[stateObj.attributes.max_temp]]'
@@ -109,7 +107,6 @@
             on-change='targetTemperatureSliderChanged'>
           </paper-slider>
           <paper-range-slider
-            id='temp-range-slider'
             min='[[stateObj.attributes.min_temp]]'
             max='[[stateObj.attributes.max_temp]]'
             pin
@@ -127,7 +124,7 @@
         <div class='single-row'>
           <div>Target Humidity</div>
           <paper-slider
-            id='humidity-slider'
+            class='humidity'
             min='[[stateObj.attributes.min_humidity]]'
             max='[[stateObj.attributes.max_humidity]]'
             secondary-progress='[[stateObj.attributes.max_humidity]]'

--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -50,6 +50,10 @@
         width: 100%;
       }
 
+      #temp-slider {
+        width: 100%;
+      }
+
       .heat {
         --paper-slider-active-color: var(--paper-orange-400);
         --paper-slider-secondary-color: var(--paper-green-400);
@@ -66,6 +70,7 @@
         --paper-range-slider-higher-color: var(--paper-blue-400);
         --paper-range-slider-knob-color: var(--primary-color);
         --paper-range-slider-pin-color: var(--primary-color);
+        --paper-range-slider-width: 100%;
       }
 
       .single-row {

--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -50,17 +50,28 @@
         width: 100%;
       }
 
-      #temp-slider {
+      #temp-slider,
+      #humidity-slider {
         width: 100%;
       }
 
-      .heat {
+      .auto #temp-slider {
+        --paper-slider-active-color: var(--paper-orange-400);
+        --paper-slider-secondary-color: var(--paper-blue-400);
+      }
+
+      .heat #temp-slider {
         --paper-slider-active-color: var(--paper-orange-400);
         --paper-slider-secondary-color: var(--paper-green-400);
       }
 
-      .cool {
+      .cool #temp-slider {
         --paper-slider-active-color: var(--paper-green-400);
+        --paper-slider-secondary-color: var(--paper-blue-400);
+      }
+
+      #humidity-slider {
+        --paper-slider-active-color: var(--paper-blue-400);
         --paper-slider-secondary-color: var(--paper-blue-400);
       }
 
@@ -116,8 +127,10 @@
         <div class='single-row'>
           <div>Target Humidity</div>
           <paper-slider
+            id='humidity-slider'
             min='[[stateObj.attributes.min_humidity]]'
             max='[[stateObj.attributes.max_humidity]]'
+            secondary-progress='[[stateObj.attributes.max_humidity]]'
             step='1' pin
             value='[[stateObj.attributes.humidity]]'
             on-change='targetHumiditySliderChanged'>


### PR DESCRIPTION
- Increase the width of the temp sliders to make it easier to use especially if there is a large difference between min and max values.
- Increase the width of humidity slider to match temp slider styling.
- Update color styling on humidity slider and temp slider for auto mode.

**Screenshot**
![image](https://cloud.githubusercontent.com/assets/11264693/19620544/838946d2-9845-11e6-90b5-2694147cee94.png)
