### PR TITLE
Use yarn on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   - node_modules
   - bower_components
 install:
-  - npm install
+  - yarn install
   - bower install
 addons:
   firefox: latest


### PR DESCRIPTION
This changes the travis build to use yarn for package installation. It looks like there are still further issues but this at least gets it past the installation stage.