### PR TITLE
Point es5 adapter to frontend-es5

### DIFF
--- a/hassio/script/gen-index-html.js
+++ b/hassio/script/gen-index-html.js
@@ -7,7 +7,7 @@ let index = fs.readFileSync('index.html', 'utf-8');
 const toReplace = [
   [
     '<!--EXTRA_SCRIPTS-->',
-    "<script src='/static/custom-elements-es5-adapter.js'></script>"
+    "<script src='/frontend_es5/custom-elements-es5-adapter.js'></script>"
   ],
 ];
 


### PR DESCRIPTION
Make Hass.io panel work with <= Home Assistant 0.70 builds.