### PR TITLE
feature : display input number next to slider

### DIFF
--- a/.eslintrc-hound.json
+++ b/.eslintrc-hound.json
@@ -16,7 +16,8 @@
     "__DEMO__": false,
     "__BUILD__": false,
     "Polymer": true,
-    "webkitSpeechRecognition": false
+    "webkitSpeechRecognition": false,
+    "ResizeObserver": false
   },
   "env": {
     "browser": true,

--- a/src/more-infos/more-info-climate.html
+++ b/src/more-infos/more-info-climate.html
@@ -66,6 +66,17 @@
         width: 100%;
       }
 
+      .container-humidity .single-row {
+          display: flex;
+          height: 50px;
+      }
+
+      .target-humidity {
+        width: 90px;
+        font-size: 200%;
+        margin: auto;
+      }
+
       ha-climate-control.range-control-left,
       ha-climate-control.range-control-right {
         float: left;
@@ -144,17 +155,18 @@
       </div>
 
       <div class='container-humidity'>
-        <div class='single-row'>
-          <div>Target Humidity</div>
-          <paper-slider
-            class='humidity'
-            min='[[stateObj.attributes.min_humidity]]'
-            max='[[stateObj.attributes.max_humidity]]'
-            secondary-progress='[[stateObj.attributes.max_humidity]]'
-            step='1' pin
-            value='[[stateObj.attributes.humidity]]'
-            on-change='targetHumiditySliderChanged'>
-          </paper-slider>
+        <div>Target Humidity</div>
+          <div class="single-row">
+            <div class="target-humidity">[[stateObj.attributes.humidity]] %</div>
+            <paper-slider
+              class='humidity'
+              min='[[stateObj.attributes.min_humidity]]'
+              max='[[stateObj.attributes.max_humidity]]'
+              secondary-progress='[[stateObj.attributes.max_humidity]]'
+              step='1' pin
+              value='[[stateObj.attributes.humidity]]'
+              on-change='targetHumiditySliderChanged'>
+            </paper-slider>
         </div>
       </div>
 

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -122,7 +122,7 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
 
     if (this.$.slider.offsetWidth < 100) {
       this.$.sliderstate.hidden = true;
-    } else if (this.$.slider.offsetWidth >= 145) {
+    } else if (this.$.slider.offsetWidth >= 125) {
       this.$.sliderstate.hidden = false;
     }
   }

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -139,6 +139,7 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
   }
 
   stateObjectChanged(newVal) {
+    const prevMode = this.mode;
     this.setProperties({
       min: Number(newVal.attributes.min),
       max: Number(newVal.attributes.max),
@@ -149,7 +150,7 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
       hiddenbox: (newVal.attributes.mode !== 'box'),
       hiddenslider: (newVal.attributes.mode !== 'slider'),
     });
-    if (this.mode !== newVal.mode) {
+    if (this.mode === 'slider' && prevMode !== 'slider') {
       this.hiddenState();
     }
   }

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -133,7 +133,7 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
     this.step = Number(newVal.attributes.step);
     this.value = Number(newVal.state);
     this.mode = String(newVal.attributes.mode);
-    this.maxlength = this.max.legnth;
+    this.maxlength = this.max.length;
     if (newVal.attributes.mode === 'slider') {
       this.hiddenbox = true;
       this.hiddenslider = false;

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -71,9 +71,7 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
 
   ready() {
     super.ready();
-    if (this.mode === 'slider') {
-      this.addEventListener('iron-resize', this.hiddenState);
-    }
+    this.addEventListener('iron-resize', this.hiddenState);
   }
 
   static get properties() {
@@ -120,6 +118,8 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
   }
 
   hiddenState() {
+    if (this.mode !== 'slider') return;
+
     if (this.$.slider.offsetWidth < 100) {
       this.$.sliderstate.hidden = true;
     } else if (this.$.slider.offsetWidth >= 145) {
@@ -138,6 +138,9 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
       hiddenbox: (newVal.attributes.mode !== 'box'),
       hiddenslider: (newVal.attributes.mode !== 'slider'),
     });
+    if (this.mode !== newVal.mode) {
+      this.hiddenState();
+    }
   }
 
   selectedValueChanged() {

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -15,7 +15,15 @@
     <style is="custom-style" include="iron-flex iron-flex-alignment"></style>
     <style>
       paper-slider {
-        margin-left: 16px;
+        margin-left: auto;
+      }
+      .state {
+        @apply(--paper-font-body1);
+        color: var(--primary-text-color);
+
+        min-width: 45px;
+        text-align: right;
+        line-height: 40px;
       }
       paper-slider[hidden] {
         display: none !important;
@@ -41,6 +49,7 @@
         hidden='[[hiddenbox]]'
       >
       </paper-input>
+      <div class="state" hidden='[[hiddenslider]]'>[[value]] [[stateObj.attributes.unit_of_measurement]]</div>
     </div>
   </template>
 </dom-module>

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -64,12 +64,14 @@
 </dom-module>
 
 <script>
-class StateCardInputNumber extends Polymer.mixinBehaviors([Polymer.IronResizableBehavior], Polymer.Element) {
+class StateCardInputNumber extends Polymer.mixinBehaviors([
+  Polymer.IronResizableBehavior
+], Polymer.Element) {
   static get is() { return 'state-card-input_number'; }
 
   ready() {
     super.ready();
-    if (this.mode == "slider") {
+    if (this.mode === 'slider') {
       this.addEventListener('iron-resize', this.hiddenState);
     }
   }

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -6,6 +6,8 @@
 
 <link rel="import" href="../../bower_components/paper-slider/paper-slider.html">
 
+<link rel="import" href="../../bower_components/iron-resizable-behavior/iron-resizable-behavior.html">
+
 <link rel="import" href="../components/entity/state-info.html">
 
 <link rel="import" href="../util/hass-util.html">
@@ -62,8 +64,15 @@
 </dom-module>
 
 <script>
-class StateCardInputNumber extends Polymer.Element {
+class StateCardInputNumber extends Polymer.mixinBehaviors([Polymer.IronResizableBehavior], Polymer.Element) {
   static get is() { return 'state-card-input_number'; }
+
+  ready() {
+    super.ready();
+    if (this.mode == "slider") {
+      this.addEventListener('iron-resize', this.hiddenState);
+    }
+  }
 
   static get properties() {
     return {
@@ -102,7 +111,18 @@ class StateCardInputNumber extends Polymer.Element {
       value: {
         type: Number,
       },
+      mode: {
+        type: String,
+      }
     };
+  }
+
+  hiddenState() {
+    if (this.$.slider.offsetWidth < 100) {
+      this.$.sliderstate.hidden = true;
+    } else if (this.$.slider.offsetWidth >= 145) {
+      this.$.sliderstate.hidden = false;
+    }
   }
 
   stateObjectChanged(newVal) {
@@ -110,13 +130,11 @@ class StateCardInputNumber extends Polymer.Element {
     this.max = Number(newVal.attributes.max);
     this.step = Number(newVal.attributes.step);
     this.value = Number(newVal.state);
+    this.mode = String(newVal.attributes.mode);
     this.maxlength = this.max.legnth;
     if (newVal.attributes.mode === 'slider') {
       this.hiddenbox = true;
       this.hiddenslider = false;
-      if (this.$.slider.offsetWidth < 100) {
-        this.$.sliderstate.hidden = true;
-      }
     } else {
       this.hiddenbox = false;
       this.hiddenslider = true;

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -21,12 +21,18 @@
         @apply(--paper-font-body1);
         color: var(--primary-text-color);
 
-        min-width: 45px;
         text-align: right;
         line-height: 40px;
       }
+      .sliderstate {
+          min-width: 45px;
+      }
       paper-slider[hidden] {
         display: none !important;
+      }
+      paper-input {
+        text-align: right;
+        margin-left: auto;
       }
     </style>
 
@@ -49,7 +55,8 @@
         hidden='[[hiddenbox]]'
       >
       </paper-input>
-      <div class="state" hidden='[[hiddenslider]]'>[[value]] [[stateObj.attributes.unit_of_measurement]]</div>
+      <div class="state" hidden='[[hiddenbox]]'>[[stateObj.attributes.unit_of_measurement]]</div>
+      <div class="state sliderstate" hidden='[[hiddenslider]]'>[[value]] [[stateObj.attributes.unit_of_measurement]]</div>
     </div>
   </template>
 </dom-module>

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -39,7 +39,7 @@
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
         <paper-slider min='[[min]]' max='[[max]]' value='{{value}}' step='[[step]]' hidden='[[hiddenslider]]' pin
-          on-change='selectedValueChanged' on-tap='stopPropagation'>
+          on-change='selectedValueChanged' on-tap='stopPropagation' id='slider'>
         </paper-slider>
       <paper-input
         no-label-float
@@ -56,7 +56,7 @@
       >
       </paper-input>
       <div class="state" hidden='[[hiddenbox]]'>[[stateObj.attributes.unit_of_measurement]]</div>
-      <div class="state sliderstate" hidden='[[hiddenslider]]'>[[value]] [[stateObj.attributes.unit_of_measurement]]</div>
+      <div id="sliderstate" class="state sliderstate" hidden='[[hiddenslider]]'>[[value]] [[stateObj.attributes.unit_of_measurement]]</div>
     </div>
   </template>
 </dom-module>
@@ -114,6 +114,9 @@ class StateCardInputNumber extends Polymer.Element {
     if (newVal.attributes.mode === 'slider') {
       this.hiddenbox = true;
       this.hiddenslider = false;
+      if(this.$.slider.offsetWidth < 100) {
+        this.$.sliderstate.hidden = true;
+      }
     } else {
       this.hiddenbox = false;
       this.hiddenslider = true;

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -114,7 +114,7 @@ class StateCardInputNumber extends Polymer.Element {
     if (newVal.attributes.mode === 'slider') {
       this.hiddenbox = true;
       this.hiddenslider = false;
-      if(this.$.slider.offsetWidth < 100) {
+      if (this.$.slider.offsetWidth < 100) {
         this.$.sliderstate.hidden = true;
       }
     } else {

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -71,7 +71,16 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
 
   ready() {
     super.ready();
-    this.addEventListener('iron-resize', this.hiddenState);
+    if (typeof ResizeObserver === 'function') {
+      const ro = new ResizeObserver((entries) => {
+        entries.forEach((entry) => {
+          this.hiddenState(entry.contentRect.width);
+        });
+      });
+      ro.observe(this.$.slider);
+    } else {
+      this.addEventListener('iron-resize', this.hiddenState);
+    }
   }
 
   static get properties() {
@@ -117,12 +126,14 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
     };
   }
 
-  hiddenState() {
+  hiddenState(sliderwidth) {
     if (this.mode !== 'slider') return;
-
-    if (this.$.slider.offsetWidth < 100) {
+    if (isNaN(sliderwidth)) {
+      sliderwidth = this.$.slider.offsetWidth;
+    }
+    if (sliderwidth < 100) {
       this.$.sliderstate.hidden = true;
-    } else if (this.$.slider.offsetWidth >= 125) {
+    } else if (sliderwidth >= 145) {
       this.$.sliderstate.hidden = false;
     }
   }

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -128,19 +128,16 @@ class StateCardInputNumber extends Polymer.mixinBehaviors([
   }
 
   stateObjectChanged(newVal) {
-    this.min = Number(newVal.attributes.min);
-    this.max = Number(newVal.attributes.max);
-    this.step = Number(newVal.attributes.step);
-    this.value = Number(newVal.state);
-    this.mode = String(newVal.attributes.mode);
-    this.maxlength = this.max.length;
-    if (newVal.attributes.mode === 'slider') {
-      this.hiddenbox = true;
-      this.hiddenslider = false;
-    } else {
-      this.hiddenbox = false;
-      this.hiddenslider = true;
-    }
+    this.setProperties({
+      min: Number(newVal.attributes.min),
+      max: Number(newVal.attributes.max),
+      step: Number(newVal.attributes.step),
+      value: Number(newVal.state),
+      mode: String(newVal.attributes.mode),
+      maxlength: String(newVal.attributes.max).length,
+      hiddenbox: (newVal.attributes.mode !== 'box'),
+      hiddenslider: (newVal.attributes.mode !== 'slider'),
+    });
   }
 
   selectedValueChanged() {


### PR DESCRIPTION
See feature request here : https://community.home-assistant.io/t/input-slider-should-show-set-value-and-have-unit/4489

Improve the slider of component `input_number` to have state shown next to it. Displayed state uses the specified `unit_of_measurement` in the configuration file.
<img width="514" alt="capture d ecran 2018-01-16 a 10 00 34" src="https://user-images.githubusercontent.com/3236171/34980389-b0a322f6-faa4-11e7-8f8e-570659132cb4.png">


Also add the state on the humidity slider of the climate component in a design similar to the target temperature value
<img width="390" alt="capture d ecran 2018-01-16 a 10 00 55" src="https://user-images.githubusercontent.com/3236171/34980395-b3bc7db6-faa4-11e7-860c-f71169a806b5.png">