### PR TITLE
Make displayed attributes configurable

### DIFF
--- a/src/components/ha-attributes.html
+++ b/src/components/ha-attributes.html
@@ -18,7 +18,7 @@
     </style>
 
     <div class='layout vertical'>
-      <template is='dom-repeat' items="[[computeDisplayAttributes(stateObj, filtersArray)]]" as="attribute">
+      <template is='dom-repeat' items="[[computeDisplayAttributes(stateObj, filtersArray, whitelistArray, whitelist)]]" as="attribute">
         <div class='data-entry layout justified horizontal'>
           <div class='key'>[[formatAttribute(attribute)]]</div>
           <div class='value'>[[formatAttributeValue(stateObj, attribute)]]</div>
@@ -46,17 +46,40 @@ class HaAttributes extends Polymer.Element {
         type: Array,
         computed: 'computeFiltersArray(extraFilters)',
       },
+      whitelistArray: {
+        type: Array,
+        computed: 'computeWhitelistArray(stateObj)',
+      },
+      whitelist: {
+        type: Boolean,
+        value: false
+      },
     };
+  }
+
+  computeWhitelistArray(stateObj) {
+    if ((!stateObj) || (!stateObj.attributes.display_attributes)) {
+      return [];
+    }
+
+    return stateObj.attributes.display_attributes.split(',');
   }
 
   computeFiltersArray(extraFilters) {
     return Object.keys(window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES).concat(extraFilters ? extraFilters.split(',') : []);
   }
 
-  computeDisplayAttributes(stateObj, filtersArray) {
+  computeDisplayAttributes(stateObj, filtersArray, whitelistArray, whitelist) {
     if (!stateObj) {
       return [];
     }
+
+    if (whitelist) {
+      return Object.keys(stateObj.attributes).filter(function (key) {
+        return whitelistArray.indexOf(key) !== -1;
+      });
+    }
+
     return Object.keys(stateObj.attributes).filter(function (key) {
       return filtersArray.indexOf(key) === -1;
     });

--- a/src/more-infos/more-info-alarm_control_panel.html
+++ b/src/more-infos/more-info-alarm_control_panel.html
@@ -36,6 +36,8 @@
         hidden$='[[!armAwayButtonVisible]]'
         disabled='[[!codeValid]]'>Arm Away</paper-button>
     </div>
+
+    <ha-attributes state-obj="[[stateObj]]" whitelist></ha-attributes>
   </template>
 </dom-module>
 

--- a/src/more-infos/more-info-camera.html
+++ b/src/more-infos/more-info-camera.html
@@ -16,6 +16,8 @@
 
     <img class='camera-image' src="[[computeCameraImageUrl(hass, stateObj, isVisible)]]"
          on-load='imageLoaded' alt='[[computeStateName(stateObj)]]' />
+    
+    <ha-attributes state-obj="[[stateObj]]" whitelist></ha-attributes>
   </template>
 </dom-module>
 

--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -177,6 +177,8 @@
         </div>
       </div>
     </div>
+
+    <ha-attributes state-obj="[[stateObj]]" whitelist></ha-attributes>
   </template>
 </dom-module>
 

--- a/src/more-infos/more-info-cover.html
+++ b/src/more-infos/more-info-cover.html
@@ -52,6 +52,8 @@
       </div>
 
     </div>
+
+    <ha-attributes state-obj="[[stateObj]]" whitelist></ha-attributes>
   </template>
 </dom-module>
 

--- a/src/more-infos/more-info-media_player.html
+++ b/src/more-infos/more-info-media_player.html
@@ -118,6 +118,8 @@
         <paper-icon-button icon='mdi:send' on-tap='sendTTS'></paper-icon-button>
       </div>
     </div>
+
+    <ha-attributes state-obj="[[stateObj]]" whitelist></ha-attributes>
   </template>
 </dom-module>
 

--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -51,6 +51,10 @@ window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES =
       description: 'Device class',
       domains: ['binary_sensor', 'cover']
     },
+    display_attributes: {
+      type: 'string',
+      description: 'Additional attributes to display'
+    },
     hidden: { type: 'boolean', description: 'Hide from UI' },
     assumed_state: {
       type: 'boolean',


### PR DESCRIPTION
This allows (almost) all device types to display a list of attributes at the bottom of the "more info" card, just as e.g. the `sensor` and `fan` components already do. Obviously it's not useful to display *all* attributes. The list of attributes displayed is configured via the `displayed_attributes` attribute (attributeception!).

For example, if I want to see the battery level of my Xiaomi Aquara window contact sensor in its "more info" panel, I would add to my configuration:

```
homeassistant:
  customize:
    binary_sensor.door_window_sensor_XXXXXXXX:
      displayed_attributes: battery_level
```
(The XXXXXXX are what I assume to be a MAC address. Aquara has weird entity names.)

Multiple attributes can be comma separated.

I did for now not touch any "more info" panels which already had a `<ha-attributes>` element. These continue working as before, using their "blacklist"-based approach (i.e., display everything but a few filtered-out attributes). I did not want to change too much for this first PR. However, I think we could even make the new "whitelist" approach the default. Then, components which already have that list at the bottom of their card would just by default set the attribute `displayed_attributes` to whatever the current default is. This way, people could customize even these.

Going one step further I could imagine that certain platforms would like to add things to the `displayed_attributes` list, making certain attributes of certain devices visible by default.

What do you think? 