### PR TITLE
Use name for entities

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.js
+++ b/src/panels/lovelace/cards/hui-entities-card.js
@@ -132,8 +132,8 @@ class HuiEntitiesCard extends EventsMixin(PolymerElement) {
       }
       element.stateObj = stateObj;
       element.hass = this.hass;
-      if (entity.title) {
-        element.overrideName = entity.title;
+      if (entity.name) {
+        element.overrideName = entity.name;
       }
       this._elements.push({ entityId, element });
       const container = document.createElement('div');

--- a/src/panels/lovelace/cards/hui-glance-card.js
+++ b/src/panels/lovelace/cards/hui-glance-card.js
@@ -94,7 +94,7 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   }
 
   _computeName(item, states) {
-    return item.title || computeStateName(states[item.entity]);
+    return item.name || computeStateName(states[item.entity]);
   }
 
   _computeStateObj(item, states) {


### PR DESCRIPTION
Cards have titles
Entities have names

When configuring an entity and you want to override the name, you should specify `name`, not `title`.