### PR TITLE
Mailbox empty state styling

### DIFF
--- a/panels/mailbox/ha-panel-mailbox.html
+++ b/panels/mailbox/ha-panel-mailbox.html
@@ -40,6 +40,11 @@
         cursor: pointer;
       }
 
+      .empty {
+        text-align: center;
+        color: var(--secondary-text-color);
+      }
+
       .header {
         @apply(--paper-font-title);
       }
@@ -99,7 +104,7 @@
       <div class='content'>
         <paper-card>
           <template is='dom-if' if='[[!_messages.length]]'>
-            <div class='card-content'>
+            <div class='card-content empty'>
               [[localize('ui.panel.mailbox.empty')]]
             </div>
           </template>


### PR DESCRIPTION
## Description
This PR adds some small style changes to the empty mailbox state to more closely match material design.

### Screenshots
#### Before
![screenshot from 2017-12-23 11-42-37](https://user-images.githubusercontent.com/1386547/34321202-5542eb9c-e7d7-11e7-9e6a-ea93e0ebf40b.png)
#### After
![screenshot from 2017-12-23 11-47-45](https://user-images.githubusercontent.com/1386547/34321203-5a801f94-e7d7-11e7-9a8f-2831ab8332f5.png)

