### PR TITLE
ACP dialog: localization, new codeFormat

### DIFF
--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
@@ -74,15 +74,15 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
 
       <div class="layout horizontal center-justified actions">
         <template is="dom-if" if="[[_disarmVisible]]">
-          <paper-button raised class="disarm" on-click="_callService" data-service="alarm_disarm" disabled="[[_equal(_enteredCode, '')]]">
+          <paper-button raised class="disarm" on-click="_callService" data-service="alarm_disarm" disabled="[[!_validateCode(_enteredCode, _codeFormat)]]">
             [[localize('ui.card.alarm_control_panel.disarm')]]
           </paper-button>
         </template>
         <template is="dom-if" if="[[_armVisible]]">
-          <paper-button raised on-click="_callService" data-service="alarm_arm_home" disabled="[[_equal(_enteredCode, '')]]">
+          <paper-button raised on-click="_callService" data-service="alarm_arm_home" disabled="[[!_validateCode(_enteredCode, _codeFormat)]]">
             [[localize('ui.card.alarm_control_panel.arm_home')]]
           </paper-button>
-          <paper-button raised on-click="_callService" data-service="alarm_arm_away" disabled="[[_equal(_enteredCode, '')]]">
+          <paper-button raised on-click="_callService" data-service="alarm_arm_away" disabled="[[!_validateCode(_enteredCode, _codeFormat)]]">
             [[localize('ui.card.alarm_control_panel.arm_away')]]
           </paper-button>
         </template>
@@ -146,6 +146,10 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
 
   _equal(a, b) {
     return a === b;
+  }
+
+  _validateCode(code, format) {
+    return format === 'None' || code.length > 0;
   }
 
   _digitClicked(ev) {

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
@@ -64,7 +64,7 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
               <paper-button on-click='_digitClicked' disabled='[[!_inputEnabled]]' data-digit="3" raised>3</paper-button>
               <paper-button on-click='_digitClicked' disabled='[[!_inputEnabled]]' data-digit="6" raised>6</paper-button>
               <paper-button on-click='_digitClicked' disabled='[[!_inputEnabled]]' data-digit="9" raised>9</paper-button>
-              <paper-button on-click='_clear_enteredCode' disabled='[[!_inputEnabled]]' raised>
+              <paper-button on-click='_clearEnteredCode' disabled='[[!_inputEnabled]]' raised>
                 [[localize('ui.card.alarm_control_panel.clear_code')]]
               </paper-button>
             </div>
@@ -74,15 +74,15 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
 
       <div class="layout horizontal center-justified actions">
         <template is="dom-if" if="[[_disarmVisible]]">
-          <paper-button raised class="disarm" on-click="_callService" data-service="alarm_disarm" disabled="[[!_validateCode(_enteredCode, _codeFormat)]]">
+          <paper-button raised class="disarm" on-click="_callService" data-service="alarm_disarm" disabled="[[!_codeValid]]">
             [[localize('ui.card.alarm_control_panel.disarm')]]
           </paper-button>
         </template>
         <template is="dom-if" if="[[_armVisible]]">
-          <paper-button raised on-click="_callService" data-service="alarm_arm_home" disabled="[[!_validateCode(_enteredCode, _codeFormat)]]">
+          <paper-button raised on-click="_callService" data-service="alarm_arm_home" disabled="[[!_codeValid]]">
             [[localize('ui.card.alarm_control_panel.arm_home')]]
           </paper-button>
-          <paper-button raised on-click="_callService" data-service="alarm_arm_away" disabled="[[!_validateCode(_enteredCode, _codeFormat)]]">
+          <paper-button raised on-click="_callService" data-service="alarm_arm_away" disabled="[[!_codeValid)]]">
             [[localize('ui.card.alarm_control_panel.arm_away')]]
           </paper-button>
         </template>
@@ -95,27 +95,31 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
       hass: Object,
       stateObj: {
         type: Object,
-        observer: '_stateObjChanged',
+        observer: '_stateObjChanged'
       },
       _enteredCode: {
         type: String,
-        value: '',
+        value: ''
       },
       _codeFormat: {
         type: String,
-        value: '',
+        value: ''
+      },
+      _codeValid: {
+        type: Boolean,
+        computed: '_validateCode(_enteredCode, _codeFormat)'
       },
       _disarmVisible: {
         type: Boolean,
-        value: false,
+        value: false
       },
       _armVisible: {
         type: Boolean,
-        value: false,
+        value: false
       },
       _inputEnabled: {
         type: Boolean,
-        value: false,
+        value: false
       }
     };
   }
@@ -156,7 +160,7 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
     this._enteredCode += ev.target.getAttribute('data-digit');
   }
 
-  _clear_enteredCode() {
+  _clearEnteredCode() {
     this._enteredCode = '';
   }
 

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
@@ -38,7 +38,7 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
         }
       </style>
 
-      <template is="dom-if" if="[[!_equal(_codeFormat, 'None')]]">
+      <template is="dom-if" if="[[_codeFormat]]">
         <paper-input
           label="[[localize('ui.card.alarm_control_panel.code')]]"
           value="{{_enteredCode}}"
@@ -47,7 +47,7 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
           disabled="[[!_inputEnabled]]"
         ></paper-input>
 
-        <template is="dom-if" if="[[_equal(_codeFormat, 'Number')]]">
+        <template is="dom-if" if="[[_isNumber(_codeFormat)]]">
           <div class="pad">
             <div>
               <paper-button on-click='_digitClicked' disabled='[[!_inputEnabled]]' data-digit="1" raised>1</paper-button>
@@ -82,7 +82,7 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
           <paper-button raised on-click="_callService" data-service="alarm_arm_home" disabled="[[!_codeValid]]">
             [[localize('ui.card.alarm_control_panel.arm_home')]]
           </paper-button>
-          <paper-button raised on-click="_callService" data-service="alarm_arm_away" disabled="[[!_codeValid)]]">
+          <paper-button raised on-click="_callService" data-service="alarm_arm_away" disabled="[[!_codeValid]]">
             [[localize('ui.card.alarm_control_panel.arm_away')]]
           </paper-button>
         </template>
@@ -148,12 +148,12 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(EventsMixin(PolymerElement
     }
   }
 
-  _equal(a, b) {
-    return a === b;
+  _isNumber(format) {
+    return format === 'Number';
   }
 
   _validateCode(code, format) {
-    return format === 'None' || code.length > 0;
+    return !format || code.length > 0;
   }
 
   _digitClicked(ev) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -315,6 +315,13 @@
   },
   "ui": {
     "card": {
+      "alarm_control_panel": {
+        "code": "Code",
+        "clear_code": "Clear",
+        "disarm": "Disarm",
+        "arm_home": "Arm home",
+        "arm_away": "Arm away"
+      },
       "camera": {
         "not_available": "Image not available"
       },


### PR DESCRIPTION
-add localization
-codeFormat is now None, 'Any', 'Number' (main PR: https://github.com/home-assistant/home-assistant/pull/14686)
-action buttons are raised and have colors now
-code refactored
![acp](https://user-images.githubusercontent.com/11984118/40679980-f7131ebe-6384-11e8-9e1a-4e69af39f7ec.png)
