### PR TITLE
ZWave Node Management - Show hidden nodes

### DIFF
--- a/panels/config/zwave/ha-config-zwave.html
+++ b/panels/config/zwave/ha-config-zwave.html
@@ -449,8 +449,7 @@ class HaConfigZwave extends window.hassMixins.LocalizeMixin(Polymer.Element) {
     return Object.keys(hass.states)
       .map(function (key) { return hass.states[key]; })
       .filter(function (ent) {
-        return (!ent.attributes.hidden &&
-                (ent.entity_id).match('zwave[.]'));
+        return ((ent.entity_id).match('zwave[.]'));
       })
       .sort(window.hassUtil.sortByName);
   }


### PR DESCRIPTION
Fixes issue where only visible entities where shown in the config panel.
The Node Management node entries shouldn't depend on the entities being visible.
E.g. for covers it's enough to have the cover entity visible in order to have access to the full functionality.

The issue lead to great confusion seen here:
[Home-Assistant#7972](https://github.com/home-assistant/home-assistant/issues/7972)
[Home-Assistant#8309](https://github.com/home-assistant/home-assistant/issues/8309)
[Community.Home-Assistant](https://community.home-assistant.io/t/nodes-not-showing-under-z-wave-node-controls/20174)