### PR TITLE
Lovelace: entity-filter: hide card when entities[] empty

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -77,16 +77,14 @@ class HuiEntitiesCard extends PolymerElement {
     element.hass = hass;
   }
 
-  _computeVisibility(entitiesLength) {
-    if (this._config.hide_if_empty) {
-      this.style.display = entitiesLength ? 'block' : 'none';
-    }
-  }
-
   _updateCardConfig(element) {
     if (!element || element.tagName === 'HUI-ERROR-CARD' || !this.hass) return;
     const entitiesList = this._getEntities(this.hass, this._config.filter);
-    this._computeVisibility(entitiesList.length);
+    if (entitiesList.length === 0) {
+      this.style.display = (this._config.show_empty === false) ? 'none' : 'block';
+    } else {
+      this.style.display = 'block';
+    }
     element.setConfig(Object.assign(
       {},
       element._filterRawConfig,

--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -77,12 +77,20 @@ class HuiEntitiesCard extends PolymerElement {
     element.hass = hass;
   }
 
+  _computeVisibility(entitiesLength) {
+    if (this._config.hide_if_empty) {
+      this.style.display = entitiesLength ? 'block' : 'none';
+    }
+  }
+
   _updateCardConfig(element) {
     if (!element || element.tagName === 'HUI-ERROR-CARD' || !this.hass) return;
+    const entitiesList = this._getEntities(this.hass, this._config.filter);
+    this._computeVisibility(entitiesList.length);
     element.setConfig(Object.assign(
       {},
       element._filterRawConfig,
-      { entities: this._getEntities(this.hass, this._config.filter) }
+      { entities: entitiesList }
     ));
   }
 }


### PR DESCRIPTION
Implements https://github.com/home-assistant/ui-schema/issues/48

- [ ] developer documentation

Sample:
```yaml
title: Lovelace Demo
views:
  - title: Home
    icon: mdi:heart
    cards:
      - type: entity-filter
        hide_if_empty: true
        filter:
          - domain: lig2ht
        card:
          title: domain light
```