### PR TITLE
Allow specifying external resources

### DIFF
--- a/src/common/dom/load_resource.js
+++ b/src/common/dom/load_resource.js
@@ -1,7 +1,7 @@
 // Load a resource and get a promise when loading done.
 // From: https://davidwalsh.name/javascript-loader
 
-function _load(tag, url) {
+function _load(tag, url, type) {
   // This promise will be used by Promise.all to determine success or failure
   return new Promise(function (resolve, reject) {
     const element = document.createElement(tag);
@@ -16,6 +16,9 @@ function _load(tag, url) {
     switch (tag) {
       case 'script':
         element.async = true;
+        if (type) {
+          element.type = type;
+        }
         break;
       case 'link':
         element.type = 'text/css';
@@ -33,3 +36,4 @@ function _load(tag, url) {
 export const loadCSS = url => _load('link', url);
 export const loadJS = url => _load('script', url);
 export const loadImg = url => _load('img', url);
+export const loadModule = url => _load('script', url, 'module');

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -11,7 +11,11 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import EventsMixin from '../../mixins/events-mixin.js';
 import '../../layouts/ha-app-layout.js';
+import { loadModule, loadJS } from '../../common/dom/load_resource.js';
 import './hui-view.js';
+
+// JS should only be imported once. Modules and HTML are safe.
+const JS_CACHE = {};
 
 class HUIRoot extends EventsMixin(PolymerElement) {
   static get template() {
@@ -138,7 +142,8 @@ class HUIRoot extends EventsMixin(PolymerElement) {
     this.$.view.lastChild.hass = hass;
   }
 
-  _configChanged() {
+  _configChanged(config) {
+    this._loadResources(config.resources);
     // On config change, recreate the view from scratch.
     this._selectView(this._curView);
   }
@@ -148,6 +153,28 @@ class HUIRoot extends EventsMixin(PolymerElement) {
     this.$.view.lastChild.columns = columns;
   }
 
+  _loadResources(resources) {
+    resources.forEach((resource) => {
+      switch(resource.type) {
+        case 'js':
+          if (resource.url in JS_CACHE) break;
+          JS_CACHE[resource.url] = loadJS(resource.url);
+          break;
+
+        case 'module':
+          loadModule(resource.url);
+          break;
+
+        case 'html':
+          import(/* webpackChunkName: "import-href-polyfill" */ '../../resources/html-import/import-href.js')
+            .then(({ importHref }) => importHref(resource.url));
+          break;
+
+        default:
+          console.warn('Unknown resource type specified: ${resource.type}');
+      }
+    });
+  }
 
   /**
    * Scroll to a specific y coordinate.

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -155,7 +155,7 @@ class HUIRoot extends EventsMixin(PolymerElement) {
 
   _loadResources(resources) {
     resources.forEach((resource) => {
-      switch(resource.type) {
+      switch (resource.type) {
         case 'js':
           if (resource.url in JS_CACHE) break;
           JS_CACHE[resource.url] = loadJS(resource.url);
@@ -171,6 +171,7 @@ class HUIRoot extends EventsMixin(PolymerElement) {
           break;
 
         default:
+          // eslint-disable-next-line
           console.warn('Unknown resource type specified: ${resource.type}');
       }
     });


### PR DESCRIPTION
Allow importing extra resources from Lovelace config. Dedupes JS imports, ES and HTML imports are already deduped.

```yaml
# Example ui-lovelace.yaml
resources:
  - url: https://s3.amazonaws.com/home-assistant-demos/lovelace-examples/wired-cards.js
    type: module
views:
- name: Example 
  cards:
  - type: "custom:wired-toggle-card"
    entities:
      - input_boolean.switch_ac_kitchen
      - input_boolean.switch_ac_livingroom
      - input_boolean.switch_tv
```