### PR TITLE
Add Object.values polyfill

### DIFF
--- a/js/compatibility.js
+++ b/js/compatibility.js
@@ -3,3 +3,7 @@ import 'unfetch/polyfill';
 import objAssign from 'es6-object-assign';
 
 objAssign.polyfill();
+
+if (Object.values === undefined) {
+  Object.values = target => Object.keys(target).map(key => target[key]);
+}


### PR DESCRIPTION
Add Object.values polyfill

The [tc39](https://github.com/tc39/proposal-object-values-entries/blob/master/polyfill.js) implementation uses `Reflect.ownKeys` which is fairly new.
The [es-shims](https://github.com/es-shims/Object.values/blob/master/implementation.js) implementation is large.