### PR TITLE
Multiple weather card graphs

### DIFF
--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -21,7 +21,7 @@
     <google-legacy-loader on-api-load='googleApiLoaded'></google-legacy-loader>
     <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
-        <div id='[[computeChartId(stateObj)]]'></div>
+        <div id$='[[computeChartId(stateObj)]]'></div>
         <ha-attributes state-obj='[[stateObj]]' extra-filters='forecast'></ha-attributes>
       </div>
     </ha-card>

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -49,8 +49,8 @@
     computeTitle: function (stateObj) {
       return stateObj.attributes.friendly_name;
     },
-    
-    computeChartId: function(stateObj) {
+
+    computeChartId: function (stateObj) {
       return 'chart_area_' + stateObj.id;
     },
 

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -83,7 +83,7 @@
       }
 
       if (!this.chartEngine) {
-        this.chartEngine = new window.google.visualization.LineChart(document.getElementById('chart_area' + this.stateObj.id));
+        this.chartEngine = new window.google.visualization.LineChart(document.getElementById(this.computeChartId(this.stateObj)));
       }
 
       this.drawChart();

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -21,7 +21,7 @@
     <google-legacy-loader on-api-load='googleApiLoaded'></google-legacy-loader>
     <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
-        <div id='chart_area'></div>
+        <div id='[[computeChartId(stateObj)]]'></div>
         <ha-attributes state-obj='[[stateObj]]' extra-filters='forecast'></ha-attributes>
       </div>
     </ha-card>
@@ -48,6 +48,10 @@
 
     computeTitle: function (stateObj) {
       return stateObj.attributes.friendly_name;
+    },
+    
+    computeChartId: function(stateObj) {
+      return 'chart_area_' + stateObj.id;
     },
 
     getDataArray: function () {
@@ -79,7 +83,7 @@
       }
 
       if (!this.chartEngine) {
-        this.chartEngine = new window.google.visualization.LineChart(document.getElementById('chart_area'));
+        this.chartEngine = new window.google.visualization.LineChart(document.getElementById('chart_area' + this.stateObj.id));
       }
 
       this.drawChart();

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -83,7 +83,8 @@
       }
 
       if (!this.chartEngine) {
-        this.chartEngine = new window.google.visualization.LineChart(document.getElementById(this.computeChartId(this.stateObj)));
+        this.chartEngine = new window.google.visualization.LineChart(
+          document.getElementById(this.computeChartId(this.stateObj)));
       }
 
       this.drawChart();


### PR DESCRIPTION
Because of the way how the Weather Card currently selects the are to show the graph, they all select the same area to draw the graph. This makes only 1 graph show up, even when having multiple weather platforms configured. (Can be seen using the demo platform).

This change makes sure each weather card uses it's unique ID to select the graph area, resulting in each card having a graph.