### PR TITLE
Allow the use of set credentials when fetching manifest.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Home Assistant</title>
 
-    <link rel='manifest' href='/manifest.json'>
+    <link rel='manifest' href='/manifest.json' crossorigin="use-credentials">
     <link rel='icon' href='/static/icons/favicon.ico'>
     <link rel='apple-touch-icon' sizes='180x180'
           href='/static/icons/favicon-apple-180x180.png'>


### PR DESCRIPTION
Fixes #940 

This allows fetching of manifest.json when home-assistant is running behind an authenticating proxy.