### PR TITLE
Replace existing translations on upload

### DIFF
--- a/script/translations_upload_base
+++ b/script/translations_upload_base
@@ -36,4 +36,5 @@ docker run \
     --token ${API_TOKEN} \
     import ${PROJECT_ID} \
     --file /opt/src/${LOCAL_FILE} \
-    --lang_iso ${LANG_ISO}
+    --lang_iso ${LANG_ISO} \
+    --replace 1


### PR DESCRIPTION
CC @c727 

When we upload the base English translations, we should replace these values so that changes made in git are reflected in Lokalise.