### PR TITLE
Auto deploy base translations with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,15 @@ script:
   - npm run test
   - xvfb-run wct
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct --plugin sauce; fi
+services:
+  - docker
+before_deploy:
+  - docker pull lokalise/lokalise-cli
+deploy:
+  provider: script
+  script: script/travis_deploy
+  on:
+    branch: master
 dist: trusty
 addons:
   sauce_connect: true

--- a/script/translations_upload_base
+++ b/script/translations_upload_base
@@ -26,8 +26,7 @@ LANG_ISO=en
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [ "$CURRENT_BRANCH" != "master" ]
-then
+if [ "${CURRENT_BRANCH}" != "master" ] && [ "${TRAVIS_BRANCH}" != "master" ] ; then
   echo "Please only run the translations upload script from a clean checkout of master."
   exit 1
 fi

--- a/script/travis_deploy
+++ b/script/travis_deploy
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Safe bash settings
+# -e            Exit on command fail
+# -u            Exit on unset variable
+# -o pipefail   Exit if piped command has error code
+set -eu -o pipefail
+
+cd "$(dirname "$0")/.."
+
+if git diff "${TRAVIS_COMMIT_RANGE}" --name-only | grep -Fxq "src/translations/en.json" ; then
+    script/translations_upload_base
+else
+    echo "No changes to src/translations/en.json. Skipping translation upload."
+fi


### PR DESCRIPTION
This will require an environment variable `LOKALISE_TOKEN` in Travis. @balloob should probably create a new bot user for this purpose, so the history shows the keys were auto-uploaded, instead of a user's upload.