### PR TITLE
When /states/bad_view is selected - fall back to default view.

### DIFF
--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -183,7 +183,7 @@
 
         currentView: {
           type: String,
-          computed: '_computeCurrentView(routeMatch, routeData)',
+          computed: '_computeCurrentView(hass, routeMatch, routeData)',
         },
 
         views: {
@@ -288,8 +288,12 @@
       }
     }
 
-    _computeCurrentView(routeMatch, routeData) {
-      return routeMatch ? routeData.view : '';
+    _computeCurrentView(hass, routeMatch, routeData) {
+      if (!routeMatch) return '';
+      if (!hass.states[routeData.view] || !hass.states[routeData.view].attributes.view) {
+        return '';
+      }
+      return routeData.view;
     }
 
     computeTitle(views, defaultView, locationName) {


### PR DESCRIPTION
When `/states/bad_view` URL is selected - fall back to default view instead of throwing an error.