### PR TITLE
Pass language to charts and fix JS error

### DIFF
--- a/src/components/state-history-charts.html
+++ b/src/components/state-history-charts.html
@@ -105,6 +105,7 @@ class StateHistoryCharts extends Polymer.Element {
   _googleApiLoaded() {
     window.google.load('visualization', '1', {
       packages: ['timeline', 'corechart'],
+      language: navigator.language,
       callback: function () {
         this._apiLoaded = true;
       }.bind(this),

--- a/src/data/ha-state-history-data.html
+++ b/src/data/ha-state-history-data.html
@@ -140,7 +140,7 @@
       super.connectedCallback();
       this.filterChanged(
         this.filterType, this.entityId, this.startTime, this.endTime,
-        this.cacheConfig
+        this.cacheConfig, this.localize, this.language
       );
     }
 


### PR DESCRIPTION
* Fix history panel JS error
* Pass `navigator.language` to Google Charts