### PR TITLE
Nicer scrolling for more-info

### DIFF
--- a/src/dialogs/more-info/more-info-controls.html
+++ b/src/dialogs/more-info/more-info-controls.html
@@ -66,27 +66,27 @@
         state-obj="[[stateObj]]"
         hass='[[hass]]' in-dialog></state-card-content>
     </template>
-
-    <template is='dom-if' if="[[_computeShowHistoryComponent(hass, stateObj)]]" restamp>
-      <ha-state-history-data
-        hass='[[hass]]'
-        filter-type='recent-entity'
-        entity-id='[[stateObj.entity_id]]'
-        data='{{_stateHistory}}'
-        is-loading='{{_stateHistoryLoading}}'
-        cache-config='[[_cacheConfig]]'
-      ></ha-state-history-data>
-      <state-history-charts
-        history-data="[[_stateHistory]]"
-        is-loading-data="[[_stateHistoryLoading]]"
-        up-to-now
-        no-single=[[large]]
-        is-zoomable=[[large]]
-      ></state-history-charts>
-    </template>
     <paper-dialog-scrollable dialog-element='[[dialogElement]]'>
+      <template is='dom-if' if="[[_computeShowHistoryComponent(hass, stateObj)]]" restamp>
+        <ha-state-history-data
+          hass='[[hass]]'
+          filter-type='recent-entity'
+          entity-id='[[stateObj.entity_id]]'
+          data='{{_stateHistory}}'
+          is-loading='{{_stateHistoryLoading}}'
+          cache-config='[[_cacheConfig]]'
+        ></ha-state-history-data>
+        <state-history-charts
+          history-data="[[_stateHistory]]"
+          is-loading-data="[[_stateHistoryLoading]]"
+          up-to-now
+          no-single=[[large]]
+          is-zoomable=[[large]]
+        ></state-history-charts>
+      </template>
       <more-info-content
-          state-obj="[[stateObj]]" hass='[[hass]]'></more-info-content>
+        state-obj="[[stateObj]]" hass='[[hass]]'
+      ></more-info-content>
     </paper-dialog-scrollable>
   </template>
 </dom-module>

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -172,7 +172,7 @@
         }
 
         --paper-dialog-scrollable: {
-          -webkit-overflow-scrolling: auto;
+          -webkit-overflow-scrolling: touch;
           margin-bottom: 16px;
         }
       }
@@ -183,7 +183,7 @@
         }
         :host {
           --paper-dialog-scrollable: {
-            -webkit-overflow-scrolling: auto;
+            -webkit-overflow-scrolling: touch;
             margin-bottom: 0px;
           }
         }


### PR DESCRIPTION
Enables rubberband/momentum scrolling on iOS and macOS Safari.

Moves the chart into the scrolling area. This has two advantages:
- it fixes some resizing issues (because of the chart rendering later) because of which the dialog height would be too large and the bottom part of the controls would not be visible.
- it gives more vertical space (when scrolled) for all the controls. Especially in the climate dialog which has a lot of controls and a larger line-chart