### PR TITLE
Possibility to hide developer tools and configuration panel in themes

### DIFF
--- a/src/components/ha-sidebar.html
+++ b/src/components/ha-sidebar.html
@@ -94,6 +94,14 @@
         padding: 0 8px;
         opacity: var(--dark-secondary-opacity);
       }
+      
+      .dev-section {
+        display:var(--display-dev)!important;
+      }
+      
+      [data-panel="config"] {
+        display:var(--display-dev, var(--layout-horizontal_-_display))!important;
+      }
     </style>
 
     <app-toolbar>
@@ -120,7 +128,7 @@
       </paper-icon-item>
     </paper-listbox>
 
-    <div>
+    <div class="dev-section">
       <div class='divider'></div>
 
       <div class='subheader'>[[localize('ui.sidebar.developer_tools')]]</div>

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -74,6 +74,7 @@
     --light-disabled-opacity: 0.3; /* or hint text or icon */
     --light-secondary-opacity: 0.7;
     --light-primary-opacity: 1.0;
+    /* --display-dev: none - Can be used to hide the developer section and the configuration button in the sidebar */    
   }
 </style>
 </custom-style>


### PR DESCRIPTION
Added support to hide the developer tools and configuration panel in themes by setting the variable _--display-dev_ to _none_. 
This will also allow some basic child proofing using the input_text (mode: password), themes and some automations/scripts (e.g. group.set_visibility+frontend.set_theme if input_text mode:password is...). 
e.g. https://community.home-assistant.io/t/multiple-users-accounts/396/51?u=covrig
```
added class="dev-section" to div
added display:var(--display-dev)!important to class="dev-tools" and to class="dev-section"
added [data-panel="config"] {display:var(--display-dev, var(--layout-horizontal_-_display))!important;}
```
In combination with: 
https://github.com/home-assistant/home-assistant/pull/11849
https://github.com/home-assistant/home-assistant.github.io/pull/4489