### PR TITLE
Enable frontend to request lower-resolution images from cameras

### DIFF
--- a/src/cards/ha-camera-card.html
+++ b/src/cards/ha-camera-card.html
@@ -101,7 +101,10 @@
     updateCameraFeedSrc() {
       var attr = this.stateObj.attributes;
       var time = (new Date()).getTime();
-      this.cameraFeedSrc = attr.entity_picture + '&time=' + time;
+      this.cameraFeedSrc = attr.entity_picture + '&time=' + time
+      if (this.scrollWidth) {
+        this.cameraFeedSrc += '&maxwidth=' + this.scrollWidth;
+      }
     }
 
     imageLoadSuccess() {


### PR DESCRIPTION
This enables the frontend to request images from a camera of a specific size to reduce bandwidth consumption.

The related backend pull request is: https://github.com/home-assistant/home-assistant/pull/11577

This capability should probably be configurable on the backend, though I am not sure the best place to add that.