### PR TITLE
Add entity_picture capability to plant card

### DIFF
--- a/src/cards/ha-plant-card.js
+++ b/src/cards/ha-plant-card.js
@@ -11,10 +11,34 @@ class HaPlantCard extends EventsMixin(PolymerElement) {
   static get template() {
     return html`
     <style>
+      .banner {
+        display: flex;
+        align-items: flex-end;
+        background-repeat: no-repeat;
+        background-size: cover;
+        background-position: center;
+        padding-top: 12px;
+      }
+      .has-plant-image .banner {
+        padding-top: 30%;
+      }
+      .header {
+        @apply --paper-font-headline;
+        line-height: 40px;
+        padding: 8px 16px;
+      }
+      .has-plant-image .header {
+        color: white;
+        width: 100%;
+        background:rgba(0, 0, 0, var(--dark-secondary-opacity));
+      }
       .content {
         display: flex;
         justify-content: space-between;
-        padding: 0 32px 24px 32px;
+        padding: 16px 32px 24px 32px;
+      }
+      .has-plant-image .content {
+        padding-bottom: 16px;
       }
       iron-icon {
         color: var(--paper-item-icon-color);
@@ -35,12 +59,15 @@ class HaPlantCard extends EventsMixin(PolymerElement) {
       }
     </style>
 
-    <ha-card header="[[computeTitle(stateObj)]]">
+    <ha-card class$="[[computeImageClass(stateObj.attributes.entity_picture)]]">
+      <div class="banner" style="background-image:url([[stateObj.attributes.entity_picture]])">
+        <div class="header">[[computeTitle(stateObj)]]</div>
+      </div>
       <div class="content">
         <template is="dom-repeat" items="[[computeAttributes(stateObj.attributes)]]">
           <div class="attributes" on-click="attributeClicked">
             <div><iron-icon icon="[[computeIcon(item, stateObj.attributes.battery)]]"></iron-icon></div>
-            <div class\$="[[computeClass(stateObj.attributes.problem, item)]]">
+            <div class$="[[computeAttributeClass(stateObj.attributes.problem, item)]]">
               [[computeValue(stateObj.attributes, item)]]
             </div>
             <div class="uom">[[computeUom(stateObj.attributes.unit_of_measurement_dict, item)]]</div>
@@ -97,8 +124,12 @@ class HaPlantCard extends EventsMixin(PolymerElement) {
     return dict[attr] || '';
   }
 
-  computeClass(problem, attr) {
+  computeAttributeClass(problem, attr) {
     return problem.indexOf(attr) === -1 ? '' : 'problem';
+  }
+
+  computeImageClass(entityPicture) {
+    return entityPicture ? 'has-plant-image' : '';
   }
 
   attributeClicked(ev) {

--- a/src/cards/ha-plant-card.js
+++ b/src/cards/ha-plant-card.js
@@ -28,6 +28,10 @@ class HaPlantCard extends EventsMixin(PolymerElement) {
         padding: 8px 16px;
       }
       .has-plant-image .header {
+        font-size: 16px;
+        font-weight: 500;
+        line-height: 16px;
+        padding: 16px;
         color: white;
         width: 100%;
         background:rgba(0, 0, 0, var(--dark-secondary-opacity));


### PR DESCRIPTION
Adds the ability to set a background image to the plant card:

![image](https://user-images.githubusercontent.com/16738570/39677170-67fa5a94-516e-11e8-8b4f-9bc81576ddec.png)

Can specify via customising the entity_picture:
```
  customize:
    plant.miflora_3:
      friendly_name: Ponytail Palm (Bedroom)
      entity_picture: /local/ponytail_palm.jpg
```
Appreciate any feedback on layout.

@c727 , let me know any coding improvements
@ChristianKuehnel, let me know your thoughts
