### PR TITLE
Fix Markdown build script on macOS

### DIFF
--- a/script/build_markdown
+++ b/script/build_markdown
@@ -34,7 +34,7 @@ for pkg in $pkgs; do
 */
 EOF
     echo "Downloading $name@$version"
-    echo "$(curl -s "$tarball" | tar -xzO "package/$js_path" | ./node_modules/.bin/uglifyjs -c -m)" >> $output
+    curl -s "$tarball" | tar -xzO "package/$js_path" | ./node_modules/.bin/uglifyjs -c -m >> $output
 done
 
 echo "</script>" >> $output


### PR DESCRIPTION
@balloob 

First, let me say I'm sorry I'm causing issues here; that's certainly not my intention.

I noticed your commit of `markdown-js.html` after accepting my PR looked off. Indeed, that version is completely broken. I've found that the script broke newlines on macOS (which I assume you're running.)

The fix was simple enough (I had some unneeded quoting), and I've verified the build has the same hash (MD5:88150e6059c7a0385c98e7e192c27342) on linux and macOS (10.12).

This PR only includes the script fix, as I assume you'll want to run the script yourself to update `markdown-js.html` and verify the hash is correct before accepting.