### PR TITLE
Love: change keys from "name" to "title"

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -89,7 +89,7 @@ class HuiPictureElementsCard extends LocalizeMixin(EventsMixin(PolymerElement)) 
         if (element.type === 'state-badge') {
           const entityId = element.entity;
           el = document.createElement('state-badge');
-          el.addEventListener('click', () => this._handleClick(entityId, element.action === 'toggle'));
+          el.addEventListener('click', () => this._handleClick(entityId, element.tap_action === 'toggle'));
           el.classList.add('clickable');
           this._requiresStateObj.push({ el, entityId });
         } else if (element.type === 'state-text') {

--- a/src/panels/lovelace/cards/hui-picture-entity-card.js
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.js
@@ -141,8 +141,8 @@ class HuiPictureEntityCard extends LocalizeMixin(PolymerElement) {
       return;
     }
 
-    const stateDomain = computeDomain(entityId);
-    if (stateDomain === 'weblink') {
+    const domain = computeDomain(entityId);
+    if (domain === 'weblink') {
       window.open(this.hass.states[entityId].state);
     } else {
       toggleEntity(this.hass, entityId);

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -62,11 +62,11 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
           <paper-tabs scrollable selected="[[_curView]]" on-iron-activate="_handleViewSelected">
             <template is="dom-repeat" items="[[config.views]]">
               <paper-tab>
-                <template is="dom-if" if="[[item.tab_icon]]">
-                  <iron-icon title$="[[item.name]]" icon="[[item.tab_icon]]"></iron-icon>
+                <template is="dom-if" if="[[item.icon]]">
+                  <iron-icon title$="[[item.title]]" icon="[[item.icon]]"></iron-icon>
                 </template>
-                <template is="dom-if" if="[[!item.tab_icon]]">
-                  [[_computeTabTitle(item)]]
+                <template is="dom-if" if="[[!item.icon]]">
+                  [[_computeTabTitle(item.title)]]
                 </template>
               </paper-tab>
             </template>
@@ -131,15 +131,15 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
   }
 
   _computeTitle(config) {
-    return config.name || 'Home Assistant';
+    return config.title || 'Home Assistant';
   }
 
   _computeTabsHidden(views) {
     return views.length < 2;
   }
 
-  _computeTabTitle(view) {
-    return view.tab_title || view.name || 'Unnamed View';
+  _computeTabTitle(title) {
+    return title || 'Unnamed view';
   }
 
   _handleRefresh() {


### PR DESCRIPTION
fix: https://github.com/home-assistant/ui-schema/issues/54

```
name: -> title
view.name -> view.title
view.tab_icon -> view.icon
```