### PR TITLE
Add device class for low battery

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -32,6 +32,10 @@
       "on": "[%key:state::default::on%]"
     },
     "binary_sensor": {
+      "battery": {
+        "off": "Normal",
+        "on": "Low"
+      },
       "default": {
         "off": "[%key:state::default::off%]",
         "on": "[%key:state::default::on%]"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -32,13 +32,13 @@
       "on": "[%key:state::default::on%]"
     },
     "binary_sensor": {
-      "battery": {
-        "off": "Normal",
-        "on": "Low"
-      },
       "default": {
         "off": "[%key:state::default::off%]",
         "on": "[%key:state::default::on%]"
+      },
+      "battery": {
+        "off": "Normal",
+        "on": "Low"
       },
       "moisture": {
         "off": "Dry",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -37,34 +37,22 @@
         "on": "[%key:state::default::on%]"
       },
       "battery": {
-        "off": "[%key:state::plant::ok%]",
+        "off": "Normal",
         "on": "Low"
-      },
-      "moisture": {
-        "off": "Dry",
-        "on": "Wet"
       },
       "gas": {
         "off": "Clear",
         "on": "Detected"
+      },
+      "moisture": {
+        "off": "Dry",
+        "on": "Wet"
       },
       "motion": {
         "off": "[%key:state::binary_sensor::gas::off%]",
         "on": "[%key:state::binary_sensor::gas::on%]"
       },
       "occupancy": {
-        "off": "[%key:state::binary_sensor::gas::off%]",
-        "on": "[%key:state::binary_sensor::gas::on%]"
-      },
-      "smoke": {
-        "off": "[%key:state::binary_sensor::gas::off%]",
-        "on": "[%key:state::binary_sensor::gas::on%]"
-      },
-      "sound": {
-        "off": "[%key:state::binary_sensor::gas::off%]",
-        "on": "[%key:state::binary_sensor::gas::on%]"
-      },
-      "vibration": {
         "off": "[%key:state::binary_sensor::gas::off%]",
         "on": "[%key:state::binary_sensor::gas::on%]"
       },
@@ -79,6 +67,18 @@
       "safety": {
         "off": "Safe",
         "on": "Unsafe"
+      },
+      "smoke": {
+        "off": "[%key:state::binary_sensor::gas::off%]",
+        "on": "[%key:state::binary_sensor::gas::on%]"
+      },
+      "sound": {
+        "off": "[%key:state::binary_sensor::gas::off%]",
+        "on": "[%key:state::binary_sensor::gas::on%]"
+      },
+      "vibration": {
+        "off": "[%key:state::binary_sensor::gas::off%]",
+        "on": "[%key:state::binary_sensor::gas::on%]"
       }
     },
     "calendar": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -37,7 +37,7 @@
         "on": "[%key:state::default::on%]"
       },
       "battery": {
-        "off": "Normal",
+        "off": "[%key:state::plant::ok%]",
         "on": "Low"
       },
       "moisture": {

--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -3,7 +3,7 @@ window.hassAttributeUtil = window.hassAttributeUtil || {};
 
 window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
   binary_sensor: [
-    'battery', 'cold', 'connectivity', 'gas',  'heat', 'light', 'moisture',
+    'battery', 'cold', 'connectivity', 'gas', 'heat', 'light', 'moisture',
     'motion', 'moving', 'occupancy', 'opening', 'plug', 'power', 'presence',
     'safety', 'smoke', 'sound', 'vibration'],
   cover: ['garage'],

--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -3,9 +3,9 @@ window.hassAttributeUtil = window.hassAttributeUtil || {};
 
 window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
   binary_sensor: [
-    'connectivity', 'light', 'moisture', 'motion', 'occupancy', 'opening',
-    'sound', 'vibration', 'gas', 'power', 'safety', 'smoke', 'cold', 'heat',
-    'moving', 'plug', 'presence', 'battery'],
+    'battery', 'cold', 'connectivity', 'gas',  'heat', 'light', 'moisture',
+    'motion', 'moving', 'occupancy', 'opening', 'plug', 'power', 'presence',
+    'safety', 'smoke', 'sound', 'vibration'],
   cover: ['garage'],
 };
 

--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -5,7 +5,7 @@ window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
   binary_sensor: [
     'connectivity', 'light', 'moisture', 'motion', 'occupancy', 'opening',
     'sound', 'vibration', 'gas', 'power', 'safety', 'smoke', 'cold', 'heat',
-    'moving', 'plug', 'presence'],
+    'moving', 'plug', 'presence', 'battery'],
   cover: ['garage'],
 };
 

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -292,6 +292,8 @@ window.hassUtil.domainIcon = function (domain, state) {
 window.hassUtil.binarySensorIcon = function (state) {
   var activated = state.state && state.state === 'off';
   switch (state.attributes.device_class) {
+    case 'battery':
+      return activated ? 'mdi:battery' : 'mdi:battery-outline';
     case 'connectivity':
       return activated ? 'mdi:server-network-off' : 'mdi:server-network';
     case 'light':


### PR DESCRIPTION
- Adds `battery` device class
- [Related PR](https://github.com/home-assistant/home-assistant/pull/10829)