### PR TITLE
Code split out more things

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       #ha-init-skeleton::before {
         display: block;
         content: "";
-        height: 48px;
+        height: 64px;
         background-color: {{ theme_color }};
       }
 

--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -1,6 +1,6 @@
-/* polyfill for paper-dropdown */
-import 'web-animations-js/web-animations-next-lite.min.js';
-
+/* eslint-disable import/first */
+// Load polyfill first so HTML imports start resolving
+import '../resources/html-import/polyfill.js';
 import '@polymer/app-route/app-location.js';
 import '@polymer/app-route/app-route.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
@@ -17,10 +17,7 @@ import {
 
 import translationMetadata from '../../build-translations/translationMetadata.json';
 import '../layouts/home-assistant-main.js';
-import '../layouts/login-form.js';
-import '../managers/notification-manager.js';
 import '../resources/ha-style.js';
-import '../resources/html-import/polyfill.js';
 import '../util/ha-pref-storage.js';
 import { getActiveTranslation, getTranslation } from '../util/hass-translation.js';
 import '../util/legacy-support';
@@ -31,6 +28,12 @@ import '../components/ha-iconset-svg.js';
 
 import computeStateName from '../common/entity/compute_state_name.js';
 import applyThemesOnElement from '../common/dom/apply_themes_on_element.js';
+
+/* polyfill for paper-dropdown */
+import(/* webpackChunkName: "polyfill-web-animations-next" */ 'web-animations-js/web-animations-next-lite.min.js');
+import(/* webpackChunkName: "login-form" */ '../layouts/login-form.js');
+import(/* webpackChunkName: "notification-manager" */ '../managers/notification-manager.js');
+
 
 setPassiveTouchGestures(true);
 /* LastPass createElement workaround. See #428 */

--- a/src/layouts/home-assistant-main.js
+++ b/src/layouts/home-assistant-main.js
@@ -6,7 +6,6 @@ import '@polymer/iron-pages/iron-pages.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
-import '../components/ha-sidebar.js';
 import '../util/ha-url-sync.js';
 
 import './partial-cards.js';
@@ -14,6 +13,7 @@ import './partial-panel-resolver.js';
 import EventsMixin from '../mixins/events-mixin.js';
 import NavigateMixin from '../mixins/navigate-mixin.js';
 
+import(/* webpackChunkName: "ha-sidebar" */ '../components/ha-sidebar.js');
 import(/* webpackChunkName: "more-info-dialog" */ '../dialogs/ha-more-info-dialog.js');
 import(/* webpackChunkName: "voice-command-dialog" */ '../dialogs/ha-voice-command-dialog.js');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,7 +84,7 @@ function createConfig(isProdBuild, latestBuild) {
   }
 
   const chunkFilename = isProdBuild ?
-    '[name]-[chunkhash].chunk.js' : '[name].chunk.js';
+    '[chunkhash].chunk.js' : '[name].chunk.js';
 
   return {
     mode: isProdBuild ? 'production' : 'development',


### PR DESCRIPTION
Code split out:

 - polyfill-web-animations-next (50kb polyfill used by paper-dropdown) 
 - login-form
 - notification-manager (show toast if you're offline)
 - ha-sidebar

I decided not to code split out partial-cards or ha-cards. The effect is that the UI will show up way later. In that optimizations for fast startup are missing their point.

Also:
 - made the skeleton blue toolbar 64 instead of 48px, so it won't shift when real component loads.
 - Chunks in prod will not contain the chunk name, just the hash. The names get kinda crazy because if different chunks have overlap, they will get a combination chunk. Those names were eating precious bytes ;)