### PR TITLE
Fix for Lokalise backend misinterpretation of keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 services:
   - docker
 before_deploy:
-  - docker pull lokalise/lokalise-cli@sha256:79b3108211ed1fcc9f7b09a011bfc53c240fc2f3b7fa7f0c8390f593271b4cd7
+  - docker pull lokalise/lokalise-cli@sha256:2198814ebddfda56ee041a4b427521757dd57f75415ea9693696a64c550cef21
 deploy:
   provider: script
   script: script/travis_deploy

--- a/script/translations_upload_base
+++ b/script/translations_upload_base
@@ -33,9 +33,10 @@ fi
 
 docker run \
     -v ${LOCAL_FILE}:/opt/src/${LOCAL_FILE} \
-    lokalise/lokalise-cli@sha256:79b3108211ed1fcc9f7b09a011bfc53c240fc2f3b7fa7f0c8390f593271b4cd7 lokalise \
+    lokalise/lokalise-cli@sha256:2198814ebddfda56ee041a4b427521757dd57f75415ea9693696a64c550cef21 lokalise \
     --token ${LOKALISE_TOKEN} \
     import ${PROJECT_ID} \
     --file /opt/src/${LOCAL_FILE} \
     --lang_iso ${LANG_ISO} \
+    --convert_placeholders 0 \
     --replace 1


### PR DESCRIPTION
## Description
The Lokalise server has a bug that the internal portion of key references was misinterpreted as a symfony key, and was getting auto converted by the convert placeholders feature. Since we don't use this we're turning it off to work around the bug.

Fixes https://github.com/home-assistant/home-assistant-polymer/issues/1103