### PR TITLE
Add image type for picture-elements card.

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -4,18 +4,18 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../../../components/buttons/ha-call-service-button.js';
 import '../../../components/entity/ha-state-label-badge.js';
 import '../../../components/entity/state-badge.js';
-import '../components/hui-image.js';
 import '../../../components/ha-icon.js';
 import '../../../components/ha-card.js';
+import '../components/hui-image.js';
 
 import computeStateDisplay from '../../../common/entity/compute_state_display.js';
 import computeStateName from '../../../common/entity/compute_state_name.js';
+import computeDomain from '../../../common/entity/compute_domain';
 import toggleEntity from '../common/entity/toggle-entity.js';
 
 import EventsMixin from '../../../mixins/events-mixin.js';
 import LocalizeMixin from '../../../mixins/localize-mixin.js';
 import NavigateMixin from '../../../mixins/navigate-mixin.js';
-import computeDomain from '../../../common/entity/compute_domain';
 
 const VALID_TYPES = new Set([
   'image',
@@ -60,6 +60,9 @@ class HuiPictureElementsCard extends NavigateMixin(EventsMixin(LocalizeMixin(Pol
       ha-call-service-button {
         color: var(--primary-color);
         white-space: nowrap;
+      }
+      hui-image {
+        overflow-y: hidden;
       }
     </style>
 
@@ -176,7 +179,6 @@ class HuiPictureElementsCard extends NavigateMixin(EventsMixin(LocalizeMixin(Pol
           el.addEventListener('click', () => this._handleImageClick(element));
           el.classList.add('clickable');
           this._images.push(el);
-          break;
       }
 
       el.classList.add('element');


### PR DESCRIPTION
***Depends on #1423***

Allows adding images to a picture-elements card
Closes: https://github.com/home-assistant/ui-schema/issues/75

Example using `state_image` and `state_filter`:
```yaml
- type: image
  entity: light.living_room
  tap_action: toggle
  image: /local/living_room.png
  state_image:
    'off': /local/living_room_off.png
  filter: brightness(100%)
  state_filter:
    'on': brightness(130%) saturate(1.5)
  style:
    ... 
```

Example using camera and service call:
```yaml
- type: image
  entity: camera.demo_camera
  tap_action: call_service
  service: camera.snapshot
  service_data:
    filename: /tmp/snapshot
  style:
    ... 
```