### PR TITLE
Hassio: select audio input/output for add-ons

### DIFF
--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -12,29 +12,20 @@
 <dom-module id="hassio-addon-audio">
   <template>
     <style include="ha-style">
-      :host {
-        display: block;
-      }
-      paper-card {
+      :host,
+      paper-card,
+      paper-dropdown-menu {
         display: block;
       }
       .errors {
         color: var(--google-red-500);
         margin-bottom: 16px;
       }
-      paper-dropdown-menu {
-        width: 100%;
-      }
       paper-item {
         width: 450px;
       }
       .card-actions {
-        @apply --layout;
-        @apply --layout-justified;
-      }
-      paper-button {
-        margin-right: 0;
-        margin-left: auto;
+        text-align: right;
       }
     </style>
     <paper-card heading='Audio'>
@@ -45,14 +36,14 @@
         
         <paper-dropdown-menu label="Input">
           <paper-listbox slot="dropdown-content" attr-for-selected="device" selected="{{selectedInput}}">
-            <template is='dom-repeat' items='[[listInput]]'>
+            <template is='dom-repeat' items='[[inputDevices]]'>
               <paper-item device$="[[item.device]]">[[item.name]]</paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>
         <paper-dropdown-menu label="Output">
           <paper-listbox slot="dropdown-content" attr-for-selected="device" selected="{{selectedOutput}}">
-            <template is='dom-repeat' items='[[listOutput]]'>
+            <template is='dom-repeat' items='[[outputDevices]]'>
               <paper-item device$="[[item.device]]">[[item.name]]</paper-item>
             </template>
           </paper-listbox>
@@ -60,7 +51,7 @@
       </div>
       <div class="card-actions">
         <paper-button
-          on-click='saveTapped'
+          on-click='_saveSettings'
         >Save</paper-button>
       </div>
     </paper-card>
@@ -74,13 +65,12 @@ class HassioAddonAudio extends Polymer.Element {
   static get properties() {
     return {
       hass: Object,
-      addonSlug: String,
       addon: {
         type: Object,
         observer: 'addonChanged'
       },
-      listInput: Array,
-      listOutput: Array,
+      inputDevices: Array,
+      outputDevices: Array,
       selectedInput: String,
       selectedOutput: String,
       error: String,
@@ -92,36 +82,28 @@ class HassioAddonAudio extends Polymer.Element {
       selectedInput: addon.audio_input || 'null',
       selectedOutput: addon.audio_output || 'null'
     });
-    if (this.listOutput) return;
+    if (this.outputDevices) return;
 
-    const listInput = [{ device: 'null', name: '-' }];
-    const listOutput = [{ device: 'null', name: '-' }];
-    this.hass.callApi('get', 'hassio/host/hardware').then((resp) => {
-      const data = resp.data.audio;
-      Object.keys(data).forEach((audio) => {
-        Object.keys(data[audio].devices).forEach((device) => {
-          if (data[audio].devices[device] === 'digital audio capture') {
-            listInput.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
-          } else if (data[audio].devices[device] === 'digital audio playback') {
-            listOutput.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
-          }
-        });
-      });
+    const noDevice = [{ device: 'null', name: '-' }];
+    this.hass.callApi('get', 'hassio/hardware/audio').then((resp) => {
+      const audio = resp.data.audio;
       this.setProperties({
-        listInput,
-        listOutput
+        inputDevices: noDevice.concat(
+          Object.keys(audio.input).map(key => ({ device: key, name: audio.input[key] }))),
+        outputDevices: noDevice.concat(
+          Object.keys(audio.output).map(key => ({ device: key, name: audio.output[key] })))
       });
     }, () => {
       this.setProperties({
-        listInput,
-        listOutput
+        inputDevices: noDevice,
+        outputDevices: noDevice
       });
     });
   }
 
-  saveTapped() {
+  _saveSettings() {
     this.error = null;
-    const path = `hassio/addons/${this.addonSlug}/options`;
+    const path = `hassio/addons/${this.addon.slug}/options`;
     this.hass.callApi('post', path, {
       audio_input: this.selectedInput === 'null' ? null : this.selectedInput,
       audio_output: this.selectedOutput === 'null' ? null : this.selectedOutput

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -88,10 +88,8 @@ class HassioAddonAudio extends Polymer.Element {
     this.hass.callApi('get', 'hassio/hardware/audio').then((resp) => {
       const audio = resp.data.audio;
       this.setProperties({
-        inputDevices: noDevice.concat(
-          Object.keys(audio.input).map(key => ({ device: key, name: audio.input[key] }))),
-        outputDevices: noDevice.concat(
-          Object.keys(audio.output).map(key => ({ device: key, name: audio.output[key] })))
+        inputDevices: noDevice.concat(Object.keys(audio.input).map(key => ({ device: key, name: audio.input[key] }))),
+        outputDevices: noDevice.concat(Object.keys(audio.output).map(key => ({ device: key, name: audio.output[key] })))
       });
     }, () => {
       this.setProperties({

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -59,7 +59,7 @@
 </dom-module>
 
 <script>
-class HassioAddonAudio extends Polymer.Element {
+class HassioAddonAudio extends window.hassMixins.EventsMixin(Polymer.Element) {
   static get is() { return 'hassio-addon-audio'; }
 
   static get properties() {

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -94,8 +94,8 @@ class HassioAddonAudio extends Polymer.Element {
     const output = [{ device: 'null', name: '-' }];
     this.hass.callApi('get', 'hassio/host/hardware').then((resp) => {
       const data = resp.data.audio;
-      Object.keys(data).forEach(audio => {
-        Object.keys(data[audio].devices).forEach(device => {
+      Object.keys(data).forEach((audio) => {
+        Object.keys(data[audio].devices).forEach((device) => {
           if (data[audio].devices[device] === 'digital audio capture') {
             input.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
           } else if (data[audio].devices[device] === 'digital audio playback') {
@@ -105,7 +105,7 @@ class HassioAddonAudio extends Polymer.Element {
       });
       this.listInput = input;
       this.listOutput = output;
-    }, (resp) => {
+    }, () => {
       this.listInput = input;
       this.listOutput = output;
     });
@@ -113,8 +113,8 @@ class HassioAddonAudio extends Polymer.Element {
 
   saveTapped() {
     this.error = null;
-
-    this.hass.callApi('post', `hassio/addons/${this.addonSlug}/options`, {
+    const path = `hassio/addons/${this.addonSlug}/options`;
+    this.hass.callApi('post', path, {
       audio_input: this.selectedInput === 'null' ? null : this.selectedInput,
       audio_output: this.selectedOutput === 'null' ? null : this.selectedOutput
     }).then(() => {

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -87,9 +87,15 @@ class HassioAddonAudio extends Polymer.Element {
     const noDevice = [{ device: 'null', name: '-' }];
     this.hass.callApi('get', 'hassio/hardware/audio').then((resp) => {
       const audio = resp.data.audio;
+      const inputDevices = noDevice.concat(Object.keys(audio.input).map((key) => {
+        return { device: key, name: audio.input[key] };
+      }));
+      const outputDevices = noDevice.concat(Object.keys(audio.output).map((key) => {
+        return { device: key, name: audio.output[key] };
+      }));
       this.setProperties({
-        inputDevices: noDevice.concat(Object.keys(audio.input).map(key => ({ device: key, name: audio.input[key] }))),
-        outputDevices: noDevice.concat(Object.keys(audio.output).map(key => ({ device: key, name: audio.output[key] })))
+        inputDevices,
+        outputDevices
       });
     }, () => {
       this.setProperties({

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -88,28 +88,34 @@ class HassioAddonAudio extends Polymer.Element {
   }
 
   addonChanged(addon) {
-    this.selectedInput = addon.audio_input ? addon.audio_input : 'null';
-    this.selectedOutput = addon.audio_output ? addon.audio_output : 'null';
+    this.setProperties({
+      selectedInput: addon.audio_input || 'null',
+      selectedOutput: addon.audio_output || 'null'
+    });
     if (this.listOutput) return;
 
-    const input = [{ device: 'null', name: '-' }];
-    const output = [{ device: 'null', name: '-' }];
+    const listInput = [{ device: 'null', name: '-' }];
+    const listOutput = [{ device: 'null', name: '-' }];
     this.hass.callApi('get', 'hassio/host/hardware').then((resp) => {
       const data = resp.data.audio;
       Object.keys(data).forEach((audio) => {
         Object.keys(data[audio].devices).forEach((device) => {
           if (data[audio].devices[device] === 'digital audio capture') {
-            input.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
+            listInput.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
           } else if (data[audio].devices[device] === 'digital audio playback') {
-            output.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
+            listOutput.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
           }
         });
       });
-      this.listInput = input;
-      this.listOutput = output;
+      this.setProperties({
+        listInput,
+        listOutput
+      });
     }, () => {
-      this.listInput = input;
-      this.listOutput = output;
+      this.setProperties({
+        listInput,
+        listOutput
+      });
     });
   }
 

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -86,12 +86,12 @@ class HassioAddonAudio extends Polymer.Element {
 
     const noDevice = [{ device: 'null', name: '-' }];
     this.hass.callApi('get', 'hassio/hardware/audio').then((resp) => {
-      const audio = resp.data.audio;
-      const inputDevices = noDevice.concat(Object.keys(audio.input).map(key => ({ device: key, name: audio.input[key] })));
-      const outputDevices = noDevice.concat(Object.keys(audio.output).map(key => ({ device: key, name: audio.output[key] })));
+      const dev = resp.data.audio;
+      const input = Object.keys(dev.input).map(key => ({ device: key, name: dev.input[key] }));
+      const output = Object.keys(dev.output).map(key => ({ device: key, name: dev.output[key] }));
       this.setProperties({
-        inputDevices,
-        outputDevices
+        inputDevices: noDevice.concat(input),
+        outputDevices: noDevice.concat(output)
       });
     }, () => {
       this.setProperties({

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -44,16 +44,16 @@
         </template>
         
         <paper-dropdown-menu label="Input">
-          <paper-listbox slot="dropdown-content" attr-for-selected="item-device" selected="{{selectedInput}}">
+          <paper-listbox slot="dropdown-content" attr-for-selected="device" selected="{{selectedInput}}">
             <template is='dom-repeat' items='[[listInput]]'>
-              <paper-item item-device="[[item.device]]">[[item.name]]</paper-item>
+              <paper-item device$="[[item.device]]">[[item.name]]</paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>
         <paper-dropdown-menu label="Output">
-          <paper-listbox slot="dropdown-content" attr-for-selected="item-device" selected="{{selectedOutput}}">
+          <paper-listbox slot="dropdown-content" attr-for-selected="device" selected="{{selectedOutput}}">
             <template is='dom-repeat' items='[[listOutput]]'>
-              <paper-item item-device="[[item.device]]">[[item.name]]</paper-item>
+              <paper-item device$="[[item.device]]">[[item.name]]</paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -1,0 +1,129 @@
+<link rel="import" href="../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel='import' href='../../bower_components/paper-listbox/paper-listbox.html'>
+<link rel='import' href='../../bower_components/paper-item/paper-item.html'>
+<link rel='import' href='../../bower_components/neon-animation/web-animations.html'>
+
+<link rel='import' href='../../src/resources/ha-style.html'>
+
+<dom-module id="hassio-addon-audio">
+  <template>
+    <style include="ha-style">
+      :host {
+        display: block;
+      }
+      paper-card {
+        display: block;
+      }
+      .errors {
+        color: var(--google-red-500);
+        margin-bottom: 16px;
+      }
+      paper-dropdown-menu {
+        width: 100%;
+      }
+      paper-item {
+        width: 450px;
+      }
+      .card-actions {
+        @apply --layout;
+        @apply --layout-justified;
+      }
+      paper-button {
+        margin-right: 0;
+        margin-left: auto;
+      }
+    </style>
+    <paper-card heading='Audio'>
+      <div class="card-content">
+        <template is='dom-if' if='[[error]]'>
+          <div class='errors'>[[error]]</div>
+        </template>
+        
+        <paper-dropdown-menu label="Input">
+          <paper-listbox slot="dropdown-content" attr-for-selected="device" selected="{{selectedInput}}">
+            <template is='dom-repeat' items='[[listInput]]'>
+              <paper-item device="[[item.device]]">[[item.name]]</paper-item>
+            </template>
+          </paper-listbox>
+        </paper-dropdown-menu>
+        <paper-dropdown-menu label="Output">
+          <paper-listbox slot="dropdown-content" attr-for-selected="device" selected="{{selectedOutput}}">
+            <template is='dom-repeat' items='[[listOutput]]'>
+              <paper-item device="[[item.device]]">[[item.name]]</paper-item>
+            </template>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </div>
+      <div class="card-actions">
+        <paper-button
+          on-click='saveTapped'
+        >Save</paper-button>
+      </div>
+    </paper-card>
+  </template>
+</dom-module>
+
+<script>
+class HassioAddonAudio extends Polymer.Element {
+  static get is() { return 'hassio-addon-audio'; }
+
+  static get properties() {
+    return {
+      hass: Object,
+      addonSlug: String,
+      addon: {
+        type: Object,
+        observer: 'addonChanged'
+      },
+      listInput: Array,
+      listOutput: Array,
+      selectedInput: String,
+      selectedOutput: String,
+      error: String,
+    };
+  }
+
+  addonChanged(addon) {
+    this.selectedInput = addon.audio_input ? addon.audio_input : 'null';
+    this.selectedOutput = addon.audio_output ? addon.audio_output : 'null';
+    if (this.listOutput) return;
+
+    const input = [{ device: 'null', name: '-' }];
+    const output = [{ device: 'null', name: '-' }];
+    this.hass.callApi('get', 'hassio/host/hardware').then((resp) => {
+      const data = resp.data.audio;
+      Object.keys(data).forEach(audio => {
+        Object.keys(data[audio].devices).forEach(device => {
+          if (data[audio].devices[device] === 'digital audio capture') {
+            input.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
+          } else if (data[audio].devices[device] === 'digital audio playback') {
+            output.push({ device: `${audio},${device}`, name: `${data[audio].name}: ${device}` });
+          }
+        });
+      });
+      this.listInput = input;
+      this.listOutput = output;
+    }, (resp) => {
+      this.listInput = input;
+      this.listOutput = output;
+    });
+  }
+
+  saveTapped() {
+    this.error = null;
+
+    this.hass.callApi('post', `hassio/addons/${this.addonSlug}/options`, {
+      audio_input: this.selectedInput === 'null' ? null : this.selectedInput,
+      audio_output: this.selectedOutput === 'null' ? null : this.selectedOutput
+    }).then(() => {
+      this.fire('hass-api-called', { success: true, path: path });
+    }, (resp) => {
+      this.error = resp.body.message;
+    });
+  }
+}
+
+customElements.define(HassioAddonAudio.is, HassioAddonAudio);
+</script>

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -1,11 +1,13 @@
 <link rel="import" href="../../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel='import' href='../../bower_components/paper-listbox/paper-listbox.html'>
 <link rel='import' href='../../bower_components/paper-item/paper-item.html'>
 <link rel='import' href='../../bower_components/neon-animation/web-animations.html'>
 
 <link rel='import' href='../../src/resources/ha-style.html'>
+<link rel='import' href='../../src/util/hass-mixins.html'>
 
 <dom-module id="hassio-addon-audio">
   <template>
@@ -42,16 +44,16 @@
         </template>
         
         <paper-dropdown-menu label="Input">
-          <paper-listbox slot="dropdown-content" attr-for-selected="device" selected="{{selectedInput}}">
+          <paper-listbox slot="dropdown-content" attr-for-selected="item-device" selected="{{selectedInput}}">
             <template is='dom-repeat' items='[[listInput]]'>
-              <paper-item device="[[item.device]]">[[item.name]]</paper-item>
+              <paper-item item-device="[[item.device]]">[[item.name]]</paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>
         <paper-dropdown-menu label="Output">
-          <paper-listbox slot="dropdown-content" attr-for-selected="device" selected="{{selectedOutput}}">
+          <paper-listbox slot="dropdown-content" attr-for-selected="item-device" selected="{{selectedOutput}}">
             <template is='dom-repeat' items='[[listOutput]]'>
-              <paper-item device="[[item.device]]">[[item.name]]</paper-item>
+              <paper-item item-device="[[item.device]]">[[item.name]]</paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>

--- a/hassio/addon-view/hassio-addon-audio.html
+++ b/hassio/addon-view/hassio-addon-audio.html
@@ -87,12 +87,8 @@ class HassioAddonAudio extends Polymer.Element {
     const noDevice = [{ device: 'null', name: '-' }];
     this.hass.callApi('get', 'hassio/hardware/audio').then((resp) => {
       const audio = resp.data.audio;
-      const inputDevices = noDevice.concat(Object.keys(audio.input).map((key) => {
-        return { device: key, name: audio.input[key] };
-      }));
-      const outputDevices = noDevice.concat(Object.keys(audio.output).map((key) => {
-        return { device: key, name: audio.output[key] };
-      }));
+      const inputDevices = noDevice.concat(Object.keys(audio.input).map(key => ({ device: key, name: audio.input[key] })));
+      const outputDevices = noDevice.concat(Object.keys(audio.output).map(key => ({ device: key, name: audio.output[key] })));
       this.setProperties({
         inputDevices,
         outputDevices

--- a/hassio/addon-view/hassio-addon-view.html
+++ b/hassio/addon-view/hassio-addon-view.html
@@ -10,6 +10,7 @@
 
 <link rel="import" href="./hassio-addon-info.html">
 <link rel="import" href="./hassio-addon-config.html">
+<link rel="import" href="./hassio-addon-audio.html">
 <link rel="import" href="./hassio-addon-network.html">
 <link rel="import" href="./hassio-addon-logs.html">
 <link rel='import' href='../hassio-markdown-dialog.html'>
@@ -28,6 +29,7 @@
       }
       hassio-addon-info,
       hassio-addon-network,
+      hassio-addon-audio,
       hassio-addon-config {
         margin-bottom: 24px;
       }
@@ -62,6 +64,14 @@
             addon='[[addon]]'
             addon-slug='[[routeData.slug]]'
           ></hassio-addon-config>
+
+          <template is='dom-if' if='[[addon.audio]]'>
+            <hassio-addon-audio
+              hass='[[hass]]'
+              addon='[[addon]]'
+              addon-slug='[[routeData.slug]]'
+            ></hassio-addon-audio>
+          </template>
 
           <template is='dom-if' if='[[addon.network]]'>
             <hassio-addon-network

--- a/hassio/addon-view/hassio-addon-view.html
+++ b/hassio/addon-view/hassio-addon-view.html
@@ -69,7 +69,6 @@
             <hassio-addon-audio
               hass='[[hass]]'
               addon='[[addon]]'
-              addon-slug='[[routeData.slug]]'
             ></hassio-addon-audio>
           </template>
 

--- a/hassio/system/hassio-host-info.html
+++ b/hassio/system/hassio-host-info.html
@@ -137,7 +137,7 @@ class HassioHostInfo extends window.hassMixins.EventsMixin(Polymer.Element) {
   }
 
   _showHardware() {
-    this.hass.callApi('get', 'hassio/host/hardware')
+    this.hass.callApi('get', 'hassio/hardware/info')
       .then(
         resp => this._objectToMarkdown(resp.data)
         , () => 'Error getting hardware info'


### PR DESCRIPTION
![audio](https://user-images.githubusercontent.com/11984118/38590786-b566dea0-3d33-11e8-9246-9c91ccda476a.PNG)

@pvizeli
api doesn't accept the keys atm: 
```
extra keys not allowed @ data['audio_input']. Got '0,0' extra keys not allowed @ data['audio_output']. Got None
```