### PR TITLE
More entity improvement

### DIFF
--- a/.eslintrc-hound.json
+++ b/.eslintrc-hound.json
@@ -45,6 +45,7 @@
     "no-restricted-globals": 0,
     "prefer-promise-reject-errors": 0,
     "import/prefer-default-export": 0,
+    "object-curly-newline": 0,
     "react/jsx-no-bind": [2, { "ignoreRefs": true }],
     "react/jsx-no-duplicate-props": 2,
     "react/self-closing-comp": 2,

--- a/js/automation-editor/automation.js
+++ b/js/automation-editor/automation.js
@@ -42,7 +42,7 @@ export default class Automation extends Component {
     });
   }
 
-  render({ automation, isWide }) {
+  render({ automation, isWide, hass }) {
     const {
       alias, trigger, condition, action
     } = automation;
@@ -77,7 +77,11 @@ export default class Automation extends Component {
               Learn more about triggers.
             </a></p>
           </span>
-          <Trigger trigger={trigger} onChange={this.triggerChanged} />
+          <Trigger
+            trigger={trigger}
+            onChange={this.triggerChanged}
+            hass={hass}
+          />
         </ha-config-section>
 
         <ha-config-section is-wide={isWide}>
@@ -93,7 +97,11 @@ export default class Automation extends Component {
               Learn more about conditions.
             </a></p>
           </span>
-          <Condition condition={condition || []} onChange={this.conditionChanged} />
+          <Condition
+            condition={condition || []}
+            onChange={this.conditionChanged}
+            hass={hass}
+          />
         </ha-config-section>
 
         <ha-config-section is-wide={isWide}>
@@ -104,7 +112,11 @@ export default class Automation extends Component {
               Learn more about actions.
             </a></p>
           </span>
-          <Script script={action} onChange={this.actionChanged} />
+          <Script
+            script={action}
+            onChange={this.actionChanged}
+            hass={hass}
+          />
         </ha-config-section>
       </div>
     );

--- a/js/automation-editor/trigger/index.js
+++ b/js/automation-editor/trigger/index.js
@@ -32,7 +32,7 @@ export default class Trigger extends Component {
     this.props.onChange(trigger);
   }
 
-  render({ trigger }) {
+  render({ trigger, hass }) {
     return (
       <div class="triggers">
         {trigger.map((trg, idx) => (
@@ -40,6 +40,7 @@ export default class Trigger extends Component {
             index={idx}
             trigger={trg}
             onChange={this.triggerChanged}
+            hass={hass}
           />))}
         <paper-card>
           <div class='card-actions add-card'>

--- a/js/automation-editor/trigger/numeric_state.js
+++ b/js/automation-editor/trigger/numeric_state.js
@@ -7,20 +7,29 @@ export default class NumericStateTrigger extends Component {
     super();
 
     this.onChange = onChangeEvent.bind(this, 'trigger');
+    this.entityPicked = this.entityPicked.bind(this);
+  }
+
+  entityPicked(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.trigger,
+      entity_id: ev.target.value,
+    });
   }
 
   /* eslint-disable camelcase */
-  render({ trigger }) {
+  render({ trigger, hass }) {
     const {
       value_template, entity_id, below, above
     } = trigger;
+
     return (
       <div>
-        <paper-input
-          label="Entity Id"
-          name="entity_id"
+        <ha-entity-picker
           value={entity_id}
-          onChange={this.onChange}
+          onChange={this.entityPicked}
+          hass={hass}
+          allowCustomEntity
         />
         <paper-input
           label="Above"

--- a/js/automation-editor/trigger/state.js
+++ b/js/automation-editor/trigger/state.js
@@ -7,20 +7,28 @@ export default class StateTrigger extends Component {
     super();
 
     this.onChange = onChangeEvent.bind(this, 'trigger');
+    this.entityPicked = this.entityPicked.bind(this);
+  }
+
+  entityPicked(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.trigger,
+      entity_id: ev.target.value,
+    });
   }
 
   /* eslint-disable camelcase */
-  render({ trigger }) {
+  render({ trigger, hass }) {
     const { entity_id, to } = trigger;
     const trgFrom = trigger.from;
     const trgFor = trigger.for;
     return (
       <div>
-        <paper-input
-          label="Entity Id"
-          name="entity_id"
+        <ha-entity-picker
           value={entity_id}
-          onChange={this.onChange}
+          onChange={this.entityPicked}
+          hass={hass}
+          allowCustomEntity
         />
         <paper-input
           label="From"

--- a/js/automation-editor/trigger/trigger_edit.js
+++ b/js/automation-editor/trigger/trigger_edit.js
@@ -42,7 +42,7 @@ export default class TriggerEdit extends Component {
     }
   }
 
-  render({ index, trigger, onChange }) {
+  render({ index, trigger, onChange, hass }) {
     const Comp = TYPES[trigger.platform];
     const selected = OPTIONS.indexOf(trigger.platform);
 
@@ -69,6 +69,7 @@ export default class TriggerEdit extends Component {
           index={index}
           trigger={trigger}
           onChange={onChange}
+          hass={hass}
         />
       </div>
     );

--- a/js/automation-editor/trigger/zone.js
+++ b/js/automation-editor/trigger/zone.js
@@ -1,6 +1,12 @@
 import { h, Component } from 'preact';
 
 import { onChangeEvent } from '../../common/util/event';
+import { hasLocation } from '../../common/util/location';
+import computeDomain from '../../common/util/compute_domain';
+
+function zoneAndLocationFilter(stateObj) {
+  return hasLocation(stateObj) && computeDomain(stateObj) !== 'zone';
+}
 
 export default class ZoneTrigger extends Component {
   constructor() {
@@ -8,6 +14,22 @@ export default class ZoneTrigger extends Component {
 
     this.onChange = onChangeEvent.bind(this, 'trigger');
     this.radioGroupPicked = this.radioGroupPicked.bind(this);
+    this.entityPicked = this.entityPicked.bind(this);
+    this.zonePicked = this.zonePicked.bind(this);
+  }
+
+  entityPicked(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.trigger,
+      entity_id: ev.target.value,
+    });
+  }
+
+  zonePicked(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.trigger,
+      zone: ev.target.value,
+    });
   }
 
   radioGroupPicked(ev) {
@@ -18,21 +40,25 @@ export default class ZoneTrigger extends Component {
   }
 
   /* eslint-disable camelcase */
-  render({ trigger }) {
+  render({ trigger, hass }) {
     const { entity_id, zone, event } = trigger;
     return (
       <div>
-        <paper-input
-          label="Entity Id"
-          name="entity_id"
+        <ha-entity-picker
+          label='Entity with location'
           value={entity_id}
-          onChange={this.onChange}
+          onChange={this.entityPicked}
+          hass={hass}
+          allowCustomEntity
+          entityFilter={zoneAndLocationFilter}
         />
-        <paper-input
-          label="Zone"
-          name="zone"
+        <ha-entity-picker
+          label='Zone'
           value={zone}
-          onChange={this.onChange}
+          onChange={this.zonePicked}
+          hass={hass}
+          allowCustomEntity
+          domainFilter='zone'
         />
         <label id="eventlabel">Event:</label>
         <paper-radio-group

--- a/js/common/component/condition/condition_edit.js
+++ b/js/common/component/condition/condition_edit.js
@@ -36,7 +36,7 @@ export default class ConditionRow extends Component {
     }
   }
 
-  render({ index, condition, onChange }) {
+  render({ index, condition, onChange, hass }) {
     const Comp = TYPES[condition.condition];
     const selected = OPTIONS.indexOf(condition.condition);
 
@@ -64,6 +64,7 @@ export default class ConditionRow extends Component {
           index={index}
           condition={condition}
           onChange={onChange}
+          hass={hass}
         />
       </div>
     );

--- a/js/common/component/condition/index.js
+++ b/js/common/component/condition/index.js
@@ -30,7 +30,7 @@ export default class Condition extends Component {
     this.props.onChange(condition);
   }
 
-  render({ condition }) {
+  render({ condition, hass }) {
     return (
       <div class="triggers">
         {condition.map((cnd, idx) => (
@@ -38,6 +38,7 @@ export default class Condition extends Component {
             index={idx}
             condition={cnd}
             onChange={this.conditionChanged}
+            hass={hass}
           />))}
         <paper-card>
           <div class='card-actions add-card'>

--- a/js/common/component/condition/numeric_state.js
+++ b/js/common/component/condition/numeric_state.js
@@ -7,20 +7,28 @@ export default class NumericStateCondition extends Component {
     super();
 
     this.onChange = onChangeEvent.bind(this, 'condition');
+    this.entityPicked = this.entityPicked.bind(this);
+  }
+
+  entityPicked(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.condition,
+      entity_id: ev.target.value,
+    });
   }
 
   /* eslint-disable camelcase */
-  render({ condition }) {
+  render({ condition, hass }) {
     const {
       value_template, entity_id, below, above
     } = condition;
     return (
       <div>
-        <paper-input
-          label="Entity Id"
-          name="entity_id"
+        <ha-entity-picker
           value={entity_id}
-          onChange={this.onChange}
+          onChange={this.entityPicked}
+          hass={hass}
+          allowCustomEntity
         />
         <paper-input
           label="Above"

--- a/js/common/component/condition/state.js
+++ b/js/common/component/condition/state.js
@@ -7,19 +7,27 @@ export default class StateCondition extends Component {
     super();
 
     this.onChange = onChangeEvent.bind(this, 'condition');
+    this.entityPicked = this.entityPicked.bind(this);
+  }
+
+  entityPicked(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.condition,
+      entity_id: ev.target.value,
+    });
   }
 
   /* eslint-disable camelcase */
-  render({ condition }) {
+  render({ condition, hass }) {
     const { entity_id, state } = condition;
     const cndFor = condition.for;
     return (
       <div>
-        <paper-input
-          label="Entity Id"
-          name="entity_id"
+        <ha-entity-picker
           value={entity_id}
-          onChange={this.onChange}
+          onChange={this.entityPicked}
+          hass={hass}
+          allowCustomEntity
         />
         <paper-input
           label="State"

--- a/js/common/component/condition/zone.js
+++ b/js/common/component/condition/zone.js
@@ -1,30 +1,56 @@
 import { h, Component } from 'preact';
 
 import { onChangeEvent } from '../../util/event';
+import { hasLocation } from '../../util/location';
+import computeDomain from '../../util/compute_domain';
+
+function zoneAndLocationFilter(stateObj) {
+  return hasLocation(stateObj) && computeDomain(stateObj) !== 'zone';
+}
 
 export default class ZoneCondition extends Component {
   constructor() {
     super();
 
     this.onChange = onChangeEvent.bind(this, 'condition');
+    this.entityPicked = this.entityPicked.bind(this);
+    this.zonePicked = this.zonePicked.bind(this);
+  }
+
+  entityPicked(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.condition,
+      entity_id: ev.target.value,
+    });
+  }
+
+  zonePicked(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.condition,
+      zone: ev.target.value,
+    });
   }
 
   /* eslint-disable camelcase */
-  render({ condition }) {
+  render({ condition, hass }) {
     const { entity_id, zone } = condition;
     return (
       <div>
-        <paper-input
-          label="Entity Id"
-          name="entity_id"
+        <ha-entity-picker
+          label='Entity with location'
           value={entity_id}
-          onChange={this.onChange}
+          onChange={this.entityPicked}
+          hass={hass}
+          allowCustomEntity
+          entityFilter={zoneAndLocationFilter}
         />
-        <paper-input
-          label="Zone entity id"
-          name="zone"
+        <ha-entity-picker
+          label='Zone'
           value={zone}
-          onChange={this.onChange}
+          onChange={this.zonePicked}
+          hass={hass}
+          allowCustomEntity
+          domainFilter='zone'
         />
       </div>
     );

--- a/js/common/component/script/action_edit.js
+++ b/js/common/component/script/action_edit.js
@@ -42,7 +42,7 @@ export default class Action extends Component {
     }
   }
 
-  render({ index, action, onChange }) {
+  render({ index, action, onChange, hass }) {
     const type = getType(action);
     const Comp = type && TYPES[type];
     const selected = OPTIONS.indexOf(type);
@@ -70,6 +70,7 @@ export default class Action extends Component {
           index={index}
           action={action}
           onChange={onChange}
+          hass={hass}
         />
       </div>
     );

--- a/js/common/component/script/call_service.js
+++ b/js/common/component/script/call_service.js
@@ -1,14 +1,20 @@
 import { h, Component } from 'preact';
 
 import JSONTextArea from '../json_textarea';
-import { onChangeEvent } from '../../util/event';
 
 export default class CallServiceAction extends Component {
   constructor() {
     super();
 
-    this.onChange = onChangeEvent.bind(this, 'action');
+    this.serviceChanged = this.serviceChanged.bind(this);
     this.serviceDataChanged = this.serviceDataChanged.bind(this);
+  }
+
+  serviceChanged(ev) {
+    this.props.onChange(this.props.index, {
+      ...this.props.action,
+      service: ev.target.value,
+    });
   }
 
   serviceDataChanged(data) {
@@ -18,21 +24,15 @@ export default class CallServiceAction extends Component {
     });
   }
 
-  render({ action }) {
-    const { alias, service, data } = action;
+  render({ action, hass }) {
+    const { service, data } = action;
+
     return (
       <div>
-        <paper-input
-          label="Alias"
-          name="alias"
-          value={alias}
-          onChange={this.onChange}
-        />
-        <paper-input
-          label="Service"
-          name="service"
+        <ha-service-picker
+          hass={hass}
           value={service}
-          onChange={this.onChange}
+          onChange={this.serviceChanged}
         />
         <JSONTextArea
           label="Service Data"

--- a/js/common/component/script/condition.js
+++ b/js/common/component/script/condition.js
@@ -5,12 +5,13 @@ import ConditionEdit from '../condition/condition_edit';
 
 export default class ConditionAction extends Component {
   // eslint-disable-next-line
-  render({ action, index, onChange }) {
+  render({ action, index, onChange, hass }) {
     return (
       <ConditionEdit
         condition={action}
         onChange={onChange}
         index={index}
+        hass={hass}
       />
     );
   }

--- a/js/common/component/script/index.js
+++ b/js/common/component/script/index.js
@@ -30,7 +30,7 @@ export default class Script extends Component {
     this.props.onChange(script);
   }
 
-  render({ script }) {
+  render({ script, hass }) {
     return (
       <div class="script">
         {script.map((act, idx) => (
@@ -38,6 +38,7 @@ export default class Script extends Component {
             index={idx}
             action={act}
             onChange={this.actionChanged}
+            hass={hass}
           />))}
         <paper-card>
           <div class='card-actions add-card'>

--- a/js/common/util/location.js
+++ b/js/common/util/location.js
@@ -1,0 +1,4 @@
+export function hasLocation(stateObj) {
+  return ('latitude' in stateObj.attributes &&
+          'longitude' in stateObj.attributes);
+}

--- a/panels/config/automation/ha-automation-editor.html
+++ b/panels/config/automation/ha-automation-editor.html
@@ -16,6 +16,9 @@
 <link rel="import" href="../../../bower_components/paper-fab/paper-fab.html">
 <link rel="import" href="../../../bower_components/iron-autogrow-textarea/iron-autogrow-textarea.html">
 
+<link rel='import' href='../../../src/components/entity/ha-entity-picker.html'>
+<link rel='import' href='../../../src/components/ha-combo-box.html'>
+<link rel='import' href='../../../src/components/ha-service-picker.html'>
 <link rel='import' href='../../../src/util/hass-mixins.html'>
 
 <link rel="import" href="../ha-config-section.html">
@@ -117,6 +120,7 @@ class HaAutomationEditor extends window.hassMixins.EventsMixin(Polymer.Element) 
     return {
       hass: {
         type: Object,
+        observer: '_updateComponent',
       },
 
       narrow: {
@@ -160,7 +164,7 @@ class HaAutomationEditor extends window.hassMixins.EventsMixin(Polymer.Element) 
 
       isWide: {
         type: Boolean,
-        observer: 'isWideChanged',
+        observer: '_updateComponent',
       },
     };
   }
@@ -169,6 +173,7 @@ class HaAutomationEditor extends window.hassMixins.EventsMixin(Polymer.Element) 
     super.ready();
     this.configChanged = this.configChanged.bind(this);
     this._rendered = null;
+    this._renderScheduled = false;
   }
 
   disconnectedCallback() {
@@ -182,15 +187,16 @@ class HaAutomationEditor extends window.hassMixins.EventsMixin(Polymer.Element) 
     // onChange gets called a lot during initial rendering causing recursing calls.
     if (this._rendered === null) return;
     this.config = config;
+    console.log("NEW CONFIG", config)
     this.errors = null;
     this.dirty = true;
-    this._updateComponent(config);
+    this._updateComponent();
   }
 
   automationChanged(newVal, oldVal) {
     if (!newVal) return;
     if (!this.hass) {
-      setTimeout(this.automationChanged.bind(this, newVal, oldVal), 0);
+      setTimeout(() => this.automationChanged(newVal, oldVal), 0);
       return;
     }
     if (oldVal && oldVal.attributes.id === newVal.attributes.id) {
@@ -230,11 +236,6 @@ class HaAutomationEditor extends window.hassMixins.EventsMixin(Polymer.Element) 
     this._updateComponent();
   }
 
-  isWideChanged() {
-    if (this.config === null) return;
-    this._updateComponent();
-  }
-
   backTapped() {
     if (this.dirty &&
         // eslint-disable-next-line
@@ -245,11 +246,17 @@ class HaAutomationEditor extends window.hassMixins.EventsMixin(Polymer.Element) 
   }
 
   _updateComponent() {
-    this._rendered = window.AutomationEditor(this.$.root, {
-      automation: this.config,
-      onChange: this.configChanged,
-      isWide: this.isWide,
-    }, this._rendered);
+    if (this._renderScheduled || !this.hass || !this.config) return;
+    this._renderScheduled = true;
+    Promise.resolve().then(() => {
+      this._rendered = window.AutomationEditor(this.$.root, {
+        automation: this.config,
+        onChange: this.configChanged,
+        isWide: this.isWide,
+        hass: this.hass,
+      }, this._rendered);
+      this._renderScheduled = false;
+    });
   }
 
   saveAutomation() {

--- a/panels/config/automation/ha-automation-editor.html
+++ b/panels/config/automation/ha-automation-editor.html
@@ -187,7 +187,6 @@ class HaAutomationEditor extends window.hassMixins.EventsMixin(Polymer.Element) 
     // onChange gets called a lot during initial rendering causing recursing calls.
     if (this._rendered === null) return;
     this.config = config;
-    console.log("NEW CONFIG", config)
     this.errors = null;
     this.dirty = true;
     this._updateComponent();

--- a/panels/dev-service/ha-panel-dev-service.html
+++ b/panels/dev-service/ha-panel-dev-service.html
@@ -9,7 +9,8 @@
 <link rel="import" href="../../bower_components/app-storage/app-localstorage/app-localstorage-document.html">
 
 <link rel='import' href='../../src/components/ha-menu-button.html'>
-<link rel='import' href='../../src/components/ha-combo-box.html'>
+<link rel='import' href='../../src/components/entity/ha-entity-picker.html'>
+<link rel='import' href='../../src/components/ha-service-picker.html'>
 <link rel='import' href='../../src/resources/ha-style.html'>
 
 <dom-module id='ha-panel-dev-service'>
@@ -27,7 +28,7 @@
 
       .ha-form {
         margin-right: 16px;
-        max-width: 500px;
+        max-width: 400px;
       }
 
       .description {
@@ -67,6 +68,14 @@
       h1 {
         white-space: normal;
       }
+
+      td {
+        padding: 4px;
+      }
+
+      .error {
+        color: var(--google-red-500);
+      }
     </style>
 
     <app-header-layout has-scrolling-region>
@@ -78,77 +87,77 @@
       </app-header>
 
       <app-localstorage-document
-        key='panel-dev-service-state-domain'
-        data='{{domain}}'>
+        key='panel-dev-service-state-domain-service'
+        data='{{domainService}}'>
       </app-localstorage-document>
       <app-localstorage-document
-        key='[[computeServiceKey(domain)]]'
-        data='{{service}}'>
-      </app-localstorage-document>
-      <app-localstorage-document
-        key='[[computeServicedataKey(domain, service)]]'
+        key='[[_computeServicedataKey(domainService)]]'
         data='{{serviceData}}'>
       </app-localstorage-document>
 
       <div class='content'>
         <p>
-          Call a service from a component.
+          The service dev tool allows you to call any available service in Home Assistant.
         </p>
 
         <div class='ha-form'>
-          <ha-combo-box
-            label='Domain'
-            items='[[computeDomains(serviceDomains)]]'
-            value='{{domain}}'
-          ></ha-combo-box>
-          <ha-combo-box
-            label='Service'
-            items='[[computeServices(serviceDomains, domain)]]'
-            value='{{service}}'
-          ></ha-combo-box>
+          <ha-service-picker
+            hass='[[hass]]'
+            value='{{domainService}}'
+          ></ha-service-picker>
+          <template is='dom-if' if='[[_computeHasEntity(_attributes)]]'>
+            <ha-entity-picker
+              hass='[[hass]]'
+              value='[[_computeEntityValue(parsedJSON)]]'
+              on-change='_entityPicked'
+              disabled='[[!validJSON]]'
+              domain-filter='[[_computeEntityDomainFilter(_domain)]]'
+              allow-custom-entity
+            ></ha-entity-picker>
+          </template>
           <paper-textarea
             always-float-label
             label='Service Data (JSON, optional)'
             value='{{serviceData}}'
           ></paper-textarea>
-          <paper-button on-tap='callService' raised>Call Service</paper-button>
+          <paper-button
+            on-tap='_callService'
+            raised
+            disabled='[[!validJSON]]'
+          >Call Service</paper-button>
+          <template is='dom-if' if='[[!validJSON]]'>
+              <span class='error'>Invalid JSON</span>
+          </template>
         </div>
 
-        <template is='dom-if' if='[[!domain]]'>
-          <h1>Select a domain and service to see the description</h1>
+        <template is='dom-if' if='[[!domainService]]'>
+          <h1>Select a service to see the description</h1>
         </template>
 
-        <template is='dom-if' if='[[domain]]'>
-          <template is='dom-if' if='[[!service]]'>
-            <h1>Select a service to see the description</h1>
+        <template is='dom-if' if='[[domainService]]'>
+          <template is='dom-if' if='[[!_description]]'>
+            <h1>No description is available</h1>
           </template>
-        </template>
+          <template is='dom-if' if='[[_description]]'>
+            <h3>[[_description]]</h3>
 
-        <template is='dom-if' if='[[domain]]'>
-          <template is='dom-if' if='[[service]]'>
-            <template is='dom-if' if='[[!_description]]'>
-              <h1>No description is available</h1>
-            </template>
-            <template is='dom-if' if='[[_description]]'>
-              <h3>[[_description]]</h3>
-            </template>
-            <template is='dom-if' if='[[_attributes.length]]'>
-              <h1>Valid Parameters</h1>
-              <table class='attributes'>
+            <table class='attributes'>
+              <tr>
+                <th>Parameter</th>
+                <th>Description</th>
+                <th>Example</th>
+              </tr>
+              <template is='dom-if' if='[[!_attributes.length]]'>
+                <tr><td colspan='3'>This service takes no parameters.</td></tr>
+              </template>
+              <template is='dom-repeat' items='[[_attributes]]' as='attribute'>
                 <tr>
-                  <th>Parameter</th>
-                  <th>Description</th>
-                  <th>Example</th>
+                  <td><pre>[[attribute.key]]</pre></td>
+                  <td>[[attribute.description]]</td>
+                  <td>[[attribute.example]]</td>
                 </tr>
-                <template is='dom-repeat' items='[[_attributes]]' as='attribute'>
-                  <tr>
-                    <td><pre>[[attribute.key]]</pre></td>
-                    <td>[[attribute.description]]</td>
-                    <td>[[attribute.example]]</td>
-                  </tr>
-                </template>
-              </table>
-            </template>
+              </template>
+            </table>
           </template>
         </template>
       </div>
@@ -158,6 +167,8 @@
 </dom-module>
 
 <script>
+{
+const ERROR_SENTINEL = {};
 class HaPanelDevService extends Polymer.Element {
   static get is() { return 'ha-panel-dev-service'; }
 
@@ -177,16 +188,19 @@ class HaPanelDevService extends Polymer.Element {
         value: false,
       },
 
-      domain: {
+      domainService: {
         type: String,
-        value: '',
-        observer: 'domainChanged',
+        observer: '_domainServiceChanged',
       },
 
-      service: {
+      _domain: {
         type: String,
-        value: '',
-        observer: 'serviceChanged',
+        computed: '_computeDomain(domainService)',
+      },
+
+      _service: {
+        type: String,
+        computed: '_computeService(domainService)',
       },
 
       serviceData: {
@@ -194,92 +208,103 @@ class HaPanelDevService extends Polymer.Element {
         value: '',
       },
 
+      parsedJSON: {
+        type: Object,
+        computed: '_computeParsedServiceData(serviceData)'
+      },
+
+      validJSON: {
+        type: Boolean,
+        computed: '_computeValidJSON(parsedJSON)',
+      },
+
       _attributes: {
         type: Array,
-        computed: 'computeAttributesArray(serviceDomains, domain, service)',
+        computed: '_computeAttributesArray(hass, _domain, _service)',
       },
 
       _description: {
         type: String,
-        computed: 'computeDescription(serviceDomains, domain, service)',
-      },
-
-      serviceDomains: {
-        type: Object,
-        computed: 'computeServiceDomains(hass)',
+        computed: '_computeDescription(hass, _domain, _service)',
       },
     };
   }
 
-  computeServiceDomains(hass) {
-    return hass.config.services;
+  _domainServiceChanged() {
+    this.serviceData = '';
   }
 
-  computeAttributesArray(serviceDomains, domain, service) {
-    if (!serviceDomains) return [];
+  _computeAttributesArray(hass, domain, service) {
+    const serviceDomains = hass.config.services;
     if (!(domain in serviceDomains)) return [];
     if (!(service in serviceDomains[domain])) return [];
 
-    var fields = serviceDomains[domain][service].fields;
+    const fields = serviceDomains[domain][service].fields;
     return Object.keys(fields).map(function (field) {
-      return Object.assign({}, fields[field], { key: field });
+      return Object.assign({ key: field }, fields[field]);
     });
   }
 
-  computeDescription(serviceDomains, domain, service) {
-    if (!serviceDomains) return undefined;
+  _computeDescription(hass, domain, service) {
+    const serviceDomains = hass.config.services;
     if (!(domain in serviceDomains)) return undefined;
     if (!(service in serviceDomains[domain])) return undefined;
     return serviceDomains[domain][service].description;
   }
 
-  computeDomains(serviceDomains) {
-    return Object.keys(serviceDomains).sort();
+  _computeServicedataKey(domainService) {
+    return 'panel-dev-service-state-servicedata.${domainService}';
   }
 
-  computeServices(serviceDomains, domain) {
-    if (!(domain in serviceDomains)) return [];
-
-    return Object.keys(serviceDomains[domain]).sort();
+  _computeDomain(domainService) {
+    return domainService.split('.', 1)[0]
   }
 
-  computeServiceKey(domain) {
-    if (!domain) {
-      return 'panel-dev-service-state-service';
-    }
-    return 'panel-dev-service-state-service.' + domain;
+  _computeService(domainService) {
+    return domainService.split('.', 2)[1] || null;
   }
 
-  computeServicedataKey(domain, service) {
-    if (!domain || !service) {
-      return 'panel-dev-service-state-servicedata';
-    }
-    return 'panel-dev-service-state-servicedata.' + domain + '.' + service;
-  }
-
-  domainChanged() {
-    this.service = '';
-    this.serviceData = '';
-  }
-
-  serviceChanged() {
-    this.serviceData = '';
-  }
-
-  callService() {
-    var serviceData;
+  _computeParsedServiceData(serviceData) {
     try {
-      serviceData = this.serviceData ? JSON.parse(this.serviceData) : {};
+      return this.serviceData ? JSON.parse(this.serviceData) : {};
     } catch (err) {
-      /* eslint-disable no-alert */
-      alert('Error parsing JSON: ' + err);
-      /* eslint-enable no-alert */
-      return;
+      return ERROR_SENTINEL;
+    }
+  }
+
+  _computeValidJSON(parsedJSON) {
+    return parsedJSON !== ERROR_SENTINEL;
+  }
+
+  _computeHasEntity(attributes) {
+    return attributes.some(attr => attr.key === 'entity_id');
+  }
+
+  _computeEntityValue(parsedJSON) {
+    return parsedJSON === ERROR_SENTINEL ? '' : parsedJSON.entity_id;
+  }
+
+  _computeEntityDomainFilter(domain) {
+    return domain === 'homeassistant' ? null : domain;
+  }
+
+  _callService() {
+    if (this.parsedJSON === ERROR_SENTINEL) {
+      // eslint-disable-next-line
+      alert(`Error parsing JSON: ${this.serviceData}`);
     }
 
-    this.hass.callService(this.domain, this.service, serviceData);
+    this.hass.callService(this.domain, this.service, this.parsedJSON);
+  }
+
+  _entityPicked(ev) {
+    this.serviceData = JSON.stringify(
+      Object.assign({}, this.parsedJSON, {
+        entity_id: ev.target.value
+      }), null, 2);
   }
 }
 
 customElements.define(HaPanelDevService.is, HaPanelDevService);
+}
 </script>

--- a/panels/dev-service/ha-panel-dev-service.html
+++ b/panels/dev-service/ha-panel-dev-service.html
@@ -168,143 +168,142 @@
 
 <script>
 {
-const ERROR_SENTINEL = {};
-class HaPanelDevService extends Polymer.Element {
-  static get is() { return 'ha-panel-dev-service'; }
+  const ERROR_SENTINEL = {};
+  class HaPanelDevService extends Polymer.Element {
+    static get is() { return 'ha-panel-dev-service'; }
 
-  static get properties() {
-    return {
-      hass: {
-        type: Object,
-      },
+    static get properties() {
+      return {
+        hass: {
+          type: Object,
+        },
 
-      narrow: {
-        type: Boolean,
-        value: false,
-      },
+        narrow: {
+          type: Boolean,
+          value: false,
+        },
 
-      showMenu: {
-        type: Boolean,
-        value: false,
-      },
+        showMenu: {
+          type: Boolean,
+          value: false,
+        },
 
-      domainService: {
-        type: String,
-        observer: '_domainServiceChanged',
-      },
+        domainService: {
+          type: String,
+          observer: '_domainServiceChanged',
+        },
 
-      _domain: {
-        type: String,
-        computed: '_computeDomain(domainService)',
-      },
+        _domain: {
+          type: String,
+          computed: '_computeDomain(domainService)',
+        },
 
-      _service: {
-        type: String,
-        computed: '_computeService(domainService)',
-      },
+        _service: {
+          type: String,
+          computed: '_computeService(domainService)',
+        },
 
-      serviceData: {
-        type: String,
-        value: '',
-      },
+        serviceData: {
+          type: String,
+          value: '',
+        },
 
-      parsedJSON: {
-        type: Object,
-        computed: '_computeParsedServiceData(serviceData)'
-      },
+        parsedJSON: {
+          type: Object,
+          computed: '_computeParsedServiceData(serviceData)'
+        },
 
-      validJSON: {
-        type: Boolean,
-        computed: '_computeValidJSON(parsedJSON)',
-      },
+        validJSON: {
+          type: Boolean,
+          computed: '_computeValidJSON(parsedJSON)',
+        },
 
-      _attributes: {
-        type: Array,
-        computed: '_computeAttributesArray(hass, _domain, _service)',
-      },
+        _attributes: {
+          type: Array,
+          computed: '_computeAttributesArray(hass, _domain, _service)',
+        },
 
-      _description: {
-        type: String,
-        computed: '_computeDescription(hass, _domain, _service)',
-      },
-    };
-  }
-
-  _domainServiceChanged() {
-    this.serviceData = '';
-  }
-
-  _computeAttributesArray(hass, domain, service) {
-    const serviceDomains = hass.config.services;
-    if (!(domain in serviceDomains)) return [];
-    if (!(service in serviceDomains[domain])) return [];
-
-    const fields = serviceDomains[domain][service].fields;
-    return Object.keys(fields).map(function (field) {
-      return Object.assign({ key: field }, fields[field]);
-    });
-  }
-
-  _computeDescription(hass, domain, service) {
-    const serviceDomains = hass.config.services;
-    if (!(domain in serviceDomains)) return undefined;
-    if (!(service in serviceDomains[domain])) return undefined;
-    return serviceDomains[domain][service].description;
-  }
-
-  _computeServicedataKey(domainService) {
-    return 'panel-dev-service-state-servicedata.${domainService}';
-  }
-
-  _computeDomain(domainService) {
-    return domainService.split('.', 1)[0]
-  }
-
-  _computeService(domainService) {
-    return domainService.split('.', 2)[1] || null;
-  }
-
-  _computeParsedServiceData(serviceData) {
-    try {
-      return this.serviceData ? JSON.parse(this.serviceData) : {};
-    } catch (err) {
-      return ERROR_SENTINEL;
-    }
-  }
-
-  _computeValidJSON(parsedJSON) {
-    return parsedJSON !== ERROR_SENTINEL;
-  }
-
-  _computeHasEntity(attributes) {
-    return attributes.some(attr => attr.key === 'entity_id');
-  }
-
-  _computeEntityValue(parsedJSON) {
-    return parsedJSON === ERROR_SENTINEL ? '' : parsedJSON.entity_id;
-  }
-
-  _computeEntityDomainFilter(domain) {
-    return domain === 'homeassistant' ? null : domain;
-  }
-
-  _callService() {
-    if (this.parsedJSON === ERROR_SENTINEL) {
-      // eslint-disable-next-line
-      alert(`Error parsing JSON: ${this.serviceData}`);
+        _description: {
+          type: String,
+          computed: '_computeDescription(hass, _domain, _service)',
+        },
+      };
     }
 
-    this.hass.callService(this.domain, this.service, this.parsedJSON);
-  }
+    _domainServiceChanged() {
+      this.serviceData = '';
+    }
 
-  _entityPicked(ev) {
-    this.serviceData = JSON.stringify(
-      Object.assign({}, this.parsedJSON, {
+    _computeAttributesArray(hass, domain, service) {
+      const serviceDomains = hass.config.services;
+      if (!(domain in serviceDomains)) return [];
+      if (!(service in serviceDomains[domain])) return [];
+
+      const fields = serviceDomains[domain][service].fields;
+      return Object.keys(fields).map(function (field) {
+        return Object.assign({ key: field }, fields[field]);
+      });
+    }
+
+    _computeDescription(hass, domain, service) {
+      const serviceDomains = hass.config.services;
+      if (!(domain in serviceDomains)) return undefined;
+      if (!(service in serviceDomains[domain])) return undefined;
+      return serviceDomains[domain][service].description;
+    }
+
+    _computeServicedataKey(domainService) {
+      return `panel-dev-service-state-servicedata.${domainService}`;
+    }
+
+    _computeDomain(domainService) {
+      return domainService.split('.', 1)[0];
+    }
+
+    _computeService(domainService) {
+      return domainService.split('.', 2)[1] || null;
+    }
+
+    _computeParsedServiceData(serviceData) {
+      try {
+        return serviceData ? JSON.parse(serviceData) : {};
+      } catch (err) {
+        return ERROR_SENTINEL;
+      }
+    }
+
+    _computeValidJSON(parsedJSON) {
+      return parsedJSON !== ERROR_SENTINEL;
+    }
+
+    _computeHasEntity(attributes) {
+      return attributes.some(attr => attr.key === 'entity_id');
+    }
+
+    _computeEntityValue(parsedJSON) {
+      return parsedJSON === ERROR_SENTINEL ? '' : parsedJSON.entity_id;
+    }
+
+    _computeEntityDomainFilter(domain) {
+      return domain === 'homeassistant' ? null : domain;
+    }
+
+    _callService() {
+      if (this.parsedJSON === ERROR_SENTINEL) {
+        // eslint-disable-next-line
+        alert(`Error parsing JSON: ${this.serviceData}`);
+      }
+
+      this.hass.callService(this.domain, this.service, this.parsedJSON);
+    }
+
+    _entityPicked(ev) {
+      this.serviceData = JSON.stringify(Object.assign({}, this.parsedJSON, {
         entity_id: ev.target.value
       }), null, 2);
+    }
   }
-}
 
-customElements.define(HaPanelDevService.is, HaPanelDevService);
+  customElements.define(HaPanelDevService.is, HaPanelDevService);
 }
 </script>

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -26,9 +26,9 @@
         padding: 16px;
       }
 
-      ha-entity-picker {
+      ha-entity-picker, .state-input, paper-textarea {
         display: block;
-        max-width: 300px;
+        max-width: 400px;
       }
 
       .entities th {
@@ -78,7 +78,12 @@
             value="{{_entityId}}"
             allow-custom-entity
           ></ha-entity-picker>
-          <paper-input label="State" required value='{{_state}}'></paper-input>
+          <paper-input
+            label="State"
+            required
+            value='{{_state}}'
+            class='state-input'
+          ></paper-input>
           <paper-textarea label="State attributes (JSON, optional)" value='{{_stateAttributes}}'></paper-textarea>
           <paper-button on-tap='handleSetState' raised>Set State</paper-button>
         </div>

--- a/src/components/entity/ha-entity-picker.html
+++ b/src/components/entity/ha-entity-picker.html
@@ -14,32 +14,36 @@
         padding: 2px;
         color: var(--secondary-text-color);
       }
+      [hidden] {
+        display: none;
+      }
     </style>
     <vaadin-combo-box-light
-      items='[[computeStates(_hass)]]'
+      items='[[_states]]'
       item-value-path='entity_id'
       item-label-path='entity_id'
       value='{{value}}'
       opened='{{opened}}'
       allow-custom-value='[[allowCustomEntity]]'
-      pattern="(\w|\d)+\.(\w|\d)+"
-      prevent-invalid-input
     >
       <paper-input
         autofocus="[[autofocus]]"
         label="[[label]]"
         class="input"
+        disabled='[[disabled]]'
       >
         <paper-icon-button
           slot="suffix"
           class="clear-button"
           icon="mdi:close"
           no-ripple
+          hidden$='[[!value]]'
         >Clear</paper-icon-button>
         <paper-icon-button
           slot="suffix"
           class="toggle-button"
           icon='[[_computeToggleIcon(opened)]]'
+          hidden='[[!_states.length]]'
         >Toggle</paper-icon-button>
       </paper-input>
       <template>
@@ -75,6 +79,10 @@ class HaEntityPicker extends Polymer.Element {
         observer: '_hassChanged',
       },
       _hass: Object,
+      _states: {
+        type: Array,
+        computed: '_computeStates(_hass, domainFilter, entityFilter)',
+      },
       autofocus: Boolean,
       label: {
         type: String,
@@ -89,11 +97,35 @@ class HaEntityPicker extends Polymer.Element {
         value: false,
         observer: '_openedChanged',
       },
+      domainFilter: {
+        type: String,
+        value: null,
+      },
+      entityFilter: {
+        type: Function,
+        value: null,
+      },
+      disabled: Boolean,
     };
   }
 
-  computeStates(hass) {
-    return Object.keys(hass.states).sort().map(key => hass.states[key]);
+  _computeStates(hass, domainFilter, entityFilter) {
+    if (!hass) return [];
+
+    let entityIds = Object.keys(hass.states);
+
+    if (domainFilter) {
+      entityIds = entityIds.filter(
+        ent_id => ent_id.substr(0, ent_id.indexOf('.')) === domainFilter)
+    }
+
+    let entities = entityIds.sort().map(key => hass.states[key]);
+
+    if (entityFilter) {
+      entities = entities.filter(entityFilter);
+    }
+
+    return entities;
   }
 
   computeStateName(state) {

--- a/src/components/entity/ha-entity-picker.html
+++ b/src/components/entity/ha-entity-picker.html
@@ -115,8 +115,7 @@ class HaEntityPicker extends Polymer.Element {
     let entityIds = Object.keys(hass.states);
 
     if (domainFilter) {
-      entityIds = entityIds.filter(
-        ent_id => ent_id.substr(0, ent_id.indexOf('.')) === domainFilter)
+      entityIds = entityIds.filter(eid => eid.substr(0, eid.indexOf('.')) === domainFilter);
     }
 
     let entities = entityIds.sort().map(key => hass.states[key]);

--- a/src/components/ha-combo-box.html
+++ b/src/components/ha-combo-box.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../../bower_components/vaadin-combo-box/vaadin-combo-box-light.html">
-<link rel="import" href="../../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../bower_components/paper-item/paper-item.html">
 
 <dom-module id="ha-combo-box">
   <template>
@@ -11,6 +11,9 @@
         padding: 2px;
         color: var(--secondary-text-color);
       }
+      [hidden] {
+        display: none;
+      }
     </style>
     <vaadin-combo-box-light
       items='[[items]]'
@@ -19,8 +22,6 @@
       value='{{value}}'
       opened='{{opened}}'
       allow-custom-value='[[allowCustomValue]]'
-      pattern="[[pattern]]"
-      prevent-invalid-input="[[preventInvalidInput]]"
     >
       <paper-input
         autofocus="[[autofocus]]"
@@ -31,12 +32,14 @@
           slot="suffix"
           class="clear-button"
           icon="mdi:close"
+          hidden$='[[!value]]'
         >Clear</paper-icon-button>
         <paper-icon-button
           slot="suffix"
           class="toggle-button"
           icon='[[_computeToggleIcon(opened)]]'
-        >Toggle</paper-icon-button>
+          hidden$='[[!items.length]]'
+          >Toggle</paper-icon-button>
       </paper-input>
       <template>
         <style>
@@ -71,8 +74,6 @@ class HaComboBox extends Polymer.Element {
         value: false,
         observer: '_openedChanged',
       },
-      pattern: String,
-      preventInvalidInput: Boolean,
       value: {
         type: String,
         notify: true,

--- a/src/components/ha-service-picker.html
+++ b/src/components/ha-service-picker.html
@@ -1,0 +1,47 @@
+<link rel="import" href="../../bower_components/polymer/polymer-element.html">
+
+<link rel="import" href="./ha-combo-box.html">
+
+<dom-module id="ha-service-picker">
+  <template>
+    <ha-combo-box
+      label='Service'
+      items='[[_computeServices(hass)]]'
+      value='{{value}}'
+      allow-custom-value
+    ></ha-combo-box>
+  </template>
+</dom-module>
+
+<script>
+class HaServicePicker extends Polymer.Element {
+  static get is() { return 'ha-service-picker'; }
+
+  static get properties() {
+    return {
+      hass: Object,
+      value: {
+        type: String,
+        notify: true,
+      },
+    };
+  }
+
+  _computeServices(hass) {
+    const result = [];
+
+    Object.keys(hass.config.services).sort().forEach((domain) => {
+      const services = Object.keys(hass.config.services[domain]).sort();
+
+      for (let i = 0; i < services.length; i++) {
+        result.push(`${domain}.${services[i]}`);
+      }
+    });
+
+    return result;
+  }
+
+}
+
+customElements.define(HaServicePicker.is, HaServicePicker);
+</script>

--- a/src/components/ha-service-picker.html
+++ b/src/components/ha-service-picker.html
@@ -40,7 +40,6 @@ class HaServicePicker extends Polymer.Element {
 
     return result;
   }
-
 }
 
 customElements.define(HaServicePicker.is, HaServicePicker);

--- a/test-mocha/common/util/location.js
+++ b/test-mocha/common/util/location.js
@@ -1,0 +1,38 @@
+import { hasLocation } from '../../../js/common/util/location';
+
+const assert = require('assert');
+
+describe('hasLocation', () => {
+  it('flags states with location', () => {
+    const stateObj = {
+      attributes: {
+        latitude: 12.34,
+        longitude: 12.34
+      }
+    };
+    assert(hasLocation(stateObj));
+  });
+  it('does not flag states with only latitude', () => {
+    const stateObj = {
+      attributes: {
+        latitude: 12.34,
+      }
+    };
+    assert(!hasLocation(stateObj));
+  });
+  it('does not flag states with only longitude', () => {
+    const stateObj = {
+      attributes: {
+        longitude: 12.34
+      }
+    };
+    assert(!hasLocation(stateObj));
+  });
+  it('does not flag states with no location', () => {
+    const stateObj = {
+      attributes: {
+      }
+    };
+    assert(!hasLocation(stateObj));
+  });
+});


### PR DESCRIPTION
This PR depends on #674 so this PR merges into that branch.

 - Add entity picker to the script and automation editors
 - Allow filtering by entity and domain inside entity picker
 - Add new service picker for scripts editor
 - Add service picker and entity picker to dev services tool

In the automation editor: when configuring a zone we only autocomplete entities that have a location.

![screen shot 2017-11-23 at 23 39 41](https://user-images.githubusercontent.com/1444314/33202449-70865f34-d0b1-11e7-858d-75422a99f92a.png)
