### PR TITLE
Plot data card - for making custom graph

### DIFF
--- a/src/cards/ha-card-chooser.html
+++ b/src/cards/ha-card-chooser.html
@@ -7,6 +7,7 @@
 <link rel='import' href='./ha-weather-card.html'>
 <link rel='import' href='./ha-persistent_notification-card.html'>
 <link rel='import' href='./ha-plant-card.html'>
+<link rel='import' href='./ha-plot_data-card.html'>
 
 <script>
 class HaCardChooser extends Polymer.Element {
@@ -22,9 +23,9 @@ class HaCardChooser extends Polymer.Element {
 
   cardDataChanged(newData) {
     if (!newData) return;
-
+    const card_type = ((newData.stateObj.attributes._plot_data) ? 'PLOT_DATA' : newData.cardType.toUpperCase())
     window.hassUtil.dynamicContentUpdater(
-      this, 'HA-' + newData.cardType.toUpperCase() + '-CARD',
+      this, 'HA-' + card_type + '-CARD',
       newData
     );
   }

--- a/src/cards/ha-card-chooser.html
+++ b/src/cards/ha-card-chooser.html
@@ -23,9 +23,9 @@ class HaCardChooser extends Polymer.Element {
 
   cardDataChanged(newData) {
     if (!newData) return;
-    const card_type = ((newData.stateObj.attributes._plot_data) ? 'PLOT_DATA' : newData.cardType.toUpperCase())
+    const cardType = ((newData.stateObj.attributes._plot_data) ? 'PLOT_DATA' : newData.cardType.toUpperCase());
     window.hassUtil.dynamicContentUpdater(
-      this, 'HA-' + card_type + '-CARD',
+      this, 'HA-' + cardType + '-CARD',
       newData
     );
   }

--- a/src/cards/ha-plot_data-card.html
+++ b/src/cards/ha-plot_data-card.html
@@ -1,0 +1,140 @@
+<link rel='import' href='../../bower_components/polymer/polymer-element.html'>
+<link rel='import' href='../../bower_components/iron-flex-layout/iron-flex-layout-classes.html'>
+<link rel='import' href='../../bower_components/google-apis/google-legacy-loader.html'>
+<link rel='import' href='../components/ha-card.html'>
+
+<link rel='import' href='../util/hass-mixins.html'>
+
+<dom-module id='ha-plot_data-card'>
+  <template>
+    <style>
+        .content {
+          padding: 0 16px 16px;
+        }
+        .attribution {
+          color: var(--secondary-text-color);
+          text-align: right;
+        }
+        span.line {
+          display: block;
+        }
+        .clear {
+          clear: both;
+        }
+    </style>
+    <google-legacy-loader on-api-load='googleApiLoaded'></google-legacy-loader>
+    <ha-card header='[[computeTitle(stateObj)]]'>
+      <div class='content'>
+          <div class='attribution attribution'>[[stateObj.state]] [[stateObj.attributes.unit_of_measurement]]</div>
+        <div id='chart_id' hidden$="[[!attr._plot_data]]"></div>
+      </div>
+    </ha-card>
+  </template>
+</dom-module>
+
+<script>
+{
+
+  class HaPlotDataCard extends window.hassMixins.LocalizeMixin(Polymer.Element) {
+    static get is() { return 'ha-plot_data-card'; }
+    static get properties() {
+      return {
+        hass: Object,
+        stateObj: {
+          type: Object,
+          observer: 'checkRequirements'
+        },
+      };
+    }
+
+    computeTitle(stateObj) {
+      return stateObj.attributes.friendly_name;
+    }
+
+    checkRequirements() {
+      if (!this.stateObj) {
+        return;
+      }
+      if (!this.stateObj.attributes) {
+        return;
+      }
+      if (!this.stateObj.attributes._plot_data) {
+        return;
+      }
+      if (!window.google || !window.google.visualization) {
+        return;
+      }
+
+      if (!this.chartEngine) {
+        this.chartEngine = new window.google.visualization.LineChart(this.$.chart_id);
+      }
+      this.drawChart();
+    }
+
+    drawChart() {
+      var dataGrid = new window.google.visualization.DataTable();
+      var plot_data = this.stateObj.attributes._plot_data;
+      if (!plot_data || !plot_data.data) {
+        return;
+      }
+
+      var colors = ['red'];
+      if (plot_data.color){
+        colors = plot_data.color;
+      } 
+      dataGrid.addColumn('datetime', 'Time');
+      var j;
+      for (j = 0; j < plot_data.attr.length; j++) {
+        dataGrid.addColumn('number', plot_data.attr[j]);
+      }
+
+      var dataArray = [];
+      var i;
+      for (i = 0; i < plot_data.data.length; i++) {
+        var _row = [new Date(plot_data.data[i].x)];
+        var _y = plot_data.data[i].y; 
+        var j;
+        for (j = 0; j < _y.length; j++) {
+          _row.push(_y[j]);
+        }
+        dataArray.push(_row);
+      }
+      dataGrid.addRows(dataArray);
+
+      var options = {
+        legend: {
+          position: 'top'
+        },
+        interpolateNulls: true,
+        titlePosition: 'none',
+        chartArea: {
+          left: 25,
+          top: 5,
+          height: '100%',
+          width: '90%',
+          bottom: 25,
+        },
+        curveType: 'function',
+        focusTarget: 'category',
+        colors: colors,
+        annotations: {
+          textStyle: {
+            fontSize: '24',
+          }
+        }
+      };
+      this.chartEngine.draw(dataGrid, options);
+      }
+
+    googleApiLoaded() {
+      window.google.load('visualization', '1', {
+        packages: ['corechart'],
+        callback: function () {
+          this.checkRequirements();
+        }.bind(this),
+      });
+    }
+  }
+  customElements.define(HaPlotDataCard.is, HaPlotDataCard);
+}
+</script>

--- a/src/cards/ha-plot_data-card.html
+++ b/src/cards/ha-plot_data-card.html
@@ -72,7 +72,6 @@
     drawChart() {
       var dataGrid = new window.google.visualization.DataTable();
       var plotData = this.stateObj.attributes._plot_data;
-      var j;
       if (!plotData || !plotData.data) {
         return;
       }
@@ -82,16 +81,18 @@
         colors = plotData.color;
       }
       dataGrid.addColumn('datetime', 'Time');
+      var j;
       for (j = 0; j < plotData.attr.length; j++) {
         dataGrid.addColumn('number', plotData.attr[j]);
       }
 
       var dataArray = [];
-      for (j = 0; j < plotData.data.length; j++) {
-        var _row = [new Date(plotData.data[j].x)];
-        var _y = plotData.data[j].y;
+      var k;
+      for (k = 0; k < plotData.data.length; k++) {
+        var _row = [new Date(plotData.data[k].x)];
+        var _y = plotData.data[k].y;
         var i;
-        for (i = 0; j < _y.length; i++) {
+        for (i = 0; i < _y.length; i++) {
           _row.push(_y[i]);
         }
         dataArray.push(_row);

--- a/src/cards/ha-plot_data-card.html
+++ b/src/cards/ha-plot_data-card.html
@@ -31,10 +31,8 @@
     </ha-card>
   </template>
 </dom-module>
-
 <script>
 {
-
   class HaPlotDataCard extends window.hassMixins.LocalizeMixin(Polymer.Element) {
     static get is() { return 'ha-plot_data-card'; }
     static get properties() {
@@ -73,28 +71,25 @@
 
     drawChart() {
       var dataGrid = new window.google.visualization.DataTable();
-      var plot_data = this.stateObj.attributes._plot_data;
-      if (!plot_data || !plot_data.data) {
+      var plotData = this.stateObj.attributes._plot_data;
+      if (!plotData || !plotData.data) {
         return;
       }
 
       var colors = ['red'];
-      if (plot_data.color){
-        colors = plot_data.color;
-      } 
+      if (plotData.color) {
+        colors = plotData.color;
+      }
       dataGrid.addColumn('datetime', 'Time');
-      var j;
-      for (j = 0; j < plot_data.attr.length; j++) {
-        dataGrid.addColumn('number', plot_data.attr[j]);
+      for (var j = 0; j < plotData.attr.length; j++) {
+        dataGrid.addColumn('number', plotData.attr[j]);
       }
 
       var dataArray = [];
-      var i;
-      for (i = 0; i < plot_data.data.length; i++) {
-        var _row = [new Date(plot_data.data[i].x)];
-        var _y = plot_data.data[i].y; 
-        var j;
-        for (j = 0; j < _y.length; j++) {
+      for (var i = 0; i < plotData.data.length; i++) {
+        var _row = [new Date(plotData.data[i].x)];
+        var _y = plotData.data[i].y; 
+        for (var j = 0; j < _y.length; j++) {
           _row.push(_y[j]);
         }
         dataArray.push(_row);

--- a/src/cards/ha-plot_data-card.html
+++ b/src/cards/ha-plot_data-card.html
@@ -72,6 +72,7 @@
     drawChart() {
       var dataGrid = new window.google.visualization.DataTable();
       var plotData = this.stateObj.attributes._plot_data;
+      var j;
       if (!plotData || !plotData.data) {
         return;
       }
@@ -81,16 +82,17 @@
         colors = plotData.color;
       }
       dataGrid.addColumn('datetime', 'Time');
-      for (var j = 0; j < plotData.attr.length; j++) {
+      for (j = 0; j < plotData.attr.length; j++) {
         dataGrid.addColumn('number', plotData.attr[j]);
       }
 
       var dataArray = [];
-      for (var i = 0; i < plotData.data.length; i++) {
-        var _row = [new Date(plotData.data[i].x)];
-        var _y = plotData.data[i].y; 
-        for (var j = 0; j < _y.length; j++) {
-          _row.push(_y[j]);
+      for (j = 0; j < plotData.data.length; j++) {
+        var _row = [new Date(plotData.data[j].x)];
+        var _y = plotData.data[j].y;
+        var i;
+        for (i = 0; j < _y.length; i++) {
+          _row.push(_y[i]);
         }
         dataArray.push(_row);
       }
@@ -119,7 +121,7 @@
         }
       };
       this.chartEngine.draw(dataGrid, options);
-      }
+    }
 
     googleApiLoaded() {
       window.google.load('visualization', '1', {

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -324,7 +324,6 @@
           };
         }
 
-
         coll[domain].states.push(state);
       });
 

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -328,8 +328,6 @@
         coll[domain].states.push(state);
       });
 
-
-
       iterateDomainSorted(badgesColl, (domain) => {
         cards.badges.push.apply(cards.badges, domain.states);
       });

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -252,7 +252,7 @@
         entities.forEach((entity) => {
           const domain = computeDomain(entity);
 
-          if (domain in DOMAINS_WITH_CARD) {
+          if (domain in DOMAINS_WITH_CARD || entity.attributes._plot_data) {
             owncard.push(entity);
             size += DOMAINS_WITH_CARD[domain];
           } else {
@@ -305,7 +305,7 @@
           return;
         }
 
-        const priority = getPriority(domain);
+        const priority = ((state.attributes._plot_data) ? 100 : getPriority(domain));
         let coll;
 
         if (priority < 0) {
@@ -324,8 +324,11 @@
           };
         }
 
+
         coll[domain].states.push(state);
       });
+
+
 
       iterateDomainSorted(badgesColl, (domain) => {
         cards.badges.push.apply(cards.badges, domain.states);


### PR DESCRIPTION
This will add a possibility for a component to make a custom graph. All components can provide a _plot_data dictionary as an attribute, and this will result in a custom graph in the frontend.

![untitled](https://user-images.githubusercontent.com/650502/35860712-5337eaaa-0b45-11e8-9a72-e37b2eb73532.png)

I am planing to use it in the backend like this: https://github.com/home-assistant/home-assistant/compare/tibber_plot?expand=1#diff-43f211c43ec818fda11c8afe6bab1ee5R95

This will allow the Tibber sensor to show the coming electricity prices, and not only the historic ones.
I guess other components could use this functionality too. And I already have an idea of adding another Tibber sensor, where this will be required.

(I have not done much frontend development, so hope to get some good feedback)
