### PR TITLE
WIP: Ha-card for plant component

### DIFF
--- a/src/cards/ha-card-chooser.html
+++ b/src/cards/ha-card-chooser.html
@@ -6,6 +6,7 @@
 <link rel='import' href='./ha-media_player-card.html'>
 <link rel='import' href='./ha-weather-card.html'>
 <link rel='import' href='./ha-persistent_notification-card.html'>
+<link rel='import' href='./ha-plant-card.html'>
 
 <script>
 class HaCardChooser extends Polymer.Element {

--- a/src/cards/ha-plant-card.html
+++ b/src/cards/ha-plant-card.html
@@ -7,20 +7,22 @@
   <template>
     <style>
       .content {
-        display: grid;
-        grid-template: repeat(2, auto) / repeat(5, 1fr);
-        grid-auto-flow: column;
-        justify-items: center;
-        text-align: center;
         padding: 0 32px 24px 32px;
       }
       paper-icon-button {
         color: var(--paper-item-icon-color);
       }
-      paper-icon-button[disabled], .missing {
+      paper-icon-button[disabled], td.missing {
         color: var(--disabled-text-color);
       }
-      .problem {
+      th {
+        width: 20%;
+      }
+      td {
+        text-align: center;
+        color: var(--primary-text-color);
+      }
+      td.problem {
         color: var(--label-badge-red);
         font-weight: bold;
       }
@@ -28,17 +30,26 @@
 
     <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
-        <template is='dom-repeat' items='{{sensors}}'>
-          <paper-icon-button
-            disabled$='[[computeDisabled(stateObj, item)]]'
-            icon='[[computeIcon(stateObj, item)]]'
-            on-tap='showSensorHistory'>
-          </paper-icon-button>
-          <div class$='[[computeClass(stateObj, item)]]'>
-            [[computeValue(stateObj, item)]]<br>
-            [[computeUOM(stateObj, item)]]
-          </div>
-        </template>
+          <table style='width:100%'>
+            <tr>
+              <template is='dom-repeat' items='{{sensors}}'>
+                <th>
+                  <paper-icon-button
+                    disabled$='[[computeDisabled(stateObj, item)]]'
+                    icon='[[computeIcon(stateObj, item)]]'
+                    on-tap='showSensorHistory'>
+                  </paper-icon-button>
+                </th>
+              </template>
+            </tr><tr>
+              <template is='dom-repeat' items='{{sensors}}'>
+                <td class$='[[computeClass(stateObj, item)]]'>
+                  [[computeValue(stateObj, item)]]<br>
+                  [[computeUOM(stateObj, item)]]
+                </td>
+              </template>
+            </tr>
+          </table>
       </div>
     </ha-card>
   </template>

--- a/src/cards/ha-plant-card.html
+++ b/src/cards/ha-plant-card.html
@@ -1,67 +1,44 @@
 <link rel='import' href='../../bower_components/polymer/polymer-element.html'>
+<link rel='import' href='../../bower_components/paper-icon-button/paper-icon-button.html'>
 <link rel='import' href='../components/ha-card.html'>
 <link rel='import' href='../util/hass-mixins.html'>
 
 <dom-module id="ha-plant-card">
   <template>
     <style>
-      :host {
-        @apply(--paper-font-body1);
-        line-height: 1.5;
-      }
-      .header-more-info {
-        cursor: pointer;
-      }
       .content {
-        padding: 0 32px 16px 32px;
+        display: grid;
+        grid-template: repeat(2, auto) / repeat(5, 1fr);
+        grid-auto-flow: column;
+        justify-items: center;
+        text-align: center;
+        padding: 0 32px 24px 32px;
       }
-      iron-icon {
+      paper-icon-button {
         color: var(--paper-item-icon-color);
       }
-      iron-icon[disabled] {
+      paper-icon-button[disabled], .missing {
         color: var(--disabled-text-color);
       }
-      table {
-        width: 100%
-      }
-      th {
-        width: 20%;
-      }
-      td {
-        text-align: center;
-        color: var(--primary-text-color);
-      }
-      td.problem {
+      .problem {
         color: var(--label-badge-red);
         font-weight: bold;
       }
-      td.missing {
-        color: var(--disabled-text-color);
-      }
     </style>
 
-    <ha-card class='header-more-info' header='[[computeTitle(stateObj)]]'>
+    <ha-card header='[[computeTitle(stateObj)]]'>
       <div class='content'>
-          <table>
-            <tr>
-              <template is='dom-repeat' items='{{sensors}}'>
-                <th>
-                  <iron-icon
-                    id='[[item]]'
-                    icon='[[computeIcon(stateObj, item)]]'
-                    disabled$='[[computeDisabled(stateObj, item)]]'>
-                  </iron-icon>
-                </th>
-              </template>
-            </tr><tr>
-              <template is='dom-repeat' items='{{sensors}}'>
-                <td class$='[[computeClass(stateObj, item)]]'>
-                  [[computeValue(stateObj, item)]]<br>
-                  [[computeUOM(stateObj, item)]]
-                </td>
-              </template>
-            </tr>
-          </table>
+        <template is='dom-repeat' items='{{sensors}}'>
+          <paper-icon-button
+            disabled$='[[computeDisabled(stateObj, item)]]'
+            icon='[[computeIcon(stateObj, item)]]'
+            on-tap='showSensorHistory'>
+          </paper-icon-button>
+          <div class$='[[computeClass(stateObj, item)]]'>
+            [[computeValue(stateObj, item)]]<br>
+            [[computeUOM(stateObj, item)]]
+          </div>
+        </template>
       </div>
     </ha-card>
   </template>
@@ -69,10 +46,10 @@
 
 <script>
 {
-  var _SENSORS = ['temperature', 'moisture', 'brightness', 'conductivity', 'battery'];
+  var _SENSORS = ['moisture', 'temperature', 'brightness', 'conductivity', 'battery'];
   var _CONFIG = {
-    temperature: { icon: 'mdi:thermometer', uom: '°C' },
     moisture: { icon: 'mdi:water', uom: '%' },
+    temperature: { icon: 'mdi:thermometer', uom: '°C' },
     brightness: { icon: 'mdi:white-balance-sunny', uom: 'lx' },
     conductivity: { icon: 'mdi:emoticon-poop', uom: 'µS/cm' },
     battery: { icon: 'mdi:battery', uom: '%' }
@@ -83,14 +60,9 @@
     static get properties() {
       return {
         hass: Object,
-        stateObj: Object
+        stateObj: Object,
+        sensors: { type: Object, value: _SENSORS }
       };
-    }
-
-    ready() {
-      super.ready();
-      this.addEventListener('tap', () => this.showMoreInfo());
-      this.sensors = _SENSORS;
     }
 
     computeTitle(stateObj) {
@@ -107,7 +79,7 @@
 
     computeIcon(stateObj, sensor) {
       var icon = _CONFIG[sensor].icon;
-      if (sensor === 'battery') {
+      if (sensor === 'battery' && typeof stateObj.attributes.battery !== 'undefined') {
         var level = stateObj.attributes.battery;
         if (level <= 5) {
           icon += '-alert';
@@ -133,8 +105,10 @@
       return (typeof stateObj.attributes[sensor] === 'undefined');
     }
 
-    showMoreInfo() {
-      this.fire('hass-more-info', { entityId: this.stateObj.entity_id });
+    showSensorHistory(ev) {
+      ev.stopPropagation();
+      var sensorId = this.stateObj.attributes.sensors[ev.model.item];
+      this.fire('hass-more-info', { entityId: sensorId });
     }
   }
 

--- a/src/cards/ha-plant-card.html
+++ b/src/cards/ha-plant-card.html
@@ -1,0 +1,143 @@
+<link rel='import' href='../../bower_components/polymer/polymer-element.html'>
+<link rel='import' href='../components/ha-card.html'>
+<link rel='import' href='../util/hass-mixins.html'>
+
+<dom-module id="ha-plant-card">
+  <template>
+    <style>
+      :host {
+        @apply(--paper-font-body1);
+        line-height: 1.5;
+      }
+      .header-more-info {
+        cursor: pointer;
+      }
+      .content {
+        padding: 0 32px 16px 32px;
+      }
+      iron-icon {
+        color: var(--paper-item-icon-color);
+      }
+      iron-icon[disabled] {
+        color: var(--disabled-text-color);
+      }
+      table {
+        width: 100%
+      }
+      th {
+        width: 20%;
+      }
+      td {
+        text-align: center;
+        color: var(--primary-text-color);
+      }
+      td.problem {
+        color: var(--label-badge-red);
+        font-weight: bold;
+      }
+      td.missing {
+        color: var(--disabled-text-color);
+      }
+    </style>
+
+    <ha-card class='header-more-info' header='[[computeTitle(stateObj)]]'>
+      <div class='content'>
+          <table>
+            <tr>
+              <template is='dom-repeat' items='{{sensors}}'>
+                <th>
+                  <iron-icon
+                    id='[[item]]'
+                    icon='[[computeIcon(stateObj, item)]]'
+                    disabled$='[[computeDisabled(stateObj, item)]]'>
+                  </iron-icon>
+                </th>
+              </template>
+            </tr><tr>
+              <template is='dom-repeat' items='{{sensors}}'>
+                <td class$='[[computeClass(stateObj, item)]]'>
+                  [[computeValue(stateObj, item)]]<br>
+                  [[computeUOM(stateObj, item)]]
+                </td>
+              </template>
+            </tr>
+          </table>
+      </div>
+    </ha-card>
+  </template>
+</dom-module>
+
+<script>
+{
+  var _SENSORS = ['temperature', 'moisture', 'brightness', 'conductivity', 'battery'];
+  var _CONFIG = {
+    temperature: { icon: 'mdi:thermometer', uom: '°C' },
+    moisture: { icon: 'mdi:water', uom: '%' },
+    brightness: { icon: 'mdi:white-balance-sunny', uom: 'lx' },
+    conductivity: { icon: 'mdi:emoticon-poop', uom: 'µS/cm' },
+    battery: { icon: 'mdi:battery', uom: '%' }
+  };
+
+  class HaPlantCard extends window.hassMixins.EventsMixin(Polymer.Element) {
+    static get is() { return 'ha-plant-card'; }
+    static get properties() {
+      return {
+        hass: Object,
+        stateObj: Object
+      };
+    }
+
+    ready() {
+      super.ready();
+      this.addEventListener('tap', () => this.showMoreInfo());
+      this.sensors = _SENSORS;
+    }
+
+    computeTitle(stateObj) {
+      return window.hassUtil.computeStateName(stateObj);
+    }
+
+    computeClass(stateObj, sensor) {
+      if (typeof stateObj.attributes[sensor] === 'undefined') {
+        return 'missing';
+      }
+      var prob = stateObj.attributes.problem;
+      return (prob.indexOf(sensor) === -1) ? 'ok' : 'problem';
+    }
+
+    computeIcon(stateObj, sensor) {
+      var icon = _CONFIG[sensor].icon;
+      if (sensor === 'battery') {
+        var level = stateObj.attributes.battery;
+        if (level <= 5) {
+          icon += '-alert';
+        } else if (level < 95) {
+          icon += '-' + (Math.round((level / 10) - 0.01) * 10).toString();
+        }
+      }
+      return icon;
+    }
+
+    computeValue(stateObj, sensor) {
+      if (typeof stateObj.attributes[sensor] === 'undefined') {
+        return '-';
+      }
+      return stateObj.attributes[sensor];
+    }
+
+    computeUOM(stateObj, sensor) {
+      return _CONFIG[sensor].uom;
+    }
+
+    computeDisabled(stateObj, sensor) {
+      return (typeof stateObj.attributes[sensor] === 'undefined');
+    }
+
+    showMoreInfo() {
+      this.fire('hass-more-info', { entityId: this.stateObj.entity_id });
+    }
+  }
+
+  customElements.define(HaPlantCard.is, HaPlantCard);
+}
+</script>

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -84,6 +84,7 @@
     history_graph: 4,
     media_player: 3,
     persistent_notification: 0,
+    plant: 3,
     weather: 4,
   };
 


### PR DESCRIPTION
This introduces an ha-card for the Plant component (written by @ChristianKuehnel) that makes visible the plant's state and highlights the cause of any problems (i.e. needs water/fertilzer).

![image](https://user-images.githubusercontent.com/16738570/32455771-2ceb80fe-c31b-11e7-8ce4-9bca27a25576.png)

This is a work-in-progress and dependent on design decisions progressing in the backend Plant PR (https://github.com/home-assistant/home-assistant/pull/9534) but raising for visibility/comment.