### PR TITLE
Use current date for input_datetime time rendering

### DIFF
--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -29,6 +29,7 @@ export default function computeStateDisplay(localize, stateObj, language) {
       } else if (!stateObj.attributes.has_date) {
         const now = new Date();
         date = new Date(
+          // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548 don't use artificial 1970 year.
           now.getFullYear(), now.getMonth(), now.getDay(),
           stateObj.attributes.hour,
           stateObj.attributes.minute

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -27,8 +27,9 @@ export default function computeStateDisplay(localize, stateObj, language) {
         );
         stateObj._stateDisplay = formatDate(date, language);
       } else if (!stateObj.attributes.has_date) {
+        const now = new Date();
         date = new Date(
-          1970, 0, 1,
+          now.getFullYear(), now.getMonth(), now.getDay(),
           stateObj.attributes.hour,
           stateObj.attributes.minute
         );

--- a/js/common/util/compute_state_display.js
+++ b/js/common/util/compute_state_display.js
@@ -29,7 +29,8 @@ export default function computeStateDisplay(localize, stateObj, language) {
       } else if (!stateObj.attributes.has_date) {
         const now = new Date();
         date = new Date(
-          // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548 don't use artificial 1970 year.
+          // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548
+          // don't use artificial 1970 year.
           now.getFullYear(), now.getMonth(), now.getDay(),
           stateObj.attributes.hour,
           stateObj.attributes.minute


### PR DESCRIPTION
This fixes https://github.com/home-assistant/home-assistant/issues/10784 which is in turn caused by https://bugs.chromium.org/p/chromium/issues/detail?id=797548

Using the current date for rendering the time instead of 1970-01-01 should be more reliable