### PR TITLE
Use css columns for ha-cards

### DIFF
--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -42,6 +42,9 @@
         .clear {
           clear: both;
         }
+        #chart_id {
+          overflow: hidden;
+        }
     </style>
     <google-legacy-loader on-api-load='googleApiLoaded'></google-legacy-loader>
     <ha-card header='[[computeTitle(stateObj)]]'>

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -15,7 +15,7 @@
     <style>
       :host {
         display: block;
-        padding: 8px 6px;
+        padding: 8px 8px;
         transform: translateZ(0);
       }
 
@@ -35,12 +35,12 @@
         break-inside: avoid-column;
         box-sizing: border-box;
         width: 100%;
-        padding: 6px;
+        padding: 8px;
       }
 
       @media (max-width: 500px) {
         ha-card-chooser {
-          padding: 6px 0;
+          padding: 8px 0;
         }
         :host {
           padding: 8px 0;

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -37,8 +37,11 @@
         max-width: 1800px;
         margin: auto;
       }
-      .cards.no-columns { max-width: 500px; }
-      .cards.two-columns { max-width: 800px; }
+
+      .cards.cols-1 { max-width: 500px; }
+      .cards.cols-2 { max-width: 883px; } /* 3 * 295px - 2px */
+      .cards.cols-3 { max-width: 1177px; } /* 4 * 295px - 3px */
+
       ha-card-chooser {
         display: inline-block;
         break-inside: avoid-column;
@@ -219,8 +222,7 @@
     }
 
     computeClasses(cards) {
-      if (cards.length < 2) return 'cards no-columns';
-      if (cards.length < 5) return 'cards two-columns';
+      if (cards.length < 4) return `cards cols-${cards.length}`;
       return 'cards';
     }
 

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -15,7 +15,7 @@
     <style>
       :host {
         display: block;
-        padding: 8px 8px;
+        padding: 4px 4px;
         transform: translateZ(0);
       }
 
@@ -35,12 +35,12 @@
         break-inside: avoid-column;
         box-sizing: border-box;
         width: 100%;
-        padding: 8px;
+        padding: 4px;
       }
 
       @media (max-width: 500px) {
         ha-card-chooser {
-          padding: 8px 0;
+          padding: 4px 0;
         }
         :host {
           padding: 8px 0;
@@ -48,7 +48,7 @@
       }
       @media (min-width: 1000px) {
         .columns {
-          column-width: 350px; /* force wider columns on bigger screens */
+          column-width: 330px; /* force wider columns on bigger screens */
           column-count: 4;
         }
       }

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -25,7 +25,13 @@
       }
 
       .cards {
-        column-width: 295px; /* allow two columns untill forced sidbar docking */
+        /* sidebar is 256px and collapes at 870px
+          taking 4px container padding into account column
+          width should be between 286px and 303px to
+          not flicker between 2 and 3 columns around
+          sidebar collapse
+        */
+        column-width: 295px;
         column-gap: 0;
         column-count: 4;
         max-width: 1800px;

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -313,14 +313,14 @@
         Object.keys(badgesColl)
           .map(key => badgesColl[key])
           .forEach((domain) => {
-            view.badges.push.apply(view.badges, domain.states);
+            view.badges.push(...domain.states);
           });
 
         view.badges.sort((e1, e2) => orderedGroupEntities[e1.entity_id] -
           orderedGroupEntities[e2.entity_id]);
       } else {
         iterateDomainSorted(badgesColl, (domain) => {
-          view.badges.push.apply(view.badges, domain.states);
+          view.badges.push(...domain.states);
         });
       }
 

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -63,18 +63,18 @@
     </style>
 
     <div id='main'>
-      <template is='dom-if' if='[[cards.badges]]'>
+      <template is='dom-if' if='[[view.badges]]'>
         <div class='badges'>
-          <template is='dom-if' if='[[cards.demo]]'>
+          <template is='dom-if' if='[[view.demo]]'>
             <ha-demo-badge></ha-demo-badge>
           </template>
 
-          <ha-badges-card states='[[cards.badges]]' hass='[[hass]]'></ha-badges-card>
+          <ha-badges-card states='[[view.badges]]' hass='[[hass]]'></ha-badges-card>
         </div>
       </template>
 
-      <div class$='[[computeClasses(cards)]]'>
-        <template is='dom-repeat' items='[[cards.cards]]' as='card'>
+      <div class$='[[computeClasses(view.cards)]]'>
+        <template is='dom-repeat' items='[[view.cards]]' as='card'>
             <!-- <template is='dom-repeat' items='[[column]]' as='card'> -->
               <ha-card-chooser card-data='[[card]]'></ha-card-chooser>
             <!-- </template> -->
@@ -173,17 +173,17 @@
 
         orderedGroupEntities: Array,
 
-        cards: Object,
+        view: Object,
       };
     }
 
     static get observers() {
       return [
-        'updateCards(states, panelVisible, viewVisible, orderedGroupEntities)',
+        'updateView(states, panelVisible, viewVisible, orderedGroupEntities)',
       ];
     }
 
-    updateCards(
+    updateView(
       states,
       panelVisible,
       viewVisible,
@@ -204,13 +204,13 @@
         () => {
           // Things might have changed since it got scheduled.
           if (this.panelVisible && this.viewVisible) {
-            this.cards = this.computeCards(states, orderedGroupEntities);
+            this.view = this.computeCards(states, orderedGroupEntities);
           }
         }
       );
     }
 
-    emptyCards() {
+    emptyView() {
       return {
         demo: false,
         badges: [],
@@ -219,15 +219,15 @@
     }
 
     computeClasses(cards) {
-      if (cards.cards.length < 2) return 'cards no-columns';
-      if (cards.cards.length < 5) return 'cards two-columns';
+      if (cards.length < 2) return 'cards no-columns';
+      if (cards.length < 5) return 'cards two-columns';
       return 'cards';
     }
 
     computeCards(states, orderedGroupEntities) {
       const hass = this.hass;
 
-      const cards = this.emptyCards();
+      const view = this.emptyView();
 
       const entityCount = [];
 
@@ -249,7 +249,7 @@
         });
 
         if (other.length > 0) {
-          cards.cards.push({
+          view.cards.push({
             hass: hass,
             cardType: 'entities',
             states: other,
@@ -258,7 +258,7 @@
         }
 
         owncard.forEach((entity) => {
-          cards.cards.push({
+          view.cards.push({
             hass: hass,
             cardType: computeDomain(entity),
             stateObj: entity,
@@ -283,7 +283,7 @@
         const domain = computeDomain(state);
 
         if (domain === 'a') {
-          cards.demo = true;
+          view.demo = true;
           return;
         }
 
@@ -313,14 +313,14 @@
         Object.keys(badgesColl)
           .map(key => badgesColl[key])
           .forEach((domain) => {
-            cards.badges.push.apply(cards.badges, domain.states);
+            view.badges.push.apply(view.badges, domain.states);
           });
 
-        cards.badges.sort((e1, e2) => orderedGroupEntities[e1.entity_id] -
+        view.badges.sort((e1, e2) => orderedGroupEntities[e1.entity_id] -
           orderedGroupEntities[e2.entity_id]);
       } else {
         iterateDomainSorted(badgesColl, (domain) => {
-          cards.badges.push.apply(cards.badges, domain.states);
+          view.badges.push.apply(view.badges, domain.states);
         });
       }
 
@@ -341,7 +341,7 @@
         addEntitiesCard(domain.domain, domain.states);
       });
 
-      return cards;
+      return view;
     }
   }
   customElements.define(HaCards.is, HaCards);

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -15,8 +15,7 @@
     <style>
       :host {
         display: block;
-        padding-top: 8px;
-        padding-right: 8px;
+        padding: 8px 6px;
         transform: translateZ(0);
       }
 
@@ -25,30 +24,32 @@
         text-align: center;
       }
 
-      .column {
-        max-width: 500px;
-        overflow-x: hidden;
+      .columns {
+        column-width: 295px; /* allow two columns untill forced sidbar docking */
+        column-gap: 0;
+        align: center;
       }
 
       ha-card-chooser {
-        display: block;
-        margin-left: 8px;
-        margin-bottom: 8px;
+        display: inline-block;
+        break-inside: avoid-column;
+        box-sizing: border-box;
+        width: 100%;
+        padding: 6px;
       }
 
       @media (max-width: 500px) {
-        :host {
-          padding-right: 0;
-        }
-
         ha-card-chooser {
-          margin-left: 0;
+          padding: 6px 0;
+        }
+        :host {
+          padding: 8px 0;
         }
       }
-
-      @media (max-width: 599px) {
-        .column {
-          max-width: 600px;
+      @media (min-width: 1000px) {
+        .columns {
+          column-width: 350px; /* force wider columns on bigger screens */
+          column-count: 4;
         }
       }
     </style>
@@ -64,12 +65,11 @@
         </div>
       </template>
 
-      <div class='horizontal layout center-justified'>
-        <template is='dom-repeat' items='[[cards.columns]]' as='column'>
-          <div class='column flex-1'>
-            <template is='dom-repeat' items='[[column]]' as='card'>
+      <div class='columns'>
+        <template is='dom-repeat' items='[[cards.cards]]' as='card'>
+            <!-- <template is='dom-repeat' items='[[column]]' as='card'> -->
               <ha-card-chooser card-data='[[card]]'></ha-card-chooser>
-            </template>
+            <!-- </template> -->
           </div>
         </template>
     </div>
@@ -171,12 +171,11 @@
 
     static get observers() {
       return [
-        'updateCards(columns, states, panelVisible, viewVisible, orderedGroupEntities)',
+        'updateCards(states, panelVisible, viewVisible, orderedGroupEntities)',
       ];
     }
 
     updateCards(
-      columns,
       states,
       panelVisible,
       viewVisible,
@@ -197,7 +196,7 @@
         () => {
           // Things might have changed since it got scheduled.
           if (this.panelVisible && this.viewVisible) {
-            this.cards = this.computeCards(columns, states, orderedGroupEntities);
+            this.cards = this.computeCards(states, orderedGroupEntities);
           }
         }
       );
@@ -207,38 +206,16 @@
       return {
         demo: false,
         badges: [],
-        columns: [],
+        cards: [],
       };
     }
 
-    computeCards(columns, states, orderedGroupEntities) {
+    computeCards(states, orderedGroupEntities) {
       const hass = this.hass;
 
       const cards = this.emptyCards();
 
       const entityCount = [];
-      for (let i = 0; i < columns; i++) {
-        cards.columns.push([]);
-        entityCount.push(0);
-      }
-
-      // Find column with < 5 entities, else column with lowest count
-      function getIndex(size) {
-        let minIndex = 0;
-        for (let i = 0; i < entityCount.length; i++) {
-          if (entityCount[i] < 5) {
-            minIndex = i;
-            break;
-          }
-          if (entityCount[i] < entityCount[minIndex]) {
-            minIndex = i;
-          }
-        }
-
-        entityCount[minIndex] += size;
-
-        return minIndex;
-      }
 
       function addEntitiesCard(name, entities, groupEntity) {
         if (entities.length === 0) return;
@@ -246,27 +223,19 @@
         const owncard = [];
         const other = [];
 
-        let size = 0;
 
         entities.forEach((entity) => {
           const domain = computeDomain(entity);
 
           if (domain in DOMAINS_WITH_CARD) {
             owncard.push(entity);
-            size += DOMAINS_WITH_CARD[domain];
           } else {
             other.push(entity);
-            size++;
           }
         });
 
-        // Add 1 to the size if we're rendering entities card
-        size += other.length > 0;
-
-        const curIndex = getIndex(size);
-
         if (other.length > 0) {
-          cards.columns[curIndex].push({
+          cards.cards.push({
             hass: hass,
             cardType: 'entities',
             states: other,
@@ -275,7 +244,7 @@
         }
 
         owncard.forEach((entity) => {
-          cards.columns[curIndex].push({
+          cards.cards.push({
             hass: hass,
             cardType: computeDomain(entity),
             stateObj: entity,
@@ -359,7 +328,6 @@
       });
 
       // Remove empty columns
-      cards.columns = cards.columns.filter(val => val.length > 0);
 
       return cards;
     }

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -229,8 +229,6 @@
 
       const view = this.emptyView();
 
-      const entityCount = [];
-
       function addEntitiesCard(name, entities, groupEntity) {
         if (entities.length === 0) return;
 

--- a/src/components/ha-cards.html
+++ b/src/components/ha-cards.html
@@ -24,12 +24,15 @@
         text-align: center;
       }
 
-      .columns {
+      .cards {
         column-width: 295px; /* allow two columns untill forced sidbar docking */
         column-gap: 0;
-        align: center;
+        column-count: 4;
+        max-width: 1800px;
+        margin: auto;
       }
-
+      .cards.no-columns { max-width: 500px; }
+      .cards.two-columns { max-width: 800px; }
       ha-card-chooser {
         display: inline-block;
         break-inside: avoid-column;
@@ -49,7 +52,6 @@
       @media (min-width: 1000px) {
         .columns {
           column-width: 330px; /* force wider columns on bigger screens */
-          column-count: 4;
         }
       }
     </style>
@@ -65,7 +67,7 @@
         </div>
       </template>
 
-      <div class='columns'>
+      <div class$='[[computeClasses(cards)]]'>
         <template is='dom-repeat' items='[[cards.cards]]' as='card'>
             <!-- <template is='dom-repeat' items='[[column]]' as='card'> -->
               <ha-card-chooser card-data='[[card]]'></ha-card-chooser>
@@ -210,6 +212,12 @@
       };
     }
 
+    computeClasses(cards) {
+      if (cards.cards.length < 2) return 'cards no-columns';
+      if (cards.cards.length < 5) return 'cards two-columns';
+      return 'cards';
+    }
+
     computeCards(states, orderedGroupEntities) {
       const hass = this.hass;
 
@@ -326,8 +334,6 @@
       iterateDomainSorted(afterGroupedColl, (domain) => {
         addEntitiesCard(domain.domain, domain.states);
       });
-
-      // Remove empty columns
 
       return cards;
     }

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -211,27 +211,6 @@
       };
     }
 
-    ready() {
-      this.handleWindowChange = this.handleWindowChange.bind(this);
-      this.mqls = [300, 600, 900, 1200].map(width => matchMedia(`(min-width: ${width}px)`));
-      super.ready();
-    }
-
-    connectedCallback() {
-      super.connectedCallback();
-      this.mqls.forEach(mql => mql.addListener(this.handleWindowChange));
-    }
-
-    disconnectedCallback() {
-      super.disconnectedCallback();
-      this.mqls.forEach(mql => mql.removeListener(this.handleWindowChange));
-    }
-
-    handleWindowChange() {
-      const matchColumns = this.mqls.reduce((cols, mql) => cols + mql.matches, 0);
-      // Do -1 column if the menu is docked and open
-      this._columns = Math.max(1, matchColumns - (!this.narrow && this.showMenu));
-    }
 
     areTabsHidden(views, showTabs) {
       return !views || !views.length || !showTabs;

--- a/src/layouts/partial-cards.html
+++ b/src/layouts/partial-cards.html
@@ -110,7 +110,6 @@
         <ha-cards
           data-view=''
           states='[[viewStates]]'
-          columns='[[_columns]]'
           hass='[[hass]]'
           panel-visible='[[panelVisible]]'
           ordered-group-entities='[[orderedGroupEntities]]'
@@ -120,7 +119,6 @@
           <ha-cards
             data-view$='[[item.entity_id]]'
             states='[[viewStates]]'
-            columns='[[_columns]]'
             hass='[[hass]]'
             panel-visible='[[panelVisible]]'
             ordered-group-entities='[[orderedGroupEntities]]'
@@ -156,10 +154,7 @@
           value: false,
         },
 
-        showMenu: {
-          type: Boolean,
-          observer: 'handleWindowChange',
-        },
+        showMenu: Boolean,
 
         panelVisible: {
           type: Boolean,
@@ -169,11 +164,6 @@
         route: Object,
         routeData: Object,
         routeMatch: Boolean,
-
-        _columns: {
-          type: Number,
-          value: 1,
-        },
 
         locationName: {
           type: String,


### PR DESCRIPTION
This moves the responsibility to distribute the cards among columns to the browser.
 It does not change the order the cards are added to defined views, although the browser decides after which card exactly the column will break to distribute content.

Column count is limited to 4 (like now) but also based on the amount of cards.
~When there less than 3 cards it will show one column, when there are less than 5 it will show two columns.~
[changed] When there are less than 4 cards to show, the amount of columns is limited to the amount of cards.

We don't hide overflow on cards by default, but the weather card chart does not repaint on resize so added `overflow: hidden` there.

The downside of letting the browser handle the distribution instead of fixing it is that cards might move when a card changes it's height. (like the media player)

Image.
left = css columns, right = current behavior
![unknown](https://user-images.githubusercontent.com/411716/38688115-95fd7524-3e78-11e8-887f-b7aabd23f7c0.png)

