### PR TITLE
Expose build type on window

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
   "globals": {
     "__DEV__": false,
     "__DEMO__": false,
+    "__BUILD__": false,
     "Polymer": true,
     "webkitSpeechRecognition": false,
   },

--- a/gulp/tasks/hassio-panel.js
+++ b/gulp/tasks/hassio-panel.js
@@ -37,7 +37,7 @@ async function buildHassioPanel(es6) {
   });
 
   return minifyStream(stream, es6)
-    .pipe(rename('hassio-main.html'))
+    .pipe(rename(`hassio-main-${es6 ? 'latest' : 'es5'}.html`))
     .pipe(gulp.dest('build-temp'));
 }
 

--- a/js/core.js
+++ b/js/core.js
@@ -3,10 +3,11 @@ import * as HAWS from 'home-assistant-js-websocket';
 window.HAWS = HAWS;
 window.HASS_DEMO = __DEMO__;
 window.HASS_DEV = __DEV__;
+window.HASS_BUILD = __BUILD__;
 
 const init = window.createHassConnection = function (password) {
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
-  const url = `${proto}://${window.location.host}/api/websocket${window.location.search}`;
+  const url = `${proto}://${window.location.host}/api/websocket?${window.HASS_BUILD}`;
   const options = {
     setupRetry: 10,
   };

--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -39,7 +39,7 @@ class HaPanelHassio extends Polymer.Element {
   connectedCallback() {
     super.connectedCallback();
     if (!window.HASS_DEV) {
-      Polymer.importHref('/api/hassio/panel', null, () => {
+      Polymer.importHref(`/api/hassio/panel_${window.HASS_BUILD}`, null, () => {
         // eslint-disable-next-line
         alert('Failed to load the Hass.io panel from supervisor.');
       });

--- a/rollup.config-es6.js
+++ b/rollup.config-es6.js
@@ -31,6 +31,7 @@ const plugins = [
     values: {
       __DEV__: JSON.stringify(DEV),
       __DEMO__: JSON.stringify(DEMO),
+      __BUILD__: JSON.stringify('latest'),
     },
   }),
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,6 +41,7 @@ const plugins = [
     values: {
       __DEV__: JSON.stringify(DEV),
       __DEMO__: JSON.stringify(DEMO),
+      __BUILD__: JSON.stringify('es5'),
     },
   }),
 ];


### PR DESCRIPTION
Expose the build type as `window.HASS_BUILD`. Is going to be either `es5` or `latest`. This is better than depending on `window.location.search` because that gets cleared when we change panels. Now we can depend on the build type after the bootstrap phase too.

Hass.io panel will import the panel based on the build type. Either `panel_es5` or `panel_latest`.

Related PRs:
 -  https://github.com/home-assistant/home-assistant/pull/10589
 - https://github.com/home-assistant/hassio/pull/249
 - https://github.com/home-assistant/hassio-build/pull/47