### PR TITLE
Add Template extension points

### DIFF
--- a/src/components/entity/state-info.js
+++ b/src/components/entity/state-info.js
@@ -8,6 +8,14 @@ import computeStateName from '../../common/entity/compute_state_name.js';
 class StateInfo extends PolymerElement {
   static get template() {
     return html`
+    ${this.styleTemplate}
+    ${this.stateBadgeTemplate}
+    ${this.infoTemplate}
+`;
+  }
+
+  static get styleTemplate() {
+    return html`
     <style>
     :host {
       @apply --paper-font-body1;
@@ -38,23 +46,31 @@ class StateInfo extends PolymerElement {
       color: var(--secondary-text-color);
     }
     </style>
+`;
+  }
 
-      <state-badge state-obj="[[stateObj]]"></state-badge>
+  static get stateBadgeTemplate() {
+    return html`
+    <state-badge state-obj="[[stateObj]]"></state-badge>
+`;
+  }
 
-      <div class="info">
-        <div class="name" in-dialog\$="[[inDialog]]">[[computeStateName(stateObj)]]</div>
+  static get infoTemplate() {
+    return html`
+    <div class="info">
+      <div class="name" in-dialog\$="[[inDialog]]">[[computeStateName(stateObj)]]</div>
 
-        <template is="dom-if" if="[[inDialog]]">
-          <div class="time-ago">
-            <ha-relative-time datetime="[[stateObj.last_changed]]"></ha-relative-time>
-          </div>
-        </template>
-        <template is="dom-if" if="[[!inDialog]]">
-          <div class="extra-info">
-            <slot>
-          </slot></div>
-        </template>
-      </div>
+      <template is="dom-if" if="[[inDialog]]">
+        <div class="time-ago">
+          <ha-relative-time datetime="[[stateObj.last_changed]]"></ha-relative-time>
+        </div>
+      </template>
+      <template is="dom-if" if="[[!inDialog]]">
+        <div class="extra-info">
+          <slot>
+        </slot></div>
+      </template>
+    </div>
 `;
   }
 

--- a/src/state-summary/state-card-climate.js
+++ b/src/state-summary/state-card-climate.js
@@ -22,9 +22,21 @@ class StateCardClimate extends PolymerElement {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
-      <ha-climate-state state-obj="[[stateObj]]"></ha-climate-state>
+      ${this.stateInfoTemplate}
+      ${this.haClimateStateTemplate}
     </div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+`;
+  }
+
+  static get haClimateStateTemplate() {
+    return html`
+    <ha-climate-state state-obj="[[stateObj]]"></ha-climate-state>
 `;
   }
 

--- a/src/state-summary/state-card-climate.js
+++ b/src/state-summary/state-card-climate.js
@@ -23,7 +23,7 @@ class StateCardClimate extends PolymerElement {
 
     <div class="horizontal justified layout">
       ${this.stateInfoTemplate}
-      ${this.haClimateStateTemplate}
+      <ha-climate-state state-obj="[[stateObj]]"></ha-climate-state>
     </div>
 `;
   }
@@ -31,12 +31,6 @@ class StateCardClimate extends PolymerElement {
   static get stateInfoTemplate() {
     return html`
     <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
-`;
-  }
-
-  static get haClimateStateTemplate() {
-    return html`
-    <ha-climate-state state-obj="[[stateObj]]"></ha-climate-state>
 `;
   }
 

--- a/src/state-summary/state-card-configurator.js
+++ b/src/state-summary/state-card-configurator.js
@@ -20,7 +20,7 @@ class StateCardConfigurator extends PolymerElement {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+      ${this.stateInfoTemplate}
       <paper-button hidden\$="[[inDialog]]">[[stateObj.state]]</paper-button>
     </div>
 
@@ -28,6 +28,12 @@ class StateCardConfigurator extends PolymerElement {
     <template is="dom-if" if="[[stateObj.attributes.description_image]]">
       <img hidden="" src="[[stateObj.attributes.description_image]]">
     </template>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
 `;
   }
 

--- a/src/state-summary/state-card-cover.js
+++ b/src/state-summary/state-card-cover.js
@@ -18,12 +18,30 @@ class StateCardCover extends PolymerElement {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+      ${this.stateInfoTemplate}
       <div class="horizontal layout">
-        <ha-cover-controls hidden\$="[[entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
-        <ha-cover-tilt-controls hidden\$="[[!entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
+        ${this.haCoverControlsTemplate}
+        ${this.haCoverTiltControlsTemplate}
       </div>
     </div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+`;
+  }
+
+  static get haCoverControlsTemplate() {
+    return html`
+    <ha-cover-controls hidden\$="[[entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
+`;
+  }
+
+  static get haCoverTiltControlsTemplate() {
+    return html`
+    <ha-cover-tilt-controls hidden\$="[[!entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
 `;
   }
 

--- a/src/state-summary/state-card-cover.js
+++ b/src/state-summary/state-card-cover.js
@@ -20,8 +20,8 @@ class StateCardCover extends PolymerElement {
     <div class="horizontal justified layout">
       ${this.stateInfoTemplate}
       <div class="horizontal layout">
-        ${this.haCoverControlsTemplate}
-        ${this.haCoverTiltControlsTemplate}
+        <ha-cover-controls hidden\$="[[entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
+        <ha-cover-tilt-controls hidden\$="[[!entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
       </div>
     </div>
 `;
@@ -30,18 +30,6 @@ class StateCardCover extends PolymerElement {
   static get stateInfoTemplate() {
     return html`
     <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
-`;
-  }
-
-  static get haCoverControlsTemplate() {
-    return html`
-    <ha-cover-controls hidden\$="[[entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-controls>
-`;
-  }
-
-  static get haCoverTiltControlsTemplate() {
-    return html`
-    <ha-cover-tilt-controls hidden\$="[[!entityObj.isTiltOnly]]" hass="[[hass]]" state-obj="[[stateObj]]"></ha-cover-tilt-controls>
 `;
   }
 

--- a/src/state-summary/state-card-display.js
+++ b/src/state-summary/state-card-display.js
@@ -39,8 +39,14 @@ class StateCardDisplay extends LocalizeMixin(PolymerElement) {
       }
     </style>
 
-    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+    ${this.stateInfoTemplate}
     <div class\$="[[computeClassNames(stateObj)]]">[[computeStateDisplay(localize, stateObj, language)]]</div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
 `;
   }
 

--- a/src/state-summary/state-card-input_number.js
+++ b/src/state-summary/state-card-input_number.js
@@ -38,14 +38,20 @@ class StateCardInputNumber extends mixinBehaviors([
     </style>
 
     <div class="horizontal justified layout" id="input_number_card">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
-        <paper-slider min="[[min]]" max="[[max]]" value="{{value}}" step="[[step]]" hidden="[[hiddenslider]]" pin="" on-change="selectedValueChanged" on-click="stopPropagation" id="slider" ignore-bar-touch="">
-        </paper-slider>
+      ${this.stateInfoTemplate}
+      <paper-slider min="[[min]]" max="[[max]]" value="{{value}}" step="[[step]]" hidden="[[hiddenslider]]" pin="" on-change="selectedValueChanged" on-click="stopPropagation" id="slider" ignore-bar-touch="">
+      </paper-slider>
       <paper-input no-label-float="" auto-validate="" pattern="[0-9]+([\\.][0-9]+)?" step="[[step]]" min="[[min]]" max="[[max]]" value="{{value}}" type="number" on-change="selectedValueChanged" on-click="stopPropagation" hidden="[[hiddenbox]]">
       </paper-input>
       <div class="state" hidden="[[hiddenbox]]">[[stateObj.attributes.unit_of_measurement]]</div>
       <div id="sliderstate" class="state sliderstate" hidden="[[hiddenslider]]">[[value]] [[stateObj.attributes.unit_of_measurement]]</div>
     </div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
 `;
   }
 

--- a/src/state-summary/state-card-input_select.js
+++ b/src/state-summary/state-card-input_select.js
@@ -31,7 +31,7 @@ class StateCardInputSelect extends PolymerElement {
       }
     </style>
 
-    <state-badge state-obj="[[stateObj]]"></state-badge>
+    ${this.stateBadgeTemplate}
     <paper-dropdown-menu on-click="stopPropagation" selected-item-label="{{selectedOption}}" label="[[_computeStateName(stateObj)]]">
       <paper-listbox slot="dropdown-content" selected="[[computeSelected(stateObj)]]">
         <template is="dom-repeat" items="[[stateObj.attributes.options]]">
@@ -39,6 +39,12 @@ class StateCardInputSelect extends PolymerElement {
         </template>
       </paper-listbox>
     </paper-dropdown-menu>
+`;
+  }
+
+  static get stateBadgeTemplate() {
+    return html`
+    <state-badge state-obj="[[stateObj]]"></state-badge>
 `;
   }
 

--- a/src/state-summary/state-card-input_text.js
+++ b/src/state-summary/state-card-input_text.js
@@ -16,12 +16,19 @@ class StateCardInputText extends PolymerElement {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+      ${this.stateInfoTemplate}
       <paper-input no-label-float="" minlength="[[stateObj.attributes.min]]" maxlength="[[stateObj.attributes.max]]" value="{{value}}" auto-validate="[[stateObj.attributes.pattern]]" pattern="[[stateObj.attributes.pattern]]" type="[[stateObj.attributes.mode]]" on-change="selectedValueChanged" on-click="stopPropagation" placeholder="(empty value)">
       </paper-input>
     </div>
 `;
   }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+`;
+  }
+
 
   static get properties() {
     return {

--- a/src/state-summary/state-card-media_player.js
+++ b/src/state-summary/state-card-media_player.js
@@ -42,12 +42,18 @@ class StateCardMediaPlayer extends LocalizeMixin(PolymerElement) {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+      ${this.stateInfoTemplate}
       <div class="state">
         <div class="main-text" take-height\$="[[!playerObj.secondaryTitle]]">[[computePrimaryText(localize, playerObj)]]</div>
         <div class="secondary-text">[[playerObj.secondaryTitle]]</div>
       </div>
     </div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
 `;
   }
 

--- a/src/state-summary/state-card-scene.js
+++ b/src/state-summary/state-card-scene.js
@@ -24,9 +24,15 @@ class StateCardScene extends LocalizeMixin(PolymerElement) {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+      ${this.stateInfoTemplate}
       <paper-button on-click="activateScene">[[localize('ui.card.scene.activate')]]</paper-button>
     </div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
 `;
   }
 

--- a/src/state-summary/state-card-script.js
+++ b/src/state-summary/state-card-script.js
@@ -30,7 +30,7 @@ class StateCardScript extends LocalizeMixin(PolymerElement) {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+      ${this.stateInfoTemplate}
       <template is="dom-if" if="[[stateObj.attributes.can_cancel]]">
         <ha-entity-toggle state-obj="[[stateObj]]" hass="[[hass]]"></ha-entity-toggle>
       </template>
@@ -38,6 +38,12 @@ class StateCardScript extends LocalizeMixin(PolymerElement) {
         <paper-button on-click="fireScript">[[localize('ui.card.script.execute')]]</paper-button>
       </template>
     </div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
 `;
   }
 

--- a/src/state-summary/state-card-timer.js
+++ b/src/state-summary/state-card-timer.js
@@ -28,9 +28,15 @@ class StateCardTimer extends LocalizeMixin(PolymerElement) {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+      ${this.stateInfoTemplate}
       <div class="state">[[_secondsToDuration(timeRemaining)]]</div>
     </div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
 `;
   }
 

--- a/src/state-summary/state-card-toggle.js
+++ b/src/state-summary/state-card-toggle.js
@@ -17,9 +17,15 @@ class StateCardToggle extends PolymerElement {
     </style>
 
     <div class="horizontal justified layout">
-      <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
+      ${this.stateInfoTemplate}
       <ha-entity-toggle state-obj="[[stateObj]]" hass="[[hass]]"></ha-entity-toggle>
     </div>
+`;
+  }
+
+  static get stateInfoTemplate() {
+    return html`
+    <state-info state-obj="[[stateObj]]" in-dialog="[[inDialog]]"></state-info>
 `;
   }
 

--- a/src/state-summary/state-card-weblink.js
+++ b/src/state-summary/state-card-weblink.js
@@ -23,8 +23,14 @@ class StateCardWeblink extends PolymerElement {
       }
     </style>
 
-    <state-badge state-obj="[[stateObj]]"></state-badge>
+    ${this.stateBadgeTemplate}
     <a href\$="[[stateObj.state]]" target="_blank" class="name" id="link">[[_computeStateName(stateObj)]]</a>
+`;
+  }
+
+  static get stateBadgeTemplate() {
+    return html`
+    <state-badge state-obj="[[stateObj]]"></state-badge>
 `;
   }
 


### PR DESCRIPTION
Polymer allows the use of sub templates as extension of the main one: [Polymer dev docs](https://www.polymer-project.org/3.0/docs/devguide/dom-template#insertcontent). The advantage in using those would be that smaller changes in `custom_components` would be a bit simpler, since it would only be required to override a subtemplate whereas the rest stays the same.

Especially useful for changes to `state-info`, regarding only one domain.

My idea was to add them for all `state-cards` first and continue only as needed with the files in the `components` directory.

If that's something we what to implement, we should have a brief discussion about the extend to which I'm going to use it.

CC: @balloob 