### PR TITLE
Fix pushSupported not bubbling to config-core

### DIFF
--- a/panels/config/core/ha-config-section-push-notifications.html
+++ b/panels/config/core/ha-config-section-push-notifications.html
@@ -44,7 +44,10 @@ class HaConfigSectionPushNotifications extends Polymer.Element {
     return {
       hass: Object,
       isWide: Boolean,
-      pushSupported: Boolean,
+      pushSupported: {
+        type: Boolean,
+        notify: true,
+      },
     };
   }
 }


### PR DESCRIPTION
I missed this as part of #700. pushSupported needs to bubble up to config-core to correctly hide the push notification section when not supported.