### PR TITLE
Improvements for customize config panel

### DIFF
--- a/panels/config/customize/ha-config-customize.html
+++ b/panels/config/customize/ha-config-customize.html
@@ -32,7 +32,7 @@
           <span slot='header'>Customization</span>
           <span slot='introduction'>
             Tweak per-entity attributes.<br>
-            Added/edited customizations will take effect immidiately. Removed customizations will take effect when the entity is updated.
+            Added/edited customizations will take effect immediately. Removed customizations will take effect when the entity is updated.
           </span>
           <ha-entity-config
             hass='[[hass]]'

--- a/panels/config/customize/ha-form-customize.html
+++ b/panels/config/customize/ha-form-customize.html
@@ -160,7 +160,9 @@ class HaFormCustomize extends Polymer.Element {
       this.globalAttributes, this.existingAttributes, this.newAttributes);
     attrs.forEach((attr) => {
       if (attr.closed || attr.secondary || !attr.attribute || !attr.value) return;
-      data[attr.attribute] = (attr.type === 'json' ? JSON.parse(attr.value) : attr.value);
+      const value = attr.type === 'json' ? JSON.parse(attr.value) : attr.value;
+      if (!value) return;
+      data[attr.attribute] = value;
     });
 
     const objectId = this.entity.entity_id;
@@ -213,7 +215,11 @@ class HaFormCustomize extends Polymer.Element {
   getNewAttributesOptions(localAttributes, globalAttributes, existingAttributes, newAttributes) {
     const knownKeys =
         Object.keys(window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES)
-            .filter(key => window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES[key])
+            .filter((key) => {
+              const conf = window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES[key];
+              return conf && (!conf.domains || !this.entity ||
+                              conf.domains.includes(window.hassUtil.computeDomain(this.entity)));
+            })
             .filter(this.filterFromAttributes(localAttributes))
             .filter(this.filterFromAttributes(globalAttributes))
             .filter(this.filterFromAttributes(existingAttributes))

--- a/panels/config/customize/types/ha-customize-array.html
+++ b/panels/config/customize/types/ha-customize-array.html
@@ -44,13 +44,8 @@ class HaCustomizeArray extends window.hassMixins.EventsMixin(Polymer.Element) {
   }
 
   getOptions(item) {
-    const domain = item.domain;
-    if (!domain) {
-      this.item.type = 'string';
-      this.fire('item-changed');
-      return [];
-    }
-    const options = item.options[domain];
+    const domain = item.domain || '*';
+    const options = item.options[domain] || item.options['*'];
     if (!options) {
       this.item.type = 'string';
       this.fire('item-changed');

--- a/src/util/hass-attributes-util.js
+++ b/src/util/hass-attributes-util.js
@@ -24,27 +24,27 @@ window.hassAttributeUtil.TYPE_TO_TAG = {
 // 1) Any key of this object won't be shown in more-info window.
 // 2) Any key which has value other than undefined will appear in customization
 //    config according to its value.
-// TODO: Allow per-domain config, as some attributes are only relevant for some
-// domains.
-window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES = {
-  entity_picture: undefined,
-  friendly_name: { type: 'string', description: 'Name' },
-  icon: { type: 'icon' },
-  emulated_hue: { type: 'boolean' },
-  emulated_hue_name: { type: 'string' },
-  haaska_hidden: undefined,
-  haaska_name: undefined,
-  homebridge_hidden: { type: 'boolean' },
-  homebridge_name: { type: 'string' },
-  supported_features: undefined,
-  attribution: undefined,
-  custom_ui_state_card: { type: 'string' },
-  device_class: {
-    type: 'array',
-    options: window.hassAttributeUtil.DOMAIN_DEVICE_CLASS,
-    description: 'Device class' },
-  hidden: { type: 'boolean', description: 'Hide from UI' },
-  assumed_state: { type: 'boolean' },
-  initial_state: { type: 'string' },
-  unit_of_measurement: { type: 'string' },
-};
+window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES =
+  window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES || {
+    entity_picture: undefined,
+    friendly_name: { type: 'string', description: 'Name' },
+    icon: { type: 'icon' },
+    emulated_hue: { type: 'boolean' },
+    emulated_hue_name: { type: 'string' },
+    haaska_hidden: undefined,
+    haaska_name: undefined,
+    homebridge_hidden: { type: 'boolean' },
+    homebridge_name: { type: 'string' },
+    supported_features: undefined,
+    attribution: undefined,
+    custom_ui_state_card: { type: 'string' },
+    device_class: {
+      type: 'array',
+      options: window.hassAttributeUtil.DOMAIN_DEVICE_CLASS,
+      description: 'Device class',
+      domains: ['binary_sensor', 'cover'] },
+    hidden: { type: 'boolean', description: 'Hide from UI' },
+    assumed_state: { type: 'boolean' },
+    initial_state: { type: 'string' },
+    unit_of_measurement: { type: 'string' },
+  };


### PR DESCRIPTION
Improvements for customize config panel:
* Don't save empty json values.
* Allow per-domain attributes.
* Allow '*' - all-domains array lists.
* Prevent reassignment of LOGIC_STATE_ATTRIBUTES as `script` tag can be loaded more than once.

