### PR TITLE
Some more state wrapping fixes

### DIFF
--- a/src/components/ha-climate-state.html
+++ b/src/components/ha-climate-state.html
@@ -7,6 +7,7 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
+        white-space: nowrap;
       }
 
       .target {

--- a/src/state-summary/state-card-display.html
+++ b/src/state-summary/state-card-display.html
@@ -16,12 +16,17 @@
         @apply(--layout-baseline);
       }
 
+      state-info {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
       .state {
         @apply --paper-font-body1;
         color: var(--primary-text-color);
         margin-left: 16px;
         text-align: right;
-        flex: 1 0 50px;
+        max-width: 40%;
+        flex: 0 0 auto;
       }
       .state.has-unit_of_measurement {
         white-space: nowrap;


### PR DESCRIPTION
Fixes: #1079 

In the images below, the unnecessary wrapping of the input_datetime state is fixed, and long states can take a little more space too.
Before:
<img width="320" alt="schermafbeelding 2018-04-12 om 21 35 13" src="https://user-images.githubusercontent.com/411716/38699889-aaf25258-3e99-11e8-9025-b136fd17dbdc.png">

after:
<img width="321" alt="schermafbeelding 2018-04-12 om 21 34 25" src="https://user-images.githubusercontent.com/411716/38699899-b1c6cb4a-3e99-11e8-837d-4e3233c6a399.png">
