### PR TITLE
RFC: Remove 'history not found'

### DIFF
--- a/src/components/state-history-charts.js
+++ b/src/components/state-history-charts.js
@@ -13,21 +13,16 @@ class StateHistoryCharts extends LocalizeMixin(PolymerElement) {
     <style>
     :host {
       display: block;
-      /* height of single timeline chart = 58px */
-      min-height: 58px;
     }
     .info {
       text-align: center;
-      line-height: 58px;
+      /* height of single timeline chart = 55px */
+      line-height: 55px;
       color: var(--secondary-text-color);
     }
     </style>
     <template is="dom-if" class="info" if="[[_computeIsLoading(isLoadingData)]]">
       <div class="info">[[localize('ui.components.history_charts.loading_history')]]</div>
-    </template>
-
-    <template is="dom-if" class="info" if="[[_computeIsEmpty(isLoadingData, historyData)]]">
-      <div class="info">[[localize('ui.components.history_charts.no_history_found')]]</div>
     </template>
 
     <template is="dom-if" if="[[historyData.timeline.length]]">
@@ -63,13 +58,6 @@ class StateHistoryCharts extends LocalizeMixin(PolymerElement) {
 
   _computeIsSingleLineChart(data, noSingle) {
     return !noSingle && data && data.length === 1;
-  }
-
-  _computeIsEmpty(isLoadingData, historyData) {
-    const historyDataEmpty = (!historyData || !historyData.timeline || !historyData.line ||
-                              (historyData.timeline.length === 0 &&
-                              historyData.line.length === 0));
-    return !isLoadingData && historyDataEmpty;
   }
 
   _computeIsLoading(isLoading) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -417,8 +417,7 @@
         "never": "Never"
       },
       "history_charts": {
-        "loading_history": "Loading state history...",
-        "no_history_found": "No state history found."
+        "loading_history": "Loading state history..."
       },
       "service-picker": {
         "service": "Service"


### PR DESCRIPTION
I would suggest removing the message `No state history found.` from the `more-info` dialogs. As I see it the most common case for this message is that the entity (or domain) has been excluded in the `recorder`. If users have chosen to do so, it would thus only be logical to hide the warning. We already hide it if the `history` component is disabled.

Example config
```yaml
cover:
  - platform: demo
recorder:
  exclude:
    domains:
      - cover
history:
```
![with message](https://user-images.githubusercontent.com/30130371/40890778-b0940e9e-677b-11e8-85d1-ffb6b8f7fed3.JPG)


With history disabled:

![history_disabled](https://user-images.githubusercontent.com/30130371/40890792-f121ae94-677b-11e8-82b8-ff08732fe84b.JPG)


