### PR TITLE
Fix eslint import extension

### DIFF
--- a/.eslintrc-hound.json
+++ b/.eslintrc-hound.json
@@ -46,6 +46,8 @@
     "no-restricted-globals": 0,
     "prefer-promise-reject-errors": 0,
     "import/prefer-default-export": 0,
+    "import/no-unresolved": 0,
+    "import/extensions": [2, "ignorePackages"],
     "react/jsx-no-bind": [2, { "ignoreRefs": true }],
     "react/jsx-no-duplicate-props": 2,
     "react/self-closing-comp": 2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,5 +6,8 @@
   ],
   "env": {
     "browser": true
+  },
+  "rules": {
+    "import/no-unresolved": 2
   }
 }

--- a/js/automation-editor/automation-editor.js
+++ b/js/automation-editor/automation-editor.js
@@ -1,5 +1,5 @@
 import { h, render } from 'preact';
-import Automation from './automation';
+import Automation from './automation.js';
 
 window.AutomationEditor = function (mountEl, props, mergeEl) {
   return render(h(Automation, props), mountEl, mergeEl);

--- a/js/automation-editor/automation.js
+++ b/js/automation-editor/automation.js
@@ -1,8 +1,8 @@
 import { h, Component } from 'preact';
 
-import Trigger from './trigger';
-import Condition from '../common/component/condition';
-import Script from '../common/component/script';
+import Trigger from './trigger/index.js';
+import Condition from '../common/component/condition/index.js';
+import Script from '../common/component/script/index.js';
 
 export default class Automation extends Component {
   constructor() {

--- a/js/automation-editor/trigger/event.js
+++ b/js/automation-editor/trigger/event.js
@@ -1,8 +1,7 @@
 import { h, Component } from 'preact';
 
-import JSONTextArea from '../../common/component/json_textarea';
-
-import { onChangeEvent } from '../../common/util/event';
+import JSONTextArea from '../../common/component/json_textarea.js';
+import { onChangeEvent } from '../../common/util/event.js';
 
 export default class EventTrigger extends Component {
   constructor() {

--- a/js/automation-editor/trigger/index.js
+++ b/js/automation-editor/trigger/index.js
@@ -1,7 +1,7 @@
 import { h, Component } from 'preact';
 
-import TriggerRow from './trigger_row';
-import StateTrigger from './state';
+import TriggerRow from './trigger_row.js';
+import StateTrigger from './state.js';
 
 export default class Trigger extends Component {
   constructor() {

--- a/js/automation-editor/trigger/mqtt.js
+++ b/js/automation-editor/trigger/mqtt.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../common/util/event';
+import { onChangeEvent } from '../../common/util/event.js';
 
 export default class MQTTTrigger extends Component {
   constructor() {

--- a/js/automation-editor/trigger/numeric_state.js
+++ b/js/automation-editor/trigger/numeric_state.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../common/util/event';
+import { onChangeEvent } from '../../common/util/event.js';
 
 export default class NumericStateTrigger extends Component {
   constructor() {

--- a/js/automation-editor/trigger/state.js
+++ b/js/automation-editor/trigger/state.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../common/util/event';
+import { onChangeEvent } from '../../common/util/event.js';
 
 export default class StateTrigger extends Component {
   constructor() {

--- a/js/automation-editor/trigger/sun.js
+++ b/js/automation-editor/trigger/sun.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../common/util/event';
+import { onChangeEvent } from '../../common/util/event.js';
 
 export default class SunTrigger extends Component {
   constructor() {

--- a/js/automation-editor/trigger/template.js
+++ b/js/automation-editor/trigger/template.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../common/util/event';
+import { onChangeEvent } from '../../common/util/event.js';
 
 export default class TemplateTrigger extends Component {
   constructor() {

--- a/js/automation-editor/trigger/time.js
+++ b/js/automation-editor/trigger/time.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../common/util/event';
+import { onChangeEvent } from '../../common/util/event.js';
 
 export default class TimeTrigger extends Component {
   constructor() {

--- a/js/automation-editor/trigger/trigger_edit.js
+++ b/js/automation-editor/trigger/trigger_edit.js
@@ -1,14 +1,14 @@
 import { h, Component } from 'preact';
 
-import EventTrigger from './event';
-import HassTrigger from './homeassistant';
-import MQTTTrigger from './mqtt';
-import NumericStateTrigger from './numeric_state';
-import StateTrigger from './state';
-import SunTrigger from './sun';
-import TemplateTrigger from './template';
-import TimeTrigger from './time';
-import ZoneTrigger from './zone';
+import EventTrigger from './event.js';
+import HassTrigger from './homeassistant.js';
+import MQTTTrigger from './mqtt.js';
+import NumericStateTrigger from './numeric_state.js';
+import StateTrigger from './state.js';
+import SunTrigger from './sun.js';
+import TemplateTrigger from './template.js';
+import TimeTrigger from './time.js';
+import ZoneTrigger from './zone.js';
 
 const TYPES = {
   event: EventTrigger,

--- a/js/automation-editor/trigger/trigger_row.js
+++ b/js/automation-editor/trigger/trigger_row.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import TriggerEdit from './trigger_edit';
+import TriggerEdit from './trigger_edit.js';
 
 export default class TriggerRow extends Component {
   constructor() {

--- a/js/automation-editor/trigger/zone.js
+++ b/js/automation-editor/trigger/zone.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../common/util/event';
+import { onChangeEvent } from '../../common/util/event.js';
 
 export default class ZoneTrigger extends Component {
   constructor() {

--- a/js/common/component/condition/condition_edit.js
+++ b/js/common/component/condition/condition_edit.js
@@ -1,11 +1,11 @@
 import { h, Component } from 'preact';
 
-import NumericStateCondition from './numeric_state';
-import StateCondition from './state';
-import SunCondition from './sun';
-import TemplateCondition from './template';
-import TimeCondition from './time';
-import ZoneCondition from './zone';
+import NumericStateCondition from './numeric_state.js';
+import StateCondition from './state.js';
+import SunCondition from './sun.js';
+import TemplateCondition from './template.js';
+import TimeCondition from './time.js';
+import ZoneCondition from './zone.js';
 
 const TYPES = {
   state: StateCondition,

--- a/js/common/component/condition/condition_row.js
+++ b/js/common/component/condition/condition_row.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import ConditionEdit from './condition_edit';
+import ConditionEdit from './condition_edit.js';
 
 export default class ConditionRow extends Component {
   constructor() {

--- a/js/common/component/condition/index.js
+++ b/js/common/component/condition/index.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import ConditionRow from './condition_row';
+import ConditionRow from './condition_row.js';
 
 export default class Condition extends Component {
   constructor() {

--- a/js/common/component/condition/numeric_state.js
+++ b/js/common/component/condition/numeric_state.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../util/event';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class NumericStateCondition extends Component {
   constructor() {

--- a/js/common/component/condition/state.js
+++ b/js/common/component/condition/state.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../util/event';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class StateCondition extends Component {
   constructor() {

--- a/js/common/component/condition/sun.js
+++ b/js/common/component/condition/sun.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../util/event';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class SunCondition extends Component {
   constructor() {

--- a/js/common/component/condition/template.js
+++ b/js/common/component/condition/template.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../util/event';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class TemplateCondition extends Component {
   constructor() {

--- a/js/common/component/condition/time.js
+++ b/js/common/component/condition/time.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../util/event';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class TimeCondition extends Component {
   constructor() {

--- a/js/common/component/condition/zone.js
+++ b/js/common/component/condition/zone.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import { onChangeEvent } from '../../util/event';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class ZoneCondition extends Component {
   constructor() {

--- a/js/common/component/script/action_edit.js
+++ b/js/common/component/script/action_edit.js
@@ -1,10 +1,10 @@
 import { h, Component } from 'preact';
 
-import CallServiceAction from './call_service';
-import ConditionAction from './condition';
-import DelayAction from './delay';
-import EventAction from './event';
-import WaitAction from './wait';
+import CallServiceAction from './call_service.js';
+import ConditionAction from './condition.js';
+import DelayAction from './delay.js';
+import EventAction from './event.js';
+import WaitAction from './wait.js';
 
 const TYPES = {
   'Call Service': CallServiceAction,

--- a/js/common/component/script/action_row.js
+++ b/js/common/component/script/action_row.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import ActionEdit from './action_edit';
+import ActionEdit from './action_edit.js';
 
 export default class Action extends Component {
   constructor() {

--- a/js/common/component/script/call_service.js
+++ b/js/common/component/script/call_service.js
@@ -1,7 +1,7 @@
 import { h, Component } from 'preact';
 
-import JSONTextArea from '../json_textarea';
-import { onChangeEvent } from '../../util/event';
+import JSONTextArea from '../json_textarea.js';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class CallServiceAction extends Component {
   constructor() {

--- a/js/common/component/script/condition.js
+++ b/js/common/component/script/condition.js
@@ -1,7 +1,7 @@
 import { h, Component } from 'preact';
 
-import StateCondition from '../condition/state';
-import ConditionEdit from '../condition/condition_edit';
+import StateCondition from '../condition/state.js';
+import ConditionEdit from '../condition/condition_edit.js';
 
 export default class ConditionAction extends Component {
   // eslint-disable-next-line

--- a/js/common/component/script/delay.js
+++ b/js/common/component/script/delay.js
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact';
-import { onChangeEvent } from '../../util/event';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class DelayAction extends Component {
   constructor() {

--- a/js/common/component/script/event.js
+++ b/js/common/component/script/event.js
@@ -1,7 +1,7 @@
 import { h, Component } from 'preact';
 
-import JSONTextArea from '../json_textarea';
-import { onChangeEvent } from '../../util/event';
+import JSONTextArea from '../json_textarea.js';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class EventAction extends Component {
   constructor() {

--- a/js/common/component/script/index.js
+++ b/js/common/component/script/index.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import ActionRow from './action_row';
+import ActionRow from './action_row.js';
 
 export default class Script extends Component {
   constructor() {

--- a/js/common/component/script/wait.js
+++ b/js/common/component/script/wait.js
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact';
-import { onChangeEvent } from '../../util/event';
+import { onChangeEvent } from '../../util/event.js';
 
 export default class WaitAction extends Component {
   constructor() {

--- a/js/common/util/compute_domain.js
+++ b/js/common/util/compute_domain.js
@@ -1,7 +1,3 @@
-export default function computeDomain(stateObj) {
-  if (!stateObj._domain) {
-    stateObj._domain = stateObj.entity_id.substr(0, stateObj.entity_id.indexOf('.'));
-  }
-
-  return stateObj._domain;
+export default function computeDomain(entityId) {
+  return entityId.substr(0, entityId.indexOf('.'));
 }

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -1,11 +1,11 @@
-import computeDomain from './compute_domain';
-import formatDateTime from './format_date_time';
-import formatDate from './format_date';
-import formatTime from './format_time';
+import computeStateDomain from './compute_state_domain.js';
+import formatDateTime from './format_date_time.js';
+import formatDate from './format_date.js';
+import formatTime from './format_time.js';
 
 export default function computeStateDisplay(haLocalize, stateObj, language) {
   if (!stateObj._stateDisplay) {
-    const domain = computeDomain(stateObj);
+    const domain = computeStateDomain(stateObj);
     if (domain === 'binary_sensor') {
       // Try device class translation, then default binary sensor translation
       if (stateObj.attributes.device_class) {

--- a/js/common/util/compute_state_domain.js
+++ b/js/common/util/compute_state_domain.js
@@ -1,0 +1,9 @@
+import computeDomain from './compute_domain.js';
+
+export default function computeStateDomain(stateObj) {
+  if (!stateObj._domain) {
+    stateObj._domain = computeDomain(stateObj.entity_id);
+  }
+
+  return stateObj._domain;
+}

--- a/js/script-editor/script-editor.js
+++ b/js/script-editor/script-editor.js
@@ -1,5 +1,5 @@
 import { h, render } from 'preact';
-import Script from './script';
+import Script from './script.js';
 
 window.ScriptEditor = function (mountEl, props, mergeEl) {
   return render(h(Script, props), mountEl, mergeEl);

--- a/js/script-editor/script.js
+++ b/js/script-editor/script.js
@@ -1,6 +1,6 @@
 import { h, Component } from 'preact';
 
-import Script from '../common/component/script';
+import Script from '../common/component/script/index.js';
 
 export default class ScriptEditor extends Component {
   constructor() {

--- a/js/util.js
+++ b/js/util.js
@@ -6,12 +6,12 @@
  * import these functions where we need them.
  */
 
-import attributeClassNames from './common/util/attribute_class_names';
-import computeDomain from './common/util/compute_domain';
-import computeStateDisplay from './common/util/compute_state_display';
-import formatDate from './common/util/format_date';
-import formatDateTime from './common/util/format_date_time';
-import formatTime from './common/util/format_time';
+import attributeClassNames from './common/util/attribute_class_names.js';
+import computeStateDomain from './common/util/compute_state_domain.js';
+import computeStateDisplay from './common/util/compute_state_display.js';
+import formatDate from './common/util/format_date.js';
+import formatDateTime from './common/util/format_date_time.js';
+import formatTime from './common/util/format_time.js';
 
 window.hassUtil = window.hassUtil || {};
 
@@ -21,7 +21,7 @@ const language = navigator.languages ?
 window.fecha.masks.haDateTime = window.fecha.masks.shortTime + ' ' + window.fecha.masks.mediumDate;
 
 window.hassUtil.attributeClassNames = attributeClassNames;
-window.hassUtil.computeDomain = computeDomain;
+window.hassUtil.computeDomain = computeStateDomain;
 window.hassUtil.computeStateDisplay = computeStateDisplay;
 window.hassUtil.formatDate = dateObj => formatDate(dateObj, language);
 window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, language);

--- a/test-mocha/common/util/compute_domain.js
+++ b/test-mocha/common/util/compute_domain.js
@@ -3,10 +3,10 @@ import computeDomain from '../../../js/common/util/compute_domain';
 const assert = require('assert');
 
 describe('computeDomain', () => {
-  it('Detects sensor domain', () => {
-    const stateObj = {
-      entity_id: 'sensor.test',
-    };
-    assert.strictEqual(computeDomain(stateObj), 'sensor');
+  it('Returns domains', () => {
+    assert.equal(computeDomain('sensor.bla'), 'sensor');
+    assert.equal(computeDomain('switch.bla'), 'switch');
+    assert.equal(computeDomain('light.bla'), 'light');
+    assert.equal(computeDomain('persistent_notification.bla'), 'persistent_notification');
   });
 });

--- a/test-mocha/common/util/compute_state_domain.js
+++ b/test-mocha/common/util/compute_state_domain.js
@@ -1,0 +1,12 @@
+import computeStateDomain from '../../../js/common/util/compute_state_domain.js';
+
+const assert = require('assert');
+
+describe('computeStateDomain', () => {
+  it('Detects sensor domain', () => {
+    const stateObj = {
+      entity_id: 'sensor.test',
+    };
+    assert.strictEqual(computeStateDomain(stateObj), 'sensor');
+  });
+});


### PR DESCRIPTION
Extracted ESLint fixes from #680. Also renames computeDomain to computeStateDomain and extracts computeDomain as one that takes in an entityId.