### PR TITLE
Organize createElement

### DIFF
--- a/src/common/dom/fire_event.js
+++ b/src/common/dom/fire_event.js
@@ -1,7 +1,3 @@
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
-
-import fireEvent from '../common/dom/fire_event.js';
-
 // Polymer legacy event helpers used courtesy of the Polymer project.
 //
 // Copyright (c) 2017 The Polymer Authors. All rights reserved.
@@ -32,25 +28,30 @@ import fireEvent from '../common/dom/fire_event.js';
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-/* @polymerMixin */
-export default dedupingMixin(superClass => class extends superClass {
-  /**
-   * Dispatches a custom event with an optional detail value.
-   *
-   * @param {string} type Name of event type.
-   * @param {*=} detail Detail value containing event-specific
-   *   payload.
-   * @param {{ bubbles: (boolean|undefined),
-               cancelable: (boolean|undefined),
-                composed: (boolean|undefined) }=}
-    *  options Object specifying options.  These may include:
-    *  `bubbles` (boolean, defaults to `true`),
-    *  `cancelable` (boolean, defaults to false), and
-    *  `node` on which to fire the event (HTMLElement, defaults to `this`).
-    * @return {Event} The new event that was fired.
-    */
-  fire(type, detail, options) {
-    options = options || {};
-    return fireEvent(options.node || this, type, detail, options);
-  }
-});
+/**
+ * Dispatches a custom event with an optional detail value.
+ *
+ * @param {string} type Name of event type.
+ * @param {*=} detail Detail value containing event-specific
+ *   payload.
+ * @param {{ bubbles: (boolean|undefined),
+             cancelable: (boolean|undefined),
+             composed: (boolean|undefined) }=}
+  *  options Object specifying options.  These may include:
+  *  `bubbles` (boolean, defaults to `true`),
+  *  `cancelable` (boolean, defaults to false), and
+  *  `node` on which to fire the event (HTMLElement, defaults to `this`).
+  * @return {Event} The new event that was fired.
+  */
+export default function fire(node, type, detail, options) {
+  options = options || {};
+  detail = (detail === null || detail === undefined) ? {} : detail;
+  const event = new Event(type, {
+    bubbles: options.bubbles === undefined ? true : options.bubbles,
+    cancelable: Boolean(options.cancelable),
+    composed: options.composed === undefined ? true : options.composed
+  });
+  event.detail = detail;
+  node.dispatchEvent(event);
+  return event;
+}

--- a/src/common/util/debounce.js
+++ b/src/common/util/debounce.js
@@ -1,0 +1,20 @@
+// From: https://davidwalsh.name/javascript-debounce-function
+
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// N milliseconds. If `immediate` is passed, trigger the function on the
+// leading edge, instead of the trailing.
+export default function debounce(func, wait, immediate) {
+  let timeout;
+  return function (...args) {
+    const context = this;
+    const later = () => {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    const callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}

--- a/src/panels/lovelace/cards/hui-error-card.js
+++ b/src/panels/lovelace/cards/hui-error-card.js
@@ -12,15 +12,14 @@ class HuiErrorCard extends PolymerElement {
           padding: 8px;
         }
       </style>
-      [[error]]
-      <pre>[[_toStr(config)]]</pre>
+      [[config.error]]
+      <pre>[[_toStr(config.origConfig)]]</pre>
     `;
   }
 
   static get properties() {
     return {
       config: Object,
-      error: String
     };
   }
 

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -27,13 +27,12 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
       #root {
         position: relative;
         overflow: hidden;
-        line-height: 0;
       }
       #root img {
+        display: block;
         width: 100%;
       }
       .element {
-        line-height: initial;
         white-space: nowrap;
         position: absolute;
         transform: translate(-50%, -50%);

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -1,3 +1,5 @@
+import fireEvent from '../../../common/dom/fire_event.js';
+
 import '../cards/hui-camera-preview-card.js';
 import '../cards/hui-entities-card.js';
 import '../cards/hui-entity-filter-card.js';
@@ -13,11 +15,14 @@ import '../cards/hui-plant-status-card.js';
 import '../cards/hui-weather-forecast-card';
 import '../cards/hui-error-card.js';
 
+import createErrorCardConfig from './create-error-card-config.js';
+
 const CARD_TYPES = [
   'camera-preview',
   'entities',
   'entity-filter',
   'entity-picture',
+  'error',
   'glance',
   'history-graph',
   'iframe',
@@ -31,33 +36,41 @@ const CARD_TYPES = [
 
 const CUSTOM_TYPE_PREFIX = 'custom:';
 
-export default function
-createCardElement(config, elementNotDefinedCallback = null, invalidConfig = null) {
-  let error = invalidConfig;
-  let tag;
-
-  if (!error && config && typeof config === 'object' && config.type) {
-    if (CARD_TYPES.includes(config.type)) {
-      tag = `hui-${config.type}-card`;
-    } else if (config.type.startsWith(CUSTOM_TYPE_PREFIX)) {
-      tag = config.type.substr(CUSTOM_TYPE_PREFIX.length);
-    }
-
-    if (tag) {
-      if (!customElements.get(tag)) {
-        error = 'Custom element doesn\'t exist.';
-        if (elementNotDefinedCallback) elementNotDefinedCallback(tag);
-      }
-    } else {
-      error = 'Unknown card type encountered.';
-    }
-  } else {
-    error = 'No card type configured.';
-  }
-
-  if (error) tag = 'hui-error-card';
+function _createElement(tag, config) {
   const element = document.createElement(tag);
-  if (error) element.error = error;
   element.config = config;
   return element;
+}
+
+function _createErrorElement(error, config) {
+  return _createElement('hui-error-card', createErrorCardConfig(error, config));
+}
+
+export default function createCardElement(config) {
+  let tag;
+
+  if (!config || typeof config !== 'object' || !config.type) {
+    return _createErrorElement('No card type configured.', config);
+  }
+
+  if (config.type.startsWith(CUSTOM_TYPE_PREFIX)) {
+    tag = config.type.substr(CUSTOM_TYPE_PREFIX.length);
+
+    if (customElements.get(tag)) {
+      return _createElement(tag, config);
+    }
+
+    const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);
+
+    customElements.whenDefined(tag)
+      .then(() => fireEvent(element, 'rebuild-view'));
+
+    return element;
+  }
+
+  if (!CARD_TYPES.includes(config.type)) {
+    return _createErrorElement(`Unknown card type encountered: ${config.type}.`, config);
+  }
+
+  return _createElement(`hui-${config.type}-card`, config);
 }

--- a/src/panels/lovelace/common/create-error-card-config.js
+++ b/src/panels/lovelace/common/create-error-card-config.js
@@ -1,0 +1,7 @@
+export default function createErrorConfig(error, origConfig) {
+  return {
+    type: 'error',
+    error,
+    origConfig,
+  };
+}


### PR DESCRIPTION
Clean up createElement to make it more re-usable:

 - Filter entity card will no longer mutate the config object but instead create new objects
 - createElement is now responsible for making sure we rebuild the view when a tag is defined. No longer ever caller of createElement needs to implement this.
 - Error cards now follows the same config pattern as the other cards.
 - Added a helper to generate a config for error cards.