### PR TITLE
Improve UX template editor

### DIFF
--- a/panels/dev-template/ha-panel-dev-template.html
+++ b/panels/dev-template/ha-panel-dev-template.html
@@ -48,6 +48,12 @@
         right: 8px;
       }
 
+      paper-textarea {
+        --paper-input-container-input: {
+          @apply(--paper-font-code1);
+        }
+      }
+
       .rendered {
         @apply(--paper-font-code1)
         clear: both;
@@ -76,7 +82,11 @@
             <li><a href='http://jinja.pocoo.org/docs/dev/templates/' target='_blank'>Jinja2 template documentation</a></li>
             <li><a href='https://home-assistant.io/topics/templating/' target='_blank'>Home Assistant template extensions</a></li>
           </ul>
-          <paper-textarea label="Template" value='{{template}}'></paper-textarea>
+          <paper-textarea
+            label="Template Editor"
+            value='{{template}}'
+            autofocus
+          ></paper-textarea>
         </div>
 
         <div class='render-pane'>
@@ -121,31 +131,27 @@ class HaPanelDevTemplate extends Polymer.Element {
       template: {
         type: String,
         /* eslint-disable max-len */
-        value: 'Imitate available variables:\n' +
-               '{% set my_test_json = {\n' +
-               '  "temperature": 25,\n' +
-               '  "unit": "°C"\n' +
-               '} %}\n' +
-               '\n' +
-               'The temperature is {{ my_test_json.temperature }} {{ my_test_json.unit }}. \n' +
-               '\n' +
-               '{% if is_state("device_tracker.paulus", "home") and \n' +
-               '       is_state("device_tracker.anne_therese", "home") -%}\n' +
-               '\n' +
-               '  You are both home, you silly\n' +
-               '\n' +
-               '{%- else -%}\n' +
-               '\n' +
-               '  Anne Therese is at {{ states("device_tracker.anne_therese") }} and ' +
-               'Paulus is at {{ states("device_tracker.paulus") }}\n' +
-               '\n' +
-               '{%- endif %}\n' +
-               '\n' +
-               'For loop example:\n' +
-               '{% for state in states.sensor -%}\n' +
-               '  {%- if loop.first %}The {% elif loop.last %} and the {% else %}, the {% endif -%}\n' +
-               '  {{ state.name | lower }} is {{state.state_with_unit}}\n' +
-               '{%- endfor -%}.',
+        value: `Imitate available variables:
+{% set my_test_json = {
+  "temperature": 25,
+  "unit": "°C"
+} %}
+
+The temperature is {{ my_test_json.temperature }} {{ my_test_json.unit }}.
+
+{% if is_state("device_tracker.paulus", "home") and
+      is_state("device_tracker.anne_therese", "home") -%}
+  You are both home, you silly
+{%- else -%}
+  Anne Therese is at {{ states("device_tracker.anne_therese") }} and  +
+Paulus is at {{ states("device_tracker.paulus") }}
+{%- endif %}
+
+For loop example:
+{% for state in states.sensor -%}
+  {%- if loop.first %}The {% elif loop.last %} and the {% else %}, the {% endif -%}
+  {{ state.name | lower }} is {{state.state_with_unit}}
+{%- endfor -%}.`,
         /* eslint-enable max-len */
         observer: 'templateChanged',
       },

--- a/panels/dev-template/ha-panel-dev-template.html
+++ b/panels/dev-template/ha-panel-dev-template.html
@@ -83,7 +83,7 @@
             <li><a href='https://home-assistant.io/topics/templating/' target='_blank'>Home Assistant template extensions</a></li>
           </ul>
           <paper-textarea
-            label="Template Editor"
+            label="Template editor"
             value='{{template}}'
             autofocus
           ></paper-textarea>
@@ -143,15 +143,15 @@ The temperature is {{ my_test_json.temperature }} {{ my_test_json.unit }}.
       is_state("device_tracker.anne_therese", "home") -%}
   You are both home, you silly
 {%- else -%}
-  Anne Therese is at {{ states("device_tracker.anne_therese") }} and  +
-Paulus is at {{ states("device_tracker.paulus") }}
+  Anne Therese is at {{ states("device_tracker.anne_therese") }}
+  Paulus is at {{ states("device_tracker.paulus") }}
 {%- endif %}
 
 For loop example:
 {% for state in states.sensor -%}
   {%- if loop.first %}The {% elif loop.last %} and the {% else %}, the {% endif -%}
   {{ state.name | lower }} is {{state.state_with_unit}}
-{%- endfor -%}.`,
+{%- endfor %}.`,
         /* eslint-enable max-len */
         observer: 'templateChanged',
       },


### PR DESCRIPTION
I was hanging out in #general when I noticed some confusion about the template dev tool. People didn't realize that the left was editable.

Changes made:
 - Change label from "template" to "Template editor"
 - Autofocus the template editor
 - Change font of editor to monospace font