### PR TITLE
Restore old Hass.io HTML build

### DIFF
--- a/hassio/index.html
+++ b/hassio/index.html
@@ -19,7 +19,7 @@
     function addScript(src) {
       var e = document.createElement('script');
       e.src = src;
-      document.head.appendChild(e);
+      document.write(e.outerHTML);
     }
     var webComponentsSupported = (
       'customElements' in window &&
@@ -29,6 +29,10 @@
       addScript('/static/webcomponents-bundle.js');
     }
     </script>
-    <script src="./app.js"></script>
+    <!--
+      Disabled while we make Home Assistant able to serve the right files.
+      <script src="./app.js"></script>
+    -->
+    <link rel='import' href='./hassio-app.html'>
   </body>
 </html>

--- a/hassio/script/build_hassio
+++ b/hassio/script/build_hassio
@@ -12,3 +12,11 @@ rm -rf $OUTPUT_DIR_ES5
 node script/gen-icons.js
 NODE_ENV=production ../node_modules/.bin/webpack -p
 node script/gen-index-html.js
+
+# Temporarily re-create old HTML import
+echo "<script>" > $OUTPUT_DIR_ES5/hassio-app.html
+cat $OUTPUT_DIR_ES5/app.js >> $OUTPUT_DIR_ES5/hassio-app.html
+cat $OUTPUT_DIR_ES5/chunk.*.js >> $OUTPUT_DIR_ES5/hassio-app.html
+echo "</script>" >> $OUTPUT_DIR_ES5/hassio-app.html
+rm $OUTPUT_DIR_ES5/app.js*
+rm $OUTPUT_DIR_ES5/chunk.*

--- a/hassio/webpack.config.js
+++ b/hassio/webpack.config.js
@@ -11,7 +11,7 @@ if (!version) {
 const VERSION = version[0];
 const isProdBuild = process.env.NODE_ENV === 'production'
 const chunkFilename = isProdBuild ?
-  '[name]-[chunkhash].chunk.js' : '[name].chunk.js';
+  'chunk.[chunkhash].js' : '[name].chunk.js';
 
 const plugins = [
   new webpack.DefinePlugin({
@@ -33,7 +33,9 @@ if (isProdBuild) {
 
 module.exports = {
   mode: isProdBuild ? 'production' : 'development',
-  devtool: isProdBuild ? 'source-map ' : 'inline-source-map',
+  // Disabled in prod while we make Home Assistant able to serve the right files.
+  // Was source-map
+  devtool: isProdBuild ? 'none' : 'inline-source-map',
   entry: {
     app: './src/hassio-app.js',
   },


### PR DESCRIPTION
This restores the exact same files as the Hass.io panel produced previously. This is necessary because Home Assistant has exactly only `index.html` and `hassio-app.html` whitelisted. 

This will change in 0.70 with https://github.com/home-assistant/home-assistant/pull/14655, but that's too late.

So for now we're going to package up the new files and be serving it as the old files.