### PR TITLE
Always show the brightness slider in more-info

### DIFF
--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -132,6 +132,8 @@ Polymer({
       } else {
         this.effectIndex = -1;
       }
+    } else {
+      this.brightnessSliderValue = 0;
     }
 
     this.async(function () {
@@ -143,9 +145,10 @@ Polymer({
     var classes = window.hassUtil.attributeClassNames(
       stateObj, ['rgb_color', 'color_temp', 'white_value',
         'effect_list']);
+    var BRIGHTNESS_SUPPORTED = 1;
     // If brightness is supported - show the slider even if the attribute is
     // missing (because the light is off).
-    if (stateObj && (stateObj.attributes.supported_features & 1)) {
+    if (stateObj && (stateObj.attributes.supported_features & BRIGHTNESS_SUPPORTED)) {
       classes += ' has-brightness';
     }
     return classes;

--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -140,9 +140,15 @@ Polymer({
   },
 
   computeClassNames: function (stateObj) {
-    return window.hassUtil.attributeClassNames(
-      stateObj, ['brightness', 'rgb_color', 'color_temp', 'white_value',
+    var classes = window.hassUtil.attributeClassNames(
+      stateObj, ['rgb_color', 'color_temp', 'white_value',
         'effect_list']);
+    // If brightness is supported - show the slider even if the attribute is
+    // missing (because the light is off).
+    if (stateObj && (stateObj.attributes.supported_features & 1)) {
+      classes = classes + ' has-brightness';
+    }
+    return classes;
   },
 
   effectChanged: function (effectIndex) {

--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -146,7 +146,7 @@ Polymer({
     // If brightness is supported - show the slider even if the attribute is
     // missing (because the light is off).
     if (stateObj && (stateObj.attributes.supported_features & 1)) {
-      classes = classes + ' has-brightness';
+      classes += ' has-brightness';
     }
     return classes;
   },


### PR DESCRIPTION
Always show the brightness slider in more-info if it is supported.
Even when the light is currently off.

Implements (1) of this: https://community.home-assistant.io/t/ui-more-suited-for-dimmers/8660/3



light off
![cold_start](https://cloud.githubusercontent.com/assets/5478779/21656330/5e00e6c0-d2c6-11e6-85ee-ef7d5e8de4d4.png)



Moving the slider turns the light on to set brightness
![turned_onn](https://cloud.githubusercontent.com/assets/5478779/21656324/55beeea8-d2c6-11e6-980e-57c858abfee9.png)

