### PR TITLE
Hassio panel on demand

### DIFF
--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -1,69 +1,19 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
-
-<link rel="import" href="./dashboard/hassio-dashboard.html">
-<link rel="import" href="./addon-view/hassio-addon-view.html">
-<link rel="import" href="./addon-store/hassio-addon-store.html">
-<link rel="import" href="./supervisor/hassio-supervisor.html">
-<link rel="import" href="./hassio-loading.html">
-<link rel="import" href="./hassio-data.html">
+<link rel="import" href="./hassio-main.html">
 
 <dom-module id="ha-panel-hassio">
   <template>
     <style>
-      iron-pages {
-        height: 100%;
+      [hidden] {
+        display: none !important;
       }
     </style>
-    <hassio-data
-      id='data'
+
+    <hassio-main
       hass='[[hass]]'
-      supervisor='{{supervisorInfo}}'
-      homeassistant='{{hassInfo}}'
-      host='{{hostInfo}}'
-    ></hassio-data>
-
-    <template is='dom-if' if='[[dashboardSelected(currentPage)]]'>
-      <template is='dom-if' if='[[!loaded]]'>
-        <hassio-loading
-          narrow='[[narrow]]'
-          hass='[[hass]]'
-          show-menu='[[showMenu]]'
-        ></hassio-loading>
-      </template>
-      <template is='dom-if' if='[[loaded]]'>
-        <hassio-dashboard
-          hass='[[hass]]'
-          narrow='[[narrow]]'
-          show-menu='[[showMenu]]'
-          supervisor-info='[[supervisorInfo]]'
-          host-info='[[hostInfo]]'
-          hass-info='[[hassInfo]]'
-        ></hassio-dashboard>
-      </template>
-    </template>
-
-    <template is='dom-if' if='[[addonViewSelected(currentPage)]]' restamp>
-      <hassio-addon-view
-        hass='[[hass]]'
-        supervisor-info='[[supervisorInfo]]'
-        host-info='[[hostInfo]]'
-        addon='[[addon]]'
-      ></hassio-addon-view>
-    </template>
-
-    <template is='dom-if' if='[[addonStoreSelected(currentPage)]]'>
-      <hassio-addon-store
-        hass='[[hass]]'
-        supervisor-info='[[supervisorInfo]]'
-      ></hassio-addon-store>
-    </template>
-
-    <template is='dom-if' if='[[supervisorSelected(currentPage)]]'>
-      <hassio-supervisor
-        hass='[[hass]]'
-        supervisor-info='[[supervisorInfo]]'
-      ></hassio-supervisor>
-    </template>
+      narrow='[[narrow]]'
+      show-menu='[[showMenu]]'
+    ></hassio-main>
   </template>
 </dom-module>
 
@@ -85,114 +35,19 @@ Polymer({
       value: false,
     },
 
-    addon: {
-      type: String,
-      value: '',
-    },
-
-    supervisorInfo: {
-      type: Object,
-      value: null,
-    },
-
-    hostInfo: {
-      type: Object,
-      value: null,
-    },
-
-    hassInfo: {
-      type: Object,
-      value: null,
-    },
-
-    forceLoading: {
+    loaded: {
       type: Boolean,
       value: false,
     },
-
-    loaded: {
-      type: Boolean,
-      computed: 'computeIsLoaded(supervisorInfo, hostInfo, hassInfo, forceLoading)',
-    },
-
-    currentPage: {
-      type: String,
-      value: 'dashboard',
-    },
-
-    lastPage: {
-      type: String,
-      value: 'dashboard',
-    },
   },
 
-  listeners: {
-    'hassio-select-addon': 'addonSelected',
-    'hassio-show-page': 'showPage',
-    'hass-api-called': 'apiCalled',
-  },
-
-  apiCalled: function (ev) {
-    if (ev.detail.success) {
-      var tries = 1;
-
-      var tryUpdate = function () {
-        this.$.data.refresh().catch(function () {
-          tries += 1;
-          setTimeout(tryUpdate, Math.min(tries, 5) * 1000);
-        });
-      }.bind(this);
-
-      tryUpdate();
+  attached: function () {
+    if (!window.HASS_DEV) {
+      this.importHref('/api/hassio/panel', null, function () {
+        // eslint-disable-next-line
+        alert('Failed to load the Hass.io panel from supervisor.');
+      });
     }
   },
-
-  computeIsLoaded: function (supervisorInfo, hostInfo, hassInfo, forceLoading) {
-    return (supervisorInfo !== null &&
-            hostInfo !== null &&
-            hassInfo !== null &&
-            !forceLoading);
-  },
-
-  addonSelected: function (ev) {
-    var addon = ev.detail.addon;
-
-    if (this.currentPage === this.lastPage) {
-      this.lastPage = 'dashboard';
-    }
-
-    if (addon) {
-      this.lastPage = this.currentPage;
-      this.currentPage = 'addon-view';
-      this.addon = addon;
-    } else {
-      this.currentPage = this.lastPage;
-      // Give time to cleanup the addon-view panel or it crashes
-      setTimeout(function () {
-        this.addon = addon;
-      }.bind(this), 0);
-    }
-  },
-
-  showPage: function (ev) {
-    this.currentPage = ev.detail.page;
-  },
-
-  dashboardSelected: function (currentPage) {
-    return currentPage === 'dashboard';
-  },
-
-  addonStoreSelected: function (currentPage) {
-    return currentPage === 'addon-store';
-  },
-
-  addonViewSelected: function (currentPage) {
-    return currentPage === 'addon-view';
-  },
-
-  supervisorSelected: function (currentPage) {
-    return currentPage === 'supervisor';
-  },
-
 });
 </script>

--- a/panels/hassio/hassio-main.html
+++ b/panels/hassio/hassio-main.html
@@ -1,0 +1,193 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+
+<link rel="import" href="../../src/layouts/hass-loading-screen.html">
+
+<link rel="import" href="./dashboard/hassio-dashboard.html">
+<link rel="import" href="./addon-view/hassio-addon-view.html">
+<link rel="import" href="./addon-store/hassio-addon-store.html">
+<link rel="import" href="./supervisor/hassio-supervisor.html">
+<link rel="import" href="./hassio-data.html">
+
+<dom-module id="hassio-main">
+  <template>
+    <hassio-data
+      id='data'
+      hass='[[hass]]'
+      supervisor='{{supervisorInfo}}'
+      homeassistant='{{hassInfo}}'
+      host='{{hostInfo}}'
+    ></hassio-data>
+
+    <template is='dom-if' if='[[dashboardSelected(currentPage)]]'>
+      <template is='dom-if' if='[[!loaded]]'>
+        <hass-loading-screen
+          narrow='[[narrow]]'
+          show-menu='[[showMenu]]'
+        ></hass-loading-screen>
+      </template>
+      <template is='dom-if' if='[[loaded]]'>
+        <hassio-dashboard
+          hass='[[hass]]'
+          narrow='[[narrow]]'
+          show-menu='[[showMenu]]'
+          supervisor-info='[[supervisorInfo]]'
+          host-info='[[hostInfo]]'
+          hass-info='[[hassInfo]]'
+        ></hassio-dashboard>
+      </template>
+    </template>
+
+    <template is='dom-if' if='[[addonViewSelected(currentPage)]]' restamp>
+      <hassio-addon-view
+        hass='[[hass]]'
+        supervisor-info='[[supervisorInfo]]'
+        host-info='[[hostInfo]]'
+        addon='[[addon]]'
+      ></hassio-addon-view>
+    </template>
+
+    <template is='dom-if' if='[[addonStoreSelected(currentPage)]]'>
+      <hassio-addon-store
+        hass='[[hass]]'
+        supervisor-info='[[supervisorInfo]]'
+      ></hassio-addon-store>
+    </template>
+
+    <template is='dom-if' if='[[supervisorSelected(currentPage)]]'>
+      <hassio-supervisor
+        hass='[[hass]]'
+        supervisor-info='[[supervisorInfo]]'
+      ></hassio-supervisor>
+    </template>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'hassio-main',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    narrow: {
+      type: Boolean,
+    },
+
+    showMenu: {
+      type: Boolean,
+      value: false,
+    },
+
+    addon: {
+      type: String,
+      value: '',
+    },
+
+    supervisorInfo: {
+      type: Object,
+      value: null,
+    },
+
+    hostInfo: {
+      type: Object,
+      value: null,
+    },
+
+    hassInfo: {
+      type: Object,
+      value: null,
+    },
+
+    forceLoading: {
+      type: Boolean,
+      value: false,
+    },
+
+    loaded: {
+      type: Boolean,
+      computed: 'computeIsLoaded(supervisorInfo, hostInfo, hassInfo, forceLoading)',
+    },
+
+    currentPage: {
+      type: String,
+      value: 'dashboard',
+    },
+
+    lastPage: {
+      type: String,
+      value: 'dashboard',
+    },
+  },
+
+  listeners: {
+    'hassio-select-addon': 'addonSelected',
+    'hassio-show-page': 'showPage',
+    'hass-api-called': 'apiCalled',
+  },
+
+  apiCalled: function (ev) {
+    if (ev.detail.success) {
+      var tries = 1;
+
+      var tryUpdate = function () {
+        this.$.data.refresh().catch(function () {
+          tries += 1;
+          setTimeout(tryUpdate, Math.min(tries, 5) * 1000);
+        });
+      }.bind(this);
+
+      tryUpdate();
+    }
+  },
+
+  computeIsLoaded: function (supervisorInfo, hostInfo, hassInfo, forceLoading) {
+    return (supervisorInfo !== null &&
+            hostInfo !== null &&
+            hassInfo !== null &&
+            !forceLoading);
+  },
+
+  addonSelected: function (ev) {
+    var addon = ev.detail.addon;
+
+    if (this.currentPage === this.lastPage) {
+      this.lastPage = 'dashboard';
+    }
+
+    if (addon) {
+      this.lastPage = this.currentPage;
+      this.currentPage = 'addon-view';
+      this.addon = addon;
+    } else {
+      this.currentPage = this.lastPage;
+      // Give time to cleanup the addon-view panel or it crashes
+      setTimeout(function () {
+        this.addon = addon;
+      }.bind(this), 0);
+    }
+  },
+
+  showPage: function (ev) {
+    this.currentPage = ev.detail.page;
+  },
+
+  dashboardSelected: function (currentPage) {
+    return currentPage === 'dashboard';
+  },
+
+  addonStoreSelected: function (currentPage) {
+    return currentPage === 'addon-store';
+  },
+
+  addonViewSelected: function (currentPage) {
+    return currentPage === 'addon-view';
+  },
+
+  supervisorSelected: function (currentPage) {
+    return currentPage === 'supervisor';
+  },
+
+});
+</script>

--- a/src/app-core.js
+++ b/src/app-core.js
@@ -2,6 +2,7 @@ import * as HAWS from 'home-assistant-js-websocket';
 
 window.HAWS = HAWS;
 window.HASS_DEMO = __DEMO__;
+window.HASS_DEV = __DEV__;
 
 const init = window.createHassConnection = function (password) {
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';

--- a/src/layouts/hass-loading-screen.html
+++ b/src/layouts/hass-loading-screen.html
@@ -4,7 +4,7 @@
 
 <link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 
-<dom-module id='hassio-loading'>
+<dom-module id='hass-loading-screen'>
   <template>
     <style include='iron-flex ha-style'>
       [hidden] {
@@ -23,7 +23,7 @@
     <div class='placeholder'>
       <app-toolbar>
         <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
-        <div main-title>Hass.io</div>
+        <div main-title>[[title]]</div>
       </app-toolbar>
       <div class='layout horizontal center-center'>
         <paper-spinner active></paper-spinner>
@@ -34,13 +34,9 @@
 
 <script>
 Polymer({
-  is: 'hassio-loading',
+  is: 'hass-loading-screen',
 
   properties: {
-    hass: {
-      type: Object,
-    },
-
     narrow: {
       type: Boolean,
       value: false,
@@ -49,6 +45,11 @@ Polymer({
     showMenu: {
       type: Boolean,
       value: false,
+    },
+
+    title: {
+      type: String,
+      value: '',
     },
   },
 });

--- a/src/layouts/partial-panel-resolver.html
+++ b/src/layouts/partial-panel-resolver.html
@@ -1,41 +1,21 @@
-<link rel='import' href='../../bower_components/paper-spinner/paper-spinner.html'>
+<link rel='import' href='../../bower_components/polymer/polymer.html'>
 
-<link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
-
-<link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
-
-<link rel='import' href='../components/ha-menu-button.html'>
-<link rel="import" href="../resources/ha-style.html">
+<link rel="import" href="./hass-loading-screen.html">
 
 <dom-module id='partial-panel-resolver'>
   <template>
-    <style include='iron-flex ha-style'>
+    <style>
       [hidden] {
         display: none !important;
       }
-
-      .placeholder {
-        height: 100%;
-      }
-
-      .layout {
-        height: calc(100% - 64px);
-      }
     </style>
 
-    <div hidden$='[[resolved]]' class='placeholder'>
-      <app-toolbar>
-        <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
-      </app-toolbar>
-      <div class='layout horizontal center-center'>
-        <template is='dom-if' if='[[!errorLoading]]'>
-          <paper-spinner active></paper-spinner>
-        </template>
-        <template is='dom-if' if='[[errorLoading]]'>
-          Error loading panel :(
-        </template>
-      </div>
-    </div>
+    <template is='dom-if' if='[[!resolved]]'>
+      <hass-loading-screen
+        narrow='[[narrow]]'
+        show-menu='[[showMenu]]'
+      ></hass-loading-screen>
+    </template>
 
     <span id='panel' hidden$='[[!resolved]]'></span>
   </template>


### PR DESCRIPTION
Hass.io is on a different release cycle than Home Assistant. This comes with the downside that improvements to the Hass.io config panel had to be released in sync with a new Hass.io release.

This PR decouples Hass.io config panel from being embedded in the Home Assistant release. Instead, in production, Home Assistant will fetch the configuration panel from the supervisor. This allows us to ship new supervisors with new functionality and make sure that users are always running the UI panel that it needs to accompany.

Url it fetches config panel from: `/api/hassio/panel`.

To build the panel that has to be included in the supervisor:
 - Clone repo (it should probably become a submodule of the supervisor repo)
 - Install dependencies as usual: `yarn && ./node_modules/.bin/bower install`
 - Build frontend: `yarn run frontend_prod`
 - Panel can be found at `build-temp/hassio-main.html`
 - When serving it from the supervisor, make sure that a gzip'd version of the panel exists on disk named `hassio-main.html.gz`. Aiohttp will automatically pick it up and serve the gzip'd version when using `aiohttp.web.StaticResource`.