### PR TITLE
Use encodeURIComponent to encode API password

### DIFF
--- a/hassio/snapshots/hassio-snapshot.html
+++ b/hassio/snapshots/hassio-snapshot.html
@@ -226,7 +226,7 @@ class HassioSnapshot extends Polymer.Element {
   }
 
   _computeDownloadUrl(snapshotSlug) {
-    const password = encodeURI(this.hass.connection.options.authToken);
+    const password = encodeURIComponent(this.hass.connection.options.authToken);
     return `/api/hassio/snapshots/${snapshotSlug}/download?api_password=${password}`;
   }
 


### PR DESCRIPTION
Currently `encodeURI` is used to encode the API password for the download link for Hassio snapshots. [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) should be used instead because it properly escapes characters like `?&#`.

Passwords with these characters currently generate a malformed or incorrect URL when trying to download a snapshot.