### PR TITLE
Guard for contentWindow == null

### DIFF
--- a/panels/hassio/ha-panel-hassio.html
+++ b/panels/hassio/ha-panel-hassio.html
@@ -54,7 +54,7 @@ class HaPanelHassio extends
   }
 
   _updateProperties(data) {
-    const setProperties = this.$.iframe.contentWindow.setProperties;
+    const setProperties = this.$.iframe.contentWindow && this.$.iframe.contentWindow.setProperties;
 
     // Delay calling setProperties until iframe loaded
     if (!setProperties) {


### PR DESCRIPTION
`contentWindow` is `null` when the iFrame is still loading.

#912