### PR TITLE
Picture elements: add service-icon

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -241,7 +241,7 @@ class HuiPictureElementsCard extends NavigateMixin(EventsMixin(LocalizeMixin(Pol
 
   _handleClick(elementConfig) {
     const tapAction = elementConfig.tap_action || (elementConfig.type === 'service-icon' ?
-      'service-call' : 'more-info');
+      'call-service' : 'more-info');
 
     switch (tapAction) {
       case 'more-info':

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -9,6 +9,8 @@ import '../../../components/ha-card.js';
 
 import computeStateDisplay from '../../../common/entity/compute_state_display.js';
 import computeStateName from '../../../common/entity/compute_state_name.js';
+
+import callService from '../common/call-service.js';
 import toggleEntity from '../common/entity/toggle-entity.js';
 
 import EventsMixin from '../../../mixins/events-mixin.js';
@@ -18,6 +20,7 @@ import NavigateMixin from '../../../mixins/navigate-mixin.js';
 const VALID_TYPES = new Set([
   'navigation',
   'service-button',
+  'service-icon',
   'state-badge',
   'state-icon',
   'state-label',
@@ -131,6 +134,14 @@ class HuiPictureElementsCard extends NavigateMixin(EventsMixin(LocalizeMixin(Pol
           el.serviceData = element.service_data || {};
           el.innerText = element.title;
           el.hass = this.hass;
+          break;
+        case 'service-icon':
+          el = document.createElement('ha-icon');
+          el.icon = element.icon;
+          el.title = element.title || '';
+          el.addEventListener('click', () =>
+                              callService(this.hass, element.service, element.service_data));
+          el.classList.add('clickable');
           break;
         case 'state-badge':
           el = document.createElement('ha-state-label-badge');

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -140,7 +140,7 @@ class HuiPictureElementsCard extends NavigateMixin(EventsMixin(LocalizeMixin(Pol
           el.icon = element.icon;
           el.title = element.title || '';
           el.addEventListener('click', () =>
-                              callService(this.hass, element.service, element.service_data));
+                              callService(this.hass, element.service, element.service_data || {}));
           el.classList.add('clickable');
           break;
         case 'state-badge':

--- a/src/panels/lovelace/cards/hui-picture-elements-card.js
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.js
@@ -140,7 +140,7 @@ class HuiPictureElementsCard extends NavigateMixin(EventsMixin(LocalizeMixin(Pol
           el.icon = element.icon;
           el.title = element.title || '';
           el.addEventListener('click', () =>
-                              callService(this.hass, element.service, element.service_data || {}));
+            callService(this.hass, element.service, element.service_data || {}));
           el.classList.add('clickable');
           break;
         case 'state-badge':

--- a/src/panels/lovelace/common/call-service.js
+++ b/src/panels/lovelace/common/call-service.js
@@ -1,0 +1,4 @@
+export default function callService(hass, domainService, serviceData = {}) {
+  const [domain, service] = domainService.split('.', 2);
+  hass.callService(domain, service, serviceData);
+}

--- a/src/panels/lovelace/common/call-service.js
+++ b/src/panels/lovelace/common/call-service.js
@@ -1,4 +1,0 @@
-export default function callService(hass, domainService, serviceData = {}) {
-  const [domain, service] = domainService.split('.', 2);
-  hass.callService(domain, service, serviceData);
-}


### PR DESCRIPTION
fix: https://github.com/home-assistant/ui-schema/issues/91

```yaml
  - title: Picture elements
    cards:
      - type: picture-elements
        image: https://images.pexels.com/photos/316465/pexels-photo-316465.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260
        elements:
          - type: service-icon
            icon: mdi:power
            title: Ligth off
            service: light.turn_off
            service_data:
              entity_id: light.ceiling_lights
```