### PR TITLE
Modify camera image error text

### DIFF
--- a/src/cards/ha-camera-card.html
+++ b/src/cards/ha-camera-card.html
@@ -42,7 +42,7 @@
     <div class='caption'>
       [[computeStateName(stateObj)]]
       <template is='dom-if' if='[[!imageLoaded]]'>
-        (Error loading image)
+        (Image not available)
       </template>
     </div>
   </template>


### PR DESCRIPTION
This is a suggestion for a slight wording change on the text that appears when a camera image is unable to be shown.  With the USPS camera component there are situations where there are no images available.  In this case the lack of an image isn't actually an error as one is never presented to home assistant to load.

Changing the text as suggested still tells the user the image is not available, but doesn't automatically assume an error has taken place.