### PR TITLE
Climate: hide "Currently: °C" in case the thermostat doesn't report the current temperature

### DIFF
--- a/src/state-summary/state-card-climate.html
+++ b/src/state-summary/state-card-climate.html
@@ -34,7 +34,7 @@
 
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
-      <div class='state'>
+      <div class='state vertical layout center-justified'>
         <div class='target'>
           <span class="operation-mode">
             [[stateObj.attributes.operation_mode]]
@@ -43,8 +43,7 @@
             [[computeTargetTemperature(stateObj)]]
           </span>
         </div>
-
-        <div class='current'>
+        <div class='current' hidden$='[[!hasCurrentTemperature(stateObj)]]'>
           <span>Currently: </span>
           <span>[[stateObj.attributes.current_temperature]]</span>
           <span> </span>
@@ -67,6 +66,10 @@ class StateCardClimate extends Polymer.Element {
         value: false,
       },
     };
+  }
+
+  hasCurrentTemperature(stateObj) {
+    return (!isNaN(parseFloat(stateObj.attributes.current_temperature)));
   }
 
   computeTargetTemperature(stateObj) {


### PR DESCRIPTION
This code checks if the thermostat reports the current room temperature.
If so, it is printed next to the target temperature (this is the current behavior).
If no valid number is returned, only the target temperature is shown, and the (unavailable) room temperature is hidden.

Fixes: https://github.com/home-assistant/home-assistant-polymer/issues/654
Fixes: https://github.com/home-assistant/home-assistant/issues/3947