### PR TITLE
Problem device class

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -107,6 +107,10 @@
         "off": "[%key:state::device_tracker::not_home%]",
         "on": "[%key:state::device_tracker::home%]"
       },
+      "problem": {
+        "off": "[%key:state::plant::ok%]",
+        "on": "[%key:state::plant::problem%]"
+      },
       "safety": {
         "off": "Safe",
         "on": "Unsafe"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -108,8 +108,8 @@
         "on": "[%key:state::device_tracker::home%]"
       },
       "problem": {
-        "off": "[%key:state::plant::ok%]",
-        "on": "[%key:state::plant::problem%]"
+        "off": "OK",
+        "on": "Problem"
       },
       "safety": {
         "off": "Safe",
@@ -184,8 +184,8 @@
       "stopped": "[%key:state::cover::stopped%]",
       "locked": "[%key:state::lock::locked%]",
       "unlocked": "[%key:state::lock::unlocked%]",
-      "ok": "[%key:state::plant::ok%]",
-      "problem": "[%key:state::plant::problem%]"
+      "ok": "[%key:state::binary_sensor::problem::off%]",
+      "problem": "[%key:state::binary_sensor::problem::on%]"
     },
     "input_boolean": {
       "off": "[%key:state::default::off%]",
@@ -208,8 +208,8 @@
       "standby": "Standby"
     },
     "plant": {
-      "ok": "OK",
-      "problem": "Problem"
+      "ok": "[%key:state::binary_sensor::problem::off%]",
+      "problem": "[%key:state::binary_sensor::problem::on%]"
     },
     "remote": {
       "off": "[%key:state::default::off%]",

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -225,6 +225,7 @@ window.hassUtil.binarySensorIcon = function (state) {
       return activated ? 'mdi:crop-portrait' : 'mdi:vibrate';
     case 'gas':
     case 'power':
+    case 'problem':
     case 'safety':
     case 'smoke':
       return activated ? 'mdi:verified' : 'mdi:alert';


### PR DESCRIPTION
## Description
I was setting up a binary sensor to detect a CI build status, and realized we don't have a good device class to represent a generic problem detection. This PR adds a problem device class.

Docs: https://github.com/home-assistant/home-assistant.github.io/pull/4200
Backend: https://github.com/home-assistant/home-assistant/pull/11130