### PR TITLE
Possibility to hide developer tools and configuration panel in themes + Add input_text mode:password

### DIFF
--- a/src/cards/ha-camera-card.html
+++ b/src/cards/ha-camera-card.html
@@ -18,35 +18,34 @@
       .camera-feed {
         width: 100%;
         height: auto;
-        border-radius: 2px;
+        border-bottom-left-radius: 2px;
+        border-bottom-right-radius: 2px;
+        margin-top: 26px;
       }
       .caption {
         @apply(--paper-font-common-nowrap);
         position: absolute;
         left: 0px;
         right: 0px;
-        bottom: 0px;
-        border-bottom-left-radius: 2px;
-        border-bottom-right-radius: 2px;
-
+        top: 0px;
+        border-top-left-radius: 2px;
+        border-top-right-radius: 2px;
         background-color: rgba(0, 0, 0, 0.3);
-        padding: 16px;
-
-        font-size: 16px;
+        padding: 13px;
+        font-size: 15px;
         font-weight: 500;
-        line-height: 16px;
         color: white;
       }
     </style>
 
-    <img src='[[cameraFeedSrc]]' class='camera-feed' hidden$='[[!imageLoaded]]'
-      on-load='imageLoadSuccess' on-error='imageLoadFail' alt='[[computeStateName(stateObj)]]'>
     <div class='caption'>
       [[computeStateName(stateObj)]]
       <template is='dom-if' if='[[!imageLoaded]]'>
         ([[localize('ui.card.camera.not_available')]])
       </template>
     </div>
+    <img src='[[cameraFeedSrc]]' class='camera-feed' hidden$='[[!imageLoaded]]'
+      on-load='imageLoadSuccess' on-error='imageLoadFail' alt='[[computeStateName(stateObj)]]'>
   </template>
 </dom-module>
 

--- a/src/cards/ha-camera-card.html
+++ b/src/cards/ha-camera-card.html
@@ -18,34 +18,35 @@
       .camera-feed {
         width: 100%;
         height: auto;
-        border-bottom-left-radius: 2px;
-        border-bottom-right-radius: 2px;
-        margin-top: 26px;
+        border-radius: 2px;
       }
       .caption {
         @apply(--paper-font-common-nowrap);
         position: absolute;
         left: 0px;
         right: 0px;
-        top: 0px;
-        border-top-left-radius: 2px;
-        border-top-right-radius: 2px;
+        bottom: 0px;
+        border-bottom-left-radius: 2px;
+        border-bottom-right-radius: 2px;
+
         background-color: rgba(0, 0, 0, 0.3);
-        padding: 13px;
-        font-size: 15px;
+        padding: 16px;
+
+        font-size: 16px;
         font-weight: 500;
+        line-height: 16px;
         color: white;
       }
     </style>
 
+    <img src='[[cameraFeedSrc]]' class='camera-feed' hidden$='[[!imageLoaded]]'
+      on-load='imageLoadSuccess' on-error='imageLoadFail' alt='[[computeStateName(stateObj)]]'>
     <div class='caption'>
       [[computeStateName(stateObj)]]
       <template is='dom-if' if='[[!imageLoaded]]'>
         ([[localize('ui.card.camera.not_available')]])
       </template>
     </div>
-    <img src='[[cameraFeedSrc]]' class='camera-feed' hidden$='[[!imageLoaded]]'
-      on-load='imageLoadSuccess' on-error='imageLoadFail' alt='[[computeStateName(stateObj)]]'>
   </template>
 </dom-module>
 

--- a/src/components/ha-sidebar.html
+++ b/src/components/ha-sidebar.html
@@ -96,7 +96,6 @@
       }
       
       .dev-section {
-        opacity: var(--dark-secondary-opacity);
         display:var(--display-dev)!important;
       }
       

--- a/src/components/ha-sidebar.html
+++ b/src/components/ha-sidebar.html
@@ -93,6 +93,10 @@
       .dev-tools {
         padding: 0 8px;
         opacity: var(--dark-secondary-opacity);
+      }
+      
+      .dev-section {
+        opacity: var(--dark-secondary-opacity);
         display:var(--display-dev)!important;
       }
       
@@ -125,7 +129,7 @@
       </paper-icon-item>
     </paper-listbox>
 
-    <div class="dev-tools">
+    <div class="dev-section">
       <div class='divider'></div>
 
       <div class='subheader'>[[localize('ui.sidebar.developer_tools')]]</div>

--- a/src/components/ha-sidebar.html
+++ b/src/components/ha-sidebar.html
@@ -93,6 +93,11 @@
       .dev-tools {
         padding: 0 8px;
         opacity: var(--dark-secondary-opacity);
+        display:var(--display-dev)!important;
+      }
+      
+      [data-panel="config"] {
+        display:var(--display-dev, var(--layout-horizontal_-_display))!important;
       }
     </style>
 
@@ -120,7 +125,7 @@
       </paper-icon-item>
     </paper-listbox>
 
-    <div>
+    <div class="dev-tools">
       <div class='divider'></div>
 
       <div class='subheader'>[[localize('ui.sidebar.developer_tools')]]</div>

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -74,6 +74,7 @@
     --light-disabled-opacity: 0.3; /* or hint text or icon */
     --light-secondary-opacity: 0.7;
     --light-primary-opacity: 1.0;
+    /* --display-dev: none can be used to hide the developer section and the configuration button in the sidebar */    
   }
 </style>
 </custom-style>

--- a/src/state-summary/state-card-input_text.html
+++ b/src/state-summary/state-card-input_text.html
@@ -27,6 +27,7 @@
         auto-validate='[[stateObj.attributes.pattern]]'
         pattern='[[stateObj.attributes.pattern]]'
         type='[[stateObj.attributes.mode]]'
+ 
         on-change='selectedValueChanged'
         on-tap='stopPropagation'
         placeholder='(empty value)'

--- a/src/state-summary/state-card-input_text.html
+++ b/src/state-summary/state-card-input_text.html
@@ -26,7 +26,7 @@
         value='{{value}}'
         auto-validate='[[stateObj.attributes.pattern]]'
         pattern='[[stateObj.attributes.pattern]]'
-        type='[stateObj.attributes.mode]]'
+        type='[[stateObj.attributes.mode]]'
         on-change='selectedValueChanged'
         on-tap='stopPropagation'
         placeholder='(empty value)'

--- a/src/state-summary/state-card-input_text.html
+++ b/src/state-summary/state-card-input_text.html
@@ -26,6 +26,7 @@
         value='{{value}}'
         auto-validate='[[stateObj.attributes.pattern]]'
         pattern='[[stateObj.attributes.pattern]]'
+        type='[stateObj.attributes.mode]]'
         on-change='selectedValueChanged'
         on-tap='stopPropagation'
         placeholder='(empty value)'


### PR DESCRIPTION
1) Added support to hide the developer tools and configuration panel in themes by setting the variable _--display-dev_ to _none_. 
This will also allow some basic child proofing using the input_text (mode: password), themes and some automations/scripts (e.g. group.set_visibility+frontend.set_theme if input_text mode:password is...). 
e.g. https://community.home-assistant.io/t/multiple-users-accounts/396/51?u=covrig
```
added class="dev-section" to div
added display:var(--display-dev)!important to class="dev-tools" and to class="dev-section"
added [data-panel="config"] {display:var(--display-dev, var(--layout-horizontal_-_display))!important;}
```
2) Added mode: password to input text.
As mentioned by @andrey-git,  this is **security-by-obscurity**. The user can just type in the url of the dev panel.
```
added type='[[stateObj.attributes.mode]]'
```
In combination with: 
https://github.com/home-assistant/home-assistant/pull/11849
https://github.com/home-assistant/home-assistant.github.io/pull/4489