### PR TITLE
Added support for humidity display in the climate state

### DIFF
--- a/src/components/ha-climate-state.html
+++ b/src/components/ha-climate-state.html
@@ -21,12 +21,11 @@
       <span class="state-label">
         [[stateObj.state]]
       </span>
-      [[computeTargetTemperature(stateObj)]]
+      [[computeTarget(stateObj)]]
     </div>
 
     <div class='current'>
-      Currently: [[stateObj.attributes.current_temperature]]
-      [[stateObj.attributes.unit_of_measurement]]
+      Currently: [[computeCurrentStatus(stateObj)]]
     </div>
   </template>
 </dom-module>
@@ -41,12 +40,27 @@ class HaClimateState extends Polymer.Element {
     };
   }
 
-  computeTargetTemperature(stateObj) {
+  computeCurrentStatus(stateObj) {
+    if (stateObj.attributes.current_temperature) {
+      return `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
+    } else if (stateObj.attributes.current_humidity) {
+      return `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
+    }
+
+    return '';
+  }
+
+  computeTarget(stateObj) {
     if (stateObj.attributes.target_temp_low &&
         stateObj.attributes.target_temp_high) {
       return `${stateObj.attributes.target_temp_low} - ${stateObj.attributes.target_temp_high} ${stateObj.attributes.unit_of_measurement}`;
     } else if (stateObj.attributes.temperature) {
       return `${stateObj.attributes.temperature} ${stateObj.attributes.unit_of_measurement}`;
+    } else if (stateObj.attributes.target_humidity_low &&
+        stateObj.attributes.target_humidity_high) {
+      return `${stateObj.attributes.target_humidity_low} - ${stateObj.attributes.target_humidity_high} ${stateObj.attributes.unit_of_measurement}`;
+    } else if (stateObj.attributes.humidity) {
+      return `${stateObj.attributes.humidity} ${stateObj.attributes.unit_of_measurement}`;
     }
 
     return '';


### PR DESCRIPTION
This is a small modification to the climate component state to display current and target humidity instead of current and target temperature according to the available component attributes.

![screen shot 2018-01-26 at 08 38 51](https://user-images.githubusercontent.com/873778/35429619-1ef92eda-0275-11e8-901f-7567789b838b.PNG)

![screen shot 2018-01-26 at 08 39 01](https://user-images.githubusercontent.com/873778/35429626-23f7f86c-0275-11e8-9d50-21a8ebb4d2ea.PNG)

I made this for a custom component, an equivalent for generic_thermostat but for humidifiers and dehumidifiers, using a sensor and a switch. I'm working on a PR for that one.