### PR TITLE
Use websocket for entity registry update

### DIFF
--- a/src/dialogs/ha-more-info-dialog.js
+++ b/src/dialogs/ha-more-info-dialog.js
@@ -145,9 +145,9 @@ class HaMoreInfoDialog extends DialogMixin(PolymerElement) {
         type: 'config/entity_registry/get',
         entity_id: newVal.entity_id,
       }).then(
-          (msg) => { this._registryInfo = msg.result; },
-          () => { this._registryInfo = false; }
-        );
+        (msg) => { this._registryInfo = msg.result; },
+        () => { this._registryInfo = false; }
+      );
     }
 
     requestAnimationFrame(() => requestAnimationFrame(() => {

--- a/src/dialogs/ha-more-info-dialog.js
+++ b/src/dialogs/ha-more-info-dialog.js
@@ -141,9 +141,11 @@ class HaMoreInfoDialog extends DialogMixin(PolymerElement) {
 
     if (isComponentLoaded(this.hass, 'config.entity_registry') &&
         (!oldVal || oldVal.entity_id !== newVal.entity_id)) {
-      this.hass.callApi('get', `config/entity_registry/${newVal.entity_id}`)
-        .then(
-          (info) => { this._registryInfo = info; },
+      this.hass.connection.sendMessagePromise({
+        type: 'config/entity_registry/get',
+        entity_id: newVal.entity_id,
+      }).then(
+          (msg) => { this._registryInfo = msg.result; },
           () => { this._registryInfo = false; }
         );
     }

--- a/src/dialogs/more-info/more-info-settings.js
+++ b/src/dialogs/more-info/more-info-settings.js
@@ -93,13 +93,12 @@ class MoreInfoSettings extends EventsMixin(PolymerElement) {
   }
 
   _save() {
-    const data = {
+    this.hass.connection.sendMessagePromise({
+      type: 'config/entity_registry/update',
+      entity_id: this.stateObj.entity_id,
       name: this._name,
-    };
-
-    this.hass.callApi('post', `config/entity_registry/${this.stateObj.entity_id}`, data)
-      .then(
-        (info) => { this.registryInfo = info; },
+    }).then(
+        (msg) => { this.registryInfo = msg.result; },
         () => { alert('save failed!'); }
       );
   }

--- a/src/dialogs/more-info/more-info-settings.js
+++ b/src/dialogs/more-info/more-info-settings.js
@@ -98,9 +98,9 @@ class MoreInfoSettings extends EventsMixin(PolymerElement) {
       entity_id: this.stateObj.entity_id,
       name: this._name,
     }).then(
-        (msg) => { this.registryInfo = msg.result; },
-        () => { alert('save failed!'); }
-      );
+      (msg) => { this.registryInfo = msg.result; },
+      () => { alert('save failed!'); }
+    );
   }
 }
 customElements.define('more-info-settings', MoreInfoSettings);


### PR DESCRIPTION
Move entity registry API from HTTP to WebSocket.

Backend PR: https://github.com/home-assistant/home-assistant/pull/14830