### PR TITLE
Default view

### DIFF
--- a/src/layouts/home-assistant-main.js
+++ b/src/layouts/home-assistant-main.js
@@ -111,7 +111,7 @@ class HomeAssistantMain extends NavigateMixin(EventsMixin(PolymerElement)) {
     super.connectedCallback();
     window.removeInitMsg();
     if (document.location.pathname === '/') {
-      this.navigate('/states', true);
+      this.navigate(`/${localStorage.defaultPage || 'states'}`, true);
     }
   }
 

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -149,7 +149,6 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
     if (index !== this._curView) {
       const id = this.config.views[index].id || index;
       this.navigate(`/lovelace/${id}`);
-      this._selectView(index);
     }
   }
 


### PR DESCRIPTION
Allow overriding what the default page is that Home Assistant navigates to. 

Currently can only be set via console. Might make a UI in the future.

Also makes sure we only rebuild config once when a tab has been changed.