### PR TITLE
Remove Safari toggle hack

### DIFF
--- a/src/components/entity/ha-entity-toggle.html
+++ b/src/components/entity/ha-entity-toggle.html
@@ -75,14 +75,6 @@ Polymer({
   toggleChanged: function (ev) {
     var newVal = ev.target.checked;
 
-    // HACK: https://github.com/PolymerElements/paper-toggle-button/issues/124
-    setTimeout(function () {
-      const el = document.activeElement;
-      el.blur();
-      el.focus();
-    }, 0);
-    // END HACK
-
     if (newVal && !this.isOn) {
       this.callService(true);
     } else if (!newVal && this.isOn) {
@@ -92,15 +84,6 @@ Polymer({
 
   isOnChanged: function (newVal) {
     this.toggleChecked = newVal;
-
-    // HACK: https://github.com/PolymerElements/paper-toggle-button/issues/124
-    var el = this.shadowRoot.querySelector('paper-toggle-button');
-
-    if (el) {
-      el.focus();
-      el.blur();
-    }
-    // END HACK
   },
 
   forceStateChange: function () {


### PR DESCRIPTION
Workaround added in #387 is no longer needed in Safari 11.

Fixes #406