### PR TITLE
add german translation

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -1,0 +1,12 @@
+{
+  "language": {
+    "de": "Deutsch"
+  },
+  "panel": {
+    "states": "Zustände",
+    "map": "Karte",
+    "logbook": "Logbuch",
+    "history": "Verlauf",
+    "log_out": "Abmelden"
+  }
+}


### PR DESCRIPTION
German Translations, here we go.

I assumed special characters need to be html encoded (ä = `&auml;`).

We probably have a ton of other words for these language strings, but for now I went with a quite literal translation.