### PR TITLE
Cover icon: account for states 'opening' and 'closing'

### DIFF
--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -269,7 +269,7 @@ window.hassUtil.binarySensorIcon = function (state) {
 };
 
 window.hassUtil.coverIcon = function (state) {
-  var open = state.state && state.state === 'open';
+  var open = state.state && state.state !== 'closed';
   switch (state.attributes.device_class) {
     case 'garage':
       return open ? 'mdi:garage-open' : 'mdi:garage';


### PR DESCRIPTION
The Cover icon should display the icon for an open window, as long as `is_closed=False`. Currently it doesn't account for state `opening` and `closing`.