### PR TITLE
Fix history data processing

### DIFF
--- a/panels/history/ha-panel-history.html
+++ b/panels/history/ha-panel-history.html
@@ -202,8 +202,9 @@ class HaPanelHistory extends window.hassMixins.LocalizeMixin(Polymer.Element) {
 
   stateHistoryObserver(newVal) {
     setTimeout(() => {
-      if (newVal === this.stateHistoryInput) {
-        // Input didn't change
+      if (newVal !== this.stateHistoryOutput) {
+        // Data did change
+        console.log('data did change')
         this.stateHistoryOutput = newVal;
       }
     }, 1);

--- a/panels/history/ha-panel-history.html
+++ b/panels/history/ha-panel-history.html
@@ -204,7 +204,6 @@ class HaPanelHistory extends window.hassMixins.LocalizeMixin(Polymer.Element) {
     setTimeout(() => {
       if (newVal !== this.stateHistoryOutput) {
         // Data did change
-        console.log('data did change')
         this.stateHistoryOutput = newVal;
       }
     }, 1);

--- a/panels/history/ha-panel-history.html
+++ b/panels/history/ha-panel-history.html
@@ -46,7 +46,7 @@
       filter-type='[[_filterType]]'
       start-time='[[_computeStartTime(_currentDate)]]'
       end-time='[[endTime]]'
-      data='{{stateHistoryInput}}'
+      data='{{stateHistory}}'
       is-loading='{{isLoadingData}}'
     ></ha-state-history-data>
     <app-header-layout has-scrolling-region>
@@ -83,7 +83,7 @@
         </div>
         <state-history-charts
           hass='[[hass]]'
-          history-data="[[stateHistoryOutput]]"
+          history-data="[[stateHistory]]"
           is-loading-data="[[isLoadingData]]"
           end-time="[[endTime]]"
           no-single>
@@ -115,13 +115,7 @@ class HaPanelHistory extends window.hassMixins.LocalizeMixin(Polymer.Element) {
         value: false,
       },
 
-      stateHistoryInput: {
-        type: Object,
-        value: null,
-        observer: 'stateHistoryObserver'
-      },
-
-      stateHistoryOutput: {
+      stateHistory: {
         type: Object,
         value: null,
       },
@@ -198,15 +192,6 @@ class HaPanelHistory extends window.hassMixins.LocalizeMixin(Polymer.Element) {
         return 7;
       default: return 1;
     }
-  }
-
-  stateHistoryObserver(newVal) {
-    setTimeout(() => {
-      if (newVal !== this.stateHistoryOutput) {
-        // Data did change
-        this.stateHistoryOutput = newVal;
-      }
-    }, 1);
   }
 }
 

--- a/src/components/state-history-charts.html
+++ b/src/components/state-history-charts.html
@@ -10,16 +10,6 @@
     :host {
       display: block;
     }
-
-    .loading-container {
-      text-align: center;
-      padding: 8px;
-    }
-
-    .loading {
-      height: 0px;
-      overflow: hidden;
-    }
     </style>
 
     <template is='dom-if' if='[[_computeIsEmpty(historyData)]]'>

--- a/src/data/ha-state-history-data.html
+++ b/src/data/ha-state-history-data.html
@@ -131,7 +131,6 @@
       };
     }
 
-    // debounce the observer because attribute changes are sequential.
     static get observers() {
       return [
         'filterChangedDebouncer(filterType, entityId, startTime, endTime, cacheConfig, localize, language)',

--- a/src/data/ha-state-history-data.html
+++ b/src/data/ha-state-history-data.html
@@ -137,14 +137,6 @@
       ];
     }
 
-    connectedCallback() {
-      super.connectedCallback();
-      this.filterChanged(
-        this.filterType, this.entityId, this.startTime, this.endTime,
-        this.cacheConfig, this.localize, this.language
-      );
-    }
-
     disconnectedCallback() {
       if (this._refreshTimeoutId) {
         window.clearInterval(this._refreshTimeoutId);

--- a/src/data/ha-state-history-data.html
+++ b/src/data/ha-state-history-data.html
@@ -185,12 +185,10 @@
       } else {
         return;
       }
-    console.log('going to wait for data()')
       this._setIsLoading(true);
 
       data.then((stateHistory) => {
         this._setData(stateHistory);
-        console.log('done')
         this._setIsLoading(false);
       });
     }

--- a/src/data/ha-state-history-data.html
+++ b/src/data/ha-state-history-data.html
@@ -131,9 +131,10 @@
       };
     }
 
+    // debounce the observer because attribute changes are sequential.
     static get observers() {
       return [
-        'filterChanged(filterType, entityId, startTime, endTime, cacheConfig, localize, language)',
+        'filterChangedDebouncer(filterType, entityId, startTime, endTime, cacheConfig, localize, language)',
       ];
     }
 
@@ -147,11 +148,21 @@
 
     hassChanged(newHass, oldHass) {
       if (!oldHass && !this._madeFirstCall) {
-        this.filterChanged(
+        this.filterChangedDebouncer(
           this.filterType, this.entityId, this.startTime, this.endTime,
           this.cacheConfig, this.localize, this.language
         );
       }
+    }
+
+    filterChangedDebouncer(...args) {
+      this._debounceFilterChanged = Polymer.Debouncer.debounce(
+        this._debounceFilterChanged,
+        Polymer.Async.timeOut.after(10),
+        () => {
+          this.filterChanged(...args);
+        }
+      );
     }
 
     filterChanged(filterType, entityId, startTime, endTime, cacheConfig, localize, language) {
@@ -174,11 +185,12 @@
       } else {
         return;
       }
-
+    console.log('going to wait for data()')
       this._setIsLoading(true);
 
       data.then((stateHistory) => {
         this._setData(stateHistory);
+        console.log('done')
         this._setIsLoading(false);
       });
     }

--- a/src/data/ha-state-history-data.html
+++ b/src/data/ha-state-history-data.html
@@ -158,7 +158,7 @@
     filterChangedDebouncer(...args) {
       this._debounceFilterChanged = Polymer.Debouncer.debounce(
         this._debounceFilterChanged,
-        Polymer.Async.timeOut.after(10),
+        Polymer.Async.timeOut.after(0),
         () => {
           this.filterChanged(...args);
         }


### PR DESCRIPTION
This changes the behaviour of ha-state-history-data element so it reduces the amount of processing.
Before this change the data would get processed sometimes 3 or 4 times on initializing the element that would display the chart.
(although there is caching, there's still quite a lot of code to be run.)

I also encountered some unnecessary styles, the loader is already gone. (if desired we could add one back in a separate PR)

I can't really figure out what the hassChanges observer in ha-state-history-data.html is for. I saw no regressions when removing it. But I left it in because it probably has a reason to be there.
If we remove it we can reduce the debouncer from `10ms` to `microTask`