### PR TITLE
Clean up calendar panel

### DIFF
--- a/src/panels/calendar/ha-big-calendar.js
+++ b/src/panels/calendar/ha-big-calendar.js
@@ -28,7 +28,17 @@ class HaBigCalendar extends EventsMixin(PolymerElement) {
       <div id="root"></div>`;
   }
 
-  update(events) {
+  static get properties() {
+    return {
+      events: {
+        type: Array,
+        observer: '_update',
+      },
+
+    };
+  }
+
+  _update(events) {
     const allViews = BigCalendar.Views.values;
 
     const BCElement = React.createElement(
@@ -37,46 +47,22 @@ class HaBigCalendar extends EventsMixin(PolymerElement) {
         views: allViews,
         popup: true,
         onNavigate: (date, viewName) => this.fire('navigate', { date, viewName }),
-        onView: viewName => this.fire('view', { viewName }),
-        eventPropGetter: this.setEventStyle,
-        defaultView: this.defaultView,
+        onView: viewName => this.fire('view-changed', { viewName }),
+        eventPropGetter: this._setEventStyle,
+        defaultView: DEFAULT_VIEW,
         defaultDate: new Date(),
       }
     );
     render(BCElement, this.$.root);
   }
 
-  setEventStyle(event) {
+  _setEventStyle(event) {
     // https://stackoverflow.com/questions/34587067/change-color-of-react-big-calendar-events
     const newStyle = {};
     if (event.color) {
       newStyle.backgroundColor = event.color;
     }
     return { style: newStyle };
-  }
-
-  static get properties() {
-    return {
-      dateUpdated: Object,
-
-      viewUpdated: Object,
-
-      defaultView: {
-        type: String,
-        value: DEFAULT_VIEW
-      },
-
-      defaultDate: {
-        type: Object,
-        value: new Date()
-      },
-
-      events: {
-        type: Array,
-        observer: 'update',
-      },
-
-    };
   }
 }
 


### PR DESCRIPTION
To go with https://github.com/home-assistant/home-assistant/pull/14973

Cleans up the calendar panel.

- Prefixed all internal methods with _
- Make UI work better on mobile
- use let/const instead of var
- Use new API
- Removed the check all checkbox as it was not fully implemented: did not uncheck when user would uncheck one of the calendars, nor would it uncheck all calendars when checkbox checked.