### PR TITLE
Use separate duration for relative time

### DIFF
--- a/src/common/datetime/relative_time.js
+++ b/src/common/datetime/relative_time.js
@@ -9,7 +9,7 @@ const tests = [
   7, 'day',
 ];
 
-export default function relativeTime(dateObj) {
+export default function relativeTime(dateObj, localize) {
   let delta = (new Date() - dateObj) / 1000;
   const tense = delta >= 0 ? 'past' : 'future';
   delta = Math.abs(delta);
@@ -17,20 +17,14 @@ export default function relativeTime(dateObj) {
   for (let i = 0; i < tests.length; i += 2) {
     if (delta < tests[i]) {
       delta = Math.floor(delta);
-      return {
-        tense,
-        value: delta,
-        unit: tests[i + 1]
-      };
+      const time = localize(`ui.components.relative_time.duration.${tests[i + 1]}`, 'count', delta);
+      return localize(`ui.components.relative_time.${tense}`, 'time', time);
     }
 
     delta /= tests[i];
   }
 
   delta = Math.floor(delta);
-  return {
-    tense,
-    value: delta,
-    unit: 'week'
-  };
+  const time = localize('ui.components.relative_time.duration.week', 'count', delta);
+  return localize(`ui.components.relative_time.${tense}`, 'time', time);
 }

--- a/src/components/ha-relative-time.js
+++ b/src/components/ha-relative-time.js
@@ -59,10 +59,7 @@ class HaRelativeTime extends LocalizeMixin(PolymerElement) {
     if (!this.parsedDateTime) {
       root.innerHTML = this.localize('ui.components.relative_time.never');
     } else {
-      const rel = relativeTime(this.parsedDateTime);
-      const time = this.localize(`ui.duration.${rel.unit}`, 'count', rel.value);
-      const relTime = this.localize(`ui.components.relative_time.${rel.tense}`, 'time', time);
-      root.innerHTML = relTime;
+      root.innerHTML = relativeTime(this.parsedDateTime, this.localize);
     }
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -417,7 +417,14 @@
       "relative_time": {
         "past": "{time} ago",
         "future": "In {time}",
-        "never": "Never"
+        "never": "Never",
+        "duration": {
+          "second": "{count} {count, plural,\n  one {second}\n  other {seconds}\n}",
+          "minute": "{count} {count, plural,\n  one {minute}\n  other {minutes}\n}",
+          "hour": "{count} {count, plural,\n  one {hour}\n  other {hours}\n}",
+          "day": "{count} {count, plural,\n  one {day}\n  other {days}\n}",
+          "week": "{count} {count, plural,\n  one {week}\n  other {weeks}\n}"
+        }
       },
       "history_charts": {
         "loading_history": "Loading state history...",


### PR DESCRIPTION
+ pass localize to the method

in German we use
```
3 days:     3 Tage
3 days ago: Vor 3 Tage_n_
```