### PR TITLE
Fix wrapping in the entities card

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.js
+++ b/src/panels/lovelace/cards/hui-entities-card.js
@@ -26,8 +26,7 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
       #states {
         margin: -4px 0;
       }
-      #states > * {
-        display: block;
+      #states > div {
         margin: 4px 0;
       }
       .header {
@@ -103,7 +102,9 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
       element.stateObj = stateObj;
       element.hass = this.hass;
       this._elements.push({ entityId, element });
-      root.appendChild(element);
+      const container = document.createElement('div');
+      container.appendChild(element);
+      root.appendChild(container);
     }
   }
 


### PR DESCRIPTION
I assumed we could style the entity display custom elements, but that was messing with their style. So now wrap it in a div and put margin on that.