### PR TITLE
Fixed invalid contant type header

### DIFF
--- a/src/util/hass-call-api.js
+++ b/src/util/hass-call-api.js
@@ -47,7 +47,7 @@ export default function hassCallApi(host, auth, method, path, parameters) {
     };
 
     if (parameters) {
-      req.setRequestHeader('Content-Type', 'application;charset=UTF-8');
+      req.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
       req.send(JSON.stringify(parameters));
     } else {
       req.send();


### PR DESCRIPTION
The `application` is not a valid MimeType:
https://www.iana.org/assignments/media-types/media-types.xhtml#application

This creates a problem when running behind more strict proxy than NGINX e.g. Spring Cloud based one like this one: https://gitlab.com/gyatso-home-automation/oauth2proxy 