### PR TITLE
Allow customUI on 'unavailable' state too.

### DIFF
--- a/src/state-summary/state-card-content.html
+++ b/src/state-summary/state-card-content.html
@@ -48,7 +48,7 @@ Polymer({
   inputChanged: function (hass, inDialog, stateObj) {
     var stateCardType;
     if (!stateObj || !hass) return;
-    if (stateObj.state !== 'unavailable' && 'custom_ui_state_card' in stateObj.attributes) {
+    if (stateObj.attributes && 'custom_ui_state_card' in stateObj.attributes) {
       stateCardType = stateObj.attributes.custom_ui_state_card;
       this._ensureCustomUILoaded(stateCardType);
     } else {


### PR DESCRIPTION
Allow customUI on 'unavailable' state too.

There is no reason for this limitation.
Related: https://github.com/andrey-git/home-assistant-custom-ui/issues/24