### PR TITLE
Only show media_player background if no album art is available.

### DIFF
--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -19,12 +19,7 @@
 
       .banner {
         position: relative;
-
-        background-position: center center;
-        background-image: url(/static/images/card_media_player_bg.png);
-        background-repeat: no-repeat;
-        background-color: var(--primary-color);
-
+        background-color: white;
         border-top-left-radius: 2px;
         border-top-right-radius: 2px;
       }
@@ -36,6 +31,13 @@
         /* removed .25% from 16:9 ratio to fix YT black bars */
         padding-top: 56%;
         transition: padding-top .8s;
+      }
+
+      .banner.no-cover {
+        background-position: center center;
+        background-image: url(/static/images/card_media_player_bg.png);
+        background-repeat: no-repeat;
+        background-color: var(--primary-color);
       }
 
       .banner.content-type-music:before {


### PR DESCRIPTION
This changes the media_player background to only show if there is no album art. If there is any album art the background is set to white. This helps with album art that has an alpha channel (transparent). Instead of the blue showing through the background will now be white.
This happens when for example playing TuneIn  radio stations in Sonos, transparent album art seems to be quite common there.