### PR TITLE
Variable colours (cards, backgrounds, sidebar, ...)

### DIFF
--- a/panels/dev-service/ha-panel-dev-service.html
+++ b/panels/dev-service/ha-panel-dev-service.html
@@ -49,7 +49,11 @@
       }
 
       .attributes tr:nth-child(even) {
-        background-color: var(--paper-listbox-background-color,#eee)
+        background-color: var(--table-row-alternative-background-color,#eee)
+      }
+
+      .attributes tr:nth-child(odd) {
+        background-color: var(--table-row-background-color,#eee)
       }
 
       .attributes td:nth-child(3) {

--- a/panels/dev-service/ha-panel-dev-service.html
+++ b/panels/dev-service/ha-panel-dev-service.html
@@ -48,12 +48,12 @@
         vertical-align: top;
       }
 
-      .attributes tr:nth-child(even) {
-        background-color: var(--table-row-alternative-background-color,#eee)
-      }
-
       .attributes tr:nth-child(odd) {
         background-color: var(--table-row-background-color,#eee)
+      }
+
+      .attributes tr:nth-child(even) {
+        background-color: var(--table-row-alternative-background-color,#eee)
       }
 
       .attributes td:nth-child(3) {

--- a/panels/dev-service/ha-panel-dev-service.html
+++ b/panels/dev-service/ha-panel-dev-service.html
@@ -49,7 +49,7 @@
       }
 
       .attributes tr:nth-child(even) {
-        background-color: #eee;
+        background-color: var(--paper-listbox-background-color,#eee)
       }
 
       .attributes td:nth-child(3) {

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -34,11 +34,11 @@
       }
 
       .entities tr:nth-child(odd) {
-        background-color: var(--table-row-background-color,#eee)
+        background-color: var(--table-row-background-color, #fff)
       }
 
       .entities tr:nth-child(even) {
-        background-color: var(--table-row-alternative-background-color,#eee)
+        background-color: var(--table-row-alternative-background-color, #eee)
       }
 
       .entities td:nth-child(3) {

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -33,8 +33,12 @@
         vertical-align: top;
       }
 
+      .entities tr:nth-child(odd) {
+        background-color: var(--table-row-background-color,#eee)
+      }
+
       .entities tr:nth-child(even) {
-        background-color: #eee;
+        background-color: var(--table-row-alternative-background-color,#eee)
       }
 
       .entities td:nth-child(3) {

--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -112,7 +112,7 @@
         padding: 8px;
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
-        background-color: white;
+        background-color: var(--primary-background-color);
       }
 
       .controls paper-icon-button {

--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -112,7 +112,7 @@
         padding: 8px;
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
-        background-color: var(--primary-background-color);
+        background-color: var(--primary-background-color, white);
       }
 
       .controls paper-icon-button {

--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -112,7 +112,7 @@
         padding: 8px;
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
-        background-color: var(--primary-background-color, white);
+        background-color: var(--paper-card-background-color, white);
       }
 
       .controls paper-icon-button {

--- a/src/components/entity/ha-state-label-badge.html
+++ b/src/components/entity/ha-state-label-badge.html
@@ -10,19 +10,27 @@
       }
 
       ha-label-badge {
-        --ha-label-badge-color: var(--label-red);
+        --ha-label-badge-color: var(--label-badge-red, #DF4C1E);
+      }
+
+      .red {
+        --ha-label-badge-color: var(--label-badge-red, #DF4C1E);
       }
 
       .blue {
-        --ha-label-badge-color: var(--label-blue);
+        --ha-label-badge-color: var(--label-badge-blue, #039be5);
       }
 
       .green {
-        --ha-label-badge-color: var(--label-green);
+        --ha-label-badge-color: var(--label-badge-green, #0DA035);
+      }
+
+      .yellow {
+        --ha-label-badge-color: var(--label-badge-yellow, #f4b400);
       }
 
       .grey {
-        --ha-label-badge-color: var(--label-grey);
+        --ha-label-badge-color: var(--label-badge-grey, --paper-grey-500);
       }
     </style>
 

--- a/src/components/entity/ha-state-label-badge.html
+++ b/src/components/entity/ha-state-label-badge.html
@@ -10,19 +10,19 @@
       }
 
       ha-label-badge {
-        --ha-label-badge-color: rgb(223, 76, 30);
+        --ha-label-badge-color: var(--label-red);
       }
 
       .blue {
-        --ha-label-badge-color: #039be5;
+        --ha-label-badge-color: var(--label-blue);
       }
 
       .green {
-        --ha-label-badge-color: #0DA035;
+        --ha-label-badge-color: var(--label-green);
       }
 
       .grey {
-        --ha-label-badge-color: var(--paper-grey-500);
+        --ha-label-badge-color: var(--label-grey);
       }
     </style>
 

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -9,7 +9,7 @@
       position: relative;
       display: inline-block;
       width: 40px;
-      color: #44739E;
+      color: var(--paper-item-icon-color, #44739e);
       border-radius: 50%;
       height: 40px;
       text-align: center;
@@ -26,7 +26,7 @@
     ha-state-icon[data-domain=switch][data-state=on],
     ha-state-icon[data-domain=binary_sensor][data-state=on],
     ha-state-icon[data-domain=sun][data-state=above_horizon] {
-      color: #FDD835;
+      color: var(--paper-item-icon-active-color, #FDD835);
     }
 
     /* Color the icon if unavailable */

--- a/src/components/ha-card.html
+++ b/src/components/ha-card.html
@@ -9,7 +9,7 @@
         border-radius: 2px;
         transition: all 0.30s ease-out;
 
-        background-color: var(--primary-background-color, white);
+        background-color: var(--paper-card-background-color, white);
       }
       .header {
         @apply(--paper-font-headline);

--- a/src/components/ha-card.html
+++ b/src/components/ha-card.html
@@ -9,7 +9,7 @@
         border-radius: 2px;
         transition: all 0.30s ease-out;
 
-        background-color: white;
+        background-color: var(--primary-background-color);
       }
       .header {
         @apply(--paper-font-headline);

--- a/src/components/ha-card.html
+++ b/src/components/ha-card.html
@@ -9,7 +9,7 @@
         border-radius: 2px;
         transition: all 0.30s ease-out;
 
-        background-color: var(--primary-background-color);
+        background-color: var(--primary-background-color, white);
       }
       .header {
         @apply(--paper-font-headline);

--- a/src/components/ha-label-badge.html
+++ b/src/components/ha-label-badge.html
@@ -23,7 +23,7 @@
       color: var(--badge-text-color, rgb(76, 76, 76));
 
       white-space: nowrap;
-      background-color: var(--badge-background-color, white);
+      background-color: var(--label-badge-background-color, white);
       background-size: cover;
       transition: border .3s ease-in-out;
     }

--- a/src/components/ha-label-badge.html
+++ b/src/components/ha-label-badge.html
@@ -20,7 +20,7 @@
       font-size: var(--ha-label-badge-font-size, 1.5em);
       border-radius: 50%;
       border: 0.1em solid var(--ha-label-badge-color, --primary-color);
-      color: var(--badge-text-color, rgb(76, 76, 76));
+      color: var(--label-badge-text-color, rgb(76, 76, 76));
 
       white-space: nowrap;
       background-color: var(--label-badge-background-color, white);

--- a/src/components/ha-label-badge.html
+++ b/src/components/ha-label-badge.html
@@ -20,10 +20,10 @@
       font-size: var(--ha-label-badge-font-size, 1.5em);
       border-radius: 50%;
       border: 0.1em solid var(--ha-label-badge-color, --primary-color);
-      color: rgb(76, 76, 76);
+      color: var(--badge-text-color, rgb(76, 76, 76));
 
       white-space: nowrap;
-      background-color: white;
+      background-color: var(--badge-background-color, white);
       background-size: cover;
       transition: border .3s ease-in-out;
     }

--- a/src/components/ha-sidebar.html
+++ b/src/components/ha-sidebar.html
@@ -25,6 +25,7 @@
         -webkit-user-select: none;
         -moz-user-select: none;
         border-right: 1px solid var(--divider-color);
+        background: var(--paper-listbox-background-color,var(--primary-background-color));
       }
 
       app-toolbar {

--- a/src/layouts/home-assistant-main.html
+++ b/src/layouts/home-assistant-main.html
@@ -18,6 +18,11 @@
 
 <dom-module id='home-assistant-main'>
   <template>
+    <style>
+      :host {
+	      color: var(--primary-text-color);
+      }
+    </style>
     <more-info-dialog hass='[[hass]]'></more-info-dialog>
     <ha-url-sync hass='[[hass]]'></ha-url-sync>
     <app-location route="{{route}}"></app-location>

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -27,7 +27,7 @@
       }
 
       app-header-layout {
-        background-color: var(--secondary-background-color, #E5E5E5);
+        background-color: var(--paper-card-background-color, #E5E5E5);
       }
 
       paper-tabs {

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -27,7 +27,7 @@
       }
 
       app-header-layout {
-        background-color: var(--paper-card-background-color, #E5E5E5);
+        background-color: var(--secondary-background-color, #E5E5E5);
       }
 
       paper-tabs {

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -27,7 +27,7 @@
       }
 
       app-header-layout {
-        background-color: #E5E5E5;
+        background-color: var(--paper-grey-200);
       }
 
       paper-tabs {

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -27,7 +27,7 @@
       }
 
       app-header-layout {
-        background-color: var(--paper-grey-200);
+        background-color: var(--secondary-background-color, #E5E5E5);
       }
 
       paper-tabs {

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -15,6 +15,7 @@
     --text-primary-color: #ffffff;
     --accent-color: #FF9800;
     --primary-background-color: var(--paper-grey-50);
+    --secondary-background-color: #E5E5E5;
     --primary-text-color: #212121;
     --secondary-text-color: #727272;
     --disabled-text-color: #bdbdbd;

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -15,12 +15,13 @@
     --text-primary-color: #ffffff;
     --accent-color: #FF9800;
     --primary-background-color: var(--paper-grey-50);
-    --secondary-background-color: #E5E5E5;
     --primary-text-color: #212121;
     --secondary-text-color: #727272;
     --disabled-text-color: #bdbdbd;
     --divider-color: rgba(0, 0, 0, .12);
 
+    --paper-card-background-color: #E5E5E5;
+    
     --paper-toggle-button-checked-ink-color: #039be5;
     --paper-toggle-button-checked-button-color: #039be5;
     --paper-toggle-button-checked-bar-color: #039be5;

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -44,11 +44,11 @@
     /* for label-badge */
     --label-badge-background-color: white;
     --label-badge-text-color: rgb(76, 76, 76);
-    --label-badge-border-red: #DF4C1E;
-    --label-badge-border-blue: #039be5;
-    --label-badge-border-green: #0DA035;
-    --label-badge-border-yellow: #f4b400;
-    --label-badge-border-grey: var(--paper-grey-500);
+    --label-badge-red: #DF4C1E;
+    --label-badge-blue: #039be5;
+    --label-badge-green: #0DA035;
+    --label-badge-yellow: #f4b400;
+    --label-badge-grey: var(--paper-grey-500);
 
     /* Taken from paper-styles/color.html */
     /* for paper-spinner */

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -36,6 +36,13 @@
     --paper-card-background-color: #FFF;
     --paper-listbox-background-color: #FFF;
 
+    /* for label-badge */
+    --label-red: #DF4C1E;
+    --label-blue: #039be5;
+    --label-green: #0DA035;
+    --label-yellow: #f4b400;
+    --label-grey: var(--paper-grey-500);
+
     /* Taken from paper-styles/color.html */
     /* for paper-spinner */
     --google-red-500: #db4437;

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -35,11 +35,11 @@
     --paper-listbox-background-color: #FFF;
 
     /* for label-badge */
-    --label-red: #DF4C1E;
-    --label-blue: #039be5;
-    --label-green: #0DA035;
-    --label-yellow: #f4b400;
-    --label-grey: var(--paper-grey-500);
+    --label-badge-red: #DF4C1E;
+    --label-badge-blue: #039be5;
+    --label-badge-green: #0DA035;
+    --label-badge-yellow: #f4b400;
+    --label-badge-grey: var(--paper-grey-500);
 
     /* Taken from paper-styles/color.html */
     /* for paper-spinner */

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -20,8 +20,6 @@
     --disabled-text-color: #bdbdbd;
     --divider-color: rgba(0, 0, 0, .12);
 
-    --paper-card-background-color: #E5E5E5;
-    
     --paper-toggle-button-checked-ink-color: #039be5;
     --paper-toggle-button-checked-button-color: #039be5;
     --paper-toggle-button-checked-bar-color: #039be5;
@@ -33,7 +31,7 @@
     --paper-slider-secondary-color: var(--light-primary-color);
     --paper-slider-container-color: var(--divider-color);
 
-    --paper-card-background-color: #FFF;
+    --paper-card-background-color: #E5E5E5;
     --paper-listbox-background-color: #FFF;
 
     /* for label-badge */

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -9,6 +9,9 @@
     --paper-grey-50: #fafafa;
     --paper-grey-200: #eeeeee;
 
+    --paper-item-icon-color: #44739e;
+    --paper-item-icon-active-color: #FDD835;
+
     --dark-primary-color: #0288D1;
     --primary-color: #03A9F4;
     --light-primary-color: #B3E5FC;
@@ -20,6 +23,9 @@
     --secondary-text-color: #727272;
     --disabled-text-color: #bdbdbd;
     --divider-color: rgba(0, 0, 0, .12);
+
+    --table-row-background-color: transparant;
+    --table-row-alternative-background-color: #eee;
 
     --paper-toggle-button-checked-ink-color: #039be5;
     --paper-toggle-button-checked-button-color: #039be5;
@@ -35,15 +41,14 @@
     --paper-card-background-color: #FFF;
     --paper-listbox-background-color: #FFF;
 
-    --table-row-background-color: #eee;
-    --table-row-alternative-background-color: #eee;
-
     /* for label-badge */
-    --label-badge-red: #DF4C1E;
-    --label-badge-blue: #039be5;
-    --label-badge-green: #0DA035;
-    --label-badge-yellow: #f4b400;
-    --label-badge-grey: var(--paper-grey-500);
+    --label-badge-background-color: white;
+    --label-badge-text-color: rgb(76, 76, 76);
+    --label-badge-border-red: #DF4C1E;
+    --label-badge-border-blue: #039be5;
+    --label-badge-border-green: #0DA035;
+    --label-badge-border-yellow: #f4b400;
+    --label-badge-border-grey: var(--paper-grey-500);
 
     /* Taken from paper-styles/color.html */
     /* for paper-spinner */

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -32,7 +32,7 @@
     --paper-slider-secondary-color: var(--light-primary-color);
     --paper-slider-container-color: var(--divider-color);
 
-    --paper-card-background-color: #E5E5E5;
+    --paper-card-background-color: #FFF;
     --paper-listbox-background-color: #FFF;
 
     --table-row-background-color: #eee;

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -34,6 +34,9 @@
     --paper-card-background-color: #E5E5E5;
     --paper-listbox-background-color: #FFF;
 
+    --table-row-background-color: #eee;
+    --table-row-alternative-background-color: #eee;
+
     /* for label-badge */
     --label-badge-red: #DF4C1E;
     --label-badge-blue: #039be5;


### PR DESCRIPTION
First contribution, apologies for any mistakes.
As discussed in the "Share your Themes thread": https://community.home-assistant.io/t/share-your-themes/22018/9?u=ahs.

Goal is to allow more flexibility with theming (allowing e.g. "night mode") by replacing some hardcoded values by variable colours (which can be defined in custom themes):

* replaced the white background colour in the state cards (ha-card.html) by the variable background colour
* replaced the light grey overall background colour by the variable paper-grey-200 colour

Note that the default paper-grey-200 is not exactly the same as the current colour (#E5E5E5) but is the closest match of the defined colours in ha-style.html. It will however lead to a slight recolouring of the default background.