### PR TITLE
Added input_text mode:password option

### DIFF
--- a/src/state-summary/state-card-input_text.html
+++ b/src/state-summary/state-card-input_text.html
@@ -26,6 +26,8 @@
         value='{{value}}'
         auto-validate='[[stateObj.attributes.pattern]]'
         pattern='[[stateObj.attributes.pattern]]'
+        type='[[stateObj.attributes.mode]]'
+ 
         on-change='selectedValueChanged'
         on-tap='stopPropagation'
         placeholder='(empty value)'


### PR DESCRIPTION
Added mode: password to input text.
```
added type='[[stateObj.attributes.mode]]'
```
In combination with: 
https://github.com/home-assistant/home-assistant/pull/11849
https://github.com/home-assistant/home-assistant.github.io/pull/4489