### PR TITLE
Fix for older Chrome browser.

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,8 +85,7 @@
         var e = document.createElement('script');
         e.onerror = initError;
         e.src = '/static/webcomponents-lite.js';
-        if (document.readyState === 'loading' &&
-          ('import' in document.createElement('link'))) {
+        if ('import' in document.createElement('link')) {
           document.write(e.outerHTML);
         } else {
           document.head.appendChild(e);

--- a/index.html
+++ b/index.html
@@ -85,7 +85,12 @@
         var e = document.createElement('script');
         e.onerror = initError;
         e.src = '/static/webcomponents-lite.js';
-        document.head.appendChild(e);
+        if (document.readyState === 'loading' &&
+          ('import' in document.createElement('link'))) {
+          document.write(e.outerHTML);
+        } else {
+          document.head.appendChild(e);
+        }
       }
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function () {


### PR DESCRIPTION
The HTML import sometimes run before webcomponents polyfill loaded on Chrome 53.
Reading code from [`webcomponents-loader.js`](https://github.com/webcomponents/webcomponentsjs/blob/master/webcomponents-loader.js) they used `document.write` on older version of Chrome browser to ensure it load before HTML import.
Follow up for
home-assistant/home-assistant-polymer#730