### PR TITLE
Mixins only needs to be imported once

### DIFF
--- a/panels/config/cloud/ha-config-cloud-account.html
+++ b/panels/config/cloud/ha-config-cloud-account.html
@@ -4,7 +4,6 @@
 <link rel="import" href='../../../bower_components/paper-button/paper-button.html'>
 
 <link rel="import" href="../../../src/layouts/hass-subpage.html">
-<link rel="import" href="../../../src/util/hass-mixins.html">
 <link rel="import" href='../../../src/resources/ha-style.html'>
 
 <dom-module id="ha-config-cloud-account">

--- a/panels/config/cloud/ha-config-cloud-forgot-password.html
+++ b/panels/config/cloud/ha-config-cloud-forgot-password.html
@@ -4,7 +4,6 @@
 <link rel="import" href='../../../bower_components/paper-input/paper-input.html'>
 
 <link rel="import" href="../../../src/layouts/hass-subpage.html">
-<link rel="import" href="../../../src/util/hass-mixins.html">
 <link rel="import" href='../../../src/resources/ha-style.html'>
 <link rel="import" href='../../../src/components/buttons/ha-progress-button.html'>
 

--- a/panels/config/cloud/ha-config-cloud-login.html
+++ b/panels/config/cloud/ha-config-cloud-login.html
@@ -4,7 +4,6 @@
 <link rel="import" href='../../../bower_components/paper-input/paper-input.html'>
 
 <link rel="import" href="../../../src/layouts/hass-subpage.html">
-<link rel="import" href="../../../src/util/hass-mixins.html">
 <link rel="import" href='../../../src/resources/ha-style.html'>
 <link rel="import" href='../../../src/components/buttons/ha-progress-button.html'>
 

--- a/panels/config/cloud/ha-config-cloud-register.html
+++ b/panels/config/cloud/ha-config-cloud-register.html
@@ -4,7 +4,6 @@
 <link rel="import" href='../../../bower_components/paper-input/paper-input.html'>
 
 <link rel="import" href="../../../src/layouts/hass-subpage.html">
-<link rel="import" href="../../../src/util/hass-mixins.html">
 <link rel="import" href='../../../src/resources/ha-style.html'>
 <link rel="import" href='../../../src/components/buttons/ha-progress-button.html'>
 

--- a/panels/config/customize/types/ha-customize-array.html
+++ b/panels/config/customize/types/ha-customize-array.html
@@ -2,7 +2,6 @@
 <link rel="import" href="../../../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel='import' href='../../../../bower_components/paper-listbox/paper-listbox.html'>
 <link rel='import' href='../../../../bower_components/paper-item/paper-item.html'>
-<link rel="import" href="../../../../src/util/hass-mixins.html">
 
 <dom-module id='ha-customize-array'>
   <template>

--- a/panels/config/dashboard/ha-config-cloud-menu.html
+++ b/panels/config/dashboard/ha-config-cloud-menu.html
@@ -4,8 +4,6 @@
 <link rel="import" href="../../../bower_components/paper-item/paper-item-body.html">
 <link rel="import" href="../../../bower_components/iron-icon/iron-icon.html">
 
-<link rel="import" href="../../../src/util/hass-mixins.html">
-
 <dom-module id="ha-config-cloud-menu">
   <template>
     <style include="iron-flex">

--- a/panels/config/ha-panel-config.html
+++ b/panels/config/ha-panel-config.html
@@ -4,7 +4,6 @@
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
 
 <link rel="import" href="../../src/layouts/hass-error-screen.html">
-<link rel="import" href="../../src/util/hass-mixins.html">
 
 <link rel="import" href="./dashboard/ha-config-dashboard.html">
 <link rel="import" href="./core/ha-config-core.html">

--- a/src/components/ha-sidebar.html
+++ b/src/components/ha-sidebar.html
@@ -8,8 +8,6 @@
 
 <link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 
-<link rel='import' href='../util/hass-mixins.html'>
-
 <link rel='import' href='./ha-push-notifications-toggle.html'>
 
 <dom-module id='ha-sidebar'>

--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -7,6 +7,7 @@
 <link rel="import" href="../bower_components/neon-animation/web-animations.html">
 
 
+<link rel='import' href='./util/hass-mixins.html'>
 <link rel='import' href='./util/hass-util.html'>
 <link rel='import' href='./util/ha-pref-storage.html'>
 <link rel='import' href='./util/hass-call-api.html'>

--- a/src/layouts/home-assistant-main.html
+++ b/src/layouts/home-assistant-main.html
@@ -14,7 +14,6 @@
 <link rel='import' href='../util/ha-url-sync.html'>
 
 <link rel='import' href='../components/ha-sidebar.html'>
-<link rel='import' href='../util/hass-mixins.html'>
 <link rel='import' href='../util/hass-util.html'>
 
 <dom-module id='home-assistant-main'>


### PR DESCRIPTION
This was my mistake on the original conversion. `hass-mixins.html` is actually just adding the mixins to `window`, so importing it more than once is just redundant.

CC @andrey-git