### PR TITLE
Change weather card to support forecasts with two modes

### DIFF
--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -80,7 +80,7 @@ class HaWeatherCard extends
         }
 
         .weekday {
-          text-transform: uppercase;
+          font-weight: bold;
         }
 
         .attributes,
@@ -128,9 +128,9 @@ class HaWeatherCard extends
             <div class="forecast">
               <template is="dom-repeat" items="[[forecast]]">
                 <div>
-                  <div class="weekday">[[computeDate(item.datetime)]]
+                  <div class="weekday">[[computeDate(item.datetime)]]<br>
                     <template is="dom-if" if="[[!item.templow]]">
-                      <br>[[computeTime(item.datetime)]]</br>
+                      [[computeTime(item.datetime)]]
                     </template>
                   </div>
                   <template is="dom-if" if="[[item.condition]]">

--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -80,7 +80,6 @@ class HaWeatherCard extends
         }
 
         .weekday {
-          font-weight: bold;
           text-transform: uppercase;
         }
 
@@ -129,10 +128,11 @@ class HaWeatherCard extends
             <div class="forecast">
               <template is="dom-repeat" items="[[forecast]]">
                 <div>
-                  <div class="weekday">[[computeDate(item.datetime)]]</div>
-                  <template is="dom-if" if="[[!item.templow]]">
-                    <div class="weekday">[[computeTime(item.datetime)]]</div>
-                  </template>
+                  <div class="weekday">[[computeDate(item.datetime)]]
+                    <template is="dom-if" if="[[!item.templow]]">
+                      <br>[[computeTime(item.datetime)]]</br>
+                    </template>
+                  </div>
                   <template is="dom-if" if="[[item.condition]]">
                     <div class="icon">
                       <iron-icon icon="[[getWeatherIcon(item.condition)]]"></iron-icon>
@@ -253,7 +253,7 @@ class HaWeatherCard extends
     const date = new Date(data);
     return date.toLocaleTimeString(
       this.hass.selectedLanguage || this.hass.language,
-      { hour: '2-digit' }
+      { hour: 'numeric' }
     );
   }
 }

--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -81,6 +81,7 @@ class HaWeatherCard extends
 
         .weekday {
           font-weight: bold;
+          text-transform: uppercase;
         }
 
         .attributes,
@@ -128,7 +129,10 @@ class HaWeatherCard extends
             <div class="forecast">
               <template is="dom-repeat" items="[[forecast]]">
                 <div>
-                  <div class="weekday">[[computeDateTime(item.datetime)]]</div>
+                  <div class="weekday">[[computeDate(item.datetime)]]</div>
+                  <template is="dom-if" if="[[!item.templow]]">
+                    <div class="weekday">[[computeTime(item.datetime)]]</div>
+                  </template>
                   <template is="dom-if" if="[[item.condition]]">
                     <div class="icon">
                       <iron-icon icon="[[getWeatherIcon(item.condition)]]"></iron-icon>
@@ -237,16 +241,20 @@ class HaWeatherCard extends
     return typeof item !== 'undefined' && item !== null;
   }
 
-  computeDateTime(data) {
+  computeDate(data) {
     const date = new Date(data);
-    const provider = this.stateObj.attributes.attribution;
-    if (provider === 'Powered by Dark Sky' || provider === 'Data provided by OpenWeatherMap') {
-      return date.toLocaleTimeString(
-        this.hass.selectedLanguage || this.hass.language,
-        { hour: 'numeric' }
-      );
-    }
-    return date.toLocaleDateString(this.hass.selectedLanguage || this.hass.language, { weekday: 'short' });
+    return date.toLocaleDateString(
+      this.hass.selectedLanguage || this.hass.language,
+      { weekday: 'short' }
+    );
+  }
+
+  computeTime(data) {
+    const date = new Date(data);
+    return date.toLocaleTimeString(
+      this.hass.selectedLanguage || this.hass.language,
+      { hour: '2-digit' }
+    );
   }
 }
 customElements.define('ha-weather-card', HaWeatherCard);


### PR DESCRIPTION
This is an attempt to adapt the weather map for use with weather components working with hourly and daily forecasts.

This PR is related to home-assistant/home-assistant#14875

I used `templow` to exclude time in daily forecasts. Of course this is not the best option, since it is possible in the future there will be hourly forecasts with `temperature` and `templow`

Hourly:
![hourly](https://user-images.githubusercontent.com/33804747/41301129-30cf2378-6e89-11e8-8c13-2cfc9c0b80ad.png)
Daily:
![daily](https://user-images.githubusercontent.com/33804747/41301144-36f77cfa-6e89-11e8-9b9b-f7c89affb76b.png)