### PR TITLE
Allow setting a custom state-badge icon color

### DIFF
--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -75,14 +75,13 @@ class StateBadge extends Polymer.Element {
     if (newVal.attributes.entity_picture) {
       hostStyle.backgroundImage = 'url(' + newVal.attributes.entity_picture + ')';
       iconStyle.display = 'none';
+    } else if (newVal.attributes.icon_color) {
+      iconStyle.color = `${newVal.attributes.icon_color}`;
     } else {
       if (newVal.attributes.hs_color) {
         const hue = newVal.attributes.hs_color[0];
         const sat = newVal.attributes.hs_color[1];
         if (sat > 10) iconStyle.color = `hsl(${hue}, 100%, ${100 - (sat / 2)}%)`;
-      } else if (newVal.attributes.rgb_color) {
-        const rgb = newVal.attributes.rgb_color;
-        iconStyle.color = `rgb(${rgb[0]}, ${rgb[1]},${rgb[2]})`;
       }
       if (newVal.attributes.brightness) {
         const brightness = newVal.attributes.brightness;

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -76,7 +76,7 @@ class StateBadge extends Polymer.Element {
       hostStyle.backgroundImage = 'url(' + newVal.attributes.entity_picture + ')';
       iconStyle.display = 'none';
     } else if (newVal.attributes.icon_color) {
-      iconStyle.color = `${newVal.attributes.icon_color}`;
+      iconStyle.color = newVal.attributes.icon_color;
     } else {
       if (newVal.attributes.hs_color) {
         const hue = newVal.attributes.hs_color[0];
@@ -89,8 +89,8 @@ class StateBadge extends Polymer.Element {
         iconStyle.filter = `brightness(${(brightness + 245) / 5}%)`;
       }
     }
-    Object.assign(this.$.icon.style, iconStyle);
-    Object.assign(this.style, hostStyle);
+    this.$.icon.updateStyles(iconStyle);
+    this.updateStyles(hostStyle);
   }
 }
 customElements.define(StateBadge.is, StateBadge);

--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -80,6 +80,9 @@ class StateBadge extends Polymer.Element {
         const hue = newVal.attributes.hs_color[0];
         const sat = newVal.attributes.hs_color[1];
         if (sat > 10) iconStyle.color = `hsl(${hue}, 100%, ${100 - (sat / 2)}%)`;
+      } else if (newVal.attributes.rgb_color) {
+        const rgb = newVal.attributes.rgb_color;
+        iconStyle.color = `rgb(${rgb[0]}, ${rgb[1]},${rgb[2]})`;
       }
       if (newVal.attributes.brightness) {
         const brightness = newVal.attributes.brightness;


### PR DESCRIPTION
This will allow setting a 'icon_color' attribute (like the 'icon' attribute we already have)
It will simple set the value as the css color value.
So you can do `icon_color: black`, `icon_color: rgba()` or any other valid css.

Setting an `icon_color` will skip any other color or brightness modification to the icon.

P.S. this is mainly to help people who use custom UI and are forced to do all kind of wierd hue/saturation calculation to get thier icons colored the right way.
I know the state is not the perfect place for this. But it's neatly coupled with `icon` now so they can move together once there's a better place.