### PR TITLE
Added sensor device_class 'light'

### DIFF
--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -31,6 +31,7 @@ window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
   sensor: [
     'battery',
     'humidity',
+    'light',
     'temperature'
   ],
 };

--- a/src/util/hass-attributes-util.html
+++ b/src/util/hass-attributes-util.html
@@ -31,7 +31,7 @@ window.hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
   sensor: [
     'battery',
     'humidity',
-    'light',
+    'illuminance',
     'temperature'
   ],
 };

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -299,7 +299,7 @@ window.hassUtil.sensorIcon = (state) => {
     case 'humidity':
       return 'mdi:water-percent';
     case 'light':
-      return 'mdi:weather-sunset';
+      return 'mdi:brightness-5';
     case 'temperature':
       return 'mdi:thermometer';
     default:

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -298,6 +298,8 @@ window.hassUtil.sensorIcon = (state) => {
     }
     case 'humidity':
       return 'mdi:water-percent';
+    case 'light':
+      return 'mdi:weather-sunset';
     case 'temperature':
       return 'mdi:thermometer';
     default:

--- a/src/util/hass-util.html
+++ b/src/util/hass-util.html
@@ -298,7 +298,7 @@ window.hassUtil.sensorIcon = (state) => {
     }
     case 'humidity':
       return 'mdi:water-percent';
-    case 'light':
+    case 'illuminance':
       return 'mdi:brightness-5';
     case 'temperature':
       return 'mdi:thermometer';


### PR DESCRIPTION
Add the `light` device_class to `sensors`.
The corresponding PR: https://github.com/home-assistant/home-assistant/pull/14282

I'm not sure which mid icon we should choose. Aside from the current `weather-sunset`, `lightbulb` would also work.

cc: @OttoWinter 