### PR TITLE
Set input_slider value after min,max,step.

### DIFF
--- a/src/state-summary/state-card-input_slider.html
+++ b/src/state-summary/state-card-input_slider.html
@@ -60,11 +60,10 @@ Polymer({
   },
 
   stateObjectChanged: function (newVal) {
-    this.value = Number(newVal.state);
     this.min = Number(newVal.attributes.min);
     this.max = Number(newVal.attributes.max);
-
     this.step = Number(newVal.attributes.step);
+    this.value = Number(newVal.state);
   },
 
   selectedValueChanged: function () {


### PR DESCRIPTION
This avoids clobbering it with the default values of min, max, and step. Fixes HA issues 7301 and 7232.

- Fixes https://github.com/home-assistant/home-assistant/issues/7301
- Fixes https://github.com/home-assistant/home-assistant/issues/7232