### PR TITLE
Media players can support turn off without turn on

### DIFF
--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -147,7 +147,7 @@
       <paper-icon-button
         icon='mdi:power'
         on-tap='handleTogglePower'
-        invisible$='[[!playerObj.supportsTurnOff]]'
+        invisible$='[[computeHidePowerButton(playerObj)]]'
         class='self-center secondary'
       ></paper-icon-button>
 
@@ -238,8 +238,8 @@ Polymer({
     return cls;
   },
 
-  computeHidePowerOnButton: function (playerObj) {
-    return !playerObj.isOff || !playerObj.supportsTurnOn;
+  computeHidePowerButton: function (playerObj) {
+    return playerObj.isOff ? !playerObj.supportsTurnOn : !playerObj.supportsTurnOff;
   },
 
   computePlayerObj: function (stateObj) {


### PR DESCRIPTION
Fixes power button display for Kodi. Kodi supports turn off, but not turn on.
