### PR TITLE
Context aware names

### DIFF
--- a/src/components/entity/state-info.html
+++ b/src/components/entity/state-info.html
@@ -41,7 +41,7 @@
       <state-badge state-obj='[[stateObj]]'></state-badge>
 
       <div class='info'>
-        <div class='name' in-dialog$='[[inDialog]]'>[[computeStateName(stateObj)]]</div>
+        <div class='name' in-dialog$='[[inDialog]]'>[[computeStateName(stateObj, inDialog)]]</div>
 
         <template is='dom-if' if='[[inDialog]]'>
           <div class='time-ago'>
@@ -75,8 +75,23 @@ Polymer({
     },
   },
 
-  computeStateName: function (stateObj) {
-    return window.hassUtil.computeStateName(stateObj);
+  _getContext: function () {
+    var element = this;
+    if (this._context === undefined) {
+      while (element && element.tagName !== 'HA-ENTITIES-CARD') {
+        element = element.domHost;
+      }
+      if (element && element.groupEntity) {
+        this._context = element.groupEntity.entity_id;
+      } else {
+        this._context = null;
+      }
+    }
+    return this._context;
+  },
+
+  computeStateName: function (stateObj, inDialog) {
+    return window.hassUtil.computeStateName(stateObj, inDialog ? null : this._getContext());
   }
 });
 </script>

--- a/src/components/entity/state-info.html
+++ b/src/components/entity/state-info.html
@@ -61,17 +61,13 @@ Polymer({
   is: 'state-info',
 
   properties: {
-    detailed: {
-      type: Boolean,
-      value: false,
-    },
-
     stateObj: {
       type: Object,
     },
 
     inDialog: {
       type: Boolean,
+      value: false,
     },
   },
 

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -415,7 +415,11 @@ window.hassUtil.computeDomain = function (stateObj) {
   return stateObj._domain;
 };
 
-window.hassUtil.computeStateName = function (stateObj) {
+window.hassUtil.computeStateName = function (stateObj, optContext) {
+  if (optContext && stateObj.attributes.friendly_names &&
+      stateObj.attributes.friendly_names[optContext] !== undefined) {
+    return stateObj.attributes.friendly_names[optContext];
+  }
   if (stateObj._entityDisplay === undefined) {
     stateObj._entityDisplay = (
       stateObj.attributes.friendly_name ||

--- a/test/state-info-test.html
+++ b/test/state-info-test.html
@@ -37,7 +37,7 @@
       
       test('default values', function() {
         assert.isUndefined(si.stateObj);
-        assert.isUndefined(si.inDialog);
+        assert.isFalse(si.inDialog);
       });
 
       test('has state-badge', function() {


### PR DESCRIPTION
Implementing https://github.com/home-assistant/home-assistant/issues/7539

Yaml example:
```yaml
homeassistant:
  customize:
    light.bathroom.light:
      friendly_name: Bathroom Light
      friendly_names:
        group.bathroom: Light

group:
  bathroom:
    entities:
      - light.bathroom.light
```

Works by looking for `<ha-entities-card>` up the dom tree to get context.