### PR TITLE
Improve language detection

### DIFF
--- a/src/util/hass-translation.html
+++ b/src/util/hass-translation.html
@@ -35,9 +35,15 @@ function getActiveTranslation() {
       }
     }
   } else {
-    translation = languageGetTranslation(navigator.language || navigator.userLanguage);
+    translation = languageGetTranslation(navigator.language);
     if (translation) {
       return translation;
+    }
+    if (navigator.language.length > 2) {
+      translation = languageGetTranslation(navigator.language.substring(0, 2));
+      if (translation) {
+        return translation;
+      }
     }
   }
 

--- a/src/util/hass-translation.html
+++ b/src/util/hass-translation.html
@@ -1,14 +1,24 @@
-<link rel='import' href='../../build-temp/translationMetadata.html' />
+<link rel='import' href='../../build-translations/translationMetadata.html' />
 
 <script>
 function getActiveTranslation() {
+  // Perform case-insenstive comparison since browser isn't required to
+  // report languages with specific cases.
+  const lookup = {};
+  /* eslint-disable no-undef */
+  Object.keys(window.translationMetadata.translations).forEach((tr) => {
+    lookup[tr.toLowerCase()] = tr;
+  });
+
+  // Search for a matching translation from most specific to general
   function languageGetTranslation(language) {
-    if (window.translationMetadata[language]) {
-      return language;
+    const lang = language.toLowerCase();
+
+    if (lookup[lang]) {
+      return lookup[lang];
     }
-    if (language.split('-')[0] === 'zh') {
-      if (language === 'zh-CN' || language === 'zh-SG') return 'zh-Hans';
-      return 'zh-Hant';
+    if (lang.split('-')[0] === 'zh') {
+      return (lang === 'zh-cn' || lang === 'zh-sg') ? 'zh-Hans' : 'zh-Hant';
     }
     return null;
   }
@@ -55,32 +65,32 @@ function getActiveTranslation() {
 // when DOM is created in Polymer. Even a cache lookup creates noticable latency.
 const translations = {};
 
-window.getTranslation = function (translationInput) {
+window.getTranslation = function (fragment, translationInput) {
   const translation = translationInput || getActiveTranslation();
-  const metadata = window.translationMetadata[translation];
+  const metadata = window.translationMetadata.translations[translation];
   if (!metadata) {
     if (translationInput !== 'en') {
-      return window.getTranslation('en');
+      return window.getTranslation(fragment, 'en');
     }
     return Promise.reject(new Error('Language en not found in metadata'));
   }
-  const translationFingerprint = metadata.fingerprint;
+  const translationFingerprint = metadata.fingerprints[
+    fragment ? `${fragment}/${translation}` : translation
+  ];
 
   // Create a promise to fetch translation from the server
   if (!translations[translationFingerprint]) {
     translations[translationFingerprint] =
-      fetch('/static/translations/' + translationFingerprint)
+      fetch(`/static/translations/${translationFingerprint}`, { credentials: 'include' })
         .then(response => response.json()).then(data => ({
           language: translation,
-          resources: {
-            [translation]: data
-          },
+          data: data,
         }))
         .catch((error) => {
           delete translations[translationFingerprint];
           if (translationInput !== 'en') {
             // Couldn't load selected translation. Try a fall back to en before failing.
-            return window.getTranslation('en');
+            return window.getTranslation(fragment, 'en');
           }
           return Promise.reject(error);
         });

--- a/src/util/hass-translation.html
+++ b/src/util/hass-translation.html
@@ -6,7 +6,7 @@ function getActiveTranslation() {
     if (window.translationMetadata[language]) {
       return language;
     }
-    if (language.substring(0, 2) === 'zh') {
+    if (language.split('-')[0] === 'zh') {
       if (language === 'zh-CN' || language === 'zh-SG') return 'zh-Hans';
       return 'zh-Hant';
     }

--- a/src/util/hass-translation.html
+++ b/src/util/hass-translation.html
@@ -2,24 +2,13 @@
 
 <script>
 function getActiveTranslation() {
-  // Perform case-insenstive comparison since browser isn't required to
-  // report languages with specific cases.
-  const lookup = {};
-  /* eslint-disable no-undef */
-  Object.keys(window.translationMetadata).forEach((tr) => {
-    lookup[tr.toLowerCase()] = tr;
-  });
-
-  // Search for a matching translation from most specific to general
   function languageGetTranslation(language) {
-    const subtags = language.toLowerCase().split('-');
-
-    for (let i = subtags.length; i >= 1; i--) {
-      const lang = subtags.slice(0, i).join('-');
-
-      if (lookup[lang]) {
-        return lookup[lang];
-      }
+    if (window.translationMetadata[language]) {
+      return language;
+    }
+    if (language.substring(0, 2) === 'zh') {
+      if (language === 'zh-CN' || language === 'zh-SG') return 'zh-Hans';
+      return 'zh-Hant';
     }
     return null;
   }

--- a/src/util/hass-translation.html
+++ b/src/util/hass-translation.html
@@ -39,8 +39,8 @@ function getActiveTranslation() {
     if (translation) {
       return translation;
     }
-    if (navigator.language.length > 2) {
-      translation = languageGetTranslation(navigator.language.substring(0, 2));
+    if (navigator.language.includes('-')) {
+      translation = languageGetTranslation(navigator.language.split('-')[0]);
       if (translation) {
         return translation;
       }


### PR DESCRIPTION
* Generalization already handled by navigator.languages
* Detection for Chinese users

Additional information:
In browser settings you can select these tags for Chinese (browsers use LOCALE, not BCP47), you can't set custom tags like `zh-Hant...`:
```
tag     Crome   Firefox
zh-CN     X         X
zh-HK     X         X
zh-SG               X
zh-TW     X         X
zh        X         X
```