### PR TITLE
Don't send the Referer header to other origins from the front-end

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <meta name="msapplication-square310x310logo" content="/static/icons/tile-win-310x310.png"/>
     <meta name="msapplication-TileColor" content="#3fbbf4ff"/>
     <meta name='mobile-web-app-capable' content='yes'>
+    <meta name='referrer' content='same-origin'>
     <meta name='viewport' content='width=device-width, user-scalable=no'>
     <meta name='theme-color' content='{{ theme_color }}'>
     <style>


### PR DESCRIPTION
Avoid leaking the Home Assistant domain name (which often contains a person's name/alias) in the Referer header for non-same-origin requests.

e.g. if the `weblink` component is used to link to third-party sites.

This should perhaps be labelled as a breaking change in case people were relying on the referrer as a poor authentication method.