### PR TITLE
Hide empty 'Currently' on climate statecard

### DIFF
--- a/src/components/ha-climate-state.html
+++ b/src/components/ha-climate-state.html
@@ -44,22 +44,22 @@ class HaClimateState extends Polymer.Element {
 
   static get properties() {
     return {
-      stateObj: {
-        type: Object,
-        observer: 'computeCurrentStatus'
+      stateObj: Object,
+      currentStatus: {
+        type: String,
+        computed: 'computeCurrentStatus(stateObj)',
       },
-      currentStatus: String
     };
   }
 
   computeCurrentStatus(stateObj) {
     if ('current_temperature' in stateObj.attributes) {
-      this.currentStatus = `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
-    } else if ('current_humidity' in stateObj.attributes) {
-      this.currentStatus = `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
-    } else {
-      this.currentStatus = null;
+      return `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
     }
+    if ('current_humidity' in stateObj.attributes) {
+      return `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
+    }
+    return null;
   }
 
   computeTarget(stateObj) {

--- a/src/components/ha-climate-state.html
+++ b/src/components/ha-climate-state.html
@@ -53,9 +53,9 @@ class HaClimateState extends Polymer.Element {
   }
 
   computeCurrentStatus(stateObj) {
-    if (stateObj.attributes.current_temperature || stateObj.attributes.current_temperature === 0) {
+    if ('current_temperature' in stateObj.attributes) {
       this.currentStatus = `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
-    } else if (stateObj.attributes.current_humidity || stateObj.attributes.current_humidity === 0) {
+    } else if ('current_humidity' in stateObj.attributes) {
       this.currentStatus = `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
     } else {
       this.currentStatus = null;

--- a/src/components/ha-climate-state.html
+++ b/src/components/ha-climate-state.html
@@ -3,6 +3,12 @@
 <dom-module id="ha-climate-state">
   <template>
     <style>
+      :host {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+
       .target {
         color: var(--primary-text-color);
       }
@@ -47,9 +53,9 @@ class HaClimateState extends Polymer.Element {
   }
 
   computeCurrentStatus(stateObj) {
-    if (stateObj.attributes.current_temperature) {
+    if (stateObj.attributes.current_temperature || stateObj.attributes.current_temperature === 0) {
       this.currentStatus = `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
-    } else if (stateObj.attributes.current_humidity) {
+    } else if (stateObj.attributes.current_humidity || stateObj.attributes.current_humidity === 0) {
       this.currentStatus = `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
     } else {
       this.currentStatus = null;

--- a/src/components/ha-climate-state.html
+++ b/src/components/ha-climate-state.html
@@ -24,9 +24,11 @@
       [[computeTarget(stateObj)]]
     </div>
 
-    <div class='current'>
-      Currently: [[computeCurrentStatus(stateObj)]]
-    </div>
+    <template is='dom-if' if='[[currentStatus]]'>
+      <div class='current'>
+        Currently: [[currentStatus]]
+      </div>
+    </template>
   </template>
 </dom-module>
 
@@ -36,18 +38,22 @@ class HaClimateState extends Polymer.Element {
 
   static get properties() {
     return {
-      stateObj: Object,
+      stateObj: {
+        type: Object,
+        observer: 'computeCurrentStatus'
+      },
+      currentStatus: String
     };
   }
 
   computeCurrentStatus(stateObj) {
-    if ('current_temperature' in stateObj.attributes) {
-      return `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
-    } else if ('current_humidity' in stateObj.attributes) {
-      return `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
+    if (stateObj.attributes.current_temperature) {
+      this.currentStatus = `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
+    } else if (stateObj.attributes.current_humidity) {
+      this.currentStatus = `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
+    } else {
+      this.currentStatus = null;
     }
-
-    return '';
   }
 
   computeTarget(stateObj) {

--- a/src/components/ha-climate-state.html
+++ b/src/components/ha-climate-state.html
@@ -53,10 +53,10 @@ class HaClimateState extends Polymer.Element {
   }
 
   computeCurrentStatus(stateObj) {
-    if ('current_temperature' in stateObj.attributes) {
+    if (stateObj.attributes.current_temperature != null) {
       return `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
     }
-    if ('current_humidity' in stateObj.attributes) {
+    if (stateObj.attributes.current_humidity != null) {
       return `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
     }
     return null;


### PR DESCRIPTION
If current_temperature or current_humidity is a falsy value (except 0) it will be hidden.
fixes #654 

Existing PR #655 got stale and was not in line with current code anymore.