### PR TITLE
Move ha styles from html to body

### DIFF
--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -2,7 +2,7 @@
 
 <custom-style>
 <style is="custom-style">/* remove is= on Polymer 2 */
-  html {
+  body {
     font-size: 14px;
 
     /* for paper-toggle-button */


### PR DESCRIPTION
Move ha styles from `html` tag to `body` tag.

`paper-styles/default-theme.html` (and maybe others) also set styles on `html`.
Ha styles are loaded later, so everything looks fine on `/states` or initially loaded panel. However when we switch panel - more sources are loaded including a source that brings `paper-styles/default-theme.html` again, causing it to be "last" css rule.

Moving ha-style to body will make sure it takes precedence.

Fixes #340 