### PR TITLE
Set icons for sensors that are in units of degrees

### DIFF
--- a/src/components/entity/ha-state-icon.html
+++ b/src/components/entity/ha-state-icon.html
@@ -4,6 +4,11 @@
 
 <dom-module id="ha-state-icon">
   <template>
+    <style>
+      iron-icon {
+        transition: 1s ease-out;
+      }
+    </style>
     <iron-icon icon="[[computeIcon(stateObj)]]"></iron-icon>
   </template>
 </dom-module>
@@ -15,11 +20,22 @@ Polymer({
   properties: {
     stateObj: {
       type: Object,
+      observer: 'computeRotation',
     },
   },
 
   computeIcon: function (stateObj) {
     return window.hassUtil.stateIcon(stateObj);
   },
+
+  computeRotation: function (stateObj) {
+    var units = stateObj.attributes.unit_of_measurement;
+    // TODO(sdague): we honestly probably want semantic meaning for
+    // sensors which we could select on, but use this as a shortcut.
+    if (units === '°') {
+      var deg = Number(stateObj.state) % 360;
+      this.children[0].style.transform = 'rotate(' + deg + 'deg)';
+    }
+  }
 });
 </script>

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -373,6 +373,8 @@ window.hassUtil.stateIcon = function (state) {
   if (unit && domain === 'sensor') {
     if (unit === '°C' || unit === '°F') {
       return 'mdi:thermometer';
+    } else if (unit === '°') {
+      return 'mdi:navigation';
     } else if (unit === 'Mice') {
       return 'mdi:mouse-variant';
     }


### PR DESCRIPTION
This also updates the icon rotation direction based on the degrees
direction, which means that something like a wind sensor will have an
icon which is in a representative direction.