### PR TITLE
Migrate cards to use setConfig to get config.

### DIFF
--- a/src/panels/lovelace/cards/hui-camera-preview-card.js
+++ b/src/panels/lovelace/cards/hui-camera-preview-card.js
@@ -3,7 +3,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../../../cards/ha-camera-card.js';
 
 import createCardElement from '../common/create-card-element.js';
-import createErrorCardConfig from '../common/create-error-card-config.js';
 import validateEntityConfig from '../common/validate-entity-config.js';
 
 class HuiCameraPreviewCard extends PolymerElement {
@@ -13,10 +12,6 @@ class HuiCameraPreviewCard extends PolymerElement {
         type: Object,
         observer: '_hassChanged'
       },
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      }
     };
   }
 
@@ -24,18 +19,16 @@ class HuiCameraPreviewCard extends PolymerElement {
     return 4;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
+    if (!validateEntityConfig(config, 'camera')) {
+      throw new Error('Error in card configuration.');
+    }
+
+    this._config = config;
     this._entityId = null;
 
     if (this.lastChild) {
       this.removeChild(this.lastChild);
-    }
-
-    if (!validateEntityConfig(config, 'camera')) {
-      const error = 'Error in card configuration.';
-      const element = createCardElement(createErrorCardConfig(error, config));
-      this.appendChild(element);
-      return;
     }
 
     const entityId = config.entity;
@@ -56,8 +49,6 @@ class HuiCameraPreviewCard extends PolymerElement {
       const element = this.lastChild;
       element.stateObj = hass.states[entityId];
       element.hass = hass;
-    } else {
-      this._configChanged(this.config);
     }
   }
 }

--- a/src/panels/lovelace/cards/hui-camera-preview-card.js
+++ b/src/panels/lovelace/cards/hui-camera-preview-card.js
@@ -2,7 +2,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import '../../../cards/ha-camera-card.js';
 
-import createCardElement from '../common/create-card-element.js';
 import validateEntityConfig from '../common/validate-entity-config.js';
 
 class HuiCameraPreviewCard extends PolymerElement {

--- a/src/panels/lovelace/cards/hui-column-card.js
+++ b/src/panels/lovelace/cards/hui-column-card.js
@@ -29,10 +29,6 @@ class HuiColumnCard extends PolymerElement {
         type: Object,
         observer: '_hassChanged'
       },
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      }
     };
   }
 
@@ -49,19 +45,16 @@ class HuiColumnCard extends PolymerElement {
     return totalSize;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
+    if (!config || !config.cards || !Array.isArray(config.cards)) {
+      throw new Error('Card config incorrect');
+    }
+
     this._elements = [];
     const root = this.$.root;
 
     while (root.lastChild) {
       root.removeChild(root.lastChild);
-    }
-
-    if (!config || !config.cards || !Array.isArray(config.cards)) {
-      const error = 'Card config incorrect.';
-      const element = createCardElement(createErrorConfig(error, config));
-      root.appendChild(element);
-      return;
     }
 
     const elements = [];

--- a/src/panels/lovelace/cards/hui-column-card.js
+++ b/src/panels/lovelace/cards/hui-column-card.js
@@ -37,6 +37,13 @@ class HuiColumnCard extends PolymerElement {
     this._elements = [];
   }
 
+  ready() {
+    super.ready();
+    if (this._config) {
+      this._buildConfig();
+    }
+  }
+
   getCardSize() {
     let totalSize = 0;
     this._elements.forEach((element) => {
@@ -49,6 +56,13 @@ class HuiColumnCard extends PolymerElement {
     if (!config || !config.cards || !Array.isArray(config.cards)) {
       throw new Error('Card config incorrect');
     }
+
+    this._config = config;
+    if (this.$) this._buildConfig();
+  }
+
+  _buildConfig() {
+    const config = this._config;
 
     this._elements = [];
     const root = this.$.root;

--- a/src/panels/lovelace/cards/hui-column-card.js
+++ b/src/panels/lovelace/cards/hui-column-card.js
@@ -39,9 +39,7 @@ class HuiColumnCard extends PolymerElement {
 
   ready() {
     super.ready();
-    if (this._config) {
-      this._buildConfig();
-    }
+    if (this._config) this._buildConfig();
   }
 
   getCardSize() {

--- a/src/panels/lovelace/cards/hui-column-card.js
+++ b/src/panels/lovelace/cards/hui-column-card.js
@@ -3,7 +3,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import computeCardSize from '../common/compute-card-size.js';
 import createCardElement from '../common/create-card-element.js';
-import createErrorConfig from '../common/create-error-card-config.js';
 
 class HuiColumnCard extends PolymerElement {
   static get template() {

--- a/src/panels/lovelace/cards/hui-entities-card.js
+++ b/src/panels/lovelace/cards/hui-entities-card.js
@@ -1,6 +1,7 @@
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 import stateCardType from '../../../common/entity/state_card_type.js';
 import computeDomain from '../../../common/entity/compute_domain.js';
@@ -50,7 +51,7 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
 
     <ha-card>
       <div class='header'>
-        <div class="name">[[_computeTitle(config)]]</div>
+        <div class="name">[[_computeTitle(_config)]]</div>
         <template is="dom-if" if="[[_showHeaderToggle(_config.show_header_toggle)]]">
           <hui-entities-toggle hass="[[hass]]" entities="[[_config.entities]]"></hui-entities-toggle>
         </template>
@@ -88,7 +89,9 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
     return show !== false;
   }
 
-  setConfig(config) {
+  async setConfig(config) {
+    await new Promise(resolve => afterNextRender(this, resolve));
+
     this._config = config;
     const root = this.$.states;
 

--- a/src/panels/lovelace/cards/hui-entities-card.js
+++ b/src/panels/lovelace/cards/hui-entities-card.js
@@ -1,7 +1,6 @@
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 import stateCardType from '../../../common/entity/state_card_type.js';
 import computeDomain from '../../../common/entity/compute_domain.js';
@@ -76,6 +75,13 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
     this._elements = [];
   }
 
+  ready() {
+    super.ready();
+    if (this._config) {
+      this._buildConfig();
+    }
+  }
+
   getCardSize() {
     // +1 for the header
     return 1 + (this._config ? this._config.entities.length : 0);
@@ -89,10 +95,13 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
     return show !== false;
   }
 
-  async setConfig(config) {
-    await new Promise(resolve => afterNextRender(this, resolve));
-
+  setConfig(config) {
     this._config = config;
+    if (this.$) this._buildConfig();
+  }
+
+  _buildConfig() {
+    const config = this._config;
     const root = this.$.states;
 
     while (root.lastChild) {

--- a/src/panels/lovelace/cards/hui-entities-card.js
+++ b/src/panels/lovelace/cards/hui-entities-card.js
@@ -77,9 +77,7 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
 
   ready() {
     super.ready();
-    if (this._config) {
-      this._buildConfig();
-    }
+    if (this._config) this._buildConfig();
   }
 
   getCardSize() {

--- a/src/panels/lovelace/cards/hui-entities-card.js
+++ b/src/panels/lovelace/cards/hui-entities-card.js
@@ -51,8 +51,8 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
     <ha-card>
       <div class='header'>
         <div class="name">[[_computeTitle(config)]]</div>
-        <template is="dom-if" if="[[_showHeaderToggle(config.show_header_toggle)]]">
-          <hui-entities-toggle hass="[[hass]]" entities="[[config.entities]]"></hui-entities-toggle>
+        <template is="dom-if" if="[[_showHeaderToggle(_config.show_header_toggle)]]">
+          <hui-entities-toggle hass="[[hass]]" entities="[[_config.entities]]"></hui-entities-toggle>
         </template>
       </div>
       <div id="states"></div>
@@ -66,10 +66,7 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
         type: Object,
         observer: '_hassChanged',
       },
-      config: {
-        type: Object,
-        observer: '_configChanged',
-      }
+      _config: Object,
     };
   }
 
@@ -80,7 +77,7 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
 
   getCardSize() {
     // +1 for the header
-    return 1 + (this.config ? this.config.entities.length : 0);
+    return 1 + (this._config ? this._config.entities.length : 0);
   }
 
   _computeTitle(config) {
@@ -91,7 +88,8 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
     return show !== false;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
+    this._config = config;
     const root = this.$.states;
 
     while (root.lastChild) {

--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -60,7 +60,7 @@ class HuiEntitiesCard extends PolymerElement {
       this.removeChild(this.lastChild);
     }
 
-    let card = 'card' in config ? Object.assign({}, config.card) : {};
+    const card = 'card' in config ? Object.assign({}, config.card) : {};
     if (!card.type) card.type = 'entities';
     card.entities = [];
 

--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -2,7 +2,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import computeStateDomain from '../../../common/entity/compute_state_domain.js';
 import createCardElement from '../common/create-card-element.js';
-import createErrorCardConfig from '../common/create-error-card-config.js';
 
 class HuiEntitiesCard extends PolymerElement {
   static get properties() {
@@ -11,10 +10,6 @@ class HuiEntitiesCard extends PolymerElement {
         type: Object,
         observer: '_hassChanged'
       },
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      }
     };
   }
 
@@ -54,16 +49,18 @@ class HuiEntitiesCard extends PolymerElement {
     return stateObj.entity_id.search(regEx) === 0;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
+    if (!config.filter || !Array.isArray(config.filter)) {
+      throw new Error('Incorrect filter config.');
+    }
+
+    this._config = config;
+
     if (this.lastChild) {
       this.removeChild(this.lastChild);
     }
 
-    let error;
-
-    if (!config.filter || !Array.isArray(config.filter)) {
-      error = 'Incorrect filter config.';
-    } else if (!config.card) {
+    if (!config.card) {
       config = Object.assign({}, config, {
         card: { type: 'entities' }
       });
@@ -73,16 +70,10 @@ class HuiEntitiesCard extends PolymerElement {
       });
     }
 
-    let element;
-
-    if (error) {
-      element = createCardElement(createErrorCardConfig(error, config.card));
-    } else {
-      element = createCardElement(config.card);
-      element._filterRawConfig = config.card;
-      this._updateCardConfig(element);
-      element.hass = this.hass;
-    }
+    const element = createCardElement(config.card);
+    element._filterRawConfig = config.card;
+    this._updateCardConfig(element);
+    element.hass = this.hass;
     this.appendChild(element);
   }
 
@@ -97,7 +88,7 @@ class HuiEntitiesCard extends PolymerElement {
     element.config = Object.assign(
       {},
       element._filterRawConfig,
-      { entities: this._getEntities(this.hass, this.config.filter) }
+      { entities: this._getEntities(this.hass, this._config.filter) }
     );
   }
 }

--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -79,11 +79,11 @@ class HuiEntitiesCard extends PolymerElement {
 
   _updateCardConfig(element) {
     if (!element || element.tagName === 'HUI-ERROR-CARD' || !this.hass) return;
-    element.config = Object.assign(
+    element.setConfig(Object.assign(
       {},
       element._filterRawConfig,
       { entities: this._getEntities(this.hass, this._config.filter) }
-    );
+    ));
   }
 }
 customElements.define('hui-entity-filter-card', HuiEntitiesCard);

--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -60,18 +60,12 @@ class HuiEntitiesCard extends PolymerElement {
       this.removeChild(this.lastChild);
     }
 
-    if (!config.card) {
-      config = Object.assign({}, config, {
-        card: { type: 'entities' }
-      });
-    } else if (!config.card.type) {
-      config = Object.assign({}, config, {
-        card: Object.assign({}, config.card, { type: 'entities' })
-      });
-    }
+    let card = 'card' in config ? Object.assign({}, config.card) : {};
+    if (!card.type) card.type = 'entities';
+    card.entities = [];
 
-    const element = createCardElement(config.card);
-    element._filterRawConfig = config.card;
+    const element = createCardElement(card);
+    element._filterRawConfig = card;
     this._updateCardConfig(element);
     element.hass = this.hass;
     this.appendChild(element);
@@ -84,7 +78,7 @@ class HuiEntitiesCard extends PolymerElement {
   }
 
   _updateCardConfig(element) {
-    if (!element || element.tagName === 'HUI-ERROR-CARD') return;
+    if (!element || element.tagName === 'HUI-ERROR-CARD' || !this.hass) return;
     element.config = Object.assign(
       {},
       element._filterRawConfig,

--- a/src/panels/lovelace/cards/hui-error-card.js
+++ b/src/panels/lovelace/cards/hui-error-card.js
@@ -12,15 +12,19 @@ class HuiErrorCard extends PolymerElement {
           padding: 8px;
         }
       </style>
-      [[config.error]]
-      <pre>[[_toStr(config.origConfig)]]</pre>
+      [[_config.error]]
+      <pre>[[_toStr(_config.origConfig)]]</pre>
     `;
   }
 
   static get properties() {
     return {
-      config: Object,
+      _config: Object,
     };
+  }
+
+  setConfig(config) {
+    this._config = config;
   }
 
   getCardSize() {

--- a/src/panels/lovelace/cards/hui-glance-card.js
+++ b/src/panels/lovelace/cards/hui-glance-card.js
@@ -67,7 +67,6 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
     return {
       hass: Object,
       _config: Object,
-      _error: Object
     };
   }
 

--- a/src/panels/lovelace/cards/hui-glance-card.js
+++ b/src/panels/lovelace/cards/hui-glance-card.js
@@ -4,10 +4,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import computeStateDisplay from '../../../common/entity/compute_state_display.js';
 import computeStateName from '../../../common/entity/compute_state_name.js';
 import computeConfigEntities from '../common/compute-config-entities';
-import createErrorCardConfig from '../common/create-error-card-config.js';
-import validateEntitiesConfig from '../common/validate-entities-config';
 
-import './hui-error-card.js';
 import '../../../components/entity/state-badge.js';
 import '../../../components/ha-card.js';
 
@@ -50,9 +47,9 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
         }
       </style>
 
-      <ha-card header="[[config.title]]">
+      <ha-card header="[[_config.title]]">
         <div class="entities">
-          <template is="dom-repeat" items="[[_entities]]">
+          <template is="dom-repeat" items="[[_computeEntities(_config)]]">
             <template is="dom-if" if="[[_showEntity(item, hass.states)]]">
               <div class="entity" on-click="_openDialog">
                 <div>[[_computeName(item, hass.states)]]</div>
@@ -62,9 +59,6 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
             </template>
           </template>
         </div>
-        <template is="dom-if" if="[[_error]]">
-          <hui-error-card config="[[_error]]"></hui-error-card>
-        </template>
       </ha-card>
     `;
   }
@@ -72,11 +66,7 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   static get properties() {
     return {
       hass: Object,
-      config: Object,
-      _entities: {
-        type: Array,
-        computed: '_computeEntities(config)'
-      },
+      _config: Object,
       _error: Object
     };
   }
@@ -86,14 +76,15 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   }
 
   _computeEntities(config) {
-    if (!validateEntitiesConfig(config)) {
-      const error = 'Error in card configuration.';
-      this._error = createErrorCardConfig(error, config);
-      return [];
+    return computeConfigEntities(config);
+  }
+
+  setConfig(config) {
+    if (!config || !config.entities || !Array.isArray(config.entities)) {
+      throw new Error('Error in card configuration.');
     }
 
-    this._error = null;
-    return computeConfigEntities(config);
+    this._config = config;
   }
 
   _showEntity(item, states) {

--- a/src/panels/lovelace/cards/hui-history-graph-card.js
+++ b/src/panels/lovelace/cards/hui-history-graph-card.js
@@ -21,7 +21,7 @@ class HuiHistoryGraphCard extends PolymerElement {
           entity-id="[[_config.entities]]"
           data="{{stateHistory}}"
           is-loading="{{stateHistoryLoading}}"
-          cache-config="[[cacheConfig]]"
+          cache-config="[[_computeCacheConfig(_config)]]"
         ></ha-state-history-data>
         <state-history-charts
           hass="[[hass]]"
@@ -40,14 +40,6 @@ class HuiHistoryGraphCard extends PolymerElement {
       _config: Object,
       stateHistory: Object,
       stateHistoryLoading: Boolean,
-      cacheConfig: {
-        type: Object,
-        value: {
-          refresh: 0,
-          cacheKey: null,
-          hoursToShow: 24,
-        },
-      },
     };
   }
 
@@ -60,13 +52,15 @@ class HuiHistoryGraphCard extends PolymerElement {
       throw new Error('Error in card configuration.');
     }
 
-    this.cacheConfig = {
+    this._config = config;
+  }
+
+  _computeCacheConfig(config) {
+    return {
       cacheKey: config.entities,
       hoursToShow: config.hours_to_show || 24,
       refresh: config.refresh_interval || 0
     };
-
-    this._config = config;
   }
 }
 

--- a/src/panels/lovelace/cards/hui-history-graph-card.js
+++ b/src/panels/lovelace/cards/hui-history-graph-card.js
@@ -1,23 +1,43 @@
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
-import './hui-error-card.js';
 import '../../../components/ha-card.js';
 import '../../../components/state-history-charts.js';
 import '../../../data/ha-state-history-data.js';
 
-import createErrorCardConfig from '../common/create-error-card-config.js';
-
 class HuiHistoryGraphCard extends PolymerElement {
+  static get template() {
+    return html`
+      <style>
+        ha-card {
+          padding: 16px;
+        }
+      </style>
+
+      <ha-card header=[[_config.title]]>
+        <ha-state-history-data
+          hass="[[hass]]"
+          filter-type="recent-entity"
+          entity-id="[[_config.entities]]"
+          data="{{stateHistory}}"
+          is-loading="{{stateHistoryLoading}}"
+          cache-config="[[cacheConfig]]"
+        ></ha-state-history-data>
+        <state-history-charts
+          hass="[[hass]]"
+          history-data="[[stateHistory]]"
+          is-loading-data="[[stateHistoryLoading]]"
+          up-to-now
+          no-single
+        ></state-history-charts>
+      </ha-card>
+    `;
+  }
+
   static get properties() {
     return {
       hass: Object,
-      config: {
-        type: Object,
-        observer: '_configChanged',
-      },
-      _error: Object,
-
+      _config: Object,
       stateHistory: Object,
       stateHistoryLoading: Boolean,
       cacheConfig: {
@@ -35,53 +55,18 @@ class HuiHistoryGraphCard extends PolymerElement {
     return 4;
   }
 
-  static get template() {
-    return html`
-      <style>
-        ha-card {
-          padding: 16px;
-        }
-      </style>
-
-      <template is="dom-if" if="[[!_error]]">
-        <ha-card header=[[config.title]]>
-          <ha-state-history-data
-            hass="[[hass]]"
-            filter-type="recent-entity"
-            entity-id="[[config.entities]]"
-            data="{{stateHistory}}"
-            is-loading="{{stateHistoryLoading}}"
-            cache-config="[[cacheConfig]]"
-          ></ha-state-history-data>
-          <state-history-charts
-            hass="[[hass]]"
-            history-data="[[stateHistory]]"
-            is-loading-data="[[stateHistoryLoading]]"
-            up-to-now
-            no-single
-          ></state-history-charts>
-        </ha-card>
-      </template>
-
-      <template is="dom-if" if="[[_error]]">
-        <hui-error-card config="[[_error]]"></hui-error-card>
-      </template>
-    `;
-  }
-
-  _configChanged(config) {
-    if (config.entities && Array.isArray(config.entities)) {
-      this._error = null;
-
-      this.cacheConfig = {
-        cacheKey: config.entities,
-        hoursToShow: config.hours_to_show || 24,
-        refresh: config.refresh_interval || 0
-      };
-    } else {
-      const error = 'Error in card configuration.';
-      this._error = createErrorCardConfig(error, config);
+  setConfig(config) {
+    if (!config.entities || !Array.isArray(config.entities)) {
+      throw new Error('Error in card configuration.');
     }
+
+    this.cacheConfig = {
+      cacheKey: config.entities,
+      hoursToShow: config.hours_to_show || 24,
+      refresh: config.refresh_interval || 0
+    };
+
+    this._config = config;
   }
 }
 

--- a/src/panels/lovelace/cards/hui-iframe-card.js
+++ b/src/panels/lovelace/cards/hui-iframe-card.js
@@ -36,9 +36,22 @@ class HuiIframeCard extends PolymerElement {
     };
   }
 
+  ready() {
+    super.ready();
+    if (this._config) {
+      this._buildConfig();
+    }
+  }
+
   setConfig(config) {
-    this.$.root.style.paddingTop = config.aspect_ratio || '50%';
     this._config = config;
+    if (this.$) this._buildConfig();
+  }
+
+  _buildConfig() {
+    const config = this._config;
+
+    this.$.root.style.paddingTop = config.aspect_ratio || '50%';
   }
 
   getCardSize() {

--- a/src/panels/lovelace/cards/hui-iframe-card.js
+++ b/src/panels/lovelace/cards/hui-iframe-card.js
@@ -2,15 +2,6 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class HuiIframeCard extends PolymerElement {
-  static get properties() {
-    return {
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      }
-    };
-  }
-
   static get template() {
     return html`
       <style>
@@ -31,16 +22,23 @@ class HuiIframeCard extends PolymerElement {
           height: 100%;
         }
       </style>
-      <ha-card header="[[config.title]]">
+      <ha-card header="[[_config.title]]">
         <div id="root">
-          <iframe src="[[config.url]]"></iframe>
+          <iframe src="[[_config.url]]"></iframe>
         </div>
       </ha-card>
     `;
   }
 
-  _configChanged(config) {
+  static get properties() {
+    return {
+      _config: Object,
+    };
+  }
+
+  setConfig(config) {
     this.$.root.style.paddingTop = config.aspect_ratio || '50%';
+    this._config = config;
   }
 
   getCardSize() {

--- a/src/panels/lovelace/cards/hui-iframe-card.js
+++ b/src/panels/lovelace/cards/hui-iframe-card.js
@@ -38,9 +38,7 @@ class HuiIframeCard extends PolymerElement {
 
   ready() {
     super.ready();
-    if (this._config) {
-      this._buildConfig();
-    }
+    if (this._config) this._buildConfig();
   }
 
   setConfig(config) {

--- a/src/panels/lovelace/cards/hui-markdown-card.js
+++ b/src/panels/lovelace/cards/hui-markdown-card.js
@@ -34,15 +34,15 @@ class HuiMarkdownCard extends PolymerElement {
           max-width: 100%;
         }
       </style>
-      <ha-card header="[[config.title]]">
-        <ha-markdown content='[[config.content]]'></ha-markdown>
+      <ha-card header="[[_config.title]]">
+        <ha-markdown content='[[_config.content]]'></ha-markdown>
       </ha-card>
     `;
   }
 
   static get properties() {
     return {
-      config: Object,
+      _config: Object,
       noTitle: {
         type: Boolean,
         reflectToAttribute: true,
@@ -51,8 +51,12 @@ class HuiMarkdownCard extends PolymerElement {
     };
   }
 
+  setConfig(config) {
+    this._config = config;
+  }
+
   getCardSize() {
-    return this.config.content.split('\n').length;
+    return this._config.content.split('\n').length;
   }
 
   _computeNoTitle(title) {

--- a/src/panels/lovelace/cards/hui-media-control-card.js
+++ b/src/panels/lovelace/cards/hui-media-control-card.js
@@ -2,7 +2,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import '../../../cards/ha-media_player-card.js';
 
-import createCardElement from '../common/create-card-element.js';
 import validateEntityConfig from '../common/validate-entity-config.js';
 
 class HuiMediaControlCard extends PolymerElement {

--- a/src/panels/lovelace/cards/hui-media-control-card.js
+++ b/src/panels/lovelace/cards/hui-media-control-card.js
@@ -3,7 +3,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../../../cards/ha-media_player-card.js';
 
 import createCardElement from '../common/create-card-element.js';
-import createErrorCardConfig from '../common/create-error-card-config.js';
 import validateEntityConfig from '../common/validate-entity-config.js';
 
 class HuiMediaControlCard extends PolymerElement {
@@ -13,10 +12,6 @@ class HuiMediaControlCard extends PolymerElement {
         type: Object,
         observer: '_hassChanged'
       },
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      }
     };
   }
 
@@ -24,18 +19,15 @@ class HuiMediaControlCard extends PolymerElement {
     return 3;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
+    if (!validateEntityConfig(config, 'media_player')) {
+      throw new Error('Error in card configuration.');
+    }
+
     this._entityId = null;
 
     if (this.lastChild) {
       this.removeChild(this.lastChild);
-    }
-
-    if (!validateEntityConfig(config, 'media_player')) {
-      const error = 'Error in card configuration.';
-      const element = createCardElement(createErrorCardConfig(error, config));
-      this.appendChild(element);
-      return;
     }
 
     const entityId = config.entity;
@@ -56,8 +48,6 @@ class HuiMediaControlCard extends PolymerElement {
       const element = this.lastChild;
       element.stateObj = hass.states[entityId];
       element.hass = hass;
-    } else {
-      this._configChanged(this.config);
     }
   }
 }

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -1,6 +1,5 @@
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 import '../../../components/buttons/ha-call-service-button.js';
 import '../../../components/entity/state-badge.js';
@@ -70,18 +69,28 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
     this._requiresTextState = [];
   }
 
+  ready() {
+    super.ready();
+    if (this._config) {
+      this._buildConfig();
+    }
+  }
+
   getCardSize() {
     return 4;
   }
 
-  async setConfig(config) {
+  setConfig(config) {
     if (!config || !config.image || !Array.isArray(config.elements)) {
       throw new Error('Invalid card configuration');
     }
 
-    await new Promise(resolve => afterNextRender(this, resolve));
-
     this._config = config;
+    if (this.$) this._buildConfig();
+  }
+
+  _buildConfig() {
+    const config = this._config;
     const root = this.$.root;
     this._requiresStateObj = [];
     this._requiresTextState = [];
@@ -124,6 +133,10 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
       }
       root.appendChild(el);
     });
+
+    if (this.hass) {
+      this._hassChanged(this.hass);
+    }
   }
 
   _hassChanged(hass) {

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -1,5 +1,6 @@
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 import '../../../components/buttons/ha-call-service-button.js';
 import '../../../components/entity/state-badge.js';
@@ -63,16 +64,24 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
     };
   }
 
+  constructor() {
+    super();
+    this._requiresStateObj = [];
+    this._requiresTextState = [];
+  }
+
   getCardSize() {
     return 4;
   }
 
-  setConfig(config) {
+  async setConfig(config) {
     if (!config || !config.image || !Array.isArray(config.elements)) {
       throw new Error('Invalid card configuration');
     }
-    this._config = config;
 
+    await new Promise(resolve => afterNextRender(this, resolve));
+
+    this._config = config;
     const root = this.$.root;
     this._requiresStateObj = [];
     this._requiresTextState = [];

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -71,9 +71,7 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
 
   ready() {
     super.ready();
-    if (this._config) {
-      this._buildConfig();
-    }
+    if (this._config) this._buildConfig();
   }
 
   getCardSize() {

--- a/src/panels/lovelace/cards/hui-picture-entity-card.js
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.js
@@ -1,7 +1,6 @@
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
-import './hui-error-card.js';
 import '../../../components/ha-card.js';
 
 import { STATES_OFF } from '../../../common/const.js';
@@ -9,7 +8,6 @@ import computeDomain from '../../../common/entity/compute_domain.js';
 import computeStateDisplay from '../../../common/entity/compute_state_display.js';
 import computeStateDomain from '../../../common/entity/compute_state_domain.js';
 import computeStateName from '../../../common/entity/compute_state_name.js';
-import createErrorCardConfig from '../common/create-error-card-config.js';
 import toggleEntity from '../common/entity/toggle-entity.js';
 
 import LocalizeMixin from '../../../mixins/localize-mixin.js';
@@ -58,9 +56,6 @@ class HuiPictureEntityCard extends LocalizeMixin(PolymerElement) {
           <div id="title"></div>
           <div id="state"></div>
         </div>
-        <template is="dom-if" if="[[_error]]">
-          <hui-error-card config="[[_error]]"></hui-error-card>
-        </template>
       </ha-card>
     `;
   }
@@ -71,11 +66,7 @@ class HuiPictureEntityCard extends LocalizeMixin(PolymerElement) {
         type: Object,
         observer: '_hassChanged'
       },
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      },
-      _error: Object
+      _config: Object,
     };
   }
 
@@ -83,17 +74,15 @@ class HuiPictureEntityCard extends LocalizeMixin(PolymerElement) {
     return 3;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
     if (!config || !config.entity || (!config.image && !config.state_image)) {
-      const error = 'Error in card configuration.';
-      this._error = createErrorCardConfig(error, config);
-      return;
+      throw new Error('Error in card configuration.');
     }
-    this._error = null;
+    this._config = config;
   }
 
   _hassChanged(hass) {
-    const config = this.config;
+    const config = this._config;
     const entityId = config && config.entity;
     if (!entityId) {
       return;
@@ -136,7 +125,7 @@ class HuiPictureEntityCard extends LocalizeMixin(PolymerElement) {
   }
 
   _cardClicked() {
-    const entityId = this.config && this.config.entity;
+    const entityId = this._config && this._config.entity;
     if (!(entityId in this.hass.states)) {
       return;
     }

--- a/src/panels/lovelace/cards/hui-plant-status-card.js
+++ b/src/panels/lovelace/cards/hui-plant-status-card.js
@@ -2,7 +2,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import '../../../cards/ha-plant-card.js';
 
-import createCardElement from '../common/create-card-element.js';
 import validateEntityConfig from '../common/validate-entity-config.js';
 
 class HuiPlantStatusCard extends PolymerElement {

--- a/src/panels/lovelace/cards/hui-plant-status-card.js
+++ b/src/panels/lovelace/cards/hui-plant-status-card.js
@@ -3,7 +3,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../../../cards/ha-plant-card.js';
 
 import createCardElement from '../common/create-card-element.js';
-import createErrorCardConfig from '../common/create-error-card-config.js';
 import validateEntityConfig from '../common/validate-entity-config.js';
 
 class HuiPlantStatusCard extends PolymerElement {
@@ -13,10 +12,6 @@ class HuiPlantStatusCard extends PolymerElement {
         type: Object,
         observer: '_hassChanged'
       },
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      }
     };
   }
 
@@ -24,18 +19,15 @@ class HuiPlantStatusCard extends PolymerElement {
     return 3;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
+    if (!validateEntityConfig(config, 'plant')) {
+      throw new Error('Error in card configuration.');
+    }
+
     this._entityId = null;
 
     if (this.lastChild) {
       this.removeChild(this.lastChild);
-    }
-
-    if (!validateEntityConfig(config, 'plant')) {
-      const error = 'Error in card configuration.';
-      const element = createCardElement(createErrorCardConfig(error, config));
-      this.appendChild(element);
-      return;
     }
 
     const entityId = config.entity;
@@ -56,8 +48,6 @@ class HuiPlantStatusCard extends PolymerElement {
       const element = this.lastChild;
       element.stateObj = hass.states[entityId];
       element.hass = hass;
-    } else {
-      this._configChanged(this.config);
     }
   }
 }

--- a/src/panels/lovelace/cards/hui-row-card.js
+++ b/src/panels/lovelace/cards/hui-row-card.js
@@ -3,7 +3,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import computeCardSize from '../common/compute-card-size.js';
 import createCardElement from '../common/create-card-element.js';
-import createErrorConfig from '../common/create-error-card-config.js';
 
 class HuiRowCard extends PolymerElement {
   static get template() {
@@ -29,10 +28,6 @@ class HuiRowCard extends PolymerElement {
         type: Object,
         observer: '_hassChanged'
       },
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      }
     };
   }
 
@@ -50,19 +45,16 @@ class HuiRowCard extends PolymerElement {
     return size;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
+    if (!config || !config.cards || !Array.isArray(config.cards)) {
+      throw new Error('Card config incorrect.');
+    }
+
     this._elements = [];
     const root = this.$.root;
 
     while (root.lastChild) {
       root.removeChild(root.lastChild);
-    }
-
-    if (!config || !config.cards || !Array.isArray(config.cards)) {
-      const error = 'Card config incorrect.';
-      const element = createCardElement(createErrorConfig(error, config));
-      root.appendChild(element);
-      return;
     }
 
     const elements = [];

--- a/src/panels/lovelace/cards/hui-row-card.js
+++ b/src/panels/lovelace/cards/hui-row-card.js
@@ -38,9 +38,7 @@ class HuiRowCard extends PolymerElement {
 
   ready() {
     super.ready();
-    if (this._config) {
-      this._buildConfig();
-    }
+    if (this._config) this._buildConfig();
   }
 
   getCardSize() {

--- a/src/panels/lovelace/cards/hui-row-card.js
+++ b/src/panels/lovelace/cards/hui-row-card.js
@@ -36,6 +36,13 @@ class HuiRowCard extends PolymerElement {
     this._elements = [];
   }
 
+  ready() {
+    super.ready();
+    if (this._config) {
+      this._buildConfig();
+    }
+  }
+
   getCardSize() {
     let size = 1;
     this._elements.forEach((element) => {
@@ -49,7 +56,11 @@ class HuiRowCard extends PolymerElement {
     if (!config || !config.cards || !Array.isArray(config.cards)) {
       throw new Error('Card config incorrect.');
     }
+    if (this.$) this._buildConfig();
+  }
 
+  _buildConfig() {
+    const config = this._config;
     this._elements = [];
     const root = this.$.root;
 

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.js
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.js
@@ -3,7 +3,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../../../cards/ha-weather-card.js';
 
 import createCardElement from '../common/create-card-element.js';
-import createErrorCardConfig from '../common/create-error-card-config.js';
 import validateEntityConfig from '../common/validate-entity-config.js';
 
 class HuiWeatherForecastCard extends PolymerElement {
@@ -24,18 +23,15 @@ class HuiWeatherForecastCard extends PolymerElement {
     return 4;
   }
 
-  _configChanged(config) {
+  setConfig(config) {
+    if (!validateEntityConfig(config, 'weather')) {
+      throw new Error('Error in card configuration.');
+    }
+
     this._entityId = null;
 
     if (this.lastChild) {
       this.removeChild(this.lastChild);
-    }
-
-    if (!validateEntityConfig(config, 'weather')) {
-      const error = 'Error in card configuration.';
-      const element = createCardElement(createErrorCardConfig(error, config));
-      this.appendChild(element);
-      return;
     }
 
     const entityId = config.entity;
@@ -56,8 +52,6 @@ class HuiWeatherForecastCard extends PolymerElement {
       const element = this.lastChild;
       element.stateObj = hass.states[entityId];
       element.hass = hass;
-    } else {
-      this._configChanged(this.config);
     }
   }
 }

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.js
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.js
@@ -11,10 +11,6 @@ class HuiWeatherForecastCard extends PolymerElement {
         type: Object,
         observer: '_hassChanged'
       },
-      config: {
-        type: Object,
-        observer: '_configChanged'
-      }
     };
   }
 

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.js
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.js
@@ -2,7 +2,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import '../../../cards/ha-weather-card.js';
 
-import createCardElement from '../common/create-card-element.js';
 import validateEntityConfig from '../common/validate-entity-config.js';
 
 class HuiWeatherForecastCard extends PolymerElement {

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -45,7 +45,7 @@ function _createElement(tag, config) {
   try {
     element.setConfig(config);
   } catch (err) {
-    console.error(err);
+    console.error(tag, err);
     return _createErrorElement(err.message, config);
   }
   return element;

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -45,7 +45,9 @@ function _createElement(tag, config) {
   try {
     element.setConfig(config);
   } catch (err) {
+    // eslint-disable-next-line
     console.error(tag, err);
+    // eslint-disable-next-line
     return _createErrorElement(err.message, config);
   }
   return element;

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -42,7 +42,12 @@ const CUSTOM_TYPE_PREFIX = 'custom:';
 
 function _createElement(tag, config) {
   const element = document.createElement(tag);
-  element.config = config;
+  try {
+    element.setConfig(config);
+  } catch (err) {
+    console.error(err);
+    return _createErrorElement(err.message, config);
+  }
   return element;
 }
 

--- a/src/panels/lovelace/common/validate-entities-config.js
+++ b/src/panels/lovelace/common/validate-entities-config.js
@@ -13,11 +13,11 @@ export default function validateEntitiesConfig(config, additionalKeys = []) {
     return false;
   }
 
-  return entities.every(entity => {
+  return entities.every((entity) => {
     if (typeof entity === 'string') {
       return validEntityId(entity) && !additionalKeys.length;
     }
     return entity && typeof entity === 'object' && !Array.isArray(entity) &&
-      'entity' in entity && validEntityId(entity.entity) && additionalKeys.every(key => key in entity)
+      'entity' in entity && validEntityId(entity.entity) && additionalKeys.every(key => key in entity);
   });
 }


### PR DESCRIPTION
Use `setConfig` method instead of a property and allowing it to raise to indicate invalid config. Also catches any other exception that the card might raise.

So this requires a small change in the cards that rely on Polymer: we need to wait for Polymer to build up our internal DOM to be able to leverage `this.$.root` for example. We use their `ready` callback for this. Only needed if we define a `template` for our card.

Any exception thrown will now show to the user and is logged without breaking the rest of rendering.

![image](https://user-images.githubusercontent.com/1444314/42096404-3e2a0068-7b83-11e8-8e0f-827f90ad8478.png)
