### PR TITLE
Fix nested group more info

### DIFF
--- a/src/more-infos/more-info-group.html
+++ b/src/more-infos/more-info-group.html
@@ -66,33 +66,31 @@ class MoreInfoGroup extends Polymer.Element {
   }
 
   statesChanged(stateObj, states) {
-    var groupDomainStateObj = false;
-    var baseStateObj;
-    var i;
-    var state;
-    var el;
+    let groupDomainStateObj = false;
 
     if (states && states.length > 0) {
-      baseStateObj = states.find(s => s.state === 'on') || states[0];
+      const baseStateObj = states.find(s => s.state === 'on') || states[0];
+      const groupDomain = window.hassUtil.computeDomain(baseStateObj);
 
-      groupDomainStateObj = Object.assign({}, baseStateObj, {
-        entity_id: stateObj.entity_id,
-        attributes: Object.assign({}, baseStateObj.attributes)
-      });
-      var groupDomain = window.hassUtil.computeDomain(groupDomainStateObj);
+      // Groups need to be filtered out or we'll show content of
+      // first child above the children of the current group
+      if (groupDomain !== 'group') {
+        groupDomainStateObj = Object.assign({}, baseStateObj, {
+          entity_id: stateObj.entity_id,
+          attributes: Object.assign({}, baseStateObj.attributes)
+        });
 
-      for (i = 0; i < states.length; i++) {
-        state = states[i];
-
-        if (groupDomain !== window.hassUtil.computeDomain(state)) {
-          groupDomainStateObj = false;
-          break;
+        for (let i = 0; i < states.length; i++) {
+          if (groupDomain !== window.hassUtil.computeDomain(states[i])) {
+            groupDomainStateObj = false;
+            break;
+          }
         }
       }
     }
 
     if (!groupDomainStateObj) {
-      el = Polymer.dom(this.$.groupedControlDetails);
+      const el = Polymer.dom(this.$.groupedControlDetails);
       if (el.lastChild) {
         el.removeChild(el.lastChild);
       }


### PR DESCRIPTION
When we look at a group that contains entities all belonging to the same domain, we would show a more info section for that domain above the individual list of entities.

This was incorrect when looking at a group of groups, as the more info for a group would show the entities inside the first group. After this fix, a group of groups will not show an extra more info section anymore.

Fixes #768