### PR TITLE
Safety check for translations upload script

### DIFF
--- a/script/translations_upload_base
+++ b/script/translations_upload_base
@@ -22,6 +22,14 @@ PROJECT_ID="3420425759f6d6d241f598.13594006"
 LOCAL_FILE="$(pwd)/src/translations/en.json"
 LANG_ISO=en
 
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$CURRENT_BRANCH" != "master" ]
+then
+  echo "Please only run the translations upload script from a clean checkout of master."
+  exit 1
+fi
+
 docker run \
     -v ${LOCAL_FILE}:/opt/src/${LOCAL_FILE} \
     lokalise/lokalise-cli lokalise \


### PR DESCRIPTION
Double-check to prevent accidental uploads from topic branches. We should only upload to Lokalise once changes to the schema are merged.