### PR TITLE
Better configure Carto Basemaps

### DIFF
--- a/src/panels/map/ha-panel-map.js
+++ b/src/panels/map/ha-panel-map.js
@@ -64,10 +64,12 @@ class HaPanelMap extends LocalizeMixin(PolymerElement) {
     this.$.map.parentNode.appendChild(style);
     map.setView([51.505, -0.09], 13);
     Leaflet.tileLayer(
-      'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+      `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}${Leaflet.Browser.retina ? '@2x.png' : '.png'}`,
       {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attributions">CARTO</a>',
-        maxZoom: 18,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>',
+        subdomains: 'abcd',
+        minZoom: 0,
+        maxZoom: 20,
       }
     ).addTo(map);
 


### PR DESCRIPTION
PR #1265 by @jaakla included a link to the [docs of the CARTO Basemaps](https://github.com/CartoDB/basemap-styles#1-web-raster-basemaps) with a nice LeafletJS example. I realized that we could (a) offer more zoom and (b) retina tiles. So this PR enables that.