### PR TITLE
Separate more JS util logic to be unit tested

### DIFF
--- a/js/common/util/can_toggle_domain.js
+++ b/js/common/util/can_toggle_domain.js
@@ -1,0 +1,14 @@
+export default function canToggleDomain(hass, domain) {
+  const services = hass.config.services[domain];
+
+  let turnOnService;
+  if (domain === 'lock') {
+    turnOnService = 'lock';
+  } else if (domain === 'cover') {
+    turnOnService = 'open_cover';
+  } else {
+    turnOnService = 'turn_on';
+  }
+
+  return services && turnOnService in services;
+}

--- a/js/common/util/can_toggle_domain.js
+++ b/js/common/util/can_toggle_domain.js
@@ -1,14 +1,11 @@
 export default function canToggleDomain(hass, domain) {
   const services = hass.config.services[domain];
+  if (!services) { return false; }
 
-  let turnOnService;
   if (domain === 'lock') {
-    turnOnService = 'lock';
+    return 'lock' in services;
   } else if (domain === 'cover') {
-    turnOnService = 'open_cover';
-  } else {
-    turnOnService = 'turn_on';
+    return 'open_cover' in services;
   }
-
-  return services && turnOnService in services;
+  return 'turn_on' in services;
 }

--- a/js/common/util/can_toggle_state.js
+++ b/js/common/util/can_toggle_state.js
@@ -1,0 +1,11 @@
+import canToggleDomain from './can_toggle_domain.js';
+import computeStateDomain from './compute_state_domain.js';
+
+export default function canToggleState(hass, stateObj) {
+  const domain = computeStateDomain(stateObj);
+  if (domain === 'group') {
+    return stateObj.state === 'on' || stateObj.state === 'off';
+  }
+
+  return canToggleDomain(hass, domain);
+}

--- a/js/common/util/feature_class_names.js
+++ b/js/common/util/feature_class_names.js
@@ -1,0 +1,10 @@
+// Expects classNames to be an object mapping feature-bit -> className
+export default function featureClassNames(stateObj, classNames) {
+  if (!stateObj || !stateObj.attributes.supported_features) return '';
+
+  const features = stateObj.attributes.supported_features;
+
+  return Object.keys(classNames).map(feature => (
+    (features & feature) !== 0 ? classNames[feature] : ''
+  )).join(' ');
+}

--- a/js/common/util/feature_class_names.js
+++ b/js/common/util/feature_class_names.js
@@ -6,5 +6,5 @@ export default function featureClassNames(stateObj, classNames) {
 
   return Object.keys(classNames).map(feature => (
     (features & feature) !== 0 ? classNames[feature] : ''
-  )).join(' ');
+  )).filter(attr => attr !== '').join(' ');
 }

--- a/js/common/util/state_card_type.js
+++ b/js/common/util/state_card_type.js
@@ -1,0 +1,31 @@
+import canToggleState from './can_toggle_state.js';
+import computeStateDomain from './compute_state_domain.js';
+
+const DOMAINS_WITH_CARD = [
+  'climate',
+  'cover',
+  'configurator',
+  'input_select',
+  'input_number',
+  'input_text',
+  'media_player',
+  'scene',
+  'script',
+  'weblink',
+];
+
+export default function stateCardType(hass, stateObj) {
+  if (stateObj.state === 'unavailable') {
+    return 'display';
+  }
+
+  const domain = computeStateDomain(stateObj);
+
+  if (DOMAINS_WITH_CARD.includes(domain)) {
+    return domain;
+  } else if (canToggleState(hass, stateObj) &&
+             stateObj.attributes.control !== 'hidden') {
+    return 'toggle';
+  }
+  return 'display';
+}

--- a/js/common/util/state_more_info_type.js
+++ b/js/common/util/state_more_info_type.js
@@ -1,0 +1,23 @@
+import computeStateDomain from './compute_state_domain.js';
+
+const DOMAINS_WITH_MORE_INFO = [
+  'alarm_control_panel', 'automation', 'camera', 'climate', 'configurator',
+  'cover', 'fan', 'group', 'history_graph', 'light', 'lock', 'media_player', 'script',
+  'sun', 'updater', 'vacuum', 'input_datetime',
+];
+
+const HIDE_MORE_INFO = [
+  'input_select', 'scene', 'input_number', 'input_text'
+];
+
+export default function stateMoreInfoType(stateObj) {
+  const domain = computeStateDomain(stateObj);
+
+  if (DOMAINS_WITH_MORE_INFO.includes(domain)) {
+    return domain;
+  }
+  if (HIDE_MORE_INFO.includes(domain)) {
+    return 'hidden';
+  }
+  return 'default';
+}

--- a/js/compatibility.js
+++ b/js/compatibility.js
@@ -1,3 +1,4 @@
+import 'mdn-polyfills/Array.prototype.includes';
 import 'unfetch/polyfill';
 import objAssign from 'es6-object-assign';
 

--- a/js/util.js
+++ b/js/util.js
@@ -7,6 +7,7 @@
  */
 
 import attributeClassNames from './common/util/attribute_class_names.js';
+import canToggleDomain from './common/util/can_toggle_domain.js';
 import computeStateDomain from './common/util/compute_state_domain.js';
 import computeStateDisplay from './common/util/compute_state_display.js';
 import featureClassNames from './common/util/feature_class_names.js';
@@ -22,6 +23,7 @@ const language = navigator.languages ?
 window.fecha.masks.haDateTime = window.fecha.masks.shortTime + ' ' + window.fecha.masks.mediumDate;
 
 window.hassUtil.attributeClassNames = attributeClassNames;
+window.hassUtil.canToggleDomain = canToggleDomain;
 window.hassUtil.computeDomain = computeStateDomain;
 window.hassUtil.computeStateDisplay = computeStateDisplay;
 window.hassUtil.featureClassNames = featureClassNames;

--- a/js/util.js
+++ b/js/util.js
@@ -8,6 +8,7 @@
 
 import attributeClassNames from './common/util/attribute_class_names.js';
 import canToggleDomain from './common/util/can_toggle_domain.js';
+import canToggleState from './common/util/can_toggle_state.js';
 import computeStateDomain from './common/util/compute_state_domain.js';
 import computeStateDisplay from './common/util/compute_state_display.js';
 import featureClassNames from './common/util/feature_class_names.js';
@@ -24,6 +25,7 @@ window.fecha.masks.haDateTime = window.fecha.masks.shortTime + ' ' + window.fech
 
 window.hassUtil.attributeClassNames = attributeClassNames;
 window.hassUtil.canToggleDomain = canToggleDomain;
+window.hassUtil.canToggleState = canToggleState;
 window.hassUtil.computeDomain = computeStateDomain;
 window.hassUtil.computeStateDisplay = computeStateDisplay;
 window.hassUtil.featureClassNames = featureClassNames;

--- a/js/util.js
+++ b/js/util.js
@@ -9,6 +9,7 @@
 import attributeClassNames from './common/util/attribute_class_names.js';
 import computeStateDomain from './common/util/compute_state_domain.js';
 import computeStateDisplay from './common/util/compute_state_display.js';
+import featureClassNames from './common/util/feature_class_names.js';
 import formatDate from './common/util/format_date.js';
 import formatDateTime from './common/util/format_date_time.js';
 import formatTime from './common/util/format_time.js';
@@ -23,6 +24,7 @@ window.fecha.masks.haDateTime = window.fecha.masks.shortTime + ' ' + window.fech
 window.hassUtil.attributeClassNames = attributeClassNames;
 window.hassUtil.computeDomain = computeStateDomain;
 window.hassUtil.computeStateDisplay = computeStateDisplay;
+window.hassUtil.featureClassNames = featureClassNames;
 window.hassUtil.formatDate = dateObj => formatDate(dateObj, language);
 window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, language);
 window.hassUtil.formatTime = dateObj => formatTime(dateObj, language);

--- a/js/util.js
+++ b/js/util.js
@@ -16,6 +16,7 @@ import formatDate from './common/util/format_date.js';
 import formatDateTime from './common/util/format_date_time.js';
 import formatTime from './common/util/format_time.js';
 import stateCardType from './common/util/state_card_type.js';
+import stateMoreInfoType from './common/util/state_more_info_type.js';
 
 window.hassUtil = window.hassUtil || {};
 
@@ -34,3 +35,4 @@ window.hassUtil.formatDate = dateObj => formatDate(dateObj, language);
 window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, language);
 window.hassUtil.formatTime = dateObj => formatTime(dateObj, language);
 window.hassUtil.stateCardType = stateCardType;
+window.hassUtil.stateMoreInfoType = stateMoreInfoType;

--- a/js/util.js
+++ b/js/util.js
@@ -15,6 +15,7 @@ import featureClassNames from './common/util/feature_class_names.js';
 import formatDate from './common/util/format_date.js';
 import formatDateTime from './common/util/format_date_time.js';
 import formatTime from './common/util/format_time.js';
+import stateCardType from './common/util/state_card_type.js';
 
 window.hassUtil = window.hassUtil || {};
 
@@ -32,3 +33,4 @@ window.hassUtil.featureClassNames = featureClassNames;
 window.hassUtil.formatDate = dateObj => formatDate(dateObj, language);
 window.hassUtil.formatDateTime = dateObj => formatDateTime(dateObj, language);
 window.hassUtil.formatTime = dateObj => formatTime(dateObj, language);
+window.hassUtil.stateCardType = stateCardType;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev-watch": "npm run gulp watch_ru_all gen-service-worker",
     "dev-es5": "npm run gulp ru_all_es5 gen-service-worker-es5",
     "dev-watch-es5": "npm run gulp watch_ru_all_es5 gen-service-worker-es5",
-    "lint_js": "eslint src panels js --ext js,html",
+    "lint_js": "eslint src panels js test-mocha --ext js,html",
     "lint_html": "ls -1 src/home-assistant.html panels/**/ha-panel-*.html | xargs polymer lint --input",
     "mocha": "node_modules/.bin/mocha --opts test-mocha/mocha.opts",
     "test": "npm run lint_js && npm run lint_html && npm run mocha"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "gulp-vinyl-zip": "^2.1.0",
     "home-assistant-js-websocket": "^1.1.2",
     "html-minifier": "^3.5.6",
+    "mdn-polyfills": "^5.5.0",
     "merge-stream": "^1.0.1",
     "mocha": "^4.0.1",
     "parse5": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "bower": "^1.8.2",
+    "chai": "^4.1.2",
     "css-slam": "^2.0.2",
     "del": "^3.0.0",
     "es6-object-assign": "^1.1.0",

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -11,17 +11,7 @@ window.hassUtil.DEFAULT_ICON = 'mdi:bookmark';
 
 window.hassUtil.OFF_STATES = ['off', 'closed', 'unlocked'];
 
-window.hassUtil.DOMAINS_WITH_MORE_INFO = [
-  'alarm_control_panel', 'automation', 'camera', 'climate', 'configurator',
-  'cover', 'fan', 'group', 'history_graph', 'light', 'lock', 'media_player', 'script',
-  'sun', 'updater', 'vacuum', 'input_datetime',
-];
-
 window.hassUtil.DOMAINS_WITH_NO_HISTORY = ['camera', 'configurator', 'history_graph', 'scene'];
-
-window.hassUtil.HIDE_MORE_INFO = [
-  'input_select', 'scene', 'input_number', 'input_text'
-];
 
 // Update root's child element to be newElementTag replacing another existing child if any.
 // Copy attributes into the child element.
@@ -83,18 +73,6 @@ window.hassUtil.relativeTime.tests = [
   24, 'hour',
   7, 'day',
 ];
-
-window.hassUtil.stateMoreInfoType = function (stateObj) {
-  var domain = window.hassUtil.computeDomain(stateObj);
-
-  if (window.hassUtil.DOMAINS_WITH_MORE_INFO.indexOf(domain) !== -1) {
-    return domain;
-  }
-  if (window.hassUtil.HIDE_MORE_INFO.indexOf(domain) !== -1) {
-    return 'hidden';
-  }
-  return 'default';
-};
 
 window.hassUtil.domainIcon = function (domain, state) {
   switch (domain) {

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -11,19 +11,6 @@ window.hassUtil.DEFAULT_ICON = 'mdi:bookmark';
 
 window.hassUtil.OFF_STATES = ['off', 'closed', 'unlocked'];
 
-window.hassUtil.DOMAINS_WITH_CARD = [
-  'climate',
-  'cover',
-  'configurator',
-  'input_select',
-  'input_number',
-  'input_text',
-  'media_player',
-  'scene',
-  'script',
-  'weblink',
-];
-
 window.hassUtil.DOMAINS_WITH_MORE_INFO = [
   'alarm_control_panel', 'automation', 'camera', 'climate', 'configurator',
   'cover', 'fan', 'group', 'history_graph', 'light', 'lock', 'media_player', 'script',
@@ -96,22 +83,6 @@ window.hassUtil.relativeTime.tests = [
   24, 'hour',
   7, 'day',
 ];
-
-window.hassUtil.stateCardType = function (hass, stateObj) {
-  if (stateObj.state === 'unavailable') {
-    return 'display';
-  }
-
-  var domain = window.hassUtil.computeDomain(stateObj);
-
-  if (window.hassUtil.DOMAINS_WITH_CARD.indexOf(domain) !== -1) {
-    return domain;
-  } else if (window.hassUtil.canToggleState(hass, stateObj) &&
-             stateObj.attributes.control !== 'hidden') {
-    return 'toggle';
-  }
-  return 'display';
-};
 
 window.hassUtil.stateMoreInfoType = function (stateObj) {
   var domain = window.hassUtil.computeDomain(stateObj);

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -45,21 +45,6 @@ window.hassUtil.canToggleState = function (hass, stateObj) {
   return window.hassUtil.canToggleDomain(hass, domain);
 };
 
-window.hassUtil.canToggleDomain = function (hass, domain) {
-  var turnOnService;
-  var services = hass.config.services[domain];
-
-  if (domain === 'lock') {
-    turnOnService = 'lock';
-  } else if (domain === 'cover') {
-    turnOnService = 'open_cover';
-  } else {
-    turnOnService = 'turn_on';
-  }
-
-  return services && turnOnService in services;
-};
-
 // Update root's child element to be newElementTag replacing another existing child if any.
 // Copy attributes into the child element.
 window.hassUtil.dynamicContentUpdater = function (root, newElementTag, attributes) {

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -36,18 +36,6 @@ window.hassUtil.HIDE_MORE_INFO = [
   'input_select', 'scene', 'input_number', 'input_text'
 ];
 
-// Expects featureClassNames to be an object mapping feature-bit -> className
-window.hassUtil.featureClassNames = function (stateObj, featureClassNames) {
-  if (!stateObj || !stateObj.attributes.supported_features) return '';
-
-  var features = stateObj.attributes.supported_features;
-
-  return Object.keys(featureClassNames).map(function (feature) {
-    return (features & feature) !== 0 ? featureClassNames[feature] : '';
-  }).join(' ');
-};
-
-
 window.hassUtil.canToggleState = function (hass, stateObj) {
   var domain = window.hassUtil.computeDomain(stateObj);
   if (domain === 'group') {

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -36,15 +36,6 @@ window.hassUtil.HIDE_MORE_INFO = [
   'input_select', 'scene', 'input_number', 'input_text'
 ];
 
-window.hassUtil.canToggleState = function (hass, stateObj) {
-  var domain = window.hassUtil.computeDomain(stateObj);
-  if (domain === 'group') {
-    return stateObj.state === 'on' || stateObj.state === 'off';
-  }
-
-  return window.hassUtil.canToggleDomain(hass, domain);
-};
-
 // Update root's child element to be newElementTag replacing another existing child if any.
 // Copy attributes into the child element.
 window.hassUtil.dynamicContentUpdater = function (root, newElementTag, attributes) {

--- a/test-mocha/common/util/attribute_class_names_test.js
+++ b/test-mocha/common/util/attribute_class_names_test.js
@@ -1,6 +1,6 @@
-import attributeClassNames from '../../../js/common/util/attribute_class_names';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import attributeClassNames from '../../../js/common/util/attribute_class_names';
 
 describe('attributeClassNames', () => {
   const attrs = ['mock_attr1', 'mock_attr2'];

--- a/test-mocha/common/util/can_toggle_domain_test.js
+++ b/test-mocha/common/util/can_toggle_domain_test.js
@@ -1,0 +1,39 @@
+import canToggleDomain from '../../../js/common/util/can_toggle_domain';
+
+const assert = require('assert');
+
+describe('canToggleDomain', () => {
+  const hass = {
+    config: {
+      services: {
+        light: {
+          turn_on: null, // Service keys only need to be present for test
+          turn_off: null,
+        },
+        lock: {
+          lock: null,
+          unlock: null,
+        },
+        sensor: {
+          custom_service: null,
+        },
+      },
+    },
+  };
+
+  it('Detects lights toggle', () => {
+    assert.strictEqual(canToggleDomain(hass, 'light'), true);
+  });
+
+  it('Detects locks toggle', () => {
+    assert.strictEqual(canToggleDomain(hass, 'lock'), true);
+  });
+
+  it('Detects sensors do not toggle', () => {
+    assert.strictEqual(canToggleDomain(hass, 'sensor'), false);
+  });
+
+  it('Detects binary sensors do not toggle', () => {
+    assert.strictEqual(canToggleDomain(hass, 'binary_sensor'), undefined);
+  });
+});

--- a/test-mocha/common/util/can_toggle_domain_test.js
+++ b/test-mocha/common/util/can_toggle_domain_test.js
@@ -34,6 +34,6 @@ describe('canToggleDomain', () => {
   });
 
   it('Detects binary sensors do not toggle', () => {
-    assert.strictEqual(canToggleDomain(hass, 'binary_sensor'), undefined);
+    assert.strictEqual(canToggleDomain(hass, 'binary_sensor'), false);
   });
 });

--- a/test-mocha/common/util/can_toggle_domain_test.js
+++ b/test-mocha/common/util/can_toggle_domain_test.js
@@ -1,6 +1,6 @@
-import canToggleDomain from '../../../js/common/util/can_toggle_domain';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import canToggleDomain from '../../../js/common/util/can_toggle_domain';
 
 describe('canToggleDomain', () => {
   const hass = {
@@ -22,18 +22,18 @@ describe('canToggleDomain', () => {
   };
 
   it('Detects lights toggle', () => {
-    assert.strictEqual(canToggleDomain(hass, 'light'), true);
+    assert.isTrue(canToggleDomain(hass, 'light'));
   });
 
   it('Detects locks toggle', () => {
-    assert.strictEqual(canToggleDomain(hass, 'lock'), true);
+    assert.isTrue(canToggleDomain(hass, 'lock'));
   });
 
   it('Detects sensors do not toggle', () => {
-    assert.strictEqual(canToggleDomain(hass, 'sensor'), false);
+    assert.isFalse(canToggleDomain(hass, 'sensor'));
   });
 
   it('Detects binary sensors do not toggle', () => {
-    assert.strictEqual(canToggleDomain(hass, 'binary_sensor'), false);
+    assert.isFalse(canToggleDomain(hass, 'binary_sensor'));
   });
 });

--- a/test-mocha/common/util/can_toggle_state_test.js
+++ b/test-mocha/common/util/can_toggle_state_test.js
@@ -1,0 +1,40 @@
+import { assert } from 'chai';
+
+import canToggleState from '../../../js/common/util/can_toggle_state';
+
+describe('canToggleState', () => {
+  const hass = {
+    config: {
+      services: {
+        light: {
+          turn_on: null, // Service keys only need to be present for test
+          turn_off: null,
+        },
+      },
+    },
+  };
+
+  it('Detects lights toggle', () => {
+    const stateObj = {
+      entity_id: 'light.bla',
+      state: 'on',
+    };
+    assert.isTrue(canToggleState(hass, stateObj));
+  });
+
+  it('Detects group with toggle', () => {
+    const stateObj = {
+      entity_id: 'group.bla',
+      state: 'on',
+    };
+    assert.isTrue(canToggleState(hass, stateObj));
+  });
+
+  it('Detects group without toggle', () => {
+    const stateObj = {
+      entity_id: 'group.devices',
+      state: 'home',
+    };
+    assert.isFalse(canToggleState(hass, stateObj));
+  });
+});

--- a/test-mocha/common/util/compute_domain.js
+++ b/test-mocha/common/util/compute_domain.js
@@ -1,6 +1,6 @@
-import computeDomain from '../../../js/common/util/compute_domain';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import computeDomain from '../../../js/common/util/compute_domain';
 
 describe('computeDomain', () => {
   it('Returns domains', () => {

--- a/test-mocha/common/util/compute_state_display.js
+++ b/test-mocha/common/util/compute_state_display.js
@@ -1,6 +1,6 @@
-import computeStateDisplay from '../../../js/common/util/compute_state_display';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import computeStateDisplay from '../../../js/common/util/compute_state_display';
 
 describe('computeStateDisplay', () => {
   const haLocalize = function (namespace, message, ...args) {

--- a/test-mocha/common/util/compute_state_display.js
+++ b/test-mocha/common/util/compute_state_display.js
@@ -156,7 +156,7 @@ describe('computeStateDisplay', () => {
   });
 
   it('Localizes custom state', () => {
-    const altHaLocalize = function (namespace, message, ...args) {
+    const altHaLocalize = function () {
       // No matches can be found
       return null;
     };

--- a/test-mocha/common/util/compute_state_domain.js
+++ b/test-mocha/common/util/compute_state_domain.js
@@ -1,6 +1,6 @@
-import computeStateDomain from '../../../js/common/util/compute_state_domain.js';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import computeStateDomain from '../../../js/common/util/compute_state_domain.js';
 
 describe('computeStateDomain', () => {
   it('Detects sensor domain', () => {

--- a/test-mocha/common/util/feature_class_names_test.js
+++ b/test-mocha/common/util/feature_class_names_test.js
@@ -1,0 +1,56 @@
+import featureClassNames from '../../../js/common/util/feature_class_names';
+
+const assert = require('assert');
+
+describe('featureClassNames', () => {
+  const classNames = {
+    1: 'has-feature_a',
+    2: 'has-feature_b',
+    4: 'has-feature_c',
+    8: 'has-feature_d',
+  };
+
+  it('Skips null states', () => {
+    const stateObj = null;
+    assert.strictEqual(
+      featureClassNames(stateObj, classNames),
+      ''
+    );
+  });
+
+  it('Matches no features', () => {
+    const stateObj = {
+      attributes: {
+        supported_features: 64,
+      },
+    };
+    assert.strictEqual(
+      featureClassNames(stateObj, classNames),
+      '   '
+    );
+  });
+
+  it('Matches one feature', () => {
+    const stateObj = {
+      attributes: {
+        supported_features: 72,
+      },
+    };
+    assert.strictEqual(
+      featureClassNames(stateObj, classNames),
+      '   has-feature_d'
+    );
+  });
+
+  it('Matches two features', () => {
+    const stateObj = {
+      attributes: {
+        supported_features: 73,
+      },
+    };
+    assert.strictEqual(
+      featureClassNames(stateObj, classNames),
+      'has-feature_a   has-feature_d'
+    );
+  });
+});

--- a/test-mocha/common/util/feature_class_names_test.js
+++ b/test-mocha/common/util/feature_class_names_test.js
@@ -1,6 +1,6 @@
-import featureClassNames from '../../../js/common/util/feature_class_names';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import featureClassNames from '../../../js/common/util/feature_class_names';
 
 describe('featureClassNames', () => {
   const classNames = {

--- a/test-mocha/common/util/feature_class_names_test.js
+++ b/test-mocha/common/util/feature_class_names_test.js
@@ -26,7 +26,7 @@ describe('featureClassNames', () => {
     };
     assert.strictEqual(
       featureClassNames(stateObj, classNames),
-      '   '
+      ''
     );
   });
 
@@ -38,7 +38,7 @@ describe('featureClassNames', () => {
     };
     assert.strictEqual(
       featureClassNames(stateObj, classNames),
-      '   has-feature_d'
+      'has-feature_d'
     );
   });
 
@@ -50,7 +50,7 @@ describe('featureClassNames', () => {
     };
     assert.strictEqual(
       featureClassNames(stateObj, classNames),
-      'has-feature_a   has-feature_d'
+      'has-feature_a has-feature_d'
     );
   });
 });

--- a/test-mocha/common/util/format_date.js
+++ b/test-mocha/common/util/format_date.js
@@ -1,6 +1,6 @@
-import formatDate from '../../../js/common/util/format_date';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import formatDate from '../../../js/common/util/format_date';
 
 describe('formatDate', () => {
   const dateObj = new Date(

--- a/test-mocha/common/util/format_date_time.js
+++ b/test-mocha/common/util/format_date_time.js
@@ -1,6 +1,6 @@
-import formatDateTime from '../../../js/common/util/format_date_time';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import formatDateTime from '../../../js/common/util/format_date_time';
 
 describe('formatDateTime', () => {
   const dateObj = new Date(

--- a/test-mocha/common/util/format_time.js
+++ b/test-mocha/common/util/format_time.js
@@ -1,6 +1,6 @@
-import formatTime from '../../../js/common/util/format_time';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import formatTime from '../../../js/common/util/format_time';
 
 describe('formatTime', () => {
   const dateObj = new Date(

--- a/test-mocha/common/util/location.js
+++ b/test-mocha/common/util/location.js
@@ -1,6 +1,6 @@
-import { hasLocation } from '../../../js/common/util/location';
+import { assert } from 'chai';
 
-const assert = require('assert');
+import { hasLocation } from '../../../js/common/util/location';
 
 describe('hasLocation', () => {
   it('flags states with location', () => {

--- a/test-mocha/common/util/state_card_type_test.js
+++ b/test-mocha/common/util/state_card_type_test.js
@@ -1,0 +1,55 @@
+import { assert } from 'chai';
+
+import stateCardType from '../../../js/common/util/state_card_type';
+
+describe('stateCardType', () => {
+  const hass = {
+    config: {
+      services: {
+        light: {
+          turn_on: null, // Service keys only need to be present for test
+          turn_off: null,
+        },
+      },
+    },
+  };
+
+  it('Returns display for unavailable states', () => {
+    const stateObj = {
+      state: 'unavailable',
+    };
+    assert.strictEqual(stateCardType(hass, stateObj), 'display');
+  });
+
+  it('Returns media_player for media_player states', () => {
+    const stateObj = {
+      entity_id: 'media_player.bla',
+    };
+    assert.strictEqual(stateCardType(hass, stateObj), 'media_player');
+  });
+
+  it('Returns toggle for states that can toggle', () => {
+    const stateObj = {
+      entity_id: 'light.bla',
+      attributes: {},
+    };
+    assert.strictEqual(stateCardType(hass, stateObj), 'toggle');
+  });
+
+  it('Returns display for states with hidden control', () => {
+    const stateObj = {
+      entity_id: 'light.bla',
+      attributes: {
+        control: 'hidden',
+      },
+    };
+    assert.strictEqual(stateCardType(hass, stateObj), 'display');
+  });
+
+  it('Returns display for entities that cannot toggle', () => {
+    const stateObj = {
+      entity_id: 'sensor.bla',
+    };
+    assert.strictEqual(stateCardType(hass, stateObj), 'display');
+  });
+});

--- a/test-mocha/common/util/state_more_info_type_test.js
+++ b/test-mocha/common/util/state_more_info_type_test.js
@@ -1,0 +1,28 @@
+import { assert } from 'chai';
+
+import stateMoreInfoType from '../../../js/common/util/state_more_info_type';
+
+describe('stateMoreInfoType', () => {
+  it('Returns media_player for media_player states', () => {
+    const stateObj = {
+      entity_id: 'media_player.bla',
+    };
+    assert.strictEqual(stateMoreInfoType(stateObj), 'media_player');
+  });
+
+  it('Returns hidden for input_select states', () => {
+    const stateObj = {
+      entity_id: 'input_select.bla',
+      attributes: {},
+    };
+    assert.strictEqual(stateMoreInfoType(stateObj), 'hidden');
+  });
+
+  it('Returns default for switch states', () => {
+    const stateObj = {
+      entity_id: 'switch.bla',
+      attributes: {},
+    };
+    assert.strictEqual(stateMoreInfoType(stateObj), 'default');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5194,6 +5194,10 @@ md5@^2.2.1:
     crypt "~0.0.1"
     is-buffer "~1.1.1"
 
+mdn-polyfills@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/mdn-polyfills/-/mdn-polyfills-5.5.0.tgz#b8ce237a0a7cbae66c56a6fdd0334b659360d364"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,7 +1707,7 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chai@^4.0.2:
+chai@^4.0.2, chai@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
   dependencies:


### PR DESCRIPTION
## Description
This PR moves more of our JS logic out of hass-util and into separate files. These are then unit tested with our mocha tests.

I switched from the node assert module to the chai assert, to allow us to use some of the improved syntax. I've also enabled eslint for our mocha tests.

There are separate commits for everything that was done if that helps when reviewing.