### PR TITLE
Fix customize config panel on FF

### DIFF
--- a/panels/config/customize/ha-customize-attribute.html
+++ b/panels/config/customize/ha-customize-attribute.html
@@ -68,7 +68,9 @@ class HaCustomizeAttribute extends Polymer.Element {
       if (wrapper.lastChild) {
         wrapper.removeChild(wrapper.lastChild);
       }
-      this.$.child = child = document.createElement(tag);
+      // Creating an element with upper case works fine in Chrome, but in FF it doesn't immediately
+      // become a defined Custom Element. Polymer does that in some later pass.
+      this.$.child = child = document.createElement(tag.toLowerCase());
       child.className = 'form-control';
       child.addEventListener('item-changed', () => {
         this.item = Object.assign({}, child.item);

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -97,7 +97,9 @@ window.hassUtil.dynamicContentUpdater = function (root, newElementTag, attribute
     if (rootEl.lastChild) {
       rootEl.removeChild(rootEl.lastChild);
     }
-    customEl = document.createElement(newElementTag);
+    // Creating an element with upper case works fine in Chrome, but in FF it doesn't immediately
+    // become a defined Custom Element. Polymer does that in some later pass.
+    customEl = document.createElement(newElementTag.toLowerCase());
   }
 
   if (customEl.setProperties) {


### PR DESCRIPTION
Fix customize config panel on FF and maybe other non-Chrome browsers.

When creating an element with upper case tag, it works fine in Chrome, but in FF it doesn't immediately become a defined Custom Element. Polymer does that in some later pass, but until that happens the element is just a dump placeholder.

Fixes https://github.com/home-assistant/home-assistant/issues/9350