### PR TITLE
Import mixin to silence build warning

### DIFF
--- a/src/components/ha-service-picker.html
+++ b/src/components/ha-service-picker.html
@@ -1,5 +1,7 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
 
+<link rel="import" href="../util/hass-mixins.html">
+
 <link rel="import" href="./ha-combo-box.html">
 
 <dom-module id="ha-service-picker">


### PR DESCRIPTION
Fix build warning by adding missing import for the localize mixin introduced in #923