### PR TITLE
Covers - Removed disable buttons

### DIFF
--- a/src/components/ha-cover-controls.html
+++ b/src/components/ha-cover-controls.html
@@ -15,28 +15,14 @@
     </style>
 
     <div class='state'>
-      <template is='dom-if' if='[[entityObj.assumeState]]'>
-        <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
-          invisible$='[[!entityObj.supportsOpen]]'></paper-icon-button>
-      </template>
-      <template is='dom-if' if='[[!entityObj.assumeState]]'>
-        <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
-          invisible$='[[!entityObj.supportsOpen]]'
-          disabled='[[entityObj.isFullyOpen]]'></paper-icon-button>
-      </template>
-
+      <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
+        invisible$='[[!entityObj.supportsOpen]]'
+        disabled='[[entityObj.disableButtonFullyOpen]]'></paper-icon-button>
       <paper-icon-button icon="mdi:stop" on-tap='onStopTap'
         invisible$='[[!entityObj.supportsStop]]'></paper-icon-button>
-
-      <template is='dom-if' if='[[entityObj.assumeState]]'>
-        <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
-          invisible$='[[!entityObj.supportsClose]]'></paper-icon-button>
-      </template>
-      <template is='dom-if' if='[[!entityObj.assumeState]]'>
-        <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
+      <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
         invisible$='[[!entityObj.supportsClose]]'
-        disabled='[[entityObj.isFullyClosed]]'></paper-icon-button>
-      </template>
+        disabled='[[entityObj.disableButtonFullyClosed]]'></paper-icon-button>
     </div>
   </template>
 </dom-module>

--- a/src/components/ha-cover-controls.html
+++ b/src/components/ha-cover-controls.html
@@ -17,12 +17,12 @@
     <div class='state'>
       <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
         invisible$='[[!entityObj.supportsOpen]]'
-        disabled='[[entityObj.disableButtonFullyOpen]]'></paper-icon-button>
+        disabled='[[computeOpenDisabled(stateObj, entityObj)]]'></paper-icon-button>
       <paper-icon-button icon="mdi:stop" on-tap='onStopTap'
         invisible$='[[!entityObj.supportsStop]]'></paper-icon-button>
       <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
         invisible$='[[!entityObj.supportsClose]]'
-        disabled='[[entityObj.disableButtonFullyClosed]]'></paper-icon-button>
+        disabled='[[computeClosedDisabled(stateObj, entityObj)]]'></paper-icon-button>
     </div>
   </template>
 </dom-module>
@@ -44,6 +44,14 @@ Polymer({
   },
   computeEntityObj: function (hass, stateObj) {
     return new window.CoverEntity(hass, stateObj);
+  },
+  computeOpenDisabled: function (stateObj, entityObj) {
+  	assumedState = stateObj.attributes.assumed_state === true;
+  	return entityObj.isFullyOpen && !assumedState;
+  },
+  computeClosedDisabled: function (stateObj, entityObj) {
+  	assumedState = (stateObj.attributes.assumed_state === true);
+  	return entityObj.isFullyClosed && !assumedState;
   },
   onOpenTap: function (ev) {
     ev.stopPropagation();

--- a/src/components/ha-cover-controls.html
+++ b/src/components/ha-cover-controls.html
@@ -46,12 +46,12 @@ Polymer({
     return new window.CoverEntity(hass, stateObj);
   },
   computeOpenDisabled: function (stateObj, entityObj) {
-  	assumedState = stateObj.attributes.assumed_state === true;
-  	return entityObj.isFullyOpen && !assumedState;
+    var assumedState = stateObj.attributes.assumed_state === true;
+    return entityObj.isFullyOpen && !assumedState;
   },
   computeClosedDisabled: function (stateObj, entityObj) {
-  	assumedState = (stateObj.attributes.assumed_state === true);
-  	return entityObj.isFullyClosed && !assumedState;
+    var assumedState = (stateObj.attributes.assumed_state === true);
+    return entityObj.isFullyClosed && !assumedState;
   },
   onOpenTap: function (ev) {
     ev.stopPropagation();

--- a/src/components/ha-cover-controls.html
+++ b/src/components/ha-cover-controls.html
@@ -15,12 +15,28 @@
     </style>
 
     <div class='state'>
-      <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
-        invisible$='[[!entityObj.supportsOpen]]'></paper-icon-button>
+      <template is='dom-if' if='[[entityObj.assumeState]]'>
+        <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
+          invisible$='[[!entityObj.supportsOpen]]'></paper-icon-button>
+      </template>
+      <template is='dom-if' if='[[!entityObj.assumeState]]'>
+        <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
+          invisible$='[[!entityObj.supportsOpen]]'
+          disabled='[[entityObj.isFullyOpen]]'></paper-icon-button>
+      </template>
+
       <paper-icon-button icon="mdi:stop" on-tap='onStopTap'
         invisible$='[[!entityObj.supportsStop]]'></paper-icon-button>
-      <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
-        invisible$='[[!entityObj.supportsClose]]'></paper-icon-button>
+
+      <template is='dom-if' if='[[entityObj.assumeState]]'>
+        <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
+          invisible$='[[!entityObj.supportsClose]]'></paper-icon-button>
+      </template>
+      <template is='dom-if' if='[[!entityObj.assumeState]]'>
+        <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
+        invisible$='[[!entityObj.supportsClose]]'
+        disabled='[[entityObj.isFullyClosed]]'></paper-icon-button>
+      </template>
     </div>
   </template>
 </dom-module>

--- a/src/components/ha-cover-controls.html
+++ b/src/components/ha-cover-controls.html
@@ -16,13 +16,11 @@
 
     <div class='state'>
       <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
-        invisible$='[[!entityObj.supportsOpen]]'
-        disabled='[[entityObj.isFullyOpen]]'></paper-icon-button>
+        invisible$='[[!entityObj.supportsOpen]]'></paper-icon-button>
       <paper-icon-button icon="mdi:stop" on-tap='onStopTap'
         invisible$='[[!entityObj.supportsStop]]'></paper-icon-button>
       <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
-        invisible$='[[!entityObj.supportsClose]]'
-        disabled='[[entityObj.isFullyClosed]]'></paper-icon-button>
+        invisible$='[[!entityObj.supportsClose]]'></paper-icon-button>
     </div>
   </template>
 </dom-module>

--- a/src/components/ha-cover-tilt-controls.html
+++ b/src/components/ha-cover-tilt-controls.html
@@ -47,15 +47,14 @@ Polymer({
     },
   },
   computeEntityObj: function (hass, stateObj) {
-    var entity = new window.CoverEntity(hass, stateObj);
-    return entity;
+    return new window.CoverEntity(hass, stateObj);
   },
   computeOpenDisabled: function (stateObj, entityObj) {
-    assumedState = stateObj.attributes.assumed_state === true;
+    var assumedState = stateObj.attributes.assumed_state === true;
     return entityObj.isFullyOpenTilt && !assumedState;
   },
   computeClosedDisabled: function (stateObj, entityObj) {
-    assumedState = (stateObj.attributes.assumed_state === true);
+    var assumedState = (stateObj.attributes.assumed_state === true);
     return entityObj.isFullyClosedTilt && !assumedState;
   },
   onOpenTiltTap: function (ev) {

--- a/src/components/ha-cover-tilt-controls.html
+++ b/src/components/ha-cover-tilt-controls.html
@@ -13,7 +13,6 @@
       :host {
         white-space: nowrap;
       }
-
       [invisible] {
         visibility: hidden !important;
       }
@@ -21,51 +20,52 @@
     <paper-icon-button icon="mdi:arrow-top-right" 
       on-tap='onOpenTiltTap' title='Open tilt'
       invisible$='[[!entityObj.supportsOpenTilt]]'
-      disabled='[[entityObj.disableButtonFullyOpenTilt]]'></paper-icon-button>
+      disabled='[[computeOpenDisabled(stateObj, entityObj)]]'></paper-icon-button>
     <paper-icon-button icon="mdi:stop" on-tap='onStopTiltTap'
       invisible$='[[!entityObj.supportsStopTilt]]'
       title='Stop tilt'></paper-icon-button>
     <paper-icon-button icon="mdi:arrow-bottom-left"
       on-tap='onCloseTiltTap' title='Close tilt'
       invisible$='[[!entityObj.supportsCloseTilt]]'
-      disabled='[[entityObj.disableButtonFullyClosedTilt]]'></paper-icon-button>
+      disabled='[[computeClosedDisabled(stateObj, entityObj)]]'></paper-icon-button>
   </template>
 </dom-module>
 
 <script>
 Polymer({
   is: 'ha-cover-tilt-controls',
-
   properties: {
     hass: {
       type: Object,
     },
-
     stateObj: {
       type: Object,
     },
-
     entityObj: {
       type: Object,
       computed: 'computeEntityObj(hass, stateObj)',
     },
   },
-
   computeEntityObj: function (hass, stateObj) {
     var entity = new window.CoverEntity(hass, stateObj);
     return entity;
   },
-
+  computeOpenDisabled: function (stateObj, entityObj) {
+    assumedState = stateObj.attributes.assumed_state === true;
+    return entityObj.isFullyOpenTilt && !assumedState;
+  },
+  computeClosedDisabled: function (stateObj, entityObj) {
+    assumedState = (stateObj.attributes.assumed_state === true);
+    return entityObj.isFullyClosedTilt && !assumedState;
+  },
   onOpenTiltTap: function (ev) {
     ev.stopPropagation();
     this.entityObj.openCoverTilt();
   },
-
   onCloseTiltTap: function (ev) {
     ev.stopPropagation();
     this.entityObj.closeCoverTilt();
   },
-
   onStopTiltTap: function (ev) {
     ev.stopPropagation();
     this.entityObj.stopCoverTilt();

--- a/src/components/ha-cover-tilt-controls.html
+++ b/src/components/ha-cover-tilt-controls.html
@@ -21,14 +21,14 @@
     <paper-icon-button icon="mdi:arrow-top-right" 
       on-tap='onOpenTiltTap' title='Open tilt'
       invisible$='[[!entityObj.supportsOpenTilt]]'
-      disabled='[[entityObj.isFullyOpenTilt]]'></paper-icon-button>
+      disabled='[[entityObj.disableButtonFullyOpenTilt]]'></paper-icon-button>
     <paper-icon-button icon="mdi:stop" on-tap='onStopTiltTap'
       invisible$='[[!entityObj.supportsStopTilt]]'
       title='Stop tilt'></paper-icon-button>
     <paper-icon-button icon="mdi:arrow-bottom-left"
       on-tap='onCloseTiltTap' title='Close tilt'
       invisible$='[[!entityObj.supportsCloseTilt]]'
-      disabled='[[entityObj.isFullyClosedTilt]]'></paper-icon-button>
+      disabled='[[entityObj.disableButtonFullyClosedTilt]]'></paper-icon-button>
   </template>
 </dom-module>
 

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -36,19 +36,19 @@
     return this.stateObj.attributes.assumed_state === true;
   });
 
-  addGetter('disableButtonFullyOpen', function() {
+  addGetter('disableButtonFullyOpen', function () {
     return this.isFullyOpen && !this.assumeState;
   });
 
-  addGetter('disableButtonFullyClosed', function() {
+  addGetter('disableButtonFullyClosed', function () {
     return this.isFullyClosed && !this.assumeState;
   });
 
-  addGetter('disableButtonFullyOpenTilt', function() {
+  addGetter('disableButtonFullyOpenTilt', function () {
     return this.isFullyOpenTilt && !this.assumeState;
   });
 
-  addGetter('disableButtonFullyClosedTilt', function() {
+  addGetter('disableButtonFullyClosedTilt', function () {
     return this.isFullyClosedTilt && !this.assumeState;
   });
 

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -31,10 +31,10 @@
   addGetter('isFullyClosedTilt', function () {
     return this.stateObj.attributes.current_tilt_position === 0;
   });
-  
+
   addGetter('assumeState', function () {
     return this.stateObj.attributes.assumed_state === true;
-  })
+  });
 
   /* eslint-disable no-bitwise */
 

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -72,7 +72,6 @@
     return supportsTilt && !supportsCover;
   });
 
-
   /* eslint-enable no-bitwise */
 
   Object.assign(window.CoverEntity.prototype, {

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -32,26 +32,6 @@
     return this.stateObj.attributes.current_tilt_position === 0;
   });
 
-  addGetter('assumeState', function () {
-    return this.stateObj.attributes.assumed_state === true;
-  });
-
-  addGetter('disableButtonFullyOpen', function () {
-    return this.isFullyOpen && !this.assumeState;
-  });
-
-  addGetter('disableButtonFullyClosed', function () {
-    return this.isFullyClosed && !this.assumeState;
-  });
-
-  addGetter('disableButtonFullyOpenTilt', function () {
-    return this.isFullyOpenTilt && !this.assumeState;
-  });
-
-  addGetter('disableButtonFullyClosedTilt', function () {
-    return this.isFullyClosedTilt && !this.assumeState;
-  });
-
   /* eslint-disable no-bitwise */
 
   addGetter('supportsOpen', function () {
@@ -91,6 +71,7 @@
     var supportsTilt = this.supportsOpenTilt || this.supportsCloseTilt || this.supportsStopTilt;
     return supportsTilt && !supportsCover;
   });
+
 
   /* eslint-enable no-bitwise */
 

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -36,6 +36,22 @@
     return this.stateObj.attributes.assumed_state === true;
   });
 
+  addGetter('disableButtonFullyOpen', function() {
+    return this.isFullyOpen && !this.assumeState;
+  });
+
+  addGetter('disableButtonFullyClosed', function() {
+    return this.isFullyClosed && !this.assumeState;
+  });
+
+  addGetter('disableButtonFullyOpenTilt', function() {
+    return this.isFullyOpenTilt && !this.assumeState;
+  });
+
+  addGetter('disableButtonFullyClosedTilt', function() {
+    return this.isFullyClosedTilt && !this.assumeState;
+  });
+
   /* eslint-disable no-bitwise */
 
   addGetter('supportsOpen', function () {

--- a/src/util/cover-model.html
+++ b/src/util/cover-model.html
@@ -31,6 +31,10 @@
   addGetter('isFullyClosedTilt', function () {
     return this.stateObj.attributes.current_tilt_position === 0;
   });
+  
+  addGetter('assumeState', function () {
+    return this.stateObj.attributes.assumed_state === true;
+  })
 
   /* eslint-disable no-bitwise */
 


### PR DESCRIPTION
Allow commands being send even if cover is open or closed. Important for cover template when using multiple covers or in end positions when cover registered as open/closed but isn't due to tolerance.

Example for multiple covers: https://github.com/home-assistant/home-assistant.github.io/pull/3013