### PR TITLE
Fix mdi icons for device_class opening

### DIFF
--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -216,7 +216,7 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'occupancy':
       return activated ? 'mdi:home' : 'mdi:home-outline';
     case 'opening':
-      return activated ? 'mdi:crop-square' : 'mdi:exit-to-app';
+      return activated ? 'mdi:door-closed' : 'mdi:door-open';
     case 'sound':
       return activated ? 'mdi:music-note-off' : 'mdi:music-note';
     case 'vibration':


### PR DESCRIPTION
This PR replaces the old MDI icons for the device_class `opening` that were hardly related to opening/closing with the newly introduced door open/close icons. Here are the new icons:
Open: ![image](https://user-images.githubusercontent.com/18319734/33643794-45b169b8-da0f-11e7-9712-f72dcd3b81e2.png)
Close: ![image](https://user-images.githubusercontent.com/18319734/33643811-56c302b6-da0f-11e7-93b8-152ed8c98bc1.png)



Replaces the need to use custom icons like https://github.com/home-assistant/home-assistant/issues/10316