### PR TITLE
Climate: add supported_features

### DIFF
--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -35,10 +35,15 @@
 
       .has-away_mode .container-away_mode,
       .has-aux_heat .container-aux_heat,
+      .has-temperature .container-temperature, // Legacy
       .has-target_temperature .container-temperature,
+      .has-humidity .container-humidity, // Legacy
       .has-target_humidity .container-humidity,
+      .has-operation_list .container-operation_list, // Legacy
       .has-operation_mode .container-operation_list,
+      .has-fan_list .container-fan_list, // Legacy
       .has-fan_mode .container-fan_list,
+      .has-swing_list .container-swing_list,
       .has-swing_mode .container-swing_list {
         display: block;
       }

--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -35,13 +35,9 @@
 
       .has-away_mode .container-away_mode,
       .has-aux_heat .container-aux_heat,
-      .has-temperature .container-temperature, // Legacy
       .has-target_temperature .container-temperature,
-      .has-humidity .container-humidity, // Legacy
       .has-target_humidity .container-humidity,
-      .has-operation_list .container-operation_list, // Legacy
       .has-operation_mode .container-operation_list,
-      .has-fan_list .container-fan_list, // Legacy
       .has-fan_mode .container-fan_list,
       .has-swing_list .container-swing_list,
       .has-swing_mode .container-swing_list {
@@ -283,31 +279,30 @@ class MoreInfoClimate extends window.hassMixins.EventsMixin(Polymer.Element) {
   }
 
   computeClassNames(stateObj) {
-    if (stateObj.attributes.supported_features) {
-      const featureClassNames = {
-        1: 'has-current_temperature',
-        2: 'has-current_humidity',
-        4: 'has-target_temperature',
-        8: 'has-target_temperature_high',
-        16: 'has-target_temperature_low',
-        32: 'has-target_humidity',
-        64: 'has-target_humidity_high',
-        128: 'has-target_humidity_low',
-        256: 'has-fan_mode',
-        512: 'has-operation_mode',
-        1024: 'has-hold_mode',
-        2048: 'has-swing_mode',
-        4096: 'has-away_mode',
-        8192: 'has-aux_heat',
-      };
+    const featureClassNames = {
+      1: 'has-target_temperature',
+      2: 'has-target_temperature_high',
+      4: 'has-target_temperature_low',
+      8: 'has-target_humidity',
+      16: 'has-target_humidity_high',
+      32: 'has-target_humidity_low',
+      64: 'has-fan_mode',
+      128: 'has-operation_mode',
+      256: 'has-hold_mode',
+      512: 'has-swing_mode',
+      1024: 'has-away_mode',
+      2048: 'has-aux_heat',
+    };
 
-      return window.hassUtil.featureClassNames(stateObj, featureClassNames);
-    }
 
-    return 'more-info-climate ' + window.hassUtil.attributeClassNames(stateObj, [
-      'away_mode', 'aux_heat', 'temperature', 'humidity', 'operation_list',
-      'fan_list', 'swing_list',
-    ]);
+    var classes = [
+      window.hassUtil.attributeClassNames(stateObj, ['current_temperature', 'current_humidity']),
+      window.hassUtil.featureClassNames(stateObj, featureClassNames),
+    ];
+
+    classes.push('more-info-climate');
+
+    return classes.join(' ');
   }
 
   targetTemperatureChanged(ev) {

--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -35,11 +35,11 @@
 
       .has-away_mode .container-away_mode,
       .has-aux_heat .container-aux_heat,
-      .has-temperature .container-temperature,
-      .has-humidity .container-humidity,
-      .has-operation_list .container-operation_list,
-      .has-fan_list .container-fan_list,
-      .has-swing_list .container-swing_list {
+      .has-target_temperature .container-temperature,
+      .has-target_humidity .container-humidity,
+      .has-operation_mode .container-operation_list,
+      .has-fan_mode .container-fan_list,
+      .has-swing_mode .container-swing_list {
         display: block;
       }
 
@@ -278,6 +278,27 @@ class MoreInfoClimate extends window.hassMixins.EventsMixin(Polymer.Element) {
   }
 
   computeClassNames(stateObj) {
+    if (stateObj.attributes.supported_features) {
+      const featureClassNames = {
+        1: 'has-current_temperature',
+        2: 'has-current_humidity',
+        4: 'has-target_temperature',
+        8: 'has-target_temperature_high',
+        16: 'has-target_temperature_low',
+        32: 'has-target_humidity',
+        64: 'has-target_humidity_high',
+        128: 'has-target_humidity_low',
+        256: 'has-fan_mode',
+        512: 'has-operation_mode',
+        1024: 'has-hold_mode',
+        2048: 'has-swing_mode',
+        4096: 'has-away_mode',
+        8192: 'has-aux_heat',
+      };
+
+      return window.hassUtil.featureClassNames(stateObj, featureClassNames);
+    }
+
     return 'more-info-climate ' + window.hassUtil.attributeClassNames(stateObj, [
       'away_mode', 'aux_heat', 'temperature', 'humidity', 'operation_list',
       'fan_list', 'swing_list',


### PR DESCRIPTION
This adds frontend support for https://github.com/home-assistant/home-assistant/pull/10658 

The fact that I've renamed some of the classes (and marked the old names "legacy" because they are still being generated from the old method of generating class names) is that in the long run I'd like to rename all "temperature"s to either "current_temperature" or "target_temperature". I think it's really confusing to have variables / constants / whatever named "temperature" when we're dealing with two different temperatures.