### PR TITLE
allow label-badge-title font-weight theming

### DIFF
--- a/src/components/ha-label-badge.html
+++ b/src/components/ha-label-badge.html
@@ -67,7 +67,7 @@
       margin-top: 1em;
       font-size: var(--ha-label-badge-title-font-size, .9em);
       width: var(--ha-label-badge-title-width, 5em);
-      font-weight: 300;
+      font-weight: var(--ha-label-badge-title-font-weight, 300);
       overflow: hidden;
       text-overflow: ellipsis;
       line-height: normal;

--- a/src/components/ha-label-badge.html
+++ b/src/components/ha-label-badge.html
@@ -67,7 +67,7 @@
       margin-top: 1em;
       font-size: var(--ha-label-badge-title-font-size, .9em);
       width: var(--ha-label-badge-title-width, 5em);
-      font-weight: var(--ha-label-badge-title-font-weight, 300);
+      font-weight: var(--ha-label-badge-title-font-weight, 400);
       overflow: hidden;
       text-overflow: ellipsis;
       line-height: normal;


### PR DESCRIPTION
Fixes #1101 

Made a wiki page to keep track of the theming variables we want to support. We shouldn't keep adding all defaults to ha-style.

https://github.com/home-assistant/home-assistant-polymer/wiki/%5BWIP%5D-Supported-Theming-Variables