### PR TITLE
Hassio reload addons and snapshots

### DIFF
--- a/hassio/addon-store/hassio-addon-store.html
+++ b/hassio/addon-store/hassio-addon-store.html
@@ -82,7 +82,7 @@ class HassioAddonStore extends Polymer.Element {
   }
 
 
-  refreshData(ev) {
+  refreshData() {
     this.hass.callApi('post', 'hassio/addons/reload')
       .then(() => {
         this.loadData();

--- a/hassio/addon-store/hassio-addon-store.html
+++ b/hassio/addon-store/hassio-addon-store.html
@@ -41,7 +41,7 @@ class HassioAddonStore extends Polymer.Element {
   ready() {
     super.ready();
     this.addEventListener('hass-api-called', ev => this.apiCalled(ev));
-    this.addEventListener('hassio-store-refresh', ev => this.refreshData(ev));
+    document.addEventListener('hassio-store-refresh', ev => this.refreshData(ev));
     this.loadData();
   }
 
@@ -82,7 +82,7 @@ class HassioAddonStore extends Polymer.Element {
   }
 
 
-  refreshData() {
+  refreshData(ev) {
     this.hass.callApi('post', 'hassio/addons/reload')
       .then(() => {
         this.loadData();

--- a/hassio/addon-store/hassio-addon-store.html
+++ b/hassio/addon-store/hassio-addon-store.html
@@ -41,7 +41,6 @@ class HassioAddonStore extends Polymer.Element {
   ready() {
     super.ready();
     this.addEventListener('hass-api-called', ev => this.apiCalled(ev));
-    document.addEventListener('hassio-store-refresh', ev => this.refreshData(ev));
     this.loadData();
   }
 

--- a/hassio/hassio-pages-with-tabs.html
+++ b/hassio/hassio-pages-with-tabs.html
@@ -4,6 +4,7 @@
 <link rel='import' href='../bower_components/app-layout/app-toolbar/app-toolbar.html'>
 <link rel='import' href='../bower_components/paper-tabs/paper-tabs.html'>
 <link rel='import' href='../bower_components/paper-tabs/paper-tab.html'>
+<link rel='import' href='../bower_components/paper-icon-button/paper-icon-button.html'>
 
 <link rel='import' href='../src/components/ha-menu-button.html'>
 <link rel='import' href='../src/util/hass-mixins.html'>
@@ -33,6 +34,12 @@
         <app-toolbar>            
           <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
           <div main-title>Hass.io</div>
+          <template is='dom-if' if='[[showRefreshButton(page)]]'>
+            <paper-icon-button
+              icon='mdi:refresh'
+              on-click='refreshClicked'
+            ></paper-icon-button>
+          </template>
         </app-toolbar>
         <paper-tabs
           scrollable
@@ -111,6 +118,14 @@ class HassioPagesWithTabs extends window.hassMixins.NavigateMixin(Polymer.Elemen
 
   equals(a, b) {
     return a === b;
+  }
+
+  showRefreshButton(page) {
+    return page === 'store' || page === 'snapshots';
+  }
+
+  refreshClicked() {
+    this.fire(`hassio-${this.page}-refresh`);   
   }
 }
 

--- a/hassio/hassio-pages-with-tabs.html
+++ b/hassio/hassio-pages-with-tabs.html
@@ -125,7 +125,11 @@ class HassioPagesWithTabs extends window.hassMixins.NavigateMixin(Polymer.Elemen
   }
 
   refreshClicked() {
-    this.fire(`hassio-${this.page}-refresh`);
+    if (this.page === 'snapshots') {
+      this.shadowRoot.querySelector('hassio-snapshots').refreshData();
+    } else {
+      this.shadowRoot.querySelector('hassio-addon-store').refreshData();
+    }
   }
 }
 

--- a/hassio/hassio-pages-with-tabs.html
+++ b/hassio/hassio-pages-with-tabs.html
@@ -49,7 +49,7 @@
         >
           <paper-tab page-name='dashboard'>Dashboard</paper-tab>
           <paper-tab page-name='snapshots'>Snapshots</paper-tab>
-          <paper-tab page-name='store'>Add-on store</paper-tab>          
+          <paper-tab page-name='store'>Add-on store</paper-tab>
           <paper-tab page-name='system'>System</paper-tab>
         </paper-tabs>
       </app-header>
@@ -81,7 +81,7 @@
         ></hassio-system>
       </template>
     </app-header-layout>
-    <template is='dom-if' if='[[equals(page, "snapshots")]]'>      
+    <template is='dom-if' if='[[equals(page, "snapshots")]]'>
       <hassio-snapshot      
         hass='[[hass]]'
         snapshot-slug='{{snapshotSlug}}'
@@ -125,7 +125,7 @@ class HassioPagesWithTabs extends window.hassMixins.NavigateMixin(Polymer.Elemen
   }
 
   refreshClicked() {
-    this.fire(`hassio-${this.page}-refresh`);   
+    this.fire(`hassio-${this.page}-refresh`);
   }
 }
 

--- a/hassio/snapshots/hassio-snapshots.html
+++ b/hassio/snapshots/hassio-snapshots.html
@@ -146,7 +146,6 @@ class HassioSnapshots extends window.hassMixins.EventsMixin(Polymer.Element) {
   ready() {
     super.ready();
     this.addEventListener('hass-api-called', ev => this.apiCalled(ev));
-    document.addEventListener('hassio-snapshots-refresh', ev => this.refreshData(ev));
     this.updateSnapshots();
   }
 

--- a/hassio/snapshots/hassio-snapshots.html
+++ b/hassio/snapshots/hassio-snapshots.html
@@ -146,6 +146,7 @@ class HassioSnapshots extends window.hassMixins.EventsMixin(Polymer.Element) {
   ready() {
     super.ready();
     this.addEventListener('hass-api-called', ev => this.apiCalled(ev));
+    document.addEventListener('hassio-snapshots-refresh', ev => this.refreshData(ev));
     this.updateSnapshots();
   }
 
@@ -240,6 +241,13 @@ class HassioSnapshots extends window.hassMixins.EventsMixin(Polymer.Element) {
       this.updateSnapshots();
       this.snapshotDeleted = false;
     }
+  }
+
+  refreshData() {
+    this.hass.callApi('post', 'hassio/snapshots/reload')
+      .then(() => {
+        this.updateSnapshots();
+      });
   }
 }
 

--- a/hassio/system/hassio-supervisor-info.html
+++ b/hassio/system/hassio-supervisor-info.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../../bower_components/paper-card/paper-card.html">
-<link rel='import' href='../../bower_components/paper-button/paper-button.html'>
 
 <link rel='import' href='../../src/util/hass-mixins.html'>
 <link rel="import" href="../../src/components/buttons/ha-call-api-button.html">
@@ -62,7 +61,11 @@
             path="hassio/supervisor/update"
           >Update</ha-call-api-button>
         </template>
-        <paper-button on-click='reloadClicked'>Reload</paper-button>
+        <ha-call-api-button
+          class='warning'
+          hass='[[hass]]'
+          path="hassio/supervisor/reload"
+        >Reload</ha-call-api-button>
       </div>
     </paper-card>
   </template>
@@ -102,12 +105,6 @@ class HassioSupervisorInfo extends window.hassMixins.EventsMixin(Polymer.Element
 
   computeUpdateAvailable(data) {
     return data.version !== data.last_version;
-  }
-
-  reloadClicked() {
-    this.hass.callApi('post', 'hassio/snapshots/reload');
-    this.hass.callApi('post', 'hassio/addons/reload');
-    this.hass.callApi('post', 'hassio/supervisor/reload');
   }
 }
 

--- a/hassio/system/hassio-supervisor-info.html
+++ b/hassio/system/hassio-supervisor-info.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel='import' href='../../bower_components/paper-button/paper-button.html'>
 
 <link rel='import' href='../../src/util/hass-mixins.html'>
 <link rel="import" href="../../src/components/buttons/ha-call-api-button.html">
@@ -61,11 +62,7 @@
             path="hassio/supervisor/update"
           >Update</ha-call-api-button>
         </template>
-        <ha-call-api-button
-          class='warning'
-          hass='[[hass]]'
-          path="hassio/supervisor/reload"
-        >Reload</ha-call-api-button>
+        <paper-button on-click='reloadClicked'>Reload</paper-button>
       </div>
     </paper-card>
   </template>
@@ -105,6 +102,12 @@ class HassioSupervisorInfo extends window.hassMixins.EventsMixin(Polymer.Element
 
   computeUpdateAvailable(data) {
     return data.version !== data.last_version;
+  }
+
+  reloadClicked() {
+    this.hass.callApi('post', 'hassio/snapshots/reload');
+    this.hass.callApi('post', 'hassio/addons/reload');
+    this.hass.callApi('post', 'hassio/supervisor/reload');
   }
 }
 


### PR DESCRIPTION
~~this adds snapshot reload and add-on reload to the reload supervisor button in system tab.
I don't know if this is the best way - I don't want to add a button in the view for a feature "normal" users would never use~~
Add a refresh button for add-ons and snapshots to the app toolbar, like in the old panel

cc: @pvizeli @cogneato