### PR TITLE
Fix race condition setting current language

### DIFF
--- a/src/home-assistant.html
+++ b/src/home-assistant.html
@@ -173,8 +173,8 @@ class HomeAssistant extends Polymer.Element {
       themes: null,
       panelUrl: this.panelUrl,
 
-      // If language and resources are already loaded, don't discard them
-      language: (this.hass && this.hass.language) || null,
+      language: window.getActiveTranslation(),
+      // If resources are already loaded, don't discard them
       resources: (this.hass && this.hass.resources) || null,
 
       translationMetadata: window.translationMetadata,

--- a/src/util/hass-translation.html
+++ b/src/util/hass-translation.html
@@ -1,7 +1,7 @@
 <link rel='import' href='../../build-translations/translationMetadata.html' />
 
 <script>
-function getActiveTranslation() {
+window.getActiveTranslation = function () {
   // Perform case-insenstive comparison since browser isn't required to
   // report languages with specific cases.
   const lookup = {};
@@ -59,7 +59,7 @@ function getActiveTranslation() {
 
   // Final fallback
   return 'en';
-}
+};
 
 // Store loaded translations in memory so translations are available immediately
 // when DOM is created in Polymer. Even a cache lookup creates noticeable latency.


### PR DESCRIPTION
We would not load resources from backend if `loadResources` was slower to succeed than the connection to Home Assistant being made (causing the guard clause in `loadBackendTranslations` to return before loading)