### PR TITLE
Show value details on zwave panel

### DIFF
--- a/panels/zwave/zwave-values.html
+++ b/panels/zwave/zwave-values.html
@@ -105,7 +105,7 @@ Polymer({
   },
 
   computeSelectCaption: function (item) {
-    return item.value.label;
+    return item.value.label + ' (Instance: ' + item.value.instance + ', Index: ' + item.value.index + ')';
   },
 
   computeGetValueName: function (selectedValue) {


### PR DESCRIPTION
This PR adds additional details to the ZWave value drop down to ensure values can be disambiguated. Requires https://github.com/home-assistant/home-assistant/pull/7786

![image](https://user-images.githubusercontent.com/1386547/27204917-eede8a3a-51fb-11e7-943a-836487b5809f.png)
