### PR TITLE
Fix history timeline legend selection.

### DIFF
--- a/src/components/state-history-chart-line.html
+++ b/src/components/state-history-chart-line.html
@@ -123,11 +123,12 @@
       }
 
       daysDelta = (endTime - startTime) / (24 * 3600 * 1000);
-      if (daysDelta > 30) {
+      // Avoid rounding up when the API returns a few extra seconds.
+      if (daysDelta > 30.1) {
         options.hAxis.format = 'MMM d';
-      } else if (daysDelta > 3) {
+      } else if (daysDelta > 3.1) {
         options.hAxis.format = 'EEE, MMM d';
-      } else if (daysDelta > 1) {
+      } else if (daysDelta > 1.1) {
         options.hAxis.format = 'EEE, MMM d, H:mm';
       }
 

--- a/src/components/state-history-chart-timeline.html
+++ b/src/components/state-history-chart-timeline.html
@@ -90,11 +90,12 @@ Polymer({
     }
     format = 'H:mm';
     daysDelta = (endTime - startTime) / (24 * 3600 * 1000);
-    if (daysDelta > 30) {
+    // Avoid rounding up when the API returns a few extra seconds.
+    if (daysDelta > 30.1) {
       format = 'MMM d';
-    } else if (daysDelta > 3) {
+    } else if (daysDelta > 3.1) {
       format = 'EEE, MMM d';
-    } else if (daysDelta > 1) {
+    } else if (daysDelta > 1.1) {
       format = 'EEE, MMM d, H:mm';
     }
 


### PR DESCRIPTION
Fix history timeline legend selection.

When 1 day is requested the API returns data for a day and a fraction of second.

Fixed #261 