### PR TITLE
Update binary sensors with open/closed states instead of on/off

### DIFF
--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -25,6 +25,7 @@
     ha-state-icon[data-domain=light][data-state=on],
     ha-state-icon[data-domain=switch][data-state=on],
     ha-state-icon[data-domain=binary_sensor][data-state=on],
+    ha-state-icon[data-domain=binary_sensor][data-state=open],
     ha-state-icon[data-domain=sun][data-state=above_horizon] {
       color: #FDD835;
     }

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -343,7 +343,7 @@ window.hassUtil.domainIcon = function (domain, state) {
 };
 
 window.hassUtil.binarySensorIcon = function (state) {
-  var activated = state.state && state.state === 'off';
+  var activated = state.state && (window.hassUtil.OFF_STATES.indexOf(state.state) != -1);
   switch (state.attributes.device_class) {
     case 'connectivity':
       return activated ? 'mdi:server-network-off' : 'mdi:server-network';

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -343,7 +343,7 @@ window.hassUtil.domainIcon = function (domain, state) {
 };
 
 window.hassUtil.binarySensorIcon = function (state) {
-  var activated = state.state && (window.hassUtil.OFF_STATES.indexOf(state.state) != -1);
+  var activated = state.state && (window.hassUtil.OFF_STATES.indexOf(state.state) !== -1);
   switch (state.attributes.device_class) {
     case 'connectivity':
       return activated ? 'mdi:server-network-off' : 'mdi:server-network';


### PR DESCRIPTION
This patch allows binary sensors to get its icon toggle and icon color change  when using non on/off states.

AlarmDecoder adds binary sensors of the opening type, like doors and windows.  It doesn't make sense that these are on/off states, so the AlarmDecoder code toggles them to open/closed.  Currently that makes it so the icons do not toggle or change color between states.

This patch allows that to happen:

[home-assistant](https://github.com/home-assistant/home-assistant) Issue opened:** home-assistant/home-assistant/issues/7309
