### PR TITLE
Filter out some modules

### DIFF
--- a/src/util/empty.js
+++ b/src/util/empty.js
@@ -1,0 +1,1 @@
+/* empty file that we alias some files to that we don't want to include */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,6 +44,18 @@ function createConfig(isProdBuild, latestBuild) {
       __VERSION__: JSON.stringify(VERSION),
     }),
     new CopyWebpackPlugin(copyPluginOpts),
+    // Ignore moment.js locales
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    // Color.js is bloated, it contains all color definitions for all material color sets.
+    new webpack.NormalModuleReplacementPlugin(
+      /@polymer\/paper-styles\/color\.js$/,
+      path.resolve(__dirname, 'src/util/empty.js')
+    ),
+    // Ignore roboto pointing at CDN. We use local font-roboto-local.
+    new webpack.NormalModuleReplacementPlugin(
+      /@polymer\/font-roboto\/roboto\.js$/,
+      path.resolve(__dirname, 'src/util/empty.js')
+    ),
   ];
 
   if (latestBuild) {


### PR DESCRIPTION
Filter out:
 - moment locales. By default it uses all locales and we are not using it.
 - paper-styles/color.js. CSS Vars for all material color sets are included. We used to exclude it.
 - font-roboto/robot.js. We use font-roboto-local instead.

Part of #1176