### PR TITLE
Minor fix in french translation

### DIFF
--- a/translations/fr.json
+++ b/translations/fr.json
@@ -517,7 +517,7 @@
         "login-form": {
             "password": "Mot de passe",
             "remember": "Se rappeler",
-            "log_in": "Identifiant"
+            "log_in": "Connexion"
         },
         "card": {
             "camera": {


### PR DESCRIPTION
Because it's displayed on a button, `ui.login-form.log_in` is supposed to be the **action to log in**, not the login as in 'login / password'

P.S: I'm not sure if I should do my PR on `master `or `release-0-57`, please tell me if I'm mistaken