### PR TITLE
Clear log entries if clear is pressed

### DIFF
--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -255,9 +255,9 @@ class HaPanelDevInfo extends Polymer.Element {
 
   serviceCalled(ev) {
     // Check if this is for us
-    if (ev.detail.success && ev.detail.domain == 'system_log') {
+    if (ev.detail.success && ev.detail.domain === 'system_log') {
       // Do the right thing depending on service
-      if (ev.detail.service == 'clear') {
+      if (ev.detail.service === 'clear') {
         this._fetchData();
       }
     }

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -258,7 +258,7 @@ class HaPanelDevInfo extends Polymer.Element {
     if (ev.detail.success && ev.detail.domain === 'system_log') {
       // Do the right thing depending on service
       if (ev.detail.service === 'clear') {
-        this._fetchData();
+        this.items = [];
       }
     }
   }

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -248,6 +248,21 @@ class HaPanelDevInfo extends Polymer.Element {
     };
   }
 
+  ready() {
+    super.ready();
+    this.addEventListener('hass-service-called', ev => this.serviceCalled(ev));
+  }
+
+  serviceCalled(ev) {
+    // Check if this is for us
+    if (ev.detail.success && ev.detail.domain == 'system_log') {
+      // Do the right thing depending on service
+      if (ev.detail.service == 'clear') {
+        this._fetchData();
+      }
+    }
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.$.scrollable.dialogElement = this.$.showlog;


### PR DESCRIPTION
Currently the system log entries are not cleared if `Clear` is pressed. This fixes that.