### PR TITLE
P3: Use paper material styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@polymer/paper-input": "^3.0.0-pre.18",
     "@polymer/paper-item": "^3.0.0-pre.18",
     "@polymer/paper-listbox": "^3.0.0-pre.18",
-    "@polymer/paper-material": "^3.0.0-pre.18",
     "@polymer/paper-menu-button": "^3.0.0-pre.18",
     "@polymer/paper-progress": "^3.0.0-pre.18",
     "@polymer/paper-radio-button": "^3.0.0-pre.18",

--- a/src/cards/ha-camera-card.js
+++ b/src/cards/ha-camera-card.js
@@ -1,5 +1,5 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import '@polymer/paper-material/paper-material.js';
+import '@polymer/paper-styles/element-styles/paper-material-styles.js';
 import '../util/hass-mixins.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
@@ -13,8 +13,9 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
     window.hassMixins.LocalizeMixin(window.hassMixins.EventsMixin(PolymerElement)) {
     static get template() {
       return html`
-    <style include="paper-material">
+    <style include="paper-material-styles">
       :host {
+        @apply --paper-material-elevation-1;
         display: block;
         position: relative;
         font-size: 0px;
@@ -69,14 +70,6 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
         imageLoaded: {
           type: Boolean,
           value: true,
-        },
-        /**
-         * The z-depth of the card, from 0-5.
-         */
-        elevation: {
-          type: Number,
-          value: 1,
-          reflectToAttribute: true,
         },
       };
     }

--- a/src/cards/ha-media_player-card.js
+++ b/src/cards/ha-media_player-card.js
@@ -1,6 +1,6 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
-import '@polymer/paper-material/paper-material.js';
+import '@polymer/paper-styles/element-styles/paper-material-styles.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/paper-progress/paper-progress.js';
 import '../util/hass-media-player-model.js';
@@ -14,8 +14,9 @@ class HaMediaPlayerCard extends
   window.hassMixins.LocalizeMixin(window.hassMixins.EventsMixin(PolymerElement)) {
   static get template() {
     return html`
-    <style include="paper-material iron-flex iron-flex-alignment iron-positioning">
+    <style include="paper-material-styles iron-flex iron-flex-alignment iron-positioning">
       :host {
+        @apply --paper-material-elevation-1;
         display: block;
         position: relative;
         font-size: 0px;
@@ -193,14 +194,6 @@ class HaMediaPlayerCard extends
         computed: 'computePlaybackControlIcon(playerObj)',
       },
       playbackPosition: Number,
-      /**
-       * The z-depth of the card, from 0-5.
-       */
-      elevation: {
-        type: Number,
-        value: 1,
-        reflectToAttribute: true,
-      },
     };
   }
 

--- a/src/components/ha-card.js
+++ b/src/components/ha-card.js
@@ -1,16 +1,16 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import '@polymer/paper-material/paper-material.js';
+import '@polymer/paper-styles/element-styles/paper-material-styles.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
 class HaCard extends PolymerElement {
   static get template() {
     return html`
-    <style include="paper-material">
+    <style include="paper-material-styles">
       :host {
+        @apply --paper-material-elevation-1;
         display: block;
         border-radius: 2px;
         transition: all 0.30s ease-out;
-
         background-color: var(--paper-card-background-color, white);
       }
       .header {
@@ -35,14 +35,6 @@ class HaCard extends PolymerElement {
     return {
       header: {
         type: String,
-      },
-      /**
-       * The z-depth of the card, from 0-5.
-       */
-      elevation: {
-        type: Number,
-        value: 1,
-        reflectToAttribute: true,
       },
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,13 +382,6 @@
     "@polymer/paper-styles" "^3.0.0-pre.19"
     "@polymer/polymer" "^3.0.0"
 
-"@polymer/paper-material@^3.0.0-pre.18":
-  version "3.0.0-pre.19"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-material/-/paper-material-3.0.0-pre.19.tgz#93cfc099a6f3c4f30615849c81e4965c08262ce0"
-  dependencies:
-    "@polymer/paper-styles" "^3.0.0-pre.19"
-    "@polymer/polymer" "^3.0.0"
-
 "@polymer/paper-menu-button@^3.0.0-pre.18", "@polymer/paper-menu-button@^3.0.0-pre.19":
   version "3.0.0-pre.19"
   resolved "https://registry.yarnpkg.com/@polymer/paper-menu-button/-/paper-menu-button-3.0.0-pre.19.tgz#92402c4da6fe4fe31295e8de19c71ff39ad2a824"


### PR DESCRIPTION
paper-material has been deprecated in favor of using paper-material-styles. paper-material also broke when migrating to Polymer 3, so a good time to upgrade.