### PR TITLE
Additional device classes for binary sensors

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -83,6 +83,10 @@
         "off": "Normal",
         "on": "Low"
       },
+      "cold": {
+        "off": "[%key:state::binary_sensor::battery::off%]",
+        "on": "Cold"
+      },
       "connectivity": {
         "off": "Disconnected",
         "on": "Connected"
@@ -98,6 +102,10 @@
       "gas": {
         "off": "Clear",
         "on": "Detected"
+      },
+      "heat": {
+        "off": "[%key:state::binary_sensor::battery::off%]",
+        "on": "Hot"
       },
       "moisture": {
         "off": "Dry",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -87,6 +87,14 @@
         "off": "Disconnected",
         "on": "Connected"
       },
+      "door": {
+        "off": "Closed",
+        "on": "Open"
+      },
+      "garage_door": {
+        "off": "[%key:state::binary_sensor::door::off%]",
+        "on": "[%key:state::binary_sensor::door::on%]"
+      },
       "gas": {
         "off": "Clear",
         "on": "Detected"
@@ -104,8 +112,8 @@
         "on": "[%key:state::binary_sensor::gas::on%]"
       },
       "opening": {
-        "off": "Closed",
-        "on": "Open"
+        "off": "[%key:state::binary_sensor::door::off%]",
+        "on": "[%key:state::binary_sensor::door::on%]"
       },
       "presence": {
         "off": "[%key:state::device_tracker::not_home%]",
@@ -130,6 +138,10 @@
       "vibration": {
         "off": "[%key:state::binary_sensor::gas::off%]",
         "on": "[%key:state::binary_sensor::gas::on%]"
+      },
+      "window": {
+        "off": "[%key:state::binary_sensor::door::off%]",
+        "on": "[%key:state::binary_sensor::door::on%]"
       }
     },
     "calendar": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -92,12 +92,12 @@
         "on": "Connected"
       },
       "door": {
-        "off": "Closed",
-        "on": "Open"
+        "off": "[%key:state::binary_sensor::opening::off%]",
+        "on": "[%key:state::binary_sensor::opening::on%]"
       },
       "garage_door": {
-        "off": "[%key:state::binary_sensor::door::off%]",
-        "on": "[%key:state::binary_sensor::door::on%]"
+        "off": "[%key:state::binary_sensor::opening::off%]",
+        "on": "[%key:state::binary_sensor::opening::on%]"
       },
       "gas": {
         "off": "Clear",
@@ -120,8 +120,8 @@
         "on": "[%key:state::binary_sensor::gas::on%]"
       },
       "opening": {
-        "off": "[%key:state::binary_sensor::door::off%]",
-        "on": "[%key:state::binary_sensor::door::on%]"
+        "off": "Closed",
+        "on": "Open"
       },
       "presence": {
         "off": "[%key:state::device_tracker::not_home%]",
@@ -148,8 +148,8 @@
         "on": "[%key:state::binary_sensor::gas::on%]"
       },
       "window": {
-        "off": "[%key:state::binary_sensor::door::off%]",
-        "on": "[%key:state::binary_sensor::door::on%]"
+        "off": "[%key:state::binary_sensor::opening::off%]",
+        "on": "[%key:state::binary_sensor::opening::on%]"
       }
     },
     "calendar": {

--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -25,7 +25,7 @@ window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
     'sound',
     'vibration',
     'window'
-    ],
+  ],
   cover: ['garage'],
 };
 

--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -3,9 +3,28 @@ window.hassAttributeUtil = window.hassAttributeUtil || {};
 
 window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
   binary_sensor: [
-    'battery', 'cold', 'connectivity', 'gas', 'heat', 'light', 'moisture',
-    'motion', 'moving', 'occupancy', 'opening', 'plug', 'power', 'presence',
-    'safety', 'smoke', 'sound', 'vibration'],
+    'battery',
+    'cold',
+    'connectivity',
+    'door',
+    'garage_door',
+    'gas',
+    'heat',
+    'light',
+    'moisture',
+    'motion',
+    'moving',
+    'occupancy',
+    'opening',
+    'plug',
+    'power',
+    'presence',
+    'problem',
+    'safety',
+    'smoke',
+    'sound',
+    'vibration',
+    'window'],
   cover: ['garage'],
 };
 

--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -24,7 +24,8 @@ window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
     'smoke',
     'sound',
     'vibration',
-    'window'],
+    'window'
+    ],
   cover: ['garage'],
 };
 

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -232,7 +232,7 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'occupancy':
       return activated ? 'mdi:home' : 'mdi:home-outline';
     case 'opening':
-      return activated ? 'mdi:square-outline' : 'mdi:square';
+      return activated ? 'mdi:square' : 'mdi:square-outline';
     case 'plug':
       return activated ? 'mdi:power-plug-off' : 'mdi:power-plug';
     case 'presence':

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -232,7 +232,7 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'occupancy':
       return activated ? 'mdi:home' : 'mdi:home-outline';
     case 'opening':
-      return activated ? 'mdi:crop-square' : 'mdi:exit-to-app';
+      return activated ? 'mdi:square-outline' : 'mdi:square';
     case 'plug':
       return activated ? 'mdi:power-plug-off' : 'mdi:power-plug';
     case 'presence':

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -207,8 +207,22 @@ window.hassUtil.binarySensorIcon = function (state) {
   switch (state.attributes.device_class) {
     case 'battery':
       return activated ? 'mdi:battery' : 'mdi:battery-outline';
+    case 'cold':
+      return activated ? 'mdi:verified' : 'mdi:snowflake';
     case 'connectivity':
       return activated ? 'mdi:server-network-off' : 'mdi:server-network';
+    case 'door':
+      return activated ? 'mdi:door-closed' : 'mdi:door-open';
+    case 'garage_door':
+      return activated ? 'mdi:garage' : 'mdi:garage-open';
+    case 'gas':
+    case 'power':
+    case 'problem':
+    case 'safety':
+    case 'smoke':
+      return activated ? 'mdi:verified' : 'mdi:alert';
+    case 'heat':
+      return activated ? 'mdi:verified' : 'mdi:fire';
     case 'light':
       return activated ? 'mdi:brightness-5' : 'mdi:brightness-7';
     case 'moisture':
@@ -218,21 +232,17 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'occupancy':
       return activated ? 'mdi:home' : 'mdi:home-outline';
     case 'opening':
-      return activated ? 'mdi:door-closed' : 'mdi:door-open';
-    case 'sound':
-      return activated ? 'mdi:music-note-off' : 'mdi:music-note';
-    case 'vibration':
-      return activated ? 'mdi:crop-portrait' : 'mdi:vibrate';
-    case 'gas':
-    case 'power':
-    case 'problem':
-    case 'safety':
-    case 'smoke':
-      return activated ? 'mdi:verified' : 'mdi:alert';
+      return activated ? 'mdi:crop-square' : 'mdi:exit-to-app';
     case 'plug':
       return activated ? 'mdi:power-plug-off' : 'mdi:power-plug';
     case 'presence':
       return activated ? 'mdi:home-outline' : 'mdi:home';
+    case 'sound':
+      return activated ? 'mdi:music-note-off' : 'mdi:music-note';
+    case 'vibration':
+      return activated ? 'mdi:crop-portrait' : 'mdi:vibrate';
+    case 'window':
+      return activated ? 'mdi:window-closed' : 'mdi:window-open';
     default:
       return activated ? 'mdi:radiobox-blank' : 'mdi:checkbox-marked-circle';
   }

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -208,7 +208,7 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'battery':
       return activated ? 'mdi:battery' : 'mdi:battery-outline';
     case 'cold':
-      return activated ? 'mdi:verified' : 'mdi:snowflake';
+      return activated ? 'mdi:thermometer' : 'mdi:snowflake';
     case 'connectivity':
       return activated ? 'mdi:server-network-off' : 'mdi:server-network';
     case 'door':
@@ -222,7 +222,7 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'smoke':
       return activated ? 'mdi:verified' : 'mdi:alert';
     case 'heat':
-      return activated ? 'mdi:verified' : 'mdi:fire';
+      return activated ? 'mdi:thermometer' : 'mdi:fire';
     case 'light':
       return activated ? 'mdi:brightness-5' : 'mdi:brightness-7';
     case 'moisture':


### PR DESCRIPTION
- Add `door`, `garage_door`, and `window` device classes for binary sensors for more accurate icon usage
- Update states for `cold` and `heat` device classes
- Update icons for `cold` and `heat` device classes
- Revert icons for `opening` device class back to generic style
- Related [PR](https://github.com/home-assistant/home-assistant/pull/11280)