### PR TITLE
Fix language detection for country codes

### DIFF
--- a/src/util/hass-translation.js
+++ b/src/util/hass-translation.js
@@ -38,12 +38,12 @@ export function getActiveTranslation() {
     }
   }
   if (navigator.languages) {
-    navigator.languages.forEach((locale) => {
+    for (const locale of navigator.languages) {
       translation = languageGetTranslation(locale);
       if (translation) {
         return translation;
       }
-    });
+    }
   }
   translation = languageGetTranslation(navigator.language);
   if (translation) {

--- a/src/util/hass-translation.js
+++ b/src/util/hass-translation.js
@@ -38,12 +38,12 @@ export function getActiveTranslation() {
     }
   }
   if (navigator.languages) {
-    for (let i = 0; i < navigator.languages.length; i++) {
-      translation = languageGetTranslation(navigator.languages[i]);
+    navigator.languages.forEach((locale) => {
+      translation = languageGetTranslation(locale);
       if (translation) {
         return translation;
       }
-    }
+    });
   }
   translation = languageGetTranslation(navigator.language);
   if (translation) {

--- a/src/util/hass-translation.js
+++ b/src/util/hass-translation.js
@@ -36,23 +36,23 @@ export function getActiveTranslation() {
     if (translation) {
       return translation;
     }
-  } else if (navigator.languages) {
+  }
+  if (navigator.languages) {
     for (let i = 0; i < navigator.languages.length; i++) {
       translation = languageGetTranslation(navigator.languages[i]);
       if (translation) {
         return translation;
       }
     }
-  } else {
-    translation = languageGetTranslation(navigator.language);
+  }
+  translation = languageGetTranslation(navigator.language);
+  if (translation) {
+    return translation;
+  }
+  if (navigator.language.includes('-')) {
+    translation = languageGetTranslation(navigator.language.split('-')[0]);
     if (translation) {
       return translation;
-    }
-    if (navigator.language.includes('-')) {
-      translation = languageGetTranslation(navigator.language.split('-')[0]);
-      if (translation) {
-        return translation;
-      }
     }
   }
 


### PR DESCRIPTION
```
navigator.languages = ["de-DE"]
navigator.language = "de-DE"
```
was detected as `en` before