### PR TITLE
Include util.js for hass.io

### DIFF
--- a/gulp/tasks/hassio-panel.js
+++ b/gulp/tasks/hassio-panel.js
@@ -52,6 +52,7 @@ gulp.task('hassio-gzip-es5', gzipOutput);
 
 gulp.task('hassio-es5', () => runSequence.use(gulp)(
   'hassio-clean',
+  'run_rollup',
   'hassio-panel-es5',
   'hassio-index-es5',
   'hassio-gzip-es5',


### PR DESCRIPTION
util.js wasn't build when we're building the Hass.io frontend, resulting in a 404 in the logs. This fixes that.

The reason it never broke anything is because util.js is mainly entity related utilities which are not used by Hass.io.