### PR TITLE
Fix template panel link

### DIFF
--- a/panels/dev-template/ha-panel-dev-template.html
+++ b/panels/dev-template/ha-panel-dev-template.html
@@ -80,7 +80,7 @@
           </p>
           <ul>
             <li><a href='http://jinja.pocoo.org/docs/dev/templates/' target='_blank'>Jinja2 template documentation</a></li>
-            <li><a href='https://home-assistant.io/topics/templating/' target='_blank'>Home Assistant template extensions</a></li>
+            <li><a href='https://home-assistant.io/docs/configuration/templating/' target='_blank'>Home Assistant template extensions</a></li>
           </ul>
           <paper-textarea
             label="Template editor"


### PR DESCRIPTION
## Description:

Clicking the "Home Assistant template extensions" link in the template panel links to https://home-assistant.io/topics/templating/, which then immediately redirects to https://home-assistant.io/docs/configuration/templating/. I guess this is because the docs were moved at some point. This PR gets rid of the redirect and links directly to where the resource resides now.

⚠️ This is a tiny change and I'd doubt that this would break anything - still though I've not tested this because I haven't set up a dev environment.