### PR TITLE
P3: Add patched iconset

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@polymer/iron-autogrow-textarea": "^3.0.0-pre.18",
     "@polymer/iron-flex-layout": "^3.0.0-pre.18",
     "@polymer/iron-icon": "^3.0.0-pre.18",
+    "@polymer/iron-iconset-svg": "^3.0.0-pre.19",
     "@polymer/iron-image": "^3.0.0-pre.18",
     "@polymer/iron-input": "^3.0.0-pre.18",
     "@polymer/iron-label": "^3.0.0-pre.18",

--- a/polymer.json
+++ b/polymer.json
@@ -28,7 +28,8 @@
     "filesToIgnore": [
       "**/*.html",
       "**/ha-paper-slider.js",
-      "**/hass-mixins.js"
+      "**/hass-mixins.js",
+      "**/ha-iconset-svg.js"
     ]
   },
   "builds": [

--- a/script/update_mdi.py
+++ b/script/update_mdi.py
@@ -34,7 +34,7 @@ def get_remote_version():
 
 def clean_component(source):
     """Clean component."""
-    return source[source.index(START_ICONSET):]
+    return source[source.index(START_ICONSET):].replace('iron-iconset-svg', 'ha-iconset-svg')
 
 
 def write_component(source):

--- a/src/components/ha-iconset-svg.js
+++ b/src/components/ha-iconset-svg.js
@@ -1,0 +1,35 @@
+import '@polymer/iron-iconset-svg/iron-iconset-svg.js';
+
+const IronIconsetClass = customElements.get('iron-iconset-svg');
+
+class HaIconset extends IronIconsetClass {
+  /**
+   * Fire 'iron-iconset-added' event at next microtask.
+   */
+  _fireIronIconsetAdded() {
+    this.async(function () {
+      this.fire('iron-iconset-added', this, { node: window });
+    });
+  }
+
+  /**
+   *
+   * When name is changed, register iconset metadata
+   *
+   */
+  _nameChanged() {
+    this._meta.value = null;
+    this._meta.key = this.name;
+    this._meta.value = this;
+    if (this.ownerDocument && this.ownerDocument.readyState === 'loading') {
+      // Document still loading. It could be that not all icons in the iconset are parsed yet.
+      this.ownerDocument.addEventListener('DOMContentLoaded', function () {
+        this._fireIronIconsetAdded();
+      }.bind(this));
+    } else {
+      this._fireIronIconsetAdded();
+    }
+  }
+}
+
+customElements.define('ha-iconset-svg', HaIconset);

--- a/src/home-assistant.js
+++ b/src/home-assistant.js
@@ -21,6 +21,8 @@ import './util/hass-translation.js';
 import './util/hass-util.js';
 import './util/legacy-support';
 import './util/roboto.js';
+// For mdi icons.
+import './components/ha-iconset-svg.js';
 
 setPassiveTouchGestures(true);
 /* LastPass createElement workaround. See #428 */


### PR DESCRIPTION
With P3, we are constantly running into the iconset being registered before the children are getting parsed. Decided to include the iron-iconset-svg fix by @andrey-git in our repo to fix it.

Code from https://github.com/PolymerElements/iron-iconset-svg/pull/77/files