### PR TITLE
Map panel now chooses tile provider based on user configuration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "iron-media-query": "PolymerElements/iron-media-query#^2.0.0",
     "iron-pages": "PolymerElements/iron-pages#^2.0.0",
     "leaflet": "^1.0.2",
+    "leaflet-providers": "^1.1.17",
     "neon-animation": "PolymerElements/neon-animation#^2.0.1",
     "paper-button": "PolymerElements/paper-button#^2.0.0",
     "paper-card": "PolymerElements/paper-card#^2.0.0",
@@ -56,5 +57,8 @@
   },
   "devDependencies": {
     "web-component-tester": "^6.3.0"
+  },
+  "resolutions": {
+    "leaflet": "^1.0.2"
   }
 }

--- a/panels/map/ha-panel-map.html
+++ b/panels/map/ha-panel-map.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 
 <script src="../../bower_components/leaflet/dist/leaflet.js"></script>
+<script src="../../bower_components/leaflet-providers/leaflet-providers.js"></script>
 
 <link rel="import" href="../../src/components/ha-menu-button.html">
 <link rel="import" href="./ha-entity-marker.html">
@@ -57,13 +58,7 @@ Polymer({
     style.setAttribute('rel', 'stylesheet');
     this.$.map.parentNode.appendChild(style);
     map.setView([51.505, -0.09], 13);
-    window.L.tileLayer(
-      'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
-      {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://cartodb.com/attributions">CartoDB</a>',
-        maxZoom: 18,
-      }
-    ).addTo(map);
+    window.L.tileLayer.provider(this.hass.config.panels.map.config.tile_provider).addTo(map);
 
     this.drawEntities(this.hass);
 


### PR DESCRIPTION
The map panel now uses [leaflet-providers](https://github.com/leaflet-extras/leaflet-providers) and allows the user to change the map provider if desired.

The default is still to use CartoDB unless overridden by the user

Related to PR home-assistant/home-assistant#10127