### PR TITLE
Fix config entries

### DIFF
--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -35,7 +35,13 @@ class HaForm extends EventsMixin(PolymerElement) {
       </template>
 
       <template is="dom-if" if="[[_equals(schema.type, &quot;string&quot;)]]" restamp="">
-        <paper-input label="[[computeLabel(schema)]]" value="{{data}}"></paper-input>
+        <paper-input
+          label="[[computeLabel(schema)]]"
+          value="{{data}}"
+          required="[[schema.required]]"
+          auto-validate="[[schema.required]]"
+          error-message='Required'
+        ></paper-input>
       </template>
 
       <template is="dom-if" if="[[_equals(schema.type, &quot;integer&quot;)]]" restamp="">
@@ -46,13 +52,26 @@ class HaForm extends EventsMixin(PolymerElement) {
           </div>
         </template>
         <template is="dom-if" if="[[!_isRange(schema)]]" restamp="">
-          <paper-input label="[[computeLabel(schema)]]" value="{{data}}" type="number"></paper-input>
+          <paper-input
+            label="[[computeLabel(schema)]]"
+            value="{{data}}"
+            type="number"
+            required="[[schema.required]]"
+            auto-validate="[[schema.required]]"
+            error-message='Required'
+          ></paper-input>
         </template>
       </template>
 
       <template is="dom-if" if="[[_equals(schema.type, &quot;float&quot;)]]" restamp="">
         <!--TODO-->
-        <paper-input label="[[computeLabel(schema)]]" value="{{data}}"></paper-input>
+        <paper-input
+          label="[[computeLabel(schema)]]"
+          value="{{data}}"
+          required="[[schema.required]]"
+          auto-validate="[[schema.required]]"
+          error-message='Required'
+      ></paper-input>
       </template>
 
       <template is="dom-if" if="[[_equals(schema.type, &quot;boolean&quot;)]]" restamp="">

--- a/src/dialogs/dialog-manager.js
+++ b/src/dialogs/dialog-manager.js
@@ -1,0 +1,23 @@
+// Allows registering dialogs and makes sure they are appended to the root element.
+export default (root) => {
+  root.addEventListener('register-dialog', (regEv) => {
+    let loaded = null;
+
+    const {
+      dialogShowEvent,
+      dialogTag,
+      dialogImport,
+    } = regEv.detail;
+
+    root.addEventListener(dialogShowEvent, (showEv) => {
+      if (!loaded) {
+        loaded = dialogImport().then(() => {
+          const dialogEl = document.createElement(dialogTag);
+          root.shadowRoot.appendChild(dialogEl);
+          return dialogEl;
+        });
+      }
+      loaded.then(dialogEl => dialogEl.showDialog(showEv.detail));
+    });
+  });
+};

--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -25,6 +25,7 @@ import { getActiveTranslation, getTranslation } from '../util/hass-translation.j
 import '../util/legacy-support';
 import '../util/roboto.js';
 import hassCallApi from '../util/hass-call-api.js';
+import makeDialogManager from '../dialogs/dialog-manager.js';
 
 import computeStateName from '../common/entity/compute_state_name.js';
 import applyThemesOnElement from '../common/dom/apply_themes_on_element.js';
@@ -94,6 +95,11 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
         observer: 'panelUrlChanged',
       },
     };
+  }
+
+  constructor() {
+    super();
+    makeDialogManager(this);
   }
 
   ready() {

--- a/src/panels/config/config-entries/ha-config-flow.js
+++ b/src/panels/config/config-entries/ha-config-flow.js
@@ -123,10 +123,6 @@ class HaConfigFlow extends
         value: false,
       },
 
-      _flowId: {
-        type: String,
-      },
-
       _step: {
         type: Object,
         value: null,
@@ -215,6 +211,7 @@ class HaConfigFlow extends
       flowFinished,
     });
 
+    this._errorMsg = null;
     this._step = null;
     this._stepData = {};
     this._dialogClosedCallback = null;

--- a/src/panels/config/config-entries/ha-config-flow.js
+++ b/src/panels/config/config-entries/ha-config-flow.js
@@ -1,6 +1,7 @@
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 import '@polymer/paper-dialog/paper-dialog.js';
+import '@polymer/paper-spinner/paper-spinner.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -10,6 +11,8 @@ import '../../../resources/ha-style.js';
 
 import EventsMixin from '../../../mixins/events-mixin.js';
 import LocalizeMixin from '../../../mixins/localize-mixin.js';
+
+let instance = 0;
 
 /*
  * @appliesMixin LocalizeMixin
@@ -30,50 +33,71 @@ class HaConfigFlow extends
         display: block;
         margin: 0 auto;
       }
+      .init-spinner {
+        padding: 10px 100px 34px;
+        text-align: center;
+      }
+      .submit-spinner {
+        margin-right: 16px;
+      }
     </style>
-    <paper-dialog id="dialog" with-backdrop="" opened="[[step]]" on-opened-changed="_openedChanged">
+    <paper-dialog id="dialog" with-backdrop="" opened="{{_opened}}" on-opened-changed="_openedChanged">
       <h2>
-        <template is="dom-if" if="[[_equals(step.type, &quot;abort&quot;)]]">
+        <template is="dom-if" if="[[_equals(_step.type, 'abort')]]">
           Aborted
         </template>
-        <template is="dom-if" if="[[_equals(step.type, &quot;create_entry&quot;)]]">
+        <template is="dom-if" if="[[_equals(_step.type, 'create_entry')]]">
           Success!
         </template>
-        <template is="dom-if" if="[[_equals(step.type, &quot;form&quot;)]]">
-          [[_computeStepTitle(localize, step)]]
+        <template is="dom-if" if="[[_equals(_step.type, 'form')]]">
+          [[_computeStepTitle(localize, _step)]]
         </template>
       </h2>
       <paper-dialog-scrollable>
-        <template is="dom-if" if="[[!step]]">
-          Loading flow.
+        <template is="dom-if" if="[[_errorMsg]]">
+          <div class='error'>[[_errorMsg]]</div>
         </template>
-        <template is="dom-if" if="[[step]]">
-          <template is="dom-if" if="[[_equals(step.type, &quot;abort&quot;)]]">
-            <ha-markdown content="[[_computeStepAbortedReason(localize, step)]]"></ha-markdown>
+        <template is="dom-if" if="[[!_step]]">
+          <div class='init-spinner'><paper-spinner active></paper-spinner></div>
+        </template>
+        <template is="dom-if" if="[[_step]]">
+          <template is="dom-if" if="[[_equals(_step.type, 'abort')]]">
+            <ha-markdown content="[[_computeStepAbortedReason(localize, _step)]]"></ha-markdown>
           </template>
 
-          <template is="dom-if" if="[[_equals(step.type, &quot;create_entry&quot;)]]">
-            <p>Created config for [[step.title]]</p>
+          <template is="dom-if" if="[[_equals(_step.type, 'create_entry')]]">
+            <p>Created config for [[_step.title]]</p>
           </template>
 
-          <template is="dom-if" if="[[_equals(step.type, &quot;form&quot;)]]">
-            <template is="dom-if" if="[[_computeStepDescription(localize, step)]]">
-              <ha-markdown content="[[_computeStepDescription(localize, step)]]"></ha-markdown>
+          <template is="dom-if" if="[[_equals(_step.type, 'form')]]">
+            <template is="dom-if" if="[[_computeStepDescription(localize, _step)]]">
+              <ha-markdown content="[[_computeStepDescription(localize, _step)]]"></ha-markdown>
             </template>
 
-            <ha-form data="{{stepData}}" schema="[[step.data_schema]]" error="[[step.errors]]" compute-label="[[_computeLabelCallback(localize, step)]]" compute-error="[[_computeErrorCallback(localize, step)]]"></ha-form>
+            <ha-form
+              data="{{_stepData}}"
+              schema="[[_step.data_schema]]"
+              error="[[_step.errors]]"
+              compute-label="[[_computeLabelCallback(localize, _step)]]"
+              compute-error="[[_computeErrorCallback(localize, _step)]]"
+            ></ha-form>
           </template>
         </template>
       </paper-dialog-scrollable>
       <div class="buttons">
-        <template is="dom-if" if="[[_equals(step.type, &quot;abort&quot;)]]">
+        <template is="dom-if" if="[[_equals(_step.type, 'abort')]]">
           <paper-button on-click="_flowDone">Close</paper-button>
         </template>
-        <template is="dom-if" if="[[_equals(step.type, &quot;create_entry&quot;)]]">
+        <template is="dom-if" if="[[_equals(_step.type, 'create_entry')]]">
           <paper-button on-click="_flowDone">Close</paper-button>
         </template>
-        <template is="dom-if" if="[[_equals(step.type, &quot;form&quot;)]]">
-          <paper-button on-click="_submitStep">Submit</paper-button>
+        <template is="dom-if" if="[[_equals(_step.type, 'form')]]">
+          <template is="dom-if" if="[[_loading]]">
+            <div class='submit-spinner'><paper-spinner active></paper-spinner></div>
+          </template>
+          <template is="dom-if" if="[[!_loading]]">
+            <paper-button on-click="_submitStep">Submit</paper-button>
+          </template>
         </template>
       </div>
     </paper-dialog>
@@ -82,19 +106,36 @@ class HaConfigFlow extends
 
   static get properties() {
     return {
-      hass: Object,
-      step: {
-        type: Object,
-        notify: true,
+      _hass: Object,
+      _dialogClosedCallback: Function,
+      _instance: Number,
+
+      _loading: {
+        type: Boolean,
+        value: false,
       },
-      flowId: {
+
+      // Error message when can't talk to server etc
+      _errorMsg: String,
+
+      _opened: {
+        type: Boolean,
+        value: false,
+      },
+
+      _flowId: {
         type: String,
-        observer: '_flowIdChanged'
       },
+
+      _step: {
+        type: Object,
+        value: null,
+      },
+
       /*
        * Store user entered data.
        */
-      stepData: Object,
+      _stepData: Object,
     };
   }
 
@@ -105,55 +146,78 @@ class HaConfigFlow extends
         this._submitStep();
       }
     });
-    // Fix for overlay showing on top of dialog.
-    this.$.dialog.addEventListener('iron-overlay-opened', (ev) => {
-      if (ev.target.withBackdrop) {
-        ev.target.parentNode.insertBefore(ev.target.backdropElement, ev.target);
-      }
+  }
+
+  showDialog({ hass, continueFlowId, newFlowForHandler, dialogClosedCallback }) {
+    this.hass = hass;
+    this._instance = instance++;
+    this._dialogClosedCallback = dialogClosedCallback;
+    this._createdFromHandler = !!newFlowForHandler;
+    this._loading = true;
+    this._opened = true;
+
+    const fetchStep = continueFlowId ?
+      this.hass.callApi('get', `config/config_entries/flow/${continueFlowId}`) :
+      this.hass.callApi('post', 'config/config_entries/flow', { handler: newFlowForHandler });
+
+    const curInstance = this._instance;
+
+    fetchStep.then((step) => {
+      if (curInstance !== this._instance) return;
+
+      this._processStep(step);
+      this._loading = false;
+      // When the flow changes, center the dialog.
+      // Don't do it on each step or else the dialog keeps bouncing.
+      setTimeout(() => this.$.dialog.center(), 0);
     });
   }
 
-  _flowIdChanged(flowId) {
-    if (!flowId) {
-      this.setProperties({
-        step: null,
-        stepData: {},
-      });
-      return;
-
-    // Check if parent passed in step data to use.
-    } else if (this.step) {
-      this._processStep(this.step);
-      return;
-    }
-
-    this.hass.callApi('get', `config/config_entries/flow/${flowId}`)
-      .then((step) => {
-        this._processStep(step);
-        // When the flow changes, center the dialog.
-        // Don't do it on each step or else the dialog keeps bouncing.
-        setTimeout(() => this.$.dialog.center(), 0);
-      });
-  }
-
   _submitStep() {
-    this.hass.callApi('post', `config/config_entries/flow/${this.flowId}`, this.stepData)
-      .then(step => this._processStep(step));
+    this._loading = true;
+    this._errorMsg = null;
+
+    const curInstance = this._instance;
+
+    this.hass.callApi('post', `config/config_entries/flow/${this._step.flow_id}`, this._stepData)
+      .then(
+        (step) => {
+          if (curInstance !== this._instance) return;
+
+          this._processStep(step);
+          this._loading = false;
+        },
+        (err) => {
+          this._errorMsg = (err && err.body && err.body.message) || 'Unknown error occurred';
+          this._loading = false;
+        }
+      );
   }
 
   _processStep(step) {
     if (!step.errors) step.errors = {};
-    this.step = step;
+    this._step = step;
     // We got a new form if there are no errors.
     if (Object.keys(step.errors).length === 0) {
-      this.stepData = {};
+      this._stepData = {};
     }
   }
 
   _flowDone() {
-    this.fire('flow-closed', {
-      flowFinished: true
+    this._opened = false;
+    const flowFinished = this._step && ['success', 'abort'].includes(this._step.type);
+
+    if (this._step && !flowFinished && this._createdFromHandler) {
+      this.hass.callApi('delete', `config/config_entries/flow/${this._step.flow_id}`);
+    }
+
+    this._dialogClosedCallback({
+      flowFinished,
     });
+
+    this._step = null;
+    this._stepData = {};
+    this._dialogClosedCallback = null;
   }
 
   _equals(a, b) {
@@ -162,10 +226,8 @@ class HaConfigFlow extends
 
   _openedChanged(ev) {
     // Closed dialog by clicking on the overlay
-    if (this.step && !ev.detail.value) {
-      this.fire('flow-closed', {
-        flowFinished: ['success', 'abort'].includes(this.step.type)
-      });
+    if (this._step && !ev.detail.value) {
+      this._flowDone();
     }
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,7 @@ function createConfig(isProdBuild, latestBuild) {
       __BUILD__: JSON.stringify(latestBuild ? 'latest' : 'es5'),
       __VERSION__: JSON.stringify(VERSION),
       __PUBLIC_PATH__: JSON.stringify(publicPath),
+      'process.env.NODE_ENV': JSON.stringify(isProdBuild ? 'production' : 'development'),
     }),
     new CopyWebpackPlugin(copyPluginOpts),
     // Ignore moment.js locales


### PR DESCRIPTION
Config entries were quite a bit of a mess. With the first major components moving to config entries, it needed a bit of polishing. This PR:

 - Fixes #1291. More info dialog backdrop is no longer broken after going through a flow
 - Adds a new dialog manager that allows any panel to register a dialog. This dialog will be loaded on demand and will be mounted at the root of the app, such that the overlays always work.
 - Starting a config flow will now show a spinner before showing the first step. This fixes that with things like Hue or Sonos, it is doing a search or installing packages, which can take time.
 - Fixes #1140. Show error message when the data is not correctly formatted. This should be handled more gracefully but at least showing an error message is a big win.
 - Always render the config section in narrow mode. The wide mode looks weird since there is no description for the config entries.
 - Listen to config_entry_discovered to reload the page when the background discovers a config entry while we're on the page.

![image](https://user-images.githubusercontent.com/1444314/41517842-29b42898-728c-11e8-9da4-69d76954d683.png)
