### PR TITLE
Fix history showing extra points.

### DIFF
--- a/src/components/state-history-chart-line.html
+++ b/src/components/state-history-chart-line.html
@@ -147,11 +147,17 @@
         dataTable.addColumn({ type: 'datetime', id: 'Time' });
 
         function pushData(values, noInterpolationValues) {
+          var timestamp = values[0];
+          if (timestamp > endTime) {
+            // Drop datapoints that are after the requested endTime. This could happen if
+            // endTime is "now" and client time is not in sync with server time.
+            return;
+          }
           if (prevValues && noInterpolationValues) {
             // if we have to prevent interpolation, we add an old value for each
             // value that should not be interpolated at the same time that our new
             // line will be published.
-            data.push([values[0]].concat(prevValues.slice(1).map(
+            data.push([timestamp].concat(prevValues.slice(1).map(
               function (val, index) {
                 return noInterpolationValues[index] ? val : null;
               })));
@@ -160,44 +166,7 @@
           prevValues = values;
         }
 
-        if (domain === 'thermostat') {
-          // We differentiate between thermostats that have a target temperature
-          // range versus ones that have just a target temperature
-          hasTargetRange = states.reduce(
-            function (cum, cur) {
-              return cum || cur.attributes.target_temp_high !== cur.attributes.target_temp_low;
-            }, false);
-
-          dataTable.addColumn('number', name + ' current temperature');
-
-          if (hasTargetRange) {
-            dataTable.addColumn('number', name + ' target temperature high');
-            dataTable.addColumn('number', name + ' target temperature low');
-
-            noInterpolations = [false, true, true];
-
-            processState = function (state) {
-              var curTemp = saveParseFloat(state.attributes.current_temperature);
-              var targetHigh = saveParseFloat(state.attributes.target_temp_high);
-              var targetLow = saveParseFloat(state.attributes.target_temp_low);
-              pushData(
-                [new Date(state.last_updated), curTemp, targetHigh, targetLow],
-                noInterpolations);
-            };
-          } else {
-            dataTable.addColumn('number', name + ' target temperature');
-
-            noInterpolations = [false, true];
-
-            processState = function (state) {
-              var curTemp = saveParseFloat(state.attributes.current_temperature);
-              var target = saveParseFloat(state.attributes.temperature);
-              pushData([new Date(state.last_updated), curTemp, target], noInterpolations);
-            };
-          }
-
-          states.forEach(processState);
-        } else if (domain === 'climate') {
+        if (domain === 'thermostat' || domain === 'climate') {
           // We differentiate between thermostats that have a target temperature
           // range versus ones that have just a target temperature
           hasTargetRange = states.reduce(

--- a/src/components/state-history-chart-timeline.html
+++ b/src/components/state-history-chart-timeline.html
@@ -112,6 +112,12 @@ Polymer({
       entityDisplay = window.hassUtil.computeStateName(stateInfo[0]);
 
       stateInfo.forEach(function (state) {
+        var timeStamp = new Date(state.last_changed);
+        if (timeStamp > endTime) {
+          // Drop datapoints that are after the requested endTime. This could happen if
+          // endTime is "now" and client time is not in sync with server time.
+          return;
+        }
         if (prevState !== null && state.state !== prevState) {
           newLastChanged = new Date(state.last_changed);
 

--- a/src/data/ha-state-history-data.html
+++ b/src/data/ha-state-history-data.html
@@ -6,7 +6,7 @@
   var DATE_CACHE = {};
   var RECENT_CACHE = {};
 
-  function computeHistory(stateHistory, endTime) {
+  function computeHistory(stateHistory) {
     var lineChartDevices = {};
     var timelineDevices = [];
     var unitStates;
@@ -22,14 +22,6 @@
       if (stateInfo.size === 0) {
         return;
       }
-
-      // Duplicate the last state to the selected endTime so the chart expands
-      // to the end of the selected time. (If no additional state changes were
-      // found, the state was still the last state as of the end time.
-      var lastState = Object.assign({}, stateInfo[stateInfo.length - 1]);
-      lastState.last_changed = endTime;
-      lastState.last_updated = endTime;
-      stateInfo.push(lastState);
 
       stateWithUnit = stateInfo.find(
         function (state) { return 'unit_of_measurement' in state.attributes; });
@@ -145,7 +137,7 @@
 
       var prom = this.hass.callApi('GET', url).then(
         function (stateHistory) {
-          return computeHistory(stateHistory, Date.now());
+          return computeHistory(stateHistory);
         },
         function () {
           RECENT_CACHE[entityId] = false;
@@ -166,7 +158,7 @@
       if (!DATE_CACHE[filter]) {
         DATE_CACHE[filter] = this.hass.callApi('GET', 'history/period/' + filter).then(
           function (stateHistory) {
-            return computeHistory(stateHistory, endTime);
+            return computeHistory(stateHistory);
           },
           function () {
             DATE_CACHE[filter] = false;


### PR DESCRIPTION
Fix history showing extra points.

History data used to duplicate the last point (sometimes beyond "now")
In addition both timeline and line added extra last point.

This PR removes the extra data point and fixes timeline and line not to log points after "now" (could be due to client-server time mismatch)