### PR TITLE
Migrate to pagedown for markdown parsing

### DIFF
--- a/public/pagedown-js.html
+++ b/public/pagedown-js.html
@@ -1,0 +1,84 @@
+<script>
+    /*
+    Pagedown 1.1.0. MIT License.
+
+    Original Markdown Copyright (c) 2004-2005 John Gruber
+      <http://daringfireball.net/projects/markdown/>
+
+
+    Original Showdown code copyright (c) 2007 John Fraser
+
+    Modifications and bugfixes (c) 2009 Dana Robinson
+    Modifications and bugfixes (c) 2009-2014 Stack Exchange Inc.
+  */
+var Markdown
+Markdown="object"==typeof exports&&"function"==typeof require?exports:{},function(){function e(e){return e}function r(e){return!1}function n(){}function t(){}n.prototype={chain:function(r,n){var t=this[r]
+if(!t)throw Error("unknown hook "+r)
+t===e?this[r]=n:this[r]=function(e){var r=Array.prototype.slice.call(arguments,0)
+return r[0]=t.apply(null,r),n.apply(null,r)}},set:function(e,r){if(!this[e])throw Error("unknown hook "+e)
+this[e]=r},addNoop:function(r){this[r]=e},addFalse:function(e){this[e]=r}},Markdown.HookCollection=n,t.prototype={set:function(e,r){this["s_"+e]=r},get:function(e){return this["s_"+e]}},Markdown.Converter=function(){function e(e){return e=e.replace(/^[ ]{0,3}\[(.+)\]:[ \t]*\n?[ \t]*<?(\S+?)>?(?=\s|$)[ \t]*\n?[ \t]*((\n*)["(](.+?)[")][ \t]*)?(?:\n+)/gm,function(e,r,n,t,a,o){return r=r.toLowerCase(),D.set(r,S(n)),a?t:(o&&W.set(r,o.replace(/"/g,"&quot;")),"")})}function r(e){return e=e.replace(/^(<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del)\b[^\r]*?\n<\/\2>[ \t]*(?=\n+))/gm,a),e=e.replace(/^(<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math)\b[^\r]*?.*<\/\2>[ \t]*(?=\n+)\n)/gm,a),e=e.replace(/\n[ ]{0,3}((<(hr)\b([^<>])*?\/?>)[ \t]*(?=\n{2,}))/g,a),e=e.replace(/\n\n[ ]{0,3}(<!(--(?:|(?:[^>-]|-[^>])(?:[^-]|-[^-])*)--)>[ \t]*(?=\n{2,}))/g,a),e=e.replace(/(?:\n\n)([ ]{0,3}(?:<([?%])[^\r]*?\2>)[ \t]*(?=\n{2,}))/g,a)}function a(e,r){var n=r
+return n=n.replace(/^\n+/,""),n=n.replace(/\n+$/g,""),n="\n\n~K"+(z.push(n)-1)+"K\n\n"}function o(e,n){e=L.preBlockGamut(e,M),e=s(e)
+var t="<hr />\n"
+return e=e.replace(/^[ ]{0,2}([ ]?\*[ ]?){3,}[ \t]*$/gm,t),e=e.replace(/^[ ]{0,2}([ ]?-[ ]?){3,}[ \t]*$/gm,t),e=e.replace(/^[ ]{0,2}([ ]?_[ ]?){3,}[ \t]*$/gm,t),e=h(e),e=v(e),e=w(e),e=L.postBlockGamut(e,M),e=r(e),e=C(e,n)}function c(e){return e=L.preSpanGamut(e),e=$(e),e=p(e),e=b(e),e=i(e),e=u(e),e=E(e),e=e.replace(/~P/g,"://"),e=S(e),e=k(e),e=e.replace(/  +\n/g," <br>\n"),e=L.postSpanGamut(e)}function p(e){var r=/(<[a-z\/!$]("[^"]*"|'[^']*'|[^'">])*>|<!(--(?:|(?:[^>-]|-[^>])(?:[^-]|-[^-])*)--)>)/gi
+return e=e.replace(r,function(e){var r=e.replace(/(.)<\/?code>(?=.)/g,"$1`")
+return r=K(r,"!"==e.charAt(1)?"\\`*_/":"\\`*_")})}function u(e){return e=e.replace(/(\[((?:\[[^\]]*\]|[^\[\]])*)\][ ]?(?:\n[ ]*)?\[(.*?)\])()()()()/g,l),e=e.replace(/(\[((?:\[[^\]]*\]|[^\[\]])*)\]\([ \t]*()<?((?:\([^)]*\)|[^()\s])*?)>?[ \t]*((['"])(.*?)\6[ \t]*)?\))/g,l),e=e.replace(/(\[([^\[\]]+)\])()()()()()/g,l)}function l(e,r,n,t,a,o,c,p){void 0==p&&(p="")
+var u=r,l=n.replace(/:\/\//g,"~P"),i=t.toLowerCase(),f=a,s=p
+if(""==f)if(""==i&&(i=l.toLowerCase().replace(/ ?\n/g," ")),f="#"+i,void 0!=D.get(i))f=D.get(i),void 0!=W.get(i)&&(s=W.get(i))
+else{if(!(u.search(/\(\s*\)$/m)>-1))return u
+f=""}f=G(f),f=K(f,"*_")
+var h='<a href="'+f+'"'
+return""!=s&&(s=g(s),s=K(s,"*_"),h+=' title="'+s+'"'),h+=">"+l+"</a>"}function i(e){return e=e.replace(/(!\[(.*?)\][ ]?(?:\n[ ]*)?\[(.*?)\])()()()()/g,f),e=e.replace(/(!\[(.*?)\]\s?\([ \t]*()<?(\S+?)>?[ \t]*((['"])(.*?)\6[ \t]*)?\))/g,f)}function g(e){return e.replace(/>/g,"&gt;").replace(/</g,"&lt;").replace(/"/g,"&quot;")}function f(e,r,n,t,a,o,c,p){var u=r,l=n,i=t.toLowerCase(),f=a,s=p
+if(s||(s=""),""==f){if(""==i&&(i=l.toLowerCase().replace(/ ?\n/g," ")),f="#"+i,void 0==D.get(i))return u
+f=D.get(i),void 0!=W.get(i)&&(s=W.get(i))}l=K(g(l),"*_[]()"),f=K(f,"*_")
+var h='<img src="'+f+'" alt="'+l+'"'
+return s=g(s),s=K(s,"*_"),h+=' title="'+s+'"',h+=" />"}function s(e){return e=e.replace(/^(.+)[ \t]*\n=+[ \t]*\n+/gm,function(e,r){return"<h1>"+c(r)+"</h1>\n\n"}),e=e.replace(/^(.+)[ \t]*\n-+[ \t]*\n+/gm,function(e,r){return"<h2>"+c(r)+"</h2>\n\n"}),e=e.replace(/^(\#{1,6})[ \t]*(.+?)[ \t]*\#*\n+/gm,function(e,r,n){var t=r.length
+return"<h"+t+">"+c(n)+"</h"+t+">\n\n"})}function h(e){e+="~0"
+var r=/^(([ ]{0,3}([*+-]|\d+[.])[ \t]+)[^\r]+?(~0|\n{2,}(?=\S)(?![ \t]*(?:[*+-]|\d+[.])[ \t]+)))/gm
+return B?e=e.replace(r,function(e,r,n){var t=r,a=n.search(/[*+-]/g)>-1?"ul":"ol",o=d(t,a)
+return o=o.replace(/\s+$/,""),o="<"+a+">"+o+"</"+a+">\n"}):(r=/(\n\n|^\n?)(([ ]{0,3}([*+-]|\d+[.])[ \t]+)[^\r]+?(~0|\n{2,}(?=\S)(?![ \t]*(?:[*+-]|\d+[.])[ \t]+)))/g,e=e.replace(r,function(e,r,n,t){var a=r,o=n,c=t.search(/[*+-]/g)>-1?"ul":"ol",p=d(o,c)
+return p=a+"<"+c+">\n"+p+"</"+c+">\n"})),e=e.replace(/~0/,"")}function d(e,r){B++,e=e.replace(/\n{2,}$/,"\n"),e+="~0"
+var n=R[r],t=RegExp("(^[ \\t]*)("+n+")[ \\t]+([^\\r]+?(\\n+))(?=(~0|\\1("+n+")[ \\t]+))","gm"),a=!1
+return e=e.replace(t,function(e,r,n,t){var p=t,u=/\n\n$/.test(p),l=u||p.search(/\n{2,}/)>-1
+return l||a?p=o(x(p),!0):(p=h(x(p)),p=p.replace(/\n$/,""),p=c(p)),a=u,"<li>"+p+"</li>\n"}),e=e.replace(/~0/g,""),B--,e}function v(e){return e+="~0",e=e.replace(/(?:\n\n|^)((?:(?:[ ]{4}|\t).*\n+)+)(\n*[ ]{0,3}[^ \t\n]|(?=~0))/g,function(e,r,n){var t=r,a=n
+return t=_(x(t)),t=y(t),t=t.replace(/^\n+/g,""),t=t.replace(/\n+$/g,""),t="<pre><code>"+t+"\n</code></pre>","\n\n"+t+"\n\n"+a}),e=e.replace(/~0/,"")}function m(e){return e=e.replace(/(^\n+|\n+$)/g,""),"\n\n~K"+(z.push(e)-1)+"K\n\n"}function $(e){return e=e.replace(/(^|[^\\])(`+)([^\r]*?[^`])\2(?!`)/gm,function(e,r,n,t,a){var o=t
+return o=o.replace(/^([ \t]*)/g,""),o=o.replace(/[ \t]*$/g,""),o=_(o),o=o.replace(/:\/\//g,"~P"),r+"<code>"+o+"</code>"})}function _(e){return e=e.replace(/&/g,"&amp;"),e=e.replace(/</g,"&lt;"),e=e.replace(/>/g,"&gt;"),e=K(e,"*_{}[]\\",!1)}function k(e){return e=e.replace(/([\W_]|^)(\*\*|__)(?=\S)([^\r]*?\S[\*_]*)\2([\W_]|$)/g,"$1<strong>$3</strong>$4"),e=e.replace(/([\W_]|^)(\*|_)(?=\S)([^\r\*_]*?\S)\2([\W_]|$)/g,"$1<em>$3</em>$4")}function w(e){return e=e.replace(/((^[ \t]*>[ \t]?.+\n(.+\n)*\n*)+)/gm,function(e,r){var n=r
+return n=n.replace(/^[ \t]*>[ \t]?/gm,"~0"),n=n.replace(/~0/g,""),n=n.replace(/^[ \t]+$/gm,""),n=o(n),n=n.replace(/(^|\n)/g,"$1  "),n=n.replace(/(\s*<pre>[^\r]+?<\/pre>)/gm,function(e,r){var n=r
+return n=n.replace(/^  /gm,"~0"),n=n.replace(/~0/g,"")}),m("<blockquote>\n"+n+"\n</blockquote>")})}function C(e,r){e=e.replace(/^\n+/g,""),e=e.replace(/\n+$/g,"")
+for(var n=e.split(/\n{2,}/g),t=[],a=/~K(\d+)K/,o=n.length,p=0;o>p;p++){var u=n[p]
+a.test(u)?t.push(u):/\S/.test(u)&&(u=c(u),u=u.replace(/^([ \t]*)/g,"<p>"),u+="</p>",t.push(u))}if(!r){o=t.length
+for(var p=0;o>p;p++)for(var l=!0;l;)l=!1,t[p]=t[p].replace(/~K(\d+)K/g,function(e,r){return l=!0,z[r]})}return t.join("\n\n")}function S(e){return e=e.replace(/&(?!#?[xX]?(?:[0-9a-fA-F]+|\w+);)/g,"&amp;"),e=e.replace(/<(?![a-z\/?!]|~D)/gi,"&lt;")}function b(e){return e=e.replace(/\\(\\)/g,q),e=e.replace(/\\([`*_{}\[\]()>#+-.!])/g,q)}function N(e,r,n,t){if(r)return e
+if(")"!==t.charAt(t.length-1))return"<"+n+t+">"
+for(var a=t.match(/[()]/g),o=0,c=0;c<a.length;c++)"("===a[c]?0>=o?o=1:o++:o--
+var p=""
+if(0>o){var u=RegExp("\\){1,"+-o+"}$")
+t=t.replace(u,function(e){return p=e,""})}return"<"+n+t+">"+p}function E(e){e=e.replace(/(="|<)?\b(https?|ftp)(:\/\/[-A-Z0-9+&@#\/%?=~_|\[\]\(\)!:,\.;]*[-A-Z0-9+&@#\/%=~_|\[\])])(?=$|\W)/gi,N)
+var r=function(e,r){return'<a href="'+r+'">'+L.plainLinkText(r)+"</a>"}
+return e=e.replace(/<((https?|ftp):[^'">\s]+)>/gi,r)}function A(e){return e=e.replace(/~E(\d+)E/g,function(e,r){var n=parseInt(r)
+return String.fromCharCode(n)})}function x(e){return e=e.replace(/^(\t|[ ]{1,4})/gm,"~0"),e=e.replace(/~0/g,"")}function y(e){if(!/\t/.test(e))return e
+var r,n=["    ","   ","  "," "],t=0
+return e.replace(/[\n\t]/g,function(e,a){return"\n"===e?(t=a+1,e):(r=(a-t)%4,t=a+1,n[r])})}function G(e){if(!e)return""
+var r=e.length
+return e.replace(T,function(n,t){return"~D"==n?"%24":":"!=n||t!=r-1&&!/[0-9\/]/.test(e.charAt(t+1))?"%"+n.charCodeAt(0).toString(16):":"})}function K(e,r,n){var t="(["+r.replace(/([\[\]\\])/g,"\\$1")+"])"
+n&&(t="\\\\"+t)
+var a=RegExp(t,"g")
+return e=e.replace(a,q)}function q(e,r){var n=r.charCodeAt(0)
+return"~E"+n+"E"}var L=this.hooks=new n
+L.addNoop("plainLinkText"),L.addNoop("preConversion"),L.addNoop("postNormalization"),L.addNoop("preBlockGamut"),L.addNoop("postBlockGamut"),L.addNoop("preSpanGamut"),L.addNoop("postSpanGamut"),L.addNoop("postConversion")
+var D,W,z,B
+this.makeHtml=function(n){if(D)throw Error("Recursive call to converter.makeHtml")
+return D=new t,W=new t,z=[],B=0,n=L.preConversion(n),n=n.replace(/~/g,"~T"),n=n.replace(/\$/g,"~D"),n=n.replace(/\r\n/g,"\n"),n=n.replace(/\r/g,"\n"),n="\n\n"+n+"\n\n",n=y(n),n=n.replace(/^[ \t]+$/gm,""),n=L.postNormalization(n),n=r(n),n=e(n),n=o(n),n=A(n),n=n.replace(/~D/g,"$$"),n=n.replace(/~T/g,"~"),n=L.postConversion(n),z=W=D=null,n}
+var M=function(e){return o(e)},R={ol:"\\d+[.]",ul:"[*+-]"},T=/(?:["'*()[\]:]|~D)/g}}();
+
+/* pagedown sanitizer */
+function(){function r(r){return r.replace(/<[^>]*>?/gi,t)}function t(r){return r.match(i)||r.match(s)||r.match(a)?r:""}function e(r){if(""==r)return""
+var t=/<\/?\w+[^>]*(\s|$|>)/g,e=r.toLowerCase().match(t),n=(e||[]).length
+if(0==n)return r
+for(var o,i,s,a="<p><img><br><li><hr>",c=[],h=[],u=!1,f=0;n>f;f++)if(o=e[f].replace(/<\/?(\w+).*/,"$1"),!(c[f]||a.search("<"+o+">")>-1)){if(i=e[f],s=-1,!/^<\//.test(i))for(var p=f+1;n>p;p++)if(!c[p]&&e[p]=="</"+o+">"){s=p
+break}-1==s?u=h[f]=!0:c[s]=!0}if(!u)return r
+var f=0
+return r=r.replace(t,function(r){var t=h[f]?"":r
+return f++,t})}var n,o
+"object"==typeof exports&&"function"==typeof require?(n=exports,o=require("./Markdown.Converter").Converter):(n=window.Markdown,o=n.Converter),n.getSanitizingConverter=function(){var t=new o
+return t.hooks.chain("postConversion",r),t.hooks.chain("postConversion",e),t}
+var i=/^(<\/?(b|blockquote|code|del|dd|dl|dt|em|h1|h2|h3|i|kbd|li|ol|p|pre|s|sup|sub|strong|strike|ul)>|<(br|hr)\s?\/?>)$/i,s=/^(<a\shref="((https?|ftp):\/\/|\/)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)]+"(\stitle="[^"<>]+")?\s?>|<\/a>)$/i,a=/^(<img\ssrc="(https?:\/\/|\/)[-A-Za-z0-9+&@#\/%?=~_|!:,.;\(\)]+"(\swidth="\d{1,3}")?(\sheight="\d{1,3}")?(\salt="[^"<>]*")?(\stitle="[^"<>]*")?\s?\/?>)$/i}()
+</script>

--- a/src/cards/ha-persistent_notification-card.html
+++ b/src/cards/ha-persistent_notification-card.html
@@ -36,9 +36,10 @@ class HaPersistentNotificationCard extends Polymer.Element {
       hass: Object,
       stateObj: Object,
       scriptLoaded: {
-        type: Boolean,
-        value: false,
-      },
+        type: Number,
+        // 0 = not loaded, 1 = success, 2 = error
+        value: 0,
+      }
     };
   }
 
@@ -53,40 +54,30 @@ class HaPersistentNotificationCard extends Polymer.Element {
             window.hassUtil.computeStateName(stateObj));
   }
 
-  loadScript() {
-    var success = function () {
-      this.scriptLoaded = true;
-    }.bind(this);
-
-    var error = function () {
-      /* eslint-disable no-console */
-      console.error('Micromarkdown was not loaded.');
-      /* eslint-enable no-console */
-    };
-
-    this.importHref(
-      '/static/micromarkdown-js.html',
-      success, error
-    );
-  }
-
   computeContent(stateObj, scriptLoaded) {
-    var el = '';
-    var message = '';
-    if (scriptLoaded) {
-      el = this.$.pnContent;
-      message = window.micromarkdown.parse(stateObj.attributes.message);
-      el.innerHTML = message;
+    if (scriptLoaded === 0) {
+      return;
+    } else if (scriptLoaded === 1) {
+      const converter = Markdown.getSanitizingConverter();
+      this.$.pnContent.innerHTML = converter.makeHtml(
+        stateObj.attributes.message);
+    } else {
+      this.$.pnContent.innerText = stateObj.attributes.message;
     }
   }
 
   ready() {
-    this.loadScript();
+    super.ready();
+
+    Polymer.importHref(
+      '/static/pagedown-js.html',
+      () => { this.scriptLoaded = 1; },
+      () => { this.scriptLoaded = 2; },
+    );
   }
 
   dismissTap(ev) {
     ev.preventDefault();
-
     this.hass.callApi('DELETE', 'states/' + this.stateObj.entity_id);
   }
 }

--- a/src/cards/ha-persistent_notification-card.html
+++ b/src/cards/ha-persistent_notification-card.html
@@ -55,13 +55,10 @@ class HaPersistentNotificationCard extends Polymer.Element {
   }
 
   computeContent(stateObj, scriptLoaded) {
-    if (scriptLoaded === 0) {
-      return;
-    } else if (scriptLoaded === 1) {
-      const converter = Markdown.getSanitizingConverter();
-      this.$.pnContent.innerHTML = converter.makeHtml(
-        stateObj.attributes.message);
-    } else {
+    if (scriptLoaded === 1) {
+      const converter = window.Markdown.getSanitizingConverter();
+      this.$.pnContent.innerHTML = converter.makeHtml(stateObj.attributes.message);
+    } else if (scriptLoaded === 2) {
       this.$.pnContent.innerText = stateObj.attributes.message;
     }
   }


### PR DESCRIPTION
We have recently been notified by Marcin Teodorczyk from https://www.intive.com about a vulnerability in Home Assistant: we did not sanitize the Markdown output. This means that our users have been vulnerable to script injection attacks. The severity is low, as to be able to create a persistent notification an attacker would need access to the instance.

Then, when migrating to the new package format, I accidentally removed the markdown file so the vulnerability no longer existed, but neither did the persistent notifications work.

While adding back a sanitized version of the markdown parser, I realized that when the component was migrated to ES6 in #465 we forgot to call `super.ready()`, so the Polymer template never initialized. That too actually resolved the vulnerability 😉 

This PR migrates to use Pagedown, the Markdown renderer used by StackExchange: https://github.com/StackExchange/pagedown . This renderer includes a sanitizer after which I was no longer able to reproduce the script injection attack supplied by Marcin.

As a bonus, when the script fails to load, we will render the message as a text content.

I think that we should take a closer look what we want to support in the persistent notification markdown. We might just want to limit it to links and maybe paragraphs? (That's for a future PR)