### PR TITLE
Remove tap highlight on mobile Safari

### DIFF
--- a/src/cards/ha-entities-card.html
+++ b/src/cards/ha-entities-card.html
@@ -108,9 +108,9 @@ class HaEntitiesCard extends
     const cards = this.root.querySelectorAll('.state');
     cards.forEach((card) => {
       if (card.classList.contains('more-info')) {
-        card.addEventListener('tap', this.entityTapped);
+        card.addEventListener('click', this.entityTapped);
       } else {
-        card.removeEventListener('tap', this.entityTapped);
+        card.removeEventListener('click', this.entityTapped);
       }
     });
   }

--- a/src/layouts/home-assistant-main.html
+++ b/src/layouts/home-assistant-main.html
@@ -19,9 +19,11 @@
     <style>
       :host {
         color: var(--primary-text-color);
+        /* remove the grey tap highlights in iOS on the fullscreen touch targets */
         -webkit-tap-highlight-color: rgba(0,0,0,0);
       }
-      iron-pages {
+      iron-pages, ha-sidebar {
+        /* allow a light tap highlight on the actual interface elements  */
         -webkit-tap-highlight-color: rgba(0,0,0,0.1);
       }
     </style>

--- a/src/layouts/home-assistant-main.html
+++ b/src/layouts/home-assistant-main.html
@@ -21,6 +21,9 @@
         color: var(--primary-text-color);
         -webkit-tap-highlight-color: rgba(0,0,0,0);
       }
+      iron-pages {
+        -webkit-tap-highlight-color: rgba(0,0,0,0.1);
+      }
     </style>
     <more-info-dialog hass='[[hass]]'></more-info-dialog>
     <ha-url-sync hass='[[hass]]'></ha-url-sync>

--- a/src/layouts/home-assistant-main.html
+++ b/src/layouts/home-assistant-main.html
@@ -19,6 +19,7 @@
     <style>
       :host {
 	      color: var(--primary-text-color);
+        -webkit-tap-highlight-color: rgba(0,0,0,0);
       }
     </style>
     <more-info-dialog hass='[[hass]]'></more-info-dialog>

--- a/src/layouts/home-assistant-main.html
+++ b/src/layouts/home-assistant-main.html
@@ -18,7 +18,7 @@
   <template>
     <style>
       :host {
-	      color: var(--primary-text-color);
+        color: var(--primary-text-color);
         -webkit-tap-highlight-color: rgba(0,0,0,0);
       }
     </style>


### PR DESCRIPTION
This removes the tap highlight (transparent grey) over the complete interface or big sections thereof.

The tap highlight behaviour doesn't work nice with the app-experience and full screen touch-listening overlays (like paper-drawer). The items where a tap-highlight would work (clickable state cards for example) don't get the highlight anyway (for some reason).

UX improvement for another PR: `:active` highlights on actually clickable/tappable elements (e.g. state-card)