### PR TITLE
Fix state-info badge colors (on polyfilled browsers)

### DIFF
--- a/src/components/entity/state-info.html
+++ b/src/components/entity/state-info.html
@@ -31,7 +31,7 @@
       line-height: 20px;
     }
 
-    .time-ago, ::slotted(*) {
+    .time-ago, .extra-info, .extra-info > * {
       @apply --paper-font-common-nowrap;
       color: var(--secondary-text-color);
     }
@@ -48,7 +48,9 @@
           </div>
         </template>
         <template is='dom-if' if='[[!inDialog]]'>
-          <slot>
+          <div class='extra-info'>
+            <slot>
+          </div>
         </template>
       </div>
   </template>


### PR DESCRIPTION
Contain slots and scope css instead of using ::slotted

Polyfill converts `::slotted(*)` to `host-tag > *` which messes up
styles of descendents that are not slotted.
Currently, on browsers that do not support the ::slotted selector, all state-badges get `color: var(--secondary-text-color);` set due to the polyfill. This overrides the style set on `:host` in the `state-badge` element

Don't know if it fixes #1030, as there's difference between themes.
But it's at least related to it.