### PR TITLE
Sensor attributes added to the more-info panel of a fan device

### DIFF
--- a/src/more-infos/more-info-fan.html
+++ b/src/more-infos/more-info-fan.html
@@ -7,6 +7,8 @@
 <link rel='import' href='../../bower_components/paper-toggle-button/paper-toggle-button.html'>
 <link rel='import' href='../../bower_components/paper-icon-button/paper-icon-button.html'>
 
+<link rel="import" href="../components/ha-attributes.html">
+
 <dom-module id='more-info-fan'>
   <template>
     <style is='custom-style' include='iron-flex'></style>
@@ -63,6 +65,8 @@
         </div>
       </div>
     </div>
+
+    <ha-attributes state-obj="[[stateObj]]" extra-filters="speed,speed_list,oscillating,direction"></ha-attributes>
   </template>
 </dom-module>
 


### PR DESCRIPTION

![more-info-attributes](https://user-images.githubusercontent.com/2735933/31574003-7edae952-b0c6-11e7-9a14-81101ce98e27.png)

Fixes https://github.com/syssi/xiaomi_airpurifier/issues/7. 