### PR TITLE
Aligning the front-end card with latest Plant component changes

### DIFF
--- a/src/cards/ha-card-chooser.html
+++ b/src/cards/ha-card-chooser.html
@@ -6,7 +6,7 @@
 <link rel='import' href='./ha-media_player-card.html'>
 <link rel='import' href='./ha-weather-card.html'>
 <link rel='import' href='./ha-persistent_notification-card.html'>
-<!-- <link rel='import' href='./ha-plant-card.html'> -->
+<link rel='import' href='./ha-plant-card.html'>
 
 <script>
 class HaCardChooser extends Polymer.Element {

--- a/src/cards/ha-plant-card.html
+++ b/src/cards/ha-plant-card.html
@@ -58,12 +58,12 @@
 <script>
 {
   var _SENSORS = ['moisture', 'temperature', 'brightness', 'conductivity', 'battery'];
-  var _CONFIG = {
-    moisture: { icon: 'mdi:water', uom: '%' },
-    temperature: { icon: 'mdi:thermometer', uom: '°C' },
-    brightness: { icon: 'mdi:white-balance-sunny', uom: 'lx' },
-    conductivity: { icon: 'mdi:emoticon-poop', uom: 'µS/cm' },
-    battery: { icon: 'mdi:battery', uom: '%' }
+  var _ICONS = {
+    moisture: 'mdi:water',
+    temperature: 'mdi:thermometer',
+    brightness: 'mdi:white-balance-sunny',
+    conductivity: 'mdi:emoticon-poop',
+    battery: 'mdi:battery'
   };
 
   class HaPlantCard extends window.hassMixins.EventsMixin(Polymer.Element) {
@@ -89,7 +89,7 @@
     }
 
     computeIcon(stateObj, sensor) {
-      var icon = _CONFIG[sensor].icon;
+      var icon = _ICONS[sensor];
       if (sensor === 'battery' && typeof stateObj.attributes.battery !== 'undefined') {
         var level = stateObj.attributes.battery;
         if (level <= 5) {
@@ -109,7 +109,10 @@
     }
 
     computeUOM(stateObj, sensor) {
-      return _CONFIG[sensor].uom;
+      if (typeof stateObj.attributes.unit_of_measurement[sensor] === 'undefined') {
+        return '';
+      }
+      return stateObj.attributes.unit_of_measurement[sensor];
     }
 
     computeDisabled(stateObj, sensor) {

--- a/src/cards/ha-plant-card.html
+++ b/src/cards/ha-plant-card.html
@@ -81,17 +81,17 @@
     }
 
     computeClass(stateObj, sensor) {
-      if (typeof stateObj.attributes[sensor] === 'undefined') {
-        return 'missing';
+      if (sensor in stateObj.attributes) {
+        const prob = stateObj.attributes.problem;
+        return (prob.indexOf(sensor) === -1) ? 'ok' : 'problem';
       }
-      var prob = stateObj.attributes.problem;
-      return (prob.indexOf(sensor) === -1) ? 'ok' : 'problem';
+      return 'missing';
     }
 
     computeIcon(stateObj, sensor) {
       var icon = _ICONS[sensor];
-      if (sensor === 'battery' && typeof stateObj.attributes.battery !== 'undefined') {
-        var level = stateObj.attributes.battery;
+      if ((sensor === 'battery') && (sensor in stateObj.attributes)) {
+        const level = stateObj.attributes.battery;
         if (level <= 5) {
           icon += '-alert';
         } else if (level < 95) {
@@ -102,21 +102,24 @@
     }
 
     computeValue(stateObj, sensor) {
-      if (typeof stateObj.attributes[sensor] === 'undefined') {
-        return '-';
+      if ((sensor === 'brightness') && ('max_brightness' in stateObj.attributes)) {
+        return stateObj.attributes.max_brightness;
       }
-      return stateObj.attributes[sensor];
+      if (sensor in stateObj.attributes) {
+        return stateObj.attributes[sensor];
+      }
+      return '-';
     }
 
     computeUOM(stateObj, sensor) {
-      if (typeof stateObj.attributes.unit_of_measurement[sensor] === 'undefined') {
-        return '';
+      if (sensor in stateObj.attributes.unit_of_measurement_dict) {
+        return stateObj.attributes.unit_of_measurement_dict[sensor];
       }
-      return stateObj.attributes.unit_of_measurement[sensor];
+      return '';
     }
 
     computeDisabled(stateObj, sensor) {
-      return (typeof stateObj.attributes[sensor] === 'undefined');
+      return (!(sensor in stateObj.attributes));
     }
 
     showSensorHistory(ev) {

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -86,7 +86,7 @@
     history_graph: 4,
     media_player: 3,
     persistent_notification: 0,
-    // plant: 3,
+    plant: 3,
     weather: 4,
   };
 

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -163,6 +163,9 @@ window.hassUtil.domainIcon = function (domain, state) {
     case 'notify':
       return 'mdi:comment-alert';
 
+    case 'plant':
+      return 'mdi:flower';
+
     case 'proximity':
       return 'mdi:apple-safari';
 


### PR DESCRIPTION
This PR continues work-in-progress from PR #583 that was merged before finalising.

This PR aligns the unit-of-measurement labels with those provided by the backend plant component but is still dependent on an outstanding review comment on the backend plant component [PR9524](https://github.com/home-assistant/home-assistant/pull/9534).