### PR TITLE
Set overflow to auto on ha-voice-command-dialog

### DIFF
--- a/src/dialogs/ha-voice-command-dialog.html
+++ b/src/dialogs/ha-voice-command-dialog.html
@@ -20,7 +20,7 @@
 
       .messages {
         max-height: 50vh;
-        overflow: scroll;
+        overflow: auto;
       }
 
       .messages::after {


### PR DESCRIPTION
For the people without a mac ;-)

![image](https://user-images.githubusercontent.com/5662298/28820819-5b20be8a-76b3-11e7-9a6c-07d707cd9c7d.png)

It showed scrollbars always, even when not necessary. Now it only shows when it is needed.