### PR TITLE
Fix chart not updating after #1104

### DIFF
--- a/src/components/entity/ha-chart-base.html
+++ b/src/components/entity/ha-chart-base.html
@@ -161,6 +161,10 @@
       };
     }
 
+    static get observers() {
+      return ['onPropsChange(data)'];
+    }
+
     connectedCallback() {
       super.connectedCallback();
       this._isAttached = true;


### PR DESCRIPTION
The chart data not update when I changed the date and period on the history panel.
Seems that the observer removed from the ha-chart-base.