### PR TITLE
Fix line charts not showing in safari es6 bug

### DIFF
--- a/src/data/ha-state-history-data.html
+++ b/src/data/ha-state-history-data.html
@@ -4,6 +4,8 @@
 <link rel='import' href='../../src/util/hass-util.html'>
 
 <script>
+'use strict';
+
 {
   const RECENT_THRESHOLD = 60000; // 1 minute
   const RECENT_CACHE = {};
@@ -14,7 +16,6 @@
   function computeHistory(stateHistory, localize, language) {
     const lineChartDevices = {};
     const timelineDevices = [];
-
     if (!stateHistory) {
       return { line: [], timeline: [] };
     }
@@ -310,7 +311,9 @@
           }
           return cache.data;
         })
-        .catch(() => {
+        .catch((err) => {
+          /* eslint-disable no-console */
+          console.error(err);
           window.stateHistoryCache[cacheKey] = undefined;
         });
       cache.prom = prom;


### PR DESCRIPTION
This is a workaround for a webkit bug. see: https://bugs.webkit.org/show_bug.cgi?id=183169

Also we at least log the error we catch. That would've saved me 2 hours of debugging...
(don't know why the catch is there, so not removing it)

note: contrary to the name of my branch, this is about the line charts, not the timeline-charts.