### PR TITLE
Fixed wrong ID used for Weather forecast graphs

### DIFF
--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -51,7 +51,7 @@
     },
 
     computeChartId: function (stateObj) {
-      return 'chart_area_' + stateObj.id;
+      return 'chart_area_' + stateObj.entity_id;
     },
 
     getDataArray: function () {

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -21,7 +21,7 @@
     <google-legacy-loader on-api-load='googleApiLoaded'></google-legacy-loader>
     <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
-        <div id$='[[computeChartId(stateObj)]]'></div>
+        <div id='chart_id'></div>
         <ha-attributes state-obj='[[stateObj]]' extra-filters='forecast'></ha-attributes>
       </div>
     </ha-card>
@@ -48,10 +48,6 @@
 
     computeTitle: function (stateObj) {
       return stateObj.attributes.friendly_name;
-    },
-
-    computeChartId: function (stateObj) {
-      return 'chart_area_' + stateObj.entity_id;
     },
 
     getDataArray: function () {
@@ -84,7 +80,7 @@
 
       if (!this.chartEngine) {
         this.chartEngine = new window.google.visualization.LineChart(
-          document.getElementById(this.computeChartId(this.stateObj)));
+          this.$.chart_id);
       }
 
       this.drawChart();


### PR DESCRIPTION
A previous fix seems to fail to do it's job.

All computed area IDs failed to get loaded, they all got 'chart_area_undefined', which results in only 1 chart being drawn. This behaviour can be easily seen be having 1 weather platform configured, and have it in 2 different groups or views.

I'm not sure why the previous PR fix did work, after a quick test, this should work, I might need to do some more testing (and perhaps run a test build to verify)