### PR TITLE
Fix tooltip with title on hass-subpage

### DIFF
--- a/panels/config/cloud/ha-config-cloud-account.html
+++ b/panels/config/cloud/ha-config-cloud-account.html
@@ -43,7 +43,7 @@
         font-weight: 500;
       }
     </style>
-    <hass-subpage title='Cloud Account'>
+    <hass-subpage header='Cloud Account'>
       <div class='content'>
         <ha-config-section
           is-wide='[[isWide]]'

--- a/panels/config/cloud/ha-config-cloud-forgot-password.html
+++ b/panels/config/cloud/ha-config-cloud-forgot-password.html
@@ -39,7 +39,7 @@
         display: none;
       }
     </style>
-    <hass-subpage title="Forgot Password">
+    <hass-subpage header="Forgot Password">
       <div class='content'>
         <paper-card>
           <div class='card-content'>

--- a/panels/config/cloud/ha-config-cloud-login.html
+++ b/panels/config/cloud/ha-config-cloud-login.html
@@ -53,7 +53,7 @@
         color: var(--secondary-text-color);
       }
     </style>
-    <hass-subpage title='Cloud Login'>
+    <hass-subpage header='Cloud Login'>
       <div class='content'>
         <ha-config-section
           is-wide='[[isWide]]'

--- a/panels/config/cloud/ha-config-cloud-register.html
+++ b/panels/config/cloud/ha-config-cloud-register.html
@@ -38,7 +38,7 @@
         display: none;
       }
     </style>
-    <hass-subpage title="Register Account">
+    <hass-subpage header="Register Account">
       <div class='content'>
         <ha-config-section
           is-wide='[[isWide]]'

--- a/panels/config/config-entries/ha-config-entries.html
+++ b/panels/config/config-entries/ha-config-entries.html
@@ -28,7 +28,7 @@
       }
     </style>
 
-    <hass-subpage title='Integrations'>
+    <hass-subpage header='Integrations'>
       <template is='dom-if' if='[[_progress.length]]'>
         <ha-config-section is-wide='[[isWide]]'>
           <span slot='header'>In Progress</span>

--- a/src/layouts/hass-subpage.html
+++ b/src/layouts/hass-subpage.html
@@ -14,7 +14,7 @@
             icon='mdi:arrow-left'
             on-click='_backTapped'
           ></paper-icon-button>
-          <div main-title>[[title]]</div>
+          <div main-title>[[header]]</div>
         </app-toolbar>
       </app-header>
 
@@ -29,7 +29,7 @@ class HassSubpage extends Polymer.Element {
 
   static get properties() {
     return {
-      title: String
+      header: String
     };
   }
 


### PR DESCRIPTION
We used `title` as a property to set the title of `hass-subpage`. However, this is also an HTML attribute that will trigger a tooltip. Changing the property name will avoid this.

Fix idea by @c727

![image](https://user-images.githubusercontent.com/1444314/38118167-ddf8fdbe-336d-11e8-9238-07d81792dc14.png)
