### PR TITLE
Configurator: control spinner via attribute

### DIFF
--- a/src/more-infos/more-info-configurator.html
+++ b/src/more-infos/more-info-configurator.html
@@ -115,7 +115,7 @@ class MoreInfoConfigurator extends Polymer.Element {
 
       isConfiguring: {
         type: Boolean,
-        value: false,
+        computed: 'computeIsConfiguring(stateObj)',
       },
 
       fieldInput: {
@@ -129,6 +129,10 @@ class MoreInfoConfigurator extends Polymer.Element {
     return stateObj.state === 'configure';
   }
 
+  computeIsConfiguring(stateObj) {
+    return stateObj.attributes.is_configuring;
+  }
+
   fieldChanged(ev) {
     var el = ev.target;
     this.fieldInput[el.name] = el.value;
@@ -140,14 +144,14 @@ class MoreInfoConfigurator extends Polymer.Element {
       fields: this.fieldInput,
     };
 
-    this.isConfiguring = true;
+    this.attributes.is_configuring = true;
 
     this.hass.callService('configurator', 'configure', data).then(
       function () {
-        this.isConfiguring = false;
+        this.attributes.is_configuring = false;
       }.bind(this),
       function () {
-        this.isConfiguring = false;
+        this.attributes.is_configuring = false;
       }.bind(this)
     );
   }

--- a/src/more-infos/more-info-configurator.html
+++ b/src/more-infos/more-info-configurator.html
@@ -118,6 +118,11 @@ class MoreInfoConfigurator extends Polymer.Element {
         computed: 'computeIsConfiguring(stateObj)',
       },
 
+      isConfiguringOverride: {
+        type: Boolean,
+        value: false,
+      },
+
       fieldInput: {
         type: Object,
         value: function () { return {}; },
@@ -130,7 +135,7 @@ class MoreInfoConfigurator extends Polymer.Element {
   }
 
   computeIsConfiguring(stateObj) {
-    return Boolean(stateObj.attributes.is_configuring);
+    return stateObj.attributes.is_configuring || this.isConfiguringOverride;
   }
 
   fieldChanged(ev) {
@@ -144,14 +149,14 @@ class MoreInfoConfigurator extends Polymer.Element {
       fields: this.fieldInput,
     };
 
-    this.attributes.is_configuring = true;
+    this.isConfiguringOverride = true;
 
     this.hass.callService('configurator', 'configure', data).then(
       function () {
-        this.attributes.is_configuring = false;
+        this.isConfiguringOverride = false;
       }.bind(this),
       function () {
-        this.attributes.is_configuring = false;
+        this.isConfiguringOverride = false;
       }.bind(this)
     );
   }

--- a/src/more-infos/more-info-configurator.html
+++ b/src/more-infos/more-info-configurator.html
@@ -130,7 +130,7 @@ class MoreInfoConfigurator extends Polymer.Element {
   }
 
   computeIsConfiguring(stateObj) {
-    return stateObj.attributes.is_configuring;
+    return Boolean(stateObj.attributes.is_configuring);
   }
 
   fieldChanged(ev) {


### PR DESCRIPTION
This gives the possibility control the spinner from within Home-Assistant. 
This allows feedback from async functions by altering the state of the configurator. 
(much like errors are set too)

I believe it is important for a good UX that a user knows Home Assistant is working in the background. Trying to connect to a slow or unreachable server for example.