### PR TITLE
Only draw weather chart when forecast is present

### DIFF
--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -21,7 +21,7 @@
     <google-legacy-loader on-api-load='googleApiLoaded'></google-legacy-loader>
     <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
-        <div id='chart_id'></div>
+        <div id='chart_id' hidden$="{{!stateObj.attributes.forecast}}"></div>
         <ha-attributes state-obj='[[stateObj]]' extra-filters='forecast'></ha-attributes>
       </div>
     </ha-card>
@@ -81,6 +81,10 @@
       if (!this.chartEngine) {
         this.chartEngine = new window.google.visualization.LineChart(
           this.$.chart_id);
+      }
+
+      if(!this.stateObj.attributes || !this.stateObj.attributes.forecast) {
+        return;
       }
 
       this.drawChart();

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -83,7 +83,7 @@
           this.$.chart_id);
       }
 
-      if(!this.stateObj.attributes || !this.stateObj.attributes.forecast) {
+      if (!this.stateObj.attributes || !this.stateObj.attributes.forecast) {
         return;
       }
 

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -21,7 +21,7 @@
     <google-legacy-loader on-api-load='googleApiLoaded'></google-legacy-loader>
     <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
-        <div id='chart_id' hidden$="{{!stateObj.attributes.forecast}}"></div>
+        <div id='chart_id' hidden$="[[!stateObj.attributes.forecast]]"></div>
         <ha-attributes state-obj='[[stateObj]]' extra-filters='forecast'></ha-attributes>
       </div>
     </ha-card>


### PR DESCRIPTION
The report of https://github.com/home-assistant/home-assistant/issues/6689 made me realize not all weather platforms might integrate forecast data (yet).
This fix hides the graph, also doesn't start processing the graph's data, when forecast isn't present as an attribute.

Fixes https://github.com/home-assistant/home-assistant/issues/6689