### PR TITLE
Capitalize card titles for default domain groups

### DIFF
--- a/src/cards/ha-entities-card.html
+++ b/src/cards/ha-entities-card.html
@@ -28,6 +28,10 @@
       .header .name {
         @apply(--paper-font-common-nowrap);
       }
+      .header.domain .name {
+        /* Capitalize cards titles for default domain groups. */
+        text-transform: capitalize;
+      }
       ha-entity-toggle {
         margin-left: 16px;
       }
@@ -85,6 +89,8 @@ Polymer({
     var classes = 'header horizontal layout center ';
     if (groupEntity) {
       classes += 'header-more-info';
+    } else {
+      classes += 'domain';
     }
     return classes;
   },


### PR DESCRIPTION
Since #164, default groups cards for domains are no longer capitalized. (automation, light, cover, etc.)

This change restores capitalization only for the domain-name cards.

@michaelarnauts 