### PR TITLE
Always run translation upload on master

### DIFF
--- a/script/travis_deploy
+++ b/script/travis_deploy
@@ -8,8 +8,4 @@ set -eu -o pipefail
 
 cd "$(dirname "$0")/.."
 
-if git diff "${TRAVIS_COMMIT_RANGE}" --name-only | grep -Fxq "src/translations/en.json" ; then
-    script/translations_upload_base
-else
-    echo "No changes to src/translations/en.json. Skipping translation upload."
-fi
+script/translations_upload_base


### PR DESCRIPTION
## Description
This ensures that if the master build gets cancelled when translations change, or if any other weird situation happens, we know the translations will be uploaded after the next build.

This doesn't fix the problem we're having, but it's been on my TODO for a while and gives us a bit more confidence that the script will run. Especially since we haven't had changes in a while.