### PR TITLE
Fix display issues on iOS 9.3.5

### DIFF
--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -85,45 +85,6 @@
     --light-secondary-opacity: 0.7;
     --light-primary-opacity: 1.0;
   }
-
-  body {
-    /* for paper-toggle-button */
-    --paper-grey-50: #fafafa;
-    --paper-grey-200: #eeeeee;
-
-    --paper-item-icon-color: #44739e;
-    --paper-item-icon-active-color: #FDD835;
-
-    --dark-primary-color: #0288D1;
-    --primary-color: #03A9F4;
-    --light-primary-color: #B3E5FC;
-    --text-primary-color: #ffffff;
-    --accent-color: #FF9800;
-    --primary-background-color: var(--paper-grey-50);
-    --secondary-background-color: #E5E5E5;
-    --primary-text-color: #212121;
-    --secondary-text-color: #727272;
-    --disabled-text-color: #bdbdbd;
-    --divider-color: rgba(0, 0, 0, .12);
-
-    --table-row-background-color: transparant;
-    --table-row-alternative-background-color: #eee;
-
-    --paper-toggle-button-checked-ink-color: #039be5;
-    --paper-toggle-button-checked-button-color: #039be5;
-    --paper-toggle-button-checked-bar-color: #039be5;
-
-    --paper-slider-knob-color: var(--primary-color);
-    --paper-slider-knob-start-color: var(--primary-color);
-    --paper-slider-pin-color: var(--primary-color);
-    --paper-slider-active-color: var(--primary-color);
-    --paper-slider-secondary-color: var(--light-primary-color);
-    --paper-slider-container-color: var(--divider-color);
-
-    --paper-card-background-color: #FFF;
-    --paper-listbox-background-color: #FFF;
-  }
-
 </style>
 </custom-style>
 

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-styles/paper-styles.html">
 
 <custom-style>
 <style is="custom-style">/* remove is= on Polymer 2 */

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -2,7 +2,7 @@
 
 <custom-style>
 <style is="custom-style">/* remove is= on Polymer 2 */
-  body {
+  html {
     font-size: 14px;
     height: 100vh;
 

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -6,9 +6,6 @@
   Home Assistant default styles.
 
   In Polymer 2.0, default styles should to be set on the html selector.
-
-  To prevent overriding of thse styles by Polymer-defaults we define
-  the overrideable content on the body selector too.
   (Setting all default styles only on body breaks shadyCSS polyfill.)
   See: https://github.com/home-assistant/home-assistant-polymer/pull/901
 */

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -75,6 +75,45 @@
     --light-secondary-opacity: 0.7;
     --light-primary-opacity: 1.0;
   }
+
+  body {
+    /* for paper-toggle-button */
+    --paper-grey-50: #fafafa;
+    --paper-grey-200: #eeeeee;
+
+    --paper-item-icon-color: #44739e;
+    --paper-item-icon-active-color: #FDD835;
+
+    --dark-primary-color: #0288D1;
+    --primary-color: #03A9F4;
+    --light-primary-color: #B3E5FC;
+    --text-primary-color: #ffffff;
+    --accent-color: #FF9800;
+    --primary-background-color: var(--paper-grey-50);
+    --secondary-background-color: #E5E5E5;
+    --primary-text-color: #212121;
+    --secondary-text-color: #727272;
+    --disabled-text-color: #bdbdbd;
+    --divider-color: rgba(0, 0, 0, .12);
+
+    --table-row-background-color: transparant;
+    --table-row-alternative-background-color: #eee;
+
+    --paper-toggle-button-checked-ink-color: #039be5;
+    --paper-toggle-button-checked-button-color: #039be5;
+    --paper-toggle-button-checked-bar-color: #039be5;
+
+    --paper-slider-knob-color: var(--primary-color);
+    --paper-slider-knob-start-color: var(--primary-color);
+    --paper-slider-pin-color: var(--primary-color);
+    --paper-slider-active-color: var(--primary-color);
+    --paper-slider-secondary-color: var(--light-primary-color);
+    --paper-slider-container-color: var(--divider-color);
+
+    --paper-card-background-color: #FFF;
+    --paper-listbox-background-color: #FFF;
+  }
+  
 </style>
 </custom-style>
 

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -8,8 +8,9 @@
   In Polymer 2.0, default styles should to be set on the html selector.
 
   To prevent overriding of thse styles by Polymer-defaults we define
-  the overrideable content on the body selector too. 
+  the overrideable content on the body selector too.
   (Setting all default styles only on body breaks shadyCSS polyfill.)
+  See: https://github.com/home-assistant/home-assistant-polymer/pull/901
 */
   html {
     font-size: 14px;
@@ -122,7 +123,7 @@
     --paper-card-background-color: #FFF;
     --paper-listbox-background-color: #FFF;
   }
-  
+
 </style>
 </custom-style>
 

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -2,6 +2,15 @@
 
 <custom-style>
 <style is="custom-style">/* remove is= on Polymer 2 */
+/*
+  Home Assistant default styles.
+
+  In Polymer 2.0, default styles should to be set on the html selector.
+
+  To prevent overriding of thse styles by Polymer-defaults we define
+  the overrideable content on the body selector too. 
+  (Setting all default styles only on body breaks shadyCSS polyfill.)
+*/
   html {
     font-size: 14px;
     height: 100vh;


### PR DESCRIPTION
This fixes some (bad) display issues on older devices.
ShadyCSS now correctly polyfills the default colors set in ha-style.
Before it somehow did not 'find' the css variables in the defaults because they were set with the wrong selector.

**documentation reference**
https://www.polymer-project.org/2.0/docs/upgrade#update-custom-property-syntax
see the comment in the code snippet under "After (hybrid code)" which states:
` /* In a 2.x custom-style use the html selector to set global defaults */`

**Images before and after**
![img_0270](https://user-images.githubusercontent.com/411716/36359063-82b89aa0-1517-11e8-8d60-a40fc403e7f9.PNG)
![img_0271](https://user-images.githubusercontent.com/411716/36359066-8e0df3fa-1517-11e8-93b3-e52185a4dbb2.PNG)
