### PR TITLE
[WIP] Allow inclusion and exclusion on entity-filter cards

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -50,7 +50,7 @@ class HuiEntitiesCard extends PolymerElement {
   }
 
   setConfig(config) {
-    if (!config.filter || !Array.isArray(config.filter)) {
+    if (!config.filter.include || !Array.isArray(config.filter.include)) {
       throw new Error('Incorrect filter config.');
     }
 
@@ -79,7 +79,11 @@ class HuiEntitiesCard extends PolymerElement {
 
   _updateCardConfig(element) {
     if (!element || element.tagName === 'HUI-ERROR-CARD' || !this.hass) return;
-    const entitiesList = this._getEntities(this.hass, this._config.filter);
+    let entitiesList = this._getEntities(this.hass, this._config.filter.include);
+    if (this._config.filter.exclude) {
+      const excludeEntities = this._getEntities(this.hass, this._config.filter.exclude);
+      entitiesList = entitiesList.filter(el => !excludeEntities.includes(el));
+    }
     if (entitiesList.length === 0) {
       this.style.display = (this._config.show_empty === false) ? 'none' : 'block';
     } else {


### PR DESCRIPTION
Work in progress to support filter entities. Fixes https://github.com/home-assistant/ui-schema/issues/41

```yaml
      - type: entity-filter
        filter:
          include: [{}]
          exclude:
            - domain: cover
            - domain: switch
            - domain: group
```

- [ ] Proper config validation in setConfig
- [ ] Update documentation