### PR TITLE
Don't use global event. It is unsupported in Chrome64

### DIFF
--- a/.eslintrc-hound.json
+++ b/.eslintrc-hound.json
@@ -43,7 +43,7 @@
     "radix": 0,
     "no-alert": 0,
     "prefer-destructuring": 0,
-    "no-restricted-globals": 0,
+    "no-restricted-globals": [2, "event"],
     "prefer-promise-reject-errors": 0,
     "import/prefer-default-export": 0,
     "import/no-unresolved": 0,

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -287,7 +287,7 @@ class HaPanelDevInfo extends Polymer.Element {
     return window.hassUtil.formatTime(new Date(date * 1000));
   }
 
-  openLog() {
+  openLog(event) {
     this.selectedItem = event.model.item;
     this.$.showlog.open();
   }


### PR DESCRIPTION
Don't use global event. It is nonstandard and seems that it is dropped in Chrome64