### PR TITLE
Show an error screen when panel cannot be resolved

### DIFF
--- a/src/layouts/partial-panel-resolver.js
+++ b/src/layouts/partial-panel-resolver.js
@@ -195,10 +195,7 @@ class PartialPanelResolver extends NavigateMixin(PolymerElement) {
         });
         this._state = 'loaded';
       },
-
-      (err) => {
-        this._state = 'error';
-      },
+      () => { this._state = 'error'; },
     );
   }
 


### PR DESCRIPTION
When a panel can't be loaded, we were showing an annoying error. Now it's a nice error.