### PR TITLE
Compatibility fix for custom panel

### DIFF
--- a/src/entrypoints/compatibility.js
+++ b/src/entrypoints/compatibility.js
@@ -6,5 +6,7 @@ import objAssign from 'es6-object-assign';
 objAssign.polyfill();
 
 if (Object.values === undefined) {
-  Object.values = target => Object.keys(target).map(key => target[key]);
+  Object.values = function(target) {
+    return Object.keys(target).map(function(key) { return target[key]; });
+  }
 }

--- a/src/entrypoints/compatibility.js
+++ b/src/entrypoints/compatibility.js
@@ -6,7 +6,7 @@ import objAssign from 'es6-object-assign';
 objAssign.polyfill();
 
 if (Object.values === undefined) {
-  Object.values = function(target) {
-    return Object.keys(target).map(function(key) { return target[key]; });
-  }
+  Object.values = function (target) {
+    return Object.keys(target).map(function (key) { return target[key]; });
+  };
 }

--- a/src/entrypoints/custom-panel.js
+++ b/src/entrypoints/custom-panel.js
@@ -12,7 +12,10 @@ let es5Loaded = null;
 
 window.loadES5Adapter = () => {
   if (!es5Loaded) {
-    es5Loaded = loadJS(`${__PUBLIC_PATH__}custom-elements-es5-adapter.js`).catch();
+    es5Loaded = Promise.all([
+      loadJS(`${__PUBLIC_PATH__}custom-elements-es5-adapter.js`).catch(),
+      loadJS(`${__PUBLIC_PATH__}compatibility.js`),
+    ]);
   }
   return es5Loaded;
 };

--- a/src/util/custom-panel/load-custom-panel.js
+++ b/src/util/custom-panel/load-custom-panel.js
@@ -3,18 +3,24 @@ import { loadJS } from '../../common/dom/load_resource.js';
 // Make sure we only import every JS-based panel once (HTML import has this built-in)
 const JS_CACHE = {};
 
-export default function loadCustomPanel(panelConfig) {
-  if ('html_url' in panelConfig) {
-    return Promise.all([
-      import(/* webpackChunkName: "legacy-support" */ '../legacy-support.js'),
+export default async function loadCustomPanel(panelConfig) {
+  if (panelConfig.html_url) {
+    const toLoad = [
       import(/* webpackChunkName: "import-href-polyfill" */ '../../resources/html-import/import-href.js'),
-    // eslint-disable-next-line
-    ]).then(([{}, { importHrefPromise }]) => importHrefPromise(panelConfig.html_url));
+    ];
+
+    if (!panelConfig.embed_iframe) {
+      toLoad.push(import(/* webpackChunkName: "legacy-support" */ '../legacy-support.js'));
+    }
+
+    const [{ importHrefPromise }] = await Promise.all(toLoad);
+    await importHrefPromise(panelConfig.html_url);
   } else if (panelConfig.js_url) {
     if (!(panelConfig.js_url in JS_CACHE)) {
       JS_CACHE[panelConfig.js_url] = loadJS(panelConfig.js_url);
     }
-    return JS_CACHE[panelConfig.js_url];
+    await JS_CACHE[panelConfig.js_url];
+  } else {
+    throw new Error('No valid url found in panel config.');
   }
-  return Promise.reject('No valid url found in panel config.');
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ function createConfig(isProdBuild, latestBuild) {
     app: './src/entrypoints/app.js',
     authorize: './src/entrypoints/authorize.js',
     core: './src/entrypoints/core.js',
+    compatibility: './src/entrypoints/compatibility.js',
     'custom-panel': './src/entrypoints/custom-panel.js',
   };
 
@@ -81,7 +82,6 @@ function createConfig(isProdBuild, latestBuild) {
     babelOptions.presets = [
       [require('babel-preset-env').default, { modules: false }]
     ];
-    entry.compatibility = './src/entrypoints/compatibility.js';
   }
 
   if (isProdBuild) {


### PR DESCRIPTION
Two fixes for custom panels (including Hass.io):

 - When an HTML panel is loaded inside an iframe, do not include our legacy support.
 - When a panel is in an iframe and loads the es5 custom elements adapter, also load the compatibility layer (polyfills for older browsers)