### PR TITLE
Use local font-robot file for development

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "app-storage": "^2.0.2",
     "fecha": "~2.3.0",
     "font-roboto-local": "~1.0.1",
+    "font-roboto": "PolymerElements/font-roboto-local#~1.0.1",
     "google-apis": "GoogleWebComponents/google-apis#~2.0.0",
     "iron-autogrow-textarea": "PolymerElements/iron-autogrow-textarea#^2.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^2.0.0",


### PR DESCRIPTION
Use font-roboto-local to replace font-roboto on development to reduce page load time.