### PR TITLE
Convert toggle margin to padding

### DIFF
--- a/src/state-summary/state-card-toggle.html
+++ b/src/state-summary/state-card-toggle.html
@@ -10,7 +10,8 @@
     <style is="custom-style" include="iron-flex iron-flex-alignment"></style>
     <style>
       ha-entity-toggle {
-        margin-left: 16px;
+        margin: -4px -16px -4px 0;
+        padding: 4px 16px;
       }
     </style>
 


### PR DESCRIPTION
Our toggle is 48x48 px like [material design](https://material.io/guidelines/usability/accessibility.html#accessibility-style) guidelines say.

I have added 11px horizontal space around the toggle that will not activate more-info.

Fixes #714