### PR TITLE
Love: Picture elements: Add service button and text state

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -32,7 +32,7 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
         position: absolute;
         transform: translate(-50%, -50%);
       }
-      div.element {
+      .state-text {
         padding: 8px;
       }
       .clickable {
@@ -92,7 +92,7 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
           const entityId = element.entity;
           el = document.createElement('div');
           el.addEventListener('click', () => this._handleClick(entityId, false));
-          el.classList.add('clickable');
+          el.classList.add('clickable', 'state-text');
           this._requiresTextState.push({ el, entityId });
         } else if (element.type === 'service-button') {
           el = document.createElement('ha-call-service-button');
@@ -102,12 +102,12 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
           el.serviceData = (element.service && element.service.data) || {};
           el.innerText = element.text;
         }
+        el.classList.add('element');
         if (element.style) {
           Object.keys(element.style).forEach((prop) => {
             el.style.setProperty(prop, element.style[prop]);
           });
         }
-        el.classList.add('element');
         root.appendChild(el);
       });
     }

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -98,9 +98,9 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
         } else if (element.type === 'service-button') {
           el = document.createElement('ha-call-service-button');
           el.hass = this.hass;
-          el.domain = element.service && element.domain || 'homeassistant';
-          el.service = element.service && element.service.service || '';
-          el.serviceData = element.service && element.service.data || {};
+          el.domain = (element.service && element.domain) || 'homeassistant';
+          el.service = (element.service && element.service.service) || '';
+          el.serviceData = (element.service && element.service.data) || {};
           el.innerText = element.text;
         }
         if (element.style) {

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -21,13 +21,19 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
   static get template() {
     return html`
     <style>
+      ha-card {
+        overflow: hidden;
+      }
       #root {
         position: relative;
+        overflow: hidden;
+        line-height: 0;
       }
       #root img {
         width: 100%;
       }
       .element {
+        line-height: initial;
         white-space: nowrap;
         position: absolute;
         transform: translate(-50%, -50%);

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -21,9 +21,6 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
   static get template() {
     return html`
     <style>
-      ha-card {
-        line-height: 0;
-      }
       #root {
         position: relative;
       }
@@ -36,8 +33,7 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
         transform: translate(-50%, -50%);
       }
       div.element {
-        padding: 4px;
-        line-height: 1em;
+        padding: 8px;
       }
       .clickable {
         cursor: pointer;

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -30,11 +30,14 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
       #root img {
         width: 100%;
       }
-      .entity {
-        line-height: 1em;
+      .element {
         white-space: nowrap;
         position: absolute;
         transform: translate(-50%, -50%);
+      }
+      div.element {
+        padding: 4px;
+        line-height: 1em;
       }
       .clickable {
         cursor: pointer;
@@ -108,7 +111,7 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
             el.style.setProperty(prop, element.style[prop]);
           });
         }
-        el.classList.add('entity');
+        el.classList.add('element');
         root.appendChild(el);
       });
     }


### PR DESCRIPTION
![11](https://user-images.githubusercontent.com/11984118/41975567-668048e2-7a1b-11e8-8f87-1729c139374f.PNG)
```yaml
    cards:
      - type: picture-elements
        title: picture elements
        image: /local/floorplan.png
        elements:
          - type: state-badge
            entity: light.ceiling_lights
            style:
              top: 30%
              left: 55%
              '--paper-item-icon-color': green
          - type: state-badge
            action: toggle
            entity: light.ceiling_lights
            style:
              top: 30%
              left: 20%
          - type: service-button
            text: turn light off
            style:
              top: 15%
              left: 85%
            service:
              domain: light
              service: turn_off
              data:
                entity_id: light.ceiling_lights
          - type: state-text
            entity: sensor.temperature
            style:
              top: 50%
              left: 55%
```