### PR TITLE
Make custom cards work as panel

### DIFF
--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -23,6 +23,7 @@ import '../../components/ha-icon.js';
 import { loadModule, loadJS } from '../../common/dom/load_resource.js';
 import './hui-unused-entities.js';
 import './hui-view.js';
+import debounce from '../../common/util/debounce.js';
 
 import createCardElement from './common/create-card-element.js';
 
@@ -142,7 +143,7 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
 
   constructor() {
     super();
-    this._debouncedConfigChanged = debounce(this._configChanged, 100);
+    this._debouncedConfigChanged = debounce(() => this._selectView(this._curView), 100);
   }
 
   _routeChanged(route) {

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -105,7 +105,7 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
         </div>
       </app-header>
 
-      <div id='view'></div>
+      <div id='view' on-rebuild-view='_debouncedConfigChanged'></div>
     </app-header-layout>
     `;
   }
@@ -138,6 +138,11 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
       },
       routeData: Object
     };
+  }
+
+  constructor() {
+    super();
+    this._debouncedConfigChanged = debounce(this._configChanged, 100);
   }
 
   _routeChanged(route) {

--- a/src/panels/lovelace/hui-view.js
+++ b/src/panels/lovelace/hui-view.js
@@ -4,7 +4,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../../components/entity/ha-state-label-badge.js';
 
 import applyThemesOnElement from '../../common/dom/apply_themes_on_element.js';
-import debounce from '../../common/util/debounce.js';
 
 import createCardElement from './common/create-card-element';
 

--- a/src/panels/lovelace/hui-view.js
+++ b/src/panels/lovelace/hui-view.js
@@ -62,7 +62,7 @@ class HUIView extends PolymerElement {
       }
       </style>
       <div id="badges"></div>
-      <div id="columns" on-rebuild-view="_debouncedConfigChanged"></div>
+      <div id="columns"></div>
     `;
   }
 
@@ -89,7 +89,6 @@ class HUIView extends PolymerElement {
     super();
     this._cards = [];
     this._badges = [];
-    this._debouncedConfigChanged = debounce(this._configChanged, 100);
   }
 
   _createBadges(config) {


### PR DESCRIPTION
Make custom cards work with views that have `panel: true`

Fixes:
https://github.com/home-assistant/ui-schema/issues/95
https://github.com/ciotlosm/custom-lovelace/issues/34