### PR TITLE
Allow iOS serve latest JS again

### DIFF
--- a/public/__init__.py
+++ b/public/__init__.py
@@ -22,10 +22,9 @@ def version(useragent):
     """Get the version for given user agent."""
     useragent = parse(useragent)
 
-    # on iOS every browser is a Safari which we support from version 11.
+    # on iOS every browser is a Safari which we support from version 10.1.
     if useragent.os.family == 'iOS':
-        # Was >= 10, temp setting it to 12 to work around issue #11387
-        return useragent.os.version[0] >= 12
+        return useragent.os.version[0] >= FAMILY_MIN_VERSION['Safari']
 
     version = FAMILY_MIN_VERSION.get(useragent.browser.family)
     return version and useragent.browser.version[0] >= version


### PR DESCRIPTION
In January we switched iOS devices to always use the ES5 version of our frontend ([PR](https://github.com/home-assistant/home-assistant/pull/11387/files)).

In the meanwhile we have switched our build pipeline and I can no longer repro the issue.

Giving iOS the right version again.