### PR TITLE
Add user agent check to frontend

### DIFF
--- a/public/__init__.py
+++ b/public/__init__.py
@@ -1,8 +1,34 @@
-"""AUTO-GENERATED. DO NOT MODIFY"""
+"""Frontend for Home Assistant.
+
+AUTO-GENERATED. DO NOT MODIFY.
+"""
 import os
+from user_agents import parse
+
+FAMILY_MIN_VERSION = {
+    'Chrome': 54,          # Object.values
+    'Chrome Mobile': 54,
+    'Firefox': 47,         # Object.values
+    'Firefox Mobile': 47,
+    'Opera': 41,           # Object.values
+    'Edge': 14,            # Array.prototype.includes added in 14
+    'Safari': 10,          # Many features not supported by 9
+}
 
 
 def where():
     """Return path to the frontend."""
     return os.path.dirname(__file__)
 
+
+def version(useragent):
+    """Get the version for given user agent."""
+    useragent = parse(useragent)
+
+    # on iOS every browser is a Safari which we support from version 11.
+    if useragent.os.family == 'iOS':
+        # Was >= 10, temp setting it to 12 to work around issue #11387
+        return useragent.os.version[0] >= 12
+
+    version = FAMILY_MIN_VERSION.get(useragent.browser.family)
+    return version and useragent.browser.version[0] >= version

--- a/public/__init__.py
+++ b/public/__init__.py
@@ -1,7 +1,4 @@
-"""Frontend for Home Assistant.
-
-AUTO-GENERATED. DO NOT MODIFY.
-"""
+"""Frontend for Home Assistant."""
 import os
 from user_agents import parse
 

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,8 @@ setup(name='home-assistant-frontend',
           'hass_frontend.*',
           'hass_frontend_es5.*'
       ]),
+      install_requires=[
+          'user-agents==1.1.0',
+      ],
       include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
This moves the user agent check to the frontend, as that is also where the code lives that it impacts.

The overriding via url logic will remain in the frontend component.

CC @andrey-git 