### PR TITLE
Fix error when creating new automation

### DIFF
--- a/js/automation-editor/trigger/zone.js
+++ b/js/automation-editor/trigger/zone.js
@@ -2,10 +2,10 @@ import { h, Component } from 'preact';
 
 import { onChangeEvent } from '../../common/util/event.js';
 import { hasLocation } from '../../common/util/location.js';
-import computeDomain from '../../common/util/compute_domain.js';
+import computeStateDomain from '../../common/util/compute_state_domain.js';
 
 function zoneAndLocationFilter(stateObj) {
-  return hasLocation(stateObj) && computeDomain(stateObj) !== 'zone';
+  return hasLocation(stateObj) && computeStateDomain(stateObj) !== 'zone';
 }
 
 export default class ZoneTrigger extends Component {

--- a/js/common/component/condition/zone.js
+++ b/js/common/component/condition/zone.js
@@ -2,10 +2,10 @@ import { h, Component } from 'preact';
 
 import { onChangeEvent } from '../../util/event.js';
 import { hasLocation } from '../../util/location.js';
-import computeDomain from '../../util/compute_domain.js';
+import computeStateDomain from '../../util/compute_state_domain.js';
 
 function zoneAndLocationFilter(stateObj) {
-  return hasLocation(stateObj) && computeDomain(stateObj) !== 'zone';
+  return hasLocation(stateObj) && computeStateDomain(stateObj) !== 'zone';
 }
 
 export default class ZoneCondition extends Component {

--- a/panels/config/automation/ha-config-automation.html
+++ b/panels/config/automation/ha-config-automation.html
@@ -14,13 +14,13 @@
     </style>
     <app-route
       route='[[route]]'
-      pattern='/edit/:automation'
+      pattern='/automation/edit/:automation'
       data="{{_routeData}}"
       active="{{_edittingAutomation}}"
     ></app-route>
     <app-route
       route='[[route]]'
-      pattern='/new'
+      pattern='/automation/new'
       active="{{_creatingNew}}"
     ></app-route>
 

--- a/panels/config/cloud/ha-config-cloud.html
+++ b/panels/config/cloud/ha-config-cloud.html
@@ -18,7 +18,7 @@
     </style>
     <app-route
       route='[[route]]'
-      pattern='/:page'
+      pattern='/cloud/:page'
       data="{{_routeData}}"
       tail="{{_routeTail}}"
     ></app-route>
@@ -32,7 +32,7 @@
     </template>
 
     <template is='dom-if' if='[[!account]]' restamp>
-      <template is='dom-if' if='[[_isLoginPage(_routeData.page)]]' restamp>
+      <template is='dom-if' if='[[_equals(_routeData.page, "login")]]' restamp>
         <ha-config-cloud-login
           page-name='login'
           hass='[[hass]]'
@@ -41,7 +41,7 @@
         ></ha-config-cloud-login>
       </template>
 
-      <template is='dom-if' if='[[_isRegisterPage(_routeData.page)]]' restamp>
+      <template is='dom-if' if='[[_equals(_routeData.page, "register")]]' restamp>
         <ha-config-cloud-register
           page-name='register'
           hass='[[hass]]'
@@ -50,7 +50,7 @@
         ></ha-config-cloud-register>
       </template>
 
-      <template is='dom-if' if='[[_isForgotPasswordPage(_routeData.page)]]' restamp>
+      <template is='dom-if' if='[[_equals(_routeData.page, "forgot-password")]]' restamp>
         <ha-config-cloud-forgot-password
           page-name='forgot-password'
           hass='[[hass]]'
@@ -63,51 +63,53 @@
 </dom-module>
 
 <script>
-class HaConfigCloud extends window.hassMixins.NavigateMixin(Polymer.Element) {
-  static get is() { return 'ha-config-cloud'; }
+{
+  class HaConfigCloud extends window.hassMixins.NavigateMixin(Polymer.Element) {
+    static get is() { return 'ha-config-cloud'; }
 
-  static get properties() {
-    return {
-      hass: Object,
-      isWide: Boolean,
-      loadingAccount: {
-        type: Boolean,
-        value: false
-      },
-      account: {
-        type: Object,
-        value: null,
-      },
+    static get properties() {
+      return {
+        hass: Object,
+        isWide: Boolean,
+        loadingAccount: {
+          type: Boolean,
+          value: false
+        },
+        account: {
+          type: Object,
+          value: null,
+        },
 
-      route: Object,
+        route: Object,
 
-      _routeData: Object,
-      _routeTail: Object,
-      _loginEmail: String,
-    };
-  }
+        _routeData: Object,
+        _routeTail: Object,
+        _loginEmail: String,
+      };
+    }
 
-  static get observers() {
-    return [
-      '_checkRoute(route, account)'
-    ];
-  }
+    static get observers() {
+      return [
+        '_checkRoute(route, account)'
+      ];
+    }
 
-  _checkRoute(route, account) {
-    if (!route || route.prefix !== '/config/cloud') return;
+    _checkRoute(route, account) {
+      if (!route || route.path.substr(0, 6) !== '/cloud') return;
 
-    if (!account && ['/forgot-password', '/register'].indexOf(route.path) === -1) {
-      this.navigate('/config/cloud/login', true);
-    } else if (account &&
-               ['/login', '/register', '/forgot-password'].indexOf(route.path) !== -1) {
-      this.navigate('/config/cloud/account', true);
+      if (!account && ['/cloud/forgot-password', '/cloud/register'].indexOf(route.path) === -1) {
+        this.navigate('/config/cloud/login', true);
+      } else if (account &&
+                 ['/cloud/login', '/cloud/register', '/cloud/forgot-password'].indexOf(route.path) !== -1) {
+        this.navigate('/config/cloud/account', true);
+      }
+    }
+
+    _equals(a, b) {
+      return a === b;
     }
   }
 
-  _isRegisterPage(page) { return page === 'register'; }
-  _isForgotPasswordPage(page) { return page === 'forgot-password'; }
-  _isLoginPage(page) { return page === 'login'; }
+  customElements.define(HaConfigCloud.is, HaConfigCloud);
 }
-
-customElements.define(HaConfigCloud.is, HaConfigCloud);
 </script>

--- a/panels/config/ha-panel-config.html
+++ b/panels/config/ha-panel-config.html
@@ -25,7 +25,6 @@
       route='[[route]]'
       pattern='/:page'
       data="{{_routeData}}"
-      tail="{{_routeTail}}"
     ></app-route>
 
     <iron-media-query query="(min-width: 1040px)" query-matches="{{wide}}">
@@ -47,7 +46,7 @@
 
       <ha-config-cloud
         page-name='cloud'
-        route='[[_routeTail]]'
+        route='[[route]]'
         hass='[[hass]]'
         is-wide='[[isWide]]'
         account='[[account]]'
@@ -64,14 +63,14 @@
 
       <ha-config-automation
         page-name='automation'
-        route='[[_routeTail]]'
+        route='[[route]]'
         hass='[[hass]]'
         is-wide='[[isWide]]'
       ></ha-config-automation>
 
       <ha-config-script
         page-name='script'
-        route='[[_routeTail]]'
+        route='[[route]]'
         hass='[[hass]]'
         is-wide='[[isWide]]'
       ></ha-config-script>
@@ -117,7 +116,6 @@ class HaPanelConfig extends window.hassMixins.EventsMixin(Polymer.Element) {
       },
 
       _routeData: Object,
-      _routeTail: Object,
 
       wide: Boolean,
       wideSidebar: Boolean,

--- a/panels/config/script/ha-config-script.html
+++ b/panels/config/script/ha-config-script.html
@@ -14,13 +14,13 @@
     </style>
     <app-route
       route='[[route]]'
-      pattern='/edit/:script'
+      pattern='/script/edit/:script'
       data="{{_routeData}}"
       active="{{_edittingScript}}"
     ></app-route>
     <app-route
       route='[[route]]'
-      pattern='/new'
+      pattern='/script/new'
       active="{{_creatingNew}}"
     ></app-route>
 

--- a/src/components/entity/ha-entity-picker.html
+++ b/src/components/entity/ha-entity-picker.html
@@ -30,6 +30,7 @@
         autofocus="[[autofocus]]"
         label="[[label]]"
         class="input"
+        value='[[value]]'
         disabled='[[disabled]]'
       >
         <paper-icon-button

--- a/src/components/ha-combo-box.html
+++ b/src/components/ha-combo-box.html
@@ -27,6 +27,7 @@
         autofocus="[[autofocus]]"
         label="[[label]]"
         class="input"
+        value='[[value]]'
       >
         <paper-icon-button
           slot="suffix"

--- a/src/components/ha-service-picker.html
+++ b/src/components/ha-service-picker.html
@@ -30,6 +30,8 @@ class HaServicePicker extends Polymer.Element {
   _computeServices(hass) {
     const result = [];
 
+    if (!hass) return result;
+
     Object.keys(hass.config.services).sort().forEach((domain) => {
       const services = Object.keys(hass.config.services[domain]).sort();
 


### PR DESCRIPTION
Fix #681 

After way too long stumbling around, I realized that the error that was reported in #681 was not actually from the automation editor but from the script editor, which got triggered by the same route suffix as the automation editor.

 - Fix all config panels that consume routes to only respond to their own route
 - Optimize `<ha-panel-config>` by only stamping out pages that are visible
 - Fix `<ha-service-picker>` being initialized before `hass` is set.