### PR TITLE
Add an entity picker

### DIFF
--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -10,6 +10,7 @@
 <link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
 
 <link rel="import" href="../../src/components/ha-menu-button.html">
+<link rel="import" href="../../src/components/entity/ha-entity-dropdown.html">
 <link rel="import" href="../../src/resources/ha-style.html">
 
 <dom-module id="ha-panel-dev-state">
@@ -23,6 +24,11 @@
 
       .content {
         padding: 16px;
+      }
+
+      ha-entity-dropdown {
+        display: block;
+        max-width: 300px;
       }
 
       .entities th {
@@ -66,7 +72,11 @@
             This will not communicate with the actual device.
           </p>
 
-          <paper-input label="Entity ID" autofocus required value='{{_entityId}}'></paper-input>
+          <ha-entity-dropdown
+            autofocus
+            hass="[[hass]]"
+            value="{{_entityId}}"
+          ></ha-entity-dropdown>
           <paper-input label="State" required value='{{_state}}'></paper-input>
           <paper-textarea label="State attributes (JSON, optional)" value='{{_stateAttributes}}'></paper-textarea>
           <paper-button on-tap='handleSetState' raised>Set State</paper-button>

--- a/src/components/entity/ha-entity-dropdown.html
+++ b/src/components/entity/ha-entity-dropdown.html
@@ -55,7 +55,7 @@ class HaEntityDropdown extends Polymer.Element {
   }
 
   computeStates(hass) {
-    return Object.keys(hass.states).sort().map(key => hass.states[key])
+    return Object.keys(hass.states).sort().map(key => hass.states[key]);
   }
 
   computeStateName(state) {

--- a/src/components/entity/ha-entity-dropdown.html
+++ b/src/components/entity/ha-entity-dropdown.html
@@ -1,0 +1,67 @@
+<link rel="import" href="../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../bower_components/vaadin-combo-box/vaadin-combo-box.html">
+<link rel="import" href="../../../bower_components/paper-listbox/paper-listbox.html">
+<link rel="import" href="../../../bower_components/paper-item/paper-icon-item.html">
+<link rel="import" href="../../../bower_components/paper-item/paper-item-body.html">
+
+<link rel="import" href="./state-badge.html">
+
+<dom-module id="ha-entity-dropdown">
+  <template>
+    <vaadin-combo-box
+      autofocus="[[autofocus]]"
+      label="[[label]]"
+      items='[[computeStates(hass)]]'
+      item-value-path='entity_id'
+      item-label-path='entity_id'
+      value='{{value}}'
+    >
+      <template>
+        <style>
+          paper-icon-item {
+            margin: -13px -16px;
+          }
+        </style>
+        <paper-icon-item>
+          <state-badge state-obj="[[item]]" slot='item-icon'></state-badge>
+          <paper-item-body two-line>
+            <div>[[computeStateName(item)]]</div>
+            <div secondary>[[item.entity_id]]</div>
+          </paper-item-body>
+        </paper-icon-item>
+      </template>
+    </vaadin-combo-box>
+
+  </template>
+</dom-module>
+
+<script>
+class HaEntityDropdown extends Polymer.Element {
+  static get is() { return 'ha-entity-dropdown'; }
+
+  static get properties() {
+    return {
+      hass: Object,
+      autofocus: Boolean,
+      label: {
+        type: String,
+        value: 'Entity',
+      },
+      value: {
+        type: String,
+        notify: true,
+      }
+    };
+  }
+
+  computeStates(hass) {
+    return Object.keys(hass.states).sort().map(key => hass.states[key])
+  }
+
+  computeStateName(state) {
+    return window.hassUtil.computeStateName(state);
+  }
+}
+
+customElements.define(HaEntityDropdown.is, HaEntityDropdown);
+</script>


### PR DESCRIPTION
Who doesn't like a good entity picker?

![image](https://user-images.githubusercontent.com/1444314/33115978-d5b4d3ea-cf17-11e7-8548-f511108ce456.png)

Based on the `<vaadin-combo-box>`, the same as we use for service auto-completion. This component allows users to type a value and the dropdown will render the current state of the entity.

This is MVP. It works ok for the dev state tool. Dropdown is sorted by entity ID. 

For automation editor we might want to consider not showing hidden entities / add other filter options to the component. (in another PR)
