### PR TITLE
prevent state display line-wrapping

### DIFF
--- a/src/state-summary/state-card-display.html
+++ b/src/state-summary/state-card-display.html
@@ -17,6 +17,7 @@
         margin-left: 16px;
         text-align: right;
         line-height: 40px;
+        white-space: nowrap;
       }
     </style>
 

--- a/src/state-summary/state-card-display.html
+++ b/src/state-summary/state-card-display.html
@@ -17,6 +17,8 @@
         margin-left: 16px;
         text-align: right;
         line-height: 40px;
+      }
+      .state.has-unit_of_measurement {
         white-space: nowrap;
       }
     </style>
@@ -54,7 +56,6 @@ class StateCardDisplay extends window.hassMixins.LocalizeMixin(Polymer.Element) 
     ];
     return classes.join(' ');
   }
-
 }
 customElements.define(StateCardDisplay.is, StateCardDisplay);
 </script>

--- a/src/state-summary/state-card-display.html
+++ b/src/state-summary/state-card-display.html
@@ -23,7 +23,7 @@
 
     <div class='horizontal justified layout'>
       <state-info state-obj="[[stateObj]]" in-dialog='[[inDialog]]'></state-info>
-      <div class='state'>[[computeStateDisplay(localize, stateObj, language)]]</div>
+      <div class$='[[computeClassNames(stateObj)]]'>[[computeStateDisplay(localize, stateObj, language)]]</div>
     </div>
   </template>
 </dom-module>
@@ -46,6 +46,15 @@ class StateCardDisplay extends window.hassMixins.LocalizeMixin(Polymer.Element) 
   computeStateDisplay(localize, stateObj, language) {
     return window.hassUtil.computeStateDisplay(localize, stateObj, language);
   }
+
+  computeClassNames(stateObj) {
+    var classes = [
+      'state',
+      window.hassUtil.attributeClassNames(stateObj, ['unit_of_measurement']),
+    ];
+    return classes.join(' ');
+  }
+
 }
 customElements.define(StateCardDisplay.is, StateCardDisplay);
 </script>

--- a/src/state-summary/state-card-display.html
+++ b/src/state-summary/state-card-display.html
@@ -50,7 +50,7 @@ class StateCardDisplay extends window.hassMixins.LocalizeMixin(Polymer.Element) 
   }
 
   computeClassNames(stateObj) {
-    var classes = [
+    const classes = [
       'state',
       window.hassUtil.attributeClassNames(stateObj, ['unit_of_measurement']),
     ];


### PR DESCRIPTION
Only for applies to default statecards (state-card-display), not for
component specific statecards.

**before**
<img width="398" alt="schermafbeelding 2018-02-26 om 14 24 43" src="https://user-images.githubusercontent.com/411716/36672890-42dc9aea-1b01-11e8-90c1-08e72dd291b2.png">

**after**
<img width="398" alt="schermafbeelding 2018-02-26 om 14 24 24" src="https://user-images.githubusercontent.com/411716/36672894-47b0a462-1b01-11e8-8736-6751d8ee6b6f.png">
