### PR TITLE
Add filters to dev-state page

### DIFF
--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -196,16 +196,18 @@ class HaPanelDevState extends Polymer.Element {
 
   computeEntities(hass, _entityFilter, _stateFilter, _attributeFilter) {
     return Object.keys(hass.states).map(function (key) { return hass.states[key]; })
-      .filter(function(value, index, arrayObject) {
-        if (!value.entity_id.includes(_entityFilter.toLowerCase()))
+      .filter(function (value) {
+        if (!value.entity_id.includes(_entityFilter.toLowerCase())) {
           return false;
+        }
 
-        if (!value.state.includes(_stateFilter.toLowerCase()))
+        if (!value.state.includes(_stateFilter.toLowerCase())) {
           return false;
+        }
 
         if (_attributeFilter !== '') {
           var attributeFilter = _attributeFilter.toLowerCase();
-          var colonIndex = attributeFilter.indexOf(":");
+          var colonIndex = attributeFilter.indexOf(':');
           var multiMode = colonIndex !== -1;
 
           var keyFilter = attributeFilter;
@@ -217,31 +219,29 @@ class HaPanelDevState extends Polymer.Element {
             valueFilter = attributeFilter.substring(colonIndex + 1).trim();
           }
 
-          for (const key of Object.keys(value.attributes)) {
-            if (key.includes(keyFilter) && !multiMode)
+          var attributeKeys = Object.keys(value.attributes);
+
+          for (var i = 0; i < attributeKeys.length; i++) {
+            var key = attributeKeys[i];
+
+            if (key.includes(keyFilter) && !multiMode) {
               return true; // in single mode we're already satisfied with this match
-            else if (!key.includes(keyFilter) && multiMode)
-              continue; // key does not match, we're not interested in the value
+            } else if (!key.includes(keyFilter) && multiMode) {
+              continue;
+            }
 
             var attributeValue = value.attributes[key];
 
-            if (attributeValue === null)
-              continue;
-
-            if (Array.isArray(attributeValue)) {
-              if (attributeValue.join("").toLowerCase().includes(valueFilter))
-                return true;
-            }
-
-            if (value.attributes[key].toString().toLowerCase().includes(valueFilter)) {
+            if (attributeValue !== null
+                && JSON.stringify(attributeValue).toLowerCase().includes(valueFilter)) {
               return true;
-            }              
+            }
           }
 
           // there are no attributes where the key and/or value can be matched
           return false;
         }
-        
+
         return true;
       })
       .sort(function (entityA, entityB) {

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -197,12 +197,52 @@ class HaPanelDevState extends Polymer.Element {
   computeEntities(hass, _entityFilter, _stateFilter, _attributeFilter) {
     return Object.keys(hass.states).map(function (key) { return hass.states[key]; })
       .filter(function(value, index, arrayObject) {
-        // entities and states are simple string contains checks
-        var entityHit = _entityFilter === '' || value.entity_id.includes(_entityFilter);
-        var stateHit = _stateFilter === '' || value.state.includes(_stateFilter);
-        var attributesHit = _attributeFilter === '';
+        if (!value.entity_id.includes(_entityFilter.toLowerCase()))
+          return false;
 
-        return entityHit && stateHit && attributesHit;
+        if (!value.state.includes(_stateFilter.toLowerCase()))
+          return false;
+
+        if (_attributeFilter !== '') {
+          var attributeFilter = _attributeFilter.toLowerCase();
+          var colonIndex = attributeFilter.indexOf(":");
+          var multiMode = colonIndex !== -1;
+
+          var keyFilter = attributeFilter;
+          var valueFilter = attributeFilter;
+
+          if (multiMode) {
+            // we need to filter keys and values separately
+            keyFilter = attributeFilter.substring(0, colonIndex).trim();
+            valueFilter = attributeFilter.substring(colonIndex + 1).trim();
+          }
+
+          for (const key of Object.keys(value.attributes)) {
+            if (key.includes(keyFilter) && !multiMode)
+              return true; // in single mode we're already satisfied with this match
+            else if (!key.includes(keyFilter) && multiMode)
+              continue; // key does not match, we're not interested in the value
+
+            var attributeValue = value.attributes[key];
+
+            if (attributeValue === null)
+              continue;
+
+            if (Array.isArray(attributeValue)) {
+              if (attributeValue.join("").toLowerCase().includes(valueFilter))
+                return true;
+            }
+
+            if (value.attributes[key].toString().toLowerCase().includes(valueFilter)) {
+              return true;
+            }              
+          }
+
+          // there are no attributes where the key and/or value can be matched
+          return false;
+        }
+        
+        return true;
       })
       .sort(function (entityA, entityB) {
         if (entityA.entity_id < entityB.entity_id) {

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -85,7 +85,7 @@
           <tr>
             <th><paper-input label="Filter entities" type="search" value='{{_entityFilter}}'></paper-input></th>
             <th><paper-input label="Filter states" type="search" value='{{_stateFilter}}'></paper-input></th>
-            <th hidden$='[[!_showAttributes]]'><paper-input label="Filter attributes" type="search" value='{{_attributeFilter}}'></paper-input></th>
+            <th hidden$='[[!computeShowAttributes(narrow, _showAttributes)]]'><paper-input label="Filter attributes" type="search" value='{{_attributeFilter}}'></paper-input></th>
           </tr>
           <tr hidden$='[[!computeShowEntitiesPlaceholder(_entities)]]'>
             <td colspan="3">No entities</td>

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -82,6 +82,14 @@
               <paper-checkbox checked='{{_showAttributes}}'></paper-checkbox>
             </th>
           </tr>
+          <tr>
+            <th><paper-input label="Filter entities" type="search" value='{{_entityFilter}}'></paper-input></th>
+            <th><paper-input label="Filter states" type="search" value='{{_stateFilter}}'></paper-input></th>
+            <th hidden$='[[!_showAttributes]]'><paper-input label="Filter attributes" type="search" value='{{_attributeFilter}}'></paper-input></th>
+          </tr>
+          <tr hidden$='[[!computeShowEntitiesPlaceholder(_entities)]]'>
+            <td colspan="3">No entities</td>
+          </tr>
           <template is='dom-repeat' items='[[_entities]]' as='entity'>
             <tr>
               <td><a href='#' on-tap='entitySelected'>[[entity.entity_id]]</a></td>
@@ -122,6 +130,21 @@ class HaPanelDevState extends Polymer.Element {
         value: '',
       },
 
+      _entityFilter: {
+        type: String,
+        value: '',
+      },
+
+      _stateFilter: {
+        type: String,
+        value: '',
+      },
+
+      _attributeFilter: {
+        type: String,
+        value: '',
+      },
+
       _state: {
         type: String,
         value: '',
@@ -139,7 +162,7 @@ class HaPanelDevState extends Polymer.Element {
 
       _entities: {
         type: Array,
-        computed: 'computeEntities(hass)',
+        computed: 'computeEntities(hass, _entityFilter, _stateFilter, _attributeFilter)',
       },
     };
   }
@@ -171,8 +194,16 @@ class HaPanelDevState extends Polymer.Element {
     });
   }
 
-  computeEntities(hass) {
+  computeEntities(hass, _entityFilter, _stateFilter, _attributeFilter) {
     return Object.keys(hass.states).map(function (key) { return hass.states[key]; })
+      .filter(function(value, index, arrayObject) {
+        // entities and states are simple string contains checks
+        var entityHit = _entityFilter === '' || value.entity_id.includes(_entityFilter);
+        var stateHit = _stateFilter === '' || value.state.includes(_stateFilter);
+        var attributesHit = _attributeFilter === '';
+
+        return entityHit && stateHit && attributesHit;
+      })
       .sort(function (entityA, entityB) {
         if (entityA.entity_id < entityB.entity_id) {
           return -1;
@@ -182,6 +213,10 @@ class HaPanelDevState extends Polymer.Element {
         }
         return 0;
       });
+  }
+
+  computeShowEntitiesPlaceholder(_entities) {
+    return _entities.length === 0;
   }
 
   computeShowAttributes(narrow, _showAttributes) {


### PR DESCRIPTION
One of the features I've been wanting to add for some time now is the ability to filter on entities on the states page in the developer tools, and I'm not the [only](https://community.home-assistant.io/t/filter-and-sort-entity-ids-in-ha/6647) [one](https://community.home-assistant.io/t/searchable-entities-in-states-tab-of-developer-tools/30683).

I've added three input fields, one for each column in the states table. The entities and states filter work by using simple string comparison. The attributes filter is more complex in code, due to the nature of the attributes object in an entity. If the user enters a string for an attribute, as long as no colon ( : ) has been typed, the string will be matched against all keys and values, and if any of those give a hit, the entity is returned. Once the user has entered a colon, the key must always be matched, and the value is again matched based on string comparison.

All string comparisons work based on simple `.includes()` operations. So part of a key or value is enough to be matched. This to keep the filter flexible and lean, where any user would be able to quickly filter on what the user wants to see.

I've included a gif showing all three filters:

![dev_state_filter](https://user-images.githubusercontent.com/9115757/32573957-0d2e3156-c4d0-11e7-9373-c3f3329a1f84.gif)

This is my first contribution to this project. I've tried to stick as much as possible to the conventions I could see in the rest of the code. Working with Polymer is new for me, so any constructive criticism about that is more than welcome. There was already a nice foundation of the `_entities` object being sorted and mapped, so an `filter()` call was quite easily added.

Regarding translations: because translations are a new thing in HASS, I've left it out for now. Should it be necessary for this PR I will gladly add them.