### PR TITLE
Try to use existing updateStyles for theming

### DIFF
--- a/src/common/dom/apply_themes_on_element.js
+++ b/src/common/dom/apply_themes_on_element.js
@@ -23,8 +23,10 @@ export default function applyThemesOnElement(element, themes, localTheme, update
       styles[prefixedKey] = theme[key];
     });
   }
-  // implement updateStyles() method of Polemer elements
-  if (window.ShadyCSS) {
+  if (element.updateStyles) {
+    element.updateStyles(styles);
+  } else if (window.ShadyCSS) {
+    // implement updateStyles() method of Polemer elements
     window.ShadyCSS.styleSubtree(/** @type {!HTMLElement} */(element), styles);
   }
 


### PR DESCRIPTION
Polymer elements have `updateStyles` function which is implemented as
```js
if (window.ShadyCSS) {
  // implement updateStyles() method of Polemer elements
  window.ShadyCSS.styleSubtree(/** @type {!HTMLElement} */(element), styles);
}
```

When there is no native shadowCSS support and the element is not a custom element - this implementation does nothing.

This PR tries to call `updateStyles` first, which might be another better polyfill.

Example polyfill:
```js
// Polyfill 'updateStyles'.
if (!container.updateStyles) {
  container.updateStyles = (styles) => {
    Object.keys(styles).forEach((key) => {
      container.style.setProperty(key, styles[key]);
    });
  };
}
```