### PR TITLE
Don't allow toggle if can't toggle. Allow hiding info

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-entity-card.js
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.js
@@ -8,7 +8,6 @@ import computeDomain from '../../../common/entity/compute_domain.js';
 import computeStateDisplay from '../../../common/entity/compute_state_display.js';
 import computeStateDomain from '../../../common/entity/compute_state_domain.js';
 import computeStateName from '../../../common/entity/compute_state_name.js';
-import canToggleState from '../../../common/entity/can_toggle_state.js';
 import toggleEntity from '../common/entity/toggle-entity.js';
 
 import EventsMixin from '../../../mixins/events-mixin.js';
@@ -111,7 +110,7 @@ class HuiPictureEntityCard extends EventsMixin(LocalizeMixin(PolymerElement)) {
     if (stateObj) {
       name = config.name || computeStateName(stateObj);
       state = stateObj.state;
-      state_label = this._computeState(stateObj);
+      state_label = this._computeStateLabel(stateObj);
     } else {
       name = config.name || entityId;
       state = UNAVAILABLE;
@@ -125,7 +124,7 @@ class HuiPictureEntityCard extends EventsMixin(LocalizeMixin(PolymerElement)) {
     this.$.card.classList.toggle('canInteract', canInteract);
   }
 
-  _computeState(stateObj) {
+  _computeStateLabel(stateObj) {
     const domain = computeStateDomain(stateObj);
     switch (domain) {
       case 'scene':
@@ -158,7 +157,7 @@ class HuiPictureEntityCard extends EventsMixin(LocalizeMixin(PolymerElement)) {
     const domain = computeDomain(entityId);
     if (domain === 'weblink') {
       window.open(this.hass.states[entityId].state);
-    } else if (canToggleState(this.hass, stateObj)) {
+    } else {
       toggleEntity(this.hass, entityId);
     }
   }

--- a/src/panels/lovelace/cards/hui-picture-entity-card.js
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.js
@@ -104,22 +104,22 @@ class HuiPictureEntityCard extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
     let name;
     let state;
-    let state_label;
+    let stateLabel;
     let canInteract = true;
 
     if (stateObj) {
       name = config.name || computeStateName(stateObj);
       state = stateObj.state;
-      state_label = this._computeStateLabel(stateObj);
+      stateLabel = this._computeStateLabel(stateObj);
     } else {
       name = config.name || entityId;
       state = UNAVAILABLE;
-      state_label = UNAVAILABLE;
+      stateLabel = UNAVAILABLE;
       canInteract = false;
     }
 
     this.$.name.innerText = name;
-    this.$.state.innerText = state_label;
+    this.$.state.innerText = stateLabel;
     this._oldState = state;
     this.$.card.classList.toggle('canInteract', canInteract);
   }


### PR DESCRIPTION
- Now that we have `state_image`, showing the info bar can be redundant. Add new option `show_info: false` to hide the infobar. (related to https://github.com/home-assistant/ui-schema/issues/63 )
- Make card not clickable when the state is not toggle-able. Fixes https://github.com/home-assistant/ui-schema/issues/68
