### PR TITLE
Calendar Panel

### DIFF
--- a/panels/calendar/ha-panel-calendar.html
+++ b/panels/calendar/ha-panel-calendar.html
@@ -24,14 +24,17 @@
       </app-header>
       <div class='content'>
         <paper-card>
-          <template is='dom-if' items='[[!platforms.length]]'>
+          <template is='dom-if' if='[[!_platforms.length]]'>
             <div class='card-content'>
               No platforms
             </div>
           </template>
-          <template is='dom-repeat' items='[[platforms]]'>
+          <template is='dom-repeat' items='[[_platforms]]' as="platform">
             <div class='card-content'>
-                Platforms
+              [[platform.name]]
+              <template is='dom-if' if='[[!platform.events]]'>
+                No Events?
+              </template>
             </div>
           </template>
         </paper-card>
@@ -58,21 +61,24 @@ Polymer({
       value: false,
     },
 
-    platforms: {
+    _platforms: {
       type: Array,
+      notify: true,
+      reflectToAttribute: true
     },
 
     _events: {
-      type: Array,
+      type: Object,
     },
   },
 
   attached: function () {
     this.hassChanged = this.hassChanged.bind(this);
-    console.log('attached');
     this.computePlatforms().then(function(platforms) {
-      console.log(platforms);
-      this.platforms = platforms;
+      this._platforms = platforms.map(function(platform) {
+        return { name: platform };
+      }.bind(this));
+
       this.hassChanged();
     }.bind(this));
   },
@@ -80,10 +86,34 @@ Polymer({
   hassChanged: function() {
     console.log('hass changed');
     // TODO: Load events
+
+    if(this._platforms) {
+      this._platforms.forEach(function(platform) {
+        this.computeEvents(platform.name).then(function(events) {
+          platform.events = events;
+          console.log(platform);
+          console.log(this._platforms);
+          return platform;
+        }.bind(this));
+
+        console.log(this._platforms);
+       // return platform;
+       }.bind(this));
+        /*console.log(i);
+        this.computeEvents(this.platforms[i].name).then(function(events) {
+          this.platforms[i].events = events;
+          console.log(this.platforms);
+        //});*/
+      }
+
   },
 
   computePlatforms: function () {
      return this.hass.callApi('GET', 'calendar/platforms');
+  },
+
+  computeEvents: function (platform) {
+    return this.hass.callApi('GET', 'calendar/events/' + platform);
   },
 });
 

--- a/panels/calendar/ha-panel-calendar.html
+++ b/panels/calendar/ha-panel-calendar.html
@@ -15,6 +15,10 @@
 <dom-module id='ha-panel-calendar'>
   <template>
     <style include='ha-style'>
+      .event-active .row {
+        color: green;
+        font-weight: bold;
+      }
     </style>
 
     <app-header-layout has-scrolling-region>
@@ -32,7 +36,7 @@
                 No Events?
               </template>
               <template is='dom-repeat'items='[[platform.events]]' as='event' sort="sortEvents">
-                <paper-item disabled='[[eventPassed(event)]]'>
+                <paper-item disabled='[[eventPassed(event)]]' class$="[[checkActive(event)]]">
                   <paper-item-body style="width:100%" two-line>
                     <div class="row">
                       <div>[[event.text]]</div>
@@ -99,11 +103,10 @@ Polymer({
           this.notifyPath('_platforms.' + index + '.events');
         }.bind(this));
        }.bind(this));
-      }
+    }
   },
 
   computePlatforms: function () {
-    console.log(new Date());
      return this.hass.callApi('GET', 'calendar/platforms');
   },
 
@@ -117,6 +120,10 @@ Polymer({
 
   eventPassed: function(event) {
     return (new Date(event.start) < new Date() && new Date(event.end) < new Date());
+  },
+
+  checkActive: function(event) {
+    return (new Date(event.start) < new Date() && new Date(event.end) > new Date()) ? 'event-active': '';
   }
 });
 

--- a/panels/calendar/ha-panel-calendar.html
+++ b/panels/calendar/ha-panel-calendar.html
@@ -32,7 +32,7 @@
                 No Events?
               </template>
               <template is='dom-repeat'items='[[platform.events]]' as='event' sort="sortEvents">
-                <paper-item>
+                <paper-item disabled='[[eventPassed(event)]]'>
                   <paper-item-body style="width:100%" two-line>
                     <div class="row">
                       <div>[[event.text]]</div>
@@ -112,6 +112,10 @@ Polymer({
 
   sortEvents: function(a, b) {
     return new Date(a.start) - new Date(b.start);    
+  },
+
+  eventPassed: function(event) {
+    return new Date(event.start) < new Date();
   }
 });
 

--- a/panels/calendar/ha-panel-calendar.html
+++ b/panels/calendar/ha-panel-calendar.html
@@ -1,6 +1,8 @@
 <link rel='import' href='../../bower_components/polymer/polymer.html'>
 
 <link rel='import' href='../../bower_components/paper-card/paper-card.html'>
+<link rel='import' href='../../bower_components/paper-item/paper-item.html'>
+<link rel='import' href='../../bower_components/paper-item/paper-item-body.html'>
 
 <link rel='import' href='../../bower_components/app-layout/app-header-layout/app-header-layout.html'>
 <link rel='import' href='../../bower_components/app-layout/app-header/app-header.html'>
@@ -23,17 +25,23 @@
         </app-toolbar>
       </app-header>
       <div class='content'>
-        <paper-card>
-          <template is='dom-if' if='[[!_platforms.length]]'>
+        <template is='dom-repeat' items='[[_platforms]]' as="platform">
+          <paper-card heading='[[platform.name]]'>
             <div class='card-content'>
-              No platforms
-            </div>
-          </template>
-          <template is='dom-repeat' items='[[_platforms]]' as="platform">
-            <div class='card-content'>
-              [[platform.name]]
               <template is='dom-if' if='[[!platform.events]]'>
                 No Events?
+              </template>
+              <template is='dom-repeat'items='[[platform.events]]' as='event' sort="sortEvents">
+                <paper-item>
+                  <paper-item-body style="width:100%" two-line>
+                    <div class="row">
+                      <div>[[event.text]]</div>
+                    </div>
+                    <div secondary>
+                      <span class="date">[[event.start]] - [[event.end]]</span>
+                    </div>
+                  </paper-item-body>
+                </paper-item>
               </template>
             </div>
           </template>
@@ -84,28 +92,14 @@ Polymer({
   },
 
   hassChanged: function() {
-    console.log('hass changed');
-    // TODO: Load events
-
     if(this._platforms) {
-      this._platforms.forEach(function(platform) {
+      this._platforms.forEach(function(platform, index) {
         this.computeEvents(platform.name).then(function(events) {
           platform.events = events;
-          console.log(platform);
-          console.log(this._platforms);
-          return platform;
+          this.notifyPath('_platforms.' + index + '.events');
         }.bind(this));
-
-        console.log(this._platforms);
-       // return platform;
        }.bind(this));
-        /*console.log(i);
-        this.computeEvents(this.platforms[i].name).then(function(events) {
-          this.platforms[i].events = events;
-          console.log(this.platforms);
-        //});*/
       }
-
   },
 
   computePlatforms: function () {
@@ -115,6 +109,10 @@ Polymer({
   computeEvents: function (platform) {
     return this.hass.callApi('GET', 'calendar/events/' + platform);
   },
+
+  sortEvents: function(a, b) {
+    return new Date(a.start) - new Date(b.start);    
+  }
 });
 
 </script>

--- a/panels/calendar/ha-panel-calendar.html
+++ b/panels/calendar/ha-panel-calendar.html
@@ -103,6 +103,7 @@ Polymer({
   },
 
   computePlatforms: function () {
+    console.log(new Date());
      return this.hass.callApi('GET', 'calendar/platforms');
   },
 
@@ -115,7 +116,7 @@ Polymer({
   },
 
   eventPassed: function(event) {
-    return new Date(event.start) < new Date();
+    return (new Date(event.start) < new Date() && new Date(event.end) < new Date());
   }
 });
 

--- a/panels/calendar/ha-panel-calendar.html
+++ b/panels/calendar/ha-panel-calendar.html
@@ -83,7 +83,7 @@ Polymer({
   },
 
   computePlatforms: function () {
-     return this.hass.callApi('GET', 'mailbox/platforms');
+     return this.hass.callApi('GET', 'calendar/platforms');
   },
 });
 

--- a/panels/calendar/ha-panel-calendar.html
+++ b/panels/calendar/ha-panel-calendar.html
@@ -1,0 +1,90 @@
+<link rel='import' href='../../bower_components/polymer/polymer.html'>
+
+<link rel='import' href='../../bower_components/paper-card/paper-card.html'>
+
+<link rel='import' href='../../bower_components/app-layout/app-header-layout/app-header-layout.html'>
+<link rel='import' href='../../bower_components/app-layout/app-header/app-header.html'>
+<link rel='import' href='../../bower_components/app-layout/app-toolbar/app-toolbar.html'>
+
+<link rel='import' href='../../src/components/ha-menu-button.html'>
+<link rel='import' href='../../src/resources/ha-style.html'>
+
+
+<dom-module id='ha-panel-calendar'>
+  <template>
+    <style include='ha-style'>
+    </style>
+
+    <app-header-layout has-scrolling-region>
+      <app-header slot="header" fixed>
+        <app-toolbar>
+          <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
+          <div main-title>Calendar</div>
+        </app-toolbar>
+      </app-header>
+      <div class='content'>
+        <paper-card>
+          <template is='dom-if' items='[[!platforms.length]]'>
+            <div class='card-content'>
+              No platforms
+            </div>
+          </template>
+          <template is='dom-repeat' items='[[platforms]]'>
+            <div class='card-content'>
+                Platforms
+            </div>
+          </template>
+        </paper-card>
+      </div>
+    </app-header-layout>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'ha-panel-calendar',
+  properties: {
+    hass: {
+      type: Object,
+    },
+
+    narrow: {
+      type: Boolean,
+      value: false,
+    },
+
+    showMenu: {
+      type: Boolean,
+      value: false,
+    },
+
+    platforms: {
+      type: Array,
+    },
+
+    _events: {
+      type: Array,
+    },
+  },
+
+  attached: function () {
+    this.hassChanged = this.hassChanged.bind(this);
+    console.log('attached');
+    this.computePlatforms().then(function(platforms) {
+      console.log(platforms);
+      this.platforms = platforms;
+      this.hassChanged();
+    }.bind(this));
+  },
+
+  hassChanged: function() {
+    console.log('hass changed');
+    // TODO: Load events
+  },
+
+  computePlatforms: function () {
+     return this.hass.callApi('GET', 'mailbox/platforms');
+  },
+});
+
+</script>

--- a/polymer.json
+++ b/polymer.json
@@ -16,7 +16,8 @@
     "panels/logbook/ha-panel-logbook.html",
     "panels/map/ha-panel-map.html",
     "panels/shopping-list/ha-panel-shopping-list.html",
-    "panels/mailbox/ha-panel-mailbox.html"
+    "panels/mailbox/ha-panel-mailbox.html",
+    "panels/calendar/ha-panel-calendar.html"
   ],
   "sources": [
     "src/**/*",

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -107,6 +107,7 @@
     sensor: 5,
     binary_sensor: 6,
     mailbox: 7,
+    calendar: 8,
   };
 
   function getPriority(domain) {


### PR DESCRIPTION
This is the frontend implementation of the [Calendar Panel PR](https://github.com/home-assistant/home-assistant/pull/10191)  in the main repo.
Since I could not find a proper Polymer Calendar library to use, I have set up the system to show each calendar in a card, listing the events. Users will be able to see all their events in the components (past, current and future), example below.

![image](https://user-images.githubusercontent.com/13683094/32135866-4f1d994e-bc06-11e7-9ecc-fdf84dd19f01.png)

As you can see, there are greyed out events, which are the ones that have passed already. Current running events are green, future events are plain black text.

The calendar view does not support updating when the component itself updates yet, will likely still come. Refreshign the view does load new events.