### PR TITLE
add static colors for waterfurnace states

### DIFF
--- a/src/components/state-history-chart-timeline.html
+++ b/src/components/state-history-chart-timeline.html
@@ -46,7 +46,14 @@ class StateHistoryChartTimeline extends Polymer.Element {
       off: 0,
       unavailable: '#a0a0a0',
       unknown: '#606060',
-      idle: 2
+      idle: 2,
+      'heating 1': '#FF8447',
+      'heating 2': '#C7582E',
+      'aux heat': '#941400',
+      'cooling 1': '#95CEDE',
+      'cooling 2': '#5F7EA3',
+      'standby': 2,
+      'fan only': '#807B76'
     };
     let stateHistory = this.data;
 


### PR DESCRIPTION
In order to keep these colors stable for state, add all the furnance
states from waterfurnace. These colors from their web UI, but should
be appropriate to other platforms as well.