### PR TITLE
Track when cards get defined

### DIFF
--- a/src/panels/lovelace/hui-view.js
+++ b/src/panels/lovelace/hui-view.js
@@ -106,6 +106,7 @@ class HUIView extends PolymerElement {
   constructor() {
     super();
     this._elements = [];
+    this._whenDefined = {};
   }
 
   _getElements(cards) {
@@ -123,6 +124,10 @@ class HUIView extends PolymerElement {
           error = `Unknown card type encountered: "${cardConfig.type}".`;
         } else if (!customElements.get(tag)) {
           error = `Custom element doesn't exist: "${tag}".`;
+          if (!(tag in this._whenDefined)) {
+            this._whenDefined[tag] = customElements.whenDefined(tag)
+              .then(() => this._configChanged());
+          }
         }
       }
       if (error) {


### PR DESCRIPTION
When a card is getting defined after the config has been created, rebuild the UI.

This is helpful if the card is defined in, or depends on an external resource.