### PR TITLE
Fix bug on initial fragment load

### DIFF
--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -309,8 +309,7 @@ class HomeAssistant extends Polymer.Element {
   }
 
   loadTranslationFragment(panelUrl) {
-    if (this.hass.translationMetadata
-      && this.hass.translationMetadata.fragments.includes(panelUrl)) {
+    if (window.translationMetadata.fragments.includes(panelUrl)) {
       this.loadResources(panelUrl);
     }
   }


### PR DESCRIPTION
Currently, the translation fragment doesn't load if the first page after login is the translation fragment target. This PR ensures that translation fragments can load before the initial hass data is set. The translation metadata is imported on this page, so it is already safe to use directly.