### PR TITLE
updating cover more-info to use supported features for configuration

### DIFF
--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -19,7 +19,7 @@
       .has-close_tilt .tilt,
       .has-stop_tilt .tilt,
       .has-set_tilt_position .tilt,
-      .has_current_tilt_position .tilt
+      .has-current_tilt_position .tilt
       {
         max-height: 90px;
       }

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -27,7 +27,6 @@
         visibility: hidden !important;
       }
     </style>
-WHAT DA FEQ
     <div class$='[[computeClassNames(stateObj)]]'>
 
       <div class='current_position'>

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -112,8 +112,7 @@ Polymer({
 
   computeClassNames: function (stateObj) {
     var classes = [
-      window.hassUtil.attributeClassNames(stateObj, ['current_position']),
-      window.hassUtil.attributeClassNames(stateObj, ['current_tilt_position']),
+      window.hassUtil.attributeClassNames(stateObj, ['current_position', 'current_tilt_position']),
       window.hassUtil.featureClassNames(stateObj, this.featureClassNames),
     ];
     return classes.join(' ');

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -10,11 +10,16 @@
   <template>
     <style is="custom-style" include="iron-flex"></style>
     <style>
-      .current_position {
+      .current_position, .tilt {
         max-height: 0px;
         overflow: hidden;
       }
-      .has-current_position .current_position {
+      .has-current_position .current_position,
+      .has-open_tilt .tilt,
+      .has-close_tilt .tilt,
+      .has-stop_tilt .tilt,
+      .has-set_tilt_position .tilt
+      {
         max-height: 90px;
       }
 
@@ -22,7 +27,7 @@
         visibility: hidden !important;
       }
     </style>
-
+WHAT DA FEQ
     <div class$='[[computeClassNames(stateObj)]]'>
 
       <div class='current_position'>
@@ -35,7 +40,7 @@
           on-change='coverPositionSliderChanged'></paper-slider>
       </div>
 
-      <div class='current_tilt_position' hidden$="[[!supportsTilt]]">
+      <div class='tilt'>
         <div>Tilt position</div>
         <paper-icon-button icon="mdi:arrow-top-right" 
           on-tap='onOpenTiltTap' title='Open tilt'
@@ -87,10 +92,6 @@ Polymer({
       type: Number,
     },
 
-    supportsTilt: {
-      type: Boolean,
-      value: false,
-    },
   },
 
   computeEntityObj: function (hass, stateObj) {
@@ -100,12 +101,21 @@ Polymer({
   stateObjChanged: function (newVal) {
     this.coverPositionSliderValue = newVal.attributes.current_position;
     this.coverTiltPositionSliderValue = newVal.attributes.current_tilt_position;
-    this.supportsTilt = (newVal.attributes.supported_features & 16) !== 0;
+  },
+
+  featureClassNames: {
+    16: 'has-open_tilt',
+    32: 'has-close_tilt',
+    64: 'has-stop_tilt',
+    128: 'has-set_tilt_position',
   },
 
   computeClassNames: function (stateObj) {
-    return window.hassUtil.attributeClassNames(
-      stateObj, ['current_position']);
+    var classes = [
+      window.hassUtil.attributeClassNames(stateObj, ['current_position']),
+      window.hassUtil.featureClassNames(stateObj, this.featureClassNames),
+    ];
+    return classes.join(' ');
   },
 
   coverPositionSliderChanged: function (ev) {

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -18,7 +18,8 @@
       .has-open_tilt .tilt,
       .has-close_tilt .tilt,
       .has-stop_tilt .tilt,
-      .has-set_tilt_position .tilt
+      .has-set_tilt_position .tilt,
+      .has_current_tilt_position .tilt
       {
         max-height: 90px;
       }
@@ -112,6 +113,7 @@ Polymer({
   computeClassNames: function (stateObj) {
     var classes = [
       window.hassUtil.attributeClassNames(stateObj, ['current_position']),
+      window.hassUtil.attributeClassNames(stateObj, ['current_tilt_position']),
       window.hassUtil.featureClassNames(stateObj, this.featureClassNames),
     ];
     return classes.join(' ');

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -10,12 +10,11 @@
   <template>
     <style is="custom-style" include="iron-flex"></style>
     <style>
-      .current_position, .current_tilt_position {
+      .current_position {
         max-height: 0px;
         overflow: hidden;
       }
-      .has-current_position .current_position,
-      .has-current_tilt_position .current_tilt_position {
+      .has-current_position .current_position {
         max-height: 90px;
       }
 
@@ -36,7 +35,7 @@
           on-change='coverPositionSliderChanged'></paper-slider>
       </div>
 
-      <div class='current_tilt_position'>
+      <div class='current_tilt_position' hidden$="[[!supportsTilt]]">
         <div>Tilt position</div>
         <paper-icon-button icon="mdi:arrow-top-right" 
           on-tap='onOpenTiltTap' title='Open tilt'
@@ -87,6 +86,11 @@ Polymer({
     coverTiltPositionSliderValue: {
       type: Number,
     },
+
+    supportsTilt: {
+      type: Boolean,
+      value: false,
+    },
   },
 
   computeEntityObj: function (hass, stateObj) {
@@ -96,11 +100,12 @@ Polymer({
   stateObjChanged: function (newVal) {
     this.coverPositionSliderValue = newVal.attributes.current_position;
     this.coverTiltPositionSliderValue = newVal.attributes.current_tilt_position;
+    this.supportsTilt = (newVal.attributes.supported_features & 16) !== 0;
   },
 
   computeClassNames: function (stateObj) {
     return window.hassUtil.attributeClassNames(
-      stateObj, ['current_position', 'current_tilt_position']);
+      stateObj, ['current_position']);
   },
 
   coverPositionSliderChanged: function (ev) {


### PR DESCRIPTION
Updating cover-more-info to use supported features to hide/show tilt controls rather than depending on current value to avoid chicken/egg situation