### PR TITLE
Another dropdown-hidden-behind-header fix

### DIFF
--- a/src/layouts/ha-app-layout.html
+++ b/src/layouts/ha-app-layout.html
@@ -56,10 +56,12 @@ transform: translate(0) is added.
       #contentContainer {
         /* Create a stacking context here so that all children appear below the header. */
         position: relative;
+        z-index: 0;
+      }
+      .scroll-limiter {
         /* Using 'transform' will cause 'position: fixed' elements to behave like
            'position: absolute' relative to this element. */
         transform: translate(0);
-        z-index: 0;
       }
       :host([has-scrolling-region]) .scroll-limiter {
         overflow-y: auto;


### PR DESCRIPTION
Another dropdown-hidden-behind-header fix.

The fix introduced in #542 worked, until it was broken by #632 that fixed FAB position.

Current fix was tested to work for both dropdowns and FAB

Fixes  home-assistant/home-assistant#10433
Replaces #708