### PR TITLE
Badge sorting

### DIFF
--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -143,14 +143,6 @@
       });
   };
 
-  const iterateDomain = (collection, func) => {
-    Object.keys(collection)
-      .map(key => collection[key])
-      .forEach((domain) => {
-        func(domain);
-      });
-  };
-
   const computeDomain = window.hassUtil.computeDomain;
 
   class HaCards extends Polymer.Element {
@@ -336,9 +328,11 @@
       });
 
       if (orderedGroupEntities) {
-        iterateDomain(badgesColl, (domain) => {
-          cards.badges.push.apply(cards.badges, domain.states);
-        });
+        Object.keys(badgesColl)
+          .map(key => badgesColl[key])
+          .forEach((domain) => {
+            cards.badges.push.apply(cards.badges, domain.states);
+          });
 
         cards.badges.sort((e1, e2) => orderedGroupEntities[e1.entity_id] -
           orderedGroupEntities[e2.entity_id]);

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -134,7 +134,8 @@
   };
 
   const iterateDomainSorted = (collection, func) => {
-    Object.values(collection)
+    Object.keys(collection)
+      .map(key => collection[key])
       .sort(sortPriority)
       .forEach((domain) => {
         domain.states.sort(entitySortBy);
@@ -143,7 +144,8 @@
   };
 
   const iterateDomain = (collection, func) => {
-    Object.values(collection)
+    Object.keys(collection)
+      .map(key => collection[key])
       .forEach((domain) => {
         func(domain);
       });

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -172,7 +172,7 @@
           value: false,
         },
 
-        orderedGroups: Array,
+        orderedGroupEntities: Array,
 
         cards: Object,
       };
@@ -180,7 +180,7 @@
 
     static get observers() {
       return [
-        'updateCards(columns, states, panelVisible, viewVisible, orderedGroups)',
+        'updateCards(columns, states, panelVisible, viewVisible, orderedGroupEntities)',
       ];
     }
 
@@ -189,7 +189,7 @@
       states,
       panelVisible,
       viewVisible,
-      orderedGroups
+      orderedGroupEntities
     ) {
       if (!panelVisible || !viewVisible) {
         if (this.$.main.parentNode) {
@@ -206,7 +206,7 @@
         () => {
           // Things might have changed since it got scheduled.
           if (this.panelVisible && this.viewVisible) {
-            this.cards = this.computeCards(columns, states, orderedGroups);
+            this.cards = this.computeCards(columns, states, orderedGroupEntities);
           }
         }
       );
@@ -220,7 +220,7 @@
       };
     }
 
-    computeCards(columns, states, orderedGroups) {
+    computeCards(columns, states, orderedGroupEntities) {
       const hass = this.hass;
 
       const cards = this.emptyCards();
@@ -293,9 +293,9 @@
       }
 
       const splitted = window.HAWS.splitByGroups(states);
-      if (orderedGroups) {
-        splitted.groups.sort((gr1, gr2) => orderedGroups[gr1.entity_id] -
-          orderedGroups[gr2.entity_id]);
+      if (orderedGroupEntities) {
+        splitted.groups.sort((gr1, gr2) => orderedGroupEntities[gr1.entity_id] -
+          orderedGroupEntities[gr2.entity_id]);
       } else {
         splitted.groups.sort((gr1, gr2) => gr1.attributes.order - gr2.attributes.order);
       }
@@ -335,13 +335,13 @@
         coll[domain].states.push(state);
       });
 
-      if (orderedGroups) {
+      if (orderedGroupEntities) {
         iterateDomain(badgesColl, (domain) => {
           cards.badges.push.apply(cards.badges, domain.states);
         });
         
-        cards.badges.sort((e1, e2) => orderedGroups[e1.entity_id] -
-          orderedGroups[e2.entity_id]);
+        cards.badges.sort((e1, e2) => orderedGroupEntities[e1.entity_id] -
+          orderedGroupEntities[e2.entity_id]);
       } else {
         iterateDomainSorted(badgesColl, (domain) => {
           cards.badges.push.apply(cards.badges, domain.states);

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -143,6 +143,14 @@
       });
   };
 
+  const iterateDomain = (collection, func) => {
+    Object.keys(collection)
+      .map(key => collection[key])
+      .forEach((domain) => {
+        func(domain);
+      });
+  };
+
   const computeDomain = window.hassUtil.computeDomain;
 
   class HaCards extends Polymer.Element {
@@ -327,9 +335,18 @@
         coll[domain].states.push(state);
       });
 
-      iterateDomainSorted(badgesColl, (domain) => {
-        cards.badges.push.apply(cards.badges, domain.states);
-      });
+      if (orderedGroups) {
+        iterateDomain(badgesColl, (domain) => {
+          cards.badges.push.apply(cards.badges, domain.states);
+        });
+        
+        cards.badges.sort((e1, e2) => orderedGroups[e1.entity_id] -
+          orderedGroups[e2.entity_id]);
+      } else {
+        iterateDomainSorted(badgesColl, (domain) => {
+          cards.badges.push.apply(cards.badges, domain.states);
+        });
+      }
 
       iterateDomainSorted(beforeGroupColl, (domain) => {
         addEntitiesCard(domain.domain, domain.states);

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -134,8 +134,7 @@
   };
 
   const iterateDomainSorted = (collection, func) => {
-    Object.keys(collection)
-      .map(key => collection[key])
+    Object.values(collection)
       .sort(sortPriority)
       .forEach((domain) => {
         domain.states.sort(entitySortBy);
@@ -144,8 +143,7 @@
   };
 
   const iterateDomain = (collection, func) => {
-    Object.keys(collection)
-      .map(key => collection[key])
+    Object.values(collection)
       .forEach((domain) => {
         func(domain);
       });

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -339,7 +339,7 @@
         iterateDomain(badgesColl, (domain) => {
           cards.badges.push.apply(cards.badges, domain.states);
         });
-        
+
         cards.badges.sort((e1, e2) => orderedGroupEntities[e1.entity_id] -
           orderedGroupEntities[e2.entity_id]);
       } else {

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -113,7 +113,7 @@
           columns='[[_columns]]'
           hass='[[hass]]'
           panel-visible='[[panelVisible]]'
-          ordered-groups='[[orderedGroups]]'
+          ordered-group-entities='[[orderedGroupEntities]]'
         ></ha-cards>
 
         <template is='dom-repeat' items='[[views]]'>
@@ -123,7 +123,7 @@
             columns='[[_columns]]'
             hass='[[hass]]'
             panel-visible='[[panelVisible]]'
-            ordered-groups='[[orderedGroups]]'
+            ordered-group-entities='[[orderedGroupEntities]]'
           ></ha-cards>
         </template>
 
@@ -198,9 +198,9 @@
           computed: 'computeViewStates(currentView, hass, defaultView)',
         },
 
-        orderedGroups: {
+        orderedGroupEntities: {
           type: Array,
-          computed: 'computeOrderedGroups(currentView, hass, defaultView)',
+          computed: 'computeOrderedGroupEntities(currentView, hass, defaultView)',
         },
 
         showTabs: {
@@ -372,19 +372,19 @@
     /*
       Compute the ordered list of groups for this view
     */
-    computeOrderedGroups(currentView, hass, defaultView) {
+    computeOrderedGroupEntities(currentView, hass, defaultView) {
       if (!this.isView(currentView, defaultView)) {
         return null;
       }
 
-      var orderedGroups = {};
+      var orderedGroupEntities = {};
       var entitiesList = hass.states[currentView || DEFAULT_VIEW_ENTITY_ID].attributes.entity_id;
 
       for (var i = 0; i < entitiesList.length; i++) {
-        orderedGroups[entitiesList[i]] = i;
+        orderedGroupEntities[entitiesList[i]] = i;
       }
 
-      return orderedGroups;
+      return orderedGroupEntities;
     }
   }
 


### PR DESCRIPTION
Sort badges by the order they are specified in their parent group. This is the same logic that is used for group cards.
If there is no sorting specified (the user has not specified a view), it maintains the old behavior. 