### PR TITLE
Fix icon for device_class occupancy

### DIFF
--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -241,7 +241,7 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'motion':
       return activated ? 'mdi:walk' : 'mdi:run';
     case 'occupancy':
-      return activated ? 'mdi:home' : 'mdi:home-outline';
+      return activated ? 'mdi:home-outline' : 'mdi:home';
     case 'opening':
       return activated ? 'mdi:square' : 'mdi:square-outline';
     case 'plug':


### PR DESCRIPTION
The icons for `device_class: occupancy` are inverted.

Fixes: https://github.com/home-assistant/home-assistant/issues/11664