### PR TITLE
Updated 'ha-camera-card.html' - moved overlapping title

### DIFF
--- a/src/cards/ha-camera-card.html
+++ b/src/cards/ha-camera-card.html
@@ -18,35 +18,34 @@
       .camera-feed {
         width: 100%;
         height: auto;
-        border-radius: 2px;
+        border-bottom-left-radius: 2px;
+        border-bottom-right-radius: 2px;
+        margin-top: 26px;
       }
       .caption {
         @apply(--paper-font-common-nowrap);
         position: absolute;
         left: 0px;
         right: 0px;
-        bottom: 0px;
-        border-bottom-left-radius: 2px;
-        border-bottom-right-radius: 2px;
-
+        top: 0px;
+        border-top-left-radius: 2px;
+        border-top-right-radius: 2px;
         background-color: rgba(0, 0, 0, 0.3);
-        padding: 16px;
-
-        font-size: 16px;
+        padding: 13px;
+        font-size: 15px;
         font-weight: 500;
-        line-height: 16px;
         color: white;
       }
     </style>
 
-    <img src='[[cameraFeedSrc]]' class='camera-feed' hidden$='[[!imageLoaded]]'
-      on-load='imageLoadSuccess' on-error='imageLoadFail' alt='[[computeStateName(stateObj)]]'>
     <div class='caption'>
       [[computeStateName(stateObj)]]
       <template is='dom-if' if='[[!imageLoaded]]'>
         ([[localize('ui.card.camera.not_available')]])
       </template>
     </div>
+    <img src='[[cameraFeedSrc]]' class='camera-feed' hidden$='[[!imageLoaded]]'
+      on-load='imageLoadSuccess' on-error='imageLoadFail' alt='[[computeStateName(stateObj)]]'>
   </template>
 </dom-module>
 


### PR DESCRIPTION
If you agree, I would suggest moving the overlapping camera title. It is a shame to hide part of the camera feed.

I really don't see the need for a title since the image is self-explanatory, but that is only my opinion. 
Adding an `:hover` selector trick could also be an option.

![image](https://user-images.githubusercontent.com/8059190/35411069-a92babfe-0217-11e8-9e7d-f542311b2c5a.png)
