### PR TITLE
Fix unavailable state icon

### DIFF
--- a/src/components/entity/state-badge.html
+++ b/src/components/entity/state-badge.html
@@ -32,7 +32,7 @@
 
     /* Color the icon if unavailable */
     ha-state-icon[data-state=unavailable] {
-      color: var(--state-icon-unavailable);
+      color: var(--state-icon-unavailable-color);
     }
     </style>
 


### PR DESCRIPTION
In #1041, there was a big clean up to make theming easier. However, the CSS color variable used for greying out the state icon is called `--state-icon-unavailable-color`, not `--state-icon-unavailable`. See

https://github.com/home-assistant/home-assistant-polymer/pull/1041/files#diff-aa1f698747bd071a4896f0dbeb31585eR33

Unavailable entities would show up like this without this fix:

<img width="492" alt="screen shot 2018-04-22 at 18 13 19" src="https://user-images.githubusercontent.com/6833237/39097152-e3879fc6-4658-11e8-842f-c804ba32890a.png">