### PR TITLE
P3: Send parsed date to history/logbook

### DIFF
--- a/panels/history/ha-panel-history.js
+++ b/panels/history/ha-panel-history.js
@@ -153,14 +153,9 @@ class HaPanelHistory extends window.hassMixins.LocalizeMixin(PolymerElement) {
   connectedCallback() {
     super.connectedCallback();
     // We are unable to parse date because we use intl api to render date
-    // So we just return last known date.
-    var lastFormatDate = new Date();
-    this.$.picker.set('i18n.parseDate', function () {
-      return lastFormatDate;
-    });
+    this.$.picker.set('i18n.parseDate', null);
     this.$.picker.set('i18n.formatDate', function (date) {
-      lastFormatDate = date;
-      return window.hassUtil.formatDate(date);
+      return window.hassUtil.formatDate(new Date(date.year, date.month, date.day));
     });
   }
 

--- a/panels/logbook/ha-panel-logbook.js
+++ b/panels/logbook/ha-panel-logbook.js
@@ -129,14 +129,9 @@ class HaPanelLogbook extends window.hassMixins.LocalizeMixin(PolymerElement) {
   connectedCallback() {
     super.connectedCallback();
     // We are unable to parse date because we use intl api to render date
-    // So we just return last known date.
-    var lastFormatDate = new Date();
-    this.$.picker.set('i18n.parseDate', function () {
-      return lastFormatDate;
-    });
+    this.$.picker.set('i18n.parseDate', null);
     this.$.picker.set('i18n.formatDate', function (date) {
-      lastFormatDate = date;
-      return window.hassUtil.formatDate(date);
+      return window.hassUtil.formatDate(new Date(date.year, date.month, date.day));
     });
   }
 


### PR DESCRIPTION
In v3, the date object provided by vaadin-date-picker is an object containing year/month/date instead of a date object. We convert it back to a date object now before parsing it to the formatter.

I realized that the way we format/parse the date, we prevent people from manually editing the input field. We used to work around it by just returning the last formatted date. That's bad UX. I noticed now that we can set it to null and the user is unable to type in the field, UX issue resolved.