### PR TITLE
Change plant card to show real-time brightness

### DIFF
--- a/src/cards/ha-plant-card.html
+++ b/src/cards/ha-plant-card.html
@@ -102,9 +102,6 @@
     }
 
     computeValue(stateObj, sensor) {
-      if ((sensor === 'brightness') && ('max_brightness' in stateObj.attributes)) {
-        return stateObj.attributes.max_brightness;
-      }
       if (sensor in stateObj.attributes) {
         return stateObj.attributes[sensor];
       }


### PR DESCRIPTION
Currently plant card shows real-time sensor values for all attributes except for Brightness (which shows maximum value seen in previous period). This PR removes the special treatment of brightness and instead shows the real-time value consistent with the other attributes. Based on user feedback from forum [(post)](https://community.home-assistant.io/t/xiaomi-mi-plants-monitor-flower/3388/264). We still retain a link to max_brightness by highlighting the real-time value if outside of "healthy" bounds.

@ChristianKuehnel, for any feedback