### PR TITLE
Preact: Import components in pages that need them

### DIFF
--- a/src/panels/config/automation/ha-automation-editor.js
+++ b/src/panels/config/automation/ha-automation-editor.js
@@ -1,29 +1,13 @@
 import '@polymer/app-layout/app-header/app-header.js';
 import '@polymer/app-layout/app-toolbar/app-toolbar.js';
-import '@polymer/iron-autogrow-textarea/iron-autogrow-textarea.js';
-import '@polymer/paper-card/paper-card.js';
-import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light.js';
-import '@polymer/paper-fab/paper-fab.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
-import '@polymer/paper-input/paper-input.js';
-import '@polymer/paper-input/paper-textarea.js';
-import '@polymer/paper-item/paper-item-body.js';
-import '@polymer/paper-item/paper-item.js';
-import '@polymer/paper-listbox/paper-listbox.js';
-import '@polymer/paper-menu-button/paper-menu-button.js';
-import '@polymer/paper-radio-button/paper-radio-button.js';
-import '@polymer/paper-radio-group/paper-radio-group.js';
+import '@polymer/paper-fab/paper-fab.js';
+
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { h, render } from 'preact';
 
-import '../../../components/entity/ha-entity-picker.js';
-import '../../../components/ha-combo-box.js';
-import '../../../components/ha-markdown.js';
-import '../../../components/ha-service-picker.js';
 import '../../../layouts/ha-app-layout.js';
-
-import '../ha-config-section.js';
 
 import Automation from '../js/automation.js';
 import unmountPreact from '../../../common/preact/unmount.js';

--- a/src/panels/config/js/automation.js
+++ b/src/panels/config/js/automation.js
@@ -1,5 +1,10 @@
 import { h, Component } from 'preact';
 
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-input/paper-input.js';
+import '../ha-config-section.js';
+import '../../../components/ha-markdown.js';
+
 import Trigger from './trigger/index.js';
 import Condition from './condition/index.js';
 import Script from './script/index.js';

--- a/src/panels/config/js/condition/condition_edit.js
+++ b/src/panels/config/js/condition/condition_edit.js
@@ -1,4 +1,7 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light.js';
+import '@polymer/paper-listbox/paper-listbox.js';
+import '@polymer/paper-item/paper-item.js';
 
 import NumericStateCondition from './numeric_state.js';
 import StateCondition from './state.js';

--- a/src/panels/config/js/condition/condition_row.js
+++ b/src/panels/config/js/condition/condition_row.js
@@ -1,4 +1,9 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-menu-button/paper-menu-button.js';
+import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/paper-listbox/paper-listbox.js';
+import '@polymer/paper-item/paper-item.js';
 
 import ConditionEdit from './condition_edit.js';
 

--- a/src/panels/config/js/condition/index.js
+++ b/src/panels/config/js/condition/index.js
@@ -1,4 +1,6 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
 
 import ConditionRow from './condition_row.js';
 

--- a/src/panels/config/js/condition/numeric_state.js
+++ b/src/panels/config/js/condition/numeric_state.js
@@ -1,4 +1,7 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
+import '@polymer/paper-input/paper-textarea.js';
+import '../../../../components/entity/ha-entity-picker.js';
 
 import { onChangeEvent } from '../../../../common/preact/event.js';
 

--- a/src/panels/config/js/condition/state.js
+++ b/src/panels/config/js/condition/state.js
@@ -1,4 +1,6 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
+import '../../../../components/entity/ha-entity-picker.js';
 
 import { onChangeEvent } from '../../../../common/preact/event.js';
 

--- a/src/panels/config/js/condition/sun.js
+++ b/src/panels/config/js/condition/sun.js
@@ -1,4 +1,7 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
+import '@polymer/paper-radio-button/paper-radio-button.js';
+import '@polymer/paper-radio-group/paper-radio-group.js';
 
 import { onChangeEvent } from '../../../../common/preact/event.js';
 

--- a/src/panels/config/js/condition/template.js
+++ b/src/panels/config/js/condition/template.js
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-textarea.js';
 
 import { onChangeEvent } from '../../../../common/preact/event.js';
 

--- a/src/panels/config/js/condition/time.js
+++ b/src/panels/config/js/condition/time.js
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
 
 import { onChangeEvent } from '../../../../common/preact/event.js';
 

--- a/src/panels/config/js/condition/zone.js
+++ b/src/panels/config/js/condition/zone.js
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact';
-
+import '../../../../components/entity/ha-entity-picker.js';
 import { onChangeEvent } from '../../../../common/preact/event.js';
 import hasLocation from '../../../../common/entity/has_location.js';
 import computeStateDomain from '../../../../common/entity/compute_state_domain.js';

--- a/src/panels/config/js/json_textarea.js
+++ b/src/panels/config/js/json_textarea.js
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-textarea.js';
 
 
 export default class JSONTextArea extends Component {

--- a/src/panels/config/js/script.js
+++ b/src/panels/config/js/script.js
@@ -1,5 +1,9 @@
 import { h, Component } from 'preact';
 
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-input/paper-input.js';
+import '../ha-config-section.js';
+
 import Script from './script/index.js';
 
 export default class ScriptEditor extends Component {

--- a/src/panels/config/js/script/action_edit.js
+++ b/src/panels/config/js/script/action_edit.js
@@ -1,4 +1,7 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light.js';
+import '@polymer/paper-listbox/paper-listbox.js';
+import '@polymer/paper-item/paper-item.js';
 
 import CallServiceAction from './call_service.js';
 import ConditionAction from './condition.js';

--- a/src/panels/config/js/script/action_row.js
+++ b/src/panels/config/js/script/action_row.js
@@ -1,4 +1,9 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-menu-button/paper-menu-button.js';
+import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/paper-item/paper-item.js';
+import '@polymer/paper-listbox/paper-listbox.js';
 
 import ActionEdit from './action_edit.js';
 

--- a/src/panels/config/js/script/call_service.js
+++ b/src/panels/config/js/script/call_service.js
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import '../../../../components/ha-service-picker.js';
 
 import JSONTextArea from '../json_textarea.js';
 

--- a/src/panels/config/js/script/delay.js
+++ b/src/panels/config/js/script/delay.js
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
 import { onChangeEvent } from '../../../../common/preact/event.js';
 
 export default class DelayAction extends Component {

--- a/src/panels/config/js/script/event.js
+++ b/src/panels/config/js/script/event.js
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
 
 import JSONTextArea from '../json_textarea.js';
 import { onChangeEvent } from '../../../../common/preact/event.js';

--- a/src/panels/config/js/script/index.js
+++ b/src/panels/config/js/script/index.js
@@ -1,4 +1,6 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
 
 import ActionRow from './action_row.js';
 

--- a/src/panels/config/js/script/wait.js
+++ b/src/panels/config/js/script/wait.js
@@ -1,4 +1,7 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
+import '@polymer/paper-input/paper-textarea.js';
+
 import { onChangeEvent } from '../../../../common/preact/event.js';
 
 export default class WaitAction extends Component {

--- a/src/panels/config/js/trigger/event.js
+++ b/src/panels/config/js/trigger/event.js
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
 
 import JSONTextArea from '../json_textarea.js';
 import { onChangeEvent } from '../../../../common/preact/event.js';

--- a/src/panels/config/js/trigger/homeassistant.js
+++ b/src/panels/config/js/trigger/homeassistant.js
@@ -1,4 +1,6 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-radio-button/paper-radio-button.js';
+import '@polymer/paper-radio-group/paper-radio-group.js';
 
 export default class HassTrigger extends Component {
   constructor() {

--- a/src/panels/config/js/trigger/index.js
+++ b/src/panels/config/js/trigger/index.js
@@ -1,4 +1,6 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-button/paper-button.js';
 
 import TriggerRow from './trigger_row.js';
 import StateTrigger from './state.js';

--- a/src/panels/config/js/trigger/mqtt.js
+++ b/src/panels/config/js/trigger/mqtt.js
@@ -1,4 +1,5 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
 
 import { onChangeEvent } from '../../../../common/preact/event.js';
 

--- a/src/panels/config/js/trigger/numeric_state.js
+++ b/src/panels/config/js/trigger/numeric_state.js
@@ -1,4 +1,8 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-input/paper-input.js';
+import '@polymer/paper-input/paper-textarea.js';
+
+import '../../../../components/entity/ha-entity-picker.js';
 
 import { onChangeEvent } from '../../../../common/preact/event.js';
 

--- a/src/panels/config/js/trigger/state.js
+++ b/src/panels/config/js/trigger/state.js
@@ -1,5 +1,8 @@
 import { h, Component } from 'preact';
 
+import '@polymer/paper-input/paper-input.js';
+import '../../../../components/entity/ha-entity-picker.js';
+
 import { onChangeEvent } from '../../../../common/preact/event.js';
 
 export default class StateTrigger extends Component {

--- a/src/panels/config/js/trigger/sun.js
+++ b/src/panels/config/js/trigger/sun.js
@@ -1,5 +1,9 @@
 import { h, Component } from 'preact';
 
+import '@polymer/paper-input/paper-input.js';
+import '@polymer/paper-radio-button/paper-radio-button.js';
+import '@polymer/paper-radio-group/paper-radio-group.js';
+
 import { onChangeEvent } from '../../../../common/preact/event.js';
 
 export default class SunTrigger extends Component {

--- a/src/panels/config/js/trigger/template.js
+++ b/src/panels/config/js/trigger/template.js
@@ -1,5 +1,7 @@
 import { h, Component } from 'preact';
 
+import '@polymer/paper-input/paper-textarea.js';
+
 import { onChangeEvent } from '../../../../common/preact/event.js';
 
 export default class TemplateTrigger extends Component {

--- a/src/panels/config/js/trigger/time.js
+++ b/src/panels/config/js/trigger/time.js
@@ -1,5 +1,7 @@
 import { h, Component } from 'preact';
 
+import '@polymer/paper-input/paper-input.js';
+
 import { onChangeEvent } from '../../../../common/preact/event.js';
 
 export default class TimeTrigger extends Component {

--- a/src/panels/config/js/trigger/trigger_edit.js
+++ b/src/panels/config/js/trigger/trigger_edit.js
@@ -1,5 +1,9 @@
 import { h, Component } from 'preact';
 
+import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light.js';
+import '@polymer/paper-item/paper-item.js';
+import '@polymer/paper-listbox/paper-listbox.js';
+
 import EventTrigger from './event.js';
 import HassTrigger from './homeassistant.js';
 import MQTTTrigger from './mqtt.js';

--- a/src/panels/config/js/trigger/trigger_row.js
+++ b/src/panels/config/js/trigger/trigger_row.js
@@ -1,4 +1,9 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-menu-button/paper-menu-button.js';
+import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/paper-item/paper-item.js';
+import '@polymer/paper-listbox/paper-listbox.js';
 
 import TriggerEdit from './trigger_edit.js';
 

--- a/src/panels/config/js/trigger/zone.js
+++ b/src/panels/config/js/trigger/zone.js
@@ -1,4 +1,7 @@
 import { h, Component } from 'preact';
+import '@polymer/paper-radio-button/paper-radio-button.js';
+import '@polymer/paper-radio-group/paper-radio-group.js';
+import '../../../../components/entity/ha-entity-picker.js';
 
 import { onChangeEvent } from '../../../../common/preact/event.js';
 import hasLocation from '../../../../common/entity/has_location.js';

--- a/src/panels/config/script/ha-script-editor.js
+++ b/src/panels/config/script/ha-script-editor.js
@@ -1,27 +1,13 @@
 import '@polymer/app-layout/app-header/app-header.js';
 import '@polymer/app-layout/app-toolbar/app-toolbar.js';
-import '@polymer/iron-autogrow-textarea/iron-autogrow-textarea.js';
-import '@polymer/paper-card/paper-card.js';
-import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light.js';
-import '@polymer/paper-fab/paper-fab.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
-import '@polymer/paper-input/paper-input.js';
-import '@polymer/paper-input/paper-textarea.js';
-import '@polymer/paper-item/paper-item-body.js';
-import '@polymer/paper-item/paper-item.js';
-import '@polymer/paper-listbox/paper-listbox.js';
-import '@polymer/paper-menu-button/paper-menu-button.js';
-import '@polymer/paper-radio-button/paper-radio-button.js';
-import '@polymer/paper-radio-group/paper-radio-group.js';
+import '@polymer/paper-fab/paper-fab.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { h, render } from 'preact';
 
-import '../../../components/entity/ha-entity-picker.js';
-import '../../../components/ha-combo-box.js';
 import '../../../layouts/ha-app-layout.js';
 
-import '../ha-config-section.js';
 import Script from '../js/script.js';
 import unmountPreact from '../../../common/preact/unmount.js';
 


### PR DESCRIPTION
Pre-webpack days, the web components were imported from the HTML page that mounted the compiled preact component. Now it's all in 1 file, and we can put the actual imports in the Preact component files that use them.