### PR TITLE
Make paper-scrollable in fullscreen dialog resize properly

### DIFF
--- a/hassio/hassio-markdown-dialog.html
+++ b/hassio/hassio-markdown-dialog.html
@@ -31,7 +31,16 @@
       @media all and (max-width: 450px), all and (max-height: 500px) {
         paper-dialog {
           max-height: 100%;
-          height: 100%;
+        }
+        paper-dialog::before {
+          content: "";
+          position: fixed;
+          z-index: -1;
+          top: 0px;
+          left: 0px;
+          right: 0px;
+          bottom: 0px;
+          background-color: inherit;
         }
         app-toolbar {
           color: var(--text-primary-color);

--- a/src/dialogs/ha-more-info-dialog.html
+++ b/src/dialogs/ha-more-info-dialog.html
@@ -43,6 +43,16 @@
         :host {
           @apply(--ha-dialog-fullscreen);
         }
+        :host::before {
+          content: "";
+          position: fixed;
+          z-index: -1;
+          top: 0px;
+          left: 0px;
+          right: 0px;
+          bottom: 0px;
+          background-color: inherit;
+        }
       }
 
       :host([data-domain=camera]) {

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -164,7 +164,6 @@
         }
 
         --ha-dialog-fullscreen: {
-          min-height: 100% !important;
           width: 100% !important;
           border-radius: 0px;
           position: fixed !important;


### PR DESCRIPTION
Currently paper-dialog-behaviour&paper-dialog-scrollable don't work properly with a fixed size as in our full-screen version of the more-info-dialog.

The issue is that an incorrect max-height is set on the scrollable. It's not allowed to take more than it's initial space because iron-fit-behaviour has calculated that the dialog is already at it's maximum size. (see here: https://github.com/PolymerElements/iron-fit-behavior/blob/af1d2e40466608b6209252e93d38c89bf62b18d6/iron-fit-behavior.html#L478)

This PR removes the max-height to make the calculation work properly again... now any growth of scrollable content will let the scrollable grow until the max-height.
The 'empty' space below the dialog is filled with a psuedo-element that is fixed-positioned behind all the more-info content.