### PR TITLE
Fix login form with translations

### DIFF
--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -72,10 +72,6 @@ class HomeAssistant extends Polymer.Element {
         type: Object,
         value: null,
       },
-      language: {
-        type: Object,
-        value: null,
-      },
       showMain: {
         type: Boolean,
         computed: 'computeShowMain(hass)',
@@ -101,7 +97,7 @@ class HomeAssistant extends Polymer.Element {
 
   loadResources() {
     window.getTranslation().then((result) => {
-      this._updateLanguage({
+      this._updateHass({
         language: result.language,
         resources: result.resources,
       });
@@ -158,7 +154,7 @@ class HomeAssistant extends Polymer.Element {
         var auth = conn.options.authToken ? conn.options : {};
         return window.hassCallApi(host, auth, method, path, parameters);
       },
-    }, this.language, this.$.storage.getStoredState());
+    }, this.$.storage.getStoredState());
 
     var reconnected = () => {
       this._updateHass({ connected: true });
@@ -256,18 +252,13 @@ class HomeAssistant extends Polymer.Element {
   }
 
   selectLanguage(event) {
-    this._updateLanguage({ selectedLanguage: event.detail.language });
+    this._updateHass({ selectedLanguage: event.detail.language });
     this.$.storage.storeState();
     this.loadResources();
   }
 
   _updateHass(obj) {
     this.hass = Object.assign({}, this.hass, obj);
-  }
-
-  _updateLanguage(obj) {
-    this.language = Object.assign({}, this.language, obj);
-    if (this.hass) this._updateHass(obj);
   }
 }
 

--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -92,7 +92,8 @@ class HomeAssistant extends Polymer.Element {
 
   computeShowLoading(connectionPromise, hass) {
     // Show loading when connecting or when connected but not all pieces loaded yet
-    return (connectionPromise != null || (hass && hass.connection && (!hass.states || !hass.config)));
+    return (connectionPromise != null
+      || (hass && hass.connection && (!hass.states || !hass.config)));
   }
 
   loadResources() {

--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -92,7 +92,7 @@ class HomeAssistant extends Polymer.Element {
 
   computeShowLoading(connectionPromise, hass) {
     // Show loading when connecting or when connected but not all pieces loaded yet
-    return (connectionPromise != null || (hass && (!hass.states || !hass.config)));
+    return (connectionPromise != null || (hass && hass.connection && (!hass.states || !hass.config)));
   }
 
   loadResources() {
@@ -110,7 +110,17 @@ class HomeAssistant extends Polymer.Element {
       this.unsubConnection = null;
     }
     if (!conn) {
-      this.hass = null;
+      this._updateHass({
+        connection: null,
+        connected: false,
+        states: null,
+        config: null,
+        themes: null,
+        dockedSidebar: false,
+        moreInfoEntityId: null,
+        callService: null,
+        callApi: null,
+      });
       return;
     }
     var notifications = this.$.notifications;

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -221,7 +221,7 @@
 
     disconnectedCallback() {
       super.disconnectedCallback();
-      this.mqls.forEach(function (mql) {
+      this.mqls.forEach((mql) => {
         mql.removeListener(this.handleWindowChange);
       });
     }

--- a/src/managers/notification-manager.html
+++ b/src/managers/notification-manager.html
@@ -19,7 +19,7 @@
       id='connToast'
       duration='0'
       text='Connection lost. Reconnecting…'
-      opened='[[!isStreaming]]'
+      opened='[[connectionLost]]'
     ></paper-toast>
   </template>
 </dom-module>
@@ -32,11 +32,17 @@ class NotificationManager extends Polymer.Element {
     return {
       hass: {
         type: Object,
+        observer: 'hassChanged',
       },
 
-      isStreaming: {
+      wasConnected: {
         type: Boolean,
-        computed: 'computeIsStreaming(hass)',
+        value: false,
+      },
+
+      connectionLost: {
+        type: Boolean,
+        computed: 'computeConnectionLost(wasConnected, hass)',
       },
 
       _cancelOnOutsideClick: {
@@ -56,8 +62,19 @@ class NotificationManager extends Polymer.Element {
     };
   }
 
-  computeIsStreaming(hass) {
-    return !hass || hass.connected;
+  hassChanged(hass) {
+    if (hass && hass.connected) {
+      // Once the connetion is established, set wasConnected to true
+      this.wasConnected = true;
+    }
+    if (!hass || !hass.connection) {
+      // If the users logs out, reset wasConnected
+      this.wasConnected = false;
+    }
+  }
+
+  computeConnectionLost(wasConnected, hass) {
+    return wasConnected && hass && !hass.connected;
   }
 
   constructor() {


### PR DESCRIPTION
## Description
Alternative to https://github.com/home-assistant/home-assistant-polymer/pull/564

This PR ensures that the login form is still displayed if hass exists, but hasn't been connected yet (because the translation resources were loaded). It also ensures that the translation resources are preserved when logging out.