### PR TITLE
Lovelace: Style view backgroud

### DIFF
--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -205,7 +205,7 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
         view.config = viewConfig;
         view.columns = this.columns;
       }
-      viewConfig.background && (background = viewConfig.background);
+      if (viewConfig.background) background = viewConfig.background;
     }
 
     this.$.view.style.background = background;

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -206,6 +206,10 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
       }
     }
 
+    if ('background' in viewConfig) {
+      this.$.view.style.setProperty('background', viewConfig.background);
+    }
+
     view.hass = this.hass;
     root.appendChild(view);
   }

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -191,9 +191,9 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
     }
 
     let view;
+    let background = this.config.background || '';
 
     if (viewIndex === 'unused') {
-      this.$.view.style.background = '';
       view = document.createElement('hui-unused-entities');
       view.config = this.config;
     } else {
@@ -205,8 +205,10 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
         view.config = viewConfig;
         view.columns = this.columns;
       }
-      this.$.view.style.background = viewConfig.background || '';
+      viewConfig.background && (background = viewConfig.background);
     }
+
+    this.$.view.style.background = background;
 
     view.hass = this.hass;
     root.appendChild(view);

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -206,11 +206,7 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
       }
     }
 
-    if ('background' in viewConfig) {
-      this.$.view.style.setProperty('background', viewConfig.background);
-    } else {
-      this.$.view.style.background = '';
-    }
+    this.$.view.style.background = viewConfig.background || '';
 
     view.hass = this.hass;
     root.appendChild(view);

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -193,6 +193,7 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
     let view;
 
     if (viewIndex === 'unused') {
+      this.$.view.style.background = '';
       view = document.createElement('hui-unused-entities');
       view.config = this.config;
     } else {
@@ -204,9 +205,8 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
         view.config = viewConfig;
         view.columns = this.columns;
       }
+      this.$.view.style.background = viewConfig.background || '';
     }
-
-    this.$.view.style.background = viewConfig.background || '';
 
     view.hass = this.hass;
     root.appendChild(view);

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -208,6 +208,8 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
 
     if ('background' in viewConfig) {
       this.$.view.style.setProperty('background', viewConfig.background);
+    } else {
+      this.$.view.style.background = '';
     }
 
     view.hass = this.hass;

--- a/src/panels/lovelace/hui-unused-entities.js
+++ b/src/panels/lovelace/hui-unused-entities.js
@@ -12,7 +12,8 @@ class HuiUnusedEntities extends PolymerElement {
       <style>
         #root {
           max-width: 600px;
-          margin: 8px auto;
+          margin: 0 auto;
+          padding: 8px 0;
         }
       </style>
       <div id="root"></div>


### PR DESCRIPTION
depends on: #1403

fix: https://github.com/home-assistant/ui-schema/issues/30

```yaml
title: Lovelace Demo
background: content-box radial-gradient(crimson, skyblue)
views:
  - title: Home
    icon: mdi:heart
    background: center / cover no-repeat url("https://images.pexels.com/photos/977736/pexels-photo-977736.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260") fixed
    cards:
```

```yaml
background: center / cover no-repeat url("https://images.pexels.com/photos/977736/pexels-photo-977736.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260") fixed

background: radial-gradient(crimson, skyblue)

background: orange
```

https://developer.mozilla.org/en-US/docs/Web/CSS/background