### PR TITLE
Fix cover icons for closing & opening

### DIFF
--- a/src/common/entity/domain_icon.js
+++ b/src/common/entity/domain_icon.js
@@ -65,7 +65,7 @@ export default function domainIcon(domain, state) {
       return state && state === 'off' ? 'hass:radiobox-blank' : 'hass:checkbox-marked-circle';
 
     case 'cover':
-      return state && state === 'open' ? 'hass:window-open' : 'hass:window-closed';
+      return state && state === 'closed' ? 'hass:window-closed' : 'hass:window-open';
 
     case 'lock':
       return state && state === 'unlocked' ? 'hass:lock-open' : 'hass:lock';

--- a/src/common/entity/domain_icon.js
+++ b/src/common/entity/domain_icon.js
@@ -65,7 +65,7 @@ export default function domainIcon(domain, state) {
       return state && state === 'off' ? 'hass:radiobox-blank' : 'hass:checkbox-marked-circle';
 
     case 'cover':
-      return state && state === 'closed' ? 'hass:window-closed' : 'hass:window-open';
+      return state === 'closed' ? 'hass:window-closed' : 'hass:window-open';
 
     case 'lock':
       return state && state === 'unlocked' ? 'hass:lock-open' : 'hass:lock';


### PR DESCRIPTION
Covers also support `opening` and `closing` which currently result in the icon displaying a closed window, although it's still open.