### PR TITLE
Fix exception when no password is configured

### DIFF
--- a/src/layouts/login-form.html
+++ b/src/layouts/login-form.html
@@ -131,7 +131,9 @@ Polymer({
   isValidatingChanged: function (newVal) {
     if (!newVal) {
       this.async(function () {
-        this.$.passwordInput.inputElement.inputElement.focus();
+        if (this.$.passwordInput.inputElement.inputElement) {
+          this.$.passwordInput.inputElement.inputElement.focus();
+        }
       }.bind(this), 10);
     }
   },


### PR DESCRIPTION
It looks like when there is no password configured, this element is never completely rendered, causing an exception when trying to focus after Home Assistant successfully connects. I reproduced the behavior in Firefox and Chrome.