### PR TITLE
Fix history jump

### DIFF
--- a/src/components/state-history-chart-line.html
+++ b/src/components/state-history-chart-line.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/iron-resizable-behavior/iron-resizable-behavior.html">
+<link rel="import" href="../../bower_components/polymer/lib/utils/debounce.html">
 
 <script>
 {
@@ -19,8 +19,7 @@
     return !isNaN(parsed) && isFinite(parsed) ? parsed : null;
   }
 
-  class StateHistoryChartLine extends
-    Polymer.mixinBehaviors([Polymer.IronResizableBehavior], Polymer.Element) {
+  class StateHistoryChartLine extends Polymer.Element {
     static get is() { return 'state-history-chart-line'; }
     static get properties() {
       return {
@@ -55,9 +54,25 @@
       super.connectedCallback();
       this._isAttached = true;
       this.drawChart();
-      this.addEventListener('iron-resize', () => {
-        setTimeout(() => this.drawChart(), 10);
-      });
+
+      this._resizeListener = () => {
+        this._debouncer = Polymer.Debouncer.debounce(
+          this._debouncer,
+          Polymer.Async.timeOut.after(10),
+          () => {
+            if (this._isAttached) {
+              this.drawChart();
+            }
+          }
+        );
+      };
+      window.addEventListener('resize', this._resizeListener);
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this._isAttached = false;
+      window.removeEventListener('resize', this._resizeListener);
     }
 
     dataChanged() {

--- a/src/components/state-history-chart-timeline.html
+++ b/src/components/state-history-chart-timeline.html
@@ -1,9 +1,8 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
-<link rel="import" href="../../bower_components/iron-resizable-behavior/iron-resizable-behavior.html">
+<link rel="import" href="../../bower_components/polymer/lib/utils/debounce.html">
 
 <script>
-class StateHistoryChartTimeline extends
-  Polymer.mixinBehaviors([Polymer.IronResizableBehavior], Polymer.Element) {
+class StateHistoryChartTimeline extends Polymer.Element {
   static get is() { return 'state-history-chart-timeline'; }
   static get properties() {
     return {
@@ -23,9 +22,25 @@ class StateHistoryChartTimeline extends
     super.connectedCallback();
     this._isAttached = true;
     this.drawChart();
-    this.addEventListener('iron-resize', () => {
-      setTimeout(() => this.drawChart(), 10);
-    });
+
+    this._resizeListener = () => {
+      this._debouncer = Polymer.Debouncer.debounce(
+        this._debouncer,
+        Polymer.Async.timeOut.after(10),
+        () => {
+          if (this._isAttached) {
+            this.drawChart();
+          }
+        }
+      );
+    };
+    window.addEventListener('resize', this._resizeListener);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._isAttached = false;
+    window.removeEventListener('resize', this._resizeListener);
   }
 
   dataChanged() {


### PR DESCRIPTION
In #786 got reported that the history page would keep scrolling to the top.

Managed to track it down. It was introduced in #432 as a fix to redraw the graphs when the window resizes. It hadded the `IronResizableBehavior` and started to listen to `iron-resize`.

The problem is that whenever `hass` changes (most often because of a state change), `iron-resize` gets triggered 8 times! (and it's consistently 8 times). A single trigger is already enough to cause the screen to scroll to the top. 

It should trigger 0 times because none of the graph data is changing.

Fixed it by removing iron-resizable-behavior and adding our own listener to window. Also added a debouncer so that we don't keep redrawing while resizing is in progress.

Fixes #786

Not sure if we should merge this as there is a PR open to change up all charting.