### PR TITLE
Add es5 adapter to es5 panel

### DIFF
--- a/src/entrypoints/custom-panel.js
+++ b/src/entrypoints/custom-panel.js
@@ -25,6 +25,10 @@ function setProperties(properties) {
 }
 
 function initialize(panel, properties) {
+  const style = document.createElement('style');
+  style.innerHTML = 'body{margin:0}';
+  document.head.appendChild(style);
+
   const config = panel.config._panel_custom;
   let start = Promise.resolve();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,10 @@ function createConfig(isProdBuild, latestBuild) {
     ],
   };
 
-  const copyPluginOpts = [];
+  const copyPluginOpts = [
+    // Leave here until Hass.io no longer references the ES5 build.
+    'node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js'
+  ];
 
   const plugins = [
     new webpack.DefinePlugin({
@@ -69,7 +72,6 @@ function createConfig(isProdBuild, latestBuild) {
     copyPluginOpts.push('node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js.map')
     copyPluginOpts.push({ from: 'node_modules/leaflet/dist/leaflet.css', to: `images/leaflet/` });
     copyPluginOpts.push({ from: 'node_modules/leaflet/dist/images', to: `images/leaflet/` });
-    copyPluginOpts.push('node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js');
     entry['hass-icons'] = './src/entrypoints/hass-icons.js';
     entry['service-worker-hass'] = './src/entrypoints/service-worker-hass.js';
   } else {


### PR DESCRIPTION
I removed the es5 custom elements adapter from the ES5 frontend build. However, the Hass.io supervisor still references it. This adds it back.

Hotfix to fix beta 0.71