### PR TITLE
Media player progress style

### DIFF
--- a/src/cards/ha-media_player-card.html
+++ b/src/cards/ha-media_player-card.html
@@ -101,8 +101,10 @@
 
       .progress {
         width: 100%;
+        height: var(--paper-progress-height, 4px);
+        margin-top: calc(-1*var(--paper-progress-height, 4px));
         --paper-progress-active-color: var(--accent-color);
-        --paper-progress-container-color: #FFF;
+        --paper-progress-container-color: rgba(200,200,200,0.5);
       }
 
       .controls {


### PR DESCRIPTION
My intention was to fix the height change of the card upon playing/pausing. But it turns out that's actually a glitch of the media_player demo platform.

Still proposing this change because I think looks nice. And it may still prevent an non-animated 4px height change when stopping the player or when source without progress is chosen.
<img width="396" alt="image" src="https://user-images.githubusercontent.com/411716/38773114-f5905c94-4045-11e8-81ce-af9603ceff5f.png">