### PR TITLE
Fix build attempting to include translationMaster

### DIFF
--- a/gulp/tasks/translations.js
+++ b/gulp/tasks/translations.js
@@ -72,7 +72,7 @@ gulp.task(taskName, function () {
     .pipe(transform(function(data, file) {
       return lokalise_transform(data, data);
     }))
-    .pipe(rename('translation-master.json'))
+    .pipe(rename('translationMaster.json'))
     .pipe(gulp.dest(outDir));
 });
 tasks.push(taskName);
@@ -90,7 +90,7 @@ gulp.task(taskName, ['build-master-translation'], function () {
       //       than a base translation + region.
       const tr = path.basename(file.history[0], '.json');
       const subtags = tr.split('-');
-      const src = [outDir + '/translation-master.json'];
+      const src = [outDir + '/translationMaster.json'];
       for (let i = 1; i <= subtags.length; i++) {
         const lang = subtags.slice(0, i).join('-');
         src.push(inDir + '/' + lang + '.json');
@@ -119,7 +119,7 @@ tasks.push(taskName);
 
 taskName = 'build-translation-fingerprints';
 gulp.task(taskName, ['build-merged-translations'], function () {
-  return gulp.src(outDir + '/!(translationFingerprints).json')
+  return gulp.src(outDir + '/!(translationFingerprints|translationMaster).json')
     .pipe(rename({
       extname: '',
     }))

--- a/script/build_frontend
+++ b/script/build_frontend
@@ -79,5 +79,5 @@ echo "CREATED_AT = `date +%s`" >> $OUTPUT_DIR_ES5/__init__.py
 # Generate the MD5 hash of the new frontend
 script/fingerprint_frontend.py --base_dir $OUTPUT_DIR
 script/fingerprint_frontend.py --base_dir $OUTPUT_DIR_ES5
-gulp gen-index-html
-gulp gen-index-html-es5
+./node_modules/.bin/gulp gen-index-html
+./node_modules/.bin/gulp gen-index-html-es5


### PR DESCRIPTION
## Description
The build is currently attempting to include translation-master as a translation, but it's failing because there is no native name translation.

I think there were multiple PRs merged in a few days, and I missed this on the merge reconciliation.

I also updated the case on the filename to be consistent with translationFingerprints, although I could also update that if we'd prefer. No preference.