### PR TITLE
Use localized operation modes in climate more-info

### DIFF
--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -29,9 +29,6 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
     <style>
       :host {
         color: var(--primary-text-color);
-        --paper-input-container-input: {
-          text-transform: capitalize;
-        }
       }
 
       .container-on,
@@ -109,9 +106,6 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
       .single-row {
         padding: 8px 0;
       }
-
-      .capitalize {
-        text-transform: capitalize;
       }
     </style>
 
@@ -157,10 +151,10 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
       <template is="dom-if" if="[[supportsOperationMode(stateObj)]]">
         <div class="container-operation_list">
           <div class="controls">
-            <paper-dropdown-menu class="capitalize" label-float="" dynamic-align="" label="[[localize('ui.card.climate.operation')]]">
+            <paper-dropdown-menu label-float="" dynamic-align="" label="[[localize('ui.card.climate.operation')]]">
               <paper-listbox slot="dropdown-content" selected="{{operationIndex}}">
                 <template is="dom-repeat" items="[[stateObj.attributes.operation_list]]" on-dom-change="handleOperationListUpdate">
-                  <paper-item class="capitalize">[[item]]</paper-item>
+                  <paper-item>[[_localizeOperationMode(localize, item)]]</paper-item>
                 </template>
               </paper-listbox>
             </paper-dropdown-menu>
@@ -462,6 +456,10 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
       .then(() => {
         this.stateObjChanged(this.stateObj);
       });
+  }
+
+  _localizeOperationMode(localize, mode) {
+    return localize(`state.climate.${mode}`) || mode;
   }
 }
 


### PR DESCRIPTION
## Description
This PR is a small tweak for the climate more-info to localize operation mode selections.

![image](https://user-images.githubusercontent.com/1386547/41632721-40388f04-7409-11e8-8032-fbe7b1ad0b58.png)