### PR TITLE
Love: Update hui-image to use entity instead of state.

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-entity-card.js
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.js
@@ -135,10 +135,6 @@ class HuiPictureEntityCard extends LocalizeMixin(PolymerElement) {
       toggleEntity(this.hass, entityId);
     }
   }
-
-  _getStateObj() {
-    return this.hass && this.hass.states[this._config.entity];
-  }
 }
 
 customElements.define('hui-picture-entity-card', HuiPictureEntityCard);

--- a/src/panels/lovelace/cards/hui-picture-entity-card.js
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.js
@@ -52,7 +52,7 @@ class HuiPictureEntityCard extends LocalizeMixin(PolymerElement) {
           image="[[_config.image]]" 
           state-image="[[_config.state_image]]" 
           camera-image="[[_config.camera_image]]" 
-          state="[[_getStateObj(_oldState)]]"
+          entity="[[_config.entity]]"
         ></hui-image>
         <div class="box">
           <div id="title"></div>
@@ -77,7 +77,8 @@ class HuiPictureEntityCard extends LocalizeMixin(PolymerElement) {
   }
 
   setConfig(config) {
-    if (!config || !config.entity || (!config.image && !config.state_image)) {
+    if (!config || !config.entity ||
+      (!config.image && !config.state_image && !config.camera_image)) {
       throw new Error('Error in card configuration.');
     }
     this._config = config;

--- a/src/panels/lovelace/cards/hui-picture-glance-card.js
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.js
@@ -60,7 +60,9 @@ class HuiPictureGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
         <hui-image 
           hass="[[hass]]" 
           image="[[_config.image]]" 
+          state-image="[[_config.state_image]]"
           camera-image="[[_config.camera_image]]"
+          entity="[[_config.entity]]"
         ></hui-image>
         <div class="box">
           <div class="title">[[_config.title]]</div>
@@ -115,7 +117,8 @@ class HuiPictureGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   setConfig(config) {
     if (!config || !config.entities || !Array.isArray(config.entities) ||
-      !(config.image || config.camera_image)) {
+      !(config.image || config.camera_image || config.state_image) ||
+      (config.state_image && !config.entity)) {
       throw new Error('Invalid card configuration');
     }
 

--- a/src/panels/lovelace/components/hui-image.js
+++ b/src/panels/lovelace/components/hui-image.js
@@ -49,12 +49,11 @@ class HuiImage extends LocalizeMixin(PolymerElement) {
 
   static get properties() {
     return {
-      hass: Object,
-      state: {
+      hass: {
         type: Object,
-        value: null,
-        observer: '_stateChanged'
+        observer: '_hassChanged'
       },
+      entity: String,
       image: String,
       stateImage: Object,
       cameraImage: String,
@@ -102,11 +101,12 @@ class HuiImage extends LocalizeMixin(PolymerElement) {
     this._error = false;
   }
 
-  _stateChanged(state) {
-    if (this.cameraImage) {
+  _hassChanged(hass) {
+    if (this.cameraImage || !this.entity || !isValidObject(hass, ['states'])) {
       return;
     }
 
+    const state = hass.states[this.entity];
     const unavailable = !isValidObject(state, ['state']);
 
     if (!this.stateImage) {
@@ -114,8 +114,7 @@ class HuiImage extends LocalizeMixin(PolymerElement) {
       return;
     }
 
-    const stateImg = !unavailable ?
-      (this.stateImage[state.state] || this.stateImage.default) : this.stateImage.unavailable;
+    const stateImg = !unavailable ? this.stateImage[state.state] : this.stateImage.unavailable;
 
     this.setProperties({
       _imageClass: !stateImg && (unavailable || STATES_OFF.includes(state.state)) ? 'state-off' : '',

--- a/src/panels/lovelace/components/hui-image.js
+++ b/src/panels/lovelace/components/hui-image.js
@@ -102,7 +102,7 @@ class HuiImage extends LocalizeMixin(PolymerElement) {
   }
 
   _hassChanged(hass) {
-    if (this.cameraImage || !this.entity || !isValidObject(hass, ['states'])) {
+    if (this.cameraImage || !this.entity) {
       return;
     }
 


### PR DESCRIPTION
Also adds `entity` and `state_image` to `picture-glance` card and removes `state_image.default` from `picture-entity`