### PR TITLE
General sound mode support

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -16,275 +16,325 @@ import isComponentLoaded from '../../../common/config/is_component_loaded.js';
 import EventsMixin from '../../../mixins/events-mixin.js';
 import LocalizeMixin from '../../../mixins/localize-mixin.js';
 
-/*
- * @appliesMixin EventsMixin
- */
-class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
-  static get template() {
-    return html`
-  <style include="iron-flex iron-flex-alignment"></style>
-  <style>
-    .media-state {
-      text-transform: capitalize;
-    }
+{
+  /*
+   * @appliesMixin EventsMixin
+   */
+  class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
+    static get template() {
+      return html`
+    <style include="iron-flex iron-flex-alignment"></style>
+    <style>
+      .media-state {
+        text-transform: capitalize;
+      }
 
-    paper-icon-button[highlight] {
-      color: var(--accent-color);
-    }
+      paper-icon-button[highlight] {
+        color: var(--accent-color);
+      }
 
-    .volume {
-      margin-bottom: 8px;
+      .volume {
+        margin-bottom: 8px;
 
-      max-height: 0px;
-      overflow: hidden;
-      transition: max-height .5s ease-in;
-    }
+        max-height: 0px;
+        overflow: hidden;
+        transition: max-height .5s ease-in;
+      }
 
-    .has-volume_level .volume {
-      max-height: 40px;
-    }
+      .has-volume_level .volume {
+        max-height: 40px;
+      }
 
-    iron-icon.source-input {
-      padding: 7px;
-      margin-top: 15px;
-    }
+      iron-icon.source-input {
+        padding: 7px;
+        margin-top: 15px;
+      }
 
-    paper-dropdown-menu.source-input {
-      margin-left: 10px;
-    }
+      paper-dropdown-menu.source-input {
+        margin-left: 10px;
+      }
 
-    [hidden] {
-      display: none !important;
-    }
+      [hidden] {
+        display: none !important;
+      }
 
-    paper-item {
-      cursor: pointer;
-    }
-  </style>
+      paper-item {
+        cursor: pointer;
+      }
+    </style>
 
-  <div class\$="[[computeClassNames(stateObj)]]">
-    <div class="layout horizontal">
-      <div class="flex">
-        <paper-icon-button icon="hass:power" highlight\$="[[playerObj.isOff]]" on-click="handleTogglePower" hidden\$="[[computeHidePowerButton(playerObj)]]"></paper-icon-button>
+    <div class\$="[[computeClassNames(stateObj)]]">
+      <div class="layout horizontal">
+        <div class="flex">
+          <paper-icon-button icon="hass:power" highlight\$="[[playerObj.isOff]]" on-click="handleTogglePower" hidden\$="[[computeHidePowerButton(playerObj)]]"></paper-icon-button>
+        </div>
+        <div>
+          <template is="dom-if" if="[[computeShowPlaybackControls(playerObj)]]">
+            <paper-icon-button icon="hass:skip-previous" on-click="handlePrevious" hidden\$="[[!playerObj.supportsPreviousTrack]]"></paper-icon-button>
+            <paper-icon-button icon="[[computePlaybackControlIcon(playerObj)]]" on-click="handlePlaybackControl" hidden\$="[[!computePlaybackControlIcon(playerObj)]]" highlight=""></paper-icon-button>
+            <paper-icon-button icon="hass:skip-next" on-click="handleNext" hidden\$="[[!playerObj.supportsNextTrack]]"></paper-icon-button>
+          </template>
+        </div>
       </div>
-      <div>
-        <template is="dom-if" if="[[computeShowPlaybackControls(playerObj)]]">
-          <paper-icon-button icon="hass:skip-previous" on-click="handlePrevious" hidden\$="[[!playerObj.supportsPreviousTrack]]"></paper-icon-button>
-          <paper-icon-button icon="[[computePlaybackControlIcon(playerObj)]]" on-click="handlePlaybackControl" hidden\$="[[!computePlaybackControlIcon(playerObj)]]" highlight=""></paper-icon-button>
-          <paper-icon-button icon="hass:skip-next" on-click="handleNext" hidden\$="[[!playerObj.supportsNextTrack]]"></paper-icon-button>
+      <!-- VOLUME -->
+      <div class="volume_buttons center horizontal layout" hidden\$="[[computeHideVolumeButtons(playerObj)]]">
+        <paper-icon-button on-click="handleVolumeTap" icon="hass:volume-off"></paper-icon-button>
+        <paper-icon-button id="volumeDown" disabled\$="[[playerObj.isMuted]]" on-mousedown="handleVolumeDown" on-touchstart="handleVolumeDown" icon="hass:volume-medium"></paper-icon-button>
+        <paper-icon-button id="volumeUp" disabled\$="[[playerObj.isMuted]]" on-mousedown="handleVolumeUp" on-touchstart="handleVolumeUp" icon="hass:volume-high"></paper-icon-button>
+      </div>
+      <div class="volume center horizontal layout" hidden\$="[[!playerObj.supportsVolumeSet]]">
+        <paper-icon-button on-click="handleVolumeTap" hidden\$="[[playerObj.supportsVolumeButtons]]" icon="[[computeMuteVolumeIcon(playerObj)]]"></paper-icon-button>
+        <ha-paper-slider disabled\$="[[playerObj.isMuted]]" min="0" max="100" value="[[playerObj.volumeSliderValue]]" on-change="volumeSliderChanged" class="flex" ignore-bar-touch="">
+        </ha-paper-slider>
+      </div>
+      <!-- SOURCE PICKER -->
+      <div class="controls layout horizontal justified" hidden\$="[[computeHideSelectSource(playerObj)]]">
+        <iron-icon class="source-input" icon="hass:login-variant"></iron-icon>
+        <paper-dropdown-menu class="flex source-input" dynamic-align="" label-float="" label="Source">
+          <paper-listbox slot="dropdown-content" selected="{{sourceIndex}}">
+            <template is="dom-repeat" items="[[playerObj.sourceList]]">
+              <paper-item>[[item]]</paper-item>
+            </template>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </div>
+      <!-- SOUND MODE PICKER -->
+      <div class="controls layout horizontal justified">
+        <template is='dom-if' if='[[!computeHideSelectSoundMode(playerObj)]]'>
+          <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
+          <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
+            <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
+              <template is='dom-repeat' items='[[playerObj.soundModeList]]'>
+                <paper-item>[[item]]</paper-item>
+              </template>
+            </paper-listbox>
+          </paper-dropdown-menu>
         </template>
       </div>
+      <!-- TTS -->
+      <div hidden\$="[[computeHideTTS(ttsLoaded, playerObj)]]" class="layout horizontal end">
+        <paper-input id="ttsInput" label="[[localize('ui.card.media_player.text_to_speak')]]" class="flex" value="{{ttsMessage}}" on-keydown="ttsCheckForEnter"></paper-input>
+        <paper-icon-button icon="hass:send" on-click="sendTTS"></paper-icon-button>
+      </div>
     </div>
-    <!-- VOLUME -->
-    <div class="volume_buttons center horizontal layout" hidden\$="[[computeHideVolumeButtons(playerObj)]]">
-      <paper-icon-button on-click="handleVolumeTap" icon="hass:volume-off"></paper-icon-button>
-      <paper-icon-button id="volumeDown" disabled\$="[[playerObj.isMuted]]" on-mousedown="handleVolumeDown" on-touchstart="handleVolumeDown" icon="hass:volume-medium"></paper-icon-button>
-      <paper-icon-button id="volumeUp" disabled\$="[[playerObj.isMuted]]" on-mousedown="handleVolumeUp" on-touchstart="handleVolumeUp" icon="hass:volume-high"></paper-icon-button>
-    </div>
-    <div class="volume center horizontal layout" hidden\$="[[!playerObj.supportsVolumeSet]]">
-      <paper-icon-button on-click="handleVolumeTap" hidden\$="[[playerObj.supportsVolumeButtons]]" icon="[[computeMuteVolumeIcon(playerObj)]]"></paper-icon-button>
-      <ha-paper-slider disabled\$="[[playerObj.isMuted]]" min="0" max="100" value="[[playerObj.volumeSliderValue]]" on-change="volumeSliderChanged" class="flex" ignore-bar-touch="">
-      </ha-paper-slider>
-    </div>
-    <!-- SOURCE PICKER -->
-    <div class="controls layout horizontal justified" hidden\$="[[computeHideSelectSource(playerObj)]]">
-      <iron-icon class="source-input" icon="hass:login-variant"></iron-icon>
-      <paper-dropdown-menu class="flex source-input" dynamic-align="" label-float="" label="Source">
-        <paper-listbox slot="dropdown-content" selected="{{sourceIndex}}">
-          <template is="dom-repeat" items="[[playerObj.sourceList]]">
-            <paper-item>[[item]]</paper-item>
-          </template>
-        </paper-listbox>
-      </paper-dropdown-menu>
-    </div>
-    <!-- TTS -->
-    <div hidden\$="[[computeHideTTS(ttsLoaded, playerObj)]]" class="layout horizontal end">
-      <paper-input id="ttsInput" label="[[localize('ui.card.media_player.text_to_speak')]]" class="flex" value="{{ttsMessage}}" on-keydown="ttsCheckForEnter"></paper-input>
-      <paper-icon-button icon="hass:send" on-click="sendTTS"></paper-icon-button>
-    </div>
-  </div>
 `;
-  }
-
-  static get properties() {
-    return {
-      hass: Object,
-      stateObj: Object,
-      playerObj: {
-        type: Object,
-        computed: 'computePlayerObj(hass, stateObj)',
-        observer: 'playerObjChanged',
-      },
-
-      sourceIndex: {
-        type: Number,
-        value: 0,
-        observer: 'handleSourceChanged',
-      },
-
-      ttsLoaded: {
-        type: Boolean,
-        computed: 'computeTTSLoaded(hass)',
-      },
-
-      ttsMessage: {
-        type: String,
-        value: '',
-      },
-
-    };
-  }
-
-  computePlayerObj(hass, stateObj) {
-    return new HassMediaPlayerEntity(hass, stateObj);
-  }
-
-  playerObjChanged(newVal, oldVal) {
-    if (newVal && newVal.sourceList !== undefined) {
-      this.sourceIndex = newVal.sourceList.indexOf(newVal.source);
     }
 
-    if (oldVal) {
-      setTimeout(() => {
-        this.fire('iron-resize');
-      }, 500);
-    }
-  }
+    static get properties() {
+      return {
+        hass: Object,
+        stateObj: Object,
+        playerObj: {
+          type: Object,
+          computed: 'computePlayerObj(hass, stateObj)',
+          observer: 'playerObjChanged',
+        },
 
-  computeClassNames(stateObj) {
-    return attributeClassNames(stateObj, ['volume_level']);
-  }
+        sourceIndex: {
+          type: Number,
+          value: 0,
+          observer: 'handleSourceChanged',
+        },
 
-  computeMuteVolumeIcon(playerObj) {
-    return playerObj.isMuted ? 'hass:volume-off' : 'hass:volume-high';
-  }
+        soundModeIndex: {
+          type: Number,
+          value: 0,
+          observer: 'handleSoundModeChanged',
+        },
 
-  computeHideVolumeButtons(playerObj) {
-    return !playerObj.supportsVolumeButtons || playerObj.isOff;
-  }
+        ttsLoaded: {
+          type: Boolean,
+          computed: 'computeTTSLoaded(hass)',
+        },
 
-  computeShowPlaybackControls(playerObj) {
-    return !playerObj.isOff && playerObj.hasMediaControl;
-  }
+        ttsMessage: {
+          type: String,
+          value: '',
+        },
 
-  computePlaybackControlIcon(playerObj) {
-    if (playerObj.isPlaying) {
-      return playerObj.supportsPause ? 'hass:pause' : 'hass:stop';
-    }
-    return playerObj.supportsPlay ? 'hass:play' : null;
-  }
-
-  computeHidePowerButton(playerObj) {
-    return playerObj.isOff ? !playerObj.supportsTurnOn : !playerObj.supportsTurnOff;
-  }
-
-  computeHideSelectSource(playerObj) {
-    return playerObj.isOff || !playerObj.supportsSelectSource || !playerObj.sourceList;
-  }
-
-  computeHideTTS(ttsLoaded, playerObj) {
-    return !ttsLoaded || !playerObj.supportsPlayMedia;
-  }
-
-  computeTTSLoaded(hass) {
-    return isComponentLoaded(hass, 'tts');
-  }
-
-  handleTogglePower() {
-    this.playerObj.togglePower();
-  }
-
-  handlePrevious() {
-    this.playerObj.previousTrack();
-  }
-
-  handlePlaybackControl() {
-    this.playerObj.mediaPlayPause();
-  }
-
-  handleNext() {
-    this.playerObj.nextTrack();
-  }
-
-  handleSourceChanged(sourceIndex, sourceIndexOld) {
-    // Selected Option will transition to '' before transitioning to new value
-    if (!this.playerObj
-        || !this.playerObj.supportsSelectSource
-        || this.playerObj.sourceList === undefined
-        || sourceIndex < 0
-        || sourceIndex >= this.playerObj.sourceList
-        || sourceIndexOld === undefined
-    ) {
-      return;
+      };
     }
 
-    const sourceInput = this.playerObj.sourceList[sourceIndex];
-
-    if (sourceInput === this.playerObj.source) {
-      return;
+    computePlayerObj(hass, stateObj) {
+      return new HassMediaPlayerEntity(hass, stateObj);
     }
 
-    this.playerObj.selectSource(sourceInput);
-  }
+    playerObjChanged(newVal, oldVal) {
+      if (newVal && newVal.sourceList !== undefined) {
+        this.sourceIndex = newVal.sourceList.indexOf(newVal.source);
+      }
 
-  handleVolumeTap() {
-    if (!this.playerObj.supportsVolumeMute) {
-      return;
-    }
-    this.playerObj.volumeMute(!this.playerObj.isMuted);
-  }
+      if (newVal && newVal.soundModeList !== undefined) {
+        this.soundModeIndex = newVal.soundModeList.indexOf(newVal.soundMode);
+      }
 
-  handleVolumeUp() {
-    const obj = this.$.volumeUp;
-    this.handleVolumeWorker('volume_up', obj, true);
-  }
-
-  handleVolumeDown() {
-    const obj = this.$.volumeDown;
-    this.handleVolumeWorker('volume_down', obj, true);
-  }
-
-  handleVolumeWorker(service, obj, force) {
-    if (force || (obj !== undefined && obj.pointerDown)) {
-      this.playerObj.callService(service);
-      setTimeout(() => this.handleVolumeWorker(service, obj, false), 500);
-    }
-  }
-
-  volumeSliderChanged(ev) {
-    const volPercentage = parseFloat(ev.target.value);
-    const volume = volPercentage > 0 ? volPercentage / 100 : 0;
-    this.playerObj.setVolume(volume);
-  }
-
-  ttsCheckForEnter(ev) {
-    if (ev.keyCode === 13) this.sendTTS();
-  }
-
-  sendTTS() {
-    const services = this.hass.config.services.tts;
-    const serviceKeys = Object.keys(services).sort();
-    let service;
-    let i;
-
-    for (i = 0; i < serviceKeys.length; i++) {
-      if (serviceKeys[i].indexOf('_say') !== -1) {
-        service = serviceKeys[i];
-        break;
+      if (oldVal) {
+        setTimeout(() => {
+          this.fire('iron-resize');
+        }, 500);
       }
     }
 
-    if (!service) {
-      return;
+    computeClassNames(stateObj) {
+      return attributeClassNames(stateObj, ['volume_level']);
     }
 
-    this.hass.callService('tts', service, {
-      entity_id: this.stateObj.entity_id,
-      message: this.ttsMessage,
-    });
-    this.ttsMessage = '';
-    this.$.ttsInput.focus();
-  }
-}
+    computeMuteVolumeIcon(playerObj) {
+      return playerObj.isMuted ? 'hass:volume-off' : 'hass:volume-high';
+    }
 
-customElements.define('more-info-media_player', MoreInfoMediaPlayer);
+    computeHideVolumeButtons(playerObj) {
+      return !playerObj.supportsVolumeButtons || playerObj.isOff;
+    }
+
+    computeShowPlaybackControls(playerObj) {
+      return !playerObj.isOff && playerObj.hasMediaControl;
+    }
+
+    computePlaybackControlIcon(playerObj) {
+      if (playerObj.isPlaying) {
+        return playerObj.supportsPause ? 'hass:pause' : 'hass:stop';
+      }
+      return playerObj.supportsPlay ? 'hass:play' : null;
+    }
+
+    computeHidePowerButton(playerObj) {
+      return playerObj.isOff ? !playerObj.supportsTurnOn : !playerObj.supportsTurnOff;
+    }
+
+    computeHideSelectSource(playerObj) {
+      return playerObj.isOff || !playerObj.supportsSelectSource || !playerObj.sourceList;
+    }
+
+    computeHideSelectSoundMode(playerObj) {
+      return playerObj.isOff || !playerObj.supportsSelectSoundMode || !playerObj.soundModeList;
+    }
+
+    computeHideTTS(ttsLoaded, playerObj) {
+      return !ttsLoaded || !playerObj.supportsPlayMedia;
+    }
+
+    computeTTSLoaded(hass) {
+      return isComponentLoaded(hass, 'tts');
+    }
+
+    handleTogglePower() {
+      this.playerObj.togglePower();
+    }
+
+    handlePrevious() {
+      this.playerObj.previousTrack();
+    }
+
+    handlePlaybackControl() {
+      this.playerObj.mediaPlayPause();
+    }
+
+    handleNext() {
+      this.playerObj.nextTrack();
+    }
+
+    handleSourceChanged(sourceIndex, sourceIndexOld) {
+      // Selected Option will transition to '' before transitioning to new value
+      if (!this.playerObj
+          || !this.playerObj.supportsSelectSource
+          || this.playerObj.sourceList === undefined
+          || sourceIndex < 0
+          || sourceIndex >= this.playerObj.sourceList
+          || sourceIndexOld === undefined
+      ) {
+        return;
+      }
+
+      const sourceInput = this.playerObj.sourceList[sourceIndex];
+
+      if (sourceInput === this.playerObj.source) {
+        return;
+      }
+
+      this.playerObj.selectSource(sourceInput);
+    }
+
+    handleSoundModeChanged(soundModeIndex, soundModeIndexOld) {
+      // Selected Option will transition to '' before transitioning to new value
+      if (!this.playerObj
+          || !this.playerObj.supportsSelectSoundMode
+          || this.playerObj.soundModeList === undefined
+          || soundModeIndex < 0
+          || soundModeIndex >= this.playerObj.soundModeList
+          || soundModeIndexOld === undefined
+      ) {
+        return;
+      }
+
+      const soundModeInput = this.playerObj.soundModeList[soundModeIndex];
+
+      if (soundModeInput === this.playerObj.soundMode) {
+        return;
+      }
+
+      this.playerObj.selectSoundMode(soundModeInput);
+    }
+
+    handleVolumeTap() {
+      if (!this.playerObj.supportsVolumeMute) {
+        return;
+      }
+      this.playerObj.volumeMute(!this.playerObj.isMuted);
+    }
+
+    handleVolumeUp() {
+      const obj = this.$.volumeUp;
+      this.handleVolumeWorker('volume_up', obj, true);
+    }
+
+    handleVolumeDown() {
+      const obj = this.$.volumeDown;
+      this.handleVolumeWorker('volume_down', obj, true);
+    }
+
+    handleVolumeWorker(service, obj, force) {
+      if (force || (obj !== undefined && obj.pointerDown)) {
+        this.playerObj.callService(service);
+        setTimeout(() => this.handleVolumeWorker(service, obj, false), 500);
+      }
+    }
+
+    volumeSliderChanged(ev) {
+      const volPercentage = parseFloat(ev.target.value);
+      const volume = volPercentage > 0 ? volPercentage / 100 : 0;
+      this.playerObj.setVolume(volume);
+    }
+
+    ttsCheckForEnter(ev) {
+      if (ev.keyCode === 13) this.sendTTS();
+    }
+
+    sendTTS() {
+      const services = this.hass.config.services.tts;
+      const serviceKeys = Object.keys(services).sort();
+      let service;
+      let i;
+
+      for (i = 0; i < serviceKeys.length; i++) {
+        if (serviceKeys[i].indexOf('_say') !== -1) {
+          service = serviceKeys[i];
+          break;
+        }
+      }
+
+      if (!service) {
+        return;
+      }
+
+      this.hass.callService('tts', service, {
+        entity_id: this.stateObj.entity_id,
+        message: this.ttsMessage,
+      });
+      this.ttsMessage = '';
+      this.$.ttsInput.focus();
+    }
+  }
+
+  customElements.define('more-info-media_player', MoreInfoMediaPlayer);
+}

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -100,11 +100,11 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
     <!-- SOUND MODE PICKER -->
     <template is='dom-if' if='[[!computeHideSelectSoundMode(playerObj)]]'>
       <div class="controls layout horizontal justified">
-        <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
+        <iron-icon class="source-input" icon="hass:music-note"></iron-icon>
         <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
-          <paper-listbox slot="dropdown-content" attr-for-selected="selectedSoundMode" selected="{{SoundModeInput}}">
+          <paper-listbox slot="dropdown-content" attr-for-selected="item-name" selected="{{SoundModeInput}}">
             <template is='dom-repeat' items='[[playerObj.soundModeList]]'>
-              <paper-item selectedSoundMode\$="[[item]]">[[item]]</paper-item>
+              <paper-item item-name$="[[item]]">[[item]]</paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>
@@ -254,21 +254,13 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this.playerObj.selectSource(sourceInput);
   }
 
-  handleSoundModeChanged(SoundModeInput, SoundModeInputOld) {
-    // Selected Option will transition to '' before transitioning to new value
-    if (!this.playerObj
-        || !this.playerObj.supportsSelectSoundMode
-        || this.playerObj.soundModeList === undefined
-        || SoundModeInputOld === undefined
+  handleSoundModeChanged(newVal, oldVal) {
+    if (oldVal
+        && newVal !== this.playerObj.soundMode
+        && this.playerObj.supportsSelectSoundMode
     ) {
-      return;
+      this.playerObj.selectSoundMode(newVal);
     }
-
-    if (SoundModeInput === this.playerObj.soundMode) {
-      return;
-    }
-
-    this.playerObj.selectSoundMode(SoundModeInput);
   }
 
   handleVolumeTap() {

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -102,9 +102,9 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
       <div class="controls layout horizontal justified">
         <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
         <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
-          <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
+          <paper-listbox slot="dropdown-content" attr-for-selected="selectedSoundMode" selected="{{SoundModeInput}}">
             <template is='dom-repeat' items='[[playerObj.soundModeList]]'>
-              <paper-item>[[item]]</paper-item>
+              <paper-item selectedSoundMode\$="[[item]]">[[item]]</paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>
@@ -135,9 +135,9 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: 'handleSourceChanged',
       },
 
-      soundModeIndex: {
-        type: Number,
-        value: 0,
+      SoundModeInput: {
+        type: String,
+        value: '',
         observer: 'handleSoundModeChanged',
       },
 
@@ -164,7 +164,7 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
     }
 
     if (newVal && newVal.soundModeList !== undefined) {
-      this.soundModeIndex = newVal.soundModeList.indexOf(newVal.soundMode);
+      this.SoundModeInput = newVal.soundMode;
     }
 
     if (oldVal) {
@@ -254,25 +254,21 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this.playerObj.selectSource(sourceInput);
   }
 
-  handleSoundModeChanged(soundModeIndex, soundModeIndexOld) {
+  handleSoundModeChanged(SoundModeInput, SoundModeInputOld) {
     // Selected Option will transition to '' before transitioning to new value
     if (!this.playerObj
         || !this.playerObj.supportsSelectSoundMode
         || this.playerObj.soundModeList === undefined
-        || soundModeIndex < 0
-        || soundModeIndex >= this.playerObj.soundModeList
-        || soundModeIndexOld === undefined
+        || SoundModeInputOld === undefined
     ) {
       return;
     }
 
-    const soundModeInput = this.playerObj.soundModeList[soundModeIndex];
-
-    if (soundModeInput === this.playerObj.soundMode) {
+    if (SoundModeInput === this.playerObj.soundMode) {
       return;
     }
 
-    this.playerObj.selectSoundMode(soundModeInput);
+    this.playerObj.selectSoundMode(SoundModeInput);
   }
 
   handleVolumeTap() {

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -98,8 +98,8 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
       </paper-dropdown-menu>
     </div>
     <!-- SOUND MODE PICKER -->
-    <div class="controls layout horizontal justified">
-      <template is='dom-if' if='[[!computeHideSelectSoundMode(playerObj)]]'>
+    <template is='dom-if' if='[[!computeHideSelectSoundMode(playerObj)]]'>
+      <div class="controls layout horizontal justified">
         <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
         <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
           <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
@@ -108,8 +108,8 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
             </template>
           </paper-listbox>
         </paper-dropdown-menu>
-      </template>
-    </div>
+      </div>
+    </template>
     <!-- TTS -->
     <div hidden\$="[[computeHideTTS(ttsLoaded, playerObj)]]" class="layout horizontal end">
       <paper-input id="ttsInput" label="[[localize('ui.card.media_player.text_to_speak')]]" class="flex" value="{{ttsMessage}}" on-keydown="ttsCheckForEnter"></paper-input>

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -16,325 +16,323 @@ import isComponentLoaded from '../../../common/config/is_component_loaded.js';
 import EventsMixin from '../../../mixins/events-mixin.js';
 import LocalizeMixin from '../../../mixins/localize-mixin.js';
 
-{
-  /*
-   * @appliesMixin EventsMixin
-   */
-  class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
-    static get template() {
-      return html`
-    <style include="iron-flex iron-flex-alignment"></style>
-    <style>
-      .media-state {
-        text-transform: capitalize;
-      }
+/*
+ * @appliesMixin EventsMixin
+ */
+class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
+  static get template() {
+    return html`
+  <style include="iron-flex iron-flex-alignment"></style>
+  <style>
+    .media-state {
+      text-transform: capitalize;
+    }
 
-      paper-icon-button[highlight] {
-        color: var(--accent-color);
-      }
+    paper-icon-button[highlight] {
+      color: var(--accent-color);
+    }
 
-      .volume {
-        margin-bottom: 8px;
+    .volume {
+      margin-bottom: 8px;
 
-        max-height: 0px;
-        overflow: hidden;
-        transition: max-height .5s ease-in;
-      }
+      max-height: 0px;
+      overflow: hidden;
+      transition: max-height .5s ease-in;
+    }
 
-      .has-volume_level .volume {
-        max-height: 40px;
-      }
+    .has-volume_level .volume {
+      max-height: 40px;
+    }
 
-      iron-icon.source-input {
-        padding: 7px;
-        margin-top: 15px;
-      }
+    iron-icon.source-input {
+      padding: 7px;
+      margin-top: 15px;
+    }
 
-      paper-dropdown-menu.source-input {
-        margin-left: 10px;
-      }
+    paper-dropdown-menu.source-input {
+      margin-left: 10px;
+    }
 
-      [hidden] {
-        display: none !important;
-      }
+    [hidden] {
+      display: none !important;
+    }
 
-      paper-item {
-        cursor: pointer;
-      }
-    </style>
+    paper-item {
+      cursor: pointer;
+    }
+  </style>
 
-    <div class\$="[[computeClassNames(stateObj)]]">
-      <div class="layout horizontal">
-        <div class="flex">
-          <paper-icon-button icon="hass:power" highlight\$="[[playerObj.isOff]]" on-click="handleTogglePower" hidden\$="[[computeHidePowerButton(playerObj)]]"></paper-icon-button>
-        </div>
-        <div>
-          <template is="dom-if" if="[[computeShowPlaybackControls(playerObj)]]">
-            <paper-icon-button icon="hass:skip-previous" on-click="handlePrevious" hidden\$="[[!playerObj.supportsPreviousTrack]]"></paper-icon-button>
-            <paper-icon-button icon="[[computePlaybackControlIcon(playerObj)]]" on-click="handlePlaybackControl" hidden\$="[[!computePlaybackControlIcon(playerObj)]]" highlight=""></paper-icon-button>
-            <paper-icon-button icon="hass:skip-next" on-click="handleNext" hidden\$="[[!playerObj.supportsNextTrack]]"></paper-icon-button>
+  <div class\$="[[computeClassNames(stateObj)]]">
+    <div class="layout horizontal">
+      <div class="flex">
+        <paper-icon-button icon="hass:power" highlight\$="[[playerObj.isOff]]" on-click="handleTogglePower" hidden\$="[[computeHidePowerButton(playerObj)]]"></paper-icon-button>
+      </div>
+      <div>
+        <template is="dom-if" if="[[computeShowPlaybackControls(playerObj)]]">
+          <paper-icon-button icon="hass:skip-previous" on-click="handlePrevious" hidden\$="[[!playerObj.supportsPreviousTrack]]"></paper-icon-button>
+          <paper-icon-button icon="[[computePlaybackControlIcon(playerObj)]]" on-click="handlePlaybackControl" hidden\$="[[!computePlaybackControlIcon(playerObj)]]" highlight=""></paper-icon-button>
+          <paper-icon-button icon="hass:skip-next" on-click="handleNext" hidden\$="[[!playerObj.supportsNextTrack]]"></paper-icon-button>
+        </template>
+      </div>
+    </div>
+    <!-- VOLUME -->
+    <div class="volume_buttons center horizontal layout" hidden\$="[[computeHideVolumeButtons(playerObj)]]">
+      <paper-icon-button on-click="handleVolumeTap" icon="hass:volume-off"></paper-icon-button>
+      <paper-icon-button id="volumeDown" disabled\$="[[playerObj.isMuted]]" on-mousedown="handleVolumeDown" on-touchstart="handleVolumeDown" icon="hass:volume-medium"></paper-icon-button>
+      <paper-icon-button id="volumeUp" disabled\$="[[playerObj.isMuted]]" on-mousedown="handleVolumeUp" on-touchstart="handleVolumeUp" icon="hass:volume-high"></paper-icon-button>
+    </div>
+    <div class="volume center horizontal layout" hidden\$="[[!playerObj.supportsVolumeSet]]">
+      <paper-icon-button on-click="handleVolumeTap" hidden\$="[[playerObj.supportsVolumeButtons]]" icon="[[computeMuteVolumeIcon(playerObj)]]"></paper-icon-button>
+      <ha-paper-slider disabled\$="[[playerObj.isMuted]]" min="0" max="100" value="[[playerObj.volumeSliderValue]]" on-change="volumeSliderChanged" class="flex" ignore-bar-touch="">
+      </ha-paper-slider>
+    </div>
+    <!-- SOURCE PICKER -->
+    <div class="controls layout horizontal justified" hidden\$="[[computeHideSelectSource(playerObj)]]">
+      <iron-icon class="source-input" icon="hass:login-variant"></iron-icon>
+      <paper-dropdown-menu class="flex source-input" dynamic-align="" label-float="" label="Source">
+        <paper-listbox slot="dropdown-content" selected="{{sourceIndex}}">
+          <template is="dom-repeat" items="[[playerObj.sourceList]]">
+            <paper-item>[[item]]</paper-item>
           </template>
-        </div>
-      </div>
-      <!-- VOLUME -->
-      <div class="volume_buttons center horizontal layout" hidden\$="[[computeHideVolumeButtons(playerObj)]]">
-        <paper-icon-button on-click="handleVolumeTap" icon="hass:volume-off"></paper-icon-button>
-        <paper-icon-button id="volumeDown" disabled\$="[[playerObj.isMuted]]" on-mousedown="handleVolumeDown" on-touchstart="handleVolumeDown" icon="hass:volume-medium"></paper-icon-button>
-        <paper-icon-button id="volumeUp" disabled\$="[[playerObj.isMuted]]" on-mousedown="handleVolumeUp" on-touchstart="handleVolumeUp" icon="hass:volume-high"></paper-icon-button>
-      </div>
-      <div class="volume center horizontal layout" hidden\$="[[!playerObj.supportsVolumeSet]]">
-        <paper-icon-button on-click="handleVolumeTap" hidden\$="[[playerObj.supportsVolumeButtons]]" icon="[[computeMuteVolumeIcon(playerObj)]]"></paper-icon-button>
-        <ha-paper-slider disabled\$="[[playerObj.isMuted]]" min="0" max="100" value="[[playerObj.volumeSliderValue]]" on-change="volumeSliderChanged" class="flex" ignore-bar-touch="">
-        </ha-paper-slider>
-      </div>
-      <!-- SOURCE PICKER -->
-      <div class="controls layout horizontal justified" hidden\$="[[computeHideSelectSource(playerObj)]]">
-        <iron-icon class="source-input" icon="hass:login-variant"></iron-icon>
-        <paper-dropdown-menu class="flex source-input" dynamic-align="" label-float="" label="Source">
-          <paper-listbox slot="dropdown-content" selected="{{sourceIndex}}">
-            <template is="dom-repeat" items="[[playerObj.sourceList]]">
+        </paper-listbox>
+      </paper-dropdown-menu>
+    </div>
+    <!-- SOUND MODE PICKER -->
+    <div class="controls layout horizontal justified">
+      <template is='dom-if' if='[[!computeHideSelectSoundMode(playerObj)]]'>
+        <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
+        <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
+          <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
+            <template is='dom-repeat' items='[[playerObj.soundModeList]]'>
               <paper-item>[[item]]</paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>
-      </div>
-      <!-- SOUND MODE PICKER -->
-      <div class="controls layout horizontal justified">
-        <template is='dom-if' if='[[!computeHideSelectSoundMode(playerObj)]]'>
-          <iron-icon class="source-input" icon="mdi:music-note"></iron-icon>
-          <paper-dropdown-menu class="flex source-input" dynamic-align label-float label='Sound Mode'>
-            <paper-listbox slot="dropdown-content" selected="{{soundModeIndex}}">
-              <template is='dom-repeat' items='[[playerObj.soundModeList]]'>
-                <paper-item>[[item]]</paper-item>
-              </template>
-            </paper-listbox>
-          </paper-dropdown-menu>
-        </template>
-      </div>
-      <!-- TTS -->
-      <div hidden\$="[[computeHideTTS(ttsLoaded, playerObj)]]" class="layout horizontal end">
-        <paper-input id="ttsInput" label="[[localize('ui.card.media_player.text_to_speak')]]" class="flex" value="{{ttsMessage}}" on-keydown="ttsCheckForEnter"></paper-input>
-        <paper-icon-button icon="hass:send" on-click="sendTTS"></paper-icon-button>
-      </div>
+      </template>
     </div>
+    <!-- TTS -->
+    <div hidden\$="[[computeHideTTS(ttsLoaded, playerObj)]]" class="layout horizontal end">
+      <paper-input id="ttsInput" label="[[localize('ui.card.media_player.text_to_speak')]]" class="flex" value="{{ttsMessage}}" on-keydown="ttsCheckForEnter"></paper-input>
+      <paper-icon-button icon="hass:send" on-click="sendTTS"></paper-icon-button>
+    </div>
+  </div>
 `;
+  }
+
+  static get properties() {
+    return {
+      hass: Object,
+      stateObj: Object,
+      playerObj: {
+        type: Object,
+        computed: 'computePlayerObj(hass, stateObj)',
+        observer: 'playerObjChanged',
+      },
+
+      sourceIndex: {
+        type: Number,
+        value: 0,
+        observer: 'handleSourceChanged',
+      },
+
+      soundModeIndex: {
+        type: Number,
+        value: 0,
+        observer: 'handleSoundModeChanged',
+      },
+
+      ttsLoaded: {
+        type: Boolean,
+        computed: 'computeTTSLoaded(hass)',
+      },
+
+      ttsMessage: {
+        type: String,
+        value: '',
+      },
+
+    };
+  }
+
+  computePlayerObj(hass, stateObj) {
+    return new HassMediaPlayerEntity(hass, stateObj);
+  }
+
+  playerObjChanged(newVal, oldVal) {
+    if (newVal && newVal.sourceList !== undefined) {
+      this.sourceIndex = newVal.sourceList.indexOf(newVal.source);
     }
 
-    static get properties() {
-      return {
-        hass: Object,
-        stateObj: Object,
-        playerObj: {
-          type: Object,
-          computed: 'computePlayerObj(hass, stateObj)',
-          observer: 'playerObjChanged',
-        },
-
-        sourceIndex: {
-          type: Number,
-          value: 0,
-          observer: 'handleSourceChanged',
-        },
-
-        soundModeIndex: {
-          type: Number,
-          value: 0,
-          observer: 'handleSoundModeChanged',
-        },
-
-        ttsLoaded: {
-          type: Boolean,
-          computed: 'computeTTSLoaded(hass)',
-        },
-
-        ttsMessage: {
-          type: String,
-          value: '',
-        },
-
-      };
+    if (newVal && newVal.soundModeList !== undefined) {
+      this.soundModeIndex = newVal.soundModeList.indexOf(newVal.soundMode);
     }
 
-    computePlayerObj(hass, stateObj) {
-      return new HassMediaPlayerEntity(hass, stateObj);
-    }
-
-    playerObjChanged(newVal, oldVal) {
-      if (newVal && newVal.sourceList !== undefined) {
-        this.sourceIndex = newVal.sourceList.indexOf(newVal.source);
-      }
-
-      if (newVal && newVal.soundModeList !== undefined) {
-        this.soundModeIndex = newVal.soundModeList.indexOf(newVal.soundMode);
-      }
-
-      if (oldVal) {
-        setTimeout(() => {
-          this.fire('iron-resize');
-        }, 500);
-      }
-    }
-
-    computeClassNames(stateObj) {
-      return attributeClassNames(stateObj, ['volume_level']);
-    }
-
-    computeMuteVolumeIcon(playerObj) {
-      return playerObj.isMuted ? 'hass:volume-off' : 'hass:volume-high';
-    }
-
-    computeHideVolumeButtons(playerObj) {
-      return !playerObj.supportsVolumeButtons || playerObj.isOff;
-    }
-
-    computeShowPlaybackControls(playerObj) {
-      return !playerObj.isOff && playerObj.hasMediaControl;
-    }
-
-    computePlaybackControlIcon(playerObj) {
-      if (playerObj.isPlaying) {
-        return playerObj.supportsPause ? 'hass:pause' : 'hass:stop';
-      }
-      return playerObj.supportsPlay ? 'hass:play' : null;
-    }
-
-    computeHidePowerButton(playerObj) {
-      return playerObj.isOff ? !playerObj.supportsTurnOn : !playerObj.supportsTurnOff;
-    }
-
-    computeHideSelectSource(playerObj) {
-      return playerObj.isOff || !playerObj.supportsSelectSource || !playerObj.sourceList;
-    }
-
-    computeHideSelectSoundMode(playerObj) {
-      return playerObj.isOff || !playerObj.supportsSelectSoundMode || !playerObj.soundModeList;
-    }
-
-    computeHideTTS(ttsLoaded, playerObj) {
-      return !ttsLoaded || !playerObj.supportsPlayMedia;
-    }
-
-    computeTTSLoaded(hass) {
-      return isComponentLoaded(hass, 'tts');
-    }
-
-    handleTogglePower() {
-      this.playerObj.togglePower();
-    }
-
-    handlePrevious() {
-      this.playerObj.previousTrack();
-    }
-
-    handlePlaybackControl() {
-      this.playerObj.mediaPlayPause();
-    }
-
-    handleNext() {
-      this.playerObj.nextTrack();
-    }
-
-    handleSourceChanged(sourceIndex, sourceIndexOld) {
-      // Selected Option will transition to '' before transitioning to new value
-      if (!this.playerObj
-          || !this.playerObj.supportsSelectSource
-          || this.playerObj.sourceList === undefined
-          || sourceIndex < 0
-          || sourceIndex >= this.playerObj.sourceList
-          || sourceIndexOld === undefined
-      ) {
-        return;
-      }
-
-      const sourceInput = this.playerObj.sourceList[sourceIndex];
-
-      if (sourceInput === this.playerObj.source) {
-        return;
-      }
-
-      this.playerObj.selectSource(sourceInput);
-    }
-
-    handleSoundModeChanged(soundModeIndex, soundModeIndexOld) {
-      // Selected Option will transition to '' before transitioning to new value
-      if (!this.playerObj
-          || !this.playerObj.supportsSelectSoundMode
-          || this.playerObj.soundModeList === undefined
-          || soundModeIndex < 0
-          || soundModeIndex >= this.playerObj.soundModeList
-          || soundModeIndexOld === undefined
-      ) {
-        return;
-      }
-
-      const soundModeInput = this.playerObj.soundModeList[soundModeIndex];
-
-      if (soundModeInput === this.playerObj.soundMode) {
-        return;
-      }
-
-      this.playerObj.selectSoundMode(soundModeInput);
-    }
-
-    handleVolumeTap() {
-      if (!this.playerObj.supportsVolumeMute) {
-        return;
-      }
-      this.playerObj.volumeMute(!this.playerObj.isMuted);
-    }
-
-    handleVolumeUp() {
-      const obj = this.$.volumeUp;
-      this.handleVolumeWorker('volume_up', obj, true);
-    }
-
-    handleVolumeDown() {
-      const obj = this.$.volumeDown;
-      this.handleVolumeWorker('volume_down', obj, true);
-    }
-
-    handleVolumeWorker(service, obj, force) {
-      if (force || (obj !== undefined && obj.pointerDown)) {
-        this.playerObj.callService(service);
-        setTimeout(() => this.handleVolumeWorker(service, obj, false), 500);
-      }
-    }
-
-    volumeSliderChanged(ev) {
-      const volPercentage = parseFloat(ev.target.value);
-      const volume = volPercentage > 0 ? volPercentage / 100 : 0;
-      this.playerObj.setVolume(volume);
-    }
-
-    ttsCheckForEnter(ev) {
-      if (ev.keyCode === 13) this.sendTTS();
-    }
-
-    sendTTS() {
-      const services = this.hass.config.services.tts;
-      const serviceKeys = Object.keys(services).sort();
-      let service;
-      let i;
-
-      for (i = 0; i < serviceKeys.length; i++) {
-        if (serviceKeys[i].indexOf('_say') !== -1) {
-          service = serviceKeys[i];
-          break;
-        }
-      }
-
-      if (!service) {
-        return;
-      }
-
-      this.hass.callService('tts', service, {
-        entity_id: this.stateObj.entity_id,
-        message: this.ttsMessage,
-      });
-      this.ttsMessage = '';
-      this.$.ttsInput.focus();
+    if (oldVal) {
+      setTimeout(() => {
+        this.fire('iron-resize');
+      }, 500);
     }
   }
 
-  customElements.define('more-info-media_player', MoreInfoMediaPlayer);
+  computeClassNames(stateObj) {
+    return attributeClassNames(stateObj, ['volume_level']);
+  }
+
+  computeMuteVolumeIcon(playerObj) {
+    return playerObj.isMuted ? 'hass:volume-off' : 'hass:volume-high';
+  }
+
+  computeHideVolumeButtons(playerObj) {
+    return !playerObj.supportsVolumeButtons || playerObj.isOff;
+  }
+
+  computeShowPlaybackControls(playerObj) {
+    return !playerObj.isOff && playerObj.hasMediaControl;
+  }
+
+  computePlaybackControlIcon(playerObj) {
+    if (playerObj.isPlaying) {
+      return playerObj.supportsPause ? 'hass:pause' : 'hass:stop';
+    }
+    return playerObj.supportsPlay ? 'hass:play' : null;
+  }
+
+  computeHidePowerButton(playerObj) {
+    return playerObj.isOff ? !playerObj.supportsTurnOn : !playerObj.supportsTurnOff;
+  }
+
+  computeHideSelectSource(playerObj) {
+    return playerObj.isOff || !playerObj.supportsSelectSource || !playerObj.sourceList;
+  }
+
+  computeHideSelectSoundMode(playerObj) {
+    return playerObj.isOff || !playerObj.supportsSelectSoundMode || !playerObj.soundModeList;
+  }
+
+  computeHideTTS(ttsLoaded, playerObj) {
+    return !ttsLoaded || !playerObj.supportsPlayMedia;
+  }
+
+  computeTTSLoaded(hass) {
+    return isComponentLoaded(hass, 'tts');
+  }
+
+  handleTogglePower() {
+    this.playerObj.togglePower();
+  }
+
+  handlePrevious() {
+    this.playerObj.previousTrack();
+  }
+
+  handlePlaybackControl() {
+    this.playerObj.mediaPlayPause();
+  }
+
+  handleNext() {
+    this.playerObj.nextTrack();
+  }
+
+  handleSourceChanged(sourceIndex, sourceIndexOld) {
+    // Selected Option will transition to '' before transitioning to new value
+    if (!this.playerObj
+        || !this.playerObj.supportsSelectSource
+        || this.playerObj.sourceList === undefined
+        || sourceIndex < 0
+        || sourceIndex >= this.playerObj.sourceList
+        || sourceIndexOld === undefined
+    ) {
+      return;
+    }
+
+    const sourceInput = this.playerObj.sourceList[sourceIndex];
+
+    if (sourceInput === this.playerObj.source) {
+      return;
+    }
+
+    this.playerObj.selectSource(sourceInput);
+  }
+
+  handleSoundModeChanged(soundModeIndex, soundModeIndexOld) {
+    // Selected Option will transition to '' before transitioning to new value
+    if (!this.playerObj
+        || !this.playerObj.supportsSelectSoundMode
+        || this.playerObj.soundModeList === undefined
+        || soundModeIndex < 0
+        || soundModeIndex >= this.playerObj.soundModeList
+        || soundModeIndexOld === undefined
+    ) {
+      return;
+    }
+
+    const soundModeInput = this.playerObj.soundModeList[soundModeIndex];
+
+    if (soundModeInput === this.playerObj.soundMode) {
+      return;
+    }
+
+    this.playerObj.selectSoundMode(soundModeInput);
+  }
+
+  handleVolumeTap() {
+    if (!this.playerObj.supportsVolumeMute) {
+      return;
+    }
+    this.playerObj.volumeMute(!this.playerObj.isMuted);
+  }
+
+  handleVolumeUp() {
+    const obj = this.$.volumeUp;
+    this.handleVolumeWorker('volume_up', obj, true);
+  }
+
+  handleVolumeDown() {
+    const obj = this.$.volumeDown;
+    this.handleVolumeWorker('volume_down', obj, true);
+  }
+
+  handleVolumeWorker(service, obj, force) {
+    if (force || (obj !== undefined && obj.pointerDown)) {
+      this.playerObj.callService(service);
+      setTimeout(() => this.handleVolumeWorker(service, obj, false), 500);
+    }
+  }
+
+  volumeSliderChanged(ev) {
+    const volPercentage = parseFloat(ev.target.value);
+    const volume = volPercentage > 0 ? volPercentage / 100 : 0;
+    this.playerObj.setVolume(volume);
+  }
+
+  ttsCheckForEnter(ev) {
+    if (ev.keyCode === 13) this.sendTTS();
+  }
+
+  sendTTS() {
+    const services = this.hass.config.services.tts;
+    const serviceKeys = Object.keys(services).sort();
+    let service;
+    let i;
+
+    for (i = 0; i < serviceKeys.length; i++) {
+      if (serviceKeys[i].indexOf('_say') !== -1) {
+        service = serviceKeys[i];
+        break;
+      }
+    }
+
+    if (!service) {
+      return;
+    }
+
+    this.hass.callService('tts', service, {
+      entity_id: this.stateObj.entity_id,
+      message: this.ttsMessage,
+    });
+    this.ttsMessage = '';
+    this.$.ttsInput.focus();
+  }
 }
+
+customElements.define('more-info-media_player', MoreInfoMediaPlayer);

--- a/src/util/hass-media-player-model.js
+++ b/src/util/hass-media-player-model.js
@@ -208,7 +208,7 @@ export default class MediaPlayerEntity {
   }
 
   selectSoundMode(soundMode) {
-    this.callService('select_sound_mode', { sound_mode });
+    this.callService('select_sound_mode', { sound_mode: soundMode });
   }
 
   // helper method

--- a/src/util/hass-media-player-model.js
+++ b/src/util/hass-media-player-model.js
@@ -101,6 +101,10 @@ export default class MediaPlayerEntity {
     return (this._feat & 2048) !== 0;
   }
 
+  get supportsSelectSoundMode() {
+    return (this._feat & 65536) !== 0;
+  }
+
   get supportsPlay() {
     return (this._feat & 16384) !== 0;
   }
@@ -138,6 +142,14 @@ export default class MediaPlayerEntity {
 
   get sourceList() {
     return this._attr.source_list;
+  }
+
+  get soundMode() {
+    return this._attr.sound_mode;
+  }
+
+  get soundModeList() {
+    return this._attr.sound_mode_list;
   }
 
   mediaPlayPause() {
@@ -193,6 +205,10 @@ export default class MediaPlayerEntity {
 
   selectSource(source) {
     this.callService('select_source', { source });
+  }
+
+  selectSoundMode(sound_mode) {
+    this.callService('select_sound_mode', { sound_mode });
   }
 
   // helper method

--- a/src/util/hass-media-player-model.js
+++ b/src/util/hass-media-player-model.js
@@ -207,7 +207,7 @@ export default class MediaPlayerEntity {
     this.callService('select_source', { source });
   }
 
-  selectSoundMode(sound_mode) {
+  selectSoundMode(soundMode) {
     this.callService('select_sound_mode', { sound_mode });
   }
 


### PR DESCRIPTION
Added frontend support for an drop down box select for the sound mode (also updated with status).
This is general support for all media_player components.
This box is not shown in media_players that did not (yet) implement sound mode support in the backend.

I tested this code and it works on Hassbian on my pi.

Already merged backend pull request for general sound mode support:
home-assistant/home-assistant#14729