### PR TITLE
Load the chart resources in dev too

### DIFF
--- a/src/components/entity/ha-chart-base.html
+++ b/src/components/entity/ha-chart-base.html
@@ -100,7 +100,7 @@
 // eslint-disable-next-line no-unused-vars
 /* global Chart moment Color */
 {
-  let SCRIPT_LOADED = window.HASS_DEV;
+  let SCRIPT_LOADED = false;
 
   class HaChartBase extends Polymer.Element {
     get chart() {


### PR DESCRIPTION
When switching to always loading the resources on demand, I forgot to change the default value to be always false instead of dev. This caused the charts not to load in dev.