### PR TITLE
Don't capitalize entity names in the UI

### DIFF
--- a/panels/logbook/ha-logbook.html
+++ b/panels/logbook/ha-logbook.html
@@ -30,10 +30,6 @@
         color: var(--primary-text-color);
       }
 
-      .name {
-        text-transform: capitalize;
-      }
-
       .message {
         color: var(--primary-text-color);
       }

--- a/src/cards/ha-camera-card.html
+++ b/src/cards/ha-camera-card.html
@@ -30,7 +30,6 @@
         background-color: rgba(0, 0, 0, 0.3);
         padding: 16px;
 
-        text-transform: capitalize;
         font-size: 16px;
         font-weight: 500;
         line-height: 16px;

--- a/src/cards/ha-entities-card.html
+++ b/src/cards/ha-entities-card.html
@@ -24,7 +24,6 @@
         line-height: 40px;
         color: var(--primary-text-color);
         padding: 20px 16px 12px;
-        text-transform: capitalize;
       }
       .header .name {
         @apply(--paper-font-common-nowrap);

--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -81,7 +81,6 @@
 
         padding: 8px 16px;
 
-        text-transform: capitalize;
         font-size: 14px;
         font-weight: 500;
         color: white;
@@ -92,7 +91,6 @@
       .banner.is-off > .caption {
         background-color: initial;
       }
-
 
       .banner > .caption .title {
         @apply(--paper-font-common-nowrap);


### PR DESCRIPTION
Fixes #163.

Don't capitalize entity names in the UI, causes the UI to use the specified friendly_name from the configuration.