### PR TITLE
Add-Ons > Add space between text and repository link

### DIFF
--- a/panels/hassio/addon-store/hassio-addon-repository.html
+++ b/panels/hassio/addon-store/hassio-addon-repository.html
@@ -24,7 +24,8 @@
             Maintained by [[repo.maintainer]].
           </template>
           <template is='dom-if' if='[[repo.url]]'>
-            <a href='[[repo.url]]' target='_blank'>Visit repository website.</a>
+            &nbsp;
+            <a href='[[repo.url]]' target='_blank'>Visit repository website</a>.
           </template>
         </div>
       </template>


### PR DESCRIPTION
A subtle change, but improves how it is displayed.

### Before

![screen shot 2017-11-08 at 8 57 36 am](https://user-images.githubusercontent.com/80459/32555648-fd4ec826-c462-11e7-986b-ef81755a018e.png)

### After

![screen shot 2017-11-08 at 8 59 35 am](https://user-images.githubusercontent.com/80459/32555736-31fe7ef4-c463-11e7-9be7-6d74a1808328.png)

