### PR TITLE
Show JS version and custom UIs in dev info

### DIFF
--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -123,6 +123,19 @@
           <p>
             Path to configuration.yaml: [[hass.config.core.config_dir]]
           </p>
+          <p>
+            Frontend JavaScript version: [[jsVersion]]
+            <template is='dom-if' if='[[customUiList.length]]'>
+              <div>
+                Custom Uis:
+                <template is='dom-repeat' items='[[customUiList]]'>
+                  <div>
+                    <a href='[[item.url]]' target='_blank'>[[item.name]]</a>: [[item.version]]
+                  </div>
+                </template>
+              </div>
+            </template>
+          </p>
           <p class='develop'>
             <a href='https://home-assistant.io/developers/credits/' target='_blank'>
               Developed by a bunch of awesome people.
@@ -208,9 +221,7 @@ class HaPanelDevInfo extends Polymer.Element {
 
   static get properties() {
     return {
-      hass: {
-        type: Object,
-      },
+      hass: Object,
 
       narrow: {
         type: Boolean,
@@ -242,8 +253,16 @@ class HaPanelDevInfo extends Polymer.Element {
         value: [],
       },
 
-      selectedItem: {
-        type: Object,
+      selectedItem: Object,
+
+      jsVersion: {
+        type: String,
+        value: window.HASS_BUILD,
+      },
+
+      customUiList: {
+        type: Array,
+        value: window.CUSTOM_UI_LIST || [],
       },
     };
   }

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -123,19 +123,6 @@
           <p>
             Path to configuration.yaml: [[hass.config.core.config_dir]]
           </p>
-          <p>
-            Frontend JavaScript version: [[jsVersion]]
-            <template is='dom-if' if='[[customUiList.length]]'>
-              <div>
-                Custom UIs:
-                <template is='dom-repeat' items='[[customUiList]]'>
-                  <div>
-                    <a href='[[item.url]]' target='_blank'>[[item.name]]</a>: [[item.version]]
-                  </div>
-                </template>
-              </div>
-            </template>
-          </p>
           <p class='develop'>
             <a href='https://home-assistant.io/developers/credits/' target='_blank'>
               Developed by a bunch of awesome people.
@@ -152,6 +139,19 @@
             <a href='https://www.python.org'>Python 3</a>,
             <a href='https://www.polymer-project.org' target='_blank'>Polymer [[polymerVersion]]</a>,
             Icons by <a href='https://www.google.com/design/icons/' target='_blank'>Google</a> and <a href='https://MaterialDesignIcons.com' target='_blank'>MaterialDesignIcons.com</a>.
+          </p>
+          <p>
+            Frontend JavaScript version: [[jsVersion]]
+            <template is='dom-if' if='[[customUiList.length]]'>
+              <div>
+                Custom UIs:
+                <template is='dom-repeat' items='[[customUiList]]'>
+                  <div>
+                    <a href='[[item.url]]' target='_blank'>[[item.name]]</a>: [[item.version]]
+                  </div>
+                </template>
+              </div>
+            </template>
           </p>
         </div>
 

--- a/panels/dev-info/ha-panel-dev-info.html
+++ b/panels/dev-info/ha-panel-dev-info.html
@@ -127,7 +127,7 @@
             Frontend JavaScript version: [[jsVersion]]
             <template is='dom-if' if='[[customUiList.length]]'>
               <div>
-                Custom Uis:
+                Custom UIs:
                 <template is='dom-repeat' items='[[customUiList]]'>
                   <div>
                     <a href='[[item.url]]' target='_blank'>[[item.name]]</a>: [[item.version]]


### PR DESCRIPTION
- add frontend JS version to dev info
- add custom UI info to dev info

A problem with custom UIs is that users often run old, cached, versions. This shows the ~~installed~~ running version now.

Andrey already has this for his custom-ui. This should provide an interface for everyone

code to include in your custom-state-card:
```javascript
const CUSTOM_UI_NAME = 'state-card-tiles';
const CUSTOM_UI_VERSION = '20180308';
const CUSTOM_UI_URL = 'https://github.com/c727/home-assistant-tiles';

if (!window.CUSTOM_UI_LIST) {
  window.CUSTOM_UI_LIST = [];
}
window.CUSTOM_UI_LIST.push({
  name: CUSTOM_UI_NAME,
  version: CUSTOM_UI_VERSION,
  url: CUSTOM_UI_URL
}); 
```
![cui2](https://user-images.githubusercontent.com/11984118/37259831-d1ed0e74-258b-11e8-8dfc-4f5d3709e918.PNG)
