### PR TITLE
Improve hourly daily forecast detection.

### DIFF
--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -123,7 +123,11 @@ class HaWeatherCard extends
       forecast: {
         type: Array,
         computed: 'computeForecast(stateObj.attributes.forecast)'
-      }
+      },
+      hourly: {
+        type: Array,
+        computed: 'isHourly(stateObj.attributes.forecast)'
+      },
     };
   }
 
@@ -207,13 +211,26 @@ class HaWeatherCard extends
   computeDateTime(data) {
     const date = new Date(data);
     const provider = this.stateObj.attributes.attribution;
-    if (provider === 'Powered by Dark Sky' || provider === 'Data provided by OpenWeatherMap') {
+    if (this.hourly) {
       return date.toLocaleTimeString(
         this.hass.selectedLanguage || this.hass.language,
         { hour: 'numeric' }
       );
     }
     return date.toLocaleDateString(this.hass.selectedLanguage || this.hass.language, { weekday: 'short' });
+  }
+
+  isHourly(data) {
+    if (data.length < 3) {
+      return false;
+    }
+    const date1 = new Date(data[1]['datetime']);
+    const date2 = new Date(data[2]['datetime']);
+
+    if (date2 - date1 < 80000000) {
+      return true;
+    }
+    return false;
   }
 }
 customElements.define(HaWeatherCard.is, HaWeatherCard);

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -90,13 +90,13 @@
           <div class="forecast">
             <template is='dom-repeat' items='[[forecast]]'>
               <div>
-                <div class="weekday">[[computeDateTime(item.datetime)]]</div>
-                <template is="dom-if" if="[[item.condition]]">
+                <div class="weekday">[[item.datetime]]</div>
+                <template is="dom-if" if="[[item.condicon]]">
                   <div class="icon">
-                    <iron-icon icon="[[getWeatherIcon(item.condition)]]"></iron-icon>
+                    <iron-icon icon="[[item.condicon]]"></iron-icon>
                   </div>
                 </template>
-                <div class="temp">[[item.temperature]]°</div>
+                <div class="temp">[[item.temphigh]]°</div>
                 <template is="dom-if" if="[[item.templow]]">
                   <div class="templow">[[item.templow]]°</div>
                 </template>
@@ -123,11 +123,7 @@ class HaWeatherCard extends
       forecast: {
         type: Array,
         computed: 'computeForecast(stateObj.attributes.forecast)'
-      },
-      hourly: {
-        type: Array,
-        computed: 'isHourly(stateObj.attributes.forecast)'
-      },
+      }
     };
   }
 
@@ -165,7 +161,25 @@ class HaWeatherCard extends
   }
 
   computeForecast(forecast) {
-    return forecast && forecast.slice(0, 7);
+    let new_forecast = forecast && forecast.slice(0, 7);
+    let hourly = false;
+    if (forecast.length > 3) {
+      const date1 = new Date(forecast[1].datetime);
+      const date2 = new Date(forecast[2].datetime);
+
+      if (date2 - date1 < 80000000) {
+        hourly = true;
+      }
+    }
+
+    let me = this;
+
+    return new_forecast.map( item => ({
+      datetime: me.computeDateTime(item.datetime, hourly),
+      temphigh: item.temperature,
+      templow: item.templow,
+      condicon: me.getWeatherIcon(item.condition)
+    }));
   }
 
   getUnit(unit) {
@@ -208,28 +222,15 @@ class HaWeatherCard extends
     return `${visibilty} ${this.getUnit('length')}`;
   }
 
-  computeDateTime(data) {
+  computeDateTime(data, hourly) {
     const date = new Date(data);
-    if (this.hourly) {
+    if (hourly) {
       return date.toLocaleTimeString(
         this.hass.selectedLanguage || this.hass.language,
         { hour: 'numeric' }
       );
     }
     return date.toLocaleDateString(this.hass.selectedLanguage || this.hass.language, { weekday: 'short' });
-  }
-
-  isHourly(data) {
-    if (data.length < 3) {
-      return false;
-    }
-    const date1 = new Date(data[1].datetime);
-    const date2 = new Date(data[2].datetime);
-
-    if (date2 - date1 < 80000000) {
-      return true;
-    }
-    return false;
   }
 }
 customElements.define(HaWeatherCard.is, HaWeatherCard);

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -160,8 +160,8 @@ class HaWeatherCard extends
     this.fire('hass-more-info', { entityId: this.stateObj.entity_id });
   }
 
-  computeForecast(forecast) {
-    let new_forecast = forecast && forecast.slice(0, 7);
+  computeForecast(forecastdata) {
+    const forecast = forecastdata && forecastdata.slice(0, 7);
     let hourly = false;
     if (forecast.length > 3) {
       const date1 = new Date(forecast[1].datetime);
@@ -172,9 +172,9 @@ class HaWeatherCard extends
       }
     }
 
-    let me = this;
+    const me = this;
 
-    return new_forecast.map( item => ({
+    return forecast.map(item => ({
       datetime: me.computeDateTime(item.datetime, hourly),
       temphigh: item.temperature,
       templow: item.templow,

--- a/src/cards/ha-weather-card.html
+++ b/src/cards/ha-weather-card.html
@@ -210,7 +210,6 @@ class HaWeatherCard extends
 
   computeDateTime(data) {
     const date = new Date(data);
-    const provider = this.stateObj.attributes.attribution;
     if (this.hourly) {
       return date.toLocaleTimeString(
         this.hass.selectedLanguage || this.hass.language,
@@ -224,8 +223,8 @@ class HaWeatherCard extends
     if (data.length < 3) {
       return false;
     }
-    const date1 = new Date(data[1]['datetime']);
-    const date2 = new Date(data[2]['datetime']);
+    const date1 = new Date(data[1].datetime);
+    const date2 = new Date(data[2].datetime);
 
     if (date2 - date1 < 80000000) {
       return true;

--- a/src/dialogs/more-info/controls/more-info-weather.html
+++ b/src/dialogs/more-info/controls/more-info-weather.html
@@ -104,7 +104,11 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
   static get properties() {
     return {
       hass: Object,
-      stateObj: Object
+      stateObj: Object,
+      hourly: {
+        type: Array,
+        computed: 'isHourly(stateObj.attributes.forecast)'
+      },
     };
   }
 
@@ -135,7 +139,7 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
   computeDateTime(data) {
     const date = new Date(data);
     const provider = this.stateObj.attributes.attribution;
-    if (provider === 'Powered by Dark Sky' || provider === 'Data provided by OpenWeatherMap') {
+    if (this.hourly) {
       if (new Date().getDay() === date.getDay()) {
         return date.toLocaleTimeString(
           this.hass.selectedLanguage || this.hass.language,
@@ -175,6 +179,19 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
 
   getWeatherIcon(condition) {
     return this.weatherIcons[condition];
+  }
+
+  isHourly(data) {
+    if (data.length < 3) {
+      return false;
+    }
+    const date1 = new Date(data[1]['datetime']);
+    const date2 = new Date(data[2]['datetime']);
+
+    if (date2 - date1 < 80000000) {
+      return true;
+    }
+    return false;
   }
 }
 

--- a/src/dialogs/more-info/controls/more-info-weather.html
+++ b/src/dialogs/more-info/controls/more-info-weather.html
@@ -74,16 +74,16 @@
 
     <template is="dom-if" if="[[stateObj.attributes.forecast]]">
       <div class="section">[[localize('ui.card.weather.forecast')]]:</div>
-      <template is='dom-repeat' items='[[stateObj.attributes.forecast]]'>
+      <template is='dom-repeat' items='[[forecast]]'>
         <div class="flex">
-          <template is="dom-if" if="[[item.condition]]">
-            <iron-icon icon="[[getWeatherIcon(item.condition)]]"></iron-icon>
+          <template is="dom-if" if="[[item.condicon]]">
+            <iron-icon icon="[[item.condicon]]"></iron-icon>
           </template>
-          <div class="main">[[computeDateTime(item.datetime)]]</div>
+          <div class="main">[[item.datetime]]</div>
           <template is="dom-if" if="[[item.templow]]">
             <div class="templow">[[item.templow]] [[getUnit('temperature')]]</div>
           </template>
-          <div class="temp">[[item.temperature]] [[getUnit('temperature')]]</div>
+          <div class="temp">[[item.temphigh]] [[getUnit('temperature')]]</div>
         </div>
       </template>
     </template>
@@ -105,10 +105,10 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
     return {
       hass: Object,
       stateObj: Object,
-      hourly: {
+      forecast: {
         type: Array,
-        computed: 'isHourly(stateObj.attributes.forecast)'
-      },
+        computed: 'computeForecast(stateObj.attributes.forecast)'
+      }
     };
   }
 
@@ -136,9 +136,9 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
     };
   }
 
-  computeDateTime(data) {
+  computeDateTime(data, hourly) {
     const date = new Date(data);
-    if (this.hourly) {
+    if (hourly) {
       if (new Date().getDay() === date.getDay()) {
         return date.toLocaleTimeString(
           this.hass.selectedLanguage || this.hass.language,
@@ -154,6 +154,28 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
       this.hass.selectedLanguage || this.hass.language,
       { weekday: 'long', month: 'short', day: 'numeric' }
     );
+  }
+
+  computeForecast(forecast) {
+    let new_forecast = forecast;
+    let hourly = false;
+    if (forecast.length > 3) {
+      const date1 = new Date(forecast[1].datetime);
+      const date2 = new Date(forecast[2].datetime);
+
+      if (date2 - date1 < 80000000) {
+        hourly = true;
+      }
+    }
+
+    let me = this;
+
+    return new_forecast.map( item => ({
+      datetime: me.computeDateTime(item.datetime, hourly),
+      temphigh: item.temperature,
+      templow: item.templow,
+      condicon: me.getWeatherIcon(item.condition)
+    }));
   }
 
   getUnit(unit) {
@@ -178,19 +200,6 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
 
   getWeatherIcon(condition) {
     return this.weatherIcons[condition];
-  }
-
-  isHourly(data) {
-    if (data.length < 3) {
-      return false;
-    }
-    const date1 = new Date(data[1].datetime);
-    const date2 = new Date(data[2].datetime);
-
-    if (date2 - date1 < 80000000) {
-      return true;
-    }
-    return false;
   }
 }
 

--- a/src/dialogs/more-info/controls/more-info-weather.html
+++ b/src/dialogs/more-info/controls/more-info-weather.html
@@ -138,7 +138,6 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
 
   computeDateTime(data) {
     const date = new Date(data);
-    const provider = this.stateObj.attributes.attribution;
     if (this.hourly) {
       if (new Date().getDay() === date.getDay()) {
         return date.toLocaleTimeString(
@@ -185,8 +184,8 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
     if (data.length < 3) {
       return false;
     }
-    const date1 = new Date(data[1]['datetime']);
-    const date2 = new Date(data[2]['datetime']);
+    const date1 = new Date(data[1].datetime);
+    const date2 = new Date(data[2].datetime);
 
     if (date2 - date1 < 80000000) {
       return true;

--- a/src/dialogs/more-info/controls/more-info-weather.html
+++ b/src/dialogs/more-info/controls/more-info-weather.html
@@ -157,7 +157,6 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
   }
 
   computeForecast(forecast) {
-    let new_forecast = forecast;
     let hourly = false;
     if (forecast.length > 3) {
       const date1 = new Date(forecast[1].datetime);
@@ -168,9 +167,9 @@ class MoreInfoWeather extends window.hassMixins.LocalizeMixin(Polymer.Element) {
       }
     }
 
-    let me = this;
+    const me = this;
 
-    return new_forecast.map( item => ({
+    return forecast.map(item => ({
       datetime: me.computeDateTime(item.datetime, hourly),
       temphigh: item.temperature,
       templow: item.templow,


### PR DESCRIPTION
The hourly forecast detect using provider string before, it may not support third party weather platform.

This PR change the detection checking the interval between `forecast[1].datetime` and `forecast[2].datetime` bug enough for daily forecast.