### PR TITLE
On Safari 10 constructor check is broken

### DIFF
--- a/src/state-summary/state-card-content.html
+++ b/src/state-summary/state-card-content.html
@@ -46,7 +46,7 @@ Polymer({
     // If Polymer component for the required element is not loaded try to load it.
     // Don't try to load unconditionally because it cause onflict between vulcanized
     // and non-vulacanized versions.
-    if (!isLoaded) {
+    if (!isLoaded || /Version\/1.*Safari/.test(navigator.userAgent)) {
       this.importHref(
           '/local/custom_ui/state-card-' + stateType + '.html',
           function () {},

--- a/src/state-summary/state-card-content.html
+++ b/src/state-summary/state-card-content.html
@@ -35,30 +35,16 @@ Polymer({
     'inputChanged(hass, inDialog, stateObj)',
   ],
 
-  _isLoaded: function (name) {
-    var elem = document.createElement(name);
-    // If Polymer was already loaded for <name> - it replaced the constructor.
-    return (elem.constructor !== HTMLElement);
-  },
-
   _maybeLoadCustomUi: function (stateType) {
-    // Constructor check doesn't work on Safari 10.
-    // Bypassing this check mean that in order to user a built-in
-    // i.e. state-card-toggle a dummy empty html file must be created.
-    var isLoaded = !/Version\/1.*Safari/.test(navigator.userAgent) &&
-        this._isLoaded('STATE-CARD-' + stateType.toUpperCase());
-    // If Polymer component for the required element is not loaded try to load it.
-    // Don't try to load unconditionally because it cause onflict between vulcanized
-    // and non-vulacanized versions.
-    if (!isLoaded) {
-      this.importHref(
-          '/local/custom_ui/state-card-' + stateType + '.html',
-          function () {},
-          /* eslint-disable no-console */
-          function () { console.error('Error loading %s from /local/custom_ui/state-card-%s.html', stateType, stateType); },
-          /* eslint-enable no-console */
-          true);
-    }
+    // Checking if element is already loaded by comparing constructor to
+    // HTMLElement doesn't work on Safari 10.
+    this.importHref(
+        '/local/custom_ui/state-card-' + stateType + '.html',
+        function () {},
+        /* eslint-disable no-console */
+        function () { console.error('Error loading %s from /local/custom_ui/state-card-%s.html', stateType, stateType); },
+        /* eslint-enable no-console */
+        true);
   },
 
   inputChanged: function (hass, inDialog, stateObj) {

--- a/src/state-summary/state-card-content.html
+++ b/src/state-summary/state-card-content.html
@@ -35,9 +35,7 @@ Polymer({
     'inputChanged(hass, inDialog, stateObj)',
   ],
 
-  _maybeLoadCustomUi: function (stateType) {
-    // Checking if element is already loaded by comparing constructor to
-    // HTMLElement doesn't work on Safari 10.
+  _ensureCustomUILoaded: function (stateType) {
     this.importHref(
         '/local/custom_ui/state-card-' + stateType + '.html',
         function () {},
@@ -52,7 +50,7 @@ Polymer({
     if (!stateObj || !hass) return;
     if (stateObj.state !== 'unavailable' && 'custom_ui_state_card' in stateObj.attributes) {
       stateCardType = stateObj.attributes.custom_ui_state_card;
-      this._maybeLoadCustomUi(stateCardType);
+      this._ensureCustomUILoaded(stateCardType);
     } else {
       stateCardType = window.hassUtil.stateCardType(hass, stateObj);
     }

--- a/src/state-summary/state-card-content.html
+++ b/src/state-summary/state-card-content.html
@@ -42,11 +42,15 @@ Polymer({
   },
 
   _maybeLoadCustomUi: function (stateType) {
-    var isLoaded = this._isLoaded('STATE-CARD-' + stateType.toUpperCase());
+    // Constructor check doesn't work on Safari 10.
+    // Bypassing this check mean that in order to user a built-in
+    // i.e. state-card-toggle a dummy empty html file must be created.
+    var isLoaded = !/Version\/1.*Safari/.test(navigator.userAgent) &&
+        this._isLoaded('STATE-CARD-' + stateType.toUpperCase());
     // If Polymer component for the required element is not loaded try to load it.
     // Don't try to load unconditionally because it cause onflict between vulcanized
     // and non-vulacanized versions.
-    if (!isLoaded || /Version\/1.*Safari/.test(navigator.userAgent)) {
+    if (!isLoaded) {
       this.importHref(
           '/local/custom_ui/state-card-' + stateType + '.html',
           function () {},


### PR DESCRIPTION
On Safari 10 don't compare constructors when checking if custom UI element is loaded.
That check doesn't work (always says "loaded")
