### PR TITLE
Add refresh button to logbook

### DIFF
--- a/panels/logbook/ha-logbook-data.html
+++ b/panels/logbook/ha-logbook-data.html
@@ -68,6 +68,11 @@
 
       return DATE_CACHE[date];
     }
+
+    refreshLogbook() {
+      DATE_CACHE[this.filterDate] = null;
+      this.filterDateChanged(this.filterDate);
+    }
   }
 
   customElements.define(HaLogbookData.is, HaLogbookData);

--- a/panels/logbook/ha-panel-logbook.html
+++ b/panels/logbook/ha-panel-logbook.html
@@ -79,7 +79,12 @@
           disabled='[[isLoading]]'
           required
         ></vaadin-date-picker>
-        <paper-icon-button id='refresh-logbook' icon='mdi:refresh' on-click='refreshLogbook' hidden$='[[_isRefreshHidden(isLoading, _currentDate)]]'></paper-icon-button>
+        <paper-icon-button
+          id='refresh-logbook'
+          icon='mdi:refresh'
+          on-click='refreshLogbook'
+          hidden$='[[_isRefreshHidden(isLoading, _currentDate)]]'
+        ></paper-icon-button>
 
         <ha-logbook hass='[[hass]]' entries="[[entries]]" hidden$='[[isLoading]]'></ha-logbook>
       </div>

--- a/panels/logbook/ha-panel-logbook.html
+++ b/panels/logbook/ha-panel-logbook.html
@@ -112,12 +112,11 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(Polymer.Element) {
       // ISO8601 formatted date string
       _currentDate: {
         type: String,
-        value: () => {
-          const now = new Date();
-          const month = now.getMonth() < 9 ? `0${now.getMonth() + 1}` : now.getMonth() + 1;
-          const day = now.getDate() < 10 ? `0${now.getDate()}` : now.getDate();
-          return `${now.getFullYear()}-${month}-${day}`;
-        },
+        value: function () {
+          const value = new Date();
+          const today = new Date(Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()));
+          return today.toISOString().split('T')[0];
+        }
       },
 
       isLoading: {

--- a/panels/logbook/ha-panel-logbook.html
+++ b/panels/logbook/ha-panel-logbook.html
@@ -25,7 +25,7 @@
       padding: 0 16px 16px;
     }
 
-    paper-spinner, paper-icon-button {
+    paper-spinner {
       position: absolute;
       top: 15px;
       left: 186px;
@@ -56,6 +56,11 @@
         <app-toolbar>
           <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
           <div main-title>[[localize('panel.logbook')]]</div>
+          <paper-icon-button
+            icon='mdi:refresh'
+            on-click='refreshLogbook'
+            hidden$='[[isLoading]]'
+          ></paper-icon-button>
         </app-toolbar>
       </app-header>
 
@@ -73,11 +78,7 @@
           disabled='[[isLoading]]'
           required
         ></vaadin-date-picker>
-        <paper-icon-button
-          icon='mdi:refresh'
-          on-click='refreshLogbook'
-          hidden$='[[_isRefreshHidden(isLoading, _currentDate)]]'
-        ></paper-icon-button>
+
 
         <ha-logbook hass='[[hass]]' entries="[[entries]]" hidden$='[[isLoading]]'></ha-logbook>
       </div>
@@ -111,10 +112,11 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(Polymer.Element) {
       // ISO8601 formatted date string
       _currentDate: {
         type: String,
-        value: function () {
-          var value = new Date();
-          var today = new Date(Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()));
-          return today.toISOString().split('T')[0];
+        value: () => {
+          const now = new Date();
+          const month = now.getMonth() < 9 ? `0${now.getMonth() + 1}` : now.getMonth() + 1;
+          const day = now.getDate() < 10 ? `0${now.getDate()}` : now.getDate();
+          return `${now.getFullYear()}-${month}-${day}`;
         },
       },
 
@@ -155,11 +157,6 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(Polymer.Element) {
 
   refreshLogbook() {
     this.shadowRoot.querySelector('ha-logbook-data').refreshLogbook();
-  }
-
-  _isRefreshHidden(isLoading, _currentDate) {
-    var today = new Date().toISOString().split('T')[0];
-    return (_currentDate !== today) || this.isLoading;
   }
 }
 

--- a/panels/logbook/ha-panel-logbook.html
+++ b/panels/logbook/ha-panel-logbook.html
@@ -31,6 +31,12 @@
       left: 186px;
     }
 
+    #refresh-logbook {
+      position: absolute;
+      top: 15px;
+      left: 186px;
+    }
+
     vaadin-date-picker {
       --vaadin-date-picker-clear-icon: {
         display: none;
@@ -73,6 +79,7 @@
           disabled='[[isLoading]]'
           required
         ></vaadin-date-picker>
+        <paper-icon-button id='refresh-logbook' icon='mdi:refresh' on-click='refreshLogbook' hidden$='[[_isRefreshHidden(isLoading, _currentDate,_today)]]'></paper-icon-button>
 
         <ha-logbook hass='[[hass]]' entries="[[entries]]" hidden$='[[isLoading]]'></ha-logbook>
       </div>
@@ -112,6 +119,15 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(Polymer.Element) {
           return today.toISOString().split('T')[0];
         },
       },
+      _today: {
+        type: String,
+        value: function () {
+          var value = new Date();
+          var today = new Date(Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()));
+          return today.toISOString().split('T')[0];
+        },
+      },
+
 
       isLoading: {
         type: Boolean,
@@ -146,6 +162,15 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(Polymer.Element) {
     var parts = _currentDate.split('-');
     parts[1] = parseInt(parts[1]) - 1;
     return new Date(parts[0], parts[1], parts[2]).toISOString();
+  }
+
+  refreshLogbook() {
+    this.shadowRoot.querySelector('ha-logbook-data').refreshLogbook();
+  }
+
+  _isRefreshHidden(isLoading, _currentDate, _today) {
+    // if (this.isLoading) return true;
+    return (_currentDate !== _today) || this.isLoading;
   }
 }
 

--- a/panels/logbook/ha-panel-logbook.html
+++ b/panels/logbook/ha-panel-logbook.html
@@ -169,7 +169,6 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(Polymer.Element) {
   }
 
   _isRefreshHidden(isLoading, _currentDate, _today) {
-    // if (this.isLoading) return true;
     return (_currentDate !== _today) || this.isLoading;
   }
 }

--- a/panels/logbook/ha-panel-logbook.html
+++ b/panels/logbook/ha-panel-logbook.html
@@ -79,7 +79,7 @@
           disabled='[[isLoading]]'
           required
         ></vaadin-date-picker>
-        <paper-icon-button id='refresh-logbook' icon='mdi:refresh' on-click='refreshLogbook' hidden$='[[_isRefreshHidden(isLoading, _currentDate,_today)]]'></paper-icon-button>
+        <paper-icon-button id='refresh-logbook' icon='mdi:refresh' on-click='refreshLogbook' hidden$='[[_isRefreshHidden(isLoading, _currentDate)]]'></paper-icon-button>
 
         <ha-logbook hass='[[hass]]' entries="[[entries]]" hidden$='[[isLoading]]'></ha-logbook>
       </div>
@@ -119,15 +119,6 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(Polymer.Element) {
           return today.toISOString().split('T')[0];
         },
       },
-      _today: {
-        type: String,
-        value: function () {
-          var value = new Date();
-          var today = new Date(Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()));
-          return today.toISOString().split('T')[0];
-        },
-      },
-
 
       isLoading: {
         type: Boolean,
@@ -168,8 +159,9 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(Polymer.Element) {
     this.shadowRoot.querySelector('ha-logbook-data').refreshLogbook();
   }
 
-  _isRefreshHidden(isLoading, _currentDate, _today) {
-    return (_currentDate !== _today) || this.isLoading;
+  _isRefreshHidden(isLoading, _currentDate) {
+    var today = new Date().toISOString().split('T')[0];
+    return (_currentDate !== today) || this.isLoading;
   }
 }
 

--- a/panels/logbook/ha-panel-logbook.html
+++ b/panels/logbook/ha-panel-logbook.html
@@ -25,13 +25,7 @@
       padding: 0 16px 16px;
     }
 
-    paper-spinner {
-      position: absolute;
-      top: 15px;
-      left: 186px;
-    }
-
-    #refresh-logbook {
+    paper-spinner, paper-icon-button {
       position: absolute;
       top: 15px;
       left: 186px;
@@ -80,7 +74,6 @@
           required
         ></vaadin-date-picker>
         <paper-icon-button
-          id='refresh-logbook'
           icon='mdi:refresh'
           on-click='refreshLogbook'
           hidden$='[[_isRefreshHidden(isLoading, _currentDate)]]'


### PR DESCRIPTION
Adds a refresh button to the Logbook panel to refresh events from the current day. Refresh button is hidden on days in the past as the logbook data shouldn't change for those days.

Fixes https://github.com/home-assistant/home-assistant-polymer/issues/284