### PR TITLE
retry importHref in the error callback once to solve a webkit refresh issue

### DIFF
--- a/src/layouts/partial-panel-resolver.html
+++ b/src/layouts/partial-panel-resolver.html
@@ -99,11 +99,22 @@ class PartialPanelResolver extends Polymer.Element {
       },
 
       () => {
-        this.errorLoading = true;
+        // a single retry of importHref in the error callback fixes a webkit refresh issue
+        if (!this.retrySetPanelForWebkit(panel)) {
+          this.errorLoading = true;
+        }
       },
 
       true /* async */
     );
+  }
+
+  retrySetPanelForWebkit(panel) {
+    if (this._retryingPanelChanged) {
+      return false;
+    }
+    this._retryingPanelChanged = true;
+    return this.panelChanged(panel);
   }
 
   updateAttributes() {


### PR DESCRIPTION
Tested this (compiled and uncompiled) in Safari, Chrome and Firefox.