### PR TITLE
Fix climate state without translation

### DIFF
--- a/src/components/ha-climate-state.js
+++ b/src/components/ha-climate-state.js
@@ -85,7 +85,7 @@ class HaClimateState extends LocalizeMixin(PolymerElement) {
   }
 
   _localizeState(state) {
-    return this.localize(`state.climate.${state}`);
+    return this.localize(`state.climate.${state}`) || state;
   }
 }
 customElements.define('ha-climate-state', HaClimateState);


### PR DESCRIPTION
**Fixes:** https://github.com/home-assistant/home-assistant/issues/14886

Some climate platforms support additional states, that don't have a translation. If that's the case, we should default to the `state` name instead of displaying nothing.

I though about adding those states to the translation file, but I'm not sure if we should do that since most of them are only used for one platform. In addition the bug would reoccur if a new platform is added with other custom states.