### PR TITLE
Tweak panel padding so they match

### DIFF
--- a/panels/dev-event/ha-panel-dev-event.html
+++ b/panels/dev-event/ha-panel-dev-event.html
@@ -27,7 +27,7 @@
       }
       .content {
         @apply(--paper-font-body1);
-        padding: 24px;
+        padding: 16px;
       }
 
       .ha-form {

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -21,7 +21,7 @@
       }
 
       .content {
-        padding: 24px;
+        padding: 16px;
       }
 
       .about {

--- a/panels/dev-service/ha-panel-dev-service.html
+++ b/panels/dev-service/ha-panel-dev-service.html
@@ -25,7 +25,7 @@
       }
 
       .content {
-        padding: 24px;
+        padding: 16px;
       }
 
       .ha-form {

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -24,7 +24,7 @@
       }
 
       .content {
-        padding: 24px;
+        padding: 16px;
       }
 
       .entities th {
@@ -59,8 +59,10 @@
 
       <div class='content'>
         <div>
-          Set the representation of a device within Home Assistant.<br />
-          This will not communicate with the actual device.
+          <p>
+            Set the representation of a device within Home Assistant.<br />
+            This will not communicate with the actual device.
+          </p>
 
           <paper-input label="Entity ID" autofocus required value='{{_entityId}}'></paper-input>
           <paper-input label="State" required value='{{_state}}'></paper-input>

--- a/panels/dev-template/ha-panel-dev-template.html
+++ b/panels/dev-template/ha-panel-dev-template.html
@@ -23,7 +23,7 @@
       }
 
       .content {
-        padding: 24px;
+        padding: 16px;
       }
 
       .edit-pane {

--- a/panels/history/ha-panel-history.html
+++ b/panels/history/ha-panel-history.html
@@ -16,19 +16,11 @@
   <template>
     <style include="iron-flex ha-style">
       .content {
-        background-color: white;
-      }
-
-      .content.wide {
-        padding: 8px;
+        padding: 16px;
       }
 
       paper-input {
         max-width: 200px;
-      }
-
-      .narrow paper-input {
-        margin-left: 8px;
       }
     </style>
 
@@ -44,7 +36,7 @@
         </app-toolbar>
       </app-header>
 
-      <div class$="[[computeContentClasses(narrow)]]">
+      <div class="flex content">
         <paper-input
           label='Showing entries for'
           id='datePicker'
@@ -156,8 +148,5 @@ Polymer({
     this.datePicker.destroy();
   },
 
-  computeContentClasses: function (narrow) {
-    return narrow ? 'flex content narrow' : 'flex content wide';
-  },
 });
 </script>

--- a/panels/logbook/ha-logbook.html
+++ b/panels/logbook/ha-logbook.html
@@ -9,7 +9,6 @@
     <style>
       :host {
         display: block;
-        padding: 16px;
       }
 
       .entry {

--- a/panels/logbook/ha-panel-logbook.html
+++ b/panels/logbook/ha-panel-logbook.html
@@ -18,8 +18,8 @@
 <dom-module id="ha-panel-logbook">
   <template>
     <style include="ha-style">
-    .selected-date-container {
-      padding: 0 16px;
+    .content {
+      padding: 16px;
     }
 
     paper-input {
@@ -43,7 +43,7 @@
         </app-toolbar>
       </app-header>
 
-      <div>
+      <div class="flex content">
         <div class='selected-date-container'>
           <paper-input
             label='Showing entries for'
@@ -167,5 +167,6 @@ Polymer({
   detached: function () {
     this.datePicker.destroy();
   },
+
 });
 </script>


### PR DESCRIPTION
The History panel and Logbook panel had different paddings around the panel content. This caused the datepicker to "jump" when switching panels.

The paddings varied between 8px, 16px and 24px. I've all changed them to 16px, to make the interface more uniform. This also fixes a scrollbar issue that appeared in the History panel.

Before:
![screenshot from 2017-01-06 08-58-41](https://cloud.githubusercontent.com/assets/1193779/21712475/57dc4bba-d3f5-11e6-8697-6b9a169c891f.png)
![screenshot from 2017-01-06 08-58-54](https://cloud.githubusercontent.com/assets/1193779/21712476/57eeedc4-d3f5-11e6-8508-a7a6cd2529bd.png)
