### PR TITLE
Lock state of button reversed

### DIFF
--- a/src/components/entity/ha-entity-toggle.js
+++ b/src/components/entity/ha-entity-toggle.js
@@ -122,7 +122,7 @@ class HaEntityToggle extends PolymerElement {
 
     if (stateDomain === 'lock') {
       serviceDomain = 'lock';
-      service = turnOn ? 'unlock' : 'lock';
+      service = turnOn ? 'lock' : 'unlock';
     } else if (stateDomain === 'cover') {
       serviceDomain = 'cover';
       service = turnOn ? 'open_cover' : 'close_cover';


### PR DESCRIPTION
Fixes https://github.com/home-assistant/home-assistant/issues/15276
Button position was reversed in the ui. Icon and actual state was correct.