### PR TITLE
Change padding logic

### DIFF
--- a/src/components/state-history-chart-line.html
+++ b/src/components/state-history-chart-line.html
@@ -253,16 +253,6 @@ class StateHistoryChartLine extends Polymer.Element {
             ticks: {
               maxTicksLimit: 7,
             },
-            // Add space to prevent cut-off.
-            afterDataLimits: (axis) => {
-              const min = axis.min;
-              const max = axis.max;
-              if (isFinite(min) && isFinite(max)) {
-                const padding = (max - min) * 0.05;
-                axis.min -= padding;
-                axis.max += padding;
-              }
-            },
           }],
         },
         tooltips: {
@@ -270,6 +260,11 @@ class StateHistoryChartLine extends Polymer.Element {
         },
         hover: {
           mode: 'neareach',
+        },
+        layout: {
+          padding: {
+            top: 5
+          },
         },
         elements: {
           line: {


### PR DESCRIPTION
The original padding may make the chart 1/2 empty.
Tool-tips should be OK with default padding but the mouse-over dot may cut-off.