### PR TITLE
Remove untranslated strings

### DIFF
--- a/translations/it.json
+++ b/translations/it.json
@@ -5,8 +5,6 @@
   "panel": {
     "states": "Stati",
     "map": "Mappa",
-    "logbook": "Logbook",
-    "history": "Storico",
-    "log_out": "Log Out"
+    "history": "Storico"
   }
 }


### PR DESCRIPTION
our translations guidelines are still wip, but we don't add strings that don't differ from en.json

@luca-angemi