### PR TITLE
Allow placeholders for config flow description

### DIFF
--- a/src/panels/config/config-entries/ha-config-flow.js
+++ b/src/panels/config/config-entries/ha-config-flow.js
@@ -49,7 +49,7 @@ class HaConfigFlow extends
         </template>
         <template is="dom-if" if="[[step]]">
           <template is="dom-if" if="[[_equals(step.type, &quot;abort&quot;)]]">
-            <p>[[_computeStepAbortedReason(localize, step)]]</p>
+            <ha-markdown content="[[_computeStepAbortedReason(localize, step)]]"></ha-markdown>
           </template>
 
           <template is="dom-if" if="[[_equals(step.type, &quot;create_entry&quot;)]]">
@@ -178,7 +178,13 @@ class HaConfigFlow extends
   }
 
   _computeStepDescription(localize, step) {
-    return localize(`component.${step.handler}.config.step.${step.step_id}.description`);
+    const args = [`component.${step.handler}.config.step.${step.step_id}.description`];
+    const placeholders = step.description_placeholders || {};
+    Object.keys(placeholders).forEach((key) => {
+      args.push(key);
+      args.push(placeholders[key]);
+    });
+    return localize(...args);
   }
 
   _computeLabelCallback(localize, step) {


### PR DESCRIPTION
Config flows:

 - Render abort in markdown so we can link to the docs if applicable.
 - Allow for placeholders to be passed for localizing the description. This way we can include a dynamic url.