### PR TITLE
Add base for French translation

### DIFF
--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1,0 +1,12 @@
+{
+  "language": {
+    "fr": "Français"
+  },
+  "panel": {
+    "states": "États",
+    "map": "Carte",
+    "logbook": "Registre",
+    "history": "Historique",
+    "log_out": "Se déconnecter"
+  }
+}


### PR DESCRIPTION
Note really happy with `logbook` translation but someone will probably find something more suitable.