### PR TITLE
Keep language/resources on login

### DIFF
--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -131,8 +131,11 @@ class HomeAssistant extends Polymer.Element {
       states: null,
       config: null,
       themes: null,
-      language: null,
-      resources: null,
+
+      // If language and resources are already loaded, don't discard them
+      language: (this.hass && this.hass.language) || null,
+      resources: (this.hass && this.hass.resources) || null,
+
       translationMetadata: window.translationMetadata,
       dockedSidebar: false,
       moreInfoEntityId: null,


### PR DESCRIPTION
## Description
Don't delete language/resources when opening a new hass connection. Currently, if the hass frontend is loaded, the user clicks "Log out", and logs back in, the connection wipes out the translation resources, and it isn't triggered to get reloaded. These don't need to be wiped when a new connection is opened.

Fixes #645