### PR TITLE
Prevent hound from running eslint on html files

### DIFF
--- a/.eslintrc-hound.json
+++ b/.eslintrc-hound.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./.eslintrc.json",
+  "plugins": [
+    "react"
+  ]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
     "__DEMO__": false,
     "__BUILD__": false,
     "Polymer": true,
-    "webkitSpeechRecognition": false,
+    "webkitSpeechRecognition": false
   },
   "env": {
     "browser": true

--- a/.hound.yml
+++ b/.hound.yml
@@ -3,4 +3,4 @@ jshint:
 
 eslint:
   enabled: true
-  config_file: .eslintrc
+  config_file: .eslintrc-hound.json


### PR DESCRIPTION
Prevent hound from running eslint on html files since it doesn't support it.
houndci/linters#167