### PR TITLE
Use backend translation for config entries

### DIFF
--- a/panels/config/config-entries/ha-config-entries.html
+++ b/panels/config/config-entries/ha-config-entries.html
@@ -32,7 +32,7 @@
           <template is='dom-repeat' items='[[_entries]]'>
             <paper-card heading='[[item.title]]'>
               <div class='card-content'>
-                Integration: [[item.domain]]<br>
+                Integration: [[_computeIntegrationTitle(localize, item.domain)]]<br>
                 State: [[item.state]]<br>
                 Added by: [[item.source]]
               </div>
@@ -47,7 +47,7 @@
           <h1>To be finished</h1>
           <div class='entries layout horizontal wrap'>
             <template is='dom-repeat' items='[[_progress]]'>
-              <paper-card heading='[[item.domain]]'>
+              <paper-card heading='[[_computeIntegrationTitle(localize, item.domain)]]'>
                 <div class="card-actions">
                   <paper-button on-click='_continueFlow'>Configure</paper-button>
                 </div>
@@ -59,7 +59,7 @@
         <h1>Add integration</h1>
         <div class='entries layout horizontal wrap'>
           <template is='dom-repeat' items='[[_handlers]]'>
-            <paper-card heading='[[item]]'>
+            <paper-card heading='[[_computeIntegrationTitle(localize, item)]]'>
               <!-- <div class="card-content">Some content</div> -->
               <div class="card-actions">
                 <paper-button on-click='_createFlow'>Configure</paper-button>
@@ -81,7 +81,12 @@
 
 <script>
 {
-  class HaConfigManager extends window.hassMixins.NavigateMixin(Polymer.Element) {
+  /*
+   * @appliesMixin window.hassMixins.LocalizeMixin
+   * @appliesMixin window.hassMixins.EventsMixin
+   */
+  class HaConfigManager extends
+    window.hassMixins.LocalizeMixin(window.hassMixins.EventsMixin(Polymer.Element)) {
     static get is() { return 'ha-config-entries'; }
 
     static get properties() {
@@ -178,6 +183,10 @@
     _loadDiscovery() {
       this.hass.callApi('get', 'config/config_entries/flow')
         .then((progress) => { this._progress = progress; });
+    }
+
+    _computeIntegrationTitle(localize, integration) {
+      return localize(`component.${integration}.config.title`);
     }
   }
 

--- a/panels/config/config-entries/ha-config-flow.html
+++ b/panels/config/config-entries/ha-config-flow.html
@@ -62,12 +62,11 @@
             </template>
 
             <ha-form
-              hass='[[hass]]'
               data='{{stepData}}'
-              domain='[[step.domain]]'
-              step-id='[[step.step_id]]'
               schema='[[step.data_schema]]'
               error='[[step.errors]]'
+              compute-label='[[_computeLabelCallback(localize, step)]]'
+              compute-error='[[_computeErrorCallback(localize, step)]]'
             ></ha-form>
           </template>
         </template>
@@ -199,6 +198,16 @@ class HaConfigFlow extends
 
   _computeBaseError(localize, step) {
     return localize(`component.${step.domain}.config.error.${step.errors.base}`);
+  }
+
+  _computeLabelCallback(localize, step) {
+    // Returns a callback for ha-form to calculate labels per schema object
+    return schema => localize(`component.${step.domain}.config.step.${step.step_id}.data.${schema.name}`);
+  }
+
+  _computeErrorCallback(localize, step) {
+    // Returns a callback for ha-form to calculate error messages
+    return error => localize(`component.${step.domain}.config.error.${error}`);
   }
 }
 

--- a/panels/config/config-entries/ha-config-flow.html
+++ b/panels/config/config-entries/ha-config-flow.html
@@ -36,7 +36,7 @@
           Success!
         </template>
         <template is='dom-if' if='[[_equals(step.type, "form")]]'>
-          [[step.title]]
+          [[_computeStepTitle(localize, step)]]
         </template>
       </h2>
       <paper-dialog-scrollable>
@@ -45,7 +45,7 @@
         </template>
         <template is='dom-if' if='[[step]]'>
           <template is='dom-if' if='[[_equals(step.type, "abort")]]'>
-            <p>[[step.reason]]</p>
+            <p>[[_computeStepAbortedReason(localize, step)]]</p>
           </template>
 
           <template is='dom-if' if='[[_equals(step.type, "create_entry")]]'>
@@ -53,16 +53,19 @@
           </template>
 
           <template is='dom-if' if='[[_equals(step.type, "form")]]'>
-            <template is='dom-if' if='[[step.description]]'>
-              <ha-markdown content='[[step.description]]'></ha-markdown>
+            <template is='dom-if' if='[[_computeStepDescription(localize, step)]]'>
+              <ha-markdown content='[[_computeStepDescription(localize, step)]]'></ha-markdown>
             </template>
 
             <template is='dom-if' if='[[step.errors.base]]'>
-              <div class='error'>[[step.errors.base]]</div>
+              <div class='error'>[[_computeBaseError(localize, step)]]</div>
             </template>
 
             <ha-form
+              hass='[[hass]]'
               data='{{stepData}}'
+              domain='[[step.domain]]'
+              step-id='[[step.step_id]]'
               schema='[[step.data_schema]]'
               error='[[step.errors]]'
             ></ha-form>
@@ -85,7 +88,12 @@
 </dom-module>
 
 <script>
-class HaConfigFlow extends window.hassMixins.EventsMixin(Polymer.Element) {
+/*
+ * @appliesMixin window.hassMixins.LocalizeMixin
+ * @appliesMixin window.hassMixins.EventsMixin
+ */
+class HaConfigFlow extends
+  window.hassMixins.LocalizeMixin(window.hassMixins.EventsMixin(Polymer.Element)) {
   static get is() { return 'ha-config-flow'; }
 
   static get properties() {
@@ -175,6 +183,22 @@ class HaConfigFlow extends window.hassMixins.EventsMixin(Polymer.Element) {
         flowFinished: ['success', 'abort'].includes(this.step.type)
       });
     }
+  }
+
+  _computeStepAbortedReason(localize, step) {
+    return localize(`component.${step.domain}.config.abort.${step.reason}`);
+  }
+
+  _computeStepTitle(localize, step) {
+    return localize(`component.${step.domain}.config.step.${step.step_id}.title`);
+  }
+
+  _computeStepDescription(localize, step) {
+    return localize(`component.${step.domain}.config.step.${step.step_id}.description`);
+  }
+
+  _computeBaseError(localize, step) {
+    return localize(`component.${step.domain}.config.error.${step.errors.base}`);
   }
 }
 

--- a/panels/config/config-entries/ha-form.html
+++ b/panels/config/config-entries/ha-form.html
@@ -17,24 +17,23 @@
     <template is='dom-if' if='[[_isArray(schema)]]' restamp>
       <template is='dom-repeat' items='[[schema]]'>
         <ha-form
-          hass='[[hass]]'
-          domain='[[domain]]'
-          step-id='[[stepId]]'
           data='[[_getValue(data, item)]]'
           schema='[[item]]'
           error='[[_getValue(error, item)]]'
           on-data-changed='_valueChanged'
+          compute-label='[[computeLabel]]'
+          compute-error='[[computeError]]'
         ></ha-form>
       </template>
     </template>
     <template is='dom-if' if='[[!_isArray(schema)]]' restamp>
       <template is='dom-if' if='[[error]]'>
-        <div class='error'>[[_computeError(localize, domain, error)]]</div>
+        <div class='error'>[[computeError(error, schema)]]</div>
       </template>
 
       <template is='dom-if' if='[[_equals(schema.type, "string")]]' restamp>
         <paper-input
-          label='[[_computeLabel(localize, domain, stepId, schema)]]'
+          label='[[computeLabel(schema)]]'
           value='{{data}}'
         ></paper-input>
       </template>
@@ -42,7 +41,7 @@
       <template is='dom-if' if='[[_equals(schema.type, "integer")]]' restamp>
         <template is='dom-if' if='[[_isRange(schema)]]' restamp>
           <div>
-            [[_computeLabel(localize, domain, stepId, schema)]]
+            [[computeLabel(schema)]]
             <paper-slider
               pin
               value='{{data}}'
@@ -53,7 +52,7 @@
         </template>
         <template is='dom-if' if='[[!_isRange(schema)]]' restamp>
           <paper-input
-            label='[[_computeLabel(localize, domain, stepId, schema)]]'
+            label='[[computeLabel(schema)]]'
             value='{{data}}'
             type='number'
           ></paper-input>
@@ -63,7 +62,7 @@
       <template is='dom-if' if='[[_equals(schema.type, "float")]]' restamp>
         <!--TODO-->
         <paper-input
-          label='[[_computeLabel(localize, domain, stepId, schema)]]'
+          label='[[computeLabel(schema)]]'
           value='{{data}}'
         ></paper-input>
       </template>
@@ -71,11 +70,11 @@
       <template is='dom-if' if='[[_equals(schema.type, "boolean")]]' restamp>
         <paper-checkbox
           checked='{{data}}'
-        >[[_computeLabel(localize, domain, stepId, schema)]]</paper-checkbox>
+        >[[computeLabel(schema)]]</paper-checkbox>
       </template>
 
       <template is='dom-if' if='[[_equals(schema.type, "select")]]' restamp>
-        <paper-dropdown-menu label='[[_computeLabel(localize, domain, stepId, schema)]]'>
+        <paper-dropdown-menu label='[[computeLabel(schema)]]'>
           <paper-listbox
             slot="dropdown-content"
             attr-for-selected="item-name"
@@ -94,25 +93,31 @@
 </dom-module>
 
 <script>
-/*
- * @appliesMixin window.hassMixins.LocalizeMixin
- * @appliesMixin window.hassMixins.EventsMixin
- */
-class HaForm extends
-  window.hassMixins.LocalizeMixin(window.hassMixins.EventsMixin(Polymer.Element)) {
+class HaForm extends window.hassMixins.EventsMixin(Polymer.Element) {
   static get is() { return 'ha-form'; }
 
   static get properties() {
     return {
-      hass: Object,
       data: {
         type: Object,
         notify: true,
       },
-      domain: String,
-      stepId: String,
       schema: Object,
       error: Object,
+
+      // A function that will computes the label to be displayed for a given
+      // schema object.
+      computeLabel: {
+        type: Function,
+        value: schema => schema && schema.name,
+      },
+
+      // A function that will computes an error message to be displayed for a
+      // given error ID, and relevant schema object
+      computeError: {
+        type: Function,
+        value: (error, schema) => error, // eslint-disable-line no-unused-vars
+      },
     };
   }
 
@@ -134,14 +139,6 @@ class HaForm extends
 
   _valueChanged(ev) {
     this.set(['data', ev.model.item.name], ev.detail.value);
-  }
-
-  _computeLabel(localize, domain, stepId, schema) {
-    return localize(`component.${domain}.config.step.${stepId}.data.${schema.name}`);
-  }
-
-  _computeError(localize, domain, error) {
-    return localize(`component.${domain}.config.error.${error}`);
   }
 }
 

--- a/panels/config/config-entries/ha-form.html
+++ b/panels/config/config-entries/ha-form.html
@@ -17,6 +17,9 @@
     <template is='dom-if' if='[[_isArray(schema)]]' restamp>
       <template is='dom-repeat' items='[[schema]]'>
         <ha-form
+          hass='[[hass]]'
+          domain='[[domain]]'
+          step-id='[[stepId]]'
           data='[[_getValue(data, item)]]'
           schema='[[item]]'
           error='[[_getValue(error, item)]]'
@@ -26,12 +29,12 @@
     </template>
     <template is='dom-if' if='[[!_isArray(schema)]]' restamp>
       <template is='dom-if' if='[[error]]'>
-        <div class='error'>[[error]]</div>
+        <div class='error'>[[_computeError(localize, domain, error)]]</div>
       </template>
 
       <template is='dom-if' if='[[_equals(schema.type, "string")]]' restamp>
         <paper-input
-          label='[[schema.name]]'
+          label='[[_computeLabel(localize, domain, stepId, schema)]]'
           value='{{data}}'
         ></paper-input>
       </template>
@@ -39,7 +42,7 @@
       <template is='dom-if' if='[[_equals(schema.type, "integer")]]' restamp>
         <template is='dom-if' if='[[_isRange(schema)]]' restamp>
           <div>
-            [[schema.name]]
+            [[_computeLabel(localize, domain, stepId, schema)]]
             <paper-slider
               pin
               value='{{data}}'
@@ -50,7 +53,7 @@
         </template>
         <template is='dom-if' if='[[!_isRange(schema)]]' restamp>
           <paper-input
-            label='[[schema.name]]'
+            label='[[_computeLabel(localize, domain, stepId, schema)]]'
             value='{{data}}'
             type='number'
           ></paper-input>
@@ -60,7 +63,7 @@
       <template is='dom-if' if='[[_equals(schema.type, "float")]]' restamp>
         <!--TODO-->
         <paper-input
-          label='[[schema.name]]'
+          label='[[_computeLabel(localize, domain, stepId, schema)]]'
           value='{{data}}'
         ></paper-input>
       </template>
@@ -68,11 +71,11 @@
       <template is='dom-if' if='[[_equals(schema.type, "boolean")]]' restamp>
         <paper-checkbox
           checked='{{data}}'
-        >[[schema.name]]</paper-checkbox>
+        >[[_computeLabel(localize, domain, stepId, schema)]]</paper-checkbox>
       </template>
 
       <template is='dom-if' if='[[_equals(schema.type, "select")]]' restamp>
-        <paper-dropdown-menu label='[[schema.name]]'>
+        <paper-dropdown-menu label='[[_computeLabel(localize, domain, stepId, schema)]]'>
           <paper-listbox
             slot="dropdown-content"
             attr-for-selected="item-name"
@@ -91,15 +94,23 @@
 </dom-module>
 
 <script>
-class HaForm extends window.hassMixins.EventsMixin(Polymer.Element) {
+/*
+ * @appliesMixin window.hassMixins.LocalizeMixin
+ * @appliesMixin window.hassMixins.EventsMixin
+ */
+class HaForm extends
+  window.hassMixins.LocalizeMixin(window.hassMixins.EventsMixin(Polymer.Element)) {
   static get is() { return 'ha-form'; }
 
   static get properties() {
     return {
+      hass: Object,
       data: {
         type: Object,
         notify: true,
       },
+      domain: String,
+      stepId: String,
       schema: Object,
       error: Object,
     };
@@ -123,6 +134,14 @@ class HaForm extends window.hassMixins.EventsMixin(Polymer.Element) {
 
   _valueChanged(ev) {
     this.set(['data', ev.model.item.name], ev.detail.value);
+  }
+
+  _computeLabel(localize, domain, stepId, schema) {
+    return localize(`component.${domain}.config.step.${stepId}.data.${schema.name}`);
+  }
+
+  _computeError(localize, domain, error) {
+    return localize(`component.${domain}.config.error.${error}`);
   }
 }
 

--- a/panels/config/config-entries/ha-form.html
+++ b/panels/config/config-entries/ha-form.html
@@ -7,6 +7,8 @@
 <link rel='import' href='../../../bower_components/paper-listbox/paper-listbox.html'>
 <link rel='import' href='../../../bower_components/paper-item/paper-item.html'>
 
+<link rel='import' href='../../../src/util/hass-mixins.html'>
+
 <dom-module id="ha-form">
   <template>
     <style>


### PR DESCRIPTION
## Description
This PR updates the config flow elements to use localized backend strings for the forms. This PR doesn't cover localization of the frontend config flow strings.

Backend PR: https://github.com/home-assistant/home-assistant/pull/13066