### PR TITLE
Add HassIO panel

### DIFF
--- a/panels/config/core/ha-config-section-core.html
+++ b/panels/config/core/ha-config-section-core.html
@@ -10,7 +10,7 @@
 <link rel="import" href="../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 
 <link rel="import" href="../../../src/components/ha-menu-button.html">
-<link rel="import" href="../../../src/components/ha-call-service-button.html">
+<link rel="import" href="../../../src/components/buttons/ha-call-service-button.html">
 <link rel="import" href="../../../src/resources/ha-style.html">
 
 <link rel="import" href="../ha-config-section.html">
@@ -45,10 +45,6 @@
 
       .validate-log {
         white-space: pre-wrap;
-      }
-
-      .card-actions.warning ha-call-service-button {
-        color: var(--google-red-500);
       }
     </style>
     <ha-config-section
@@ -120,11 +116,13 @@
         </div>
         <div class='card-actions warning'>
           <ha-call-service-button
+            class='warning'
             hass='[[hass]]'
             domain='homeassistant'
             service='restart'
           >Restart</ha-call-service-button>
           <ha-call-service-button
+            class='warning'
             hass='[[hass]]'
             domain='homeassistant'
             service='stop'

--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -1,0 +1,101 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+
+<link rel="import" href="./hassio-dashboard.html">
+<link rel="import" href="./hassio-addon-view.html">
+<link rel="import" href="./hassio-loading.html">
+
+<dom-module id="ha-panel-hassio">
+  <style>
+    iron-pages {
+      height: 100%;
+    }
+  </style>
+  <template>
+    <hassio-data
+      hass='[[hass]]'
+      supervisor='{{supervisorInfo}}'
+      host='{{hostInfo}}'
+    ></hassio-data>
+
+    <template is='dom-if' if='[[!loaded]]'>
+      <hassio-loading
+        narrow='[[narrow]]'
+        hass='[[hass]]'
+        show-menu='[[dockedSidebar]]'
+      ></hassio-loading>
+    </template>
+    <template is='dom-if' if='[[loaded]]'>
+      <template is='dom-if' if='[[addon]]' restamp>
+        <hassio-addon-view
+          narrow='[[narrow]]'
+          hass='[[hass]]'
+          show-menu='[[dockedSidebar]]'
+          supervisor-info='{{supervisorInfo}}'
+          host-info='{{hostInfo}}'
+          addon='[[addon]]'
+        ></hassio-addon-view>
+      </template>
+
+      <template is='dom-if' if='[[!addon]]'>
+        <hassio-dashboard
+          hass='[[hass]]'
+          supervisor-info='{{supervisorInfo}}'
+          host-info='{{hostInfo}}'
+        ></hassio-dashboard>
+      </template>
+    </template>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'ha-panel-hassio',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    narrow: {
+      type: Boolean,
+    },
+
+    showMenu: {
+      type: Boolean,
+      value: false,
+    },
+
+    addon: {
+      type: String,
+      value: null,
+    },
+
+    supervisorInfo: {
+      type: Object,
+      value: null,
+    },
+
+    hostInfo: {
+      type: Object,
+      value: null,
+    },
+
+    loaded: {
+      type: Boolean,
+      computed: 'computeIsLoaded(supervisorInfo, hostInfo)',
+    }
+  },
+
+  listeners: {
+    'hassio-select-addon': 'addonSelected',
+  },
+
+  computeIsLoaded: function (supervisorInfo, hostInfo) {
+    return supervisorInfo !== null && hostInfo !== null;
+  },
+
+  addonSelected: function (ev) {
+    this.addon = ev.detail.addon;
+  },
+});
+</script>

--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -67,7 +67,7 @@ Polymer({
 
     addon: {
       type: String,
-      value: null,
+      value: 'smb_config',
     },
 
     supervisorInfo: {

--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -14,6 +14,7 @@
     <hassio-data
       hass='[[hass]]'
       supervisor='{{supervisorInfo}}'
+      homeassistant='{{hassInfo}}'
       host='{{hostInfo}}'
     ></hassio-data>
 
@@ -30,8 +31,8 @@
           narrow='[[narrow]]'
           hass='[[hass]]'
           show-menu='[[dockedSidebar]]'
-          supervisor-info='{{supervisorInfo}}'
-          host-info='{{hostInfo}}'
+          supervisor-info='[[supervisorInfo]]'
+          host-info='[[hostInfo]]'
           addon='[[addon]]'
         ></hassio-addon-view>
       </template>
@@ -41,6 +42,7 @@
           hass='[[hass]]'
           supervisor-info='{{supervisorInfo}}'
           host-info='{{hostInfo}}'
+          hass-info='[[hassInfo]]'
         ></hassio-dashboard>
       </template>
     </template>
@@ -80,6 +82,11 @@ Polymer({
       value: null,
     },
 
+    hassInfo: {
+      type: Object,
+      value: null,
+    },
+
     forceLoading: {
       type: Boolean,
       value: false,
@@ -87,7 +94,7 @@ Polymer({
 
     loaded: {
       type: Boolean,
-      computed: 'computeIsLoaded(supervisorInfo, hostInfo, forceLoading)',
+      computed: 'computeIsLoaded(supervisorInfo, hostInfo, hassInfo, forceLoading)',
     }
   },
 
@@ -95,8 +102,11 @@ Polymer({
     'hassio-select-addon': 'addonSelected',
   },
 
-  computeIsLoaded: function (supervisorInfo, hostInfo, forceLoading) {
-    return supervisorInfo !== null && hostInfo !== null && !forceLoading;
+  computeIsLoaded: function (supervisorInfo, hostInfo, hassInfo, forceLoading) {
+    return (supervisorInfo !== null &&
+            hostInfo !== null &&
+            hassInfo !== null &&
+            !forceLoading);
   },
 
   addonSelected: function (ev) {

--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -24,8 +24,8 @@
         show-menu='[[dockedSidebar]]'
       ></hassio-loading>
     </template>
-    <template is='dom-if' if='[[loaded]]'>
-      <template is='dom-if' if='[[addon]]' restamp>
+    <template is='dom-if' if='[[loaded]]' restamp>
+      <template is='dom-if' if='[[addon]]'>
         <hassio-addon-view
           narrow='[[narrow]]'
           hass='[[hass]]'
@@ -80,9 +80,14 @@ Polymer({
       value: null,
     },
 
+    forceLoading: {
+      type: Boolean,
+      value: false,
+    },
+
     loaded: {
       type: Boolean,
-      computed: 'computeIsLoaded(supervisorInfo, hostInfo)',
+      computed: 'computeIsLoaded(supervisorInfo, hostInfo, forceLoading)',
     }
   },
 
@@ -90,12 +95,16 @@ Polymer({
     'hassio-select-addon': 'addonSelected',
   },
 
-  computeIsLoaded: function (supervisorInfo, hostInfo) {
-    return supervisorInfo !== null && hostInfo !== null;
+  computeIsLoaded: function (supervisorInfo, hostInfo, forceLoading) {
+    return supervisorInfo !== null && hostInfo !== null && !forceLoading;
   },
 
   addonSelected: function (ev) {
-    this.addon = ev.detail.addon;
+    this.forceLoading = true;
+    setTimeout(function () {
+      this.addon = ev.detail.addon;
+      this.forceLoading = false;
+    }.bind(this), 0);
   },
 });
 </script>

--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -67,7 +67,7 @@ Polymer({
 
     addon: {
       type: String,
-      value: 'smb_config',
+      value: '',
     },
 
     supervisorInfo: {

--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -22,15 +22,13 @@
       <hassio-loading
         narrow='[[narrow]]'
         hass='[[hass]]'
-        show-menu='[[dockedSidebar]]'
+        show-menu='[[showMenu]]'
       ></hassio-loading>
     </template>
     <template is='dom-if' if='[[loaded]]' restamp>
       <template is='dom-if' if='[[addon]]'>
         <hassio-addon-view
-          narrow='[[narrow]]'
           hass='[[hass]]'
-          show-menu='[[dockedSidebar]]'
           supervisor-info='[[supervisorInfo]]'
           host-info='[[hostInfo]]'
           addon='[[addon]]'
@@ -40,6 +38,8 @@
       <template is='dom-if' if='[[!addon]]'>
         <hassio-dashboard
           hass='[[hass]]'
+          narrow='[[narrow]]'
+          show-menu='[[showMenu]]'
           supervisor-info='{{supervisorInfo}}'
           host-info='{{hostInfo}}'
           hass-info='[[hassInfo]]'

--- a/panels/hassio/hassio-addon-view.html
+++ b/panels/hassio/hassio-addon-view.html
@@ -23,6 +23,9 @@
       paper-card {
         display: block;
       }
+      .controls paper-card {
+        margin-bottom: 24px;
+      }
       iron-autogrow-textarea {
         width: 100%;
       }
@@ -134,21 +137,31 @@
         </div>
 
         <template is='dom-if' if='[[addonState]]'>
-          <paper-card heading='Options'>
-            <div class="card-content">
-              <iron-autogrow-textarea value="{{options}}"></iron-autogrow-textarea>
-            </div>
-            <div class="card-actions">
-              <ha-call-api-button
-                hass='[[hass]]'
-                disabled='[[!optionsParsed]]'
-                data='[[computeOptionsData(optionsParsed)]]'
-                path="[[pathOptions(addon)]]"
-              >Save</ha-call-api-button>
-            </div>
-          </paper-card>
-        </template>
+          <div class='controls'>
+            <paper-card heading='Options'>
+              <div class="card-content">
+                <iron-autogrow-textarea value="{{options}}"></iron-autogrow-textarea>
+              </div>
+              <div class="card-actions">
+                <ha-call-api-button
+                  hass='[[hass]]'
+                  disabled='[[!optionsParsed]]'
+                  data='[[computeOptionsData(optionsParsed)]]'
+                  path="[[pathOptions(addon)]]"
+                >Save</ha-call-api-button>
+              </div>
+            </paper-card>
 
+            <paper-card heading='Logs'>
+              <div class="card-content">
+                <pre>[[addonLogs]]</pre>
+              </div>
+              <div class="card-actions">
+                <paper-button on-tap='refreshLogs'>Refresh</paper-button>
+              </div>
+            </paper-card>
+          </div>
+        </template>
       </div>
     </app-header-layout>
   </template>
@@ -205,6 +218,11 @@ Polymer({
       value: null,
       observer: 'addonStateChanged',
     },
+
+    addonLogs: {
+      type: String,
+      value: '',
+    },
   },
 
   addonChanged: function (addon) {
@@ -219,6 +237,14 @@ Polymer({
         if (info.result != 'error') {
           this.addonState = info.data;
         }
+      }.bind(this));
+    this.refreshLogs();
+  },
+
+  refreshLogs: function () {
+    this.hass.callApi('get', 'hassio/addons/' + this.addon + '/logs')
+      .then(function (info) {
+        this.addonLogs = info;
       }.bind(this));
   },
 

--- a/panels/hassio/hassio-addon-view.html
+++ b/panels/hassio/hassio-addon-view.html
@@ -243,7 +243,7 @@ Polymer({
     this.hass.callApi('get', 'hassio/addons/' + addon + '/info')
       .then(function (info) {
         // Error if addon not installed.
-        if (info.result != 'error') {
+        if (info.result !== 'error') {
           this.addonState = info.data;
         }
       }.bind(this));
@@ -279,11 +279,11 @@ Polymer({
     return addon.installed || 'Not installed';
   },
 
-  computeUpdateAvailable: function(data) {
-    return data.version != data.last_version;
+  computeUpdateAvailable: function (data) {
+    return data.version !== data.last_version;
   },
 
-  parseOptions: function(options) {
+  parseOptions: function (options) {
     try {
       return JSON.parse(options);
     } catch (err) {
@@ -291,7 +291,7 @@ Polymer({
     }
   },
 
-  computeOptionsData: function(optionsParsed) {
+  computeOptionsData: function (optionsParsed) {
     return {
       options: optionsParsed,
     };

--- a/panels/hassio/hassio-addon-view.html
+++ b/panels/hassio/hassio-addon-view.html
@@ -24,6 +24,16 @@
         max-width: 600px;
         margin: 0 auto;
       }
+      .status {
+        @apply(--layout-horizontal);
+        margin-bottom: 24px;
+      }
+      .status > * {
+        @apply(--layout-flex);
+      }
+      .status > *:first-child {
+        margin-right: 24px;
+      }
     </style>
     <app-header-layout has-scrolling-region>
       <app-header fixed>
@@ -37,7 +47,89 @@
       </app-header>
 
       <div class='content'>
-        [[addonInfo.description]]
+        <div class='status'>
+          <paper-card heading='Info'>
+            <div class="card-content">
+              <div>[[addonInfo.description]]</div>
+              <table class='info'>
+                <tr>
+                  <td>Installed</td>
+                  <td>[[computeInstallStatus(addonInfo)]]</td>
+                </tr>
+                <tr>
+                  <td>Version</td>
+                  <td>[[addonInfo.version]]</td>
+                </tr>
+                <tr>
+                  <td>Dedicated</td>
+                  <td>[[addonInfo.dedicated]]</td>
+                </tr>
+              </table>
+            </div>
+            <template is='dom-if' if='[[!addonState]]'>
+              <div class="card-actions">
+                <ha-call-api-button
+                  hass='[[hass]]'
+                  path="[[pathInstall(addon)]]"
+                >Install</ha-call-api-button>
+              </div>
+            </template>
+          </paper-card>
+
+          <paper-card heading='Installed'>
+            <template is='dom-if' if='[[!addonState]]'>
+              <div class="card-content">
+                <div>Add-on is not installed.</div>
+              </div>
+            </template>
+
+            <template is='dom-if' if='[[addonState]]'>
+              <div class="card-content">
+                <table class='info'>
+                  <tr>
+                    <td>Version</td>
+                    <td>[[addonState.version]]</td>
+                  </tr>
+                  <tr>
+                    <td>State</td>
+                    <td>[[addonState.state]]</td>
+                  </tr>
+                  <tr>
+                    <td>Boot</td>
+                    <td>[[addonState.boot]]</td>
+                  </tr>
+                  <tr>
+                    <td>Options</td>
+                    <td>
+                      <pre>[[computeOptions(addonState)]]</pre>
+                    </td>
+                  </tr>
+                </table>
+              <div class="card-actions">
+                <ha-call-api-button
+                  hass='[[hass]]'
+                  path="[[pathStart(addon)]]"
+                >Start</ha-call-api-button>
+                <template is='dom-if' if='[[computeUpdateAvailable(addonInfo)]]'>
+                  <ha-call-api-button
+                    hass='[[hass]]'
+                    path="[[pathUpdate(addon)]]"
+                  >Update</ha-call-api-button>
+                </template>
+                <ha-call-api-button
+                  class='warning'
+                  hass='[[hass]]'
+                  path="[[pathStop(addon)]]"
+                >Stop</ha-call-api-button>
+                <ha-call-api-button
+                  class='warning'
+                  hass='[[hass]]'
+                  path="[[pathUninstall(addon)]]"
+                >Uninstall</ha-call-api-button>
+              </div>
+            </template>
+          </paper-card>
+        </div>
       </div>
     </app-header-layout>
   </template>
@@ -63,6 +155,7 @@ Polymer({
 
     addon: {
       type: String,
+      observer: 'addonChanged',
     },
 
     supervisorInfo: {
@@ -76,7 +169,27 @@ Polymer({
     addonInfo: {
       type: Object,
       computed: 'computeAddonInfo(supervisorInfo, addon)',
+    },
+
+    addonState: {
+      type: Object,
+      value: null,
+    },
+  },
+
+  addonChanged: function (addon) {
+    if (!this.hass) {
+      setTimeout(function () { this.addonChanged(addon); }.bind(this), 0);
+      return;
     }
+
+    this.hass.callApi('get', 'hassio/addons/' + addon + '/info')
+      .then(function (info) {
+        // Error if addon not installed.
+        if (info.result != 'error') {
+          this.addonState = info.data;
+        }
+      }.bind(this));
   },
 
   computeAddonInfo: function (supervisorInfo, addon) {
@@ -89,8 +202,40 @@ Polymer({
     return null;
   },
 
+  computeInstallStatus(addon) {
+    return addon.installed || 'Not installed';
+  },
+
+  computeUpdateAvailable: function(data) {
+    return data.current != data.last_version;
+  },
+
   backTapped: function () {
     this.fire('hassio-select-addon', { addon: null });
-  }
+  },
+
+  computeOptions: function (addonState) {
+    return JSON.stringify(addonState.options, null, 2);
+  },
+
+  pathStart: function (addon) {
+    return 'hassio/addons/' + addon + '/start';
+  },
+
+  pathStop: function (addon) {
+    return 'hassio/addons/' + addon + '/stop';
+  },
+
+  pathInstall: function (addon) {
+    return 'hassio/addons/' + addon + '/install';
+  },
+
+  pathUninstall: function (addon) {
+    return 'hassio/addons/' + addon + '/uninstall';
+  },
+
+  pathUpdate: function (addon) {
+    return 'hassio/addons/' + addon + '/update';
+  },
 });
 </script>

--- a/panels/hassio/hassio-addon-view.html
+++ b/panels/hassio/hassio-addon-view.html
@@ -111,21 +111,25 @@
                 </table>
               </div>
               <div class="card-actions">
-                <ha-call-api-button
-                  hass='[[hass]]'
-                  path="[[pathStart(addon)]]"
-                >Start</ha-call-api-button>
+                <template is='dom-if' if='[[!isRunning]]'>
+                  <ha-call-api-button
+                    hass='[[hass]]'
+                    path="[[pathStart(addon)]]"
+                  >Start</ha-call-api-button>
+                </template>
                 <template is='dom-if' if='[[computeUpdateAvailable(addonInfo)]]'>
                   <ha-call-api-button
                     hass='[[hass]]'
                     path="[[pathUpdate(addon)]]"
                   >Update</ha-call-api-button>
                 </template>
-                <ha-call-api-button
-                  class='warning'
-                  hass='[[hass]]'
-                  path="[[pathStop(addon)]]"
-                >Stop</ha-call-api-button>
+                <template is='dom-if' if='[[isRunning]]'>
+                  <ha-call-api-button
+                    class='warning'
+                    hass='[[hass]]'
+                    path="[[pathStop(addon)]]"
+                  >Stop</ha-call-api-button>
+                </template>
                 <ha-call-api-button
                   class='warning'
                   hass='[[hass]]'
@@ -208,6 +212,11 @@ Polymer({
       type: Object,
     },
 
+    isRunning: {
+      type: Boolean,
+      computed: 'computeIsRunning(addonState)',
+    },
+
     addonInfo: {
       type: Object,
       computed: 'computeAddonInfo(supervisorInfo, addon)',
@@ -262,12 +271,16 @@ Polymer({
     return null;
   },
 
+  computeIsRunning: function (addonState) {
+    return addonState && addonState.state === 'started';
+  },
+
   computeInstallStatus(addon) {
     return addon.installed || 'Not installed';
   },
 
   computeUpdateAvailable: function(data) {
-    return data.current != data.last_version;
+    return data.version != data.last_version;
   },
 
   parseOptions: function(options) {

--- a/panels/hassio/hassio-addon-view.html
+++ b/panels/hassio/hassio-addon-view.html
@@ -8,6 +8,7 @@
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item-body.html">
 <link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+<link rel="import" href="../../bower_components/iron-autogrow-textarea/iron-autogrow-textarea.html">
 
 <link rel="import" href="../../src/components/ha-menu-button.html">
 
@@ -19,6 +20,12 @@
 <dom-module id="hassio-addon-view">
   <template>
     <style include="iron-flex ha-style">
+      paper-card {
+        display: block;
+      }
+      iron-autogrow-textarea {
+        width: 100%;
+      }
       .content {
         padding: 24px 0 32px;
         max-width: 600px;
@@ -98,13 +105,8 @@
                     <td>Boot</td>
                     <td>[[addonState.boot]]</td>
                   </tr>
-                  <tr>
-                    <td>Options</td>
-                    <td>
-                      <pre>[[computeOptions(addonState)]]</pre>
-                    </td>
-                  </tr>
                 </table>
+              </div>
               <div class="card-actions">
                 <ha-call-api-button
                   hass='[[hass]]'
@@ -130,6 +132,23 @@
             </template>
           </paper-card>
         </div>
+
+        <template is='dom-if' if='[[addonState]]'>
+          <paper-card heading='Options'>
+            <div class="card-content">
+              <iron-autogrow-textarea value="{{options}}"></iron-autogrow-textarea>
+            </div>
+            <div class="card-actions">
+              <ha-call-api-button
+                hass='[[hass]]'
+                disabled='[[!optionsParsed]]'
+                data='[[computeOptionsData(optionsParsed)]]'
+                path="[[pathOptions(addon)]]"
+              >Save</ha-call-api-button>
+            </div>
+          </paper-card>
+        </template>
+
       </div>
     </app-header-layout>
   </template>
@@ -158,6 +177,16 @@ Polymer({
       observer: 'addonChanged',
     },
 
+    options: {
+      type: String,
+      value: '',
+    },
+
+    optionsParsed: {
+      type: Object,
+      computed: 'parseOptions(options)',
+    },
+
     supervisorInfo: {
       type: Object,
     },
@@ -174,6 +203,7 @@ Polymer({
     addonState: {
       type: Object,
       value: null,
+      observer: 'addonStateChanged',
     },
   },
 
@@ -190,6 +220,10 @@ Polymer({
           this.addonState = info.data;
         }
       }.bind(this));
+  },
+
+  addonStateChanged: function (addonState) {
+    this.options = addonState ? JSON.stringify(addonState.options, null, 2) : '';
   },
 
   computeAddonInfo: function (supervisorInfo, addon) {
@@ -210,12 +244,22 @@ Polymer({
     return data.current != data.last_version;
   },
 
-  backTapped: function () {
-    this.fire('hassio-select-addon', { addon: null });
+  parseOptions: function(options) {
+    try {
+      return JSON.parse(options);
+    } catch (err) {
+      return null;
+    }
   },
 
-  computeOptions: function (addonState) {
-    return JSON.stringify(addonState.options, null, 2);
+  computeOptionsData: function(optionsParsed) {
+    return {
+      options: optionsParsed,
+    };
+  },
+
+  backTapped: function () {
+    this.fire('hassio-select-addon', { addon: null });
   },
 
   pathStart: function (addon) {
@@ -236,6 +280,10 @@ Polymer({
 
   pathUpdate: function (addon) {
     return 'hassio/addons/' + addon + '/update';
+  },
+
+  pathOptions: function (addon) {
+    return 'hassio/addons/' + addon + '/options';
   },
 });
 </script>

--- a/panels/hassio/hassio-addon-view.html
+++ b/panels/hassio/hassio-addon-view.html
@@ -1,0 +1,96 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/app-layout/app-header-layout/app-header-layout.html">
+<link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
+<link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-item/paper-item-body.html">
+<link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+
+<link rel="import" href="../../src/components/ha-menu-button.html">
+
+<link rel="import" href="./hassio-data.html">
+<link rel="import" href="./hassio-host-info.html">
+<link rel="import" href="./hassio-supervisor-info.html">
+<link rel="import" href="./hassio-addons.html">
+
+<dom-module id="hassio-addon-view">
+  <template>
+    <style include="iron-flex ha-style">
+      .content {
+        padding: 24px 0 32px;
+        max-width: 600px;
+        margin: 0 auto;
+      }
+    </style>
+    <app-header-layout has-scrolling-region>
+      <app-header fixed>
+        <app-toolbar>
+          <paper-icon-button
+            icon='mdi:arrow-left'
+            on-tap='backTapped'
+          ></paper-icon-button>
+          <div main-title>[[addonInfo.name]]</div>
+        </app-toolbar>
+      </app-header>
+
+      <div class='content'>
+        [[addonInfo.description]]
+      </div>
+    </app-header-layout>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'hassio-addon-view',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    narrow: {
+      type: Boolean,
+    },
+
+    showMenu: {
+      type: Boolean,
+      value: false,
+    },
+
+    addon: {
+      type: String,
+    },
+
+    supervisorInfo: {
+      type: Object,
+    },
+
+    hostInfo: {
+      type: Object,
+    },
+
+    addonInfo: {
+      type: Object,
+      computed: 'computeAddonInfo(supervisorInfo, addon)',
+    }
+  },
+
+  computeAddonInfo: function (supervisorInfo, addon) {
+    if (!supervisorInfo) return null;
+
+    for (var i = 0; i < supervisorInfo.addons.length; i++) {
+      var addonInfo = supervisorInfo.addons[i];
+      if (addonInfo.slug === addon) return addonInfo;
+    }
+    return null;
+  },
+
+  backTapped: function () {
+    this.fire('hassio-select-addon', { addon: null });
+  }
+});
+</script>

--- a/panels/hassio/hassio-addons.html
+++ b/panels/hassio/hassio-addons.html
@@ -1,0 +1,70 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-item/paper-item-body.html">
+<link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+
+<dom-module id="hassio-addons">
+  <template>
+    <style include="iron-flex ha-style">
+      paper-card {
+        display: block;
+        padding-top: 16px;
+        padding-right: 16px;
+      }
+
+      paper-item {
+        cursor: pointer;
+      }
+    </style>
+    <paper-card heading="Addons">
+      <div class="card-content">
+        <template is='dom-repeat' items='[[data]]' as='addon'>
+          <paper-item>
+            <paper-item-body two-line on-tap='addonTapped'>
+              <div>[[addon.name]]</div>
+              <div secondary>[[addon.description]]</div>
+            </paper-item-body>
+            [[computeInstallStatus(addon)]]
+          </paper-item>
+        </template>
+      </div>
+    </paper-card>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'hassio-addons',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    narrow: {
+      type: Boolean,
+    },
+
+    showMenu: {
+      type: Boolean,
+      value: false,
+    },
+
+    data: {
+      type: Object,
+      value: [],
+    },
+  },
+
+  computeInstallStatus(addon) {
+    return addon.installed || 'Not installed';
+  },
+
+  addonTapped: function (ev) {
+    this.fire('hassio-select-addon', { addon: this.data[ev.model.index].slug });
+    ev.target.blur();
+  },
+});
+</script>

--- a/panels/hassio/hassio-dashboard.html
+++ b/panels/hassio/hassio-dashboard.html
@@ -12,6 +12,7 @@
 
 <link rel="import" href="./hassio-data.html">
 <link rel="import" href="./hassio-host-info.html">
+<link rel="import" href="./hassio-hass-info.html">
 <link rel="import" href="./hassio-supervisor-info.html">
 <link rel="import" href="./hassio-addons.html">
 
@@ -55,6 +56,13 @@
             data='[[hostInfo]]'
           ></hassio-host-info>
         </div>
+        <div class='status'>
+          <hassio-hass-info
+            hass='[[hass]]'
+            data='[[hassInfo]]'
+          ></hassio-hass-info>
+          <div></div>
+        </div>
         <hassio-addons
           hass='[[hass]]'
           data='[[supervisorInfo.addons]]'
@@ -88,6 +96,11 @@ Polymer({
     },
 
     hostInfo: {
+      type: Object,
+      value: {},
+    },
+
+    hassInfo: {
       type: Object,
       value: {},
     },

--- a/panels/hassio/hassio-dashboard.html
+++ b/panels/hassio/hassio-dashboard.html
@@ -1,0 +1,96 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/app-layout/app-header-layout/app-header-layout.html">
+<link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
+<link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-item/paper-item-body.html">
+<link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+
+<link rel="import" href="../../src/components/ha-menu-button.html">
+
+<link rel="import" href="./hassio-data.html">
+<link rel="import" href="./hassio-host-info.html">
+<link rel="import" href="./hassio-supervisor-info.html">
+<link rel="import" href="./hassio-addons.html">
+
+<dom-module id="hassio-dashboard">
+  <template>
+    <style include="iron-flex ha-style">
+      .content {
+        padding: 24px 0 32px;
+        max-width: 600px;
+        margin: 0 auto;
+      }
+      .status {
+        @apply(--layout-horizontal);
+        margin-bottom: 24px;
+      }
+      .status > * {
+        @apply(--layout-flex);
+      }
+
+      .status > *:first-child {
+        margin-right: 24px;
+      }
+    </style>
+    <app-header-layout has-scrolling-region>
+      <app-header fixed>
+        <app-toolbar>
+          <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
+          <div main-title>Hass.io</div>
+        </app-toolbar>
+      </app-header>
+
+      <div class='content'>
+        <div class='status'>
+          <hassio-supervisor-info
+            hass='[[hass]]'
+            data='[[supervisorInfo]]'
+          ></hassio-supervisor-info>
+
+          <hassio-host-info
+            hass='[[hass]]'
+            data='[[hostInfo]]'
+          ></hassio-host-info>
+        </div>
+        <hassio-addons
+          hass='[[hass]]'
+          data='[[supervisorInfo.addons]]'
+        ></hassio-addons>
+      </div>
+    </app-header-layout>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'hassio-dashboard',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    narrow: {
+      type: Boolean,
+    },
+
+    showMenu: {
+      type: Boolean,
+      value: false,
+    },
+
+    supervisorInfo: {
+      type: Object,
+      value: {},
+    },
+
+    hostInfo: {
+      type: Object,
+      value: {},
+    },
+  },
+});
+</script>

--- a/panels/hassio/hassio-data.html
+++ b/panels/hassio/hassio-data.html
@@ -1,0 +1,40 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+
+<script>
+Polymer({
+  is: 'hassio-data',
+
+  properties: {
+    supervisor: {
+      type: Object,
+      value: {},
+      notify: true,
+    },
+
+    host: {
+      type: Object,
+      value: {},
+      notify: true,
+    },
+  },
+
+  attached: function () {
+    this.fetchSupervisorInfo();
+    this.fetchHostInfo();
+  },
+
+  fetchSupervisorInfo: function () {
+    this.hass.callApi('get', 'hassio/supervisor')
+      .then(function (info) {
+        this.supervisor = JSON.parse(info);
+      }.bind(this));
+  },
+
+  fetchHostInfo: function () {
+    this.hass.callApi('get', 'hassio/host')
+      .then(function (info) {
+        this.host = JSON.parse(info);
+      }.bind(this));
+  },
+});
+</script>

--- a/panels/hassio/hassio-data.html
+++ b/panels/hassio/hassio-data.html
@@ -31,23 +31,23 @@ Polymer({
   },
 
   fetchSupervisorInfo: function () {
-    this.hass.callApi('get', 'hassio/supervisor')
+    this.hass.callApi('get', 'hassio/supervisor/info')
       .then(function (info) {
-        this.supervisor = JSON.parse(info);
+        this.supervisor = info.data;
       }.bind(this));
   },
 
   fetchHostInfo: function () {
-    this.hass.callApi('get', 'hassio/host')
+    this.hass.callApi('get', 'hassio/host/info')
       .then(function (info) {
-        this.host = JSON.parse(info);
+        this.host = info.data;
       }.bind(this));
   },
 
   fetchHassInfo: function () {
-    this.hass.callApi('get', 'hassio/homeassistant')
+    this.hass.callApi('get', 'hassio/homeassistant/info')
       .then(function (info) {
-        this.homeassistant = JSON.parse(info);
+        this.homeassistant = info.data;
       }.bind(this));
   },
 });

--- a/panels/hassio/hassio-data.html
+++ b/panels/hassio/hassio-data.html
@@ -16,11 +16,18 @@ Polymer({
       value: {},
       notify: true,
     },
+
+    homeassistant: {
+      type: Object,
+      value: {},
+      notify: true,
+    },
   },
 
   attached: function () {
     this.fetchSupervisorInfo();
     this.fetchHostInfo();
+    this.fetchHassInfo();
   },
 
   fetchSupervisorInfo: function () {
@@ -34,6 +41,13 @@ Polymer({
     this.hass.callApi('get', 'hassio/host')
       .then(function (info) {
         this.host = JSON.parse(info);
+      }.bind(this));
+  },
+
+  fetchHassInfo: function () {
+    this.hass.callApi('get', 'hassio/homeassistant')
+      .then(function (info) {
+        this.homeassistant = JSON.parse(info);
       }.bind(this));
   },
 });

--- a/panels/hassio/hassio-hass-info.html
+++ b/panels/hassio/hassio-hass-info.html
@@ -4,7 +4,7 @@
 <link rel="import" href="../../src/components/ha-menu-button.html">
 <link rel="import" href="../../src/components/buttons/ha-call-api-button.html">
 
-<dom-module id="hassio-supervisor-info">
+<dom-module id="hassio-hass-info">
   <style include="iron-flex ha-style">
     paper-card {
       display: block;
@@ -18,48 +18,34 @@
     }
   </style>
   <template>
-    <paper-card heading="Supervisor">
+    <paper-card heading="Home Assistant">
       <div class="card-content">
         <table class='info'>
           <tr>
-            <td>Version</td>
+            <td>Current version</td>
             <td>[[data.version]]</td>
           </tr>
           <tr>
-            <td>Beta channel</td>
-            <td>[[data.beta_channel]]</td>
-          </tr>
-          <tr>
-            <td>Latest available version</td>
+            <td>Latest version</td>
             <td>[[data.last_version]]</td>
           </tr>
         </table>
       </div>
-      <div class="card-actions">
-        <template is='dom-if' if='[[computeUpdateAvailable(data)]]'>
+      <template is='dom-if' if='[[computeUpdateAvailable(data)]]'>
+        <div class="card-actions">
           <ha-call-api-button
             hass='[[hass]]'
-            path="hassio/supervisor/update"
+            path="hassio/homeassistant/update"
           >Update</ha-call-api-button>
-        </template>
-        <ha-call-api-button
-          class='warning'
-          hass='[[hass]]'
-          path="hassio/supervisor/reload"
-        >Restart</ha-call-api-button>
-      </div>
+        </div>
+      </template>
     </paper-card>
   </template>
 </dom-module>
 
 <script>
-/*
-TODO:
- - Add logs: http://localhost:8123/api/hassio/logs/supervisor
-*/
-
 Polymer({
-  is: 'hassio-supervisor-info',
+  is: 'hassio-hass-info',
 
   properties: {
     hass: {

--- a/panels/hassio/hassio-hass-info.html
+++ b/panels/hassio/hassio-hass-info.html
@@ -58,8 +58,8 @@ Polymer({
     },
   },
 
-  computeUpdateAvailable: function(data) {
-    return data.version != data.last_version;
+  computeUpdateAvailable: function (data) {
+    return data.version !== data.last_version;
   },
 });
 </script>

--- a/panels/hassio/hassio-host-info.html
+++ b/panels/hassio/hassio-host-info.html
@@ -33,6 +33,10 @@
             <td>Type</td>
             <td>[[data.type]]</td>
           </tr>
+          <tr>
+            <td>OS</td>
+            <td>[[data.os]]</td>
+          </tr>
         </table>
       </div>
       <div class="card-actions">

--- a/panels/hassio/hassio-host-info.html
+++ b/panels/hassio/hassio-host-info.html
@@ -1,0 +1,55 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+
+<link rel="import" href="../../src/components/ha-menu-button.html">
+
+<dom-module id="hassio-host-info">
+  <style include="iron-flex ha-style">
+    paper-card {
+      display: block;
+      height: 100%;
+    }
+  </style>
+  <template>
+    <paper-card heading="Host OS">
+      <div class="card-content">
+        <table>
+          <tr>
+            <td>Hostname</td>
+            <td>[[data.hostname]]</td>
+          </tr>
+          <tr>
+            <td>Control version</td>
+            <td>[[data.version]]</td>
+          </tr>
+          <tr>
+            <td>Type</td>
+            <td>[[data.os]]</td> <!-- will become type -->
+          </tr>
+        </table>
+      </div>
+      <div class="card-actions">
+        <paper-button>Update</paper-button>
+        <paper-button>Restart</paper-button>
+      </div>
+    </paper-card>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'hassio-host-info',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    data: {
+      type: Object,
+      value: {},
+    },
+  },
+});
+</script>

--- a/panels/hassio/hassio-host-info.html
+++ b/panels/hassio/hassio-host-info.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/paper-card/paper-card.html">
-<link rel="import" href="../../bower_components/paper-button/paper-button.html">
 
 <link rel="import" href="../../src/components/ha-menu-button.html">
+<link rel="import" href="../../src/components/buttons/ha-call-api-button.html">
 
 <dom-module id="hassio-host-info">
   <style include="iron-flex ha-style">
@@ -10,11 +10,17 @@
       display: block;
       height: 100%;
     }
+    .info {
+      width: 100%;
+    }
+    .info td:nth-child(2) {
+      text-align: right;
+    }
   </style>
   <template>
     <paper-card heading="Host OS">
       <div class="card-content">
-        <table>
+        <table class='info'>
           <tr>
             <td>Hostname</td>
             <td>[[data.hostname]]</td>
@@ -25,13 +31,20 @@
           </tr>
           <tr>
             <td>Type</td>
-            <td>[[data.os]]</td> <!-- will become type -->
+            <td>[[data.type]]</td>
           </tr>
         </table>
       </div>
       <div class="card-actions">
-        <paper-button>Update</paper-button>
-        <paper-button>Restart</paper-button>
+        <ha-call-api-button
+          hass='[[hass]]'
+          path="hassio/host/update"
+        >Update</ha-call-api-button>
+        <ha-call-api-button
+          class='warning'
+          hass='[[hass]]'
+          path="hassio/host/reboot"
+        >Reboot</ha-call-api-button>
       </div>
     </paper-card>
   </template>

--- a/panels/hassio/hassio-loading.html
+++ b/panels/hassio/hassio-loading.html
@@ -1,0 +1,55 @@
+<link rel='import' href='../../bower_components/paper-spinner/paper-spinner.html'>
+
+<link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+
+<link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+
+<dom-module id='hassio-loading'>
+  <template>
+    <style include='iron-flex ha-style'>
+      [hidden] {
+        display: none !important;
+      }
+
+      .placeholder {
+        height: 100%;
+      }
+
+      .layout {
+        height: calc(100% - 64px);
+      }
+    </style>
+
+    <div class='placeholder'>
+      <app-toolbar>
+        <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
+        <div main-title>Hass.io</div>
+      </app-toolbar>
+      <div class='layout horizontal center-center'>
+        <paper-spinner active></paper-spinner>
+      </div>
+    </div>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'hassio-loading',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    narrow: {
+      type: Boolean,
+      value: false,
+    },
+
+    showMenu: {
+      type: Boolean,
+      value: false,
+    },
+  },
+});
+</script>

--- a/panels/hassio/hassio-supervisor-info.html
+++ b/panels/hassio/hassio-supervisor-info.html
@@ -53,11 +53,6 @@
 </dom-module>
 
 <script>
-/*
-TODO:
- - Add logs: http://localhost:8123/api/hassio/logs/supervisor
-*/
-
 Polymer({
   is: 'hassio-supervisor-info',
 
@@ -72,8 +67,8 @@ Polymer({
     },
   },
 
-  computeUpdateAvailable: function(data) {
-    return data.version != data.last_version;
+  computeUpdateAvailable: function (data) {
+    return data.version !== data.last_version;
   },
 });
 </script>

--- a/panels/hassio/hassio-supervisor-info.html
+++ b/panels/hassio/hassio-supervisor-info.html
@@ -1,0 +1,66 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+
+<link rel="import" href="../../src/components/ha-menu-button.html">
+
+<dom-module id="hassio-supervisor-info">
+  <style include="iron-flex ha-style">
+    paper-card {
+      display: block;
+      height: 100%;
+    }
+  </style>
+  <template>
+    <paper-card heading="Supervisor">
+      <div class="card-content">
+        <table>
+          <tr>
+            <td>Version</td>
+            <td>[[data.version]]</td>
+          </tr>
+          <tr>
+            <td>Beta channel</td>
+            <td>[[data.beta]]</td>
+          </tr>
+          <tr>
+            <td>Latest available version</td>
+            <td>[[data.current]]</td>
+          </tr>
+        </table>
+      </div>
+      <div class="card-actions">
+        <template is='dom-if' if='[[updateAvailable(data)]]'>
+          <paper-button>Update</paper-button>
+        </template>
+        <paper-button>Reload</paper-button>
+      </div>
+    </paper-card>
+  </template>
+</dom-module>
+
+<script>
+/*
+TODO:
+ - Add logs: http://localhost:8123/api/hassio/logs/supervisor
+*/
+
+Polymer({
+  is: 'hassio-supervisor-info',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    data: {
+      type: Object,
+      value: {},
+    },
+  },
+
+  updateAvailable: function(data) {
+    return data.current != data.version;
+  }
+});
+</script>

--- a/panels/hassio/hassio-supervisor-info.html
+++ b/panels/hassio/hassio-supervisor-info.html
@@ -36,7 +36,7 @@
         </table>
       </div>
       <div class="card-actions">
-        <template is='dom-if' if='[[updateAvailable(data)]]'>
+        <template is='dom-if' if='[[computeUpdateAvailable(data)]]'>
           <ha-call-api-button
             hass='[[hass]]'
             path="hassio/supervisor/update"
@@ -72,8 +72,8 @@ Polymer({
     },
   },
 
-  updateAvailable: function(data) {
-    return data.current != data.version;
+  computeUpdateAvailable: function(data) {
+    return data.current != data.last_version;
   }
 });
 </script>

--- a/panels/hassio/hassio-supervisor-info.html
+++ b/panels/hassio/hassio-supervisor-info.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/paper-card/paper-card.html">
-<link rel="import" href="../../bower_components/paper-button/paper-button.html">
 
 <link rel="import" href="../../src/components/ha-menu-button.html">
+<link rel="import" href="../../src/components/buttons/ha-call-api-button.html">
 
 <dom-module id="hassio-supervisor-info">
   <style include="iron-flex ha-style">
@@ -10,11 +10,17 @@
       display: block;
       height: 100%;
     }
+    .info {
+      width: 100%;
+    }
+    .info td:nth-child(2) {
+      text-align: right;
+    }
   </style>
   <template>
     <paper-card heading="Supervisor">
       <div class="card-content">
-        <table>
+        <table class='info'>
           <tr>
             <td>Version</td>
             <td>[[data.version]]</td>
@@ -31,9 +37,16 @@
       </div>
       <div class="card-actions">
         <template is='dom-if' if='[[updateAvailable(data)]]'>
-          <paper-button>Update</paper-button>
+          <ha-call-api-button
+            hass='[[hass]]'
+            path="hassio/supervisor/update"
+          >Update</ha-call-api-button>
         </template>
-        <paper-button>Reload</paper-button>
+        <ha-call-api-button
+          class='warning'
+          hass='[[hass]]'
+          path="hassio/supervisor/reload"
+        >Restart</ha-call-api-button>
       </div>
     </paper-card>
   </template>

--- a/panels/hassio/hassio-supervisor-info.html
+++ b/panels/hassio/hassio-supervisor-info.html
@@ -27,11 +27,11 @@
           </tr>
           <tr>
             <td>Beta channel</td>
-            <td>[[data.beta]]</td>
+            <td>[[data.beta_channel]]</td>
           </tr>
           <tr>
             <td>Latest available version</td>
-            <td>[[data.current]]</td>
+            <td>[[data.last_version]]</td>
           </tr>
         </table>
       </div>

--- a/panels/hassio/todo.md
+++ b/panels/hassio/todo.md
@@ -1,0 +1,19 @@
+General:
+ - Refresh data after API call
+
+Host:
+ - Use feature detection
+
+Supervisor:
+ - logs
+ - toggle beta channel (/options)
+
+Addon View:
+ - break up UI in smaller custom elements to organize code
+
+Network:
+ - show
+ - update
+
+Home Assistant:
+ - Logs

--- a/panels/zwave/ha-panel-zwave.html
+++ b/panels/zwave/ha-panel-zwave.html
@@ -5,7 +5,7 @@
 <link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 
-<link rel="import" href="../../src/components/ha-call-service-button.html">
+<link rel="import" href="../../src/components/buttons/ha-call-service-button.html">
 <link rel="import" href="../../src/resources/ha-style.html">
 
 <dom-module id="ha-panel-zwave">

--- a/src/components/buttons/ha-call-api-button.html
+++ b/src/components/buttons/ha-call-api-button.html
@@ -1,0 +1,57 @@
+<link rel="import" href="../../../bower_components/polymer/polymer.html">
+<link rel="import" href="./ha-progress-button.html">
+
+<dom-module id='ha-call-api-button'>
+  <template>
+    <ha-progress-button
+      id='progress'
+      progress='[[progress]]'
+      on-tap='buttonTapped'
+    ><slot></slot></ha-progress-button>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'ha-call-api-button',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    progress: {
+      type: Boolean,
+      value: false,
+    },
+
+    path: {
+      type: String,
+    },
+
+    method: {
+      type: String,
+      value: 'POST',
+    },
+
+    data: {
+      type: Object,
+      value: {},
+    },
+  },
+
+  buttonTapped: function () {
+    this.progress = true;
+    var el = this;
+
+    this.hass.callApi(this.method, this.path, this.data)
+      .then(function () {
+        el.progress = false;
+        el.$.progress.actionSuccess();
+      }, function () {
+        el.progress = false;
+        el.$.progress.actionError();
+      });
+  }
+});
+</script>

--- a/src/components/buttons/ha-call-api-button.html
+++ b/src/components/buttons/ha-call-api-button.html
@@ -7,6 +7,7 @@
       id='progress'
       progress='[[progress]]'
       on-tap='buttonTapped'
+      disabled='[[disabled]]'
     ><slot></slot></ha-progress-button>
   </template>
 </dom-module>
@@ -37,6 +38,11 @@ Polymer({
     data: {
       type: Object,
       value: {},
+    },
+
+    disabled: {
+      type: Boolean,
+      value: false,
     },
   },
 

--- a/src/components/buttons/ha-call-service-button.html
+++ b/src/components/buttons/ha-call-service-button.html
@@ -1,0 +1,56 @@
+<link rel="import" href="../../../bower_components/polymer/polymer.html">
+<link rel="import" href="./ha-progress-button.html">
+
+<dom-module id='ha-call-service-button'>
+  <template>
+    <ha-progress-button
+      id='progress'
+      progress='[[progress]]'
+      on-tap='buttonTapped'
+    ><slot></slot></ha-progress-button>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'ha-call-service-button',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    progress: {
+      type: Boolean,
+      value: false,
+    },
+
+    domain: {
+      type: String,
+    },
+
+    service: {
+      type: String,
+    },
+
+    serviceData: {
+      type: Object,
+      value: {},
+    },
+  },
+
+  buttonTapped: function () {
+    this.progress = true;
+    var el = this;
+
+    this.hass.callService(this.domain, this.service, this.serviceData)
+      .then(function () {
+        el.progress = false;
+        el.$.progress.actionSuccess();
+      }, function () {
+        el.progress = false;
+        el.$.progress.actionError();
+      });
+  }
+});
+</script>

--- a/src/components/buttons/ha-progress-button.html
+++ b/src/components/buttons/ha-progress-button.html
@@ -43,7 +43,7 @@
     <div class='container' id='container'>
       <paper-button
         id='button'
-        disabled='[[progress]]'
+        disabled='[[computeDisabled(disabled, progress)]]'
         on-tap='buttonTapped'
       >
         <slot></slot>
@@ -83,6 +83,11 @@ Polymer({
       type: Object,
       value: {},
     },
+
+    disabled: {
+      type: Boolean,
+      value: false,
+    },
   },
 
   tempClass: function (className) {
@@ -107,6 +112,10 @@ Polymer({
 
   actionError: function () {
     this.tempClass('error');
+  },
+
+  computeDisabled: function (disabled, progress) {
+    return disabled || progress;
   },
 });
 </script>

--- a/src/components/buttons/ha-progress-button.html
+++ b/src/components/buttons/ha-progress-button.html
@@ -99,7 +99,7 @@ Polymer({
   },
 
   listeners: {
-    'tap': 'buttonTapped',
+    tap: 'buttonTapped',
   },
 
   buttonTapped: function (ev) {

--- a/src/components/buttons/ha-progress-button.html
+++ b/src/components/buttons/ha-progress-button.html
@@ -1,8 +1,8 @@
-<link rel="import" href="../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../../bower_components/paper-spinner/paper-spinner.html">
+<link rel="import" href="../../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../../bower_components/paper-spinner/paper-spinner.html">
 
-<dom-module id='ha-call-service-button'>
+<dom-module id='ha-progress-button'>
   <template>
     <style>
       .container {
@@ -59,7 +59,7 @@
 
 <script>
 Polymer({
-  is: 'ha-call-service-button',
+  is: 'ha-progress-button',
 
   properties: {
     hass: {
@@ -93,18 +93,20 @@ Polymer({
     }, 1000);
   },
 
-  buttonTapped: function () {
-    this.progress = true;
-    var el = this;
+  listeners: {
+    'tap': 'buttonTapped',
+  },
 
-    this.hass.callService(this.domain, this.service, this.serviceData)
-      .then(function () {
-        el.tempClass('success');
-        el.progress = false;
-      }, function () {
-        el.tempClass('error');
-        el.progress = false;
-      });
-  }
+  buttonTapped: function (ev) {
+    if (this.progress) ev.stopPropagation();
+  },
+
+  actionSuccess: function () {
+    this.tempClass('success');
+  },
+
+  actionError: function () {
+    this.tempClass('error');
+  },
 });
 </script>

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -86,12 +86,14 @@
       }
 
       .card-actions > paper-button:not([disabled]),
+      .card-actions > ha-call-api-button:not([disabled]),
       .card-actions > ha-call-service-button:not([disabled]) {
         color: var(--default-primary-color);
         font-weight: 500;
       }
 
       .card-actions > paper-button.warning:not([disabled]),
+      .card-actions > ha-call-api-button.warning:not([disabled]),
       .card-actions > ha-call-service-button.warning:not([disabled]) {
         color: var(--google-red-500);
       }


### PR DESCRIPTION
Adds a HassIO config panel. Will only be visible if you are running Home Assistant on HassIO.

It functions but the code is quite messy. I want to get it out as it opens the door for beta testers 👍  It won't impact any normal users as it's code splitted away.

![screen shot 2017-04-27 at 24 32 41](https://cloud.githubusercontent.com/assets/1444314/25472850/f000a880-2ae1-11e7-9043-2f46843c2bdd.png)

![screen shot 2017-04-27 at 24 29 26](https://cloud.githubusercontent.com/assets/1444314/25472871/074fd1c8-2ae2-11e7-96f7-a080d2816504.png)
