### PR TITLE
Fix backend translations on startup

### DIFF
--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -120,7 +120,7 @@ class HomeAssistant extends Polymer.Element {
   }
 
   loadBackendTranslations() {
-    if (!this.hass.language) return;
+    if (!this.hass.selectedLanguage) return;
 
     const language = this.hass.selectedLanguage;
     this.hass.callApi('get', `translations/${language}`).then((result) => {


### PR DESCRIPTION
In #894 backend translations were introduced. In https://github.com/home-assistant/home-assistant-polymer/pull/894/commits/4bf7c3cebce76d41e7f098e6a7e549a95d37b2b2 the `language` check was changed to `selectedLanguage`, but this one line was missed.

The effect is that after startup, all translations fail to load. Reloading the page fixes it.

<img width="257" alt="screen shot 2018-03-10 at 07 42 32" src="https://user-images.githubusercontent.com/6833237/37239161-9e116eac-2436-11e8-9527-042c0a71ff86.png">

Fixes https://github.com/home-assistant/home-assistant/issues/13035