### PR TITLE
Control modification for cover

### DIFF
--- a/src/components/ha-cover-tilt-controls.html
+++ b/src/components/ha-cover-tilt-controls.html
@@ -93,17 +93,17 @@ Polymer({
   },
 
   onOpenTiltTap: function (ev) {
-      ev.stopPropagation();
+    ev.stopPropagation();
     this.entityObj.openCoverTilt();
   },
 
   onCloseTiltTap: function (ev) {
-      ev.stopPropagation();
+    ev.stopPropagation();
     this.entityObj.closeCoverTilt();
   },
 
   onStopTiltTap: function (ev) {
-      ev.stopPropagation();
+    ev.stopPropagation();
     this.entityObj.stopCoverTilt();
   },
 });

--- a/src/components/ha-cover-tilt-controls.html
+++ b/src/components/ha-cover-tilt-controls.html
@@ -10,7 +10,7 @@
   <template>
     <style is="custom-style" include="iron-flex"></style>
     <style>
-      .tilt {
+      :host {
         white-space: nowrap;
       }
 
@@ -18,22 +18,17 @@
         visibility: hidden !important;
       }
     </style>
-    <div class$='[[computeClassNames(stateObj)]]'>
-      <div class='tilt'>
-        <paper-icon-button icon="mdi:arrow-top-right" 
-          on-tap='onOpenTiltTap' title='Open tilt'
-          invisible$='[[!entityObj.supportsOpenTilt]]'
-          disabled='[[entityObj.isFullyOpenTilt]]'></paper-icon-button>
-        <paper-icon-button icon="mdi:stop" on-tap='onStopTiltTap'
-          invisible$='[[!entityObj.supportsStopTilt]]'
-          title='Stop tilt'></paper-icon-button>
-        <paper-icon-button icon="mdi:arrow-bottom-left"
-          on-tap='onCloseTiltTap' title='Close tilt'
-          invisible$='[[!entityObj.supportsCloseTilt]]'
-          disabled='[[entityObj.isFullyClosedTilt]]'></paper-icon-button>
-      </div>
-
-    </div>
+    <paper-icon-button icon="mdi:arrow-top-right" 
+      on-tap='onOpenTiltTap' title='Open tilt'
+      invisible$='[[!entityObj.supportsOpenTilt]]'
+      disabled='[[entityObj.isFullyOpenTilt]]'></paper-icon-button>
+    <paper-icon-button icon="mdi:stop" on-tap='onStopTiltTap'
+      invisible$='[[!entityObj.supportsStopTilt]]'
+      title='Stop tilt'></paper-icon-button>
+    <paper-icon-button icon="mdi:arrow-bottom-left"
+      on-tap='onCloseTiltTap' title='Close tilt'
+      invisible$='[[!entityObj.supportsCloseTilt]]'
+      disabled='[[entityObj.isFullyClosedTilt]]'></paper-icon-button>
   </template>
 </dom-module>
 
@@ -59,19 +54,6 @@ Polymer({
   computeEntityObj: function (hass, stateObj) {
     var entity = new window.CoverEntity(hass, stateObj);
     return entity;
-  },
-
-  featureClassNames: {
-    16: 'has-open_tilt',
-    32: 'has-close_tilt',
-    64: 'has-stop_tilt',
-  },
-
-  computeClassNames: function (stateObj) {
-    var classes = [
-      window.hassUtil.featureClassNames(stateObj, this.featureClassNames),
-    ];
-    return classes.join(' ').trim();
   },
 
   onOpenTiltTap: function (ev) {

--- a/src/components/ha-cover-tilt-controls.html
+++ b/src/components/ha-cover-tilt-controls.html
@@ -1,0 +1,110 @@
+<link rel='import' href='../../bower_components/polymer/polymer.html'>
+
+<link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel='import' href='../../bower_components/paper-slider/paper-slider.html'>
+
+<link rel='import' href='../util/cover-model.html'>
+
+<dom-module id='ha-cover-tilt-controls'>
+  <template>
+    <style is="custom-style" include="iron-flex"></style>
+    <style>
+      :host {
+        --ha-cover-tilt-controls-display: inline-block;
+        display: var(--ha-cover-tilt-controls-display);
+      }
+      
+      .tilt {
+        white-space: nowrap;
+        max-height: 0px;
+      }
+
+      .has-open_tilt .tilt,
+      .has-close_tilt .tilt,
+      .has-stop_tilt .tilt,
+      {
+        max-height: 40px;
+      }
+
+      [invisible] {
+        visibility: hidden !important;
+      }
+    </style>
+    <div class$='[[computeClassNames(stateObj)]]'>
+      <div class='tilt'>
+        <paper-icon-button icon="mdi:arrow-top-right" 
+          on-tap='onOpenTiltTap' title='Open tilt'
+          invisible$='[[!entityObj.supportsOpenTilt]]'
+          disabled='[[entityObj.isFullyOpenTilt]]'></paper-icon-button>
+        <paper-icon-button icon="mdi:stop" on-tap='onStopTiltTap'
+          invisible$='[[!entityObj.supportsStopTilt]]'
+          title='Stop tilt'></paper-icon-button>
+        <paper-icon-button icon="mdi:arrow-bottom-left"
+          on-tap='onCloseTiltTap' title='Close tilt'
+          invisible$='[[!entityObj.supportsCloseTilt]]'
+          disabled='[[entityObj.isFullyClosedTilt]]'></paper-icon-button>
+      </div>
+
+    </div>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'ha-cover-tilt-controls',
+
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    stateObj: {
+      type: Object,
+    },
+
+    entityObj: {
+      type: Object,
+      computed: 'computeEntityObj(hass, stateObj)',
+    },
+  },
+
+  computeEntityObj: function (hass, stateObj) {
+    var entity = new window.CoverEntity(hass, stateObj);
+    return entity;
+  },
+
+  featureClassNames: {
+    16: 'has-open_tilt',
+    32: 'has-close_tilt',
+    64: 'has-stop_tilt',
+  },
+
+  computeClassNames: function (stateObj) {
+    var classes = [
+      window.hassUtil.featureClassNames(stateObj, this.featureClassNames),
+    ];
+    var classString = classes.join(' ').trim();
+    if (classString === '') {
+      this.customStyle['--ha-cover-tilt-controls-display'] = 'none';
+      this.updateStyles();
+    }
+    return classString;
+  },
+
+  onOpenTiltTap: function (ev) {
+      ev.stopPropagation();
+    this.entityObj.openCoverTilt();
+  },
+
+  onCloseTiltTap: function (ev) {
+      ev.stopPropagation();
+    this.entityObj.closeCoverTilt();
+  },
+
+  onStopTiltTap: function (ev) {
+      ev.stopPropagation();
+    this.entityObj.stopCoverTilt();
+  },
+});
+</script>

--- a/src/components/ha-cover-tilt-controls.html
+++ b/src/components/ha-cover-tilt-controls.html
@@ -10,21 +10,8 @@
   <template>
     <style is="custom-style" include="iron-flex"></style>
     <style>
-      :host {
-        --ha-cover-tilt-controls-display: inline-block;
-        display: var(--ha-cover-tilt-controls-display);
-      }
-      
       .tilt {
         white-space: nowrap;
-        max-height: 0px;
-      }
-
-      .has-open_tilt .tilt,
-      .has-close_tilt .tilt,
-      .has-stop_tilt .tilt,
-      {
-        max-height: 40px;
       }
 
       [invisible] {
@@ -84,12 +71,7 @@ Polymer({
     var classes = [
       window.hassUtil.featureClassNames(stateObj, this.featureClassNames),
     ];
-    var classString = classes.join(' ').trim();
-    if (classString === '') {
-      this.customStyle['--ha-cover-tilt-controls-display'] = 'none';
-      this.updateStyles();
-    }
-    return classString;
+    return classes.join(' ').trim();
   },
 
   onOpenTiltTap: function (ev) {

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -40,7 +40,8 @@
       <div class='tilt'>
         <div>Tilt position</div>
         <div>
-          <ha-cover-tilt-controls hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
+          <ha-cover-tilt-controls hidden$="[[isTiltOnly(entityObj)]]" hass="[[hass]]" state-obj="[[stateObj]]">
+          </ha-cover-tilt-controls>
         </div>
         <paper-slider
           min='0' max='100'
@@ -81,6 +82,10 @@ Polymer({
       type: Number,
     },
 
+  },
+
+  isTiltOnly: function(entityObj) {
+    return entityObj.computeOnlyTilt();
   },
 
   computeEntityObj: function (hass, stateObj) {

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -40,7 +40,7 @@
       <div class='tilt'>
         <div>Tilt position</div>
         <div>
-          <ha-cover-tilt-controls hidden$="[[isTiltOnly(entityObj)]]" hass="[[hass]]" state-obj="[[stateObj]]">
+          <ha-cover-tilt-controls hidden$="[[entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]">
           </ha-cover-tilt-controls>
         </div>
         <paper-slider
@@ -82,10 +82,6 @@ Polymer({
       type: Number,
     },
 
-  },
-
-  isTiltOnly: function (entityObj) {
-    return entityObj.computeOnlyTilt();
   },
 
   computeEntityObj: function (hass, stateObj) {

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -84,7 +84,7 @@ Polymer({
 
   },
 
-  isTiltOnly: function(entityObj) {
+  isTiltOnly: function (entityObj) {
     return entityObj.computeOnlyTilt();
   },
 

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -15,9 +15,6 @@
         overflow: hidden;
       }
       .has-current_position .current_position,
-      .has-open_tilt .tilt,
-      .has-close_tilt .tilt,
-      .has-stop_tilt .tilt,
       .has-set_tilt_position .tilt,
       .has-current_tilt_position .tilt
       {
@@ -42,17 +39,6 @@
 
       <div class='tilt'>
         <div>Tilt position</div>
-        <paper-icon-button icon="mdi:arrow-top-right" 
-          on-tap='onOpenTiltTap' title='Open tilt'
-          invisible$='[[!entityObj.supportsOpenTilt]]'
-          disabled='[[entityObj.isFullyOpenTilt]]'></paper-icon-button>
-        <paper-icon-button icon="mdi:stop" on-tap='onStopTiltTap'
-          invisible$='[[!entityObj.supportsStopTilt]]'
-          title='Stop tilt'></paper-icon-button>
-        <paper-icon-button icon="mdi:arrow-bottom-left"
-          on-tap='onCloseTiltTap' title='Close tilt'
-          invisible$='[[!entityObj.supportsCloseTilt]]'
-          disabled='[[entityObj.isFullyClosedTilt]]'></paper-icon-button>
         <paper-slider
           min='0' max='100'
           value='{{coverTiltPositionSliderValue}}'
@@ -104,9 +90,6 @@ Polymer({
   },
 
   featureClassNames: {
-    16: 'has-open_tilt',
-    32: 'has-close_tilt',
-    64: 'has-stop_tilt',
     128: 'has-set_tilt_position',
   },
 
@@ -126,16 +109,5 @@ Polymer({
     this.entityObj.setCoverTiltPosition(ev.target.value);
   },
 
-  onOpenTiltTap: function () {
-    this.entityObj.openCoverTilt();
-  },
-
-  onCloseTiltTap: function () {
-    this.entityObj.closeCoverTilt();
-  },
-
-  onStopTiltTap: function () {
-    this.entityObj.stopCoverTilt();
-  },
 });
 </script>

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -39,6 +39,9 @@
 
       <div class='tilt'>
         <div>Tilt position</div>
+        <div>
+          <ha-cover-tilt-controls hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
+        </div>
         <paper-slider
           min='0' max='100'
           value='{{coverTiltPositionSliderValue}}'

--- a/src/state-summary/state-card-cover.html
+++ b/src/state-summary/state-card-cover.html
@@ -19,8 +19,8 @@
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
       <div class='horizontal layout'>
-        <ha-cover-controls hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
-        <ha-cover-tilt-controls hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
+        <ha-cover-controls hidden$="[[computeOnlyTilt(stateObj)]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
+        <ha-cover-tilt-controls hidden$="[[!computeOnlyTilt(stateObj)]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
       </div>
     </div>
   </template>
@@ -43,6 +43,32 @@ Polymer({
     stateObj: {
       type: Object,
     },
+
   },
+
+  tiltFeatureClassNames: {
+      16: 'has-open_tilt',
+      32: 'has-close_tilt',
+      64: 'has-stop_tilt',
+  },
+    
+  openFeatureClassNames: {
+      1: 'has-open',
+      2: 'has-close',
+      4: 'has-support_set_position',
+      8: 'has-support-stop',
+  },
+
+  computeOnlyTilt: function(stateObj) {
+      var tiltClasses = [
+        window.hassUtil.featureClassNames(stateObj, this.tiltFeatureClassNames),
+      ];
+      var tiltClassString = tiltClasses.join(' ').trim();
+      var openClasses = [
+        window.hassUtil.featureClassNames(stateObj, this.openFeatureClassNames),
+      ];
+      var openClassString = openClasses.join(' ').trim();
+      return tiltClassString != '' && openClassString == '';
+    }
 });
 </script>

--- a/src/state-summary/state-card-cover.html
+++ b/src/state-summary/state-card-cover.html
@@ -51,13 +51,13 @@ Polymer({
 
   },
 
-  isTiltOnly: function(entityObj) {
-      return entityObj.computeOnlyTilt();
+  isTiltOnly: function (entityObj) {
+    return entityObj.computeOnlyTilt();
   },
   computeEntityObj: function (hass, stateObj) {
     var entity = new window.CoverEntity(hass, stateObj);
     return entity;
   },
-  
+
 });
 </script>

--- a/src/state-summary/state-card-cover.html
+++ b/src/state-summary/state-card-cover.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../components/entity/state-info.html">
 
 <link rel="import" href="../components/ha-cover-controls.html">
+<link rel="import" href="../components/ha-cover-tilt-controls.html">
 
 <dom-module id="state-card-cover">
   <template>
@@ -17,7 +18,10 @@
 
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
-      <ha-cover-controls hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
+      <div class='horizontal layout'>
+        <ha-cover-controls hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
+        <ha-cover-tilt-controls hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
+      </div>
     </div>
   </template>
 </dom-module>

--- a/src/state-summary/state-card-cover.html
+++ b/src/state-summary/state-card-cover.html
@@ -19,8 +19,8 @@
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
       <div class='horizontal layout'>
-        <ha-cover-controls hidden$="[[isTiltOnly(entityObj)]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
-        <ha-cover-tilt-controls hidden$="[[!isTiltOnly(entityObj)]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
+        <ha-cover-controls hidden$="[[entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
+        <ha-cover-tilt-controls hidden$="[[!entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
       </div>
     </div>
   </template>
@@ -51,9 +51,6 @@ Polymer({
 
   },
 
-  isTiltOnly: function (entityObj) {
-    return entityObj.computeOnlyTilt();
-  },
   computeEntityObj: function (hass, stateObj) {
     var entity = new window.CoverEntity(hass, stateObj);
     return entity;

--- a/src/state-summary/state-card-cover.html
+++ b/src/state-summary/state-card-cover.html
@@ -19,8 +19,8 @@
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
       <div class='horizontal layout'>
-        <ha-cover-controls hidden$="[[computeOnlyTilt(stateObj)]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
-        <ha-cover-tilt-controls hidden$="[[!computeOnlyTilt(stateObj)]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
+        <ha-cover-controls hidden$="[[isTiltOnly(entityObj)]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
+        <ha-cover-tilt-controls hidden$="[[!isTiltOnly(entityObj)]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
       </div>
     </div>
   </template>
@@ -44,31 +44,20 @@ Polymer({
       type: Object,
     },
 
+    entityObj: {
+      type: Object,
+      computed: 'computeEntityObj(hass, stateObj)',
+    },
+
   },
 
-  tiltFeatureClassNames: {
-      16: 'has-open_tilt',
-      32: 'has-close_tilt',
-      64: 'has-stop_tilt',
+  isTiltOnly: function(entityObj) {
+      return entityObj.computeOnlyTilt();
   },
-    
-  openFeatureClassNames: {
-      1: 'has-open',
-      2: 'has-close',
-      4: 'has-support_set_position',
-      8: 'has-support-stop',
+  computeEntityObj: function (hass, stateObj) {
+    var entity = new window.CoverEntity(hass, stateObj);
+    return entity;
   },
-
-  computeOnlyTilt: function(stateObj) {
-      var tiltClasses = [
-        window.hassUtil.featureClassNames(stateObj, this.tiltFeatureClassNames),
-      ];
-      var tiltClassString = tiltClasses.join(' ').trim();
-      var openClasses = [
-        window.hassUtil.featureClassNames(stateObj, this.openFeatureClassNames),
-      ];
-      var openClassString = openClasses.join(' ').trim();
-      return tiltClassString != '' && openClassString == '';
-    }
+  
 });
 </script>

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -101,6 +101,32 @@
       this.callService('set_cover_tilt_position', { tilt_position: tiltPosition });
     },
 
+    tiltFeatureClassNames: {
+      16: 'has-open_tilt',
+      32: 'has-close_tilt',
+      64: 'has-stop_tilt',
+    },
+      
+    openFeatureClassNames: {
+      1: 'has-open',
+      2: 'has-close',
+      4: 'has-support_set_position',
+      8: 'has-support-stop',
+    },
+
+    computeOnlyTilt: function() {
+      var stateObj = this.stateObj;
+      var tiltClasses = [
+        window.hassUtil.featureClassNames(stateObj, this.tiltFeatureClassNames),
+      ];
+      var tiltClassString = tiltClasses.join(' ').trim();
+      var openClasses = [
+        window.hassUtil.featureClassNames(stateObj, this.openFeatureClassNames),
+      ];
+      var openClassString = openClasses.join(' ').trim();
+      return tiltClassString != '' && openClassString == '';
+    },
+
     // helper method
 
     callService(service, data) {

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -106,7 +106,7 @@
       32: 'has-close_tilt',
       64: 'has-stop_tilt',
     },
-      
+
     openFeatureClassNames: {
       1: 'has-open',
       2: 'has-close',
@@ -114,7 +114,7 @@
       8: 'has-support-stop',
     },
 
-    computeOnlyTilt: function() {
+    computeOnlyTilt: function () {
       var stateObj = this.stateObj;
       var tiltClasses = [
         window.hassUtil.featureClassNames(stateObj, this.tiltFeatureClassNames),
@@ -124,7 +124,7 @@
         window.hassUtil.featureClassNames(stateObj, this.openFeatureClassNames),
       ];
       var openClassString = openClasses.join(' ').trim();
-      return tiltClassString != '' && openClassString == '';
+      return tiltClassString !== '' && openClassString === '';
     },
 
     // helper method

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -68,15 +68,9 @@
 
   addGetter('isTiltOnly', function () {
     var stateObj = this.stateObj;
-    var tiltClasses = [
-      window.hassUtil.featureClassNames(stateObj, this.tiltFeatureClassNames),
-    ];
-    var tiltClassString = tiltClasses.join(' ').trim();
-    var openClasses = [
-      window.hassUtil.featureClassNames(stateObj, this.openFeatureClassNames),
-    ];
-    var openClassString = openClasses.join(' ').trim();
-    return tiltClassString !== '' && openClassString === '';
+    var supportsCover = this.supportsOpen || this.supportsClose || this.supportsStop;
+    var supportsTilt = this.supportsOpenTilt || this.supportsCloseTilt || this.supportsStopTilt;
+    return supportsTilt && !supportsCover;
   });
 
   /* eslint-enable no-bitwise */
@@ -112,19 +106,6 @@
 
     setCoverTiltPosition(tiltPosition) {
       this.callService('set_cover_tilt_position', { tilt_position: tiltPosition });
-    },
-
-    tiltFeatureClassNames: {
-      16: 'has-open_tilt',
-      32: 'has-close_tilt',
-      64: 'has-stop_tilt',
-    },
-
-    openFeatureClassNames: {
-      1: 'has-open',
-      2: 'has-close',
-      4: 'has-support_set_position',
-      8: 'has-support-stop',
     },
 
     // helper method

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -66,6 +66,19 @@
     return (this.stateObj.attributes.supported_features & 128) !== 0;
   });
 
+  addGetter('isTiltOnly', function () {
+    var stateObj = this.stateObj;
+    var tiltClasses = [
+      window.hassUtil.featureClassNames(stateObj, this.tiltFeatureClassNames),
+    ];
+    var tiltClassString = tiltClasses.join(' ').trim();
+    var openClasses = [
+      window.hassUtil.featureClassNames(stateObj, this.openFeatureClassNames),
+    ];
+    var openClassString = openClasses.join(' ').trim();
+    return tiltClassString !== '' && openClassString === '';
+  });
+
   /* eslint-enable no-bitwise */
 
   Object.assign(window.CoverEntity.prototype, {
@@ -112,19 +125,6 @@
       2: 'has-close',
       4: 'has-support_set_position',
       8: 'has-support-stop',
-    },
-
-    computeOnlyTilt: function () {
-      var stateObj = this.stateObj;
-      var tiltClasses = [
-        window.hassUtil.featureClassNames(stateObj, this.tiltFeatureClassNames),
-      ];
-      var tiltClassString = tiltClasses.join(' ').trim();
-      var openClasses = [
-        window.hassUtil.featureClassNames(stateObj, this.openFeatureClassNames),
-      ];
-      var openClassString = openClasses.join(' ').trim();
-      return tiltClassString !== '' && openClassString === '';
     },
 
     // helper method

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -67,7 +67,6 @@
   });
 
   addGetter('isTiltOnly', function () {
-    var stateObj = this.stateObj;
     var supportsCover = this.supportsOpen || this.supportsClose || this.supportsStop;
     var supportsTilt = this.supportsOpenTilt || this.supportsCloseTilt || this.supportsStopTilt;
     return supportsTilt && !supportsCover;


### PR DESCRIPTION
Modifying cover card to have up/down and/or tilt controls on the face of the card. 

Relies on https://github.com/home-assistant/home-assistant/pull/7841