### PR TITLE
Music album art aspect ratio set to 1:1

### DIFF
--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -239,7 +239,7 @@ Polymer({
       cls += ' no-cover';
     }
 
-    if (playerObj.stateObj.attributes.media_content_type == 'music') {
+    if (playerObj.stateObj.attributes.media_content_type === 'music') {
       cls += ' content-type-music';
     }
 

--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -38,6 +38,10 @@
         transition: padding-top .8s;
       }
 
+      .banner.content-type-music:before {
+        padding-top: 100%;
+      }
+
       .banner.no-cover:before {
         padding-top: 91px;
       }
@@ -233,6 +237,10 @@ Polymer({
 
     if (!playerObj.stateObj.attributes.entity_picture) {
       cls += ' no-cover';
+    }
+
+    if (playerObj.stateObj.attributes.media_content_type == 'music') {
+      cls += ' content-type-music';
     }
 
     return cls;


### PR DESCRIPTION
When playing music it bothered me that the album art was cropped. 

This PR changes the size of the entity_picture in media_player to be 1:1 when playing music.
