### PR TITLE
Add web-component-tester tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - bower install
 addons:
   firefox: latest
+  sauce_connect: true
   apt:
     sources:
     - google-chrome
@@ -16,7 +17,7 @@ addons:
     - google-chrome-stable
 script:
   - npm run test
-  - xvfb-run wct --skip_plugin sauce
+  - xvfb-run wct --skip_plugin sauce -l all
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct --skip_plugin local; fi
 dist: trusty
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,25 @@
+sudo: false
+language: node_js
 cache:
   directories:
-    - node_modules
-    - bower_components
-  
-language: node_js
-sudo: required
-env:
-  global:
-    - secure: >-
-        n4PzATQdbmNr0NAPZGYLQOWwu1UQXAtAxDTlM6b1eSwrBXBw7VNU8M+7Zs9Ho6LDBV7Wd8Ktjw6PCUkeIQUmiKrycz1p7Tthu7JsnUuEUKKCqzo0Vh41z7W63Cs7T1NryyMUXnnlen/VxMOyiQ6JA/yXl0TDavF5UoU/uXU+WsA62Fsv4+izv5hx37+2IK4bJZe4MKTr4euh0gcOqRWRwP+A7Tx8UAZYouvn7H0ho6ORRbP6OQfPxMHtbJPznDUNIvrkjtqCzOkFgQxncVBjzRcS2iKGb+8T2ax5zMUJpBX6Q1SwpY4Y0pAA1ZdFLI7tyiM+BwhoDLZqpePe5tAU024qEcohRUkY5/I3z9whyBF81/HOI9b5xZQnlwsPNBdwUdjgSUz8OGVflmBxBovuhlN7lCea/2HkHVmLA3k8r6Lpqax8JquNdjRY9IQdvJpLueWOeVYMi6TJfgIIpjXim6jVzTfICX3qH9mNjDoncQ96EhxM9Hq2O5bBBkKCJVvyXyrkeqvJPG6fnqAdDC9ybKL86VAgHBuYTKqHnjsRq+Cqy+kSu56pXzH3rTNmC3ixt2dScxluK3Z6ItmR4kfALltpYzKvElsWAx/r4hKqIkO+sBpLKXLafRiwx0J3zS/CpV2AWJNihaK/iVMRWD+8TDi9eZ/43Abc9d9Sw6AgnmU=
-    - secure: >-
-        YHkImXE3+PaTw/nL9boZcJA0TJZesmYZ0wsa1C6xGz0NEEVmn6R687N7SOklP13wjues5FwPlY2HehhLJDjn8c+vT/p02UWUr8CJmhyVkWrgufVDHSg6hopiKHroLvNxUOtbwVLQ2wYtQpgM8ru3DbvJKWgCtKbXo+7owz3TSAwD2ksaGUCjNnLQ8qXeSytLn8ck3WfPPIqJ+hA7ge63QNnglMRvPGQWKSt1rM0XyW+hZ0fbd5o/ng+4f1hwS2nIZGlM4WOQ2fTDoCRyVtZ1XfnL1uK6FoHMSunQ32T0j7n7qPGWof6W9Tl08TRk5ltPRBSzjfZt5BWD1bkfTm5Pme9X7rCHQ7Ddim54nmgvAXnWc/VflSgkn1FEdtAKcOh4zWzGX34PrYfzFgBIt8sVtvVO5Kletv+1cPxxHM804pxNtFqUjEKtBIBpFI2vS6yH+FyRX/oSQETAtFl6aCsxDW3MoeK5s9AMq7xnZ10mEC6SkCHRfkGh/rgDEsNsPYVXlpwxYiUEPWET7K2PxWyyNJYz6Qq2C5TcY7gvHIyvxbk7jnWgPZV0NzyFcCvch55mWA5/mM886w3+YDt06v1wWyKq41s4bWCWiql5UK5V9IgurZs65mBWTy7leztIe0lmipr9xn8rb5lPTQIrGdRGljBnEGthT4I7LLc/1Cj/iZI=
+  - node_modules
+  - bower_components
+install:
+  - npm install
+  - bower install
 addons:
   firefox: latest
   apt:
     sources:
-      - google-chrome
+    - google-chrome
     packages:
-      - google-chrome-stable
+    - google-chrome-stable
 script:
-  - xvfb-run wct
-  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s ''default''; fi'
-
+  - npm run test
+  - xvfb-run wct --skip_plugin sauce
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct --skip_plugin local; fi
 dist: trusty
-
-install:
-  - npm install
-  - bower install
+env:
+  global:
+  - secure: pX4tLk4gZEhsSZndyAIqevtRenC6ssBDDVG9pC3oeA4H3f3OdNNWlfrgAt5cSwxzhYEuLB0kUBkIr9SaZENG5lbronPur4JTklpZHFKPu2/XE3TAMgrcgkttq/0gYdI7F87wjzoEAXi89GbCtB7jal536k8hslpcSG6s7B3ECwU8HVCbbP9leB7cBBWcdlqz33f2/RCKUnnbND2JihmzNMuqBdNyG+TcLSPXcGKCA/8FgIDDtVlZzbPb1LVRTavZrTJUj+NM+BQo54dYgEgvpYKgRGFGXHpqDItVV/riSqmZZqsEEdMriw+o9EFjQQvPIgWciHgzwToxSQjyOk3jaXbmtsCOUqy31aKr/lsnai73mR9bbQIVamPY6D5TsRvI0+fS9khIUfW/Jj8FCPfo2HjfoHxyY+IoAxk/HPGcLdx9Pf6dP1iPvlqNtFdlBISWf3PhANvlmQOVJdg0aYEIf9dO1HPv1k3TddNVuHG/X2iAJePVN9YHhySYDxvmFkJoB5W8qcop1wqYbLJXBkvD1d0V9deTxE1bY7/PG6OEAVbGD8aTpL+cxV0F2cO/bdcfPGmaJiCS7WHK4Wh9sH1OE0bKcNgcI2BNjmlkUMkLtZO1EbflanrCJI9O8gUKUHVH1RVTWcyirY2ccoQCatzNL3bbu5ygk1f87gM4KkE/C50=
+  - secure: dOWapZ2/+33euk4LgeRVAjh89Te9igCxkk5A+0Zv8ukhy8Hx0SNb3JxrbtAdw5lN9//NxX9IbZyp6+P+H/deNGy4U8xFfz8f1aJVuM9v7Fx6Cj5F6PCyDKohJpIhnk8gemAkMepOCYJJyip5xLT8KU3yzfpf5CXn1MuKI7E+HiAZO4taY+7K6afKxKIOst42WEoEfCCgYakJ9Q8qfhCd/1P+m0VoSdRcNdSR6o2bw/hdxyTPiWrzCpRrj76LaypqcioLPChHc/6UEOCTJd3quvBWHWgv5LjQ5IcbvW/z/C9XIpBK7c7g16YX6iGKE1UdJosX6KLKOGWVkrzmC1vnWycJP6UDE6b2MI7Qq0MEJGJoVIKuHbkO7HTxRSyYYZW8TXcCRAEvXwAhBM4fgciDYsogCb1knjgzrsxTuWgRNroG2m5ie8iHIj5aNTBjskDTp+H6lIaflCyPl1ZdNo7LSvHF+uuCTwUBUVvMdE1upAl3VEfKcVOAVyJJgQ1c4/uPo4INgak91A5gcZuenaV0auVEO2eW9izS3SlKTvb2mgP7SM7kF8U+gDUP9OfL697cg2aUDDmNmbSWk/2h5EimXLHP+FaxSrrhtcVOd8XfQ0lyCPtsUpNEyW1RNdiSed1nLBGVCS0ArcK+Q8zqTukIdnVOrWOr2PJ9n0GiRpwjpRY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 script:
   - npm run test
   - xvfb-run wct --skip_plugin sauce -l all
-  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct --skip_plugin local; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct; fi
 dist: trusty
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ addons:
     - google-chrome-stable
 script:
   - npm run test
-  - xvfb-run wct --skip_plugin sauce -l all
-  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct; fi
+  - xvfb-run wct
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct --plugin sauce; fi
 dist: trusty
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,31 @@
-sudo: false
-language: node_js
 cache:
   directories:
     - node_modules
     - bower_components
+  
+language: node_js
+sudo: required
+before_script:
+  - npm install -g bower polylint web-component-tester
+  - bower install
+  - polylint
+env:
+  global:
+    - secure: >-
+        n4PzATQdbmNr0NAPZGYLQOWwu1UQXAtAxDTlM6b1eSwrBXBw7VNU8M+7Zs9Ho6LDBV7Wd8Ktjw6PCUkeIQUmiKrycz1p7Tthu7JsnUuEUKKCqzo0Vh41z7W63Cs7T1NryyMUXnnlen/VxMOyiQ6JA/yXl0TDavF5UoU/uXU+WsA62Fsv4+izv5hx37+2IK4bJZe4MKTr4euh0gcOqRWRwP+A7Tx8UAZYouvn7H0ho6ORRbP6OQfPxMHtbJPznDUNIvrkjtqCzOkFgQxncVBjzRcS2iKGb+8T2ax5zMUJpBX6Q1SwpY4Y0pAA1ZdFLI7tyiM+BwhoDLZqpePe5tAU024qEcohRUkY5/I3z9whyBF81/HOI9b5xZQnlwsPNBdwUdjgSUz8OGVflmBxBovuhlN7lCea/2HkHVmLA3k8r6Lpqax8JquNdjRY9IQdvJpLueWOeVYMi6TJfgIIpjXim6jVzTfICX3qH9mNjDoncQ96EhxM9Hq2O5bBBkKCJVvyXyrkeqvJPG6fnqAdDC9ybKL86VAgHBuYTKqHnjsRq+Cqy+kSu56pXzH3rTNmC3ixt2dScxluK3Z6ItmR4kfALltpYzKvElsWAx/r4hKqIkO+sBpLKXLafRiwx0J3zS/CpV2AWJNihaK/iVMRWD+8TDi9eZ/43Abc9d9Sw6AgnmU=
+    - secure: >-
+        YHkImXE3+PaTw/nL9boZcJA0TJZesmYZ0wsa1C6xGz0NEEVmn6R687N7SOklP13wjues5FwPlY2HehhLJDjn8c+vT/p02UWUr8CJmhyVkWrgufVDHSg6hopiKHroLvNxUOtbwVLQ2wYtQpgM8ru3DbvJKWgCtKbXo+7owz3TSAwD2ksaGUCjNnLQ8qXeSytLn8ck3WfPPIqJ+hA7ge63QNnglMRvPGQWKSt1rM0XyW+hZ0fbd5o/ng+4f1hwS2nIZGlM4WOQ2fTDoCRyVtZ1XfnL1uK6FoHMSunQ32T0j7n7qPGWof6W9Tl08TRk5ltPRBSzjfZt5BWD1bkfTm5Pme9X7rCHQ7Ddim54nmgvAXnWc/VflSgkn1FEdtAKcOh4zWzGX34PrYfzFgBIt8sVtvVO5Kletv+1cPxxHM804pxNtFqUjEKtBIBpFI2vS6yH+FyRX/oSQETAtFl6aCsxDW3MoeK5s9AMq7xnZ10mEC6SkCHRfkGh/rgDEsNsPYVXlpwxYiUEPWET7K2PxWyyNJYz6Qq2C5TcY7gvHIyvxbk7jnWgPZV0NzyFcCvch55mWA5/mM886w3+YDt06v1wWyKq41s4bWCWiql5UK5V9IgurZs65mBWTy7leztIe0lmipr9xn8rb5lPTQIrGdRGljBnEGthT4I7LLc/1Cj/iZI=
+addons:
+  firefox: latest
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
+script:
+  - xvfb-run wct
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s ''default''; fi'
+dist: trusty
+
 install:
   - npm install
-  - bower install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
   - bower install
 addons:
   firefox: latest
-  sauce_connect: true
   apt:
     sources:
     - google-chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ cache:
   
 language: node_js
 sudo: required
-before_script:
-  - npm install -g bower polylint web-component-tester
-  - polylint
 env:
   global:
     - secure: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: node_js
 sudo: required
 before_script:
   - npm install -g bower polylint web-component-tester
-  - bower install
   - polylint
 env:
   global:
@@ -25,7 +24,9 @@ addons:
 script:
   - xvfb-run wct
   - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s ''default''; fi'
+
 dist: trusty
 
 install:
   - npm install
+  - bower install

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "rollup-watch": "^3.2.2",
     "sw-precache": "^5.1.0",
     "uglify-js": "^2.8.12",
-    "vulcanize": "^1.15.3"
+    "vulcanize": "^1.15.3",
+    "web-component-tester": "^5.0.1"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -10,6 +10,7 @@
   <script>
     WCT.loadSuites([
       'state-info-test.html',
+      'state-info-test.html?dom=shadow',
     ]);
   </script>
 </body></html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+  <script>
+    WCT.loadSuites([
+      'state-info-test.html',
+    ]);
+  </script>
+</body></html>

--- a/test/state-info-test.html
+++ b/test/state-info-test.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../src/components/entity/state-info.html">
+</head>
+<body>
+  <test-fixture id="state-info">
+    <template>
+      <state-info></state-info>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('state-info', function() {
+      var si;
+      
+      setup(function() {
+        si = fixture('state-info');
+      });
+      
+      test('default stateObj', function() {
+        assert.equal(si.stateObj, undefined);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -10,6 +10,14 @@
           "browserName": "safari",
           "platform": "macOS 10.12",
           "version": "10.0"
+	}, {
+          "browserName": "firefox",
+	  "platform": "Windows 10",
+	  "version": "latest"
+	}, {
+	  "browserName": "MicrosoftEdge",
+	  "platform": "Windows 10",
+	  "version": "14.14393"
 	}
       ]
     }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,18 @@
+{
+  "plugins": {
+    "sauce": {
+      "browsers": [{
+          "browserName": "chrome",
+          "platform": "Linux",
+          "version": "latest"
+        },
+
+        {
+          "browserName": "safari",
+          "platform": "macOS 10.12",
+          "version": "10.0"
+        }
+      ]
+    }
+  }
+}

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -10,15 +10,15 @@
           "browserName": "safari",
           "platform": "macOS 10.12",
           "version": "10.0"
-	}, {
+        }, {
           "browserName": "firefox",
-	  "platform": "Windows 10",
-	  "version": "latest"
-	}, {
-	  "browserName": "MicrosoftEdge",
-	  "platform": "Windows 10",
-	  "version": "14.14393"
-	}
+          "platform": "Windows 10",
+          "version": "latest"
+        }, {
+          "browserName": "MicrosoftEdge",
+          "platform": "Windows 10",
+          "version": "14.14393"
+        }
       ]
     }
   }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,17 +1,22 @@
 {
   "plugins": {
+    "local": {
+      "browsers": ["chrome", "firefox"]
+    },
     "sauce": {
       "browsers": [{
           "browserName": "chrome",
           "platform": "Linux",
           "version": "latest"
-        },
-
-        {
+        }, {
           "browserName": "safari",
           "platform": "macOS 10.12",
           "version": "10.0"
-        }
+        }, {
+	  "browserName": "Safari",
+          "platformName": "iOS",
+	  "deviceName": "iPhone 7 Simulator"
+	}
       ]
     }
   }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,8 +1,5 @@
 {
   "plugins": {
-    "local": {
-      "browsers": ["chrome", "firefox"]
-    },
     "sauce": {
       "browsers": [{
           "browserName": "chrome",
@@ -12,10 +9,6 @@
           "browserName": "safari",
           "platform": "macOS 10.12",
           "version": "10.0"
-        }, {
-	  "browserName": "Safari",
-          "platformName": "iOS",
-	  "deviceName": "iPhone 7 Simulator"
 	}
       ]
     }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,6 +1,7 @@
 {
   "plugins": {
     "sauce": {
+      "disabled": true,
       "browsers": [{
           "browserName": "chrome",
           "platform": "Linux",


### PR DESCRIPTION
This PR sets up travis to run polymer tests.
On FF & Chrome locally on Linux.
Edge, Safari, FF-Windows, Chrome-Linux via Souce.

The test itself is just a POC

Travis run from my repo: https://travis-ci.org/andrey-git/home-assistant-polymer
Travis run from HA repo: https://travis-ci.org/home-assistant/home-assistant-polymer/jobs/218265198
Note that in the HA run there are no Souce tests because cross-repo tests are not allowed. Once a PR is submitted - Travis will run the full test suite.