### PR TITLE
picture glance: better handle if no title

### DIFF
--- a/gallery/src/demos/demo-hui-picture-glance-card.js
+++ b/gallery/src/demos/demo-hui-picture-glance-card.js
@@ -60,12 +60,12 @@ class DemoPicGlance extends PolymerElement {
     return html`
       <style>
         #root {
+          padding: 10px;
         }
         hui-picture-glance-card {
           width: 400px;
           display: inline-block;
-          margin-left: 20px;
-          margin-top: 20px;
+          margin: 10px;
         }
       </style>
       <div id='root'>

--- a/src/panels/lovelace/cards/hui-picture-glance-card.js
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.js
@@ -87,27 +87,23 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
             <div class="title">[[_config.title]]</div>
           </template>
           <div>
-            <template is="dom-repeat" items="[[_entitiesDialog]]">
-              <template is="dom-if" if="[[_showEntity(item.entity, hass.states)]]">
-                <paper-icon-button
-                  on-click="_openDialog"
-                  class$="[[_computeButtonClass(item.entity, hass.states)]]"
-                  icon="[[_computeIcon(item.entity, hass.states)]]"
-                  title="[[_computeTooltip(item.entity, hass.states)]]"
-                ></paper-icon-button>
-              </template>
+            <template is="dom-repeat" items="[[_computeVisible(_entitiesDialog, hass.states)]]">
+              <paper-icon-button
+                on-click="_openDialog"
+                class$="[[_computeButtonClass(item.entity, hass.states)]]"
+                icon="[[_computeIcon(item.entity, hass.states)]]"
+                title="[[_computeTooltip(item.entity, hass.states)]]"
+              ></paper-icon-button>
             </template>
           </div>
           <div>
-            <template is="dom-repeat" items="[[_entitiesToggle]]">
-              <template is="dom-if" if="[[_showEntity(item.entity, hass.states)]]">
-                <paper-icon-button
-                  on-click="_callService"
-                  class$="[[_computeButtonClass(item.entity, hass.states)]]"
-                  icon="[[_computeIcon(item.entity, hass.states)]]"
-                  title="[[_computeTooltip(item.entity, hass.states)]]"
-                ></paper-icon-button>
-              </template>
+            <template is="dom-repeat" items="[[_computeVisible(_entitiesToggle, hass.states)]]">
+              <paper-icon-button
+                on-click="_callService"
+                class$="[[_computeButtonClass(item.entity, hass.states)]]"
+                icon="[[_computeIcon(item.entity, hass.states)]]"
+                title="[[_computeTooltip(item.entity, hass.states)]]"
+              ></paper-icon-button>
             </template>
           </div>
         </div>
@@ -150,6 +146,10 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
       _entitiesDialog: dialog,
       _entitiesToggle: toggle
     });
+  }
+
+  _computeVisible(collection, states) {
+    return collection.filter(el => el.entity in states);
   }
 
   _showEntity(entityId, states) {

--- a/src/panels/lovelace/cards/hui-picture-glance-card.js
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.js
@@ -83,7 +83,9 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
           entity="[[_config.entity]]"
         ></hui-image>
         <div class="box">
-          <div class="title">[[_config.title]]</div>
+          <template is="dom-if" if="[[_config.title]]">
+            <div class="title">[[_config.title]]</div>
+          </template>
           <div>
             <template is="dom-repeat" items="[[_entitiesDialog]]">
               <template is="dom-if" if="[[_showEntity(item.entity, hass.states)]]">

--- a/src/panels/lovelace/cards/hui-picture-glance-card.js
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.js
@@ -87,7 +87,7 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
             <div class="title">[[_config.title]]</div>
           </template>
           <div>
-            <template is="dom-repeat" items="[[_entitiesDialog]]">
+            <template is="dom-repeat" items="[[_computeVisible(_entitiesDialog, hass.states)]]">
               <paper-icon-button
                 on-click="_openDialog"
                 class$="[[_computeButtonClass(item.entity, hass.states)]]"
@@ -96,18 +96,16 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
               ></paper-icon-button>
             </template>
           </div>
-          <template is="dom-if" if="[[_entitiesToggle.length]]">
-            <div>
-              <template is="dom-repeat" items="[[_entitiesToggle]]">
-                <paper-icon-button
-                  on-click="_callService"
-                  class$="[[_computeButtonClass(item.entity, hass.states)]]"
-                  icon="[[_computeIcon(item.entity, hass.states)]]"
-                  title="[[_computeTooltip(item.entity, hass.states)]]"
-                ></paper-icon-button>
-              </template>
-            </div>
-          </template>
+          <div>
+            <template is="dom-repeat" items="[[_computeVisible(_entitiesToggle, hass.states)]]">
+              <paper-icon-button
+                on-click="_callService"
+                class$="[[_computeButtonClass(item.entity, hass.states)]]"
+                icon="[[_computeIcon(item.entity, hass.states)]]"
+                title="[[_computeTooltip(item.entity, hass.states)]]"
+              ></paper-icon-button>
+            </template>
+          </div>
         </div>
       </ha-card>
     `;
@@ -119,14 +117,6 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
       _config: Object,
       _entitiesDialog: Array,
       _entitiesToggle: Array,
-      _visibleEntitiesDialog: {
-        type: Array,
-        computed: '_computeVisible(_entitiesDialog, hass.states)',
-      },
-      _visibleEntitiesToggle: {
-        type: Array,
-        computed: '_computeVisible(_entitiesToggle, hass.states)',
-      },
     };
   }
 

--- a/src/panels/lovelace/cards/hui-picture-glance-card.js
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.js
@@ -86,18 +86,16 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
           <template is="dom-if" if="[[_config.title]]">
             <div class="title">[[_config.title]]</div>
           </template>
-          <template is="dom-if" if="[[_entitiesDialog.length]]">
-            <div>
-              <template is="dom-repeat" items="[[_entitiesDialog]]">
-                <paper-icon-button
-                  on-click="_openDialog"
-                  class$="[[_computeButtonClass(item.entity, hass.states)]]"
-                  icon="[[_computeIcon(item.entity, hass.states)]]"
-                  title="[[_computeTooltip(item.entity, hass.states)]]"
-                ></paper-icon-button>
-              </template>
-            </div>
-          </template>
+          <div>
+            <template is="dom-repeat" items="[[_entitiesDialog]]">
+              <paper-icon-button
+                on-click="_openDialog"
+                class$="[[_computeButtonClass(item.entity, hass.states)]]"
+                icon="[[_computeIcon(item.entity, hass.states)]]"
+                title="[[_computeTooltip(item.entity, hass.states)]]"
+              ></paper-icon-button>
+            </template>
+          </div>
           <template is="dom-if" if="[[_entitiesToggle.length]]">
             <div>
               <template is="dom-repeat" items="[[_entitiesToggle]]">

--- a/src/panels/lovelace/cards/hui-picture-glance-card.js
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.js
@@ -164,10 +164,6 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
     return collection.filter(el => el.entity in states);
   }
 
-  _showEntity(entityId, states) {
-    return entityId in states;
-  }
-
   _computeIcon(entityId, states) {
     return stateIcon(states[entityId]);
   }

--- a/src/panels/lovelace/cards/hui-picture-glance-card.js
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.js
@@ -86,26 +86,30 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
           <template is="dom-if" if="[[_config.title]]">
             <div class="title">[[_config.title]]</div>
           </template>
-          <div>
-            <template is="dom-repeat" items="[[_computeVisible(_entitiesDialog, hass.states)]]">
-              <paper-icon-button
-                on-click="_openDialog"
-                class$="[[_computeButtonClass(item.entity, hass.states)]]"
-                icon="[[_computeIcon(item.entity, hass.states)]]"
-                title="[[_computeTooltip(item.entity, hass.states)]]"
-              ></paper-icon-button>
-            </template>
-          </div>
-          <div>
-            <template is="dom-repeat" items="[[_computeVisible(_entitiesToggle, hass.states)]]">
-              <paper-icon-button
-                on-click="_callService"
-                class$="[[_computeButtonClass(item.entity, hass.states)]]"
-                icon="[[_computeIcon(item.entity, hass.states)]]"
-                title="[[_computeTooltip(item.entity, hass.states)]]"
-              ></paper-icon-button>
-            </template>
-          </div>
+          <template is="dom-if" if="[[_entitiesDialog.length]]">
+            <div>
+              <template is="dom-repeat" items="[[_entitiesDialog]]">
+                <paper-icon-button
+                  on-click="_openDialog"
+                  class$="[[_computeButtonClass(item.entity, hass.states)]]"
+                  icon="[[_computeIcon(item.entity, hass.states)]]"
+                  title="[[_computeTooltip(item.entity, hass.states)]]"
+                ></paper-icon-button>
+              </template>
+            </div>
+          </template>
+          <template is="dom-if" if="[[_entitiesToggle.length]]">
+            <div>
+              <template is="dom-repeat" items="[[_entitiesToggle]]">
+                <paper-icon-button
+                  on-click="_callService"
+                  class$="[[_computeButtonClass(item.entity, hass.states)]]"
+                  icon="[[_computeIcon(item.entity, hass.states)]]"
+                  title="[[_computeTooltip(item.entity, hass.states)]]"
+                ></paper-icon-button>
+              </template>
+            </div>
+          </template>
         </div>
       </ha-card>
     `;
@@ -116,7 +120,15 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
       hass: Object,
       _config: Object,
       _entitiesDialog: Array,
-      _entitiesToggle: Array
+      _entitiesToggle: Array,
+      _visibleEntitiesDialog: {
+        type: Array,
+        computed: '_computeVisible(_entitiesDialog, hass.states)',
+      },
+      _visibleEntitiesToggle: {
+        type: Array,
+        computed: '_computeVisible(_entitiesToggle, hass.states)',
+      },
     };
   }
 


### PR DESCRIPTION
While experimenting for https://github.com/home-assistant/ui-schema/issues/104#issuecomment-406161508, I realized that we don't handle the optional title well.

Before:
<img width="474" alt="screen shot 2018-07-19 at 12 46 18 pm" src="https://user-images.githubusercontent.com/1444314/42938266-fe5ae4be-8b51-11e8-905d-423c2901ef2e.png">

After:
<img width="474" alt="screen shot 2018-07-19 at 12 47 03 pm" src="https://user-images.githubusercontent.com/1444314/42938272-03985a06-8b52-11e8-8c2c-e5d87bb9ab1a.png">
