### PR TITLE
Configurator updates

### DIFF
--- a/src/more-infos/more-info-configurator.html
+++ b/src/more-infos/more-info-configurator.html
@@ -46,13 +46,14 @@
 
         <p hidden$='[[!stateObj.attributes.description]]'>
           [[stateObj.attributes.description]]
-          <a
-            hidden$='[[!stateObj.attributes.link_url]]'
-            href='[[stateObj.attributes.link_url]]'
-            target='_blank'
-          >
-            [[stateObj.attributes.link_name]]
-          </a>
+          <p hidden$='[[!stateObj.attributes.link_url]]'>
+            <a
+              href='[[stateObj.attributes.link_url]]'
+              target='_blank'
+            >
+              [[stateObj.attributes.link_name]]
+            </a>
+          </p>
         </p>
 
         <p class='error' hidden$='[[!stateObj.attributes.errors]]'>

--- a/src/more-infos/more-info-configurator.html
+++ b/src/more-infos/more-info-configurator.html
@@ -72,7 +72,7 @@
           ></paper-input>
         </template>
 
-        <p class='submit'>
+        <p class='submit' hidden$='[[!stateObj.attributes.submit_caption]]'>
           <paper-button
             raised
             disabled='[[isConfiguring]]'
@@ -82,7 +82,7 @@
               active='[[isConfiguring]]'
               hidden='[[!isConfiguring]]'
               alt='Configuring'></paper-spinner>
-            [[submitCaption]]
+            [[stateObj.attributes.submit_caption]]
           </paper-button>
 
         </p>
@@ -116,11 +116,6 @@ Polymer({
       value: false,
     },
 
-    submitCaption: {
-      type: String,
-      computed: 'computeSubmitCaption(stateObj)',
-    },
-
     fieldInput: {
       type: Object,
       value: function () { return {}; },
@@ -129,10 +124,6 @@ Polymer({
 
   computeIsConfigurable: function (stateObj) {
     return stateObj.state === 'configure';
-  },
-
-  computeSubmitCaption: function (stateObj) {
-    return stateObj.attributes.submit_caption || 'Set configuration';
   },
 
   fieldChanged: function (ev) {


### PR DESCRIPTION
This PR includes two changes to the configurator more-info:

1) If no submit caption is configured, the submit button is not shown. (From my searching there aren't any platforms that this currently affects)
2) The link is shown on a separate line from the rest of the configurator description. (Just a preference)

**Screenshot with intended usage:**
![screenshot from 2017-08-12 12-48-33](https://user-images.githubusercontent.com/1386547/29242524-15628100-7f5d-11e7-9678-5b76af85336e.png)
