### PR TITLE
Add more-info dialog support to dev-states

### DIFF
--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -13,6 +13,8 @@
 <link rel="import" href="../../src/components/entity/ha-entity-picker.html">
 <link rel="import" href="../../src/resources/ha-style.html">
 
+<link rel='import' href='../../src/util/hass-mixins.html'>
+
 <dom-module id="ha-panel-dev-state">
   <template>
     <style include="ha-style">

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -48,7 +48,13 @@
       .entities tr:nth-child(even) {
         background-color: var(--table-row-alternative-background-color, #eee)
       }
-
+      .entities td {
+        padding: 4px;
+      }
+      .entities paper-icon-button {
+        height: 24px;
+        padding: 0;
+      }
       .entities td:nth-child(3) {
         white-space: pre-wrap;
         word-break: break-word;
@@ -110,8 +116,16 @@
           </tr>
           <template is='dom-repeat' items='[[_entities]]' as='entity'>
             <tr>
-              <td><a href='#' on-click='entitySelected'>[[entity.entity_id]]</a></td>
-              <td><a href='#' on-click='entityHistory'>[[entity.state]]</a></td>
+              <td>
+                <paper-icon-button
+                  on-click='entityMoreInfo'
+                  icon='mdi:open-in-new'
+                  alt="More Info" title="More Info"
+                  >
+                </paper-icon-button>
+                <a href='#' on-click='entitySelected'>[[entity.entity_id]]</a>
+              </td>
+              <td>[[entity.state]]</td>
               <template is='dom-if' if='[[computeShowAttributes(narrow, _showAttributes)]]'>
                 <td>[[attributeString(entity)]]</td>
               </template>
@@ -193,7 +207,7 @@ class HaPanelDevState extends window.hassMixins.EventsMixin(Polymer.Element) {
     ev.preventDefault();
   }
 
-  entityHistory(ev) {
+  entityMoreInfo(ev) {
     ev.preventDefault();
     this.fire('hass-more-info', { entityId: ev.model.entity.entity_id });
   }

--- a/panels/dev-state/ha-panel-dev-state.html
+++ b/panels/dev-state/ha-panel-dev-state.html
@@ -109,7 +109,7 @@
           <template is='dom-repeat' items='[[_entities]]' as='entity'>
             <tr>
               <td><a href='#' on-click='entitySelected'>[[entity.entity_id]]</a></td>
-              <td>[[entity.state]]</td>
+              <td><a href='#' on-click='entityHistory'>[[entity.state]]</a></td>
               <template is='dom-if' if='[[computeShowAttributes(narrow, _showAttributes)]]'>
                 <td>[[attributeString(entity)]]</td>
               </template>
@@ -122,7 +122,7 @@
 </dom-module>
 
 <script>
-class HaPanelDevState extends Polymer.Element {
+class HaPanelDevState extends window.hassMixins.EventsMixin(Polymer.Element) {
   static get is() { return 'ha-panel-dev-state'; }
 
   static get properties() {
@@ -189,6 +189,11 @@ class HaPanelDevState extends Polymer.Element {
     this._state = state.state;
     this._stateAttributes = JSON.stringify(state.attributes, null, '  ');
     ev.preventDefault();
+  }
+
+  entityHistory(ev) {
+    ev.preventDefault();
+    this.fire('hass-more-info', { entityId: ev.model.entity.entity_id });
   }
 
   handleSetState() {


### PR DESCRIPTION
When writing automations it's sometimes helpful to see the state history of an entity to see what states it has been recently. This update lets you click on the state of an entity in the dev-states page to bring up the more-info card with the history graph.

I just made the state be clickable to bring up the card, though I'm not convinced that's the best method. Also thought about adding another column with an icon to bring it up, not sure what would be best/preferred.