### PR TITLE
Compute state display tests

### DIFF
--- a/js/common/util/compute_domain.js
+++ b/js/common/util/compute_domain.js
@@ -1,5 +1,6 @@
-import { extractDomain } from 'home-assistant-js-websocket';
-
 export default function computeDomain(stateObj) {
-  return extractDomain(stateObj.entity_id);
+  if (!stateObj || !stateObj.entity_id) {
+    return null;
+  }
+  return stateObj.entity_id.substr(0, stateObj.entity_id.indexOf('.'));
 }

--- a/js/common/util/compute_domain.js
+++ b/js/common/util/compute_domain.js
@@ -1,6 +1,3 @@
 export default function computeDomain(stateObj) {
-  if (!stateObj || !stateObj.entity_id) {
-    return null;
-  }
   return stateObj.entity_id.substr(0, stateObj.entity_id.indexOf('.'));
 }

--- a/js/common/util/compute_domain.js
+++ b/js/common/util/compute_domain.js
@@ -1,3 +1,7 @@
 export default function computeDomain(stateObj) {
-  return stateObj.entity_id.substr(0, stateObj.entity_id.indexOf('.'));
+  if (!stateObj._domain) {
+    stateObj._domain = stateObj.entity_id.substr(0, stateObj.entity_id.indexOf('.'));
+  }
+
+  return stateObj._domain;
 }

--- a/js/common/util/compute_domain.js
+++ b/js/common/util/compute_domain.js
@@ -1,9 +1,5 @@
 import { extractDomain } from 'home-assistant-js-websocket';
 
 export default function computeDomain(stateObj) {
-  if (!stateObj._domain) {
-    stateObj._domain = extractDomain(stateObj.entity_id);
-  }
-
-  return stateObj._domain;
+  return extractDomain(stateObj.entity_id);
 }

--- a/js/common/util/compute_domain.js
+++ b/js/common/util/compute_domain.js
@@ -1,0 +1,9 @@
+import { extractDomain } from 'home-assistant-js-websocket';
+
+export default function computeDomain(stateObj) {
+  if (!stateObj._domain) {
+    stateObj._domain = extractDomain(stateObj.entity_id);
+  }
+
+  return stateObj._domain;
+}

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -4,56 +4,56 @@ import formatDate from './format_date';
 import formatTime from './format_time';
 
 export default function computeStateDisplay(haLocalize, stateObj, language) {
-  if (!stateObj._stateDisplay) {
-    const domain = computeDomain(stateObj);
-    if (domain === 'binary_sensor') {
-      // Try device class translation, then default binary sensor translation
-      if (stateObj.attributes.device_class) {
-        stateObj._stateDisplay =
-          haLocalize(`state.${domain}.${stateObj.attributes.device_class}`, stateObj.state);
-      }
-      if (!stateObj._stateDisplay) {
-        stateObj._stateDisplay = haLocalize(`state.${domain}.default`, stateObj.state);
-      }
-    } else if (stateObj.attributes.unit_of_measurement) {
-      stateObj._stateDisplay = stateObj.state + ' ' + stateObj.attributes.unit_of_measurement;
-    } else if (domain === 'input_datetime') {
-      let date;
-      if (!stateObj.attributes.has_time) {
-        date = new Date(
-          stateObj.attributes.year,
-          stateObj.attributes.month - 1,
-          stateObj.attributes.day
-        );
-        stateObj._stateDisplay = formatDate(date, language);
-      } else if (!stateObj.attributes.has_date) {
-        date = new Date(
-          1970, 0, 1,
-          stateObj.attributes.hour,
-          stateObj.attributes.minute
-        );
-        stateObj._stateDisplay = formatTime(date, language);
-      } else {
-        date = new Date(
-          stateObj.attributes.year, stateObj.attributes.month - 1,
-          stateObj.attributes.day, stateObj.attributes.hour,
-          stateObj.attributes.minute
-        );
-        stateObj._stateDisplay = formatDateTime(date, language);
-      }
-    } else if (domain === 'zwave') {
-      if (['initializing', 'dead'].includes(stateObj.state)) {
-        stateObj._stateDisplay = haLocalize('state.zwave.query_stage', stateObj.state, 'query_stage', stateObj.attributes.query_stage);
-      } else {
-        stateObj._stateDisplay = haLocalize('state.zwave.default', stateObj.state);
-      }
-    } else {
-      stateObj._stateDisplay = haLocalize(`state.${domain}`, stateObj.state);
-    }
-    // Fall back to default or raw state if nothing else matches.
-    stateObj._stateDisplay = stateObj._stateDisplay
-      || haLocalize('state.default', stateObj.state) || stateObj.state;
-  }
+  let stateDisplay = null;
 
-  return stateObj._stateDisplay;
+  const domain = computeDomain(stateObj);
+  if (domain === 'binary_sensor') {
+    // Try device class translation, then default binary sensor translation
+    if (stateObj.attributes.device_class) {
+      stateDisplay =
+        haLocalize(`state.${domain}.${stateObj.attributes.device_class}`, stateObj.state);
+    }
+    if (!stateDisplay) {
+      stateDisplay = haLocalize(`state.${domain}.default`, stateObj.state);
+    }
+  } else if (stateObj.attributes.unit_of_measurement) {
+    stateDisplay = stateObj.state + ' ' + stateObj.attributes.unit_of_measurement;
+  } else if (domain === 'input_datetime') {
+    let date;
+    if (!stateObj.attributes.has_time) {
+      date = new Date(
+        stateObj.attributes.year,
+        stateObj.attributes.month - 1,
+        stateObj.attributes.day
+      );
+      stateDisplay = formatDate(date, language);
+    } else if (!stateObj.attributes.has_date) {
+      date = new Date(
+        1970, 0, 1,
+        stateObj.attributes.hour,
+        stateObj.attributes.minute
+      );
+      stateDisplay = formatTime(date, language);
+    } else {
+      date = new Date(
+        stateObj.attributes.year, stateObj.attributes.month - 1,
+        stateObj.attributes.day, stateObj.attributes.hour,
+        stateObj.attributes.minute
+      );
+      stateDisplay = formatDateTime(date, language);
+    }
+  } else if (domain === 'zwave') {
+    if (['initializing', 'dead'].includes(stateObj.state)) {
+      stateDisplay = haLocalize('state.zwave.query_stage', stateObj.state, 'query_stage', stateObj.attributes.query_stage);
+    } else {
+      stateDisplay = haLocalize('state.zwave.default', stateObj.state);
+    }
+  } else {
+    stateDisplay = haLocalize(`state.${domain}`, stateObj.state);
+  }
+  // Fall back to default or raw state if nothing else matches.
+  stateDisplay = stateDisplay
+    || haLocalize('state.default', stateObj.state) || stateObj.state;
+
+  return stateDisplay;
 }

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -4,6 +4,10 @@ import formatDate from './format_date';
 import formatTime from './format_time';
 
 export default function computeStateDisplay(haLocalize, stateObj, language) {
+  if (!haLocalize || !stateObj || !language) {
+    return null;
+  }
+
   let stateDisplay = null;
 
   const domain = computeDomain(stateObj);

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -4,56 +4,56 @@ import formatDate from './format_date';
 import formatTime from './format_time';
 
 export default function computeStateDisplay(haLocalize, stateObj, language) {
-  let stateDisplay = null;
-
-  const domain = computeDomain(stateObj);
-  if (domain === 'binary_sensor') {
-    // Try device class translation, then default binary sensor translation
-    if (stateObj.attributes.device_class) {
-      stateDisplay =
-        haLocalize(`state.${domain}.${stateObj.attributes.device_class}`, stateObj.state);
-    }
-    if (!stateDisplay) {
-      stateDisplay = haLocalize(`state.${domain}.default`, stateObj.state);
-    }
-  } else if (stateObj.attributes.unit_of_measurement) {
-    stateDisplay = stateObj.state + ' ' + stateObj.attributes.unit_of_measurement;
-  } else if (domain === 'input_datetime') {
-    let date;
-    if (!stateObj.attributes.has_time) {
-      date = new Date(
-        stateObj.attributes.year,
-        stateObj.attributes.month - 1,
-        stateObj.attributes.day
-      );
-      stateDisplay = formatDate(date, language);
-    } else if (!stateObj.attributes.has_date) {
-      date = new Date(
-        1970, 0, 1,
-        stateObj.attributes.hour,
-        stateObj.attributes.minute
-      );
-      stateDisplay = formatTime(date, language);
+  if (!stateObj._stateDisplay) {
+    const domain = computeDomain(stateObj);
+    if (domain === 'binary_sensor') {
+      // Try device class translation, then default binary sensor translation
+      if (stateObj.attributes.device_class) {
+        stateObj._stateDisplay =
+          haLocalize(`state.${domain}.${stateObj.attributes.device_class}`, stateObj.state);
+      }
+      if (!stateObj._stateDisplay) {
+        stateObj._stateDisplay = haLocalize(`state.${domain}.default`, stateObj.state);
+      }
+    } else if (stateObj.attributes.unit_of_measurement) {
+      stateObj._stateDisplay = stateObj.state + ' ' + stateObj.attributes.unit_of_measurement;
+    } else if (domain === 'input_datetime') {
+      let date;
+      if (!stateObj.attributes.has_time) {
+        date = new Date(
+          stateObj.attributes.year,
+          stateObj.attributes.month - 1,
+          stateObj.attributes.day
+        );
+        stateObj._stateDisplay = formatDate(date, language);
+      } else if (!stateObj.attributes.has_date) {
+        date = new Date(
+          1970, 0, 1,
+          stateObj.attributes.hour,
+          stateObj.attributes.minute
+        );
+        stateObj._stateDisplay = formatTime(date, language);
+      } else {
+        date = new Date(
+          stateObj.attributes.year, stateObj.attributes.month - 1,
+          stateObj.attributes.day, stateObj.attributes.hour,
+          stateObj.attributes.minute
+        );
+        stateObj._stateDisplay = formatDateTime(date, language);
+      }
+    } else if (domain === 'zwave') {
+      if (['initializing', 'dead'].includes(stateObj.state)) {
+        stateObj._stateDisplay = haLocalize('state.zwave.query_stage', stateObj.state, 'query_stage', stateObj.attributes.query_stage);
+      } else {
+        stateObj._stateDisplay = haLocalize('state.zwave.default', stateObj.state);
+      }
     } else {
-      date = new Date(
-        stateObj.attributes.year, stateObj.attributes.month - 1,
-        stateObj.attributes.day, stateObj.attributes.hour,
-        stateObj.attributes.minute
-      );
-      stateDisplay = formatDateTime(date, language);
+      stateObj._stateDisplay = haLocalize(`state.${domain}`, stateObj.state);
     }
-  } else if (domain === 'zwave') {
-    if (['initializing', 'dead'].includes(stateObj.state)) {
-      stateDisplay = haLocalize('state.zwave.query_stage', stateObj.state, 'query_stage', stateObj.attributes.query_stage);
-    } else {
-      stateDisplay = haLocalize('state.zwave.default', stateObj.state);
-    }
-  } else {
-    stateDisplay = haLocalize(`state.${domain}`, stateObj.state);
+    // Fall back to default or raw state if nothing else matches.
+    stateObj._stateDisplay = stateObj._stateDisplay
+      || haLocalize('state.default', stateObj.state) || stateObj.state;
   }
-  // Fall back to default or raw state if nothing else matches.
-  stateDisplay = stateDisplay
-    || haLocalize('state.default', stateObj.state) || stateObj.state;
 
-  return stateDisplay;
+  return stateObj._stateDisplay;
 }

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -1,0 +1,50 @@
+export default function computeStateDisplay(haLocalize, stateObj) {
+  if (!stateObj._stateDisplay) {
+    const domain = window.hassUtil.computeDomain(stateObj);
+    if (domain === 'binary_sensor') {
+      // Try device class translation, then default binary sensor translation
+      stateObj._stateDisplay =
+        haLocalize(`state.${domain}.${stateObj.attributes.device_class}`, stateObj.state)
+        || haLocalize(`state.${domain}.default`, stateObj.state);
+    } else if (stateObj.attributes.unit_of_measurement) {
+      stateObj._stateDisplay = stateObj.state + ' ' + stateObj.attributes.unit_of_measurement;
+    } else if (domain === 'input_datetime') {
+      let date;
+      if (!stateObj.attributes.has_time) {
+        date = new Date(
+          stateObj.attributes.year,
+          stateObj.attributes.month - 1,
+          stateObj.attributes.day
+        );
+        stateObj._stateDisplay = window.hassUtil.formatDate(date);
+      } else if (!stateObj.attributes.has_date) {
+        date = new Date(
+          1970, 0, 1,
+          stateObj.attributes.hour,
+          stateObj.attributes.minute
+        );
+        stateObj._stateDisplay = window.hassUtil.formatTime(date);
+      } else {
+        date = new Date(
+          stateObj.attributes.year, stateObj.attributes.month - 1,
+          stateObj.attributes.day, stateObj.attributes.hour,
+          stateObj.attributes.minute
+        );
+        stateObj._stateDisplay = window.hassUtil.formatDateTime(date);
+      }
+    } else if (domain === 'zwave') {
+      if (['initializing', 'dead'].includes(stateObj.state)) {
+        stateObj._stateDisplay = haLocalize('state.zwave.query_stage', stateObj.state, 'query_stage', stateObj.attributes.query_stage);
+      } else {
+        stateObj._stateDisplay = haLocalize('state.zwave.default', stateObj.state);
+      }
+    } else {
+      stateObj._stateDisplay = haLocalize(`state.${domain}`, stateObj.state);
+    }
+    // Fall back to default or raw state if nothing else matches.
+    stateObj._stateDisplay = stateObj._stateDisplay
+      || haLocalize('state.default', stateObj.state) || stateObj.state;
+  }
+
+  return stateObj._stateDisplay;
+}

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -4,10 +4,6 @@ import formatDate from './format_date';
 import formatTime from './format_time';
 
 export default function computeStateDisplay(haLocalize, stateObj, language) {
-  if (!haLocalize || !stateObj || !language) {
-    return null;
-  }
-
   let stateDisplay = null;
 
   const domain = computeDomain(stateObj);

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -1,11 +1,20 @@
-export default function computeStateDisplay(haLocalize, stateObj) {
+import computeDomain from './compute_domain';
+import formatDateTime from './format_date_time';
+import formatDate from './format_date';
+import formatTime from './format_time';
+
+export default function computeStateDisplay(haLocalize, stateObj, language) {
   if (!stateObj._stateDisplay) {
-    const domain = window.hassUtil.computeDomain(stateObj);
+    const domain = computeDomain(stateObj);
     if (domain === 'binary_sensor') {
       // Try device class translation, then default binary sensor translation
-      stateObj._stateDisplay =
-        haLocalize(`state.${domain}.${stateObj.attributes.device_class}`, stateObj.state)
-        || haLocalize(`state.${domain}.default`, stateObj.state);
+      if (stateObj.attributes.device_class) {
+        stateObj._stateDisplay =
+          haLocalize(`state.${domain}.${stateObj.attributes.device_class}`, stateObj.state);
+      }
+      if (!stateObj._stateDisplay) {
+        stateObj._stateDisplay = haLocalize(`state.${domain}.default`, stateObj.state);
+      }
     } else if (stateObj.attributes.unit_of_measurement) {
       stateObj._stateDisplay = stateObj.state + ' ' + stateObj.attributes.unit_of_measurement;
     } else if (domain === 'input_datetime') {
@@ -16,21 +25,21 @@ export default function computeStateDisplay(haLocalize, stateObj) {
           stateObj.attributes.month - 1,
           stateObj.attributes.day
         );
-        stateObj._stateDisplay = window.hassUtil.formatDate(date);
+        stateObj._stateDisplay = formatDate(date, language);
       } else if (!stateObj.attributes.has_date) {
         date = new Date(
           1970, 0, 1,
           stateObj.attributes.hour,
           stateObj.attributes.minute
         );
-        stateObj._stateDisplay = window.hassUtil.formatTime(date);
+        stateObj._stateDisplay = formatTime(date, language);
       } else {
         date = new Date(
           stateObj.attributes.year, stateObj.attributes.month - 1,
           stateObj.attributes.day, stateObj.attributes.hour,
           stateObj.attributes.minute
         );
-        stateObj._stateDisplay = window.hassUtil.formatDateTime(date);
+        stateObj._stateDisplay = formatDateTime(date, language);
       }
     } else if (domain === 'zwave') {
       if (['initializing', 'dead'].includes(stateObj.state)) {

--- a/js/common/util/format_date.js
+++ b/js/common/util/format_date.js
@@ -1,0 +1,19 @@
+// Check for support of native locale string options
+function toLocaleDateStringSupportsOptions() {
+  try {
+    new Date().toLocaleDateString('i');
+  } catch (e) {
+    return e.name === 'RangeError';
+  }
+  return false;
+}
+
+export default (toLocaleDateStringSupportsOptions() ?
+  function (dateObj, locales) {
+    return dateObj.toLocaleDateString(
+      locales,
+      { year: 'numeric', month: 'long', day: 'numeric' },
+    );
+  } : function (dateObj, locales) { // eslint-disable-line no-unused-vars
+    return window.fecha.format(dateObj, 'mediumDate');
+  });

--- a/js/common/util/format_date_time.js
+++ b/js/common/util/format_date_time.js
@@ -1,0 +1,22 @@
+// Check for support of native locale string options
+function toLocaleStringSupportsOptions() {
+  try {
+    new Date().toLocaleString('i');
+  } catch (e) {
+    return e.name === 'RangeError';
+  }
+  return false;
+}
+
+export default (toLocaleStringSupportsOptions() ?
+  function (dateObj, locales) {
+    return dateObj.toLocaleString(locales, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  } : function (dateObj, locales) { // eslint-disable-line no-unused-vars
+    return window.fecha.format(dateObj, 'haDateTime');
+  });

--- a/js/common/util/format_time.js
+++ b/js/common/util/format_time.js
@@ -1,0 +1,19 @@
+// Check for support of native locale string options
+function toLocaleTimeStringSupportsOptions() {
+  try {
+    new Date().toLocaleTimeString('i');
+  } catch (e) {
+    return e.name === 'RangeError';
+  }
+  return false;
+}
+
+export default (toLocaleTimeStringSupportsOptions() ?
+  function (dateObj, locales) {
+    return dateObj.toLocaleTimeString(
+      locales,
+      { hour: 'numeric', minute: '2-digit' }
+    );
+  } : function (dateObj, locales) { // eslint-disable-line no-unused-vars
+    return window.fecha.format(dateObj, 'shortTime');
+  });

--- a/js/util.js
+++ b/js/util.js
@@ -15,7 +15,7 @@ import formatTime from './common/util/format_time';
 
 window.hassUtil = window.hassUtil || {};
 
-window.hassUtil.LANGUAGE = navigator.languages ?
+const language = navigator.languages ?
   navigator.languages[0] : navigator.language || navigator.userLanguage;
 
 window.fecha.masks.haDateTime = window.fecha.masks.shortTime + ' ' + window.fecha.masks.mediumDate;
@@ -23,6 +23,6 @@ window.fecha.masks.haDateTime = window.fecha.masks.shortTime + ' ' + window.fech
 window.hassUtil.attributeClassNames = attributeClassNames;
 window.hassUtil.computeDomain = computeDomain;
 window.hassUtil.computeStateDisplay = computeStateDisplay;
-window.hassUtil.formatDate = dateObj => formatDate(dateObj, window.hassUtil.LANGUAGE);
-window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, window.hassUtil.LANGUAGE);
-window.hassUtil.formatTime = dateObj => formatTime(dateObj, window.hassUtil.LANGUAGE);
+window.hassUtil.formatDate = dateObj => formatDate(dateObj, language);
+window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, language);
+window.hassUtil.formatTime = dateObj => formatTime(dateObj, language);

--- a/js/util.js
+++ b/js/util.js
@@ -8,8 +8,9 @@
 
 import attributeClassNames from './common/util/attribute_class_names';
 import computeDomain from './common/util/compute_domain';
-import formatDateTime from './common/util/format_date_time';
+import computeStateDisplay from './common/util/compute_state_display';
 import formatDate from './common/util/format_date';
+import formatDateTime from './common/util/format_date_time';
 import formatTime from './common/util/format_time';
 
 window.hassUtil = window.hassUtil || {};
@@ -21,6 +22,7 @@ window.fecha.masks.haDateTime = window.fecha.masks.shortTime + ' ' + window.fech
 
 window.hassUtil.attributeClassNames = attributeClassNames;
 window.hassUtil.computeDomain = computeDomain;
-window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, window.hassUtil.LANGUAGE);
+window.hassUtil.computeStateDisplay = computeStateDisplay;
 window.hassUtil.formatDate = dateObj => formatDate(dateObj, window.hassUtil.LANGUAGE);
+window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, window.hassUtil.LANGUAGE);
 window.hassUtil.formatTime = dateObj => formatTime(dateObj, window.hassUtil.LANGUAGE);

--- a/js/util.js
+++ b/js/util.js
@@ -7,7 +7,20 @@
  */
 
 import attributeClassNames from './common/util/attribute_class_names';
+import computeDomain from './common/util/compute_domain';
+import formatDateTime from './common/util/format_date_time';
+import formatDate from './common/util/format_date';
+import formatTime from './common/util/format_time';
 
 window.hassUtil = window.hassUtil || {};
 
+window.hassUtil.LANGUAGE = navigator.languages ?
+  navigator.languages[0] : navigator.language || navigator.userLanguage;
+
+window.fecha.masks.haDateTime = window.fecha.masks.shortTime + ' ' + window.fecha.masks.mediumDate;
+
 window.hassUtil.attributeClassNames = attributeClassNames;
+window.hassUtil.computeDomain = computeDomain;
+window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, window.hassUtil.LANGUAGE);
+window.hassUtil.formatDate = dateObj => formatDate(dateObj, window.hassUtil.LANGUAGE);
+window.hassUtil.formatTime = dateObj => formatTime(dateObj, window.hassUtil.LANGUAGE);

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -7,6 +7,8 @@
 <link rel="import" href="../cards/ha-badges-card.html">
 <link rel="import" href="../cards/ha-card-chooser.html">
 
+<link rel="import" href="../util/hass-util.html">
+
 <dom-module id="ha-cards">
   <template>
     <style is="custom-style" include="iron-flex iron-flex-factors"></style>

--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -2,7 +2,6 @@
 <script>
   Polymer.setPassiveTouchGestures(true);
 </script>
-<link rel='import' href='../bower_components/app-localize-behavior/app-localize-behavior.html'>
 <link rel='import' href='./util/roboto.html'>
 <link rel='import' href='../bower_components/paper-styles/typography.html'>
 <link rel='import' href='../bower_components/iron-flex-layout/iron-flex-layout-classes.html'>

--- a/src/state-summary/state-card-display.html
+++ b/src/state-summary/state-card-display.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 
 <link rel="import" href="../components/entity/state-info.html">
+<link rel="import" href="../util/hass-mixins.html">
 <link rel="import" href="../util/hass-util.html">
 
 <dom-module id="state-card-display">

--- a/src/state-summary/state-card-display.html
+++ b/src/state-summary/state-card-display.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 
 <link rel="import" href="../components/entity/state-info.html">
+<link rel="import" href="../util/hass-util.html">
 
 <dom-module id="state-card-display">
   <template>
@@ -20,7 +21,7 @@
 
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
-      <div class='state'>[[computeStateDisplay(haLocalize, stateObj)]]</div>
+      <div class='state'>[[computeStateDisplay(haLocalize, stateObj, language)]]</div>
     </div>
   </template>
 </dom-module>
@@ -40,55 +41,8 @@ class StateCardDisplay extends window.hassMixins.LocalizeMixin(Polymer.Element) 
     };
   }
 
-  computeStateDisplay(haLocalize, stateObj) {
-    if (!stateObj._stateDisplay) {
-      const domain = window.hassUtil.computeDomain(stateObj);
-      if (domain === 'binary_sensor') {
-        // Try device class translation, then default binary sensor translation
-        stateObj._stateDisplay =
-          haLocalize(`state.${domain}.${stateObj.attributes.device_class}`, stateObj.state)
-          || haLocalize(`state.${domain}.default`, stateObj.state);
-      } else if (stateObj.attributes.unit_of_measurement) {
-        stateObj._stateDisplay = stateObj.state + ' ' + stateObj.attributes.unit_of_measurement;
-      } else if (domain === 'input_datetime') {
-        let date;
-        if (!stateObj.attributes.has_time) {
-          date = new Date(
-            stateObj.attributes.year,
-            stateObj.attributes.month - 1,
-            stateObj.attributes.day
-          );
-          stateObj._stateDisplay = window.hassUtil.formatDate(date);
-        } else if (!stateObj.attributes.has_date) {
-          date = new Date(
-            1970, 0, 1,
-            stateObj.attributes.hour,
-            stateObj.attributes.minute
-          );
-          stateObj._stateDisplay = window.hassUtil.formatTime(date);
-        } else {
-          date = new Date(
-            stateObj.attributes.year, stateObj.attributes.month - 1,
-            stateObj.attributes.day, stateObj.attributes.hour,
-            stateObj.attributes.minute
-          );
-          stateObj._stateDisplay = window.hassUtil.formatDateTime(date);
-        }
-      } else if (domain === 'zwave') {
-        if (['initializing', 'dead'].includes(stateObj.state)) {
-          stateObj._stateDisplay = haLocalize('state.zwave.query_stage', stateObj.state, 'query_stage', stateObj.attributes.query_stage);
-        } else {
-          stateObj._stateDisplay = haLocalize('state.zwave.default', stateObj.state);
-        }
-      } else {
-        stateObj._stateDisplay = haLocalize(`state.${domain}`, stateObj.state);
-      }
-      // Fall back to default or raw state if nothing else matches.
-      stateObj._stateDisplay = stateObj._stateDisplay
-        || haLocalize('state.default', stateObj.state) || stateObj.state;
-    }
-
-    return stateObj._stateDisplay;
+  computeStateDisplay(haLocalize, stateObj, language) {
+    return window.hassUtil.computeStateDisplay(haLocalize, stateObj, language);
   }
 }
 customElements.define(StateCardDisplay.is, StateCardDisplay);

--- a/src/util/hass-mixins.html
+++ b/src/util/hass-mixins.html
@@ -1,3 +1,5 @@
+<link rel='import' href='../../bower_components/app-localize-behavior/app-localize-behavior.html'>
+
 <script>
 
 // Polymer legacy event helpers used courtesy of the Polymer project.

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -36,9 +36,6 @@ window.hassUtil.HIDE_MORE_INFO = [
   'input_select', 'scene', 'input_number', 'input_text'
 ];
 
-window.hassUtil.LANGUAGE = navigator.languages ?
-  navigator.languages[0] : navigator.language || navigator.userLanguage;
-
 // Expects featureClassNames to be an object mapping feature-bit -> className
 window.hassUtil.featureClassNames = function (stateObj, featureClassNames) {
   if (!stateObj || !stateObj.attributes.supported_features) return '';
@@ -106,77 +103,6 @@ window.hassUtil.dynamicContentUpdater = function (root, newElementTag, attribute
     rootEl.appendChild(customEl);
   }
 };
-
-// Check for support of native locale string options
-function toLocaleStringSupportsOptions() {
-  try {
-    new Date().toLocaleString('i');
-  } catch (e) {
-    return e.name === 'RangeError';
-  }
-  return false;
-}
-function toLocaleDateStringSupportsOptions() {
-  try {
-    new Date().toLocaleDateString('i');
-  } catch (e) {
-    return e.name === 'RangeError';
-  }
-  return false;
-}
-function toLocaleTimeStringSupportsOptions() {
-  try {
-    new Date().toLocaleTimeString('i');
-  } catch (e) {
-    return e.name === 'RangeError';
-  }
-  return false;
-}
-
-window.fecha.masks.haDateTime = (window.fecha.masks.shortTime + ' ' +
-                                 window.fecha.masks.mediumDate);
-
-if (toLocaleStringSupportsOptions()) {
-  window.hassUtil.formatDateTime = function (dateObj) {
-    return dateObj.toLocaleString(window.hassUtil.LANGUAGE, {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  };
-} else {
-  window.hassUtil.formatDateTime = function (dateObj) {
-    return window.fecha.format(dateObj, 'haDateTime');
-  };
-}
-
-if (toLocaleDateStringSupportsOptions()) {
-  window.hassUtil.formatDate = function (dateObj) {
-    return dateObj.toLocaleDateString(
-      window.hassUtil.LANGUAGE,
-      { year: 'numeric', month: 'long', day: 'numeric' }
-    );
-  };
-} else {
-  window.hassUtil.formatDate = function (dateObj) {
-    return window.fecha.format(dateObj, 'mediumDate');
-  };
-}
-
-if (toLocaleTimeStringSupportsOptions()) {
-  window.hassUtil.formatTime = function (dateObj) {
-    return dateObj.toLocaleTimeString(
-      window.hassUtil.LANGUAGE,
-      { hour: 'numeric', minute: '2-digit' }
-    );
-  };
-} else {
-  window.hassUtil.formatTime = function (dateObj) {
-    return window.fecha.format(dateObj, 'shortTime');
-  };
-}
 
 window.hassUtil.relativeTime = function (dateObj) {
   var delta = Math.abs(new Date() - dateObj) / 1000;
@@ -424,14 +350,6 @@ window.hassUtil.stateIcon = function (state) {
   }
 
   return window.hassUtil.domainIcon(domain, state.state);
-};
-
-window.hassUtil.computeDomain = function (stateObj) {
-  if (!stateObj._domain) {
-    stateObj._domain = window.HAWS.extractDomain(stateObj.entity_id);
-  }
-
-  return stateObj._domain;
 };
 
 window.hassUtil.computeObjectId = function (stateObj) {

--- a/test-mocha/common/util/attribute_class_names_test.js
+++ b/test-mocha/common/util/attribute_class_names_test.js
@@ -5,14 +5,14 @@ const assert = require('assert');
 describe('attributeClassNames', function() {
   const attrs = ['mock_attr1', 'mock_attr2'];
 
-  it('null state', function() {
+  it('Skips null states', function() {
     const stateObj = null;
     assert.strictEqual(
       attributeClassNames(stateObj, attrs),
       '');
   });
 
-  it('matches no attrbutes', function() {
+  it('Matches no attrbutes', function() {
     const stateObj = {
       attributes: {
         other_attr_1: 1,
@@ -24,7 +24,7 @@ describe('attributeClassNames', function() {
       '');
   });
 
-  it('matches one attrbute', function() {
+  it('Matches one attrbute', function() {
     const stateObj = {
       attributes: {
         other_attr_1: 1,
@@ -37,7 +37,7 @@ describe('attributeClassNames', function() {
       'has-mock_attr1');
   });
 
-  it('matches two attrbutes', function() {
+  it('Matches two attrbutes', function() {
     const stateObj = {
       attributes: {
         other_attr_1: 1,

--- a/test-mocha/common/util/compute_domain.js
+++ b/test-mocha/common/util/compute_domain.js
@@ -1,0 +1,12 @@
+import computeDomain from '../../../js/common/util/compute_domain';
+
+const assert = require('assert');
+
+describe('computeDomain', function() {
+  it('Detects sensor domain', function() {
+    const stateObj = {
+      entity_id: 'sensor.test',
+    };
+    assert.strictEqual(computeDomain(stateObj), 'sensor');
+  });
+});

--- a/test-mocha/common/util/compute_domain.js
+++ b/test-mocha/common/util/compute_domain.js
@@ -9,4 +9,8 @@ describe('computeDomain', function() {
     };
     assert.strictEqual(computeDomain(stateObj), 'sensor');
   });
+
+  it('Handles null state object', function() {
+    assert.strictEqual(computeDomain(null), null);
+  });
 });

--- a/test-mocha/common/util/compute_domain.js
+++ b/test-mocha/common/util/compute_domain.js
@@ -9,8 +9,4 @@ describe('computeDomain', function() {
     };
     assert.strictEqual(computeDomain(stateObj), 'sensor');
   });
-
-  it('Handles null state object', function() {
-    assert.strictEqual(computeDomain(null), null);
-  });
 });

--- a/test-mocha/common/util/compute_state_display.js
+++ b/test-mocha/common/util/compute_state_display.js
@@ -71,9 +71,6 @@ describe('computeStateDisplay', function() {
       },
     };
     assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'November 18, 2017, 11:12 AM');
-
-    // Test changing locales
-    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'de'), '2017 M11 18 11:12');
   });
 
   it('Localizes input_datetime with date', function() {
@@ -170,5 +167,18 @@ describe('computeStateDisplay', function() {
       },
     };
     assert.strictEqual(computeStateDisplay(altHaLocalize, stateObj, 'en'), 'My Custom State');
+  });
+
+  it('Only calculates state display once per immutable state object', function() {
+    const stateObj = {
+      entity_id: 'cover.test',
+      state: 'open',
+      attributes: {
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.cover.open');
+
+    stateObj.state = 'closing';
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.cover.open');
   });
 });

--- a/test-mocha/common/util/compute_state_display.js
+++ b/test-mocha/common/util/compute_state_display.js
@@ -3,16 +3,182 @@ import computeStateDisplay from '../../../js/common/util/compute_state_display';
 const assert = require('assert');
 
 describe('computeStateDisplay', function() {
-//  const haLocalize = function(namespace, message, ...args) {
-//    // Mock Localize function for testing
-//    return namespace + '.' + message + (args ? ': ' + args.join(',') : '');
-//  };
-//
-//  it('null state', function() {
-//    const stateObj = {
-//      state: ';
-//    assert.strictEqual(
-//      computeStateDisplay(stateObj, attrs),
-//      '');
-//  });
+  const haLocalize = function(namespace, message, ...args) {
+    // Mock Localize function for testing
+    return namespace + '.' + message + (args.length ? ': ' + args.join(',') : '');
+  };
+
+  it('Localizes binary sensor defaults', function() {
+    const stateObj = {
+      entity_id: 'binary_sensor.test',
+      state: 'off',
+      attributes: {
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.binary_sensor.default.off');
+  });
+
+  it('Localizes binary sensor device class', function() {
+    const stateObj = {
+      entity_id: 'binary_sensor.test',
+      state: 'off',
+      attributes: {
+        device_class: 'moisture',
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.binary_sensor.moisture.off');
+  });
+
+  it('Localizes binary sensor invalid device class', function() {
+    const altHaLocalize = function(namespace, message, ...args) {
+      if (namespace === 'state.binary_sensor.invalid_device_class') return null;
+      return haLocalize(namespace, message, ...args);
+    };
+    const stateObj = {
+      entity_id: 'binary_sensor.test',
+      state: 'off',
+      attributes: {
+        device_class: 'invalid_device_class',
+      },
+    };
+    assert.strictEqual(computeStateDisplay(altHaLocalize, stateObj, 'en'), 'state.binary_sensor.default.off');
+  });
+
+  it('Localizes sensor value with units', function() {
+    const stateObj = {
+      entity_id: 'sensor.test',
+      state: '123',
+      attributes: {
+        unit_of_measurement: 'm',
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), '123 m');
+  });
+
+  it('Localizes input_datetime with full date time', function() {
+    const stateObj = {
+      entity_id: 'input_datetime.test',
+      state: '123',
+      attributes: {
+        has_date: true,
+        has_time: true,
+        year: 2017,
+        month: 11,
+        day: 18,
+        hour: 11,
+        minute: 12,
+        second: 13,
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'November 18, 2017, 11:12 AM');
+  });
+
+  it('Localizes input_datetime with date', function() {
+    const stateObj = {
+      entity_id: 'input_datetime.test',
+      state: '123',
+      attributes: {
+        has_date: true,
+        has_time: false,
+        year: 2017,
+        month: 11,
+        day: 18,
+        hour: 11,
+        minute: 12,
+        second: 13,
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'November 18, 2017');
+  });
+
+  it('Localizes input_datetime with time', function() {
+    const stateObj = {
+      entity_id: 'input_datetime.test',
+      state: '123',
+      attributes: {
+        has_date: false,
+        has_time: true,
+        year: 2017,
+        month: 11,
+        day: 18,
+        hour: 11,
+        minute: 12,
+        second: 13,
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), '11:12 AM');
+  });
+
+  it('Localizes zwave ready', function() {
+    const stateObj = {
+      entity_id: 'zwave.test',
+      state: 'ready',
+      attributes: {
+        query_stage: 'Complete',
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.zwave.default.ready');
+  });
+
+  it('Localizes zwave initializing', function() {
+    const stateObj = {
+      entity_id: 'zwave.test',
+      state: 'initializing',
+      attributes: {
+        query_stage: 'Probe',
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.zwave.query_stage.initializing: query_stage,Probe');
+  });
+
+  it('Localizes cover open', function() {
+    const stateObj = {
+      entity_id: 'cover.test',
+      state: 'open',
+      attributes: {
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.cover.open');
+  });
+
+  it('Localizes unavailable', function() {
+    const altHaLocalize = function(namespace, message, ...args) {
+      if (namespace === 'state.sensor') return null;
+      return haLocalize(namespace, message, ...args);
+    };
+    const stateObj = {
+      entity_id: 'sensor.test',
+      state: 'unavailable',
+      attributes: {
+      },
+    };
+    assert.strictEqual(computeStateDisplay(altHaLocalize, stateObj, 'en'), 'state.default.unavailable');
+  });
+
+  it('Localizes custom state', function() {
+    const altHaLocalize = function(namespace, message, ...args) {
+      // No matches can be found
+      return null;
+    };
+    const stateObj = {
+      entity_id: 'sensor.test',
+      state: 'My Custom State',
+      attributes: {
+      },
+    };
+    assert.strictEqual(computeStateDisplay(altHaLocalize, stateObj, 'en'), 'My Custom State');
+  });
+
+  it('Only calculates state display once per immutable state object', function() {
+    const stateObj = {
+      entity_id: 'cover.test',
+      state: 'open',
+      attributes: {
+      },
+    };
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.cover.open');
+
+    stateObj.state = 'closing';
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.cover.open');
+  });
 });

--- a/test-mocha/common/util/compute_state_display.js
+++ b/test-mocha/common/util/compute_state_display.js
@@ -8,6 +8,10 @@ describe('computeStateDisplay', function() {
     return namespace + '.' + message + (args.length ? ': ' + args.join(',') : '');
   };
 
+  it('Returns null with null stateObj', function() {
+    assert.strictEqual(computeStateDisplay(haLocalize, null, 'en'), null);
+  });
+
   it('Localizes binary sensor defaults', function() {
     const stateObj = {
       entity_id: 'binary_sensor.test',

--- a/test-mocha/common/util/compute_state_display.js
+++ b/test-mocha/common/util/compute_state_display.js
@@ -71,6 +71,9 @@ describe('computeStateDisplay', function() {
       },
     };
     assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'November 18, 2017, 11:12 AM');
+
+    // Test changing locales
+    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'de'), '2017 M11 18 11:12');
   });
 
   it('Localizes input_datetime with date', function() {
@@ -167,18 +170,5 @@ describe('computeStateDisplay', function() {
       },
     };
     assert.strictEqual(computeStateDisplay(altHaLocalize, stateObj, 'en'), 'My Custom State');
-  });
-
-  it('Only calculates state display once per immutable state object', function() {
-    const stateObj = {
-      entity_id: 'cover.test',
-      state: 'open',
-      attributes: {
-      },
-    };
-    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.cover.open');
-
-    stateObj.state = 'closing';
-    assert.strictEqual(computeStateDisplay(haLocalize, stateObj, 'en'), 'state.cover.open');
   });
 });

--- a/test-mocha/common/util/compute_state_display.js
+++ b/test-mocha/common/util/compute_state_display.js
@@ -1,0 +1,18 @@
+import computeStateDisplay from '../../../js/common/util/compute_state_display';
+
+const assert = require('assert');
+
+describe('computeStateDisplay', function() {
+//  const haLocalize = function(namespace, message, ...args) {
+//    // Mock Localize function for testing
+//    return namespace + '.' + message + (args ? ': ' + args.join(',') : '');
+//  };
+//
+//  it('null state', function() {
+//    const stateObj = {
+//      state: ';
+//    assert.strictEqual(
+//      computeStateDisplay(stateObj, attrs),
+//      '');
+//  });
+});

--- a/test-mocha/common/util/compute_state_display.js
+++ b/test-mocha/common/util/compute_state_display.js
@@ -8,10 +8,6 @@ describe('computeStateDisplay', function() {
     return namespace + '.' + message + (args.length ? ': ' + args.join(',') : '');
   };
 
-  it('Returns null with null stateObj', function() {
-    assert.strictEqual(computeStateDisplay(haLocalize, null, 'en'), null);
-  });
-
   it('Localizes binary sensor defaults', function() {
     const stateObj = {
       entity_id: 'binary_sensor.test',

--- a/test-mocha/common/util/format_date.js
+++ b/test-mocha/common/util/format_date.js
@@ -1,0 +1,20 @@
+import formatDate from '../../../js/common/util/format_date';
+
+const assert = require('assert');
+
+describe('formatDate', function() {
+  const dateObj = new Date(
+    2017, 10, 18,
+    11, 12, 13, 1400,
+  );
+
+  it('Formats English dates', function() {
+    assert.strictEqual(formatDate(dateObj, 'en'), 'November 18, 2017');
+  });
+
+  // Node only contains intl support for english formats. This test at least ensures
+  // the fallback to a different locale
+  it('Formats other dates', function() {
+    assert.strictEqual(formatDate(dateObj, 'fr'), '2017 M11 18');
+  });
+});

--- a/test-mocha/common/util/format_date_time.js
+++ b/test-mocha/common/util/format_date_time.js
@@ -1,0 +1,20 @@
+import formatDateTime from '../../../js/common/util/format_date_time';
+
+const assert = require('assert');
+
+describe('formatDateTime', function() {
+  const dateObj = new Date(
+    2017, 10, 18,
+    11, 12, 13, 1400,
+  );
+
+  it('Formats English date times', function() {
+    assert.strictEqual(formatDateTime(dateObj, 'en'), 'November 18, 2017, 11:12 AM');
+  });
+
+  // Node only contains intl support for english formats. This test at least ensures
+  // the fallback to a different locale
+  it('Formats other date times', function() {
+    assert.strictEqual(formatDateTime(dateObj, 'fr'), '2017 M11 18 11:12');
+  });
+});

--- a/test-mocha/common/util/format_time.js
+++ b/test-mocha/common/util/format_time.js
@@ -1,0 +1,20 @@
+import formatTime from '../../../js/common/util/format_time';
+
+const assert = require('assert');
+
+describe('formatTime', function() {
+  const dateObj = new Date(
+    2017, 10, 18,
+    11, 12, 13, 1400,
+  );
+
+  it('Formats English times', function() {
+    assert.strictEqual(formatTime(dateObj, 'en'), '11:12 AM');
+  });
+
+  // Node only contains intl support for english formats. This test at least ensures
+  // the fallback to a different locale
+  it('Formats other times', function() {
+    assert.strictEqual(formatTime(dateObj, 'fr'), '11:12');
+  });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -11,6 +11,8 @@
     WCT.loadSuites([
       'state-info-test.html?dom=shadow',
       'state-info-test.html?dom=shady',
+      'state-card-display-test.html?dom=shadow',
+      'state-card-display-test.html?dom=shady',
     ]);
   </script>
 </body></html>

--- a/test/state-card-display-test.html
+++ b/test/state-card-display-test.html
@@ -14,7 +14,7 @@
 <body>
   <test-fixture id="stateCardDisplay">
     <template>
-      <state-card-display><state-card-display>
+      <div />
     </template>
   </test-fixture>
 
@@ -26,21 +26,20 @@
     }
 
     suite('state-card-display', function() {
-      let si;
+      let wrapper;
+      let card;
 
       setup(function() {
-        si = fixture('stateCardDisplay');
-      });
-
-      test('state display text', function(done) {
-        si.stateObj = {
+        wrapper = fixture('stateCardDisplay');
+        card = new StateCardDisplay();
+        card.stateObj = {
           entity_id: 'binary_sensor.demo',
           state: 'off',
           attributes: {
             device_class: 'moisture',
           },
         };
-        si.hass = {
+        card.hass = {
           language: 'en',
           resources: {
             'en': {
@@ -48,8 +47,12 @@
             },
           },
         };
+        wrapper.appendChild(card);
+      });
+
+      test('state display text', function(done) {
         flush(function() {
-          var stateDiv = lightOrShadow(si, '.state');
+          const stateDiv = lightOrShadow(card, '.state');
           assert.isOk(stateDiv);
           assert.deepEqual(stateDiv.innerText, 'Mock Off Text');
           done();

--- a/test/state-card-display-test.html
+++ b/test/state-card-display-test.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+<head>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <!--
+    Temporarily load core.js here so window.HAWS is available. We can remove
+    this once hass-util includes the helper function directly.
+  -->
+  <script src="../build/core.js"></script>
+  <link rel="import" href="../src/state-summary/state-card-display.html">
+</head>
+<body>
+  <test-fixture id="stateCardDisplay">
+    <template>
+      <state-card-display><state-card-display>
+    </template>
+  </test-fixture>
+
+  <script>
+    function lightOrShadow(elem, selector) {
+      return elem.shadowRoot ?
+          elem.shadowRoot.querySelector(selector) :
+          elem.querySelector(selector);
+    }
+
+    suite('state-card-display', function() {
+      let si;
+
+      setup(function() {
+        si = fixture('stateCardDisplay');
+      });
+
+      test('state display text', function(done) {
+        si.stateObj = {
+          entity_id: 'binary_sensor.demo',
+          state: 'off',
+          attributes: {
+            device_class: 'moisture',
+          },
+        };
+        si.hass = {
+          language: 'en',
+          resources: {
+            'en': {
+              'state.binary_sensor.moisture.off': 'Mock Off Text',
+            },
+          },
+        };
+        flush(function() {
+          var stateDiv = lightOrShadow(si, '.state');
+          assert.isOk(stateDiv);
+          assert.deepEqual(stateDiv.innerText, 'Mock Off Text');
+          done();
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/state-info-test.html
+++ b/test/state-info-test.html
@@ -29,10 +29,6 @@
 
       setup(function() {
         si = fixture('stateInfo');
-        window.HAWS = {};
-        window.HAWS.extractDomain = function (entityId) {
-          return entityId.substr(0, entityId.indexOf('.'));
-        };
       });
       
       test('default values', function() {


### PR DESCRIPTION
## Description
This PR migrates the computeStateDisplay logic into a separate JS module, as well as the other dependent util functions. This allows us to add stronger unit testing around this business logic.

### Note
Currently in the format* utility functions, we're invoking `fecha` off of the global window object. From what I can tell, fecha doesn't support ES6 modules currently, and alternatives are much larger. It's not really clean, but it at least only impacts the compatibility fallback for older browsers.