### PR TITLE
Hassio Panel UI Enhancements

### DIFF
--- a/hassio/addon-view/hassio-addon-logs.html
+++ b/hassio/addon-view/hassio-addon-logs.html
@@ -11,6 +11,9 @@
       paper-card {
         display: block;
       }
+      pre {
+        overflow-x: scroll;
+      }
     </style>
     <paper-card heading='Log'>
       <div class="card-content">

--- a/hassio/addon-view/hassio-addon-view.html
+++ b/hassio/addon-view/hassio-addon-view.html
@@ -23,7 +23,7 @@
       }      
       .content {
         padding: 24px 0 32px;
-        max-width: 600px;
+        max-width: 800px;
         margin: 0 auto;
       }
       hassio-addon-info,

--- a/hassio/system/hassio-supervisor-log.html
+++ b/hassio/system/hassio-supervisor-log.html
@@ -8,6 +8,9 @@
       paper-card {
         display: block;
       }
+      pre {
+        overflow-x: scroll;
+      }
     </style>
     <paper-card>
       <div class='card-content'>


### PR DESCRIPTION
This PR includes a couple of enhancements to the Hassio UI:

1. Change the add-on view `max-width` to 800px. This gives more room for the README and logs, making things more readable.
2. Set `overflow-x: scroll` on the the add-on and system logs. Currently if the logs overflow the card (pretty common) it causes the whole body to become horizontally scrollable which can be annoying, especially on mobile. This limits the scrolling inside of the `<pre>` meaning only that card content is horizontally scrollable instead of the whole page.

I've verified in Chrome and Chrome on Android that things work as they should.