### PR TITLE
Entity card: Added power off button.

### DIFF
--- a/src/cards/ha-entities-card.html
+++ b/src/cards/ha-entities-card.html
@@ -38,6 +38,9 @@
       .header-more-info {
         cursor: pointer;
       }
+      paper-icon-button[highlight] {
+        color: var(--accent-color);
+      }
     </style>
 
     <ha-card>
@@ -47,6 +50,12 @@
           <ha-entity-toggle
             hass='[[hass]]'
             state-obj='[[groupEntity]]'></ha-entity-toggle>
+        </template>
+        <template is='dom-if' if='[[showGroupPowerOff(groupEntity, states)]]'>
+          <paper-icon-button 
+            icon='mdi:power' 
+            highlight$='[[highlightGroupPowerOff(groupEntity)]]' 
+            on-tap='onGroupPowerOffTap'></paper-icon-button>
         </template>
       </div>
       <div class='states'>
@@ -115,26 +124,60 @@ Polymer({
   },
 
   showGroupToggle: function (groupEntity, states) {
-    if (!groupEntity || !states || groupEntity.attributes.control === 'hidden' ||
+    if (!groupEntity || !states || groupEntity.attributes.control ||
         (groupEntity.state !== 'on' && groupEntity.state !== 'off')) {
       return false;
     }
 
     // only show if we can toggle 2+ entities in group
+    return this.hasMultipleEntities();
+  },
+
+  showGroupPowerOff: function (groupEntity, states) {
+    if (!groupEntity || groupEntity.attributes.control !== 'power_off' ||
+        (groupEntity.state !== 'on' && groupEntity.state !== 'off')) {
+      return false;
+    }
+    
+    // only show if we can toggle 2+ entities in group
+    return this.hasMultipleEntities();
+  },
+
+  highlightGroupPowerOff: function (groupEntity) {
+    if (!groupEntity || groupEntity.state !== 'on') {
+      return false;
+    }
+
+    return true;
+  },
+
+  onGroupPowerOffTap: function (ev) {
+    ev.stopPropagation();
+    
+    if (this.groupEntity.state == 'on') {
+      this.hass.callService(
+        'homeassistant', 
+        'turn_off', 
+        { entity_id: this.groupEntity.entity_id }
+      );
+    }
+  },
+
+  hasMultipleEntities() {
     var canToggleCount = 0;
-    for (var i = 0; i < states.length; i++) {
-      if (!window.hassUtil.canToggleState(this.hass, states[i])) {
+    for (var i = 0; i < this.states.length; i++) {
+      if (!window.hassUtil.canToggleState(this.hass, this.states[i])) {
         continue;
       }
 
       canToggleCount++;
 
       if (canToggleCount > 1) {
-        break;
+        return true;
       }
     }
 
     return canToggleCount > 1;
-  },
+  }
 });
 </script>

--- a/src/cards/ha-entities-card.html
+++ b/src/cards/ha-entities-card.html
@@ -46,12 +46,12 @@
     <ha-card>
       <div class$='[[computeTitleClass(groupEntity)]]' on-tap='entityTapped'>
         <div class='flex name'>[[computeTitle(states, groupEntity)]]</div>
-        <template is='dom-if' if='[[showGroupToggle(groupEntity, states)]]'>
+        <template is='dom-if' if='[[showGroupToggle(groupEntity)]]'>
           <ha-entity-toggle
             hass='[[hass]]'
             state-obj='[[groupEntity]]'></ha-entity-toggle>
         </template>
-        <template is='dom-if' if='[[showGroupPowerOff(groupEntity, states)]]'>
+        <template is='dom-if' if='[[showGroupPowerOff(groupEntity)]]'>
           <paper-icon-button 
             icon='mdi:power' 
             highlight$='[[highlightGroupPowerOff(groupEntity)]]' 
@@ -123,8 +123,8 @@ Polymer({
     this.fire('hass-more-info', { entityId: entityId });
   },
 
-  showGroupToggle: function (groupEntity, states) {
-    if (!groupEntity || !states || groupEntity.attributes.control ||
+  showGroupToggle: function (groupEntity) {
+    if (!groupEntity || groupEntity.attributes.control ||
         (groupEntity.state !== 'on' && groupEntity.state !== 'off')) {
       return false;
     }
@@ -133,12 +133,12 @@ Polymer({
     return this.hasMultipleEntities();
   },
 
-  showGroupPowerOff: function (groupEntity, states) {
+  showGroupPowerOff: function (groupEntity) {
     if (!groupEntity || groupEntity.attributes.control !== 'power_off' ||
         (groupEntity.state !== 'on' && groupEntity.state !== 'off')) {
       return false;
     }
-    
+
     // only show if we can toggle 2+ entities in group
     return this.hasMultipleEntities();
   },
@@ -153,11 +153,11 @@ Polymer({
 
   onGroupPowerOffTap: function (ev) {
     ev.stopPropagation();
-    
-    if (this.groupEntity.state == 'on') {
+
+    if (this.groupEntity.state === 'on') {
       this.hass.callService(
-        'homeassistant', 
-        'turn_off', 
+        'homeassistant',
+        'turn_off',
         { entity_id: this.groupEntity.entity_id }
       );
     }


### PR DESCRIPTION
A power off button for group cards instead of a toggle button. Displays the current group power status and allows to turn off all elements of a group. This button can't turn on the group elements.

Can be activated by using `control: power_off` in groups.

![image](https://user-images.githubusercontent.com/5654539/29126330-5bf31ad0-7d1e-11e7-994d-a79454f760cb.png)

Modification of group component: home-assistant/home-assistant#8926