### PR TITLE
Change color of state-badge icon according to rgb or brightness

### DIFF
--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -60,67 +60,78 @@ class StateBadge extends Polymer.Element {
     return window.hassUtil.computeDomain(stateObj);
   }
 
+  _rgbFromBrightness(brightness) {
+    // Set icon bbroghtness to a scale between 15% bright to 100% bright.
+    const iconBrightness = (brightness + 45) / (255 + 45);
+    const hostBrightness = 1 - iconBrightness;
+    const re = /rgb\((\d+), (\d+), (\d+)\)/;
+    const rgbIconMatch = window.getComputedStyle(this.$.icon).color.match(re);
+    const rgbHostMatch = window.getComputedStyle(this).color.match(re);
+    let rgb;
+    if (rgbIconMatch && rgbHostMatch) {
+      const rgbIcon = rgbIconMatch.slice(1).map(v => Number.parseInt(v, 10));
+      const rgbHost = rgbHostMatch.slice(1).map(v => Number.parseInt(v, 10));
+      rgb = [
+        Math.round((rgbIcon[0] * iconBrightness) + (rgbHost[0] * hostBrightness)),
+        Math.round((rgbIcon[1] * iconBrightness) + (rgbHost[1] * hostBrightness)),
+        Math.round((rgbIcon[2] * iconBrightness) + (rgbHost[2] * hostBrightness)),
+      ];
+      if (rgb.some(v => Number.isNaN(v))) {
+        return undefined;
+      }
+    }
+    return rgb;
+  }
+
   /**
    * Called when an attribute changes that influences the color of the icon.
    */
   updateIconColor(newVal) {
+    const icon = this.$.icon;
     // hide icon if we have entity picture
     if (newVal.attributes.entity_picture) {
       this.style.backgroundImage = 'url(' + newVal.attributes.entity_picture + ')';
-      this.$.icon.style.display = 'none';
+      icon.style.display = 'none';
       return;
     }
 
+    if (this._timeoutId) {
+      window.clearTimeout(this._timeoutId);
+      this._timeoutId = null;
+    }
+
     this.style.backgroundImage = '';
-    this.$.icon.style.display = 'inline';
+    icon.style.display = 'inline';
     if (newVal.state === 'unavailable') return;
     let rgb;
     let oldColor;
     if (newVal.attributes.rgb_color) {
       rgb = newVal.attributes.rgb_color;
     } else if (newVal.attributes.brightness && newVal.attributes.brightness !== 255) {
-      if (this.$.icon.style.color !== '') {
-        oldColor = this.$.icon.style.color;
-        this.$.icon.style.transition = 'none';
-        this.$.icon.style.color = '';
+      if (icon.style.color !== '') {
+        oldColor = icon.style.color;
+        icon.style.transition = 'none';
+        icon.style.color = '';
       }
-
-      const iconBrightness = newVal.attributes.brightness / 255;
-      const hostBrightness = 1 - iconBrightness;
-      const re = /rgb\((\d+), (\d+), (\d+)\)/;
-      const rgbIconMatch = window.getComputedStyle(this.$.icon).color.match(re);
-      const rgbHostMatch = window.getComputedStyle(this).color.match(re);
-      if (rgbIconMatch && rgbHostMatch) {
-        const rgbIcon = rgbIconMatch.slice(1).map(v => Number.parseInt(v, 10));
-        const rgbHost = rgbHostMatch.slice(1).map(v => Number.parseInt(v, 10));
-        rgb = [
-          Math.round((rgbIcon[0] * iconBrightness) + (rgbHost[0] * hostBrightness)),
-          Math.round((rgbIcon[1] * iconBrightness) + (rgbHost[1] * hostBrightness)),
-          Math.round((rgbIcon[2] * iconBrightness) + (rgbHost[2] * hostBrightness)),
-        ];
-        if (rgb.some(v => Number.isNaN(v))) {
-          rgb = undefined;
-        }
-      }
+      rgb = this._rgbFromBrightness(newVal.attributes.brightness);
     }
     // Set color of icon to rgb color if available and it is not very white (sum rgb colors < 730)
     if (rgb && rgb.reduce((cur, tot) => cur + tot, 0) < 730) {
       if (oldColor) {
-        this.$.icon.style.color = oldColor;
+        icon.style.color = oldColor;
       }
       // If we had to cancel transition - wait after restoring old color so transition will start
       // from oldColor and not from css 'on' color.
-      if (this.$.icon.style.transition && oldColor) {
-        const icon = this.$.icon;
-        window.setTimeout(() => {
+      if (icon.style.transition && oldColor) {
+        this._timeoutId = window.setTimeout(() => {
           icon.style.transition = '';
           icon.style.color = 'rgb(' + rgb.join(',') + ')';
         }, 10);
       } else {
-        this.$.icon.style.color = 'rgb(' + rgb.join(',') + ')';
+        icon.style.color = 'rgb(' + rgb.join(',') + ')';
       }
     } else {
-      this.$.icon.style.color = '';
+      icon.style.color = '';
     }
   }
 }

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -1,4 +1,4 @@
-<link rel='import' href='../../../bower_components/polymer/polymer.html'>
+<link rel='import' href='../../../bower_components/polymer/polymer-element.html'>
 
 <link rel='import' href='./ha-state-icon.html'>
 
@@ -18,7 +18,7 @@
     }
 
     ha-state-icon {
-      transition: color .3s ease-in-out;
+      transition: color 0.3s ease-in-out;
     }
 
     /* Color the icon if light or sun is on */
@@ -45,24 +45,25 @@
 </dom-module>
 
 <script>
-Polymer({
-  is: 'state-badge',
+class StateBadge extends Polymer.Element {
+  static get is() { return 'state-badge'; }
+  static get properties() {
+    return {
+      stateObj: {
+        type: Object,
+        observer: 'updateIconColor',
+      },
+    };
+  }
 
-  properties: {
-    stateObj: {
-      type: Object,
-      observer: 'updateIconColor',
-    },
-  },
-
-  computeDomain: function (stateObj) {
+  computeDomain(stateObj) {
     return window.hassUtil.computeDomain(stateObj);
-  },
+  }
 
   /**
    * Called when an attribute changes that influences the color of the icon.
    */
-  updateIconColor: function (newVal) {
+  updateIconColor(newVal) {
     // hide icon if we have entity picture
     if (newVal.attributes.entity_picture) {
       this.style.backgroundImage = 'url(' + newVal.attributes.entity_picture + ')';
@@ -72,18 +73,56 @@ Polymer({
 
     this.style.backgroundImage = '';
     this.$.icon.style.display = 'inline';
+    if (newVal.state === 'unavailable') return;
+    let rgb;
+    let oldColor;
+    if (newVal.attributes.rgb_color) {
+      rgb = newVal.attributes.rgb_color;
+    } else if (newVal.attributes.brightness && newVal.attributes.brightness !== 255) {
+      if (this.$.icon.style.color !== '') {
+        oldColor = this.$.icon.style.color;
+        this.$.icon.style.transition = 'none';
+        this.$.icon.style.color = '';
+      }
 
-    // for domain light, set color of icon to light color if available and it is
-    // not very white (sum rgb colors < 730)
-    if (window.hassUtil.computeDomain(newVal) === 'light' &&
-        newVal.state === 'on' &&
-        newVal.attributes.rgb_color &&
-        newVal.attributes.rgb_color.reduce(function (cur, tot) { return cur + tot; }, 0) < 730) {
-      this.$.icon.style.color = 'rgb(' + newVal.attributes.rgb_color.join(',') + ')';
-    } else {
-      this.$.icon.style.color = null;
+      const iconBrightness = newVal.attributes.brightness / 255;
+      const hostBrightness = 1 - iconBrightness;
+      const re = /rgb\((\d+), (\d+), (\d+)\)/;
+      const rgbIconMatch = window.getComputedStyle(this.$.icon).color.match(re);
+      const rgbHostMatch = window.getComputedStyle(this).color.match(re);
+      if (rgbIconMatch && rgbHostMatch) {
+        const rgbIcon = rgbIconMatch.slice(1).map(v => Number.parseInt(v, 10));
+        const rgbHost = rgbHostMatch.slice(1).map(v => Number.parseInt(v, 10));
+        rgb = [
+          Math.round((rgbIcon[0] * iconBrightness) + (rgbHost[0] * hostBrightness)),
+          Math.round((rgbIcon[1] * iconBrightness) + (rgbHost[1] * hostBrightness)),
+          Math.round((rgbIcon[2] * iconBrightness) + (rgbHost[2] * hostBrightness)),
+        ];
+        if (rgb.some(v => Number.isNaN(v))) {
+          rgb = undefined;
+        }
+      }
     }
-  },
-
-});
+    // Set color of icon to rgb color if available and it is not very white (sum rgb colors < 730)
+    if (rgb && rgb.reduce((cur, tot) => cur + tot, 0) < 730) {
+      if (oldColor) {
+        this.$.icon.style.color = oldColor;
+      }
+      // If we had to cancel transition - wait after restoring old color so transition will start
+      // from oldColor and not from css 'on' color.
+      if (this.$.icon.style.transition && oldColor) {
+        const icon = this.$.icon;
+        window.setTimeout(() => {
+          icon.style.transition = '';
+          icon.style.color = 'rgb(' + rgb.join(',') + ')';
+        }, 10);
+      } else {
+        this.$.icon.style.color = 'rgb(' + rgb.join(',') + ')';
+      }
+    } else {
+      this.$.icon.style.color = '';
+    }
+  }
+}
+customElements.define(StateBadge.is, StateBadge);
 </script>

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -18,7 +18,7 @@
     }
 
     ha-state-icon {
-      transition: color 0.3s ease-in-out;
+      transition: color .3s ease-in-out;
     }
 
     /* Color the icon if light or sun is on */


### PR DESCRIPTION
Change color of state-badge icon according to rgb or brightness.

Now icon color will respect `rgb_color` attribute regardless of domain.
In case `brightness` attribute exists it will be used as weight to select color between "off" color and "on" color. This will work correctly even if those colored has been themed to something else.

