### PR TITLE
hui-image should use image even if camera entity is defined

### DIFF
--- a/src/panels/lovelace/components/hui-image.js
+++ b/src/panels/lovelace/components/hui-image.js
@@ -84,6 +84,8 @@ class HuiImage extends LocalizeMixin(PolymerElement) {
 
   _configChanged(image, stateImage, cameraImage) {
     if (cameraImage) {
+      if (image)
+        this._imageSrc = image;
       this._updateCameraImageSrc();
     } else if (image && !stateImage) {
       this._imageSrc = image;


### PR DESCRIPTION
So that one can specify a loading image (ex. base64) to the image option and have it display that until camera image arrives.
This will remove the jump when camera image finally loads (if loading image is same size).

This is untested as i could not set up an development environment for this at the moment.
