### PR TITLE
Adds Rebuild button for local add-ons

### DIFF
--- a/panels/hassio/addon-view/hassio-addon-info.html
+++ b/panels/hassio/addon-view/hassio-addon-info.html
@@ -161,6 +161,13 @@
             path="[[_pathStop(addonInfo.slug)]]"
           >Stop</ha-call-api-button>
         </template>
+        <template is='dom-if' if='[[addonState.build]]'>
+          <ha-call-api-button
+            class='warning'
+            hass='[[hass]]'
+            path="[[_pathRebuild(addonInfo.slug)]]"
+          >Rebuild</ha-call-api-button>
+        </template>
         <ha-call-api-button
           class='warning'
           hass='[[hass]]'
@@ -206,6 +213,10 @@ class HassioAddonInfo extends Polymer.Element {
 
   _pathRestart(addon) {
     return 'hassio/addons/' + addon + '/restart';
+  }
+
+  _pathRebuild(addon) {
+    return 'hassio/addons/' + addon + '/rebuild';
   }
 
   _pathUninstall(addon) {


### PR DESCRIPTION
# Problem/Motivation

When a user created add-ons, he needs to uninstall and install the add-on to see how a recent change works out. While this method works, it results in a loss of current settings and data. Furthermore, it makes it difficult to test/simulate add-on upgrades.

# Proposed change

This PR adds a button to the add-on view UI in the Hass.io panel, which exposes a "Rebuild"  button when the add-on was build locally. Hass.io already exposes this rebuild feature via its API, but it was never added to the interface.

# Screenshot
![screen shot 2017-12-14 at 20 34 13](https://user-images.githubusercontent.com/195327/34010769-33baab92-e10e-11e7-880b-77303fad2c4d.png)
