### PR TITLE
Add version to JS

### DIFF
--- a/.eslintrc-hound.json
+++ b/.eslintrc-hound.json
@@ -15,6 +15,7 @@
     "__DEV__": false,
     "__DEMO__": false,
     "__BUILD__": false,
+    "__VERSION__": false,
     "Polymer": true,
     "webkitSpeechRecognition": false,
     "ResizeObserver": false

--- a/gulp/tasks/rollup.js
+++ b/gulp/tasks/rollup.js
@@ -9,7 +9,11 @@ const uglify = require('../common/gulp-uglify.js');
 
 const DEV = !!JSON.parse(process.env.BUILD_DEV || 'true');
 const DEMO = !!JSON.parse(process.env.BUILD_DEMO || 'false');
-const VERSION = fs.readFileSync('setup.py', 'utf8').match(/\d{4}[^']*/)[0] || '0';
+const version = fs.readFileSync('setup.py', 'utf8').match(/\d{8}[^']*/);
+if (!version) {
+  throw Error('Version not found');
+}
+const VERSION = version[0];
 
 function getRollupInputOptions(es6) {
   const babelOpts = {

--- a/gulp/tasks/rollup.js
+++ b/gulp/tasks/rollup.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const gulp = require('gulp');
 const rollupEach = require('gulp-rollup-each');
 const commonjs = require('rollup-plugin-commonjs');
@@ -8,6 +9,7 @@ const uglify = require('../common/gulp-uglify.js');
 
 const DEV = !!JSON.parse(process.env.BUILD_DEV || 'true');
 const DEMO = !!JSON.parse(process.env.BUILD_DEMO || 'false');
+const VERSION = fs.readFileSync('setup.py', 'utf8').match(/\d{4}[^']*/)[0] || '0';
 
 function getRollupInputOptions(es6) {
   const babelOpts = {
@@ -51,6 +53,7 @@ function getRollupInputOptions(es6) {
           __DEV__: JSON.stringify(DEV),
           __DEMO__: JSON.stringify(DEMO),
           __BUILD__: JSON.stringify(es6 ? 'latest' : 'es5'),
+          __VERSION__: JSON.stringify(VERSION),
         },
       }),
     ],

--- a/js/core.js
+++ b/js/core.js
@@ -4,6 +4,7 @@ window.HAWS = HAWS;
 window.HASS_DEMO = __DEMO__;
 window.HASS_DEV = __DEV__;
 window.HASS_BUILD = __BUILD__;
+window.HASS_VERSION = __VERSION__;
 
 const init = window.createHassConnection = function (password) {
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';


### PR DESCRIPTION
Add frontend version to core.js

Potential use cases:
* Include version in error reporting.
* Custom UI can take decisions  based on version to preserve backward compatibility.