### PR TITLE
Bump min version for latest to use async/await

### DIFF
--- a/.eslintrc-hound.json
+++ b/.eslintrc-hound.json
@@ -50,6 +50,7 @@
     "no-multi-assign": 0,
     "radix": 0,
     "no-alert": 0,
+    "no-return-await": 0,
     "prefer-destructuring": 0,
     "no-restricted-globals": [2, "event"],
     "prefer-promise-reject-errors": 0,

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "preact": "^8.2.9",
     "preact-compat": "^3.18.0",
     "react-big-calendar": "^0.19.1",
+    "regenerator-runtime": "^0.11.1",
     "unfetch": "^3.0.0",
     "web-animations-js": "^2.3.1",
     "xss": "^1.0.3"

--- a/public/__init__.py
+++ b/public/__init__.py
@@ -3,13 +3,13 @@ import os
 from user_agents import parse
 
 FAMILY_MIN_VERSION = {
-    'Chrome': 54,          # Object.values
-    'Chrome Mobile': 54,
-    'Firefox': 47,         # Object.values
-    'Firefox Mobile': 47,
-    'Opera': 41,           # Object.values
-    'Edge': 14,            # Array.prototype.includes added in 14
-    'Safari': 10,          # Many features not supported by 9
+    'Chrome': 55,          # Async/await
+    'Chrome Mobile': 55,
+    'Firefox': 52,         # Async/await
+    'Firefox Mobile': 52,
+    'Opera': 42,           # Async/await
+    'Edge': 15,            # Async/await
+    'Safari': 10.1,        # Async/await
 }
 
 

--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -240,7 +240,7 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
           // If we connect with access token and get 401, refresh token and try again
           const accessToken = await window.refreshToken();
           conn.options.accessToken = accessToken;
-          return await hassCallApi(host, auth, method, path, parameters)
+          return await hassCallApi(host, auth, method, path, parameters);
         }
       },
     }, this.$.storage.getStoredState());
@@ -337,7 +337,7 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
 
     try {
       this.connection = await prom;
-    } catch(err) {
+    } catch (err) {
       this.connectionPromise = null;
     }
   }

--- a/src/entrypoints/compatibility.js
+++ b/src/entrypoints/compatibility.js
@@ -1,5 +1,6 @@
 import 'mdn-polyfills/Array.prototype.includes';
 import 'unfetch/polyfill';
+import "regenerator-runtime/runtime";
 import objAssign from 'es6-object-assign';
 
 objAssign.polyfill();

--- a/src/entrypoints/compatibility.js
+++ b/src/entrypoints/compatibility.js
@@ -1,6 +1,6 @@
 import 'mdn-polyfills/Array.prototype.includes';
 import 'unfetch/polyfill';
-import "regenerator-runtime/runtime";
+import 'regenerator-runtime/runtime';
 import objAssign from 'es6-object-assign';
 
 objAssign.polyfill();


### PR DESCRIPTION
This PR will bump the min versions of browsers that we ship 'latest' to, so that we can use async/await syntax.

Async/await functions in JavaScript work exactly like they do in Python, except that they are scheduled to run the moment you call the function. The implementation in JavaScript is powered by promises, so anything that returns a promise can now be awaited.

```
async function _eventHandler(ev) {
  await this.hass.callApi(…)
}
```

This was requested in the chat by @andrey-git recently and I really like the idea.