### PR TITLE
Improvements for the zwave rename node entry

### DIFF
--- a/panels/zwave/ha-panel-zwave.html
+++ b/panels/zwave/ha-panel-zwave.html
@@ -331,7 +331,7 @@ Polymer({
   },
 
   selectedNodeChanged: function (selectedNode) {
-    this.newNodeNameInput = "";
+    this.newNodeNameInput = '';
 
     if (selectedNode === -1) return;
     this.selectedConfigParameter = -1;

--- a/panels/zwave/ha-panel-zwave.html
+++ b/panels/zwave/ha-panel-zwave.html
@@ -331,6 +331,8 @@ Polymer({
   },
 
   selectedNodeChanged: function (selectedNode) {
+    this.newNodeNameInput = "";
+
     if (selectedNode === -1) return;
     this.selectedConfigParameter = -1;
     this.selectedConfigParameterValue = -1;
@@ -402,9 +404,7 @@ Polymer({
   computeGetNodeName: function (selectedNode) {
     if (this.selectedNode === -1 ||
       !this.nodes[selectedNode].entity_id) return -1;
-    var str = (this.nodes[selectedNode].entity_id);
-    var name = str.replace('zwave.', '');
-    return name;
+    return this.nodes[selectedNode].attributes.node_name;
   },
 
   computeNodeNameServiceData: function (newNodeNameInput) {


### PR DESCRIPTION
This PR provides a little bit of improvement to the rename node entry. The node name is now cleared when changing nodes, and the placeholder name comes from the actual node name, instead of a manipulated entity_id.

Requires https://github.com/home-assistant/home-assistant/pull/7787