### PR TITLE
Fix WCT config - specify generic Safari 10

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -9,7 +9,7 @@
         }, {
           "browserName": "safari",
           "platform": "macOS 10.12",
-          "version": "10.0"
+          "version": "10"
         }, {
           "browserName": "firefox",
           "platform": "Windows 10",


### PR DESCRIPTION
Apparently the minimum safari version has been bumped from 10.0 to 10.1. We can just specify 10 here to be more generic.