### PR TITLE
Make Lovelace filter card more robust

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -34,6 +34,7 @@ class HuiEntitiesCard extends PolymerElement {
 
     if (this.lastChild) {
       this.removeChild(this.lastChild);
+      this._element = null;
     }
 
     const card = 'card' in config ? Object.assign({}, config.card) : {};
@@ -43,14 +44,12 @@ class HuiEntitiesCard extends PolymerElement {
     const element = createCardElement(card);
     element._filterRawConfig = card;
     this._updateCardConfig(element);
-    element.hass = this.hass;
-    this.appendChild(element);
+
+    this._element = element;
   }
 
   _hassChanged(hass) {
-    const element = this.lastChild;
-    this._updateCardConfig(element);
-    element.hass = hass;
+    this._updateCardConfig(this._element);
   }
 
   _updateCardConfig(element) {
@@ -69,6 +68,10 @@ class HuiEntitiesCard extends PolymerElement {
       { entities: entitiesList }
     ));
     element.isPanel = this.isPanel;
+    element.hass = this.hass;
+
+    // Attach element if it has never been attached.
+    if (!this.lastChild) this.appendChild(element);
   }
 }
 customElements.define('hui-entity-filter-card', HuiEntitiesCard);

--- a/src/panels/lovelace/cards/hui-entity-filter-card.js
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.js
@@ -48,7 +48,7 @@ class HuiEntitiesCard extends PolymerElement {
     this._element = element;
   }
 
-  _hassChanged(hass) {
+  _hassChanged() {
     this._updateCardConfig(this._element);
   }
 


### PR DESCRIPTION
The Lovelace entity filter card would connect cards without making sure `hass` object was available. This could break cards (ie media-control). Now it will only attach a card once `hass` is available.

Fixes https://github.com/home-assistant/ui-schema/issues/82