### PR TITLE
Define textual state for connectivity device_class

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -84,8 +84,8 @@
         "on": "Low"
       },
       "connectivity": {
-        "off": "Offline",
-        "on": "Online"
+        "off": "Disconnected",
+        "on": "Connected"
       },
       "gas": {
         "off": "Clear",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -83,6 +83,10 @@
         "off": "Normal",
         "on": "Low"
       },
+      "connectivity": {
+        "off": "Offline",
+        "on": "Online"
+      },
       "gas": {
         "off": "Clear",
         "on": "Detected"


### PR DESCRIPTION
Define textual state for connectivity `device_class` for `binary_sensor`.

Without this addition, a binary sensor using the connectivity device class is simply shown as `Off` or `On`. The icon does change but only if the user hasn't defined a custom icon.


I suppose we could also use `Not connected` / `Disconnected` and `Connected` instead of `Offline` and `Online`.