### PR TITLE
Allow climate platforms to specify temperature step

### DIFF
--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -102,7 +102,7 @@
           <ha-climate-control
              value='[[stateObj.attributes.temperature]]'
              units='[[stateObj.attributes.unit_of_measurement]]'
-             step='[[computeTemperatureStepSize(stateObj.attributes.unit_of_measurement)]]'
+             step='[[computeTemperatureStepSize(stateObj)]]'
              min='[[stateObj.attributes.min_temp]]'
              max='[[stateObj.attributes.max_temp]]'
              on-change='targetTemperatureChanged'
@@ -257,8 +257,11 @@ Polymer({
     }
   },
 
-  computeTemperatureStepSize: function (units) {
-    if (units.indexOf('F') !== -1) {
+  computeTemperatureStepSize: function (stateObj) {
+    if (stateObj.attributes.target_temp_step) {
+      return stateObj.attributes.target_temp_step;
+    }
+    if (stateObj.attributes.unit_of_measurement.indexOf('F') !== -1) {
       return 1;
     }
     return 0.5;

--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -260,8 +260,7 @@ Polymer({
   computeTemperatureStepSize: function (stateObj) {
     if (stateObj.attributes.target_temp_step) {
       return stateObj.attributes.target_temp_step;
-    }
-    if (stateObj.attributes.unit_of_measurement.indexOf('F') !== -1) {
+    } else if (stateObj.attributes.unit_of_measurement.indexOf('F') !== -1) {
       return 1;
     }
     return 0.5;


### PR DESCRIPTION
Allow climate platforms to specify temperature step.
Some platforms support only whole celsius settings.