### PR TITLE
Display attributions separately in more-info

### DIFF
--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -14,23 +14,29 @@
         }
 
         .attribution {
-          color:grey;
+          color: var(--secondary-text-color);
+          text-align: right;
         }
     </style>
     <google-legacy-loader on-api-load='googleApiLoaded'></google-legacy-loader>
     <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
-        <template is='dom-repeat' items='[[computeCurrentWeather(stateObj)]]'>
-          <div>[[item.key]]: [[item.value]]</div>
+        <template is='dom-repeat' items='[[computeDisplayAttributes(stateObj)]]' as="attribute">
+          <div>[[formatAttribute(attribute)]]: [[getAttributeValue(stateObj, attribute)]]</div>
         </template>
         <div id='chart_area'></div>
-        <div class='attribution'>[[computeAttribution(stateObj)]]</div>
+        <div class='attribution' hidden$='[[!computeAttribution(stateObj)]]'>[[computeAttribution(stateObj)]]</div>
       </div>
     </ha-card>
   </template>
 </dom-module>
 
 <script>
+(function () {
+  'use strict';
+
+  var FILTER_KEYS = ['attribution', 'forecast', 'friendly_name'];
+
   Polymer({
     is: 'ha-weather-card',
 
@@ -49,20 +55,13 @@
       return stateObj.attributes.friendly_name;
     },
 
-    computeAttribution: function (stateObj) {
-      return stateObj.attributes.attribution;
+    computeDisplayAttributes: function (stateObj) {
+      return window.hassUtil.computeDisplayAttributes(stateObj, FILTER_KEYS);
     },
 
-    computeCurrentWeather: function (stateObj) {
-      return Object.keys(stateObj.attributes).filter(function (key) {
-        return ['attribution', 'forecast', 'friendly_name'].indexOf(key) === -1;
-      }).map(function (key) {
-        return {
-          key: key,
-          value: stateObj.attributes[key]
-        };
-      });
-    },
+    formatAttribute: window.hassUtil.formatAttribute,
+    getAttributeValue: window.hassUtil.getAttributeValue,
+    computeAttribution: window.hassUtil.computeAttribution,
 
     getDataArray: function () {
       var dataArray = [];
@@ -134,4 +133,5 @@
       });
     },
   });
+}());
 </script>

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -22,7 +22,7 @@
     <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
         <template is='dom-repeat' items='[[computeDisplayAttributes(stateObj)]]' as="attribute">
-          <div>[[formatAttribute(attribute)]]: [[getAttributeValue(stateObj, attribute)]]</div>
+          <div>[[formatAttribute(attribute)]]: [[formatAttributeValue(stateObj, attribute)]]</div>
         </template>
         <div id='chart_area'></div>
         <div class='attribution' hidden$='[[!computeAttribution(stateObj)]]'>[[computeAttribution(stateObj)]]</div>
@@ -60,7 +60,7 @@
     },
 
     formatAttribute: window.hassUtil.formatAttribute,
-    getAttributeValue: window.hassUtil.getAttributeValue,
+    formatAttributeValue: window.hassUtil.formatAttributeValue,
     computeAttribution: window.hassUtil.computeAttribution,
 
     getDataArray: function () {

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -59,9 +59,17 @@
       return window.hassUtil.computeDisplayAttributes(stateObj, FILTER_KEYS);
     },
 
-    formatAttribute: window.hassUtil.formatAttribute,
-    formatAttributeValue: window.hassUtil.formatAttributeValue,
-    computeAttribution: window.hassUtil.computeAttribution,
+    formatAttribute: function (attribute) {
+      return window.hassUtil.formatAttribute(attribute);
+    },
+
+    formatAttributeValue: function (stateObj, attribute) {
+      return window.hassUtil.formatAttributeValue(stateObj, attribute);
+    },
+
+    computeAttribution: function (stateObj) {
+      return window.hassUtil.computeAttribution(stateObj);
+    },
 
     getDataArray: function () {
       var dataArray = [];

--- a/src/more-infos/more-info-default.html
+++ b/src/more-infos/more-info-default.html
@@ -51,9 +51,17 @@
       return window.hassUtil.computeDisplayAttributes(stateObj, FILTER_KEYS);
     },
 
-    formatAttribute: window.hassUtil.formatAttribute,
-    formatAttributeValue: window.hassUtil.formatAttributeValue,
-    computeAttribution: window.hassUtil.computeAttribution,
+    formatAttribute: function (attribute) {
+      return window.hassUtil.formatAttribute(attribute);
+    },
+
+    formatAttributeValue: function (stateObj, attribute) {
+      return window.hassUtil.formatAttributeValue(stateObj, attribute);
+    },
+
+    computeAttribution: function (stateObj) {
+      return window.hassUtil.computeAttribution(stateObj);
+    },
   });
 }());
 </script>

--- a/src/more-infos/more-info-default.html
+++ b/src/more-infos/more-info-default.html
@@ -9,6 +9,11 @@
       .data-entry .value {
         max-width: 200px;
       }
+
+      .attribution {
+        color: var(--secondary-text-color);
+        text-align: right;
+      }
     </style>
 
     <div class='layout vertical'>
@@ -18,6 +23,7 @@
           <div class='value'>[[getAttributeValue(stateObj, attribute)]]</div>
         </div>
       </template>
+      <div class='attribution' hidden$='[[!computeAttribution(stateObj)]]'>[[computeAttribution(stateObj)]]</div>
     </div>
   </template>
 </dom-module>
@@ -29,7 +35,7 @@
   var FILTER_KEYS = [
     'entity_picture', 'friendly_name', 'icon', 'unit_of_measurement',
     'emulated_hue', 'emulated_hue_name', 'haaska_hidden', 'haaska_name',
-    'homebridge_hidden', 'homebridge_name',
+    'homebridge_hidden', 'homebridge_name', 'attribution',
   ];
 
   Polymer({
@@ -42,23 +48,12 @@
     },
 
     computeDisplayAttributes: function (stateObj) {
-      if (!stateObj) {
-        return [];
-      }
-
-      return Object.keys(stateObj.attributes).filter(
-        function (key) { return FILTER_KEYS.indexOf(key) === -1; });
+      return window.hassUtil.computeDisplayAttributes(stateObj, FILTER_KEYS);
     },
 
-    formatAttribute: function (attribute) {
-      return attribute.replace(/_/g, ' ');
-    },
-
-    getAttributeValue: function (stateObj, attribute) {
-      var value = stateObj.attributes[attribute];
-
-      return Array.isArray(value) ? value.join(', ') : value;
-    },
+    formatAttribute: window.hassUtil.formatAttribute,
+    getAttributeValue: window.hassUtil.getAttributeValue,
+    computeAttribution: window.hassUtil.computeAttribution,
   });
 }());
 </script>

--- a/src/more-infos/more-info-default.html
+++ b/src/more-infos/more-info-default.html
@@ -20,7 +20,7 @@
       <template is='dom-repeat' items="[[computeDisplayAttributes(stateObj)]]" as="attribute">
         <div class='data-entry layout justified horizontal'>
           <div class='key'>[[formatAttribute(attribute)]]</div>
-          <div class='value'>[[getAttributeValue(stateObj, attribute)]]</div>
+          <div class='value'>[[formatAttributeValue(stateObj, attribute)]]</div>
         </div>
       </template>
       <div class='attribution' hidden$='[[!computeAttribution(stateObj)]]'>[[computeAttribution(stateObj)]]</div>
@@ -52,7 +52,7 @@
     },
 
     formatAttribute: window.hassUtil.formatAttribute,
-    getAttributeValue: window.hassUtil.getAttributeValue,
+    formatAttributeValue: window.hassUtil.formatAttributeValue,
     computeAttribution: window.hassUtil.computeAttribution,
   });
 }());

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -341,4 +341,27 @@ window.hassUtil.stateIcon = function (state) {
   return window.hassUtil.domainIcon(state.domain, state.state);
 };
 
+window.hassUtil.computeDisplayAttributes = function (stateObj, filter_keys) {
+  if (!stateObj) {
+    return [];
+  }
+
+  return Object.keys(stateObj.attributes).filter(
+    function (key) { return filter_keys.indexOf(key) === -1; });
+};
+
+window.hassUtil.formatAttribute = function (attribute) {
+  return attribute.replace(/_/g, ' ');
+};
+
+window.hassUtil.getAttributeValue = function (stateObj, attribute) {
+  var value = stateObj.attributes[attribute];
+
+  return Array.isArray(value) ? value.join(', ') : value;
+};
+
+window.hassUtil.computeAttribution = function (stateObj) {
+  return stateObj.attributes.attribution;
+};
+
 </script>

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -354,7 +354,7 @@ window.hassUtil.formatAttribute = function (attribute) {
   return attribute.replace(/_/g, ' ');
 };
 
-window.hassUtil.getAttributeValue = function (stateObj, attribute) {
+window.hassUtil.formatAttributeValue = function (stateObj, attribute) {
   var value = stateObj.attributes[attribute];
 
   return Array.isArray(value) ? value.join(', ') : value;

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -341,13 +341,13 @@ window.hassUtil.stateIcon = function (state) {
   return window.hassUtil.domainIcon(state.domain, state.state);
 };
 
-window.hassUtil.computeDisplayAttributes = function (stateObj, filter_keys) {
+window.hassUtil.computeDisplayAttributes = function (stateObj, filterKeys) {
   if (!stateObj) {
     return [];
   }
 
   return Object.keys(stateObj.attributes).filter(
-    function (key) { return filter_keys.indexOf(key) === -1; });
+    function (key) { return filterKeys.indexOf(key) === -1; });
 };
 
 window.hassUtil.formatAttribute = function (attribute) {


### PR DESCRIPTION
This PR separates out attributions from the rest of the attribute list in the more-info popup. Fixes #141.

![Screenshot](http://i.imgur.com/GMdghQK.png)