### PR TITLE
Remove icon-set validation from customize

### DIFF
--- a/src/panels/config/customize/types/ha-customize-icon.js
+++ b/src/panels/config/customize/types/ha-customize-icon.js
@@ -18,7 +18,7 @@ class HaCustomizeIcon extends PolymerElement {
       }
     </style>
     <iron-icon class="icon-image" icon="[[item.value]]"></iron-icon>
-    <paper-input auto-validate="" pattern="(hass:.*)?" error-message="Must start with 'hass:'" disabled="[[item.secondary]]" label="icon" value="{{item.value}}">
+    <paper-input disabled="[[item.secondary]]" label="icon" value="{{item.value}}">
     </paper-input>
 `;
   }


### PR DESCRIPTION
we could set to `hass` or `mdi` but the user could still use a custom set