### PR TITLE
Some little tweaks (old browsers / iOS 9)

### DIFF
--- a/panels/config/ha-config-section.html
+++ b/panels/config/ha-config-section.html
@@ -58,8 +58,8 @@
         <div class='intro'>
           <slot name="introduction"></slot>
         </div>
-        <div class='flex panel'>
-          <slot>
+        <div class='panel flex-auto'>
+          <slot></slot>
         </div>
       </div>
     </div>

--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -17,8 +17,6 @@
         position: relative;
         font-size: 0px;
         border-radius: 2px;
-
-        overflow: hidden;
       }
 
       .banner {

--- a/src/components/entity/ha-entity-toggle.html
+++ b/src/components/entity/ha-entity-toggle.html
@@ -7,6 +7,7 @@
     <style>
       :host {
         white-space: nowrap;
+        min-width: 38px;
       }
       paper-icon-button {
         color: var(--paper-icon-button-inactive-color, var(--primary-text-color));


### PR DESCRIPTION
- fix config panel flex (`flex` class sets flex basis of 0.00001px, `flex-auto` should be preferred)
![unknown-2 kopie](https://user-images.githubusercontent.com/411716/38761228-48da9bfa-3f81-11e8-8857-ea5a412f12b7.png)

- fix media player card not showing because of some overflow:hidden / rendering layer glitch. The media player card has no overflowing content, so no point in hiding it)
- prevent the entity toggle being compressed and/or pushed to the right by a long name.
<img width="335" alt="schermafbeelding 2018-04-14 om 01 13 24" src="https://user-images.githubusercontent.com/411716/38761190-15560c56-3f81-11e8-9e37-0276fdc2e278.png">
