### PR TITLE
Add support for kiosk mode

### DIFF
--- a/panels/kiosk/ha-panel-kiosk.html
+++ b/panels/kiosk/ha-panel-kiosk.html
@@ -1,0 +1,26 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+
+<link rel='import' href='../../src/layouts/partial-cards.html'>
+
+<dom-module id="ha-panel-kiosk">
+  <template>
+    <partial-cards
+            id='kiosk-states'
+            hass='[[hass]]'
+            show-menu
+            route='[[route]]'
+            panel-visible
+    ></partial-cards>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'ha-panel-kiosk',
+
+  properties: {
+    hass: Object,
+    route: Object,
+  },
+});
+</script>

--- a/src/layouts/home-assistant-main.html
+++ b/src/layouts/home-assistant-main.html
@@ -26,6 +26,11 @@
       data="{{routeData}}"
       tail="{{routeTail}}"
     ></app-route>
+    <app-route
+      route="{{route}}"
+      pattern="/states"
+      tail="{{statesRouteTail}}"
+    ></app-route>
     <ha-voice-command-dialog
       hass='[[hass]]'
       id='voiceDialog'
@@ -56,7 +61,8 @@
           narrow='[[narrow]]'
           hass='[[hass]]'
           show-menu='[[dockedSidebar]]'
-          route='[[route]]'
+          route='[[statesRouteTail]]'
+          show-tabs
         ></partial-cards>
 
         <partial-panel-resolver
@@ -88,6 +94,7 @@ Polymer({
     },
     routeData: Object,
     routeTail: Object,
+    statesRouteTail: Object,
 
     dockedSidebar: {
       type: Boolean,

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -38,23 +38,19 @@
     </style>
     <app-route
       route="{{route}}"
-      pattern="/states/:view"
+      pattern="/:view"
       data="{{routeData}}"
       active="{{routeMatch}}"
     ></app-route>
     <app-header-layout has-scrolling-region id='layout'>
       <app-header effects="waterfall" condenses fixed slot="header">
         <app-toolbar>
-          <ha-menu-button
-              narrow='[[narrow]]'
-              show-menu='[[showMenu]]'
-              hidden$='[[isSidebarHidden()]]'>
-          </ha-menu-button>
+          <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
           <div main-title>[[computeTitle(views, locationName)]]</div>
           <ha-start-voice-button hass='[[hass]]'></ha-start-voice-button>
         </app-toolbar>
 
-        <div sticky hidden$='[[areTabsHidden(views)]]'>
+        <div sticky hidden$='[[areTabsHidden(views, showTabs)]]'>
           <paper-tabs
             scrollable
             selected='[[currentView]]'
@@ -199,6 +195,11 @@ Polymer({
       type: Object,
       computed: 'computeViewStates(currentView, hass, defaultView)',
     },
+
+    showTabs: {
+      type: Boolean,
+      value: false,
+    },
   },
 
   created: function () {
@@ -208,8 +209,6 @@ Polymer({
       mql.addListener(this.handleWindowChange);
       return mql;
     }.bind(this));
-    this._isKiosk = new URLSearchParams(
-        document.location.search.substring(1)).has('kiosk');
   },
 
   detached: function () {
@@ -226,12 +225,8 @@ Polymer({
     this._columns = Math.max(1, matchColumns - (!this.narrow && this.showMenu));
   },
 
-  areTabsHidden: function (views) {
-    return !views.length || this._isKiosk;
-  },
-
-  isSidebarHidden: function () {
-    return this._isKiosk;
+  areTabsHidden: function (views, showTabs) {
+    return !views.length || !showTabs;
   },
 
   /**
@@ -319,6 +314,7 @@ Polymer({
   },
 
   hassChanged: function (hass) {
+    if (!hass) return;
     var views = window.HAWS.extractViews(hass.states);
     // If default view present, it's in first index.
     if (views.length > 0 && views[0].entity_id === this.DEFAULT_VIEW_ENTITY_ID) {

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -45,12 +45,16 @@
     <app-header-layout has-scrolling-region id='layout'>
       <app-header effects="waterfall" condenses fixed slot="header">
         <app-toolbar>
-          <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
+          <ha-menu-button
+              narrow='[[narrow]]'
+              show-menu='[[showMenu]]'
+              hidden$='[[isSidebarHidden()]]'>
+          </ha-menu-button>
           <div main-title>[[computeTitle(views, locationName)]]</div>
           <ha-start-voice-button hass='[[hass]]'></ha-start-voice-button>
         </app-toolbar>
 
-        <div sticky hidden$='[[!views.length]]'>
+        <div sticky hidden$='[[areTabsHidden(views)]]'>
           <paper-tabs
             scrollable
             selected='[[currentView]]'
@@ -204,6 +208,8 @@ Polymer({
       mql.addListener(this.handleWindowChange);
       return mql;
     }.bind(this));
+    this._isKiosk = new URLSearchParams(
+        document.location.search.substring(1)).has('kiosk');
   },
 
   detached: function () {
@@ -218,6 +224,14 @@ Polymer({
     }, 0);
     // Do -1 column if the menu is docked and open
     this._columns = Math.max(1, matchColumns - (!this.narrow && this.showMenu));
+  },
+
+  areTabsHidden: function (views) {
+    return !views.length || this._isKiosk;
+  },
+
+  isSidebarHidden: function () {
+    return this._isKiosk;
   },
 
   /**

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -466,11 +466,11 @@ window.hassUtil.computeStateState = function (stateObj) {
 };
 
 window.hassUtil.isComponentLoaded = function (hass, component) {
-  return hass.config.core.components.indexOf(component) !== -1;
+  return hass && hass.config.core.components.indexOf(component) !== -1;
 };
 
 window.hassUtil.computeLocationName = function (hass) {
-  return hass.config.core.location_name;
+  return hass && hass.config.core.location_name;
 };
 
 </script>


### PR DESCRIPTION
Kiosk mode activated when the url is of type
`https://example.com:8123/states/group.group_name?kiosk`

Hides tabs, hides sidebar.

Possible future improvement: Serve a custom manifest.json to allow kiosk-mode shortcut installation.