### PR TITLE
Don't rely on get panels from websocket package

### DIFF
--- a/src/components/ha-sidebar.js
+++ b/src/components/ha-sidebar.js
@@ -171,7 +171,7 @@ class HaSidebar extends
   }
 
   computePanels(hass) {
-    var panels = hass.config.panels;
+    var panels = hass.panels;
     var sortValue = {
       map: 1,
       logbook: 2,

--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -104,7 +104,7 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
   }
 
   computeShowMain(hass) {
-    return hass && hass.states && hass.config;
+    return hass && hass.states && hass.config && hass.panels;
   }
 
   computeShowLoading(connectionPromise, hass) {
@@ -171,6 +171,7 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
       states: null,
       config: null,
       themes: null,
+      panels: null,
       panelUrl: this.panelUrl,
 
       language: getActiveTranslation(),
@@ -235,6 +236,7 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
     var reconnected = () => {
       this._updateHass({ connected: true });
       this.loadBackendTranslations();
+      this._loadPanels();
     };
 
     const disconnected = () => {
@@ -269,6 +271,8 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
     }).then(function (unsub) {
       unsubConfig = unsub;
     });
+
+    this._loadPanels();
 
     var unsubThemes;
 
@@ -369,6 +373,13 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
       this.loadResources(panelUrl);
     }
   }
+
+  _loadPanels() {
+    this.connection.sendMessagePromise({
+      type: 'get_panels'
+    }).then(msg => this._updateHass({ panels: msg.result }));
+  }
+
 
   _updateHass(obj) {
     this.hass = Object.assign({}, this.hass, obj);

--- a/src/layouts/partial-panel-resolver.js
+++ b/src/layouts/partial-panel-resolver.js
@@ -217,7 +217,7 @@ class PartialPanelResolver extends NavigateMixin(PolymerElement) {
   }
 
   computeCurrentPanel(hass) {
-    return hass.config.panels[hass.panelUrl];
+    return hass.panels[hass.panelUrl];
   }
 }
 


### PR DESCRIPTION
The "get_panels" websocket command is not part of the core websocket API but part of the frontend. So I am removing it from `home-assistant-js-websocket` and it should live inside the polymer branch.