### PR TITLE
Add experimental UI

### DIFF
--- a/src/layouts/partial-panel-resolver.js
+++ b/src/layouts/partial-panel-resolver.js
@@ -49,6 +49,10 @@ function ensureLoaded(panel) {
       imported = import(/* webpackChunkName: "panel-dev-template" */ '../panels/dev-template/ha-panel-dev-template.js');
       break;
 
+    case 'experimental-ui':
+      imported = import(/* webpackChunkName: "panel-experimental-ui" */ '../panels/experimental-ui/ha-panel-experimental-ui.js');
+      break;
+
     case 'history':
       imported = import(/* webpackChunkName: "panel-history" */ '../panels/history/ha-panel-history.js');
       break;

--- a/src/panels/experimental-ui/ha-panel-experimental-ui.js
+++ b/src/panels/experimental-ui/ha-panel-experimental-ui.js
@@ -1,6 +1,7 @@
 import '@polymer/app-layout/app-header-layout/app-header-layout.js';
 import '@polymer/app-layout/app-header/app-header.js';
 import '@polymer/app-layout/app-toolbar/app-toolbar.js';
+import '@polymer/paper-icon-button/paper-icon-button.js';
 
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -11,18 +12,23 @@ class ExperimentalUI extends PolymerElement {
   static get template() {
     return html`
     <style include='ha-style'>
+      app-header-layout {
+        height: 100%;
+      }
     </style>
-    <app-header-layout has-scrolling-region>
+    <app-header-layout>
       <app-header slot="header" fixed>
         <app-toolbar>
           <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
           <div main-title>Experimental UI</div>
+          <paper-icon-button icon='hass:refresh' on-click='_fetchConfig'></paper-icon-button>
         </app-toolbar>
       </app-header>
 
       <hui-view
         hass='[[hass]]'
         config='[[_curView]]'
+        columns='[[_columns]]'
       ></hui-view>
     </app-header-layout>
     `;
@@ -42,6 +48,11 @@ class ExperimentalUI extends PolymerElement {
         value: false,
       },
 
+      _columns: {
+        type: Number,
+        value: 1,
+      },
+
       _config: {
         type: Object,
         value: null,
@@ -54,8 +65,25 @@ class ExperimentalUI extends PolymerElement {
 
   ready() {
     super.ready();
+    this._fetchConfig();
+    this._handleWindowChange = this._handleWindowChange.bind(this);
+    this.mqls = [300, 600, 900, 1200].map((width) => {
+      const mql = matchMedia(`(min-width: ${width}px)`);
+      mql.addListener(this._handleWindowChange);
+      return mql;
+    });
+    this._handleWindowChange();
+  }
+
+  _handleWindowChange() {
+    const matchColumns = this.mqls.reduce((cols, mql) => cols + mql.matches, 0);
+    // Do -1 column if the menu is docked and open
+    this._columns = Math.max(1, matchColumns - (!this.narrow && this.showMenu));
+  }
+
+  _fetchConfig() {
     this.hass.connection.sendMessagePromise({ type: 'frontend/experimental_ui' })
-      .then(conf => { this._config = conf.result; });
+      .then((conf) => { this._config = conf.result; });
   }
 
   _configChanged(config) {

--- a/src/panels/experimental-ui/ha-panel-experimental-ui.js
+++ b/src/panels/experimental-ui/ha-panel-experimental-ui.js
@@ -1,0 +1,68 @@
+import '@polymer/app-layout/app-header-layout/app-header-layout.js';
+import '@polymer/app-layout/app-header/app-header.js';
+import '@polymer/app-layout/app-toolbar/app-toolbar.js';
+
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import './hui-view.js';
+
+class ExperimentalUI extends PolymerElement {
+  static get template() {
+    return html`
+    <style include='ha-style'>
+    </style>
+    <app-header-layout has-scrolling-region>
+      <app-header slot="header" fixed>
+        <app-toolbar>
+          <ha-menu-button narrow='[[narrow]]' show-menu='[[showMenu]]'></ha-menu-button>
+          <div main-title>Experimental UI</div>
+        </app-toolbar>
+      </app-header>
+
+      <hui-view
+        hass='[[hass]]'
+        config='[[_curView]]'
+      ></hui-view>
+    </app-header-layout>
+    `;
+  }
+
+  static get properties() {
+    return {
+      hass: Object,
+
+      narrow: {
+        type: Boolean,
+        value: false,
+      },
+
+      showMenu: {
+        type: Boolean,
+        value: false,
+      },
+
+      _config: {
+        type: Object,
+        value: null,
+        observer: '_configChanged',
+      },
+
+      _curView: Object
+    };
+  }
+
+  ready() {
+    super.ready();
+    this.hass.connection.sendMessagePromise({ type: 'frontend/experimental_ui' })
+      .then(conf => { this._config = conf.result; });
+  }
+
+  _configChanged(config) {
+    if (!config) return;
+    // Currently hardcode to first view.
+    this._curView = config.views[0];
+  }
+}
+
+customElements.define('ha-panel-experimental-ui', ExperimentalUI);

--- a/src/panels/experimental-ui/hui-entities-card.js
+++ b/src/panels/experimental-ui/hui-entities-card.js
@@ -18,9 +18,8 @@ function stateElement(hass, entityId, stateObj) {
     return 'state-card-display';
   } else if (stateObj.attributes && 'custom_ui_state_card' in stateObj.attributes) {
     return stateObj.attributes.custom_ui_state_card;
-  } else {
-    return 'state-card-' + stateCardType(hass, stateObj);
   }
+  return 'state-card-' + stateCardType(hass, stateObj);
 }
 
 class HuiEntitiesCard extends PolymerElement {
@@ -73,6 +72,11 @@ class HuiEntitiesCard extends PolymerElement {
     this._elements = [];
   }
 
+  getCardSize() {
+    // +1 for the header
+    return 1 + (this.config ? this.config.entities.length : 0);
+  }
+
   _computeTitle(config) {
     return config.title;
   }
@@ -80,7 +84,7 @@ class HuiEntitiesCard extends PolymerElement {
   _configChanged(config) {
     const root = this.$.states;
 
-    while(root.lastChild) {
+    while (root.lastChild) {
       root.removeChild(root.lastChild);
     }
 
@@ -89,9 +93,9 @@ class HuiEntitiesCard extends PolymerElement {
     for (let i = 0; i < config.entities.length; i++) {
       const entityId = config.entities[i];
       const stateObj = this.hass.states[entityId];
-      let tag = stateElement(this.hass, entityId, stateObj);
+      const tag = stateElement(this.hass, entityId, stateObj);
       const element = document.createElement(tag);
-      element.stateObj = stateObj
+      element.stateObj = stateObj;
       element.hass = this.hass;
       this._elements.push({ entityId, element });
       root.appendChild(element);
@@ -99,7 +103,7 @@ class HuiEntitiesCard extends PolymerElement {
   }
 
   _hassChanged(hass) {
-    for(let i = 0; i < this._elements.length; i++) {
+    for (let i = 0; i < this._elements.length; i++) {
       const { entityId, element } = this._elements[i];
       const stateObj = hass.states[entityId];
       element.stateObj = stateObj;

--- a/src/panels/experimental-ui/hui-entities-card.js
+++ b/src/panels/experimental-ui/hui-entities-card.js
@@ -1,0 +1,112 @@
+import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import stateCardType from '../../common/entity/state_card_type.js';
+
+import '../../components/ha-card.js';
+
+// just importing this now as shortcut to import correct state-card-*
+import '../../state-summary/state-card-content.js';
+
+// Support for overriding type from attributes should be removed
+// Instead, it should be coded inside entity config.
+// stateCardType requires `hass` because we check if a service exists.
+// This should also be determined during runtime.
+function stateElement(hass, entityId, stateObj) {
+  if (stateObj.attributes && 'custom_ui_state_card' in stateObj.attributes) {
+    return stateObj.attributes.custom_ui_state_card;
+  } else {
+    return 'state-card-' + stateCardType(hass, stateObj);
+  }
+}
+
+class HuiEntitiesCard extends PolymerElement {
+  static get template() {
+    return html`
+    <style>
+      ha-card {
+        padding: 16px;
+      }
+      .state {
+        padding: 4px 0;
+      }
+      .header {
+        @apply --paper-font-headline;
+        /* overwriting line-height +8 because entity-toggle can be 40px height,
+           compensating this with reduced padding */
+        line-height: 40px;
+        color: var(--primary-text-color);
+        padding: 4px 0 12px;
+      }
+      .header .name {
+        @apply --paper-font-common-nowrap;
+      }
+    </style>
+
+    <ha-card>
+      <div class='header'>
+        <div class="name">[[_computeTitle(config)]]</div>
+      </div>
+      <div id="states"></div>
+    </ha-card>
+`;
+  }
+
+  static get properties() {
+    return {
+      hass: {
+        type: Object,
+        observer: '_hassChanged',
+      },
+      config: {
+        type: Object,
+        observer: '_configChanged',
+      }
+    };
+  }
+
+  constructor() {
+    super();
+    this._elements = [];
+  }
+
+  _computeTitle(config) {
+    return config.title;
+  }
+
+  _computeStates(config, hass) {
+    return config.entities.map(ent => hass.states[ent]);
+  }
+
+  _configChanged(config) {
+    const root = this.$.states;
+
+    while(root.lastChild) {
+      root.removeChild(root.lastChild);
+    }
+
+    this._elements = [];
+
+    for (let i = 0; i < config.entities.length; i++) {
+      const entityId = config.entities[i];
+      const stateObj = this.hass.states[entityId];
+      let tag = stateElement(this.hass, entityId, stateObj);
+      const element = document.createElement(tag);
+      element.stateObj = stateObj
+      element.hass = this.hass;
+      this._elements.push({ entityId, element });
+      root.appendChild(element);
+    }
+  }
+
+  _hassChanged(hass) {
+    for(let i = 0; i < this._elements.length; i++) {
+      const { entityId, element } = this._elements[i];
+      const stateObj = hass.states[entityId];
+      element.stateObj = stateObj;
+      element.hass = hass;
+    }
+  }
+}
+customElements.define('hui-entities-card', HuiEntitiesCard);

--- a/src/panels/experimental-ui/hui-entities-card.js
+++ b/src/panels/experimental-ui/hui-entities-card.js
@@ -14,7 +14,9 @@ import '../../state-summary/state-card-content.js';
 // stateCardType requires `hass` because we check if a service exists.
 // This should also be determined during runtime.
 function stateElement(hass, entityId, stateObj) {
-  if (stateObj.attributes && 'custom_ui_state_card' in stateObj.attributes) {
+  if (!stateObj) {
+    return 'state-card-display';
+  } else if (stateObj.attributes && 'custom_ui_state_card' in stateObj.attributes) {
     return stateObj.attributes.custom_ui_state_card;
   } else {
     return 'state-card-' + stateCardType(hass, stateObj);
@@ -73,10 +75,6 @@ class HuiEntitiesCard extends PolymerElement {
 
   _computeTitle(config) {
     return config.title;
-  }
-
-  _computeStates(config, hass) {
-    return config.entities.map(ent => hass.states[ent]);
   }
 
   _configChanged(config) {

--- a/src/panels/experimental-ui/hui-entity-filter-card.js
+++ b/src/panels/experimental-ui/hui-entity-filter-card.js
@@ -22,25 +22,33 @@ class HuiEntitiesCard extends PolymerElement {
     };
   }
 
-  _computeCardConfig(hass, config) {
+  getCardSize() {
+    // +1 for the header
+    return 1 + this._getEntities(this.hass, this.config.filter).length;
+  }
+
+  // Return a list of entities based on a filter.
+  _getEntities(hass, filter) {
     const filters = [];
 
-    if (config.filter.domain) {
-      const domain = config.filter.domain;
+    if (filter.domain) {
+      const domain = filter.domain;
       filters.push(stateObj => computeStateDomain(stateObj) === domain);
     }
 
-    if (config.filter.state) {
-      const state = config.filter.state;
+    if (filter.state) {
+      const state = filter.state;
       filters.push(stateObj => stateObj.state === state);
     }
 
-    const entities = Object.values(hass.states)
-      .filter(stateObj => filters.every(filter => filter(stateObj)))
+    return Object.values(hass.states)
+      .filter(stateObj => filters.every(filterFunc => filterFunc(stateObj)))
       .map(stateObj => stateObj.entity_id);
+  }
 
+  _computeCardConfig(hass, config) {
     return Object.assign({}, config.card_config || {}, {
-      entities
+      entities: this._getEntities(hass, config.filter),
     });
   }
 }

--- a/src/panels/experimental-ui/hui-entity-filter-card.js
+++ b/src/panels/experimental-ui/hui-entity-filter-card.js
@@ -1,0 +1,47 @@
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import './hui-entities-card.js';
+
+import computeStateDomain from '../../common/entity/compute_state_domain.js';
+
+class HuiEntitiesCard extends PolymerElement {
+  static get template() {
+    return html`
+    <hui-entities-card
+      hass='[[hass]]'
+      config='[[_computeCardConfig(hass, config)]]'
+    ></hui-entities-card>
+`;
+  }
+
+  static get properties() {
+    return {
+      hass: Object,
+      config: Object,
+    };
+  }
+
+  _computeCardConfig(hass, config) {
+    const filters = [];
+
+    if (config.filter.domain) {
+      const domain = config.filter.domain;
+      filters.push(stateObj => computeStateDomain(stateObj) === domain);
+    }
+
+    if (config.filter.state) {
+      const state = config.filter.state;
+      filters.push(stateObj => stateObj.state === state);
+    }
+
+    const entities = Object.values(hass.states)
+      .filter(stateObj => filters.every(filter => filter(stateObj)))
+      .map(stateObj => stateObj.entity_id);
+
+    return Object.assign({}, config.card_config || {}, {
+      entities
+    });
+  }
+}
+customElements.define('hui-entity-filter-card', HuiEntitiesCard);

--- a/src/panels/experimental-ui/hui-view.js
+++ b/src/panels/experimental-ui/hui-view.js
@@ -1,0 +1,74 @@
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import './hui-entities-card.js';
+
+const VALID_TYPES = ['entities', 'group'];
+const CUSTOM_TYPE_PREFIX = 'custom:'
+
+function cardElement(type) {
+  if (VALID_TYPES.includes(type)) {
+    return `hui-${type}-card`;
+  } else if (type.startsWith(CUSTOM_TYPE_PREFIX)) {
+    return type.substr(CUSTOM_TYPE_PREFIX.length);
+  }
+  return null;
+}
+
+class HaView extends PolymerElement {
+  static get properties() {
+    return {
+      hass: {
+        type: Object,
+        observer: '_hassChanged',
+      },
+
+      config: {
+        type: Object,
+        observer: '_configChanged',
+      }
+    };
+  }
+
+  constructor() {
+    super();
+    this._elements = [];
+  }
+
+  ready() {
+    super.ready();
+    this.innerHTML = 'Loading config';
+  }
+
+  _configChanged(config) {
+    const root = this;
+
+    while(root.lastChild) {
+      root.removeChild(root.lastChild);
+    }
+
+    this._elements = [];
+
+    for (let i = 0; i < config.cards.length; i++) {
+      const cardConfig = config.cards[i];
+      let tag = cardElement(cardConfig.type);
+      if (!tag) {
+        console.error('Unknown type encountered:', cardConfig.type);
+        continue;
+      }
+      const element = document.createElement(tag);
+      element.config = cardConfig;
+      element.hass = this.hass;
+      this._elements.push(element);
+      root.appendChild(element);
+    }
+  }
+
+  _hassChanged(hass) {
+    for(let i = 0; i < this._elements.length; i++) {
+      this._elements[i].hass = hass;
+    }
+  }
+}
+
+customElements.define('hui-view', HaView);

--- a/src/panels/experimental-ui/hui-view.js
+++ b/src/panels/experimental-ui/hui-view.js
@@ -62,6 +62,14 @@ class HaView extends PolymerElement {
       this._elements.push(element);
       root.appendChild(element);
     }
+
+    if ('theme' in config) {
+      const styles = {};
+      Object.keys(config.theme).forEach(prop => {
+        styles[`--${prop}`] = config.theme[prop];
+      });
+      this.updateStyles(styles);
+    }
   }
 
   _hassChanged(hass) {

--- a/src/panels/experimental-ui/hui-view.js
+++ b/src/panels/experimental-ui/hui-view.js
@@ -3,6 +3,8 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import './hui-entities-card.js';
 
+import applyThemesOnElement from '../../common/dom/apply_themes_on_element.js';
+
 const VALID_TYPES = ['entities', 'group'];
 const CUSTOM_TYPE_PREFIX = 'custom:'
 
@@ -63,12 +65,8 @@ class HaView extends PolymerElement {
       root.appendChild(element);
     }
 
-    if ('css' in config) {
-      const styles = {};
-      Object.keys(config.css).forEach(prop => {
-        styles[`--${prop}`] = config.css[prop];
-      });
-      this.updateStyles(styles);
+    if ('theme' in config) {
+      applyThemesOnElement(this, this.hass.themes, config.theme)
     }
   }
 

--- a/src/panels/experimental-ui/hui-view.js
+++ b/src/panels/experimental-ui/hui-view.js
@@ -2,10 +2,11 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import './hui-entities-card.js';
+import './hui-entity-filter-card.js';
 
 import applyThemesOnElement from '../../common/dom/apply_themes_on_element.js';
 
-const VALID_TYPES = ['entities', 'group'];
+const VALID_TYPES = ['entities', 'entity-filter'];
 const CUSTOM_TYPE_PREFIX = 'custom:'
 
 function cardElement(type) {

--- a/src/panels/experimental-ui/hui-view.js
+++ b/src/panels/experimental-ui/hui-view.js
@@ -63,10 +63,10 @@ class HaView extends PolymerElement {
       root.appendChild(element);
     }
 
-    if ('theme' in config) {
+    if ('css' in config) {
       const styles = {};
-      Object.keys(config.theme).forEach(prop => {
-        styles[`--${prop}`] = config.theme[prop];
+      Object.keys(config.css).forEach(prop => {
+        styles[`--${prop}`] = config.css[prop];
       });
       this.updateStyles(styles);
     }


### PR DESCRIPTION
This is my take on https://github.com/home-assistant/architecture/issues/14 and #1127 which has the goal to allow users to define a UI in a standalone file.

I'm really just exploring how this could work, what data structures can work and how we can simplify it a lot.

My approach:

 - Add a websocket command to load `<config>/experimental-ui.yaml`. This file is not cached so you can edit the file and refresh to see latest version. ([branch for Home Assistant](https://github.com/home-assistant/home-assistant/tree/experimental-ui))
 - Add a new panel that is accessible via url only: `/experimental-ui`
 - Add a new family of components `<hui-*>`. These components will be used to render the new configuration format. 

It's currently written in Polymer but I think that the element creation can be done without it.

Feature set:
 - Render first view in `expeirmental-ui.yaml`
 - Able to render cards of type `entities`
 - Able to allow setting CSS variables on the view

![image](https://user-images.githubusercontent.com/1444314/40512189-08154c64-5f70-11e8-81f0-43ef271a5ef0.png)

Known breaking changes with current UI:
 - It's not possible to change the rendering type of an entity on the fly. This is because custom UI should not be defined inside state object attributes. We should define it inside our UI config. This means that the `entities` key of an `entities` card should be able to contain dictionaries specifying `entity_id` and possible `type`.

Example `<config>/experimental-ui.yaml`:

```yaml
views:
- cards:
  - type: entities
    title: Example
    entities:
      - input_boolean.switch_ac_kitchen
      - input_boolean.switch_ac_livingroom
      - input_boolean.switch_tv
  theme: dark-mode
```

And use `configuration.yaml`:

```yaml
input_boolean:
  switch_ac_kitchen:
    name: AC kitchen
  switch_ac_livingroom:
    name: AC living room
  switch_tv:
    name: TV
```

Feel free to discuss in this PR the config format. What we should support and what not.

CC @andrey-git @c727 