### PR TITLE
Do not use async await in custom panels

### DIFF
--- a/src/util/custom-panel/load-custom-panel.js
+++ b/src/util/custom-panel/load-custom-panel.js
@@ -13,7 +13,8 @@ export default function loadCustomPanel(panelConfig) {
       toLoad.push(import(/* webpackChunkName: "legacy-support" */ '../legacy-support.js'));
     }
 
-    return Promise.all(toLoad).then(([{ importHrefPromise }]) => importHrefPromise(panelConfig.html_url));
+    return Promise.all(toLoad).then(([{ importHrefPromise }]) =>
+      importHrefPromise(panelConfig.html_url));
   } else if (panelConfig.js_url) {
     if (!(panelConfig.js_url in JS_CACHE)) {
       JS_CACHE[panelConfig.js_url] = loadJS(panelConfig.js_url);

--- a/src/util/custom-panel/load-custom-panel.js
+++ b/src/util/custom-panel/load-custom-panel.js
@@ -3,7 +3,7 @@ import { loadJS } from '../../common/dom/load_resource.js';
 // Make sure we only import every JS-based panel once (HTML import has this built-in)
 const JS_CACHE = {};
 
-export default async function loadCustomPanel(panelConfig) {
+export default function loadCustomPanel(panelConfig) {
   if (panelConfig.html_url) {
     const toLoad = [
       import(/* webpackChunkName: "import-href-polyfill" */ '../../resources/html-import/import-href.js'),
@@ -13,14 +13,12 @@ export default async function loadCustomPanel(panelConfig) {
       toLoad.push(import(/* webpackChunkName: "legacy-support" */ '../legacy-support.js'));
     }
 
-    const [{ importHrefPromise }] = await Promise.all(toLoad);
-    await importHrefPromise(panelConfig.html_url);
+    return Promise.all(toLoad).then(([{ importHrefPromise }]) => importHrefPromise(panelConfig.html_url));
   } else if (panelConfig.js_url) {
     if (!(panelConfig.js_url in JS_CACHE)) {
       JS_CACHE[panelConfig.js_url] = loadJS(panelConfig.js_url);
     }
-    await JS_CACHE[panelConfig.js_url];
-  } else {
-    throw new Error('No valid url found in panel config.');
+    return JS_CACHE[panelConfig.js_url];
   }
+  return Promise.reject('No valid url found in panel config.');
 }


### PR DESCRIPTION
We were using async/await in custom panels code. However, by default we don't load the compatibility layer. This means that the es5 custom panels are currently broken.

Removed async/await and this fixes the ES5 version of the frontend being unable to load the Hass.io panel.

Fixes #1329