### PR TITLE
Fix paper card alignment in safari

### DIFF
--- a/src/resources/hassio-style.html
+++ b/src/resources/hassio-style.html
@@ -19,6 +19,7 @@
         --card-group-columns: 4;
         width: calc((100% - 12px * var(--card-group-columns)) / var(--card-group-columns));
         margin: 4px;
+        vertical-align: top;
       }
       @media screen and (max-width: 1200px) and (min-width: 901px) {
         .card-group paper-card {


### PR DESCRIPTION
Fixes alignment issue as shown in below image.
Cards are currently  aligned on baseline of text in Safari, adding `vertical-align: top;` brings them into line.

**before**
<img width="1010" alt="schermafbeelding 2018-02-26 om 14 42 57" src="https://user-images.githubusercontent.com/411716/36673554-6665c002-1b03-11e8-9eca-007ab46c062f.png">

**after**
<img width="1022" alt="schermafbeelding 2018-02-26 om 14 46 44" src="https://user-images.githubusercontent.com/411716/36673683-e50e42da-1b03-11e8-8cbf-1685e7352ffd.png">