### PR TITLE
make more-info- tags in dynamicContentUpdater lowercase

### DIFF
--- a/src/more-infos/more-info-content.html
+++ b/src/more-infos/more-info-content.html
@@ -45,7 +45,7 @@ Polymer({
       }
     } else {
       window.hassUtil.dynamicContentUpdater(
-        this, 'MORE-INFO-' + window.hassUtil.stateMoreInfoType(stateObj).toUpperCase(),
+        this, 'more-info-' + window.hassUtil.stateMoreInfoType(stateObj),
         { hass: this.hass, stateObj: stateObj, isVisible: true });
     }
   },

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -76,7 +76,7 @@ window.hassUtil.dynamicContentUpdater = function (root, newElementTag, attribute
   var rootEl = Polymer.dom(root);
   var customEl;
 
-  if (rootEl.lastChild && rootEl.lastChild.tagName === newElementTag) {
+  if (rootEl.lastChild && rootEl.lastChild.tagName.toLowerCase() === newElementTag) {
     customEl = rootEl.lastChild;
   } else {
     if (rootEl.lastChild) {


### PR DESCRIPTION
When trying to understand the source tree using `git grep` the fact
that the critical function which actually creates the more-info-
panels used MORE-INFO, makes it actually hard to find. Rework the
logic so that it's all managed in lower case for greater
discoverability of hunting through code.