### PR TITLE
[Bug] Do not overwrite the content of JSONTextField while the user is editing such

### DIFF
--- a/js/panel-config/json_textarea.js
+++ b/js/panel-config/json_textarea.js
@@ -32,10 +32,12 @@ export default class JSONTextArea extends Component {
   }
 
   componentWillReceiveProps({ value }) {
-    this.setState({
-      value: JSON.stringify(value, null, 2),
-      isValid: true,
-    });
+    if(this.state.isValid){
+      this.setState({
+        value: JSON.stringify(value, null, 2),
+        isValid: true,
+      });
+    }
   }
 
   render({ label }, { value, isValid }) {

--- a/js/panel-config/json_textarea.js
+++ b/js/panel-config/json_textarea.js
@@ -32,12 +32,11 @@ export default class JSONTextArea extends Component {
   }
 
   componentWillReceiveProps({ value }) {
-    if (this.state.isValid) {
-      this.setState({
-        value: JSON.stringify(value, null, 2),
-        isValid: true,
-      });
-    }
+    if (value === this.props.value) return;
+    this.setState({
+      value: JSON.stringify(value, null, 2),
+      isValid: true,
+    });
   }
 
   render({ label }, { value, isValid }) {

--- a/js/panel-config/json_textarea.js
+++ b/js/panel-config/json_textarea.js
@@ -32,7 +32,7 @@ export default class JSONTextArea extends Component {
   }
 
   componentWillReceiveProps({ value }) {
-    if(this.state.isValid){
+    if (this.state.isValid) {
       this.setState({
         value: JSON.stringify(value, null, 2),
         isValid: true,


### PR DESCRIPTION
Closes #816 

This change prevents the value of the JSONTextField object from being overwritten when a render is triggered while the content is invalid JSON (such as when the user is editing such!), and therefore not stored in the JSONTextField's props object.