### PR TITLE
Fingerprint charts

### DIFF
--- a/gulp/tasks/build.js
+++ b/gulp/tasks/build.js
@@ -36,7 +36,6 @@ function build(es6) {
     stripImportsStrategy([
       'bower_components/font-roboto/roboto.html',
       'bower_components/paper-styles/color.html',
-      'src/resources/ha-chart-scripts.html',
     ]),
     stripAllButEntrypointStrategy('panels/hassio/ha-panel-hassio.html')
   ]);

--- a/gulp/tasks/gen-index-html.js
+++ b/gulp/tasks/gen-index-html.js
@@ -9,6 +9,7 @@ const { minifyStream } = require('../common/transform');
 const buildReplaces = {
   '/home-assistant-polymer/build/core.js': 'core.js',
   '/home-assistant-polymer/src/home-assistant.html': 'frontend.html',
+  '/home-assistant-polymer/src/resources/ha-chart-scripts.html': 'ha-chart-scripts.html',
 };
 
 function generateIndex(es6) {

--- a/gulp/tasks/gen-service-worker.js
+++ b/gulp/tasks/gen-service-worker.js
@@ -30,12 +30,14 @@ const staticFingerprinted = [
 const staticFingerprintedEs6 = [
   'core.js',
   'frontend.html',
+  'ha-chart-scripts.html',
 ];
 
 const staticFingerprintedEs5 = [
   'compatibility.js',
   'core.js',
   'frontend.html',
+  'ha-chart-scripts.html',
 ];
 
 // These panels will always be registered inside HA and thus can

--- a/gulp/tasks/rollup.js
+++ b/gulp/tasks/rollup.js
@@ -58,7 +58,6 @@ function getRollupInputOptions(es6) {
           __DEMO__: JSON.stringify(DEMO),
           __BUILD__: JSON.stringify(es6 ? 'latest' : 'es5'),
           __VERSION__: JSON.stringify(VERSION),
-          __ROOT__: JSON.stringify(es6 ? 'frontend_latest' : 'frontend_es5'),
         },
       }),
     ],

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
           navigator.serviceWorker.register('/service_worker.js');
         });
       }
+      window.CHART_SCRIPT = '/home-assistant-polymer/src/resources/ha-chart-scripts.html';
     </script>
     <!--<script src='/home-assistant-polymer/build/_demo_data_compiled.js'></script>-->
     <!--EXTRA_SCRIPTS-->

--- a/js/core.js
+++ b/js/core.js
@@ -5,7 +5,6 @@ window.HASS_DEMO = __DEMO__;
 window.HASS_DEV = __DEV__;
 window.HASS_BUILD = __BUILD__;
 window.HASS_VERSION = __VERSION__;
-window.HASS_ROOT = __ROOT__;
 
 const init = window.createHassConnection = function (password) {
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';

--- a/src/components/entity/ha-chart-base.html
+++ b/src/components/entity/ha-chart-base.html
@@ -1,5 +1,4 @@
 <link rel='import' href='../../../bower_components/polymer/polymer-element.html'>
-<link rel='import' href='../../resources/ha-chart-scripts.html'>
 
 <dom-module id="ha-chart-base">
   <template>
@@ -148,7 +147,7 @@
 
       if (!SCRIPT_LOADED) {
         Polymer.importHref(
-          `${window.HASS_ROOT}/ha-chart-scripts.html`,
+          window.CHART_SCRIPT,
           () => {
             SCRIPT_LOADED = true;
             this.onPropsChange();


### PR DESCRIPTION
This fingerprints the chart URL like we do our other resources. Because of the order of our build steps, it meant that I had to include the url of the charts file in `index.html`.

Tested it locally and it works.

CC @andrey-git 