### PR TITLE
Add ability to set Zwave protection commandclass

### DIFF
--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -334,9 +334,7 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
 
       _protection: {
         type: Array,
-        value: function () {
-          return [];
-        },
+        value: () => [],
       },
 
       _protectionNode: {
@@ -412,10 +410,10 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
       this.hasNodeUserCodes = this.userCodes.length > 0;
       this.notifyPath('hasNodeUserCodes');
     });
-    this.hass.callApi('GET', 'zwave/protection/' + this.nodes[selectedNode].attributes.node_id).then((protections) => {
-      this.protection = this._objToArray(protections);
-      if (this.protection) {
-        if (this.protection[0] === undefined) {
+    this.hass.callApi('GET', `zwave/protection/${this.nodes[selectedNode].attributes.node_id}`).then((protections) => {
+      this._protection = this._objToArray(protections);
+      if (this._protection) {
+        if (this._protection.length === 0) {
           return;
         }
         this._protectionNode = true;

--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -226,7 +226,7 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
             hass="[[hass]]"
             nodes="[[nodes]]"
             selected-node="[[selectedNode]]"
-            _protection="[[_protection]]"
+            protection="[[_protection]]"
           ></zwave-node-protection>
         </template> 
 

--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -24,6 +24,7 @@ import './zwave-node-config.js';
 import './zwave-node-information.js';
 import './zwave-usercodes.js';
 import './zwave-values.js';
+import './zwave-node-protection.js';
 
 import sortByName from '../../../common/entity/states_sort_by_name.js';
 import computeStateName from '../../../common/entity/compute_state_name.js';
@@ -187,21 +188,57 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
 
         <template is="dom-if" if="[[computeIsNodeSelected(selectedNode)]]">
           <!--Node info card-->
-          <zwave-node-information id="zwave-node-information" nodes="[[nodes]]" selected-node="[[selectedNode]]"></zwave-node-information>
+          <zwave-node-information
+            id="zwave-node-information"
+            nodes="[[nodes]]"
+            selected-node="[[selectedNode]]"
+          ></zwave-node-information>
 
           <!--Value card-->
-          <zwave-values hass="[[hass]]" nodes="[[nodes]]" selected-node="[[selectedNode]]" values="[[values]]"></zwave-values>
+          <zwave-values
+            hass="[[hass]]"
+            nodes="[[nodes]]"
+            selected-node="[[selectedNode]]"
+            values="[[values]]"
+          ></zwave-values>
 
           <!--Group card-->
-          <zwave-groups hass="[[hass]]" nodes="[[nodes]]" selected-node="[[selectedNode]]" groups="[[groups]]"></zwave-groups>
+          <zwave-groups
+            hass="[[hass]]"
+            nodes="[[nodes]]"
+            selected-node="[[selectedNode]]"
+            groups="[[groups]]"
+          ></zwave-groups>
 
           <!--Config card-->
-          <zwave-node-config hass="[[hass]]" nodes="[[nodes]]" selected-node="[[selectedNode]]" config="[[config]]"></zwave-node-config>
+          <zwave-node-config
+            hass="[[hass]]"
+            nodes="[[nodes]]"
+            selected-node="[[selectedNode]]"
+            config="[[config]]"
+          ></zwave-node-config>
+
         </template>
+
+        <!--Protection card-->
+        <template is="dom-if" if="{{_protectionNode}}">
+          <zwave-node-protection
+            hass="[[hass]]"
+            nodes="[[nodes]]"
+            selected-node="[[selectedNode]]"
+            _protection="[[_protection]]"
+          ></zwave-node-protection>
+        </template> 
 
         <!--User Codes-->
         <template is="dom-if" if="{{hasNodeUserCodes}}">
-          <zwave-usercodes id="zwave-usercodes" hass="[[hass]]" nodes="[[nodes]]" user-codes="[[userCodes]]" selected-node="[[selectedNode]]"></zwave-usercodes>
+          <zwave-usercodes
+            id="zwave-usercodes"
+            hass="[[hass]]"
+            nodes="[[nodes]]"
+            user-codes="[[userCodes]]"
+            selected-node="[[selectedNode]]"
+          ></zwave-usercodes>
       </template>
       </ha-config-section>
 
@@ -294,6 +331,18 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
         type: Number,
         value: 0,
       },
+
+      _protection: {
+        type: Array,
+        value: function () {
+          return [];
+        },
+      },
+
+      _protectionNode: {
+        type: Boolean,
+        value: false,
+      },
     };
   }
 
@@ -362,6 +411,15 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
       this.userCodes = this._objToArray(usercodes);
       this.hasNodeUserCodes = this.userCodes.length > 0;
       this.notifyPath('hasNodeUserCodes');
+    });
+    this.hass.callApi('GET', 'zwave/protection/' + this.nodes[selectedNode].attributes.node_id).then((protections) => {
+      this.protection = this._objToArray(protections);
+      if (this.protection) {
+        if (this.protection[0] === undefined) {
+          return;
+        }
+        this._protectionNode = true;
+      }
     });
   }
 

--- a/src/panels/config/zwave/zwave-node-protection.js
+++ b/src/panels/config/zwave/zwave-node-protection.js
@@ -1,0 +1,164 @@
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-dropdown-menu/paper-dropdown-menu.js';
+import '@polymer/paper-input/paper-input.js';
+import '@polymer/paper-item/paper-item.js';
+import '@polymer/paper-listbox/paper-listbox.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import '../../../components/buttons/ha-call-api-button.js';
+
+class ZwaveProtectionConfig extends PolymerElement {
+  static get template() {
+    return html`
+    <style include="iron-flex ha-style">
+      .card-actions.warning ha-call-api-button {
+        color: var(--google-red-500);
+      }
+      .content {
+        margin-top: 24px;
+      }
+
+      paper-card {
+        display: block;
+        margin: 0 auto;
+        max-width: 600px;
+      }
+
+      .device-picker {
+        @apply --layout-horizontal;
+        @apply --layout-center-center;
+        padding-left: 24px;
+        padding-right: 24px;
+        padding-bottom: 24px;
+        }
+
+    </style>
+      <div class="content">
+        <paper-card heading="Node protection">
+          <div class="device-picker">
+          <paper-dropdown-menu label="Protection" dynamic-align="" class="flex" placeholder="{{_loadedProtectionValue}}">
+            <paper-listbox slot="dropdown-content" selected="{{_selectedProtectionParameter}}">
+              <template is="dom-repeat" items="[[_protectionOptions]]" as="state">
+                <paper-item>[[state]]</paper-item>
+              </template>
+            </paper-listbox>
+          </paper-dropdown-menu>
+          </div>
+          <div class="card-actions">
+            <ha-call-api-button hass="[[hass]]" path="[[_nodePath]]" data="[[_protectionData]]">Set Protection</ha-call-service-button>
+          </div>
+        </div>
+`;
+  }
+
+  static get properties() {
+    return {
+      hass: {
+        type: Object,
+      },
+
+      nodes: {
+        type: Array,
+        observer: 'nodesChanged'
+      },
+
+      selectedNode: {
+        type: Number,
+        value: -1,
+        observer: 'nodesChanged'
+      },
+
+      protectionNode: {
+        type: Boolean,
+        value: false,
+      },
+
+      _protectionValueID: {
+        type: Number,
+        value: -1,
+      },
+
+      _selectedProtectionParameter: {
+        type: Number,
+        value: -1,
+        observer: 'computeProtectionData',
+      },
+
+      _protectionOptions: {
+        type: Array,
+      },
+
+      _protection: {
+        type: Array,
+        value: function () {
+          return [];
+        }
+      },
+
+      _loadedProtectionValue: {
+        type: String,
+        value: ''
+      },
+
+      _protectionData: {
+        type: Object,
+        value: { },
+      },
+
+      _nodePath: {
+        type: String,
+      }
+    };
+  }
+
+  ready() {
+    super.ready();
+    this.addEventListener('hass-api-called', ev => this.apiCalled(ev));
+  }
+
+  apiCalled(ev) {
+    if (ev.detail.success) {
+      setTimeout(() => {
+        this.refreshProtection(this.selectedNode);
+      }, 5000);
+    }
+  }
+
+
+  nodesChanged() {
+    if (!this.nodes) return;
+    if (this._protection) {
+      if (this._protection[0] === undefined) { return; }
+      this.protectionNode = true;
+      this._protectionOptions = this._protection[0].value;
+      this._loadedProtectionValue = this._protection[1].value;
+      this._protectionValueID = this._protection[2].value;
+    }
+  }
+
+  async refreshProtection(selectedNode) {
+    const protectionValues = [];
+    const protections = await this.hass.callApi('GET', 'zwave/protection/' + this.nodes[selectedNode].attributes.node_id);
+    Object.keys(protections).forEach(function (key) {
+      protectionValues.push({
+        key: key,
+        value: protections[key],
+      });
+    });
+    this._protection = protectionValues;
+    this._selectedProtectionParameter = -1;
+    this._loadedProtectionValue = this._protection[1].value;
+  }
+
+  computeProtectionData(selectedProtectionParameter) {
+    if (this.selectedNode === -1 || selectedProtectionParameter === -1) return;
+    this._protectionData = {
+      selection: this._protectionOptions[selectedProtectionParameter],
+      value_id: this._protectionValueID
+    };
+    this._nodePath = 'zwave/protection/' + this.nodes[this.selectedNode].attributes.node_id;
+  }
+}
+
+customElements.define('zwave-node-protection', ZwaveProtectionConfig);

--- a/src/panels/config/zwave/zwave-node-protection.js
+++ b/src/panels/config/zwave/zwave-node-protection.js
@@ -150,7 +150,7 @@ class ZwaveNodeProtection extends PolymerElement {
       selection: this._protectionOptions[selectedProtectionParameter],
       value_id: this._protectionValueID
     };
-    this._nodePath = 'zwave/protection/' + this.nodes[this.selectedNode].attributes.node_id;
+    this._nodePath = `zwave/protection/${this.nodes[this.selectedNode].attributes.node_id}`;
   }
 }
 

--- a/src/panels/config/zwave/zwave-node-protection.js
+++ b/src/panels/config/zwave/zwave-node-protection.js
@@ -8,7 +8,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 import '../../../components/buttons/ha-call-api-button.js';
 
-class ZwaveProtectionConfig extends PolymerElement {
+class ZwaveNodeProtection extends PolymerElement {
   static get template() {
     return html`
     <style include="iron-flex ha-style">
@@ -154,4 +154,4 @@ class ZwaveProtectionConfig extends PolymerElement {
   }
 }
 
-customElements.define('zwave-node-protection', ZwaveProtectionConfig);
+customElements.define('zwave-node-protection', ZwaveNodeProtection);

--- a/src/panels/config/zwave/zwave-node-protection.js
+++ b/src/panels/config/zwave/zwave-node-protection.js
@@ -54,9 +54,7 @@ class ZwaveNodeProtection extends PolymerElement {
     return {
       hass: Object,
 
-      nodes: {
-        type: Array,
-      },
+      nodes: Array,
 
       selectedNode: {
         type: Number,
@@ -121,12 +119,13 @@ class ZwaveNodeProtection extends PolymerElement {
 
   _nodesChanged() {
     if (!this.nodes) return;
-    if (this._protection) {
-      if (this._protection.length === 0) { return; }
-      this.setProperties({ protectionNode: true });
-      this._protectionOptions = this._protection[0].value;
-      this._loadedProtectionValue = this._protection[1].value;
-      this._protectionValueID = this._protection[2].value;
+    if (this.protection) {
+      if (this.protection.length === 0) { return; }
+      this.setProperties({
+        protectionNode: true,
+        _protectionOptions: this.protection[0].value,
+        _loadedProtectionValue: this.protection[1].value,
+        _protectionValueID: this.protection[2].value });
     }
   }
 
@@ -139,9 +138,10 @@ class ZwaveNodeProtection extends PolymerElement {
         value: protections[key],
       });
     });
-    this.setProperties({ _protection: protectionValues });
-    this._selectedProtectionParameter = -1;
-    this._loadedProtectionValue = this._protection[1].value;
+    this.setProperties({
+      _protection: protectionValues,
+      _selectedProtectionParameter: -1,
+      _loadedProtectionValue: this.protection[1].value });
   }
 
   _computeProtectionData(selectedProtectionParameter) {


### PR DESCRIPTION
Allows the user via zwave control panel to set values of protection commandclass.
This is needed in some cases to allow programming of some devices.
See https://github.com/home-assistant/home-assistant/issues/11137 for reference.
Accompanying PR for backend: https://github.com/home-assistant/home-assistant/pull/15390