### PR TITLE
Add panel mode

### DIFF
--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -20,6 +20,8 @@ import '../../components/ha-start-voice-button.js';
 import { loadModule, loadJS } from '../../common/dom/load_resource.js';
 import './hui-view.js';
 
+import createCardElement from './common/create-card-element.js';
+
 // JS should only be imported once. Modules and HTML are safe.
 const JS_CACHE = {};
 
@@ -163,12 +165,20 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
     if (root.lastChild) {
       root.removeChild(root.lastChild);
     }
-    const view = document.createElement('hui-view');
-    view.setProperties({
-      hass: this.hass,
-      config: this.config.views[this._curView],
-      columns: this.columns,
-    });
+
+    const viewConfig = this.config.views[this._curView];
+
+    let view;
+
+    if (viewConfig.panel) {
+      view = createCardElement(viewConfig.cards[0]);
+    } else {
+      view = document.createElement('hui-view');
+      view.config = viewConfig;
+      view.columns = this.columns;
+    }
+
+    view.hass = this.hass;
     root.appendChild(view);
   }
 


### PR DESCRIPTION
Add a panel mode to views. This will render only the first card in a view.

![image](https://user-images.githubusercontent.com/1444314/42167970-a79457e0-7ddd-11e8-998b-c49ae0216667.png)

```yaml
views:
  - icon: mdi:home-assistant
    id: arsaboo
    # Name of the view. Will be used as the tooltip for tab icon
    title: Home
    panel: true
    cards:
      - type: picture-elements
        image: /local/floorplans/main.jpg

```