### PR TITLE
Use websocket to fetch themes and translations

### DIFF
--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -123,11 +123,16 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
     if (!this.hass.language) return;
 
     const language = this.hass.selectedLanguage || this.hass.language;
-    this.hass.callApi('get', `translations/${language}`).then((result) => {
+
+    this.hass.connection.sendMessagePromise({
+      type: 'frontend/get_translations',
+      language,
+    })
+    .then((resp) => {
       // If we've switched selected languages just ignore this response
       if ((this.hass.selectedLanguage || this.hass.language) !== language) return;
 
-      this._updateResources(language, result.resources);
+      this._updateResources(language, resp.result.resources);
     });
   }
 
@@ -272,15 +277,19 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
 
     var unsubThemes;
 
-    this.hass.callApi('get', 'themes').then((themes) => {
-      this._updateHass({ themes: themes });
+
+    this.hass.connection.sendMessagePromise({
+      type: 'frontend/get_themes',
+    }).then((resp) => {
+      this._updateHass({ themes: resp['result'] });
       applyThemesOnElement(
         document.documentElement,
-        themes,
+        resp.result,
         this.hass.selectedTheme,
         true
       );
     });
+
     conn.subscribeEvents((event) => {
       this._updateHass({ themes: event.data });
       applyThemesOnElement(

--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -128,12 +128,12 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
       type: 'frontend/get_translations',
       language,
     })
-    .then((resp) => {
+      .then((resp) => {
       // If we've switched selected languages just ignore this response
-      if ((this.hass.selectedLanguage || this.hass.language) !== language) return;
+        if ((this.hass.selectedLanguage || this.hass.language) !== language) return;
 
-      this._updateResources(language, resp.result.resources);
-    });
+        this._updateResources(language, resp.result.resources);
+      });
   }
 
   _updateResources(language, data) {
@@ -281,7 +281,7 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
     this.hass.connection.sendMessagePromise({
       type: 'frontend/get_themes',
     }).then((resp) => {
-      this._updateHass({ themes: resp['result'] });
+      this._updateHass({ themes: resp.result });
       applyThemesOnElement(
         document.documentElement,
         resp.result,


### PR DESCRIPTION
Move themes and translations frontend APIs from being over HTTP to be over the websocket connection.

Backend PR: https://github.com/home-assistant/home-assistant/pull/14828