### PR TITLE
Love: Card to show entites on picture

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-gone-wild.js
+++ b/src/panels/lovelace/cards/hui-entities-gone-wild.js
@@ -6,7 +6,6 @@ import '../../../components/ha-card.js';
 
 import { STATES_ON } from '../../../common/const.js';
 import canToggleState from '../../../common/entity/can_toggle_state.js';
-import computeDomain from '../../../common/entity/compute_domain.js';
 import computeStateDisplay from '../../../common/entity/compute_state_display.js';
 import computeStateName from '../../../common/entity/compute_state_name.js';
 import stateIcon from '../../../common/entity/state_icon.js';

--- a/src/panels/lovelace/cards/hui-entities-gone-wild.js
+++ b/src/panels/lovelace/cards/hui-entities-gone-wild.js
@@ -1,0 +1,168 @@
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import '@polymer/iron-icon/iron-icon.js';
+
+import '../../../components/ha-card.js';
+
+import { STATES_ON } from '../../../common/const.js';
+import canToggleState from '../../../common/entity/can_toggle_state.js';
+import computeDomain from '../../../common/entity/compute_domain.js';
+import computeStateDisplay from '../../../common/entity/compute_state_display.js';
+import computeStateName from '../../../common/entity/compute_state_name.js';
+import stateIcon from '../../../common/entity/state_icon.js';
+
+import EventsMixin from '../../../mixins/events-mixin.js';
+import LocalizeMixin from '../../../mixins/localize-mixin.js';
+
+/*
+ * @appliesMixin EventsMixin
+ * @appliesMixin LocalizeMixin
+ */
+class HuiEntitiesGoneWildCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
+  static get template() {
+    return html`
+    <style>
+      ha-card {
+        padding: 16px;
+      }
+      .header {
+        @apply --paper-font-headline;
+        /* overwriting line-height +8 because entity-toggle can be 40px height,
+           compensating this with reduced padding */
+        line-height: 40px;
+        color: var(--primary-text-color);
+        padding: 4px 0 12px;
+      }
+      .header .name {
+        @apply --paper-font-common-nowrap;
+      }
+      .content {
+        position: relative;
+      }
+      .content > iron-icon,
+      .content > div {
+        white-space: nowrap;
+        position: absolute;
+        transform: translate(-50%, -50%);
+      }
+      .content > div > * {
+        position: static;
+      }
+      .content img {
+        width: 100%;
+      }
+      .clickable {
+        cursor: pointer;
+        padding: 4px;
+      }
+      iron-icon,
+      paper-icon-button {
+        color: var(--icon-color, var(--state-icon-color, #44739e));
+      }
+      iron-icon.state-on {
+        color: var(--icon-color-on, var(--state-icon-active-color, #FDD835));
+      }
+    </style>
+
+    <ha-card>
+      <div class='header'>
+        <div class="name">[[config.title]]</div>
+      </div>
+      <div class="content">
+        <img src="[[config.image]]">
+        <template is="dom-repeat" items="[[config.entities]]">
+          <template is="dom-if" if="[[_equals(item.type, 'badge')]]">
+            <iron-icon
+              on-click="_openDialog"
+              class$="[[_computeClass(item.entity_id, hass)]]"
+              style$="[[_computeStyle(item)]]"
+              icon="[[_computeIcon(item.entity_id, hass.states)]]"
+              title="[[_computeTooltip(item.entity_id, hass.states)]]"
+            ></iron-icon>
+          </template>
+          <template is="dom-if" if="[[_equals(item.type, 'state')]]">
+            <div
+              on-click="_openDialog"
+              class="clickable"
+              style$="[[_computeStyle(item)]]"
+              title="[[_computeTooltip(item.entity_id, hass.states)]]"
+            >[[_computeState(item.entity_id, hass.states)]]</div>
+          </template>
+          <template is="dom-if" if="[[_equals(item.type, 'button')]]">
+            <div
+              on-click="_callService"
+              class="clickable"
+              style$="[[_computeStyle(item)]]"
+            >
+              <template is="dom-if" if="[[item.icon]]">
+                <iron-icon icon="[[item.icon]]"></iron-icon>
+              </template>
+              [[item.text]]
+            </div>
+          </template>
+          <template is="dom-if" if="[[_equals(item.type, 'text')]]">
+            <div style$="[[_computeStyle(item)]]">[[item.text]]</div>
+          </template>
+        </template>
+      </div>
+    </ha-card>
+`;
+  }
+
+  static get properties() {
+    return {
+      hass: Object,
+      config: Object
+    };
+  }
+
+  constructor() {
+    super();
+    this._elements = [];
+  }
+
+  getCardSize() {
+    return 5;
+  }
+
+  _equals(a, b) {
+    return a === b;
+  }
+
+  _computeStateObj(item, states) {
+    return states[item];
+  }
+
+  _computeState(item, states) {
+    return computeStateDisplay(this.localize, states[item]);
+  }
+
+  _computeClass(entityId, hass) {
+    return (canToggleState(hass, hass.states[entityId]) &&
+      STATES_ON.includes(hass.states[entityId].state)) ?
+      'state-on clickable' : 'clickable';
+  }
+
+  _computeStyle(item) {
+    return `top: ${item.top}; left: ${item.left}; ${item.style || ''}`;
+  }
+
+  _computeTooltip(entityId, states) {
+    return `${computeStateName(states[entityId])}: ${computeStateDisplay(this.localize, states[entityId])}`;
+  }
+
+  _computeIcon(entityId, states) {
+    return stateIcon(states[entityId]);
+  }
+
+  _openDialog(ev) {
+    this.fire('hass-more-info', { entityId: ev.model.item.entity_id });
+  }
+
+  _callService(ev) {
+    const item = ev.model.item;
+    this.hass.callService(item.domain, item.service, item.service_data);
+  }
+}
+
+customElements.define('hui-entities-gone-wild-card', HuiEntitiesGoneWildCard);

--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -1,7 +1,5 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
-import './hui-error-card';
-
 import computeStateDomain from '../../../common/entity/compute_state_domain.js';
 import createCardElement from '../common/create-card-element';
 

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -115,7 +115,7 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
   _handleClick(entityId, toggle) {
     if (toggle) {
       const turnOn = !STATES_ON.includes(this.hass.states[entityId].state);
-      const stateDomain = computeDomain(entityId)
+      const stateDomain = computeDomain(entityId);
       const serviceDomain = stateDomain === 'lock' || stateDomain === 'cover' ?
         stateDomain : 'homeassistant';
 
@@ -130,8 +130,7 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
         default:
           service = turnOn ? 'turn_on' : 'turn_off';
       }
-      this.hass.callService(serviceDomain, service, { entity_id: entityId })
-
+      this.hass.callService(serviceDomain, service, { entity_id: entityId });
     } else {
       this.fire('hass-more-info', { entityId });
     }

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -1,6 +1,5 @@
 import '../cards/hui-camera-preview-card.js';
 import '../cards/hui-entities-card.js';
-import '../cards/hui-entities-gone-wild.js';
 import '../cards/hui-entity-filter-card.js';
 import '../cards/hui-glance-card';
 import '../cards/hui-history-graph-card.js';
@@ -8,6 +7,7 @@ import '../cards/hui-iframe-card.js';
 import '../cards/hui-markdown-card.js';
 import '../cards/hui-media-control-card.js';
 import '../cards/hui-entity-picture-card.js';
+import '../cards/hui-picture-elements-card';
 import '../cards/hui-picture-glance-card';
 import '../cards/hui-plant-status-card.js';
 import '../cards/hui-weather-forecast-card';
@@ -16,7 +16,6 @@ import '../cards/hui-error-card.js';
 const CARD_TYPES = [
   'camera-preview',
   'entities',
-  'entities-gone-wild',
   'entity-filter',
   'entity-picture',
   'glance',
@@ -24,6 +23,7 @@ const CARD_TYPES = [
   'iframe',
   'markdown',
   'media-control',
+  'picture-elements',
   'picture-glance',
   'plant-status',
   'weather-forecast'

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -1,5 +1,6 @@
 import '../cards/hui-camera-preview-card.js';
 import '../cards/hui-entities-card.js';
+import '../cards/hui-entities-gone-wild.js';
 import '../cards/hui-entity-filter-card.js';
 import '../cards/hui-glance-card';
 import '../cards/hui-history-graph-card.js';
@@ -15,6 +16,7 @@ import '../cards/hui-error-card.js';
 const CARD_TYPES = [
   'camera-preview',
   'entities',
+  'entities-gone-wild',
   'entity-filter',
   'entity-picture',
   'glance',


### PR DESCRIPTION
fix: https://github.com/home-assistant/ui-schema/issues/52

![unbenannt](https://user-images.githubusercontent.com/11984118/41935208-276a6dc8-7989-11e8-9bb2-05fb59349512.PNG)


```yaml
  - name: new cards
    cards:
      - type: picture-elements
        title: picture elements
        image: /local/floorplan.png
        elements:
          - type: state-badge
            entity: light.ceiling_lights
            style:
              top: 30%
              left: 55%
              '--paper-item-icon-color': green
          - type: state-badge
            action: toggle
            entity: light.ceiling_lights
            style:
              top: 30%
              left: 20%
```