### PR TITLE
Add Sensor device_class support

### DIFF
--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -28,6 +28,11 @@ window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
     'window'
   ],
   cover: ['garage'],
+  sensor: [
+    'battery',
+    'humidity',
+    'temperature'
+  ],
 };
 
 window.hassAttributeUtil.UNKNOWN_TYPE = 'json';
@@ -70,7 +75,7 @@ window.hassAttributeUtil.LOGIC_STATE_ATTRIBUTES =
       type: 'array',
       options: window.hassAttributeUtil.DOMAIN_DEVICE_CLASS,
       description: 'Device class',
-      domains: ['binary_sensor', 'cover']
+      domains: ['binary_sensor', 'cover', 'sensor']
     },
     hidden: { type: 'boolean', description: 'Hide from UI' },
     assumed_state: {

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -281,20 +281,21 @@ window.hassUtil.coverIcon = function (state) {
   }
 };
 
-window.hassUtil.sensorIcon = function (state) {
+window.hassUtil.sensorIcon = (state) => {
   switch (state.attributes.device_class) {
-    case 'battery':
+    case 'battery': {
       if (isNaN(state.state)) {
         return 'mdi:battery-unknown';
       }
-      var batteryRound = Math.round(state.state / 10) * 10;
+      const batteryRound = Math.round(state.state / 10) * 10;
       if (batteryRound >= 100) {
         return 'mdi:battery';
       }
       if (batteryRound <= 0) {
         return 'mdi:battery-alert';
       }
-      return 'mdi:battery-' + batteryRound;
+      return `mdi:battery-${batteryRound}`;
+    }
     case 'humidity':
       return 'mdi:water-percent';
     case 'temperature':
@@ -311,8 +312,8 @@ window.hassUtil.stateIcon = function (state) {
     return state.attributes.icon;
   }
 
-  var unit = state.attributes.unit_of_measurement;
-  var domain = window.hassUtil.computeDomain(state);
+  const unit = state.attributes.unit_of_measurement;
+  const domain = window.hassUtil.computeDomain(state);
 
   if (domain === 'sensor' && state.attributes.device_class) {
     return window.hassUtil.sensorIcon(state);

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -281,6 +281,29 @@ window.hassUtil.coverIcon = function (state) {
   }
 };
 
+window.hassUtil.sensorIcon = function (state) {
+  switch (state.attributes.device_class) {
+    case 'battery':
+      if (isNaN(state.state)) {
+        return 'mdi:battery-unknown';
+      }
+      var batteryRound = Math.round(state.state / 10) * 10;
+      if (batteryRound >= 100) {
+        return 'mdi:battery';
+      }
+      if (batteryRound <= 0) {
+        return 'mdi:battery-alert';
+      }
+      return 'mdi:battery-' + batteryRound;
+    case 'humidity':
+      return 'mdi:water-percent';
+    case 'temperature':
+      return 'mdi:thermometer';
+    default:
+      return 'mdi:eye';
+  }
+};
+
 window.hassUtil.stateIcon = function (state) {
   if (!state) {
     return window.hassUtil.DEFAULT_ICON;
@@ -291,7 +314,9 @@ window.hassUtil.stateIcon = function (state) {
   var unit = state.attributes.unit_of_measurement;
   var domain = window.hassUtil.computeDomain(state);
 
-  if (unit && domain === 'sensor') {
+  if (domain === 'sensor' && state.attributes.device_class) {
+    return window.hassUtil.sensorIcon(state);
+  } else if (domain === 'sensor' && unit) {
     if (unit === '°C' || unit === '°F') {
       return 'mdi:thermometer';
     } else if (unit === 'Mice') {


### PR DESCRIPTION
This PR adds frontend `device_class` support for https://github.com/home-assistant/home-assistant/pull/14010 based on the device_class implementations of `binary_sensor` and `cover`. 

Please note that JavaScript is not my "native" language so feel free to close this in favor of a new PR if there are many problems with this code change. I'm also currently battling with the build-system and I haven't yet been able to fully test the change.

For full compatibility, the `unit_of_measurement` to icon conversion is still in there and for the `battery` device class I pretty much just took [this template](https://www.home-assistant.io/cookbook/track_battery_level/) and tried to convert it to JS. For `undefined` or `NaN` battery levels this will use the [`mdi:battery-unknown`](https://www.home-assistant.io/cookbook/track_battery_level/) icon.

Once #1100 gets merged, this PR will also need to be updated. Especially the `mdi:battery-`number automatic `mdi:*` icon detection would not work.