### PR TITLE
Don't render minimum color temp with gray border

### DIFF
--- a/src/dialogs/more-info/controls/more-info-light.html
+++ b/src/dialogs/more-info/controls/more-info-light.html
@@ -27,6 +27,8 @@
 
       .color_temp {
         --ha-slider-background: -webkit-linear-gradient(right, rgb(255, 160, 0) 0%, white 50%, rgb(166, 209, 255) 100%);
+        /* The color temp minimum value shouldn't be rendered differently. It's not "off". */
+        --paper-slider-knob-start-border-color: var(--primary-color);
       }
 
       ha-color-picker {


### PR DESCRIPTION
## Description
This PR makes the color temperature slider render the same at the minimum color temperature value, since this doesn't represent an "off" state like brightness zero does.

### Screenshots
**Before vs After:**
<img src="https://user-images.githubusercontent.com/1386547/37740028-9ef9a2a8-2d32-11e8-8c2a-7802f8cf81a9.png" width="310"> <img src="https://user-images.githubusercontent.com/1386547/37740000-89803cb6-2d32-11e8-9cfc-c594ba60a92e.png" width="310">