### PR TITLE
Changed behaviour of selecting base entity.

### DIFF
--- a/src/more-infos/more-info-group.html
+++ b/src/more-infos/more-info-group.html
@@ -73,7 +73,7 @@ class MoreInfoGroup extends Polymer.Element {
     var el;
 
     if (states && states.length > 0) {
-      baseStateObj = states[0];
+      baseStateObj = states.find(s => s.state === 'on') || states[0];
 
       groupDomainStateObj = Object.assign({}, baseStateObj, {
         entity_id: stateObj.entity_id,


### PR DESCRIPTION
Following [Display controls for all members of group...](https://github.com/home-assistant/home-assistant-polymer/pull/61#issuecomment-351988030) this slightly changes the way the base entity is selected: base entity is now the first active entity. If none is active, the old behaviour is used, selecting the first entity.