### PR TITLE
Set 'heating' graph series format only for climate graphs

### DIFF
--- a/src/components/state-history-chart-line.html
+++ b/src/components/state-history-chart-line.html
@@ -106,11 +106,6 @@
           maxZoomIn: 0.1,
         },
         seriesType: 'line',
-        // The "heating" series uses steppedArea to shade the area below the current
-        // temperature when the thermostat is calling for heat. It would be nice to
-        // apply this config in a more direct way than by column index, but it
-        // doesn't seem to be possible.
-        series: { 1: { type: 'steppedArea' } }
       };
 
       if (this.isSingleDevice) {
@@ -183,6 +178,15 @@
 
           dataTable.addColumn('number', name + ' current temperature');
           dataTable.addColumn('number', name + ' heating');
+          // The "heating" series uses steppedArea to shade the area below the current
+          // temperature when the thermostat is calling for heat.
+          // Its series index is 2 less than its column number--1 because
+          // zero-based and 1 because the first becomes the horizontal axis.
+          var seriesIndex = dataTable.getNumberOfColumns() - 2;
+          // Get existing series config, if there is any, rather than clobbering
+          options.series = Object.assign({}, options.series);
+          options.series[seriesIndex] = { type: 'steppedArea' };
+
           if (hasTargetRange) {
             dataTable.addColumn('number', name + ' target temperature high');
             dataTable.addColumn('number', name + ' target temperature low');


### PR DESCRIPTION
PR #617 added a `steppedArea` series to climate graphs to show when the thermostat is calling for heat. It also accidentally converted the second series in every graph to `steppedArea`. This moves the option specification into the `if (domain === 'thermostat' || domain === 'climate')` block so it will only be applied when it's relevant (and gets it closer to the series it's configuring).

Now the heating series will be steppedArea but the second series on other graphs remains a line (see "Precip probability", which is unfortunately zero throughout, but you can see from the legend above the graph that it's a line).
![image](https://user-images.githubusercontent.com/6598836/33109794-9e54ff02-cf11-11e7-92a7-468e05e0128b.png)

It also calculates the series index by counting the number of columns immediately after the target one is added. Which still isn't elegant, but seems solidly better than hard-coding the index as `1`.

Resolves https://github.com/home-assistant/home-assistant/issues/10722