### PR TITLE
Don't use custom element constructor

### DIFF
--- a/panels/config/automation/ha-automation-editor.html
+++ b/panels/config/automation/ha-automation-editor.html
@@ -165,8 +165,8 @@ class HaAutomationEditor extends window.hassMixins.EventsMixin(Polymer.Element) 
     };
   }
 
-  constructor() {
-    super();
+  ready() {
+    super.ready();
     this.configChanged = this.configChanged.bind(this);
     this._rendered = null;
   }

--- a/panels/config/script/ha-script-editor.html
+++ b/panels/config/script/ha-script-editor.html
@@ -164,8 +164,8 @@ class HaScriptEditor extends window.hassMixins.EventsMixin(Polymer.Element) {
     };
   }
 
-  constructor() {
-    super();
+  ready() {
+    super.ready();
     this.configChanged = this.configChanged.bind(this);
     this._rendered = null;
   }


### PR DESCRIPTION
We should not use the `constructor` but instead use the `ready()` callback on custom elements.
Fixes #635