### PR TITLE
Sort add-ons in the Hass.io add-ons store

### DIFF
--- a/panels/hassio/addon-store/hassio-addon-store-overview.html
+++ b/panels/hassio/addon-store/hassio-addon-store-overview.html
@@ -91,6 +91,22 @@ class HassioAddonStoreOverview extends window.hassMixins.EventsMixin(Polymer.Ele
   computeAddOns(repo) {
     return this.addons.filter(function (addon) {
       return addon.repository === repo;
+    }).sort(function (addonA, addonB) {
+      if (addonA.name < addonB.name) {
+        return -1;
+      }
+      if (addonA.name > addonB.name) {
+        return 1;
+      }
+      return 0;
+    }).sort(function (addonA, addonB) {
+      if (addonA.installed && !addonB.installed) {
+        return -1;
+      }
+      if (!addonA.installed && addonB.installed) {
+        return 1;
+      }
+      return 0;
     });
   }
 


### PR DESCRIPTION
# Problem/Motivation

I was a little annoyed about the add-ons store in the Hass.io panel since the add-ons per repository where unsorted.

I have added sorting by installation status and alphabet. This way installed add-ons are placed on top of the list.

See screenshot for the result.

# Screenshot
![screen shot 2017-12-14 at 18 40 25](https://user-images.githubusercontent.com/195327/34006370-53a94810-e0fe-11e7-9d29-dbf6fbed0fe1.png)

---
Signed-off-by: Franck Nijhof <frenck@addons.community>