### PR TITLE
Allow empty state name.

### DIFF
--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -394,7 +394,7 @@ window.hassUtil.computeDomain = function (stateObj) {
 };
 
 window.hassUtil.computeStateName = function (stateObj) {
-  if (!stateObj._entityDisplay) {
+  if (stateObj._entityDisplay === undefined) {
     stateObj._entityDisplay = (
       stateObj.attributes.friendly_name ||
       window.HAWS.extractObjectId(stateObj.entity_id)


### PR DESCRIPTION
Allow empty state name.
Recompute the name only if it is undefined.