### PR TITLE
BugFix: Fixing paper-dialog-scrollable clipping on IOS

### DIFF
--- a/src/dialogs/more-info-dialog.html
+++ b/src/dialogs/more-info-dialog.html
@@ -15,6 +15,9 @@
         font-size: 14px;
         width: 365px;
         border-radius: 2px;
+        --paper-dialog-scrollable: {
+          -webkit-overflow-scrolling: auto;
+        }
       }
 
       paper-dialog[data-domain=camera] {


### PR DESCRIPTION
Fixes: 
https://github.com/home-assistant/home-assistant-polymer/issues/775

Potentially also fixes:
https://github.com/home-assistant/home-assistant/issues/6285
https://github.com/home-assistant/home-assistant-polymer/issues/841
https://github.com/home-assistant/home-assistant-polymer/issues/372

Might also be helpful for https://github.com/home-assistant/home-assistant-polymer/issues/779 if someone wants to try and adapt the fix.

Note: Thanks to @cristianbote that provided the fix