### PR TITLE
Forward change event vaadin combo box

### DIFF
--- a/src/components/entity/ha-entity-picker.js
+++ b/src/components/entity/ha-entity-picker.js
@@ -11,11 +11,12 @@ import './state-badge.js';
 
 import computeStateName from '../../common/entity/compute_state_name.js';
 import LocalizeMixin from '../../mixins/localize-mixin.js';
+import EventsMixin from '../../mixins/events-mixin.js';
 
 /*
  * @appliesMixin LocalizeMixin
  */
-class HaEntityPicker extends LocalizeMixin(PolymerElement) {
+class HaEntityPicker extends EventsMixin(LocalizeMixin(PolymerElement)) {
   static get template() {
     return html`
     <style>
@@ -29,7 +30,15 @@ class HaEntityPicker extends LocalizeMixin(PolymerElement) {
         display: none;
       }
     </style>
-    <vaadin-combo-box-light items="[[_states]]" item-value-path="entity_id" item-label-path="entity_id" value="{{value}}" opened="{{opened}}" allow-custom-value="[[allowCustomEntity]]">
+    <vaadin-combo-box-light
+      items="[[_states]]"
+      item-value-path="entity_id"
+      item-label-path="entity_id"
+      value="{{value}}"
+      opened="{{opened}}"
+      allow-custom-value="[[allowCustomEntity]]"
+      on-change='_fireChanged'
+    >
       <paper-input autofocus="[[autofocus]]" label="[[_computeLabel(label, localize)]]" class="input" value="[[value]]" disabled="[[disabled]]">
         <paper-icon-button slot="suffix" class="clear-button" icon="mdi:close" no-ripple="" hidden\$="[[!value]]">Clear</paper-icon-button>
         <paper-icon-button slot="suffix" class="toggle-button" icon="[[_computeToggleIcon(opened)]]" hidden="[[!_states.length]]">Toggle</paper-icon-button>
@@ -134,6 +143,10 @@ class HaEntityPicker extends LocalizeMixin(PolymerElement) {
 
   _computeToggleIcon(opened) {
     return opened ? 'mdi:menu-up' : 'mdi:menu-down';
+  }
+
+  _fireChanged(ev) {
+    this.fire('change');
   }
 }
 

--- a/src/components/entity/ha-entity-picker.js
+++ b/src/components/entity/ha-entity-picker.js
@@ -146,6 +146,7 @@ class HaEntityPicker extends EventsMixin(LocalizeMixin(PolymerElement)) {
   }
 
   _fireChanged(ev) {
+    ev.stopPropagation();
     this.fire('change');
   }
 }

--- a/src/components/ha-combo-box.js
+++ b/src/components/ha-combo-box.js
@@ -91,6 +91,7 @@ class HaComboBox extends EventsMixin(PolymerElement) {
   }
 
   _fireChanged(ev) {
+    ev.stopPropagation();
     this.fire('change');
   }
 }

--- a/src/components/ha-combo-box.js
+++ b/src/components/ha-combo-box.js
@@ -5,7 +5,9 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '@vaadin/vaadin-combo-box/vaadin-combo-box-light.js';
 
-class HaComboBox extends PolymerElement {
+import EventsMixin from '../mixins/events-mixin.js';
+
+class HaComboBox extends EventsMixin(PolymerElement) {
   static get template() {
     return html`
     <style>
@@ -19,7 +21,15 @@ class HaComboBox extends PolymerElement {
         display: none;
       }
     </style>
-    <vaadin-combo-box-light items="[[_items]]" item-value-path="[[itemValuePath]]" item-label-path="[[itemLabelPath]]" value="{{value}}" opened="{{opened}}" allow-custom-value="[[allowCustomValue]]">
+    <vaadin-combo-box-light
+      items="[[_items]]"
+      item-value-path="[[itemValuePath]]"
+      item-label-path="[[itemLabelPath]]"
+      value="{{value}}"
+      opened="{{opened}}"
+      allow-custom-value="[[allowCustomValue]]"
+      on-change='_fireChanged'
+    >
       <paper-input autofocus="[[autofocus]]" label="[[label]]" class="input" value="[[value]]">
         <paper-icon-button slot="suffix" class="clear-button" icon="mdi:close" hidden\$="[[!value]]">Clear</paper-icon-button>
         <paper-icon-button slot="suffix" class="toggle-button" icon="[[_computeToggleIcon(opened)]]" hidden\$="[[!items.length]]">Toggle</paper-icon-button>
@@ -78,6 +88,10 @@ class HaComboBox extends PolymerElement {
 
   _computeItemLabel(item, itemLabelPath) {
     return itemLabelPath ? item[itemLabelPath] : item;
+  }
+
+  _fireChanged(ev) {
+    this.fire('change');
   }
 }
 


### PR DESCRIPTION
Looks like with the Polymer 3 migration, vaadin-combo-box change event no longer bubbles up the tree.

Fixes #1207