### PR TITLE
Fix fan rotation

### DIFF
--- a/src/dialogs/more-info/controls/more-info-fan.js
+++ b/src/dialogs/more-info/controls/more-info-fan.js
@@ -147,23 +147,23 @@ class MoreInfoFan extends EventsMixin(PolymerElement) {
   onDirectionLeft() {
     this.hass.callService('fan', 'set_direction', {
       entity_id: this.stateObj.entity_id,
-      direction: 'left'
+      direction: 'reverse'
     });
   }
 
   onDirectionRight() {
     this.hass.callService('fan', 'set_direction', {
       entity_id: this.stateObj.entity_id,
-      direction: 'right'
+      direction: 'forward'
     });
   }
 
   computeIsRotatingLeft(stateObj) {
-    return stateObj.attributes.direction === 'left';
+    return stateObj.attributes.direction === 'reverse';
   }
 
   computeIsRotatingRight(stateObj) {
-    return stateObj.attributes.direction === 'right';
+    return stateObj.attributes.direction === 'forward';
   }
 }
 


### PR DESCRIPTION
The fan rotation attributes should be `forward` and `reverse` instead of `left` and `right`. Fix for #1158.
If asked for I can rebase this PR againt the `polymer-3-modulize` branch.