### PR TITLE
Reset height when not observing

### DIFF
--- a/src/cards/ha-card-chooser.html
+++ b/src/cards/ha-card-chooser.html
@@ -38,6 +38,7 @@ class HaCardChooser extends Polymer.Element {
         this.observer.unobserve(this);
         this.observer = null;
       }
+      this.style.height = '';
       this._updateCard(newData);
       return;
     }


### PR DESCRIPTION
If Home Assistant is restarted, it is possible for a card that was disconnected to get a different type passed in. If that type is entities, we will no longer observe and would not reset the height. This results in new cards with the old cards height.

Able to repro it by running the demo, shutting down Home Assistant and then restarting it.

![image](https://user-images.githubusercontent.com/1444314/36765133-a374c24a-1be4-11e8-913f-357ef4e973ef.png)

![image](https://user-images.githubusercontent.com/1444314/36765139-aa2feab0-1be4-11e8-9fc4-afe405c93f6f.png)

![image](https://user-images.githubusercontent.com/1444314/36765142-b42c44aa-1be4-11e8-9311-fe30d3ff679b.png)

Reported in the chat by @skalavala who had quite the extreme example:
![image](https://user-images.githubusercontent.com/1444314/36765186-dc56372e-1be4-11e8-8101-54c3705f2480.png)

CC @andrey-git 