### PR TITLE
Leftover home-assistant-js references

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/home-assistant/home-assistant-polymer"
   },
   "scripts": {
-    "setup_js_dev": "git submodule init && git submodule update && cd home-assistant-js && npm install",
     "clean": "rm -rf build/* build-temp/*",
     "js_dev": "script/gen-service-worker.js && npm run watch_ru_all",
     "js_dev_demo": "BUILD_DEMO=1 npm run watch_ru_all",

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -85,7 +85,6 @@
             Source:
             <a href='https://github.com/home-assistant/home-assistant' target='_blank'>server</a> &mdash;
             <a href='https://github.com/home-assistant/home-assistant-polymer' target='_blank'>frontend-ui</a> &mdash;
-            <a href='https://github.com/home-assistant/home-assistant-js' target='_blank'>frontend-core</a>
           </p>
           <p>
             Built using


### PR DESCRIPTION
Follow-up to #180. This is breaking dev. environment setups since the `cd` will fail. I will submit a separate pull request on the main repo to remove the reference to `setup_js_dev`

r? @balloob 