### PR TITLE
Fix languages and themes top selection being cut off

### DIFF
--- a/panels/config/core/ha-config-core.html
+++ b/panels/config/core/ha-config-core.html
@@ -15,6 +15,7 @@
     <style include="iron-flex ha-style">
       .content {
         padding-bottom: 32px;
+        transform: translate(0);
       }
 
       .border {


### PR DESCRIPTION
`iron-fit-behavior` which is used by `paper-dropdown-menu` is not smart enough: After it computes the position it sets it using `position: fixed`. If there is a scrollable parent the dropdown will be positioned relative to the parent start, but it won't scroll together with the parent.

This PR adds `transform: translate(0);` to the parent that causing `position: fixed` to be relative to config content and not the whole screen.

Fixes: #475 