### PR TITLE
Use dynamic-align on all dropdowns

### DIFF
--- a/panels/config/core/ha-config-core.html
+++ b/panels/config/core/ha-config-core.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../../../bower_components/polymer/polymer-element.html">
-<link rel="import" href="../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
-<link rel="import" href="../../../bower_components/app-layout/app-header/app-header.html">
-<link rel="import" href="../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 <link rel="import" href="../../../bower_components/paper-icon-button/paper-icon-button.html">
+
+<link rel="import" href="../../../src/resources/ha-style.html">
+<link rel="import" href="../../../src/resources/panel-imports.html">
 
 <link rel="import" href="./ha-config-section-core.html">
 <!-- <link rel="import" href="./ha-config-section-group.html"> -->
@@ -15,7 +15,6 @@
     <style include="iron-flex ha-style">
       .content {
         padding-bottom: 32px;
-        transform: translate(0);
       }
 
       .border {

--- a/panels/config/core/ha-config-section-themes.html
+++ b/panels/config/core/ha-config-section-themes.html
@@ -17,7 +17,7 @@
 
       <paper-card>
         <div class='card-content'>
-          <paper-dropdown-menu label='Theme' vertical-align='bottom'>
+          <paper-dropdown-menu label='Theme' dynamic-align>
             <paper-listbox
               slot="dropdown-content"
               selected='{{selectedTheme}}'

--- a/panels/config/zwave/ha-config-zwave.html
+++ b/panels/config/zwave/ha-config-zwave.html
@@ -105,13 +105,11 @@
 
         <paper-card class="content">
           <div class='device-picker'>
-            <paper-dropdown-menu label="Nodes" class="flex">
-              <paper-listbox
-                slot="dropdown-content"
-                selected='{{selectedNode}}'>
-              <template is='dom-repeat' items='[[nodes]]' as='state'>
-                <paper-item>[[computeSelectCaption(state)]]</paper-item>
-              </template>
+            <paper-dropdown-menu dynamic-align label="Nodes" class="flex">
+              <paper-listbox slot="dropdown-content" selected='{{selectedNode}}'>
+                <template is='dom-repeat' items='[[nodes]]' as='state'>
+                  <paper-item>[[computeSelectCaption(state)]]</paper-item>
+                </template>
               </paper-listbox>
             </paper-dropdown-menu>
           </div>
@@ -198,7 +196,7 @@
            </div>
 
            <div class='device-picker'>
-            <paper-dropdown-menu label="Entities of this node" class="flex">
+            <paper-dropdown-menu label="Entities of this node" dynamic-align class="flex">
               <paper-listbox
                 slot="dropdown-content"
                 selected='{{selectedEntity}}'>

--- a/panels/config/zwave/zwave-groups.html
+++ b/panels/config/zwave/zwave-groups.html
@@ -36,7 +36,7 @@
     <paper-card class="content" heading='Node group associations'>
       <!--TODO make api for getting groups and members-->
       <div class='device-picker'>
-        <paper-dropdown-menu label="Group" class='flex'>
+        <paper-dropdown-menu label="Group" dynamic-align class='flex'>
           <paper-listbox
               slot="dropdown-content"
               selected='{{selectedGroup}}'>
@@ -48,7 +48,7 @@
       </div>
       <template is='dom-if' if='[[computeIsGroupSelected(selectedGroup)]]'>
         <div class='device-picker'>
-          <paper-dropdown-menu label="Node to control" class='flex'>
+          <paper-dropdown-menu label="Node to control" dynamic-align class='flex'>
             <paper-listbox
                 slot="dropdown-content"
                 selected='{{selectedTargetNode}}'>

--- a/panels/config/zwave/zwave-node-config.html
+++ b/panels/config/zwave/zwave-node-config.html
@@ -53,7 +53,7 @@
           </div>
         </template>
         <div class='device-picker'>
-        <paper-dropdown-menu label="Config parameter" class='flex'>
+        <paper-dropdown-menu label="Config parameter" dynamic-align class='flex'>
           <paper-listbox
             slot="dropdown-content"
             selected='{{selectedConfigParameter}}'>
@@ -65,7 +65,7 @@
         </div>
         <template is='dom-if' if="[[isConfigParameterSelected(selectedConfigParameter, 'List')]]">
           <div class='device-picker'>
-            <paper-dropdown-menu label="Config value" class='flex' placeholder='{{loadedConfigValue}}'>
+            <paper-dropdown-menu label="Config value" dynamic-align class='flex' placeholder='{{loadedConfigValue}}'>
               <paper-listbox
                 slot="dropdown-content"
                 selected='{{selectedConfigValue}}'>
@@ -90,7 +90,7 @@
         </template>
         <template is='dom-if' if="[[isConfigParameterSelected(selectedConfigParameter, 'Bool Button')]]">
           <div class='device-picker'>
-            <paper-dropdown-menu label="Config value" class='flex' placeholder='{{loadedConfigValue}}'>
+            <paper-dropdown-menu label="Config value" class='flex' dynamic-align placeholder='{{loadedConfigValue}}'>
               <paper-listbox
                 slot="dropdown-content"
                 selected='{{selectedConfigValue}}'>

--- a/panels/config/zwave/zwave-usercodes.html
+++ b/panels/config/zwave/zwave-usercodes.html
@@ -31,7 +31,7 @@
       <div class='content'>
         <paper-card heading='Node user codes'>
           <div class='device-picker'>
-          <paper-dropdown-menu label="Code slot" class='flex'>
+          <paper-dropdown-menu label="Code slot" dynamic-align class='flex'>
             <paper-listbox
               slot="dropdown-content"
               selected='{{selectedUserCode}}'>

--- a/panels/config/zwave/zwave-values.html
+++ b/panels/config/zwave/zwave-values.html
@@ -35,7 +35,7 @@
     <div class='content'>
       <paper-card heading='Node Values'>
         <div class='device-picker'>
-        <paper-dropdown-menu label="Value" class='flex'>
+        <paper-dropdown-menu label="Value" dynamic-align class='flex'>
           <paper-listbox
             slot="dropdown-content"
             selected='{{selectedValue}}'>
@@ -159,4 +159,3 @@ class ZwaveValues extends Polymer.Element {
 
 customElements.define(ZwaveValues.is, ZwaveValues);
 </script>
-

--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -124,7 +124,7 @@
 
       <div class='container-operation_list'>
         <div class='controls'>
-          <paper-dropdown-menu label-float label='Operation'>
+          <paper-dropdown-menu label-float dynamic-align label='Operation'>
             <paper-listbox slot="dropdown-content" selected="{{operationIndex}}">
               <template is='dom-repeat'
                         items='[[stateObj.attributes.operation_list]]'>
@@ -136,7 +136,7 @@
       </div>
 
       <div class='container-fan_list'>
-        <paper-dropdown-menu label-float label='Fan Mode'>
+        <paper-dropdown-menu label-float dynamic-align label='Fan Mode'>
           <paper-listbox slot="dropdown-content" selected="{{fanIndex}}">
             <template is='dom-repeat'
                       items='[[stateObj.attributes.fan_list]]'>
@@ -147,7 +147,7 @@
       </div>
 
       <div class='container-swing_list'>
-        <paper-dropdown-menu label-float label='Swing Mode'>
+        <paper-dropdown-menu label-float dynamic-align label='Swing Mode'>
           <paper-listbox slot="dropdown-content" selected="{{swingIndex}}">
             <template is='dom-repeat'
                       items='[[stateObj.attributes.swing_list]]'>

--- a/src/more-infos/more-info-fan.html
+++ b/src/more-infos/more-info-fan.html
@@ -35,7 +35,7 @@
     <div class$='[[computeClassNames(stateObj)]]'>
 
       <div class="container-speed_list">
-        <paper-dropdown-menu label-float label='Speed'>
+        <paper-dropdown-menu label-float dynamic-align label='Speed'>
           <paper-listbox slot="dropdown-content" selected='{{speedIndex}}'>
             <template is='dom-repeat'
                       items='[[stateObj.attributes.speed_list]]'>

--- a/src/more-infos/more-info-light.html
+++ b/src/more-infos/more-info-light.html
@@ -57,7 +57,7 @@
     <div class$='[[computeClassNames(stateObj)]]'>
 
       <div class='effect_list'>
-        <paper-dropdown-menu label-float label='Effect'>
+        <paper-dropdown-menu label-float dynamic-align label='Effect'>
           <paper-listbox slot="dropdown-content" selected="{{effectIndex}}">
             <template is='dom-repeat'
                       items='[[stateObj.attributes.effect_list]]'>

--- a/src/more-infos/more-info-media_player.html
+++ b/src/more-infos/more-info-media_player.html
@@ -98,7 +98,7 @@
       <div class='controls layout horizontal justified'
            hidden$='[[computeHideSelectSource(isOff, supportsSelectSource)]]'>
         <iron-icon class="source-input" icon="mdi:login-variant"></iron-icon>
-        <paper-dropdown-menu class="flex source-input" label-float label='Source'>
+        <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Source'>
           <paper-listbox slot="dropdown-content" selected="{{sourceIndex}}">
             <template is='dom-repeat' items='[[stateObj.attributes.source_list]]'>
               <paper-item>[[item]]</paper-item>

--- a/src/more-infos/more-info-vacuum.html
+++ b/src/more-infos/more-info-vacuum.html
@@ -67,7 +67,7 @@
 
     <div hidden$='[[!supportsFanSpeed(stateObj)]]'>
       <div class='horizontal justified layout'>
-        <paper-dropdown-menu label-float label='Fan speed'>
+        <paper-dropdown-menu label-float dynamic-align label='Fan speed'>
           <paper-listbox slot="dropdown-content" selected='{{fanSpeedIndex}}'>
             <template is='dom-repeat'
                       items='[[stateObj.attributes.fan_speed_list]]'>

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -101,8 +101,8 @@
 
       app-header-layout > :not([slot]) {
         /* app-header-layout creates a separate z-index stack for content.
-	 * Using 'transform' will cause 'position: fixed' elements to reside
-	 * in that stack too. */
+         * Using 'transform' will cause 'position: fixed' elements to reside
+         * in that stack too. */
         transform: translate(0);
       }
       h1 {

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -99,6 +99,12 @@
         margin-left: 24px;
       }
 
+      app-header-layout > :not([slot]) {
+        /* app-header-layout creates a separate z-index stack for content.
+	 * Using 'transform' will cause 'position: fixed' elements to reside
+	 * in that stack too. */
+        transform: translate(0);
+      }
       h1 {
         @apply(--paper-font-title);
       }


### PR DESCRIPTION
Use dynamic-align on all dropdowns.
Generalize `transform: translate(0);` hack to all content slots of app-header-layout