### PR TITLE
Pretty huge scrolling performance upgrade

### DIFF
--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -33,6 +33,8 @@
         display: block;
         margin-left: 8px;
         margin-bottom: 8px;
+        transform: translateZ(0);
+        will-change: transform;
       }
 
       @media (max-width: 500px) {

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -18,7 +18,6 @@
         padding-top: 8px;
         padding-right: 8px;
         transform: translateZ(0);
-        will-change: transform;
       }
 
       .badges {
@@ -35,8 +34,6 @@
         display: block;
         margin-left: 8px;
         margin-bottom: 8px;
-        transform: translateZ(0);
-        will-change: transform;
       }
 
       @media (max-width: 500px) {

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -17,6 +17,8 @@
         display: block;
         padding-top: 8px;
         padding-right: 8px;
+        transform: translateZ(0);
+        will-change: transform;
       }
 
       .badges {


### PR DESCRIPTION
By making ha-cards its own rendering layer the #contentContainer (scroll region) doesn't need a repaint on every scroll. 
Also setting ha-card-chooser to it's own rendering layer a change to one card doesn't lead to a repaint of the whole ha-cards element.
(Probably the IntersectionObserver, or its polyfill, is triggering a repaint of cards on scroll, but it's pretty hard to find out exactly)

Safari/webkit (desktop) benefits the most of these changes. On a busy `/states` view I went from a jittery ~7fps to a buttery smooth +30fps! (safari doesn't have an fps meter)
In Chrome it went from ~40 fps to a rather solid 60fps.
It also reduced GPU memory usage from about 70MB to 40MB

(Safari/Webkit on iOS did not have this problem, I think because it offloads scrolling stuff to gpu anyway)