### PR TITLE
Replace 'tap' with 'click' event listeners

### DIFF
--- a/hassio/addon-view/hassio-addon-config.html
+++ b/hassio/addon-view/hassio-addon-config.html
@@ -45,7 +45,7 @@
           data='[[resetData]]'
         >Reset to defaults</ha-call-api-button>
         <paper-button
-          on-tap='saveTapped'
+          on-click='saveTapped'
           disabled='[[!configParsed]]'
         >Save</paper-button>
       </div>

--- a/hassio/addon-view/hassio-addon-logs.html
+++ b/hassio/addon-view/hassio-addon-logs.html
@@ -17,7 +17,7 @@
         <pre>[[log]]</pre>
       </div>
       <div class="card-actions">
-        <paper-button on-tap='refresh'>Refresh</paper-button>
+        <paper-button on-click='refresh'>Refresh</paper-button>
       </div>
     </paper-card>
   </template>

--- a/hassio/addon-view/hassio-addon-network.html
+++ b/hassio/addon-view/hassio-addon-network.html
@@ -62,7 +62,7 @@
           data="[[resetData]]"
         >Reset to defaults</ha-call-api-button>
         <paper-button
-          on-tap='saveTapped'
+          on-click='saveTapped'
         >Save</paper-button>
       </div>
     </paper-card>

--- a/hassio/addon-view/hassio-addon-view.html
+++ b/hassio/addon-view/hassio-addon-view.html
@@ -43,7 +43,7 @@
           <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='backTapped'
+            on-click='backTapped'
           ></paper-icon-button>
           <div main-title>Hass.io: add-on details</div>
         </app-toolbar>

--- a/hassio/dashboard/hassio-addons.html
+++ b/hassio/dashboard/hassio-addons.html
@@ -17,12 +17,12 @@
       <template is='dom-if' if='[[!addons.length]]'>
         <paper-card>
           <div class='card-content'>
-            You don't have any add-ons installed yet. Head over to <a href='#' on-tap='openStore'>the add-on store</a> to get started!
+            You don't have any add-ons installed yet. Head over to <a href='#' on-click='openStore'>the add-on store</a> to get started!
           </div>
         </paper-card>
       </template>
       <template is='dom-repeat' items='[[addons]]' as='addon'>
-        <paper-card on-tap='addonTapped'>
+        <paper-card on-click='addonTapped'>
           <div class='card-content'>
             <hassio-card-content
               title='[[addon.name]]'

--- a/hassio/snapshots/hassio-snapshot.html
+++ b/hassio/snapshots/hassio-snapshot.html
@@ -16,7 +16,7 @@
       }
       .addon-version {
         color: var(--secondary-text-color);
-      }      
+      }
       .warning,
       .error {
         color: var(--google-red-500);
@@ -68,10 +68,10 @@
         </template>
       </div>
       <div class='buttons'>
-        <paper-button class='warning' on-tap='deleteTapped'>Delete</paper-button>
-        <paper-button on-tap='partialRestoreTapped'>Partial restore</paper-button>
+        <paper-button class='warning' on-click='deleteTapped'>Delete</paper-button>
+        <paper-button on-click='partialRestoreTapped'>Partial restore</paper-button>
         <template is='dom-if' if='[[isFullSnapshot(snapshot.type)]]'>
-          <paper-button on-tap='fullRestoreTapped'>Full restore</paper-button>
+          <paper-button on-click='fullRestoreTapped'>Full restore</paper-button>
         </template>
       </div>
     </paper-dialog>

--- a/hassio/snapshots/hassio-snapshots.html
+++ b/hassio/snapshots/hassio-snapshots.html
@@ -65,7 +65,7 @@
             </div>
           </div>
           <div class='card-actions'>
-            <paper-button disabled='[[creatingSnapshot]]' on-tap='createSnapshot'>Create</paper-button>
+            <paper-button disabled='[[creatingSnapshot]]' on-click='createSnapshot'>Create</paper-button>
             <template is='dom-if' if='[[error]]'>
               <p class='error'>[[error]]</p>
             </template>

--- a/hassio/system/hassio-supervisor-log.html
+++ b/hassio/system/hassio-supervisor-log.html
@@ -14,7 +14,7 @@
         <pre>[[log]]</pre>
       </div>
       <div class='card-actions'>
-        <paper-button on-tap='refreshTapped'>Refresh</paper-button>
+        <paper-button on-click='refreshTapped'>Refresh</paper-button>
       </div>
     </paper-card>
   </template>

--- a/panels/config/automation/ha-automation-editor.html
+++ b/panels/config/automation/ha-automation-editor.html
@@ -87,7 +87,7 @@
         <app-toolbar>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='backTapped'
+            on-click='backTapped'
           ></paper-icon-button>
           <div main-title>Automation [[name]]</div>
         </app-toolbar>
@@ -104,7 +104,7 @@
         dirty$='[[dirty]]'
         icon='mdi:content-save'
         title='Save'
-        on-tap='saveAutomation'
+        on-click='saveAutomation'
       ></paper-fab>
     </ha-app-layout>
 

--- a/panels/config/automation/ha-automation-picker.html
+++ b/panels/config/automation/ha-automation-picker.html
@@ -49,7 +49,7 @@
         <app-toolbar>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='_backTapped'
+            on-click='_backTapped'
           ></paper-icon-button>
           <div main-title>[[localize('ui.panel.config.automation.caption')]]</div>
         </app-toolbar>
@@ -72,7 +72,7 @@
           </template>
           <template is='dom-repeat' items='[[automations]]' as='automation'>
             <paper-item>
-              <paper-item-body two-line on-tap='automationTapped'>
+              <paper-item-body two-line on-click='automationTapped'>
                 <div>[[computeName(automation)]]</div>
                 <div secondary>[[computeDescription(automation)]]</div>
               </paper-item-body>
@@ -86,7 +86,7 @@
         is-wide$='[[isWide]]'
         icon='mdi:plus'
         title='Add Automation'
-        on-tap='addAutomation'
+        on-click='addAutomation'
       ></paper-fab>
     </ha-app-layout>
 

--- a/panels/config/cloud/ha-config-cloud-account.html
+++ b/panels/config/cloud/ha-config-cloud-account.html
@@ -63,7 +63,7 @@
                 </div>
               </paper-item-body>
               <paper-button
-                on-tap='handleLogout'
+                on-click='handleLogout'
               >Sign out</paper-button>
             </div>
 

--- a/panels/config/cloud/ha-config-cloud-forgot-password.html
+++ b/panels/config/cloud/ha-config-cloud-forgot-password.html
@@ -60,7 +60,7 @@
             </div>
             <div class='card-actions'>
               <ha-progress-button
-                on-tap='_handleEmailPasswordReset'
+                on-click='_handleEmailPasswordReset'
                 progress='[[_requestInProgress]]'
               >Send reset email</ha-progress-button>
               <button
@@ -100,7 +100,7 @@
             </div>
             <div class='card-actions'>
               <ha-progress-button
-                on-tap='_handleConfirmPasswordReset'
+                on-click='_handleConfirmPasswordReset'
                 progress='[[_requestInProgress]]'
               >Reset Password</ha-progress-button>
             </div>

--- a/panels/config/cloud/ha-config-cloud-login.html
+++ b/panels/config/cloud/ha-config-cloud-login.html
@@ -73,7 +73,7 @@
             </div>
             <div class='card-actions'>
               <ha-progress-button
-                on-tap='_handleLogin'
+                on-click='_handleLogin'
                 progress='[[_requestInProgress]]'
               >Sign in</ha-progress-button>
               <button
@@ -85,7 +85,7 @@
           </paper-card>
 
           <paper-card>
-            <paper-item on-tap='_handleRegister'>
+            <paper-item on-click='_handleRegister'>
               <paper-item-body two-line>
                 Create Account
                 <div secondary>Get up and running quickly.</div>

--- a/panels/config/cloud/ha-config-cloud-register.html
+++ b/panels/config/cloud/ha-config-cloud-register.html
@@ -80,7 +80,7 @@
               </div>
               <div class='card-actions'>
                 <ha-progress-button
-                  on-tap='_handleRegister'
+                  on-click='_handleRegister'
                   progress='[[_requestInProgress]]'
                 >Create Account</ha-progress-button>
                 <button
@@ -119,11 +119,11 @@
               </div>
               <div class='card-actions'>
                 <ha-progress-button
-                  on-tap='_handleVerifyEmail'
+                  on-click='_handleVerifyEmail'
                   progress='[[_requestInProgress]]'
                 >Verify Email</ha-progress-button>
                 <paper-button
-                  on-tap='_handleResendVerifyEmail'
+                  on-click='_handleResendVerifyEmail'
                 >Resend Verify Email</paper-button>
               </div>
             </paper-card>

--- a/panels/config/config-entries/ha-config-entries.html
+++ b/panels/config/config-entries/ha-config-entries.html
@@ -37,7 +37,7 @@
                 Added by: [[item.source]]
               </div>
               <div class="card-actions">
-                <paper-button on-tap='_removeEntry'>Remove</paper-button>
+                <paper-button on-click='_removeEntry'>Remove</paper-button>
               </div>
             </paper-card>
           </template>
@@ -49,7 +49,7 @@
             <template is='dom-repeat' items='[[_progress]]'>
               <paper-card heading='[[item.domain]]'>
                 <div class="card-actions">
-                  <paper-button on-tap='_continueFlow'>Configure</paper-button>
+                  <paper-button on-click='_continueFlow'>Configure</paper-button>
                 </div>
               </paper-card>
             </template>
@@ -62,7 +62,7 @@
             <paper-card heading='[[item]]'>
               <!-- <div class="card-content">Some content</div> -->
               <div class="card-actions">
-                <paper-button on-tap='_createFlow'>Configure</paper-button>
+                <paper-button on-click='_createFlow'>Configure</paper-button>
               </div>
             </paper-card>
           </template>

--- a/panels/config/config-entries/ha-config-flow.html
+++ b/panels/config/config-entries/ha-config-flow.html
@@ -71,13 +71,13 @@
       </paper-dialog-scrollable>
       <div class='buttons'>
         <template is='dom-if' if='[[_equals(step.type, "abort")]]'>
-          <paper-button on-tap='_flowDone'>Close</paper-button>
+          <paper-button on-click='_flowDone'>Close</paper-button>
         </template>
         <template is='dom-if' if='[[_equals(step.type, "create_entry")]]'>
-          <paper-button on-tap='_flowDone'>Close</paper-button>
+          <paper-button on-click='_flowDone'>Close</paper-button>
         </template>
         <template is='dom-if' if='[[_equals(step.type, "form")]]'>
-          <paper-button on-tap='_submitStep'>Submit</paper-button>
+          <paper-button on-click='_submitStep'>Submit</paper-button>
         </template>
       </div>
     </paper-dialog>

--- a/panels/config/core/ha-config-core.html
+++ b/panels/config/core/ha-config-core.html
@@ -37,7 +37,7 @@
         <app-toolbar>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='_backTapped'
+            on-click='_backTapped'
           ></paper-icon-button>
           <div main-title>[[localize('ui.panel.config.core.caption')]]</div>
         </app-toolbar>

--- a/panels/config/core/ha-config-section-core.html
+++ b/panels/config/core/ha-config-section-core.html
@@ -59,7 +59,7 @@
                     [[localize('ui.panel.config.core.section.core.validation.valid')]]
                   </div>
                 </template>
-                <paper-button raised on-tap='validateConfig'>
+                <paper-button raised on-click='validateConfig'>
                   [[localize('ui.panel.config.core.section.core.validation.check_config')]]
                 </paper-button>
               </template>
@@ -73,7 +73,7 @@
               <span class='text'>
                 [[localize('ui.panel.config.core.section.core.validation.invalid')]]
               </span>
-              <paper-button raised on-tap='validateConfig'>
+              <paper-button raised on-click='validateConfig'>
                 [[localize('ui.panel.config.core.section.core.validation.check_config')]]
               </paper-button>
             </div>

--- a/panels/config/core/ha-config-section-hassbian.html
+++ b/panels/config/core/ha-config-section-hassbian.html
@@ -52,12 +52,12 @@
               [[computeSuiteDescription(suiteStatus, suiteKey)]]
             </div>
             <div class='card-actions'>
-              <paper-button on-tap='suiteMoreInfoTapped'>
+              <paper-button on-click='suiteMoreInfoTapped'>
                 [[localize('ui.panel.config.core.section.hassbian.learn_more')]]
               </paper-button>
 
               <template is='dom-if' if='[[computeShowInstall(suiteStatus, suiteKey)]]'>
-                <paper-button on-tap='suiteActionTapped'>
+                <paper-button on-click='suiteActionTapped'>
                   [[localize('ui.panel.config.core.section.hassbian.install')]]
                 </paper-button>
               </template>

--- a/panels/config/customize/ha-config-customize.html
+++ b/panels/config/customize/ha-config-customize.html
@@ -22,7 +22,7 @@
         <app-toolbar>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='_backTapped'
+            on-click='_backTapped'
           ></paper-icon-button>
           <div main-title>[[localize('ui.panel.config.customize.caption')]]</div>
         </app-toolbar>

--- a/panels/config/customize/ha-customize-attribute.html
+++ b/panels/config/customize/ha-customize-attribute.html
@@ -27,7 +27,7 @@
       }
     </style>
     <div id='wrapper' class='form-group'></div>
-    <paper-icon-button class="button" icon="[[getIcon(item.secondary)]]" on-tap="tapButton"></paper-icon-button>
+    <paper-icon-button class="button" icon="[[getIcon(item.secondary)]]" on-click="tapButton"></paper-icon-button>
   </template>
 </dom-module>
 

--- a/panels/config/dashboard/ha-config-cloud-menu.html
+++ b/panels/config/dashboard/ha-config-cloud-menu.html
@@ -17,7 +17,7 @@
       }
     </style>
     <paper-card>
-      <paper-item on-tap='_navigate'>
+      <paper-item on-click='_navigate'>
         <paper-item-body two-line>
           Home Assistant Cloud
           <template is='dom-if' if='[[account]]'>

--- a/panels/config/dashboard/ha-config-entries-menu.html
+++ b/panels/config/dashboard/ha-config-entries-menu.html
@@ -17,7 +17,7 @@
       }
     </style>
     <paper-card>
-      <paper-item on-tap='_navigate'>
+      <paper-item on-click='_navigate'>
         <paper-item-body two-line>
           Integrations
           <div secondary>EXPERIMENTAL – Manage connected devices and services</div>

--- a/panels/config/dashboard/ha-config-navigation.html
+++ b/panels/config/dashboard/ha-config-navigation.html
@@ -19,7 +19,7 @@
     <paper-card>
       <template is='dom-repeat' items='[[pages]]'>
         <template is='dom-if' if='[[_computeLoaded(hass, item)]]'>
-          <paper-item on-tap='_navigate'>
+          <paper-item on-click='_navigate'>
             <paper-item-body two-line>
               [[_computeCaption(item, localize)]]
               <div secondary>[[_computeDescription(item, localize)]]</div>

--- a/panels/config/ha-entity-config.html
+++ b/panels/config/ha-entity-config.html
@@ -64,13 +64,13 @@
       </div>
       <div class='card-actions'>
         <paper-button
-          on-tap='saveEntity'
+          on-click='saveEntity'
           disabled='[[computeShowPlaceholder(formState)]]'
         >SAVE</paper-button>
         <template is='dom-if' if='[[allowDelete]]'>
           <paper-button
             class='warning'
-            on-tap='deleteEntity'
+            on-click='deleteEntity'
             disabled='[[computeShowPlaceholder(formState)]]'
           >DELETE</paper-button>
         </template>

--- a/panels/config/script/ha-script-editor.html
+++ b/panels/config/script/ha-script-editor.html
@@ -86,7 +86,7 @@
         <app-toolbar>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='backTapped'
+            on-click='backTapped'
           ></paper-icon-button>
           <div main-title>Script [[name]]</div>
         </app-toolbar>
@@ -102,7 +102,7 @@
         dirty$='[[dirty]]'
         icon='mdi:content-save'
         title='Save'
-        on-tap='saveScript'
+        on-click='saveScript'
       ></paper-fab>
     </ha-app-layout>
 

--- a/panels/config/script/ha-script-picker.html
+++ b/panels/config/script/ha-script-picker.html
@@ -45,7 +45,7 @@
         <app-toolbar>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='_backTapped'
+            on-click='_backTapped'
           ></paper-icon-button>
           <div main-title>[[localize('ui.panel.config.script.caption')]]</div>
         </app-toolbar>
@@ -68,7 +68,7 @@
           </template>
           <template is='dom-repeat' items='[[scripts]]' as='script'>
             <paper-item>
-              <paper-item-body two-line on-tap='scriptTapped'>
+              <paper-item-body two-line on-click='scriptTapped'>
                 <div>[[computeName(script)]]</div>
                 <div secondary>[[computeDescription(script)]]</div>
               </paper-item-body>
@@ -82,7 +82,7 @@
         is-wide$='[[isWide]]'
         icon='mdi:plus'
         title='Add Script'
-        on-tap='addScript'
+        on-click='addScript'
       ></paper-fab>
     </ha-app-layout>
 

--- a/panels/config/zwave/ha-config-zwave.html
+++ b/panels/config/zwave/ha-config-zwave.html
@@ -77,7 +77,7 @@
         <app-toolbar>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='_backTapped'
+            on-click='_backTapped'
           ></paper-icon-button>
           <div main-title>[[localize('ui.panel.config.zwave.caption')]]</div>
         </app-toolbar>
@@ -95,7 +95,7 @@
           <span>Z-Wave Node Management</span>
           <paper-icon-button
             class="toggle-help-icon"
-            on-tap='toggleHelp'
+            on-click='toggleHelp'
             icon='mdi:help-circle'
           ></paper-icon-button>
 

--- a/panels/config/zwave/zwave-log.html
+++ b/panels/config/zwave/zwave-log.html
@@ -37,7 +37,7 @@
         </paper-input>
       </div>
       <div class="card-actions">
-        <paper-button raised on-tap='refreshLog'>Refresh</paper-button>
+        <paper-button raised on-click='refreshLog'>Refresh</paper-button>
       </div>
       <div class='help-text'>
              <pre>[[ozwLogs]]</pre>

--- a/panels/config/zwave/zwave-network.html
+++ b/panels/config/zwave/zwave-network.html
@@ -45,7 +45,7 @@
         <span>Z-Wave Network Management</span>
         <paper-icon-button
           class="toggle-help-icon"
-          on-tap='helpTap'
+          on-click='helpTap'
           icon='mdi:help-circle'
         ></paper-icon-button>
 

--- a/panels/dev-event/ha-panel-dev-event.html
+++ b/panels/dev-event/ha-panel-dev-event.html
@@ -57,7 +57,7 @@
           <div class='ha-form'>
             <paper-input label="Event Type" autofocus required value='{{eventType}}'></paper-input>
             <paper-textarea label="Event Data (JSON, optional)" value='{{eventData}}'></paper-textarea>
-            <paper-button on-tap='fireEvent' raised>Fire Event</paper-button>
+            <paper-button on-click='fireEvent' raised>Fire Event</paper-button>
           </div>
         </div>
 

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -154,7 +154,7 @@
                 <div class='card-content'>There are no new issues!</div>
               </template>
               <template is='dom-repeat' items='[[items]]'>
-                <paper-item on-tap='openLog'>
+                <paper-item on-click='openLog'>
                   <paper-item-body two-line>
                     <div class="row">
                       [[item.message]]
@@ -173,7 +173,7 @@
                  service='clear'
                  >Clear</ha-call-service-button>
                 <ha-progress-button
-                 on-tap='_fetchData'
+                 on-click='_fetchData'
                  >Refresh</ha-progress-button>
               </div>
             </template>
@@ -181,7 +181,7 @@
         </div>
         <p class='error-log-intro'>
           Press the button to load the full Home Assistant log.
-          <paper-icon-button icon='mdi:refresh' on-tap='refreshErrorLog'></paper-icon-button>
+          <paper-icon-button icon='mdi:refresh' on-click='refreshErrorLog'></paper-icon-button>
         </p>
         <div class='error-log'>[[errorLog]]</div>
       </div>

--- a/panels/dev-mqtt/ha-panel-dev-mqtt.html
+++ b/panels/dev-mqtt/ha-panel-dev-mqtt.html
@@ -69,7 +69,7 @@
             ></paper-textarea>
           </div>
           <div class='card-actions'>
-            <paper-button on-tap='_publish'>Publish</paper-button>
+            <paper-button on-click='_publish'>Publish</paper-button>
           </div>
         </paper-card>
       </div>

--- a/panels/dev-service/ha-panel-dev-service.html
+++ b/panels/dev-service/ha-panel-dev-service.html
@@ -121,7 +121,7 @@
             value='{{serviceData}}'
           ></paper-textarea>
           <paper-button
-            on-tap='_callService'
+            on-click='_callService'
             raised
             disabled='[[!validJSON]]'
           >Call Service</paper-button>

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -85,7 +85,7 @@
             class='state-input'
           ></paper-input>
           <paper-textarea label="State attributes (JSON, optional)" value='{{_stateAttributes}}'></paper-textarea>
-          <paper-button on-tap='handleSetState' raised>Set State</paper-button>
+          <paper-button on-click='handleSetState' raised>Set State</paper-button>
         </div>
 
         <h1>Current entities</h1>
@@ -108,7 +108,7 @@
           </tr>
           <template is='dom-repeat' items='[[_entities]]' as='entity'>
             <tr>
-              <td><a href='#' on-tap='entitySelected'>[[entity.entity_id]]</a></td>
+              <td><a href='#' on-click='entitySelected'>[[entity.entity_id]]</a></td>
               <td>[[entity.state]]</td>
               <template is='dom-if' if='[[computeShowAttributes(narrow, _showAttributes)]]'>
                 <td>[[attributeString(entity)]]</td>

--- a/panels/logbook/ha-logbook.html
+++ b/panels/logbook/ha-logbook.html
@@ -51,7 +51,7 @@
             <span class='name'>[[item.name]]</span>
           </template>
           <template is='dom-if' if="[[item.entity_id]]">
-            <a href='#' on-tap="entityClicked" class='name'>[[item.name]]</a>
+            <a href='#' on-click="entityClicked" class='name'>[[item.name]]</a>
           </template>
           <span> </span>
           <span>[[item.message]]</span>

--- a/panels/mailbox/ha-panel-mailbox.html
+++ b/panels/mailbox/ha-panel-mailbox.html
@@ -109,7 +109,7 @@
             </div>
           </template>
           <template is='dom-repeat' items='[[_messages]]'>
-            <paper-item on-tap='openMP3Dialog'>
+            <paper-item on-click='openMP3Dialog'>
               <paper-item-body style="width:100%" two-line>
                 <div class="row">
                   <div>[[item.caller]]</div>
@@ -129,7 +129,7 @@
       <h2>
         [[localize('ui.panel.mailbox.playback_title')]]
         <paper-icon-button
-          on-tap='openDeleteDialog'
+          on-click='openDeleteDialog'
           icon='mdi:delete'
         ></paper-icon-button>
       </h2>
@@ -143,7 +143,7 @@
       <p>[[localize('ui.panel.mailbox.delete_prompt')]]</p>
       <div class="buttons">
         <paper-button dialog-dismiss>[[localize('ui.common.cancel')]]</paper-button>
-        <paper-button dialog-confirm autofocus on-tap="deleteSelected">[[localize('ui.panel.mailbox.delete_button')]]</paper-button>
+        <paper-button dialog-confirm autofocus on-click="deleteSelected">[[localize('ui.panel.mailbox.delete_button')]]</paper-button>
       </div>
     </paper-dialog>
   </template>

--- a/panels/map/ha-entity-marker.html
+++ b/panels/map/ha-entity-marker.html
@@ -66,7 +66,7 @@ class HaEntityMarker extends window.hassMixins.EventsMixin(Polymer.Element) {
 
   ready() {
     super.ready();
-    this.addEventListener('tap', ev => this.badgeTap(ev));
+    this.addEventListener('click', ev => this.badgeTap(ev));
   }
 
   badgeTap(ev) {

--- a/panels/shopping-list/ha-panel-shopping-list.html
+++ b/panels/shopping-list/ha-panel-shopping-list.html
@@ -79,7 +79,7 @@
             ></paper-icon-button>
             <paper-listbox slot="dropdown-content">
               <paper-item
-                on-tap="_clearCompleted"
+                on-click="_clearCompleted"
               >[[localize('ui.panel.shopping-list.clear_completed')]]</paper-item>
             </paper-listbox>
           </paper-menu-button>
@@ -92,7 +92,7 @@
             <paper-icon-button
               slot="item-icon"
               icon="mdi:plus"
-              on-tap='_addItem'
+              on-click='_addItem'
             ></paper-icon-button>
             <paper-item-body>
               <paper-input
@@ -109,7 +109,7 @@
                 <paper-checkbox
                   slot="item-icon"
                   checked='{{item.complete}}'
-                  on-tap='_itemCompleteTapped'
+                  on-click='_itemCompleteTapped'
                   tabindex='0'
                 ></paper-checkbox>
               <paper-item-body>

--- a/src/cards/ha-camera-card.html
+++ b/src/cards/ha-camera-card.html
@@ -82,7 +82,7 @@
 
     ready() {
       super.ready();
-      this.addEventListener('tap', () => this.cardTapped());
+      this.addEventListener('click', () => this.cardTapped());
     }
 
     connectedCallback() {

--- a/src/cards/ha-entities-card.html
+++ b/src/cards/ha-entities-card.html
@@ -38,7 +38,7 @@
 
     <ha-card>
       <template is='dom-if' if='[[title]]'>
-        <div class$='[[computeTitleClass(groupEntity)]]' on-tap='entityTapped'>
+        <div class$='[[computeTitleClass(groupEntity)]]' on-click='entityTapped'>
           <div class='flex name'>[[title]]</div>
           <template is='dom-if' if='[[showGroupToggle(groupEntity, states)]]'>
             <ha-entity-toggle
@@ -108,9 +108,9 @@ class HaEntitiesCard extends
     const cards = this.root.querySelectorAll('.state');
     cards.forEach((card) => {
       if (card.classList.contains('more-info')) {
-        card.addEventListener('tap', this.entityTapped);
+        card.addEventListener('click', this.entityTapped);
       } else {
-        card.removeEventListener('tap', this.entityTapped);
+        card.removeEventListener('click', this.entityTapped);
       }
     });
   }

--- a/src/cards/ha-history_graph-card.html
+++ b/src/cards/ha-history_graph-card.html
@@ -35,7 +35,7 @@
       cache-config='[[cacheConfig]]'
     ></ha-state-history-data>
     <paper-card dialog$='[[inDialog]]'
-        on-tap='cardTapped'
+        on-click='cardTapped'
         elevation='[[computeElevation(inDialog)]]'>
       <div class='header'>[[computeTitle(stateObj)]]</div>
       <div class='content'>

--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -168,7 +168,7 @@
     <div class='controls layout horizontal justified'>
       <paper-icon-button
         icon='mdi:power'
-        on-tap='handleTogglePower'
+        on-click='handleTogglePower'
         invisible$='[[computeHidePowerButton(playerObj)]]'
         class='self-center secondary'
       ></paper-icon-button>
@@ -178,26 +178,26 @@
           icon='mdi:skip-previous'
           invisible$='[[!playerObj.supportsPreviousTrack]]'
           disabled='[[playerObj.isOff]]'
-          on-tap='handlePrevious'
+          on-click='handlePrevious'
         ></paper-icon-button>
         <paper-icon-button
           class='primary'
           icon='[[computePlaybackControlIcon(playerObj)]]'
           invisible$='[[!computePlaybackControlIcon(playerObj)]]'
           disabled='[[playerObj.isOff]]'
-          on-tap='handlePlaybackControl'
+          on-click='handlePlaybackControl'
         ></paper-icon-button>
         <paper-icon-button
           icon='mdi:skip-next'
           invisible$='[[!playerObj.supportsNextTrack]]'
           disabled='[[playerObj.isOff]]'
-          on-tap='handleNext'
+          on-click='handleNext'
         ></paper-icon-button>
       </div>
 
       <paper-icon-button
         icon='mdi:dots-vertical'
-        on-tap='handleOpenMoreInfo'
+        on-click='handleOpenMoreInfo'
         class='self-center secondary'
       ></paper-icon-button>
 

--- a/src/cards/ha-persistent_notification-card.html
+++ b/src/cards/ha-persistent_notification-card.html
@@ -39,7 +39,7 @@
 
     <ha-card header='[[computeTitle(stateObj)]]'>
       <ha-markdown content='[[stateObj.attributes.message]]'></ha-markdown>
-      <paper-button on-tap='dismissTap'>[[localize('ui.card.persistent_notification.dismiss')]]</paper-button>
+      <paper-button on-click='dismissTap'>[[localize('ui.card.persistent_notification.dismiss')]]</paper-button>
     </ha-card>
   </template>
 </dom-module>

--- a/src/cards/ha-plant-card.html
+++ b/src/cards/ha-plant-card.html
@@ -37,7 +37,7 @@
                   <paper-icon-button
                     disabled$='[[computeDisabled(stateObj, item)]]'
                     icon='[[computeIcon(stateObj, item)]]'
-                    on-tap='showSensorHistory'>
+                    on-click='showSensorHistory'>
                   </paper-icon-button>
                 </th>
               </template>

--- a/src/components/buttons/ha-call-api-button.html
+++ b/src/components/buttons/ha-call-api-button.html
@@ -7,7 +7,7 @@
     <ha-progress-button
       id='progress'
       progress='[[progress]]'
-      on-tap='buttonTapped'
+      on-click='buttonTapped'
       disabled='[[disabled]]'
     ><slot></slot></ha-progress-button>
   </template>

--- a/src/components/buttons/ha-call-service-button.html
+++ b/src/components/buttons/ha-call-service-button.html
@@ -8,7 +8,7 @@
     <ha-progress-button
       id='progress'
       progress='[[progress]]'
-      on-tap='buttonTapped'
+      on-click='buttonTapped'
     ><slot></slot></ha-progress-button>
   </template>
 </dom-module>

--- a/src/components/buttons/ha-progress-button.html
+++ b/src/components/buttons/ha-progress-button.html
@@ -44,7 +44,7 @@
       <paper-button
         id='button'
         disabled='[[computeDisabled(disabled, progress)]]'
-        on-tap='buttonTapped'
+        on-click='buttonTapped'
       >
         <slot></slot>
       </paper-button>
@@ -89,7 +89,7 @@ class HaProgressButton extends Polymer.Element {
 
   ready() {
     super.ready();
-    this.addEventListener('tap', ev => this.buttonTapped(ev));
+    this.addEventListener('click', ev => this.buttonTapped(ev));
   }
 
   buttonTapped(ev) {

--- a/src/components/entity/ha-chart-base.html
+++ b/src/components/entity/ha-chart-base.html
@@ -85,7 +85,7 @@
           <div class="chartZoomInline">
             <paper-icon-button
               icon='mdi:arrow-expand-all'
-              on-tap='resetZoom'
+              on-click='resetZoom'
             ></paper-icon-button>
           </div>
         </template>

--- a/src/components/entity/ha-entity-toggle.html
+++ b/src/components/entity/ha-entity-toggle.html
@@ -24,8 +24,8 @@
     </style>
 
     <template is='dom-if' if='[[stateObj.attributes.assumed_state]]'>
-      <paper-icon-button icon="mdi:flash-off" on-tap="turnOff" state-active$='[[!isOn]]'></paper-icon-button>
-      <paper-icon-button icon="mdi:flash" on-tap="turnOn" state-active$='[[isOn]]'></paper-icon-button>
+      <paper-icon-button icon="mdi:flash-off" on-click="turnOff" state-active$='[[!isOn]]'></paper-icon-button>
+      <paper-icon-button icon="mdi:flash" on-click="turnOn" state-active$='[[isOn]]'></paper-icon-button>
     </template>
     <template is='dom-if' if='[[!stateObj.attributes.assumed_state]]'>
       <paper-toggle-button
@@ -62,7 +62,7 @@ class HaEntityToggle extends Polymer.Element {
 
   ready() {
     super.ready();
-    this.addEventListener('tap', ev => this.onTap(ev));
+    this.addEventListener('click', ev => this.onTap(ev));
     this.forceStateChange();
   }
 

--- a/src/components/entity/ha-state-label-badge.html
+++ b/src/components/entity/ha-state-label-badge.html
@@ -81,7 +81,7 @@ class HaStateLabelBadge extends
 
   ready() {
     super.ready();
-    this.addEventListener('tap', ev => this.badgeTap(ev));
+    this.addEventListener('click', ev => this.badgeTap(ev));
   }
 
   badgeTap(ev) {

--- a/src/components/ha-climate-control.html
+++ b/src/components/ha-climate-control.html
@@ -37,10 +37,10 @@
     </div>
     <div class="control-buttons">
       <div>
-        <paper-icon-button icon="mdi:chevron-up" on-tap="incrementValue"></paper-icon-button>
+        <paper-icon-button icon="mdi:chevron-up" on-click="incrementValue"></paper-icon-button>
       </div>
       <div>
-        <paper-icon-button icon="mdi:chevron-down" on-tap="decrementValue"></paper-icon-button>
+        <paper-icon-button icon="mdi:chevron-down" on-click="decrementValue"></paper-icon-button>
       </div>
     </div>
   </template>

--- a/src/components/ha-cover-controls.html
+++ b/src/components/ha-cover-controls.html
@@ -15,12 +15,12 @@
     </style>
 
     <div class='state'>
-      <paper-icon-button icon="mdi:arrow-up" on-tap='onOpenTap'
+      <paper-icon-button icon="mdi:arrow-up" on-click='onOpenTap'
         invisible$='[[!entityObj.supportsOpen]]'
         disabled='[[computeOpenDisabled(stateObj, entityObj)]]'></paper-icon-button>
-      <paper-icon-button icon="mdi:stop" on-tap='onStopTap'
+      <paper-icon-button icon="mdi:stop" on-click='onStopTap'
         invisible$='[[!entityObj.supportsStop]]'></paper-icon-button>
-      <paper-icon-button icon="mdi:arrow-down" on-tap='onCloseTap'
+      <paper-icon-button icon="mdi:arrow-down" on-click='onCloseTap'
         invisible$='[[!entityObj.supportsClose]]'
         disabled='[[computeClosedDisabled(stateObj, entityObj)]]'></paper-icon-button>
     </div>

--- a/src/components/ha-cover-tilt-controls.html
+++ b/src/components/ha-cover-tilt-controls.html
@@ -18,14 +18,14 @@
       }
     </style>
     <paper-icon-button icon="mdi:arrow-top-right" 
-      on-tap='onOpenTiltTap' title='Open tilt'
+      on-click='onOpenTiltTap' title='Open tilt'
       invisible$='[[!entityObj.supportsOpenTilt]]'
       disabled='[[computeOpenDisabled(stateObj, entityObj)]]'></paper-icon-button>
-    <paper-icon-button icon="mdi:stop" on-tap='onStopTiltTap'
+    <paper-icon-button icon="mdi:stop" on-click='onStopTiltTap'
       invisible$='[[!entityObj.supportsStopTilt]]'
       title='Stop tilt'></paper-icon-button>
     <paper-icon-button icon="mdi:arrow-bottom-left"
-      on-tap='onCloseTiltTap' title='Close tilt'
+      on-click='onCloseTiltTap' title='Close tilt'
       invisible$='[[!entityObj.supportsCloseTilt]]'
       disabled='[[computeClosedDisabled(stateObj, entityObj)]]'></paper-icon-button>
   </template>

--- a/src/components/ha-menu-button.html
+++ b/src/components/ha-menu-button.html
@@ -13,7 +13,7 @@
     <paper-icon-button
       icon='mdi:menu'
       class$='[[computeMenuButtonClass(narrow, showMenu)]]'
-      on-tap='toggleMenu'
+      on-click='toggleMenu'
     ></paper-icon-button>
   </template>
 </dom-module>

--- a/src/components/ha-sidebar.html
+++ b/src/components/ha-sidebar.html
@@ -98,23 +98,23 @@
 
     <app-toolbar>
       <div main-title>Home Assistant</div>
-      <paper-icon-button icon='mdi:chevron-left' hidden$='[[narrow]]' on-tap='toggleMenu'></paper-icon-button>
+      <paper-icon-button icon='mdi:chevron-left' hidden$='[[narrow]]' on-click='toggleMenu'></paper-icon-button>
     </app-toolbar>
 
     <paper-listbox attr-for-selected='data-panel' selected='[[hass.panelUrl]]'>
-      <paper-icon-item on-tap='menuClicked' data-panel='states'>
+      <paper-icon-item on-click='menuClicked' data-panel='states'>
         <iron-icon slot="item-icon" icon='mdi:apps'></iron-icon>
         <span class='item-text'>[[localize('panel.states')]]</span>
       </paper-icon-item>
 
       <template is='dom-repeat' items='[[panels]]'>
-        <paper-icon-item on-tap='menuClicked' data-panel$='[[item.url_path]]'>
+        <paper-icon-item on-click='menuClicked' data-panel$='[[item.url_path]]'>
           <iron-icon slot="item-icon" icon='[[item.icon]]'></iron-icon>
           <span class='item-text'>[[computePanelName(localize, item)]]</span>
         </paper-icon-item>
       </template>
 
-      <paper-icon-item on-tap='menuClicked' data-panel='logout' class='logout'>
+      <paper-icon-item on-click='menuClicked' data-panel='logout' class='logout'>
         <iron-icon slot="item-icon" icon='mdi:exit-to-app'></iron-icon>
         <span class='item-text'>[[localize('ui.sidebar.log_out')]]</span>
       </paper-icon-item>
@@ -129,29 +129,29 @@
         <paper-icon-button
           icon='mdi:remote' data-panel='dev-service'
           alt="[[localize('panel.dev-services')]]" title="[[localize('panel.dev-services')]]"
-          on-tap='menuClicked'></paper-icon-button>
+          on-click='menuClicked'></paper-icon-button>
         <paper-icon-button
           icon='mdi:code-tags' data-panel='dev-state'
           alt="[[localize('panel.dev-states')]]" title="[[localize('panel.dev-states')]]"
-          on-tap='menuClicked'></paper-icon-button>
+          on-click='menuClicked'></paper-icon-button>
         <paper-icon-button
           icon='mdi:radio-tower' data-panel='dev-event'
           alt="[[localize('panel.dev-events')]]" title="[[localize('panel.dev-events')]]"
-          on-tap='menuClicked'></paper-icon-button>
+          on-click='menuClicked'></paper-icon-button>
         <paper-icon-button
           icon='mdi:file-xml' data-panel='dev-template'
           alt="[[localize('panel.dev-templates')]]" title="[[localize('panel.dev-templates')]]"
-          on-tap='menuClicked'></paper-icon-button>
+          on-click='menuClicked'></paper-icon-button>
         <template is='dom-if' if='[[_mqttLoaded(hass)]]'>
           <paper-icon-button
             icon='mdi:altimeter' data-panel='dev-mqtt'
             alt="[[localize('panel.dev-mqtt')]]" title="[[localize('panel.dev-mqtt')]]"
-            on-tap='menuClicked'></paper-icon-button>
+            on-click='menuClicked'></paper-icon-button>
         </template>
         <paper-icon-button
           icon='mdi:information-outline' data-panel='dev-info'
           alt="[[localize('panel.dev-info')]]" title="[[localize('panel.dev-info')]]"
-          on-tap='menuClicked'></paper-icon-button>
+          on-click='menuClicked'></paper-icon-button>
       </div>
     </div>
   </template>

--- a/src/components/ha-start-voice-button.html
+++ b/src/components/ha-start-voice-button.html
@@ -7,7 +7,7 @@
   <template>
     <paper-icon-button
       icon="mdi:microphone" hidden$='[[!canListen]]'
-      on-tap="handleListenClick"
+      on-click="handleListenClick"
     ></paper-icon-button>
 
   </template>

--- a/src/dialogs/ha-voice-command-dialog.html
+++ b/src/dialogs/ha-voice-command-dialog.html
@@ -123,7 +123,7 @@
         <div class='icon' hidden$="[[results]]">
           <paper-icon-button
             icon="mdi:text-to-speech"
-            on-tap='startListening'
+            on-click='startListening'
           ></paper-icon-button>
         </div>
       </div>

--- a/src/layouts/hass-error-screen.html
+++ b/src/layouts/hass-error-screen.html
@@ -28,7 +28,7 @@
       </app-toolbar>
       <div class='layout vertical center-center'>
         <h3>[[error]]</h3>
-        <paper-button on-tap='backTapped'>go back</paper-button>
+        <paper-button on-click='backTapped'>go back</paper-button>
       </div>
     </div>
   </template>

--- a/src/layouts/hass-subpage.html
+++ b/src/layouts/hass-subpage.html
@@ -12,7 +12,7 @@
         <app-toolbar>
           <paper-icon-button
             icon='mdi:arrow-left'
-            on-tap='_backTapped'
+            on-click='_backTapped'
           ></paper-icon-button>
           <div main-title>[[title]]</div>
         </app-toolbar>

--- a/src/layouts/login-form.html
+++ b/src/layouts/login-form.html
@@ -60,7 +60,7 @@
           ></paper-input>
           <div class="layout horizontal center">
             <paper-checkbox for id='rememberLogin'>[[localize('ui.login-form.remember')]]</paper-checkbox>
-            <paper-button on-tap='validatePassword'>[[localize('ui.login-form.log_in')]]</paper-button>
+            <paper-button on-click='validatePassword'>[[localize('ui.login-form.log_in')]]</paper-button>
           </div>
         </div>
         <div id="validatebox" hidden$="[[!showSpinner]]">

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -62,7 +62,7 @@
           >
             <paper-tab
               data-entity=''
-              on-tap='scrollToTop'
+              on-click='scrollToTop'
             >
               <template is='dom-if' if='[[!defaultView]]'>
                 Home
@@ -88,7 +88,7 @@
             <template is='dom-repeat' items='[[views]]'>
               <paper-tab
                 data-entity$='[[item.entity_id]]'
-                on-tap='scrollToTop'
+                on-click='scrollToTop'
               >
                 <template is='dom-if' if='[[item.attributes.icon]]'>
                   <iron-icon title$='[[computeStateName(item)]]' icon='[[item.attributes.icon]]'></iron-icon>

--- a/src/more-infos/more-info-alarm_control_panel.html
+++ b/src/more-infos/more-info-alarm_control_panel.html
@@ -23,16 +23,16 @@
     </div>
     <div class='layout horizontal'>
       <paper-button
-        on-tap='handleDisarmTap'
+        on-click='handleDisarmTap'
         hidden$='[[!disarmButtonVisible]]'
         disabled='[[!codeValid]]'
       >Disarm</paper-button>
       <paper-button
-        on-tap='handleHomeTap'
+        on-click='handleHomeTap'
         hidden$='[[!armHomeButtonVisible]]'
         disabled=[[!codeValid]]>Arm Home</paper-button>
       <paper-button
-        on-tap='handleAwayTap'
+        on-click='handleAwayTap'
         hidden$='[[!armAwayButtonVisible]]'
         disabled='[[!codeValid]]'>Arm Away</paper-button>
     </div>

--- a/src/more-infos/more-info-automation.html
+++ b/src/more-infos/more-info-automation.html
@@ -22,7 +22,7 @@
       <ha-relative-time datetime="[[stateObj.attributes.last_triggered]]"></ha-relative-time>
     </p>
 
-    <paper-button on-tap='handleTriggerTapped'>TRIGGER</paper-button>
+    <paper-button on-click='handleTriggerTapped'>TRIGGER</paper-button>
 
   </template>
 </dom-module>

--- a/src/more-infos/more-info-configurator.html
+++ b/src/more-infos/more-info-configurator.html
@@ -68,7 +68,7 @@
           <paper-button
             raised
             disabled='[[isConfiguring]]'
-            on-tap='submitClicked'
+            on-click='submitClicked'
           >
             <paper-spinner
               active='[[isConfiguring]]'

--- a/src/more-infos/more-info-fan.html
+++ b/src/more-infos/more-info-fan.html
@@ -63,10 +63,10 @@
         <div class='direction'>
           <div>Direction</div>
           <paper-icon-button icon='mdi:rotate-left'
-            on-tap='onDirectionLeft' title='Left'
+            on-click='onDirectionLeft' title='Left'
             disabled='[[computeIsRotatingLeft(stateObj)]]'></paper-icon-button>
           <paper-icon-button icon='mdi:rotate-right'
-            on-tap='onDirectionRight' title='Right'
+            on-click='onDirectionRight' title='Right'
             disabled='[[computeIsRotatingRight(stateObj)]]'></paper-icon-button>
         </div>
       </div>

--- a/src/more-infos/more-info-lock.html
+++ b/src/more-infos/more-info-lock.html
@@ -14,8 +14,8 @@
 
     <div hidden$='[[!stateObj.attributes.code_format]]'>
       <paper-input label='code' value='{{enteredCode}}' pattern='[[stateObj.attributes.code_format]]' type='password'></paper-input>
-      <paper-button on-tap='handleUnlockTap' hidden$='[[!isLocked]]'>Unlock</paper-button>
-      <paper-button on-tap='handleLockTap' hidden$=[[isLocked]]>Lock</paper-button>
+      <paper-button on-click='handleUnlockTap' hidden$='[[!isLocked]]'>Unlock</paper-button>
+      <paper-button on-click='handleLockTap' hidden$=[[isLocked]]>Lock</paper-button>
     </div>
     <ha-attributes state-obj='[[stateObj]]' extra-filters='code_format'></ha-attributes>
   </template>

--- a/src/more-infos/more-info-media_player.html
+++ b/src/more-infos/more-info-media_player.html
@@ -58,17 +58,17 @@
       <div class='layout horizontal'>
         <div class='flex'>
           <paper-icon-button icon='mdi:power' highlight$='[[isOff]]'
-            on-tap='handleTogglePower'
+            on-click='handleTogglePower'
             hidden$='[[computeHidePowerButton(isOff, supportsTurnOn, supportsTurnOff)]]'></paper-icon-button>
         </div>
         <div>
           <template is='dom-if' if='[[computeShowPlaybackControls(isOff, hasMediaControl)]]'>
-            <paper-icon-button icon='mdi:skip-previous' on-tap='handlePrevious'
+            <paper-icon-button icon='mdi:skip-previous' on-click='handlePrevious'
               hidden$='[[!supportsPreviousTrack]]'></paper-icon-button>
             <paper-icon-button icon='[[computePlaybackControlIcon(isPlaying)]]'
-              on-tap='handlePlaybackControl'
+              on-click='handlePlaybackControl'
               hidden$='[[!computePlaybackControlIcon(isPlaying)]]' highlight></paper-icon-button>
-            <paper-icon-button icon='mdi:skip-next' on-tap='handleNext'
+            <paper-icon-button icon='mdi:skip-next' on-click='handleNext'
               hidden$='[[!supportsNextTrack]]'></paper-icon-button>
           </template>
         </div>
@@ -76,7 +76,7 @@
       <!-- VOLUME -->
       <div class='volume_buttons center horizontal layout'
           hidden$='[[computeHideVolumeButtons(isOff, supportsVolumeButtons)]]'>
-        <paper-icon-button on-tap="handleVolumeTap"
+        <paper-icon-button on-click="handleVolumeTap"
           icon="mdi:volume-off"></paper-icon-button>
         <paper-icon-button id="volumeDown" disabled$='[[isMuted]]'
           on-mousedown="handleVolumeDown" on-touchstart="handleVolumeDown"
@@ -86,7 +86,7 @@
           icon="mdi:volume-high"></paper-icon-button>
       </div>
       <div class='volume center horizontal layout' hidden$='[[!supportsVolumeSet]]'>
-        <paper-icon-button on-tap="handleVolumeTap"
+        <paper-icon-button on-click="handleVolumeTap"
           hidden$="[[supportsVolumeButtons]]"
           icon="[[computeMuteVolumeIcon(isMuted)]]"></paper-icon-button>
         <paper-slider disabled$='[[isMuted]]'
@@ -115,7 +115,7 @@
           value='{{ttsMessage}}'
           on-keydown="ttsCheckForEnter"
         ></paper-input>
-        <paper-icon-button icon='mdi:send' on-tap='sendTTS'></paper-icon-button>
+        <paper-icon-button icon='mdi:send' on-click='sendTTS'></paper-icon-button>
       </div>
     </div>
   </template>

--- a/src/more-infos/more-info-vacuum.html
+++ b/src/more-infos/more-info-vacuum.html
@@ -44,23 +44,23 @@
       <div class='horizontal justified layout'>
         <div hidden$='[[!supportsPause(stateObj)]]'>
           <paper-icon-button icon='mdi:play-pause'
-            on-tap='onPlayPause' title='Start/Pause'></paper-icon-button>
+            on-click='onPlayPause' title='Start/Pause'></paper-icon-button>
         </div>
         <div hidden$='[[!supportsStop(stateObj)]]'>
           <paper-icon-button icon='mdi:stop'
-            on-tap='onStop' title='Stop'></paper-icon-button>
+            on-click='onStop' title='Stop'></paper-icon-button>
         </div>
         <div hidden$='[[!supportsCleanSpot(stateObj)]]'>
         <paper-icon-button icon='mdi:broom'
-            on-tap='onCleanSpot' title='Clean spot'></paper-icon-button>
+            on-click='onCleanSpot' title='Clean spot'></paper-icon-button>
         </div>
         <div hidden$='[[!supportsLocate(stateObj)]]'>
         <paper-icon-button icon='mdi:map-marker'
-            on-tap='onLocate' title='Locate'></paper-icon-button>
+            on-click='onLocate' title='Locate'></paper-icon-button>
         </div>
         <div hidden$='[[!supportsReturnHome(stateObj)]]'>
         <paper-icon-button icon='mdi:home-map-marker'
-            on-tap='onReturnHome' title='Return home'></paper-icon-button>
+            on-click='onReturnHome' title='Return home'></paper-icon-button>
         </div>
       </div>
     </div>

--- a/src/state-summary/state-card-input_number.html
+++ b/src/state-summary/state-card-input_number.html
@@ -41,7 +41,7 @@
     <div class='horizontal justified layout' id='input_number_card'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
         <paper-slider min='[[min]]' max='[[max]]' value='{{value}}' step='[[step]]' hidden='[[hiddenslider]]' pin
-          on-change='selectedValueChanged' on-tap='stopPropagation' id='slider'>
+          on-change='selectedValueChanged' on-click='stopPropagation' id='slider'>
         </paper-slider>
       <paper-input
         no-label-float
@@ -53,7 +53,7 @@
         value='{{value}}'
         type='number'
         on-change='selectedValueChanged'
-        on-tap='stopPropagation'
+        on-click='stopPropagation'
         hidden='[[hiddenbox]]'
       >
       </paper-input>

--- a/src/state-summary/state-card-input_select.html
+++ b/src/state-summary/state-card-input_select.html
@@ -29,7 +29,7 @@
 
     <state-badge state-obj='[[stateObj]]'></state-badge>
     <paper-dropdown-menu
-      on-tap='stopPropagation'
+      on-click='stopPropagation'
       selected-item-label='{{selectedOption}}'
       label='[[computeStateName(stateObj)]]'>
       <paper-listbox slot="dropdown-content" selected="[[computeSelected(stateObj)]]">

--- a/src/state-summary/state-card-input_text.html
+++ b/src/state-summary/state-card-input_text.html
@@ -29,7 +29,7 @@
         type='[[stateObj.attributes.mode]]'
  
         on-change='selectedValueChanged'
-        on-tap='stopPropagation'
+        on-click='stopPropagation'
         placeholder='(empty value)'
       >
       </paper-input>

--- a/src/state-summary/state-card-scene.html
+++ b/src/state-summary/state-card-scene.html
@@ -21,7 +21,7 @@
 
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
-      <paper-button on-tap='activateScene'>ACTIVATE</paper-button>
+      <paper-button on-click='activateScene'>ACTIVATE</paper-button>
     </div>
   </template>
 </dom-module>

--- a/src/state-summary/state-card-script.html
+++ b/src/state-summary/state-card-script.html
@@ -30,7 +30,7 @@
         <ha-entity-toggle state-obj='[[stateObj]]' hass='[[hass]]'></ha-entity-toggle>
       </template>
       <template is='dom-if' if='[[!stateObj.attributes.can_cancel]]'>
-        <paper-button on-tap='fireScript'>ACTIVATE</paper-button>
+        <paper-button on-click='fireScript'>ACTIVATE</paper-button>
       </template>
     </div>
   </template>

--- a/src/state-summary/state-card-weblink.html
+++ b/src/state-summary/state-card-weblink.html
@@ -40,7 +40,7 @@ class StateCardWeblink extends Polymer.Element {
 
   ready() {
     super.ready();
-    this.addEventListener('tap', ev => this.onTap(ev));
+    this.addEventListener('click', ev => this.onTap(ev));
   }
 
   computeStateName(stateObj) {


### PR DESCRIPTION
see: https://github.com/home-assistant/home-assistant-polymer/issues/916

Converting from the Polymer 'tap' event wrapper to browser native 'click' events.
Does fix some user interaction issues.

This is recommended on: https://www.polymer-project.org/2.0/docs/devguide/gesture-events

Unless a listener function does fancy stuff on the event (like mouse coordinates) the tap and click event are the same. Did a search and did not found such behaviour.

Also did some manual testing of user interaction (by just clicking around) and it all seems fine.
Only thing I've not been able to test this on is really old (mobile) browsers.