### PR TITLE
Add New Status To More Info Panel for Alarms

### DIFF
--- a/src/more-infos/more-info-alarm_control_panel.html
+++ b/src/more-infos/more-info-alarm_control_panel.html
@@ -103,12 +103,14 @@ class MoreInfoAlarmControlPanel extends window.hassMixins.EventsMixin(Polymer.El
       this.codeInputEnabled = (
         newVal.state === 'armed_home' ||
         newVal.state === 'armed_away' ||
+        newVal.state === 'armed_custom_bypass' ||
         newVal.state === 'disarmed' ||
         newVal.state === 'pending' ||
         newVal.state === 'triggered');
       this.disarmButtonVisible = (
         newVal.state === 'armed_home' ||
         newVal.state === 'armed_away' ||
+        newVal.state === 'armed_custom_bypass' ||
         newVal.state === 'pending' ||
         newVal.state === 'triggered');
       this.armHomeButtonVisible = newVal.state === 'disarmed';


### PR DESCRIPTION
Related to https://github.com/home-assistant/home-assistant/pull/10697.

Currently, when the alarm status is ```armed_custom_bypass```, the front end doesn't allow you to Disarm the alarm or enter a code.  This PR adds ```armed_custom_bypass``` to the logic for ```codeInputEnabled``` and ```disarmButtonVisible```.  

Screenshots:

* [Armed Custom Bypass Icon](https://i.imgur.com/WjNu6xe.png)
* [Armed Night Icon](https://i.imgur.com/QLdBo62.png)
* [Disarm button and Code Input visible on More Info panel when status is Arm Custom Bypass](https://i.imgur.com/avAFY6m.png)
* [Disarm button and Code Input visible on More Info panel when status is Arm Night](https://i.imgur.com/wKNTqdD.png)

Todo (according to Discord chats):  

- [X] Update description
- [X] Add screenshots of implementation
- [X] Add icons for both ```armed_custom_bypass``` and ```armed_night```
- [X] Update translations