### PR TITLE
Fix rules for SW runtime file caching.

### DIFF
--- a/gulp/tasks/gen-service-worker.js
+++ b/gulp/tasks/gen-service-worker.js
@@ -99,8 +99,8 @@ gulp.task('gen-service-worker', () => {
           urlPattern: '/(service_worker.js|manifest.json)',
           handler: 'networkOnly',
         },
-        { // For rest of the files (on Home Assistant domain only) try both cache and network/
-          // This includes the root "/" or "/states" response and user files from ""/local".
+        { // For rest of the files (on Home Assistant domain only) try both cache and network.
+          // This includes the root "/" or "/states" response and user files from "/local".
           // First access might bring stale data from cache, but a single refresh will bring updated
           // file.
           urlPattern: '*',

--- a/gulp/tasks/gen-service-worker.js
+++ b/gulp/tasks/gen-service-worker.js
@@ -94,12 +94,12 @@ gulp.task('gen-service-worker', () => {
         { // Get static, api, and local (and home-assistant-polymer in dev mode) from network.
           // Use cache only if Home Assistant server is unreachable.
           urlPattern: '/(home-assistant-polymer|static|api|local)/*',
-          handler: 'networkFirst',
+          handler: 'networkOnly',
         },
         { // Get manifest and service worker from network.
           // Use cache only if Home Assistant server is unreachable.
           urlPattern: '/(service_worker.js|manifest.json)',
-          handler: 'networkFirst',
+          handler: 'networkOnly',
         },
         { // For rest of the files (on Home Assistant domain only) try both cache and network/
           // First access might bring stale data from cache, but a single refresh will bring updated

--- a/gulp/tasks/gen-service-worker.js
+++ b/gulp/tasks/gen-service-worker.js
@@ -92,12 +92,10 @@ gulp.task('gen-service-worker', () => {
         handler: 'cacheFirst',
         },
         { // Get static, api, and local (and home-assistant-polymer in dev mode) from network.
-          // Use cache only if Home Assistant server is unreachable.
           urlPattern: '/(home-assistant-polymer|static|api|local)/*',
           handler: 'networkOnly',
         },
         { // Get manifest and service worker from network.
-          // Use cache only if Home Assistant server is unreachable.
           urlPattern: '/(service_worker.js|manifest.json)',
           handler: 'networkOnly',
         },

--- a/gulp/tasks/gen-service-worker.js
+++ b/gulp/tasks/gen-service-worker.js
@@ -87,12 +87,12 @@ gulp.task('gen-service-worker', () => {
       ],
       // Rules are proceeded in order and negative per-domain rules are not supported.
       runtimeCaching: [
-        { // Cache translations on first access
-          urlPattern: '/static/translations/*',
-        handler: 'cacheFirst',
+        { // Cache static content (including translations) on first access.
+          urlPattern: '/static/*',
+          handler: 'cacheFirst',
         },
-        { // Get static, api, and local (and home-assistant-polymer in dev mode) from network.
-          urlPattern: '/(home-assistant-polymer|static|api|local)/*',
+        { // Get api (and home-assistant-polymer in dev mode) from network.
+          urlPattern: '/(home-assistant-polymer|api)/*',
           handler: 'networkOnly',
         },
         { // Get manifest and service worker from network.
@@ -100,10 +100,11 @@ gulp.task('gen-service-worker', () => {
           handler: 'networkOnly',
         },
         { // For rest of the files (on Home Assistant domain only) try both cache and network/
+          // This includes the root "/" or "/states" response and user files from ""/local".
           // First access might bring stale data from cache, but a single refresh will bring updated
           // file.
           urlPattern: '*',
-        handler: 'fastest',
+          handler: 'fastest',
         }
       ],
       stripPrefix: 'hass_frontend',


### PR DESCRIPTION
New runtime caching rules (processed in order):
1) Content in `/static/translations/` is cached on first access.
2) `/home-assistant-polymer` (used in dev mode) `/static`, `/api`, `/local`, service-woorker.js, and manifest.js are networkOnly. This rule is needed because negative rules are not supported.
3) The rest of the content (on Home Assistant domain) is fetched from both network and cache, so they might be stale on first access and require a refresh in that case.