### PR TITLE
input_number mode slider overflow

### DIFF
--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -21,12 +21,9 @@
 
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
-        <div hidden='[[hiddenslider]]'>
-          <paper-slider min='[[min]]' max='[[max]]' value='{{value}}' step='[[step]]' pin
-            on-change='selectedValueChanged' on-tap='stopPropagation'
-          >
-          </paper-slider>
-        </div>
+        <paper-slider min='[[min]]' max='[[max]]' value='{{value}}' step='[[step]]' hidden='[[hiddenslider]]' pin
+          on-change='selectedValueChanged' on-tap='stopPropagation'>
+        </paper-slider>
       <paper-input
         no-label-float
         auto-validate


### PR DESCRIPTION
At specific widths of the browser with the current behavior of the slider it overflows the edge of the screen.  the nested div with the hidden attribute isn't needed and can be applied directly to the paper-slider.  Tested on my end without the div and works as intended.