### PR TITLE
Badge fixes

### DIFF
--- a/src/components/ha-label-badge.html
+++ b/src/components/ha-label-badge.html
@@ -38,18 +38,19 @@
     .label-badge .label {
       position: absolute;
       bottom: -1em;
-      left: 0;
-      right: 0;
+      /* Make the label as wide as container+border. */
+      left: -0.1em;
+      right: -0.1em;
       line-height: 1em;
       font-size: 0.5em;
     }
     .label-badge .label span {
-      max-width: calc(100% - 1.6em);
+      max-width: 68%; /* Parent width minus two times 16% padding */
       display: inline-block;
       background-color: var(--ha-label-badge-color, --primary-color);
       color: white;
       border-radius: 1em;
-      padding: 0.4em 0.8em;
+      padding: 8% 16%;
       font-weight: 500;
       text-transform: uppercase;
       overflow: hidden;

--- a/src/components/ha-label-badge.html
+++ b/src/components/ha-label-badge.html
@@ -44,17 +44,20 @@
       font-size: 0.5em;
     }
     .label-badge .label span {
-      max-width: 80%;
+      max-width: calc(100% - 1.6em);
       display: inline-block;
       background-color: var(--ha-label-badge-color, --primary-color);
       color: white;
       border-radius: 1em;
-      padding: 4px 8px;
+      padding: 0.4em 0.8em;
       font-weight: 500;
       text-transform: uppercase;
       overflow: hidden;
       text-overflow: ellipsis;
       transition: background-color .3s ease-in-out;
+    }
+    .label-badge .label.big span {
+      font-size: 90%;
     }
     .badge-container .title {
       margin-top: 1em;
@@ -73,11 +76,13 @@
 
     <div class='badge-container'>
       <div class='label-badge' id='badge'>
-        <div class$='[[computeClasses(value)]]'>
+        <div class$='[[computeValueClasses(value)]]'>
           <iron-icon icon='[[icon]]' hidden$='[[computeHideIcon(icon, value, image)]]'></iron-icon>
           <span hidden$='[[computeHideValue(value, image)]]'>[[value]]</span>
         </div>
-        <div class='label' hidden$='[[!label]]'><span>[[label]]</span></div>
+        <div hidden$='[[!label]]' class$='[[computeLabelClasses(label)]]'>
+          <span>[[label]]</span>
+        </div>
       </div>
       <div class='title' hidden$='[[!description]]'>[[description]]</div>
     </div>
@@ -101,8 +106,12 @@ class HaLabelBadge extends Polymer.Element {
     };
   }
 
-  computeClasses(value) {
+  computeValueClasses(value) {
     return value && value.length > 4 ? 'value big' : 'value';
+  }
+
+  computeLabelClasses(label) {
+    return label && label.length > 5 ? 'label big' : 'label';
   }
 
   computeHideIcon(icon, value, image) {


### PR DESCRIPTION
* Use correct badge max-width (Fixes #686)
* Use `16%` padding instead of `8px` (This reduces the padding slightly from 8px to 7.42px in the normal case)
* In case the label in more than 5 characters decrease font-size by another 10% (8.925px -> 8.0325px)
* Allow badge label to be as wide as badge+border (was badge-without-border) this allows the label to fit half character more.