### PR TITLE
Convert configurator to markdown

### DIFF
--- a/src/components/ha-markdown.html
+++ b/src/components/ha-markdown.html
@@ -1,7 +1,9 @@
 <link rel='import' href='../../bower_components/polymer/polymer-element.html'>
 
+<link rel='import' href='../util/hass-mixins.html'>
+
 <script>
-class HaMarkdown extends Polymer.Element {
+class HaMarkdown extends window.hassMixins.EventsMixin(Polymer.Element) {
   static get is() { return 'ha-markdown'; }
 
   static get properties() {
@@ -28,6 +30,24 @@ class HaMarkdown extends Polymer.Element {
     if (scriptLoaded === 1) {
       const converter = window.Markdown.getSanitizingConverter();
       this.innerHTML = converter.makeHtml(content);
+
+      const walker = document.createTreeWalker(
+        this, 1 /* SHOW_ELEMENT */, null, false)
+
+      while (walker.nextNode()) {
+        const node = walker.currentNode;
+
+        // Open external links in a new window
+        if (node.tagName === 'A' &&
+            node.host !== document.location.host) {
+          node.target = '_blank';
+
+        // Fire a resize event when images loaded to notify content resized
+        } else if (node.tagName === 'IMG') {
+          console.log('attaching', node, this.resize)
+          node.addEventListener('load', this.resize);
+        }
+      }
     } else if (scriptLoaded === 2) {
       this.innerText = content;
     }
@@ -35,6 +55,7 @@ class HaMarkdown extends Polymer.Element {
 
   ready() {
     super.ready();
+    this.resize = () => this.fire('iron-resize');
 
     Polymer.importHref(
       '/static/pagedown-js.html',

--- a/src/components/ha-markdown.html
+++ b/src/components/ha-markdown.html
@@ -31,8 +31,7 @@ class HaMarkdown extends window.hassMixins.EventsMixin(Polymer.Element) {
       const converter = window.Markdown.getSanitizingConverter();
       this.innerHTML = converter.makeHtml(content);
 
-      const walker = document.createTreeWalker(
-        this, 1 /* SHOW_ELEMENT */, null, false)
+      const walker = document.createTreeWalker(this, 1 /* SHOW_ELEMENT */, null, false);
 
       while (walker.nextNode()) {
         const node = walker.currentNode;
@@ -44,7 +43,6 @@ class HaMarkdown extends window.hassMixins.EventsMixin(Polymer.Element) {
 
         // Fire a resize event when images loaded to notify content resized
         } else if (node.tagName === 'IMG') {
-          console.log('attaching', node, this.resize)
           node.addEventListener('load', this.resize);
         }
       }

--- a/src/more-infos/more-info-configurator.html
+++ b/src/more-infos/more-info-configurator.html
@@ -5,12 +5,18 @@
 <link rel='import' href='../../bower_components/paper-button/paper-button.html'>
 <link rel='import' href='../../bower_components/paper-input/paper-input.html'>
 
+<link rel='import' href='../components/ha-markdown.html'>
+
 <dom-module id='more-info-configurator'>
   <template>
     <style is="custom-style" include="iron-flex"></style>
     <style>
       p {
         margin: 8px 0;
+      }
+
+      a {
+        color: var(--primary-color);
       }
 
       p > img {
@@ -43,25 +49,10 @@
 
     <div class='layout vertical'>
       <template is='dom-if' if='[[isConfigurable]]'>
-
-        <p hidden$='[[!stateObj.attributes.description]]'>
-          [[stateObj.attributes.description]]
-          <p hidden$='[[!stateObj.attributes.link_url]]'>
-            <a
-              href='[[stateObj.attributes.link_url]]'
-              target='_blank'
-            >
-              [[stateObj.attributes.link_name]]
-            </a>
-          </p>
-        </p>
+        <ha-markdown content='[[stateObj.attributes.description]]'></ha-markdown>
 
         <p class='error' hidden$='[[!stateObj.attributes.errors]]'>
           [[stateObj.attributes.errors]]
-        </p>
-
-        <p class='center' hidden$='[[!stateObj.attributes.description_image]]'>
-          <img src='[[stateObj.attributes.description_image]]' />
         </p>
 
         <template is='dom-repeat' items='[[stateObj.attributes.fields]]'>

--- a/src/util/ha-url-sync.html
+++ b/src/util/ha-url-sync.html
@@ -30,11 +30,11 @@
 
       if (newHass.moreInfoEntityId) {
         if (DEBUG) console.log('pushing state');
-        history.pushState(null, null, window.location.pathname);
         // We keep track of where we opened moreInfo from so that we don't
         // pop the state when we close the modal if the modal has navigated
         // us away.
         this.moreInfoOpenedFromPath = window.location.pathname;
+        history.pushState(null, null, window.location.pathname);
       } else if (window.location.pathname === this.moreInfoOpenedFromPath) {
         if (DEBUG) console.log('history back');
         this.ignoreNextPopstate = true;

--- a/src/util/ha-url-sync.html
+++ b/src/util/ha-url-sync.html
@@ -31,7 +31,11 @@
       if (newHass.moreInfoEntityId) {
         if (DEBUG) console.log('pushing state');
         history.pushState(null, null, window.location.pathname);
-      } else {
+        // We keep track of where we opened moreInfo from so that we don't
+        // pop the state when we close the modal if the modal has navigated
+        // us away.
+        this.moreInfoOpenedFromPath = window.location.pathname;
+      } else if (window.location.pathname === this.moreInfoOpenedFromPath) {
         if (DEBUG) console.log('history back');
         this.ignoreNextPopstate = true;
         history.back();


### PR DESCRIPTION
- Convert the configurator to use markdown.
- Markdown element will now trigger links to external resources to open in a new window
- Markdown element will now fire `iron-resize` when images in it are done loading
- I got to use `TreeWalker` 😎 
- Somehow when clicking a link to an internal resource (ie. `/config`), instead of navigating the whole page, it uses pushState to navigate. This caused some issues with the url sync hack that we have that pops the state when we close a more info dialog. I fixed this by only popping state if the url is still the same as the url from which we pushed an extra state to the stack.

Backend PR: https://github.com/home-assistant/home-assistant/pull/10668