### PR TITLE
Thermostat icon rename

### DIFF
--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -104,7 +104,7 @@ window.hassUtil.domainIcon = function (domain, state) {
       return 'mdi:video';
 
     case 'climate':
-      return 'mdi:nest-thermostat';
+      return 'mdi:thermostat';
 
     case 'configurator':
       return 'mdi:settings';


### PR DESCRIPTION
see #1003 and http://templarian.com/2018/04/18/material-design-icons-v2-3-50/

I checked with our mdi_update script, and it does currently fetch the latest release with the renamed Icons.