### PR TITLE
IntersectionObserver fixes

### DIFF
--- a/src/cards/ha-card-chooser.html
+++ b/src/cards/ha-card-chooser.html
@@ -27,6 +27,32 @@ class HaCardChooser extends Polymer.Element {
     );
   }
 
+  createObserver() {
+    this.observer = new IntersectionObserver((entries) => {
+      if (!entries.length) return;
+      if (entries[0].isIntersecting) {
+        this.style.height = '';
+        if (this._detachedChild) {
+          this.appendChild(this._detachedChild);
+          this._detachedChild = null;
+        }
+        this._updateCard(this.cardData); // Don't use 'newData' as it might have chnaged.
+        this._updatesAllowed = true;
+      } else {
+        // Set the card to be 48px high. Otherwise if the card is kept as 0px height then all
+        // following cards would trigger the observer at once.
+        const offsetHeight = this.offsetHeight;
+        this.style.height = `${offsetHeight || 48}px`;
+        if (this.lastChild) {
+          this._detachedChild = this.lastChild;
+          this.removeChild(this.lastChild);
+        }
+        this._updatesAllowed = false;
+      }
+    });
+    this.observer.observe(this);
+  }
+
   cardDataChanged(newData) {
     if (!newData) return;
     // ha-entities-card is exempt from observer as it doesn't load heavy resources.
@@ -43,29 +69,9 @@ class HaCardChooser extends Polymer.Element {
       return;
     }
     if (!this.observer) {
-      this.observer = new IntersectionObserver((entries) => {
-        if (!entries.length) return;
-        if (entries[0].isIntersecting) {
-          this.style.height = '';
-          if (this._detachedChild) {
-            this.appendChild(this._detachedChild);
-            this._detachedChild = null;
-          }
-          this._updateCard(this.cardData); // Don't use 'newData' as it might have chnaged.
-        } else {
-          // Set the card to be 48px high. Otherwise if the card is kept as 0px height then all
-          // following cards would trigger the observer at once.
-          const offsetHeight = this.offsetHeight;
-          this.style.height = `${offsetHeight || 48}px`;
-          if (this.lastChild) {
-            this._detachedChild = this.lastChild;
-            this.removeChild(this.lastChild);
-          }
-        }
-      });
-      this.observer.observe(this);
+      this.createObserver();
     }
-    if (!this._detachedChild) {
+    if (this._updatesAllowed) {
       this._updateCard(newData);
     }
   }

--- a/src/cards/ha-card-chooser.html
+++ b/src/cards/ha-card-chooser.html
@@ -37,7 +37,7 @@ class HaCardChooser extends Polymer.Element {
           this.appendChild(this._detachedChild);
           this._detachedChild = null;
         }
-        this._updateCard(this.cardData); // Don't use 'newData' as it might have chnaged.
+        this._updateCard(this.cardData); // Don't use 'newData' as it might have changed.
         this._updatesAllowed = true;
       } else {
         // Set the card to be 48px high. Otherwise if the card is kept as 0px height then all

--- a/src/cards/ha-card-chooser.html
+++ b/src/cards/ha-card-chooser.html
@@ -28,6 +28,7 @@ class HaCardChooser extends Polymer.Element {
   }
 
   createObserver() {
+    this._updatesAllowed = false;
     this.observer = new IntersectionObserver((entries) => {
       if (!entries.length) return;
       if (entries[0].isIntersecting) {


### PR DESCRIPTION
#927 fixed a bug with visible cards not being updated, but it caused the cards to initialize once regardless of visibility.

This PR makes sure cards are updated when visible but are never initialized if invisible.