### PR TITLE
Add effects selector in light more info

### DIFF
--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -9,7 +9,11 @@
   <template>
     <style is="custom-style" include="iron-flex"></style>
     <style>
-      .brightness, .color_temp, .white_value {
+      .effect_list {
+        padding-bottom: 16px;
+      }
+
+      .effect_list, .brightness, .color_temp, .white_value {
         max-height: 0px;
         overflow: hidden;
         transition: max-height .5s ease-in;
@@ -24,6 +28,7 @@
         transition: max-height .2s ease-in;
       }
 
+      .has-effect_list .effect_list,
       .has-brightness .brightness,
       .has-color_temp .color_temp,
       .has-white_value .white_value {
@@ -36,6 +41,17 @@
     </style>
 
     <div class$='[[computeClassNames(stateObj)]]'>
+
+      <div class='effect_list'>
+        <paper-dropdown-menu label-float label='Effect'>
+          <paper-menu class="dropdown-content" selected="{{effectIndex}}">
+            <template is='dom-repeat'
+                      items='[[stateObj.attributes.effect_list]]'>
+              <paper-item>[[item]]</paper-item>
+            </template>
+          </paper-menu>
+        </paper-dropdown-menu>
+      </div>
 
       <div class='brightness'>
         <ha-labeled-slider
@@ -79,6 +95,12 @@ Polymer({
       observer: 'stateObjChanged',
     },
 
+    effectIndex: {
+      type: Number,
+      value: -1,
+      observer: 'effectChanged',
+    },
+
     brightnessSliderValue: {
       type: Number,
       value: 0,
@@ -100,6 +122,13 @@ Polymer({
       this.brightnessSliderValue = newVal.attributes.brightness;
       this.ctSliderValue = newVal.attributes.color_temp;
       this.wvSliderValue = newVal.attributes.white_value;
+
+      if (newVal.attributes.effect_list) {
+        this.effectIndex = newVal.attributes.effect_list.indexOf(
+          newVal.attributes.effect);
+      } else {
+        this.effectIndex = -1;
+      }
     }
 
     this.async(function () {
@@ -109,7 +138,22 @@ Polymer({
 
   computeClassNames: function (stateObj) {
     return window.hassUtil.attributeClassNames(
-      stateObj, ['brightness', 'rgb_color', 'color_temp', 'white_value']);
+      stateObj, ['brightness', 'rgb_color', 'color_temp', 'white_value',
+          'effect_list']);
+  },
+
+  effectChanged: function (effectIndex) {
+    var effectInput;
+    // Selected Option will transition to '' before transitioning to new value
+    if (effectIndex === '' || effectIndex === -1) return;
+
+    effectInput = this.stateObj.attributes.effect_list[effectIndex];
+    if (effectInput === this.stateObj.attributes.effect) return;
+
+    this.hass.serviceActions.callService('light', 'turn_on', {
+      entity_id: this.stateObj.entityId,
+      effect: effectInput,
+    });
   },
 
   brightnessSliderChanged: function (ev) {

--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -139,7 +139,7 @@ Polymer({
   computeClassNames: function (stateObj) {
     return window.hassUtil.attributeClassNames(
       stateObj, ['brightness', 'rgb_color', 'color_temp', 'white_value',
-          'effect_list']);
+        'effect_list']);
   },
 
   effectChanged: function (effectIndex) {


### PR DESCRIPTION
This PR is linked to home-assistant/home-assistant#4538 and leverages on the new `effect_list` to display a nice select to switch between effects and keep an eye on the current effect.

**UI rendering:**
![Light effect more infos](https://i.imgur.com/bKJXONv.png)

**Actual result:**
![Light effect rainbow](https://i.imgur.com/DjppWwk.jpg)

Ideas of improvement:
* Replace underscores with spaces in effect names
* Capitalize effect names

Unfortunately I'm not proficient enough in JS/CSS to implement this properly. I've seen it done for the climate control could not port it here. The list displays capitalized items but the selected value is not...