### PR TITLE
Add sound mode support (media_player frontend)

### DIFF
--- a/src/more-infos/more-info-media_player.html
+++ b/src/more-infos/more-info-media_player.html
@@ -107,16 +107,17 @@
         </paper-dropdown-menu>
       </div>
       <!-- SOUND MODE PICKER -->
-      <div class='controls layout horizontal justified'
-           hidden$='[[computeHideSelectSoundMode(isOff, supportsSelectSoundMode)]]'>
-        <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
-        <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
-          <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
-            <template is='dom-repeat' items='[[stateObj.attributes.sound_mode_list]]'>
-              <paper-item>[[item]]</paper-item>
-            </template>
-          </paper-listbox>
-        </paper-dropdown-menu>
+      <div class='controls layout horizontal justified'>
+        <template is='dom-if' if='[[computeHideSelectSoundMode(isOff, supportsSelectSoundMode)]]'>
+          <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
+          <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
+            <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
+              <template is='dom-repeat' items='[[stateObj.attributes.sound_mode_list]]'>
+                <paper-item>[[item]]</paper-item>
+              </template>
+            </paper-listbox>
+          </paper-dropdown-menu>
+        </template>
       </div>
       <!-- TTS -->
       <div hidden$='[[computeHideTTS(ttsLoaded, supportsPlayMedia)]]' class='layout horizontal end'>
@@ -398,7 +399,6 @@
     }
 
     handleSoundModeChanged(soundModeIndex, soundModeIndexOld) {
-      var soundModeInput;
       // Selected Option will transition to '' before transitioning to new value
       if (!this.stateObj
           || this.stateObj.attributes.sound_mode_list === undefined
@@ -409,7 +409,7 @@
         return;
       }
 
-      soundModeInput = this.stateObj.attributes.sound_mode_list[soundModeIndex];
+      const soundModeInput = this.stateObj.attributes.sound_mode_list[soundModeIndex];
 
       if (soundModeInput === this.stateObj.attributes.sound_mode) {
         return;

--- a/src/more-infos/more-info-media_player.html
+++ b/src/more-infos/more-info-media_player.html
@@ -45,15 +45,6 @@
         margin-left: 10px;
       }
 
-      iron-icon.sound-mode-input {
-        padding: 7px;
-        margin-top: 15px;
-      }
-
-      paper-dropdown-menu.sound-mode-input {
-        margin-left: 10px;
-      }
-
       [hidden] {
         display: none !important;
       }
@@ -118,8 +109,8 @@
       <!-- SOUND MODE PICKER -->
       <div class='controls layout horizontal justified'
            hidden$='[[computeHideSelectSoundMode(isOff, supportsSelectSoundMode)]]'>
-        <iron-icon class="sound-mode-input" icon="mdi:music-note"></iron-icon>
-        <paper-dropdown-menu class="flex sound-mode-input" dynamic-align label-float label='Sound Mode'>
+        <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
+        <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
           <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
             <template is='dom-repeat' items='[[stateObj.attributes.sound_mode_list]]'>
               <paper-item>[[item]]</paper-item>
@@ -359,10 +350,6 @@
 
     computeHideSelectSoundMode(isOff, supportsSelectSoundMode) {
       return isOff || !supportsSelectSoundMode;
-    }
-
-    computeSelectedSoundMode(stateObj) {
-      return stateObj.attributes.sound_mode_list.indexOf(stateObj.attributes.sound_mode);
     }
 
     computeHideTTS(ttsLoaded, supportsPlayMedia) {

--- a/src/more-infos/more-info-media_player.html
+++ b/src/more-infos/more-info-media_player.html
@@ -118,7 +118,7 @@
       <!-- SOUND MODE PICKER -->
       <div class='controls layout horizontal justified'
            hidden$='[[computeHideSelectSoundMode(isOff, supportsSelectSoundMode)]]'>
-        <iron-icon class="sound-mode-input" icon="mdi:login-variant"></iron-icon>
+        <iron-icon class="sound-mode-input" icon="mdi:music-note"></iron-icon>
         <paper-dropdown-menu class="flex sound-mode-input" dynamic-align label-float label='Sound Mode'>
           <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
             <template is='dom-repeat' items='[[stateObj.attributes.sound_mode_list]]'>

--- a/src/more-infos/more-info-media_player.html
+++ b/src/more-infos/more-info-media_player.html
@@ -45,6 +45,15 @@
         margin-left: 10px;
       }
 
+      iron-icon.sound-mode-input {
+        padding: 7px;
+        margin-top: 15px;
+      }
+
+      paper-dropdown-menu.sound-mode-input {
+        margin-left: 10px;
+      }
+
       [hidden] {
         display: none !important;
       }
@@ -101,6 +110,18 @@
         <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Source'>
           <paper-listbox slot="dropdown-content" selected="{{sourceIndex}}">
             <template is='dom-repeat' items='[[stateObj.attributes.source_list]]'>
+              <paper-item>[[item]]</paper-item>
+            </template>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </div>
+      <!-- SOUND MODE PICKER -->
+      <div class='controls layout horizontal justified'
+           hidden$='[[computeHideSelectSoundMode(isOff, supportsSelectSoundMode)]]'>
+        <iron-icon class="sound-mode-input" icon="mdi:login-variant"></iron-icon>
+        <paper-dropdown-menu class="flex sound-mode-input" dynamic-align label-float label='Sound Mode'>
+          <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
+            <template is='dom-repeat' items='[[stateObj.attributes.sound_mode_list]]'>
               <paper-item>[[item]]</paper-item>
             </template>
           </paper-listbox>
@@ -170,6 +191,17 @@
           observer: 'handleSourceChanged',
         },
 
+        soundMode: {
+          type: String,
+          value: '',
+        },
+
+        soundModeIndex: {
+          type: Number,
+          value: 0,
+          observer: 'handleSoundModeChanged',
+        },
+
         volumeSliderValue: {
           type: Number,
           value: 0,
@@ -230,6 +262,11 @@
           value: false,
         },
 
+        supportsSelectSoundMode: {
+          type: Boolean,
+          value: false,
+        },
+
         supportsPlay: {
           type: Boolean,
           value: false,
@@ -251,6 +288,7 @@
         this.volumeSliderValue = newVal.attributes.volume_level * 100;
         this.isMuted = newVal.attributes.is_volume_muted;
         this.source = newVal.attributes.source;
+        this.soundMode = newVal.attributes.sound_mode;
         this.supportsPause = (newVal.attributes.supported_features & 1) !== 0;
         this.supportsVolumeSet = (newVal.attributes.supported_features & 4) !== 0;
         this.supportsVolumeMute = (newVal.attributes.supported_features & 8) !== 0;
@@ -262,9 +300,14 @@
         this.supportsVolumeButtons = (newVal.attributes.supported_features & 1024) !== 0;
         this.supportsSelectSource = (newVal.attributes.supported_features & 2048) !== 0;
         this.supportsPlay = (newVal.attributes.supported_features & 16384) !== 0;
+        this.supportsSelectSoundMode = (newVal.attributes.supported_features & 65536) !== 0;
 
         if (newVal.attributes.source_list !== undefined) {
           this.sourceIndex = newVal.attributes.source_list.indexOf(this.source);
+        }
+
+        if (newVal.attributes.sound_mode_list !== undefined) {
+          this.soundModeIndex = newVal.attributes.sound_mode_list.indexOf(this.soundMode);
         }
       }
 
@@ -314,6 +357,14 @@
       return stateObj.attributes.source_list.indexOf(stateObj.attributes.source);
     }
 
+    computeHideSelectSoundMode(isOff, supportsSelectSoundMode) {
+      return isOff || !supportsSelectSoundMode;
+    }
+
+    computeSelectedSoundMode(stateObj) {
+      return stateObj.attributes.sound_mode_list.indexOf(stateObj.attributes.sound_mode);
+    }
+
     computeHideTTS(ttsLoaded, supportsPlayMedia) {
       return !ttsLoaded || !supportsPlayMedia;
     }
@@ -357,6 +408,27 @@
       }
 
       this.callService('select_source', { source: sourceInput });
+    }
+
+    handleSoundModeChanged(soundModeIndex, soundModeIndexOld) {
+      var soundModeInput;
+      // Selected Option will transition to '' before transitioning to new value
+      if (!this.stateObj
+          || this.stateObj.attributes.sound_mode_list === undefined
+          || soundModeIndex < 0
+          || soundModeIndex >= this.stateObj.attributes.sound_mode_list.length
+          || soundModeIndexOld === undefined
+      ) {
+        return;
+      }
+
+      soundModeInput = this.stateObj.attributes.sound_mode_list[soundModeIndex];
+
+      if (soundModeInput === this.stateObj.attributes.sound_mode) {
+        return;
+      }
+
+      this.callService('select_sound_mode', { sound_mode: soundModeInput });
     }
 
     handleVolumeTap() {


### PR DESCRIPTION
Added frontend support for an drop down box select for the sound mode (also updated with status).
This is general support for all media_player components.
This box is not shown in media_players that did not (yet) implement sound mode support in the backend.
I implemented the sound mode support (backend) for the denonavr platform and that one works perfictly.
I will make a pull request for the backend soon (still dooing some cleanup).

I tested this code and it works on Hassbian on my pi.

On the home assistant chat I heard that other platforms like onkyo and sonos could also implement sound mode support and probably most receivers could support this.

Backend pull request:
https://github.com/home-assistant/home-assistant/pull/13706
Documentation pull request:
https://github.com/home-assistant/home-assistant.github.io/pull/4470