### PR TITLE
Fix TypeError for views

### DIFF
--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -321,7 +321,7 @@
     }
 
     isView(currentView, defaultView) {
-      return this.hass.states[currentView] || this.hass.states[defaultView];
+      return (currentView || defaultView) && this.hass.states[currentView || DEFAULT_VIEW_ENTITY_ID]
     }
 
     _defaultViewFilter(hass, entityId) {

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -321,7 +321,7 @@
     }
 
     isView(currentView, defaultView) {
-      return (currentView || defaultView) && this.hass.states[currentView || DEFAULT_VIEW_ENTITY_ID]
+      return (currentView || defaultView) && this.hass.states[currentView || DEFAULT_VIEW_ENTITY_ID];
     }
 
     _defaultViewFilter(hass, entityId) {

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -321,7 +321,7 @@
     }
 
     isView(currentView, defaultView) {
-      return currentView || defaultView;
+      return this.hass.states[currentView] || this.hass.states[defaultView];
     }
 
     _defaultViewFilter(hass, entityId) {

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -321,7 +321,8 @@
     }
 
     isView(currentView, defaultView) {
-      return (currentView || defaultView) && this.hass.states[currentView || DEFAULT_VIEW_ENTITY_ID];
+      return (currentView || defaultView) &&
+        this.hass.states[currentView || DEFAULT_VIEW_ENTITY_ID];
     }
 
     _defaultViewFilter(hass, entityId) {


### PR DESCRIPTION
quick and dirty fix, maybe this file needs some more cleanup

problem:
if you have `default_view` in groups.yaml and reload groups in `computeViewStates(currentView, hass, defaultView)`
`defaultView` is (still) defined but `hass.states['group.default_view']` doesn't exist (for some "milliseconds")

Fix: #893 