### PR TITLE
Check access token expires before we use it.

### DIFF
--- a/src/common/auth/fetch_token.js
+++ b/src/common/auth/fetch_token.js
@@ -8,6 +8,9 @@ export default function fetchToken(clientId, code) {
     body: data,
   }).then((resp) => {
     if (!resp.ok) throw new Error('Unable to fetch tokens');
-    return resp.json();
+    const tokens = resp.json();
+    // shorten access token life 30 seconds to cover network cost
+    tokens.expires = ((tokens.expires_in - 30) * 1000) + Date.now();
+    return tokens;
   });
 }

--- a/src/common/auth/fetch_token.js
+++ b/src/common/auth/fetch_token.js
@@ -9,8 +9,7 @@ export default function fetchToken(clientId, code) {
   }).then((resp) => {
     if (!resp.ok) throw new Error('Unable to fetch tokens');
     const tokens = resp.json();
-    // shorten access token life 30 seconds to cover network cost
-    tokens.expires = ((tokens.expires_in - 30) * 1000) + Date.now();
+    tokens.expires = (tokens.expires_in * 1000) + Date.now();
     return tokens;
   });
 }

--- a/src/common/auth/refresh_token.js
+++ b/src/common/auth/refresh_token.js
@@ -9,8 +9,7 @@ export default function refreshAccessToken(clientId, refreshToken) {
   }).then((resp) => {
     if (!resp.ok) throw new Error('Unable to fetch tokens');
     const tokens = resp.json();
-    // shorten access token life 30 seconds to cover network cost
-    tokens.expires = ((tokens.expires_in - 30) * 1000) + Date.now();
+    tokens.expires = (tokens.expires_in * 1000) + Date.now();
     return tokens;
   });
 }

--- a/src/common/auth/refresh_token.js
+++ b/src/common/auth/refresh_token.js
@@ -8,6 +8,9 @@ export default function refreshAccessToken(clientId, refreshToken) {
     body: data,
   }).then((resp) => {
     if (!resp.ok) throw new Error('Unable to fetch tokens');
-    return resp.json();
+    const tokens = resp.json();
+    // shorten access token life 30 seconds to cover network cost
+    tokens.expires = ((tokens.expires_in - 30) * 1000) + Date.now();
+    return tokens;
   });
 }

--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -235,8 +235,8 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
         const host = window.location.protocol + '//' + window.location.host;
         const auth = conn.options;
         try {
-          if (auth.accessToken && Date.now() > auth.expires) {
-            // Refresh acess token if we know it has expired
+          // Refresh token if it will expire in 30 seconds
+          if (auth.accessToken && Date.now() + 30000 > auth.expires) {
             const accessToken = await window.refreshToken();
             conn.options.accessToken = accessToken.access_token;
             conn.options.expires = accessToken.expires;

--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -235,13 +235,20 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
         const host = window.location.protocol + '//' + window.location.host;
         const auth = conn.options;
         try {
+          if (auth.accessToken && Date.now() > auth.expires) {
+            // Refresh acess token if we know it expires
+            const accessToken = await window.refreshToken();
+            conn.options.accessToken = accessToken.access_token;
+            conn.options.expires = accessToken.expires;
+          }
           return await hassCallApi(host, auth, method, path, parameters);
         } catch (err) {
           if (!err || err.status_code !== 401 || !auth.accessToken) throw err;
 
           // If we connect with access token and get 401, refresh token and try again
           const accessToken = await window.refreshToken();
-          conn.options.accessToken = accessToken;
+          conn.options.accessToken = accessToken.access_token;
+          conn.options.expires = accessToken.expires;
           return await hassCallApi(host, auth, method, path, parameters);
         }
       },

--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -236,7 +236,7 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
         const auth = conn.options;
         try {
           if (auth.accessToken && Date.now() > auth.expires) {
-            // Refresh acess token if we know it expires
+            // Refresh acess token if we know it has expired
             const accessToken = await window.refreshToken();
             conn.options.accessToken = accessToken.access_token;
             conn.options.expires = accessToken.expires;

--- a/src/entrypoints/core.js
+++ b/src/entrypoints/core.js
@@ -40,8 +40,6 @@ function redirectLogin() {
 window.refreshToken = () =>
   refreshToken_(clientId(), window.tokens.refresh_token).then((accessTokenResp) => {
     window.tokens.access_token = accessTokenResp.access_token;
-    // shorten access token life 30 seconds to cover network cost
-    window.tokens.expires = ((accessTokenResp.expires_in - 30) * 1000) + Date.now();
     localStorage.tokens = JSON.stringify(window.tokens);
     return {
       access_token: accessTokenResp.access_token,
@@ -51,8 +49,6 @@ window.refreshToken = () =>
 
 function resolveCode(code) {
   fetchToken(clientId(), code).then((tokens) => {
-    // shorten access token life 30 seconds to cover network cost
-    tokens.expires = ((tokens.expires_in - 30) * 1000) + Date.now();
     localStorage.tokens = JSON.stringify(tokens);
     // Refresh the page and have tokens in place.
     document.location = location.pathname;
@@ -75,10 +71,11 @@ function main() {
   if (localStorage.tokens) {
     window.tokens = JSON.parse(localStorage.tokens);
     if (window.tokens.expires === undefined) {
+      // for those tokens got from previous version
       window.tokens.expires = Date.now() - 1;
     }
     if (Date.now() > window.tokens.expires) {
-      // refresh access token if we know it expires to reduce unncessary backend invalid auth event
+      // refresh access token if it has expired to reduce unncessary backend invalid auth event
       window.hassConnection = window.refreshToken().then(accessToken => init(null, accessToken));
     } else {
       const accessTokenObject = {

--- a/src/entrypoints/core.js
+++ b/src/entrypoints/core.js
@@ -74,8 +74,8 @@ function main() {
       // for those tokens got from previous version
       window.tokens.expires = Date.now() - 1;
     }
-    if (Date.now() > window.tokens.expires) {
-      // refresh access token if it has expired to reduce unncessary backend invalid auth event
+    if (Date.now() + 30000 > window.tokens.expires) {
+      // refresh access token if it will expire in 30 seconds to avoid invalid auth event
       window.hassConnection = window.refreshToken().then(accessToken => init(null, accessToken));
     } else {
       const accessTokenObject = {


### PR DESCRIPTION
If we found access token expires, we proactive call refresh token.
So that we can avoid uncessary invalid auth error in backend.

It is part of work for home-assistant/home-assistant#15209