### PR TITLE
fix for 'Lat' is not showing up #442

### DIFF
--- a/src/components/ha-attributes.html
+++ b/src/components/ha-attributes.html
@@ -50,7 +50,7 @@
     },
 
     computeFiltersArray: function (extraFilters) {
-      return Object.keys(window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES) + (extraFilters ? extraFilters.split(',') : []);
+      return Object.keys(window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES).concat(extraFilters ? extraFilters.split(',') : []);
     },
 
     computeDisplayAttributes: function (stateObj, filtersArray) {


### PR DESCRIPTION
computeFiltersArray was supposed to return an array but return value was implicitly converted to a string (#442)