### PR TITLE
Fix scrollable clipping controls because of webkit-overflow-scrolling: touch;

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -52,6 +52,7 @@
     "paper-toast": "PolymerElements/paper-toast#^2.0.0",
     "paper-toggle-button": "PolymerElements/paper-toggle-button#^2.0.0",
     "polymer": "^2.1.1",
+    "shadycss": "^1.1.0",
     "vaadin-combo-box": "vaadin/vaadin-combo-box#^3.0.2",
     "vaadin-date-picker": "vaadin/vaadin-date-picker#^2.0.0",
     "web-animations-js": "^2.2.5",

--- a/src/components/ha-labeled-slider.html
+++ b/src/components/ha-labeled-slider.html
@@ -7,31 +7,43 @@
     <style>
       :host {
         display: block;
-        padding-bottom: 16px;
+        padding-bottom: 20px;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
       }
 
       .title {
-        margin-bottom: 16px;
+        font-size: 90%;
         opacity: var(--dark-primary-opacity);
+        line-height: 1.2em;
+        padding-top: 0.3em;
+
       }
 
-      iron-icon {
-        float: left;
-        margin-top: 4px;
+      .icon-container {
+        flex: 1 1 50px;
+        text-align: center;
         opacity: var(--dark-secondary-opacity);
+        width: 60px;
+        margin-top: 5px;
       }
 
       .slider-container {
-        margin-left: 24px;
+        flex: 1 1 200px;
+        border-radius: 50%;
       }
-
       paper-slider {
+        width: 100%;
         background-image: var(--ha-slider-background);
       }
-    </style>
 
-    <div class='title'>[[caption]]</div>
-    <iron-icon icon='[[icon]]'></iron-icon>
+    </style>
+    <div class='icon-container'>
+      <iron-icon icon='[[icon]]'></iron-icon>
+      <div class='title'>[[caption]]</div>
+    </div>
     <div class='slider-container'>
       <paper-slider min='[[min]]' max='[[max]]' value='{{value}}' ignore-bar-touch='[[ignoreBarTouch]]'>
       </paper-slider>

--- a/src/components/ha-labeled-slider.html
+++ b/src/components/ha-labeled-slider.html
@@ -7,43 +7,31 @@
     <style>
       :host {
         display: block;
-        padding-bottom: 20px;
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        justify-content: space-between;
+        padding-bottom: 16px;
       }
 
       .title {
-        font-size: 90%;
+        margin-bottom: 16px;
         opacity: var(--dark-primary-opacity);
-        line-height: 1.2em;
-        padding-top: 0.3em;
-
       }
 
-      .icon-container {
-        flex: 1 1 50px;
-        text-align: center;
+      iron-icon {
+        float: left;
+        margin-top: 4px;
         opacity: var(--dark-secondary-opacity);
-        width: 60px;
-        margin-top: 5px;
       }
 
       .slider-container {
-        flex: 1 1 200px;
-        border-radius: 50%;
-      }
-      paper-slider {
-        width: 100%;
-        background-image: var(--ha-slider-background);
+        margin-left: 24px;
       }
 
+      paper-slider {
+        background-image: var(--ha-slider-background);
+      }
     </style>
-    <div class='icon-container'>
-      <iron-icon icon='[[icon]]'></iron-icon>
-      <div class='title'>[[caption]]</div>
-    </div>
+
+    <div class='title'>[[caption]]</div>
+    <iron-icon icon='[[icon]]'></iron-icon>
     <div class='slider-container'>
       <paper-slider min='[[min]]' max='[[max]]' value='{{value}}' ignore-bar-touch='[[ignoreBarTouch]]'>
       </paper-slider>

--- a/src/dialogs/more-info/more-info-controls.html
+++ b/src/dialogs/more-info/more-info-controls.html
@@ -11,7 +11,7 @@
 
 <dom-module id="more-info-controls">
   <template>
-    <style>
+    <style include='ha-style-dialog'>
       app-toolbar {
         color: var(--more-info-header-color);
         background-color: var(--more-info-header-background);

--- a/src/resources/ha-style.html
+++ b/src/resources/ha-style.html
@@ -84,6 +84,22 @@
     --light-primary-opacity: 1.0;
   }
 </style>
+
+  <style shady-unscoped>
+    /*
+      prevent clipping of positioned elements in a small scrollable
+      force smooth scrolling if can scroll
+      use non-shady selectors so this only targets iOS 9
+      conditional mixin set in ha-style-dialog does not work with shadyCSS
+    */
+    paper-dialog-scrollable:not(.can-scroll) > .scrollable {
+      -webkit-overflow-scrolling: auto !important;
+    }
+    paper-dialog-scrollable.can-scroll > .scrollable {
+      -webkit-overflow-scrolling: touch !important;
+    }
+  </style>
+
 </custom-style>
 
 <dom-module id='ha-style'>
@@ -169,22 +185,24 @@
           position: fixed !important;
           margin: 0;
         }
+      }
 
+      /* prevent clipping of positioned elements */
+      paper-dialog-scrollable {
+        --paper-dialog-scrollable: {
+          -webkit-overflow-scrolling: auto;
+        }
+      }
+      /* force smooth scrolling for iOS 10 */
+      paper-dialog-scrollable.can-scroll {
         --paper-dialog-scrollable: {
           -webkit-overflow-scrolling: touch;
-          margin-bottom: 16px;
         }
       }
 
       @media all and (max-width: 450px), all and (max-height: 500px) {
         paper-dialog {
           @apply(--ha-dialog-narrow);
-        }
-        :host {
-          --paper-dialog-scrollable: {
-            -webkit-overflow-scrolling: touch;
-            margin-bottom: 0px;
-          }
         }
       }
     </style>


### PR DESCRIPTION
Fixes: #1064 and #775 (again)

`webkit-overflow-scrolling: touch` causes positioned elements, like the dropdown, to be clipped.
Setting `webkit-overflow-scrolling: auto` fixed this, but on iOS 9 and 10 causes non-gpu-accelerated scrolling so it is very sluggish. (especially on iOS 9 devices, which are pretty slow anyway for todays standards)

This sets `webkit-overflow-scrolling: auto` by default. So small paper-dialog-scrollables don't clip content. The scrollable will grow with the content until it gets limited by it's max-height. At that point it will become actually scrollable, and we set `webkit-overflow-scrolling: touch`. By then the scrollable should be large enough to accommodate all dropdowns.

To make this work on iOS 9 we actually need to set these properties on the polyfilled light DOM. Because shadyCSS can't handle conditional mixins. For that we need shadycss ^v1.1.0 so we can use `shady-unscoped`