### PR TITLE
Update hassio-host-info.html

### DIFF
--- a/hassio/system/hassio-host-info.html
+++ b/hassio/system/hassio-host-info.html
@@ -45,16 +45,16 @@
         <h2>Host system</h2>
         <table class='info'>
           <tr>
-            <td>Version</td>
-            <td>[[data.version]]</td>
+            <td>Hostname</td>
+            <td>[[data.hostname]]</td>
           </tr>
           <tr>
-            <td>Latest version</td>
-            <td>[[data.last_version]]</td>
+            <td>System</td>
+            <td>[[data.operating_system]]</td>
           </tr>
           <tr>
-            <td>Type</td>
-            <td>[[data.type]] ([[data.os]])</td>
+            <td>Deployment</td>
+            <td>[[data.deployment]]</td>
           </tr>
         </table>
         <paper-button


### PR DESCRIPTION
Update info view for next Hass.io release. Actual we support only OTA updates, after the Hass.io OS is out and we can add the support on UI back:
https://github.com/home-assistant/hassio/blob/dev/API.md#host