### PR TITLE
Fix mdi icons for presence device_class

### DIFF
--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -229,7 +229,7 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'plug':
       return activated ? 'mdi:power-plug-off' : 'mdi:power-plug';
     case 'presence':
-      return activated ? 'mdi:home' : 'mdi:home-outline';
+      return activated ? 'mdi:home-outline' : 'mdi:home';
     default:
       return activated ? 'mdi:radiobox-blank' : 'mdi:checkbox-marked-circle';
   }


### PR DESCRIPTION
The device_class logic was inverted. 

Fixes https://github.com/home-assistant/home-assistant/issues/10946