### PR TITLE
hass-util: remove script from HIDE_MORE_INFO

### DIFF
--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -32,7 +32,7 @@ window.hassUtil.DOMAINS_WITH_MORE_INFO = [
 window.hassUtil.DOMAINS_WITH_NO_HISTORY = ['camera', 'configurator', 'history_graph', 'scene'];
 
 window.hassUtil.HIDE_MORE_INFO = [
-  'input_select', 'scene', 'script', 'input_number', 'input_text'
+  'input_select', 'scene', 'input_number', 'input_text'
 ];
 
 window.hassUtil.LANGUAGE = navigator.languages ?


### PR DESCRIPTION
"script" already listed in DOMAINS_WITH_MORE_INFO

https://github.com/home-assistant/home-assistant-polymer/blob/master/src/util/hass-util.html#L232