### PR TITLE
Fixed device_class opening icons

### DIFF
--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -243,7 +243,7 @@ window.hassUtil.binarySensorIcon = function (state) {
     case 'occupancy':
       return activated ? 'mdi:home-outline' : 'mdi:home';
     case 'opening':
-      return activated ? 'mdi:square' : 'mdi:square-outline';
+      return activated ? 'mdi:door-closed' : 'mdi:door-open';
     case 'plug':
       return activated ? 'mdi:power-plug-off' : 'mdi:power-plug';
     case 'presence':


### PR DESCRIPTION
The icons for `device_class: opening` were, probably mistakenly changed. The `mdi:square` and `mdi:square-outline` icons have nothing to do with `opening` as highlighted by several users on Discord. 

This PR fixes the same. 