### PR TITLE
Add gallery

### DIFF
--- a/gallery/.eslintrc.json
+++ b/gallery/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc.json",
+  "rules": {
+    "no-console": 0
+  }
+}

--- a/gallery/public/index.html
+++ b/gallery/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#2157BC">
+    <title>HAGallery</title>
+    <script src='./main.js' async></script>
+    <style>
+      body {
+        font-family: Roboto, Noto, sans-serif;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body></body>
+</html>

--- a/gallery/script/build_gallery
+++ b/gallery/script/build_gallery
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Run the gallery
+
+# Stop on errors
+set -e
+
+cd "$(dirname "$0")/.."
+
+OUTPUT_DIR=dist
+
+rm -rf $OUTPUT_DIR
+
+# NEW BUILD
+NODE_ENV=production ../node_modules/.bin/webpack -p --config webpack.config.js

--- a/gallery/script/develop_gallery
+++ b/gallery/script/develop_gallery
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Run the gallery
+
+# Stop on errors
+set -e
+
+cd "$(dirname "$0")/.."
+
+../node_modules/.bin/webpack-dev-server

--- a/gallery/src/data/demo_dump.js
+++ b/gallery/src/data/demo_dump.js
@@ -15,7 +15,6 @@ export default {
     },
     last_changed: '2018-07-19T12:06:18.384550+00:00',
     last_updated: '2018-07-19T12:40:30.374858+00:00',
-    _entityDisplay: 'Sun'
   },
   'zone.home': {
     entity_id: 'zone.home',
@@ -50,7 +49,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.923256+00:00',
     last_updated: '2018-07-19T10:44:45.923256+00:00',
-    _entityDisplay: 'laundry'
   },
   'input_number.box1': {
     entity_id: 'input_number.box1',
@@ -64,7 +62,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.923416+00:00',
     last_updated: '2018-07-19T10:44:45.923416+00:00',
-    _entityDisplay: 'Numeric Input Box'
   },
   'input_number.slider1': {
     entity_id: 'input_number.slider1',
@@ -79,7 +76,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.923572+00:00',
     last_updated: '2018-07-19T10:44:45.923572+00:00',
-    _entityDisplay: 'Slider'
   },
   'sensor.brightness': {
     entity_id: 'sensor.brightness',
@@ -92,7 +88,6 @@ export default {
     },
     last_changed: '2018-07-19T12:40:28.378102+00:00',
     last_updated: '2018-07-19T12:40:28.378102+00:00',
-    _entityDisplay: 'brightness'
   },
   'sensor.battery': {
     entity_id: 'sensor.battery',
@@ -105,7 +100,6 @@ export default {
     },
     last_changed: '2018-07-19T12:40:28.377758+00:00',
     last_updated: '2018-07-19T12:40:28.377758+00:00',
-    _entityDisplay: 'battery'
   },
   'sensor.outside_temperature': {
     entity_id: 'sensor.outside_temperature',
@@ -118,7 +112,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.924111+00:00',
     last_updated: '2018-07-19T10:44:45.924111+00:00',
-    _entityDisplay: 'Outside Temperature'
   },
   'sensor.outside_humidity': {
     entity_id: 'sensor.outside_humidity',
@@ -130,7 +123,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.924273+00:00',
     last_updated: '2018-07-19T10:44:45.924273+00:00',
-    _entityDisplay: 'Outside Humidity'
   },
   'sensor.conductivity': {
     entity_id: 'sensor.conductivity',
@@ -143,7 +135,6 @@ export default {
     },
     last_changed: '2018-07-19T12:40:28.377305+00:00',
     last_updated: '2018-07-19T12:40:28.377305+00:00',
-    _entityDisplay: 'conductivity'
   },
   'weather.demo_weather_south': {
     entity_id: 'weather.demo_weather_south',
@@ -336,7 +327,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.935593+00:00',
     last_updated: '2018-07-19T10:44:45.935593+00:00',
-    _entityDisplay: 'Lounge room'
   },
   'media_player.bedroom': {
     entity_id: 'media_player.bedroom',
@@ -363,7 +353,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.936499+00:00',
     last_updated: '2018-07-19T10:44:45.936499+00:00',
-    _entityDisplay: 'Bedroom'
   },
   'media_player.living_room': {
     entity_id: 'media_player.living_room',
@@ -390,7 +379,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.937400+00:00',
     last_updated: '2018-07-19T10:44:45.937400+00:00',
-    _entityDisplay: 'Living Room'
   },
   'media_player.walkman': {
     entity_id: 'media_player.walkman',
@@ -417,7 +405,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:45.938179+00:00',
     last_updated: '2018-07-19T10:44:45.938179+00:00',
-    _entityDisplay: 'Walkman'
   },
   'input_select.who_cooks': {
     entity_id: 'input_select.who_cooks',
@@ -432,7 +419,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.105361+00:00',
     last_updated: '2018-07-19T10:44:46.105361+00:00',
-    _entityDisplay: 'Cook today'
   },
   'input_boolean.notify': {
     entity_id: 'input_boolean.notify',
@@ -443,7 +429,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.105940+00:00',
     last_updated: '2018-07-19T10:44:46.105940+00:00',
-    _entityDisplay: 'Notify Anne Therese is home'
   },
   'weblink.router': {
     entity_id: 'weblink.router',
@@ -453,7 +438,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.107286+00:00',
     last_updated: '2018-07-19T10:44:46.107286+00:00',
-    _entityDisplay: 'Router'
   },
   'group.all_plants': {
     entity_id: 'group.all_plants',
@@ -480,7 +464,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.198517+00:00',
     last_updated: '2018-07-19T10:44:46.198517+00:00',
-    _entityDisplay: 'Alarm'
   },
   'binary_sensor.basement_floor_wet': {
     entity_id: 'binary_sensor.basement_floor_wet',
@@ -491,7 +474,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.198923+00:00',
     last_updated: '2018-07-19T10:44:46.198923+00:00',
-    _entityDisplay: 'Basement Floor Wet'
   },
   'binary_sensor.movement_backyard': {
     entity_id: 'binary_sensor.movement_backyard',
@@ -502,7 +484,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.199163+00:00',
     last_updated: '2018-07-19T10:44:46.199163+00:00',
-    _entityDisplay: 'Movement Backyard'
   },
   'climate.ecobee': {
     entity_id: 'climate.ecobee',
@@ -544,7 +525,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.200333+00:00',
     last_updated: '2018-07-19T10:44:46.200333+00:00',
-    _entityDisplay: 'Ecobee'
   },
   'climate.hvac': {
     entity_id: 'climate.hvac',
@@ -589,7 +569,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.200650+00:00',
     last_updated: '2018-07-19T10:44:46.200650+00:00',
-    _entityDisplay: 'Hvac'
   },
   'climate.heatpump': {
     entity_id: 'climate.heatpump',
@@ -612,7 +591,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.200946+00:00',
     last_updated: '2018-07-19T10:44:46.200946+00:00',
-    _entityDisplay: 'HeatPump'
   },
   'mailbox.demomailbox': {
     entity_id: 'mailbox.demomailbox',
@@ -622,7 +600,6 @@ export default {
     },
     last_changed: '2018-07-19T10:45:16.555210+00:00',
     last_updated: '2018-07-19T10:45:16.555210+00:00',
-    _entityDisplay: 'DemoMailbox'
   },
   'input_select.living_room_preset': {
     entity_id: 'input_select.living_room_preset',
@@ -636,7 +613,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.211150+00:00',
     last_updated: '2018-07-19T10:44:46.211150+00:00',
-    _entityDisplay: 'living room preset'
   },
   'camera.demo_camera': {
     entity_id: 'camera.demo_camera',
@@ -659,7 +635,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.218790+00:00',
     last_updated: '2018-07-19T10:44:46.218790+00:00',
-    _entityDisplay: 'Garage Door'
   },
   'cover.living_room_window': {
     entity_id: 'cover.living_room_window',
@@ -672,7 +647,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.220347+00:00',
     last_updated: '2018-07-19T10:44:46.220347+00:00',
-    _entityDisplay: 'Living Room Window'
   },
   'cover.hall_window': {
     entity_id: 'cover.hall_window',
@@ -684,7 +658,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.281104+00:00',
     last_updated: '2018-07-19T10:44:46.281104+00:00',
-    _entityDisplay: 'Hall Window'
   },
   'cover.kitchen_window': {
     entity_id: 'cover.kitchen_window',
@@ -695,7 +668,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.281449+00:00',
     last_updated: '2018-07-19T10:44:46.281449+00:00',
-    _entityDisplay: 'Kitchen Window'
   },
   'fan.living_room_fan': {
     entity_id: 'fan.living_room_fan',
@@ -715,7 +687,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.281761+00:00',
     last_updated: '2018-07-19T10:44:46.281761+00:00',
-    _entityDisplay: 'Living Room Fan'
   },
   'fan.ceiling_fan': {
     entity_id: 'fan.ceiling_fan',
@@ -733,7 +704,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.282008+00:00',
     last_updated: '2018-07-19T10:44:46.282008+00:00',
-    _entityDisplay: 'Ceiling Fan'
   },
   'light.kitchen_lights': {
     entity_id: 'light.kitchen_lights',
@@ -762,7 +732,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.282257+00:00',
     last_updated: '2018-07-19T10:44:46.282257+00:00',
-    _entityDisplay: 'Kitchen Lights'
   },
   'light.bed_light': {
     entity_id: 'light.bed_light',
@@ -775,7 +744,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.282478+00:00',
     last_updated: '2018-07-19T10:44:46.282478+00:00',
-    _entityDisplay: 'Bed Light'
   },
   'light.ceiling_lights': {
     entity_id: 'light.ceiling_lights',
@@ -804,7 +772,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.282696+00:00',
     last_updated: '2018-07-19T10:44:46.282696+00:00',
-    _entityDisplay: 'Ceiling Lights'
   },
   'lock.openable_lock': {
     entity_id: 'lock.openable_lock',
@@ -815,7 +782,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.282949+00:00',
     last_updated: '2018-07-19T10:44:46.282949+00:00',
-    _entityDisplay: 'Openable Lock'
   },
   'lock.kitchen_door': {
     entity_id: 'lock.kitchen_door',
@@ -825,7 +791,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.283175+00:00',
     last_updated: '2018-07-19T10:44:46.283175+00:00',
-    _entityDisplay: 'Kitchen Door'
   },
   'lock.front_door': {
     entity_id: 'lock.front_door',
@@ -835,7 +800,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.283396+00:00',
     last_updated: '2018-07-19T10:44:46.283396+00:00',
-    _entityDisplay: 'Front Door'
   },
   'switch.decorative_lights': {
     entity_id: 'switch.decorative_lights',
@@ -848,7 +812,6 @@ export default {
     },
     last_changed: '2018-07-19T11:33:15.735386+00:00',
     last_updated: '2018-07-19T11:33:15.735386+00:00',
-    _entityDisplay: 'Decorative Lights'
   },
   'switch.ac': {
     entity_id: 'switch.ac',
@@ -860,7 +823,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.283901+00:00',
     last_updated: '2018-07-19T10:44:46.283901+00:00',
-    _entityDisplay: 'AC'
   },
   'device_tracker.demo_paulus': {
     entity_id: 'device_tracker.demo_paulus',
@@ -875,8 +837,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.287874+00:00',
     last_updated: '2018-07-19T10:44:46.287874+00:00',
-    _stateDisplay: 'Away',
-    _entityDisplay: 'Paulus'
   },
   'device_tracker.demo_anne_therese': {
     entity_id: 'device_tracker.demo_anne_therese',
@@ -891,8 +851,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.288213+00:00',
     last_updated: '2018-07-19T10:44:46.288213+00:00',
-    _stateDisplay: 'Away',
-    _entityDisplay: 'Anne Therese'
   },
   'device_tracker.demo_home_boy': {
     entity_id: 'device_tracker.demo_home_boy',
@@ -907,8 +865,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.288533+00:00',
     last_updated: '2018-07-19T10:44:46.288533+00:00',
-    _stateDisplay: 'Away',
-    _entityDisplay: 'Home Boy'
   },
   'calendar.calendar_2': {
     entity_id: 'calendar.calendar_2',
@@ -925,8 +881,6 @@ export default {
     },
     last_changed: '2018-07-19T11:27:25.017141+00:00',
     last_updated: '2018-07-19T11:27:25.017141+00:00',
-    _stateDisplay: 'Off',
-    _entityDisplay: 'Calendar 2'
   },
   'calendar.calendar_1': {
     entity_id: 'calendar.calendar_1',
@@ -943,8 +897,6 @@ export default {
     },
     last_changed: '2018-07-19T12:15:21.378222+00:00',
     last_updated: '2018-07-19T12:15:21.378222+00:00',
-    _stateDisplay: 'Off',
-    _entityDisplay: 'Calendar 1'
   },
   'group.all_covers': {
     entity_id: 'group.all_covers',
@@ -1080,8 +1032,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:56.654838+00:00',
     last_updated: '2018-07-19T10:44:56.654838+00:00',
-    _stateDisplay: 'AC3829',
-    _entityDisplay: 'Demo Alpr'
   },
   'image_processing.demo_face': {
     entity_id: 'image_processing.demo_face',
@@ -1112,8 +1062,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:56.641372+00:00',
     last_updated: '2018-07-19T10:44:56.641372+00:00',
-    _stateDisplay: 'Hans',
-    _entityDisplay: 'Demo Face'
   },
   'persistent_notification.notification_2': {
     entity_id: 'persistent_notification.notification_2',
@@ -1142,7 +1090,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.453731+00:00',
     last_updated: '2018-07-19T10:44:46.453731+00:00',
-    _entityDisplay: 'Living Room'
   },
   'group.bedroom': {
     entity_id: 'group.bedroom',
@@ -1160,7 +1107,6 @@ export default {
     },
     last_changed: '2018-07-19T11:33:15.736625+00:00',
     last_updated: '2018-07-19T11:33:15.736625+00:00',
-    _entityDisplay: 'Bedroom'
   },
   'group.kitchen': {
     entity_id: 'group.kitchen',
@@ -1176,7 +1122,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.455730+00:00',
     last_updated: '2018-07-19T10:44:46.455730+00:00',
-    _entityDisplay: 'Kitchen'
   },
   'group.doors': {
     entity_id: 'group.doors',
@@ -1193,7 +1138,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.509528+00:00',
     last_updated: '2018-07-19T10:44:46.509528+00:00',
-    _entityDisplay: 'Doors'
   },
   'group.automations': {
     entity_id: 'group.automations',
@@ -1208,7 +1152,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.509900+00:00',
     last_updated: '2018-07-19T10:44:46.509900+00:00',
-    _entityDisplay: 'Automations'
   },
   'group.people': {
     entity_id: 'group.people',
@@ -1224,7 +1167,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.510172+00:00',
     last_updated: '2018-07-19T10:44:46.510172+00:00',
-    _entityDisplay: 'People'
   },
   'group.downstairs': {
     entity_id: 'group.downstairs',
@@ -1246,7 +1188,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.510448+00:00',
     last_updated: '2018-07-19T10:44:46.510448+00:00',
-    _entityDisplay: 'Downstairs'
   },
   'history_graph.recent_switches': {
     entity_id: 'history_graph.recent_switches',
@@ -1275,7 +1216,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.512674+00:00',
     last_updated: '2018-07-19T10:44:46.512674+00:00',
-    _entityDisplay: 'Switch on and off'
   },
   'scene.romantic_lights': {
     entity_id: 'scene.romantic_lights',
@@ -1289,7 +1229,6 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.512985+00:00',
     last_updated: '2018-07-19T10:44:46.512985+00:00',
-    _entityDisplay: 'Romantic lights'
   },
   'configurator.philips_hue': {
     entity_id: 'configurator.philips_hue',
@@ -1309,6 +1248,5 @@ export default {
     },
     last_changed: '2018-07-19T10:44:46.515160+00:00',
     last_updated: '2018-07-19T10:44:46.515160+00:00',
-    _entityDisplay: 'Philips Hue'
   }
 };

--- a/gallery/src/data/demo_dump.js
+++ b/gallery/src/data/demo_dump.js
@@ -1,0 +1,1314 @@
+export default {
+  "sun.sun": {
+    "entity_id": "sun.sun",
+    "state": "below_horizon",
+    "attributes": {
+      "next_dawn": "2018-07-19T20:48:47+00:00",
+      "next_dusk": "2018-07-20T11:46:06+00:00",
+      "next_midnight": "2018-07-19T16:17:28+00:00",
+      "next_noon": "2018-07-20T04:17:26+00:00",
+      "next_rising": "2018-07-19T21:16:31+00:00",
+      "next_setting": "2018-07-20T11:18:22+00:00",
+      "elevation": 67.69,
+      "azimuth": 338.55,
+      "friendly_name": "Sun"
+    },
+    "last_changed": "2018-07-19T12:06:18.384550+00:00",
+    "last_updated": "2018-07-19T12:40:30.374858+00:00",
+    "_entityDisplay": "Sun"
+  },
+  "zone.home": {
+    "entity_id": "zone.home",
+    "state": "zoning",
+    "attributes": {
+      "hidden": true,
+      "latitude": 0,
+      "longitude": 0,
+      "radius": 100,
+      "friendly_name": "Home",
+      "icon": "mdi:home"
+    },
+    "last_changed": "2018-07-19T10:44:45.811040+00:00",
+    "last_updated": "2018-07-19T10:44:45.811040+00:00"
+  },
+  "persistent_notification.notification": {
+    "entity_id": "persistent_notification.notification",
+    "state": "notifying",
+    "attributes": {
+      "title": "Welcome Home!",
+      "message": "Here are some resources to get started:\n\n - [Configuring Home Assistant](https://home-assistant.io/getting-started/configuration/)\n - [Available components](https://home-assistant.io/components/)\n - [Troubleshooting your configuration](https://home-assistant.io/docs/configuration/troubleshooting/)\n - [Getting help](https://home-assistant.io/help/)\n\nTo not see this card popup in the future, edit your config in\n`configuration.yaml` and disable the `introduction` component."
+    },
+    "last_changed": "2018-07-19T10:44:45.922241+00:00",
+    "last_updated": "2018-07-19T10:44:45.922241+00:00"
+  },
+  "timer.laundry": {
+    "entity_id": "timer.laundry",
+    "state": "idle",
+    "attributes": {
+      "duration": "0:01:00",
+      "remaining": "0:01:00"
+    },
+    "last_changed": "2018-07-19T10:44:45.923256+00:00",
+    "last_updated": "2018-07-19T10:44:45.923256+00:00",
+    "_entityDisplay": "laundry"
+  },
+  "input_number.box1": {
+    "entity_id": "input_number.box1",
+    "state": "30.0",
+    "attributes": {
+      "min": -20,
+      "max": 35,
+      "step": 1,
+      "mode": "box",
+      "friendly_name": "Numeric Input Box"
+    },
+    "last_changed": "2018-07-19T10:44:45.923416+00:00",
+    "last_updated": "2018-07-19T10:44:45.923416+00:00",
+    "_entityDisplay": "Numeric Input Box"
+  },
+  "input_number.slider1": {
+    "entity_id": "input_number.slider1",
+    "state": "30.0",
+    "attributes": {
+      "min": -20,
+      "max": 35,
+      "step": 1,
+      "mode": "slider",
+      "unit_of_measurement": "beers",
+      "friendly_name": "Slider"
+    },
+    "last_changed": "2018-07-19T10:44:45.923572+00:00",
+    "last_updated": "2018-07-19T10:44:45.923572+00:00",
+    "_entityDisplay": "Slider"
+  },
+  "sensor.brightness": {
+    "entity_id": "sensor.brightness",
+    "state": "12",
+    "attributes": {
+      "maximum": 20,
+      "minimum": 0,
+      "friendly_name": "brightness",
+      "icon": "mdi:hanger"
+    },
+    "last_changed": "2018-07-19T12:40:28.378102+00:00",
+    "last_updated": "2018-07-19T12:40:28.378102+00:00",
+    "_entityDisplay": "brightness"
+  },
+  "sensor.battery": {
+    "entity_id": "sensor.battery",
+    "state": "2",
+    "attributes": {
+      "maximum": 20,
+      "minimum": 0,
+      "friendly_name": "battery",
+      "icon": "mdi:hanger"
+    },
+    "last_changed": "2018-07-19T12:40:28.377758+00:00",
+    "last_updated": "2018-07-19T12:40:28.377758+00:00",
+    "_entityDisplay": "battery"
+  },
+  "sensor.outside_temperature": {
+    "entity_id": "sensor.outside_temperature",
+    "state": "15.6",
+    "attributes": {
+      "battery_level": 12,
+      "unit_of_measurement": "°C",
+      "friendly_name": "Outside Temperature",
+      "device_class": "temperature"
+    },
+    "last_changed": "2018-07-19T10:44:45.924111+00:00",
+    "last_updated": "2018-07-19T10:44:45.924111+00:00",
+    "_entityDisplay": "Outside Temperature"
+  },
+  "sensor.outside_humidity": {
+    "entity_id": "sensor.outside_humidity",
+    "state": "54",
+    "attributes": {
+      "unit_of_measurement": "%",
+      "friendly_name": "Outside Humidity",
+      "device_class": "humidity"
+    },
+    "last_changed": "2018-07-19T10:44:45.924273+00:00",
+    "last_updated": "2018-07-19T10:44:45.924273+00:00",
+    "_entityDisplay": "Outside Humidity"
+  },
+  "sensor.conductivity": {
+    "entity_id": "sensor.conductivity",
+    "state": "1",
+    "attributes": {
+      "maximum": 20,
+      "minimum": 0,
+      "friendly_name": "conductivity",
+      "icon": "mdi:hanger"
+    },
+    "last_changed": "2018-07-19T12:40:28.377305+00:00",
+    "last_updated": "2018-07-19T12:40:28.377305+00:00",
+    "_entityDisplay": "conductivity"
+  },
+  "weather.demo_weather_south": {
+    "entity_id": "weather.demo_weather_south",
+    "state": "sunny",
+    "attributes": {
+      "temperature": 21.6,
+      "humidity": 92,
+      "pressure": 1099,
+      "wind_speed": 0.5,
+      "attribution": "Powered by Home Assistant",
+      "forecast": [
+        {
+          "datetime": "2018-07-19T16:00:45.924736",
+          "condition": "rainy",
+          "precipitation": 1,
+          "temperature": 22,
+          "templow": 15
+        },
+        {
+          "datetime": "2018-07-19T20:00:45.924736",
+          "condition": "rainy",
+          "precipitation": 5,
+          "temperature": 19,
+          "templow": 8
+        },
+        {
+          "datetime": "2018-07-20T00:00:45.924736",
+          "condition": "cloudy",
+          "precipitation": 0,
+          "temperature": 15,
+          "templow": 9
+        },
+        {
+          "datetime": "2018-07-20T04:00:45.924736",
+          "condition": "sunny",
+          "precipitation": 0,
+          "temperature": 12,
+          "templow": 6
+        },
+        {
+          "datetime": "2018-07-20T08:00:45.924736",
+          "condition": "partlycloudy",
+          "precipitation": 2,
+          "temperature": 14,
+          "templow": 7
+        },
+        {
+          "datetime": "2018-07-20T12:00:45.924736",
+          "condition": "rainy",
+          "precipitation": 15,
+          "temperature": 18,
+          "templow": 7
+        },
+        {
+          "datetime": "2018-07-20T16:00:45.924736",
+          "condition": "fog",
+          "precipitation": 0.2,
+          "temperature": 21,
+          "templow": 12
+        }
+      ],
+      "friendly_name": "Demo Weather South"
+    },
+    "last_changed": "2018-07-19T10:44:45.924818+00:00",
+    "last_updated": "2018-07-19T10:44:45.924818+00:00"
+  },
+  "weather.demo_weather_north": {
+    "entity_id": "weather.demo_weather_north",
+    "state": "rainy",
+    "attributes": {
+      "temperature": -24,
+      "humidity": 54,
+      "pressure": 987,
+      "wind_speed": 4.8,
+      "attribution": "Powered by Home Assistant",
+      "forecast": [
+        {
+          "datetime": "2018-07-19T16:00:45.925119",
+          "condition": "snowy",
+          "precipitation": 2,
+          "temperature": -23,
+          "templow": -26
+        },
+        {
+          "datetime": "2018-07-19T20:00:45.925119",
+          "condition": "partlycloudy",
+          "precipitation": 1,
+          "temperature": -25,
+          "templow": -26
+        },
+        {
+          "datetime": "2018-07-20T00:00:45.925119",
+          "condition": "sunny",
+          "precipitation": 0,
+          "temperature": -28,
+          "templow": -30
+        },
+        {
+          "datetime": "2018-07-20T04:00:45.925119",
+          "condition": "sunny",
+          "precipitation": 0.1,
+          "temperature": -31,
+          "templow": -31
+        },
+        {
+          "datetime": "2018-07-20T08:00:45.925119",
+          "condition": "snowy",
+          "precipitation": 4,
+          "temperature": -28,
+          "templow": -29
+        },
+        {
+          "datetime": "2018-07-20T12:00:45.925119",
+          "condition": "sunny",
+          "precipitation": 0.3,
+          "temperature": -26,
+          "templow": -28
+        },
+        {
+          "datetime": "2018-07-20T16:00:45.925119",
+          "condition": "sunny",
+          "precipitation": 0,
+          "temperature": -23,
+          "templow": -24
+        }
+      ],
+      "friendly_name": "Demo Weather North"
+    },
+    "last_changed": "2018-07-19T10:44:45.925197+00:00",
+    "last_updated": "2018-07-19T10:44:45.925197+00:00"
+  },
+  "a.demo_mode": {
+    "entity_id": "a.demo_mode",
+    "state": "Enabled",
+    "attributes": {},
+    "last_changed": "2018-07-19T10:44:45.928682+00:00",
+    "last_updated": "2018-07-19T10:44:45.928682+00:00"
+  },
+  "plant.bonsai": {
+    "entity_id": "plant.bonsai",
+    "state": "ok",
+    "attributes": {
+      "problem": "none",
+      "sensors": {
+        "moisture": "sensor.outside_humidity",
+        "battery": "sensor.battery",
+        "temperature": "sensor.outside_temperature",
+        "conductivity": "sensor.conductivity",
+        "brightness": "sensor.brightness"
+      },
+      "unit_of_measurement_dict": {
+        "temperature": "°C",
+        "moisture": "%"
+      },
+      "moisture": 54,
+      "battery": 2,
+      "temperature": 15.6,
+      "conductivity": 1,
+      "brightness": 12,
+      "max_brightness": 20,
+      "friendly_name": "Bonsai"
+    },
+    "last_changed": "2018-07-19T10:44:45.939328+00:00",
+    "last_updated": "2018-07-19T12:40:28.379845+00:00"
+  },
+  "media_player.lounge_room": {
+    "entity_id": "media_player.lounge_room",
+    "state": "playing",
+    "attributes": {
+      "volume_level": 1,
+      "is_volume_muted": false,
+      "media_content_id": "house-of-cards-1",
+      "media_content_type": "tvshow",
+      "media_duration": 3600,
+      "media_title": "Chapter 1",
+      "media_series_title": "House of Cards",
+      "media_season": 1,
+      "media_episode": 1,
+      "app_name": "Netflix",
+      "source": "dvd",
+      "sound_mode": "Dummy Music",
+      "sound_mode_list": [
+        "Dummy Music",
+        "Dummy Movie"
+      ],
+      "shuffle": false,
+      "friendly_name": "Lounge room",
+      "entity_picture": "/api/media_player_proxy/media_player.lounge_room?token=20aea624c9d6c83d44e212e60c0795633d2700cde18d60901c6d74b0d063d6bf&cache=cb9d84451faf9351",
+      "supported_features": 117169
+    },
+    "last_changed": "2018-07-19T10:44:45.935593+00:00",
+    "last_updated": "2018-07-19T10:44:45.935593+00:00",
+    "_entityDisplay": "Lounge room"
+  },
+  "media_player.bedroom": {
+    "entity_id": "media_player.bedroom",
+    "state": "playing",
+    "attributes": {
+      "volume_level": 1,
+      "is_volume_muted": false,
+      "media_content_id": "kxopViU98Xo",
+      "media_content_type": "movie",
+      "media_duration": 360000,
+      "media_position": 54000.016711,
+      "media_position_updated_at": "2018-07-19T10:44:45.919531+00:00",
+      "media_title": "Epic sax guy 10 hours",
+      "app_name": "YouTube",
+      "sound_mode": "Dummy Music",
+      "sound_mode_list": [
+        "Dummy Music",
+        "Dummy Movie"
+      ],
+      "shuffle": false,
+      "friendly_name": "Bedroom",
+      "entity_picture": "/api/media_player_proxy/media_player.bedroom?token=b26ff1a75b0929f6ad578955689815af828229e6cffaf061b8b6fb69c4044976&cache=e4513ed94ec89151",
+      "supported_features": 115597
+    },
+    "last_changed": "2018-07-19T10:44:45.936499+00:00",
+    "last_updated": "2018-07-19T10:44:45.936499+00:00",
+    "_entityDisplay": "Bedroom"
+  },
+  "media_player.living_room": {
+    "entity_id": "media_player.living_room",
+    "state": "playing",
+    "attributes": {
+      "volume_level": 1,
+      "is_volume_muted": false,
+      "media_content_id": "eyU3bRy2x44",
+      "media_content_type": "movie",
+      "media_duration": 300,
+      "media_position": 45.017773,
+      "media_position_updated_at": "2018-07-19T10:44:45.919514+00:00",
+      "media_title": "♥♥ The Best Fireplace Video (3 hours)",
+      "app_name": "YouTube",
+      "sound_mode": "Dummy Music",
+      "sound_mode_list": [
+        "Dummy Music",
+        "Dummy Movie"
+      ],
+      "shuffle": false,
+      "friendly_name": "Living Room",
+      "entity_picture": "/api/media_player_proxy/media_player.living_room?token=e925f8db7f7bd1f317e4524dcb8333d60f6019219a3799a22604b5787f243567&cache=bc2ffb49c4f67034",
+      "supported_features": 115597
+    },
+    "last_changed": "2018-07-19T10:44:45.937400+00:00",
+    "last_updated": "2018-07-19T10:44:45.937400+00:00",
+    "_entityDisplay": "Living Room"
+  },
+  "media_player.walkman": {
+    "entity_id": "media_player.walkman",
+    "state": "playing",
+    "attributes": {
+      "volume_level": 1,
+      "is_volume_muted": false,
+      "media_content_id": "bounzz-1",
+      "media_content_type": "music",
+      "media_duration": 213,
+      "media_title": "I Wanna Be A Hippy (Flamman & Abraxas Radio Mix)",
+      "media_artist": "Technohead",
+      "media_album_name": "Bounzz",
+      "media_track": 1,
+      "sound_mode": "Dummy Music",
+      "sound_mode_list": [
+        "Dummy Music",
+        "Dummy Movie"
+      ],
+      "shuffle": false,
+      "friendly_name": "Walkman",
+      "entity_picture": "/api/media_player_proxy/media_player.walkman?token=eda2b56fa513fa80f8d9c641941a3702b83e84e239c9ed82efc665a31e80d8fd&cache=62c0c516acbc53a9",
+      "supported_features": 123325
+    },
+    "last_changed": "2018-07-19T10:44:45.938179+00:00",
+    "last_updated": "2018-07-19T10:44:45.938179+00:00",
+    "_entityDisplay": "Walkman"
+  },
+  "input_select.who_cooks": {
+    "entity_id": "input_select.who_cooks",
+    "state": "Anne Therese",
+    "attributes": {
+      "options": [
+        "Paulus",
+        "Anne Therese"
+      ],
+      "friendly_name": "Cook today",
+      "icon": "mdi:panda"
+    },
+    "last_changed": "2018-07-19T10:44:46.105361+00:00",
+    "last_updated": "2018-07-19T10:44:46.105361+00:00",
+    "_entityDisplay": "Cook today"
+  },
+  "input_boolean.notify": {
+    "entity_id": "input_boolean.notify",
+    "state": "off",
+    "attributes": {
+      "friendly_name": "Notify Anne Therese is home",
+      "icon": "mdi:car"
+    },
+    "last_changed": "2018-07-19T10:44:46.105940+00:00",
+    "last_updated": "2018-07-19T10:44:46.105940+00:00",
+    "_entityDisplay": "Notify Anne Therese is home"
+  },
+  "weblink.router": {
+    "entity_id": "weblink.router",
+    "state": "http://192.168.1.1",
+    "attributes": {
+      "friendly_name": "Router"
+    },
+    "last_changed": "2018-07-19T10:44:46.107286+00:00",
+    "last_updated": "2018-07-19T10:44:46.107286+00:00",
+    "_entityDisplay": "Router"
+  },
+  "group.all_plants": {
+    "entity_id": "group.all_plants",
+    "state": "ok",
+    "attributes": {
+      "entity_id": [
+        "plant.bonsai"
+      ],
+      "order": 0,
+      "auto": true,
+      "friendly_name": "all plants",
+      "hidden": true
+    },
+    "last_changed": "2018-07-19T10:44:46.193703+00:00",
+    "last_updated": "2018-07-19T10:44:46.193703+00:00"
+  },
+  "alarm_control_panel.alarm": {
+    "entity_id": "alarm_control_panel.alarm",
+    "state": "disarmed",
+    "attributes": {
+      "code_format": "Number",
+      "changed_by": null,
+      "friendly_name": "Alarm"
+    },
+    "last_changed": "2018-07-19T10:44:46.198517+00:00",
+    "last_updated": "2018-07-19T10:44:46.198517+00:00",
+    "_entityDisplay": "Alarm"
+  },
+  "binary_sensor.basement_floor_wet": {
+    "entity_id": "binary_sensor.basement_floor_wet",
+    "state": "off",
+    "attributes": {
+      "friendly_name": "Basement Floor Wet",
+      "device_class": "moisture"
+    },
+    "last_changed": "2018-07-19T10:44:46.198923+00:00",
+    "last_updated": "2018-07-19T10:44:46.198923+00:00",
+    "_entityDisplay": "Basement Floor Wet"
+  },
+  "binary_sensor.movement_backyard": {
+    "entity_id": "binary_sensor.movement_backyard",
+    "state": "on",
+    "attributes": {
+      "friendly_name": "Movement Backyard",
+      "device_class": "motion"
+    },
+    "last_changed": "2018-07-19T10:44:46.199163+00:00",
+    "last_updated": "2018-07-19T10:44:46.199163+00:00",
+    "_entityDisplay": "Movement Backyard"
+  },
+  "climate.ecobee": {
+    "entity_id": "climate.ecobee",
+    "state": "auto",
+    "attributes": {
+      "current_temperature": 23,
+      "min_temp": 7,
+      "max_temp": 35,
+      "temperature": null,
+      "target_temp_high": 24,
+      "target_temp_low": 21,
+      "fan_mode": "Auto Low",
+      "fan_list": [
+        "On Low",
+        "On High",
+        "Auto Low",
+        "Auto High",
+        "Off"
+      ],
+      "operation_mode": "auto",
+      "operation_list": [
+        "heat",
+        "cool",
+        "auto",
+        "off"
+      ],
+      "hold_mode": "home",
+      "swing_mode": "Auto",
+      "swing_list": [
+        "Auto",
+        "1",
+        "2",
+        "3",
+        "Off"
+      ],
+      "unit_of_measurement": "°C",
+      "friendly_name": "Ecobee",
+      "supported_features": 1014
+    },
+    "last_changed": "2018-07-19T10:44:46.200333+00:00",
+    "last_updated": "2018-07-19T10:44:46.200333+00:00",
+    "_entityDisplay": "Ecobee"
+  },
+  "climate.hvac": {
+    "entity_id": "climate.hvac",
+    "state": "cool",
+    "attributes": {
+      "current_temperature": 22,
+      "min_temp": 7,
+      "max_temp": 35,
+      "temperature": 21,
+      "humidity": 67,
+      "current_humidity": 54,
+      "min_humidity": 30,
+      "max_humidity": 99,
+      "fan_mode": "On High",
+      "fan_list": [
+        "On Low",
+        "On High",
+        "Auto Low",
+        "Auto High",
+        "Off"
+      ],
+      "operation_mode": "cool",
+      "operation_list": [
+        "heat",
+        "cool",
+        "auto",
+        "off"
+      ],
+      "swing_mode": "Off",
+      "swing_list": [
+        "Auto",
+        "1",
+        "2",
+        "3",
+        "Off"
+      ],
+      "away_mode": "on",
+      "aux_heat": "off",
+      "unit_of_measurement": "°C",
+      "friendly_name": "Hvac",
+      "supported_features": 3833
+    },
+    "last_changed": "2018-07-19T10:44:46.200650+00:00",
+    "last_updated": "2018-07-19T10:44:46.200650+00:00",
+    "_entityDisplay": "Hvac"
+  },
+  "climate.heatpump": {
+    "entity_id": "climate.heatpump",
+    "state": "heat",
+    "attributes": {
+      "current_temperature": 25,
+      "min_temp": 7,
+      "max_temp": 35,
+      "temperature": 20,
+      "operation_mode": "heat",
+      "operation_list": [
+        "heat",
+        "cool",
+        "auto",
+        "off"
+      ],
+      "unit_of_measurement": "°C",
+      "friendly_name": "HeatPump",
+      "supported_features": 4273
+    },
+    "last_changed": "2018-07-19T10:44:46.200946+00:00",
+    "last_updated": "2018-07-19T10:44:46.200946+00:00",
+    "_entityDisplay": "HeatPump"
+  },
+  "mailbox.demomailbox": {
+    "entity_id": "mailbox.demomailbox",
+    "state": "10",
+    "attributes": {
+      "friendly_name": "DemoMailbox"
+    },
+    "last_changed": "2018-07-19T10:45:16.555210+00:00",
+    "last_updated": "2018-07-19T10:45:16.555210+00:00",
+    "_entityDisplay": "DemoMailbox"
+  },
+  "input_select.living_room_preset": {
+    "entity_id": "input_select.living_room_preset",
+    "state": "Visitors",
+    "attributes": {
+      "options": [
+        "Visitors",
+        "Visitors with kids",
+        "Home Alone"
+      ]
+    },
+    "last_changed": "2018-07-19T10:44:46.211150+00:00",
+    "last_updated": "2018-07-19T10:44:46.211150+00:00",
+    "_entityDisplay": "living room preset"
+  },
+  "camera.demo_camera": {
+    "entity_id": "camera.demo_camera",
+    "state": "idle",
+    "attributes": {
+      "access_token": "2f5bb163fb91cd8770a9494fa5e7eab172d8d34f4aba806eb6b59411b8c720b8",
+      "friendly_name": "Demo camera",
+      "entity_picture": "/api/camera_proxy/camera.demo_camera?token=2f5bb163fb91cd8770a9494fa5e7eab172d8d34f4aba806eb6b59411b8c720b8"
+    },
+    "last_changed": "2018-07-19T10:44:46.217296+00:00",
+    "last_updated": "2018-07-19T12:37:34.378986+00:00"
+  },
+  "cover.garage_door": {
+    "entity_id": "cover.garage_door",
+    "state": "closed",
+    "attributes": {
+      "friendly_name": "Garage Door",
+      "supported_features": 3,
+      "device_class": "garage"
+    },
+    "last_changed": "2018-07-19T10:44:46.218790+00:00",
+    "last_updated": "2018-07-19T10:44:46.218790+00:00",
+    "_entityDisplay": "Garage Door"
+  },
+  "cover.living_room_window": {
+    "entity_id": "cover.living_room_window",
+    "state": "open",
+    "attributes": {
+      "current_position": 70,
+      "current_tilt_position": 50,
+      "friendly_name": "Living Room Window",
+      "supported_features": 255
+    },
+    "last_changed": "2018-07-19T10:44:46.220347+00:00",
+    "last_updated": "2018-07-19T10:44:46.220347+00:00",
+    "_entityDisplay": "Living Room Window"
+  },
+  "cover.hall_window": {
+    "entity_id": "cover.hall_window",
+    "state": "open",
+    "attributes": {
+      "current_position": 10,
+      "friendly_name": "Hall Window",
+      "supported_features": 15
+    },
+    "last_changed": "2018-07-19T10:44:46.281104+00:00",
+    "last_updated": "2018-07-19T10:44:46.281104+00:00",
+    "_entityDisplay": "Hall Window"
+  },
+  "cover.kitchen_window": {
+    "entity_id": "cover.kitchen_window",
+    "state": "closed",
+    "attributes": {
+      "friendly_name": "Kitchen Window",
+      "supported_features": 11
+    },
+    "last_changed": "2018-07-19T10:44:46.281449+00:00",
+    "last_updated": "2018-07-19T10:44:46.281449+00:00",
+    "_entityDisplay": "Kitchen Window"
+  },
+  "fan.living_room_fan": {
+    "entity_id": "fan.living_room_fan",
+    "state": "off",
+    "attributes": {
+      "speed": "off",
+      "speed_list": [
+        "off",
+        "low",
+        "medium",
+        "high"
+      ],
+      "oscillating": false,
+      "direction": "forward",
+      "friendly_name": "Living Room Fan",
+      "supported_features": 7
+    },
+    "last_changed": "2018-07-19T10:44:46.281761+00:00",
+    "last_updated": "2018-07-19T10:44:46.281761+00:00",
+    "_entityDisplay": "Living Room Fan"
+  },
+  "fan.ceiling_fan": {
+    "entity_id": "fan.ceiling_fan",
+    "state": "off",
+    "attributes": {
+      "speed": "off",
+      "speed_list": [
+        "off",
+        "low",
+        "medium",
+        "high"
+      ],
+      "friendly_name": "Ceiling Fan",
+      "supported_features": 1
+    },
+    "last_changed": "2018-07-19T10:44:46.282008+00:00",
+    "last_updated": "2018-07-19T10:44:46.282008+00:00",
+    "_entityDisplay": "Ceiling Fan"
+  },
+  "light.kitchen_lights": {
+    "entity_id": "light.kitchen_lights",
+    "state": "on",
+    "attributes": {
+      "min_mireds": 153,
+      "max_mireds": 500,
+      "brightness": 180,
+      "color_temp": 240,
+      "hs_color": [
+        345,
+        75
+      ],
+      "rgb_color": [
+        255,
+        63,
+        111
+      ],
+      "xy_color": [
+        0.59,
+        0.274
+      ],
+      "white_value": 200,
+      "friendly_name": "Kitchen Lights",
+      "supported_features": 151
+    },
+    "last_changed": "2018-07-19T10:44:46.282257+00:00",
+    "last_updated": "2018-07-19T10:44:46.282257+00:00",
+    "_entityDisplay": "Kitchen Lights"
+  },
+  "light.bed_light": {
+    "entity_id": "light.bed_light",
+    "state": "off",
+    "attributes": {
+      "min_mireds": 153,
+      "max_mireds": 500,
+      "friendly_name": "Bed Light",
+      "supported_features": 151
+    },
+    "last_changed": "2018-07-19T10:44:46.282478+00:00",
+    "last_updated": "2018-07-19T10:44:46.282478+00:00",
+    "_entityDisplay": "Bed Light"
+  },
+  "light.ceiling_lights": {
+    "entity_id": "light.ceiling_lights",
+    "state": "on",
+    "attributes": {
+      "min_mireds": 153,
+      "max_mireds": 500,
+      "brightness": 180,
+      "color_temp": 380,
+      "hs_color": [
+        56,
+        86
+      ],
+      "rgb_color": [
+        255,
+        240,
+        35
+      ],
+      "xy_color": [
+        0.459,
+        0.496
+      ],
+      "white_value": 200,
+      "friendly_name": "Ceiling Lights",
+      "supported_features": 151
+    },
+    "last_changed": "2018-07-19T10:44:46.282696+00:00",
+    "last_updated": "2018-07-19T10:44:46.282696+00:00",
+    "_entityDisplay": "Ceiling Lights"
+  },
+  "lock.openable_lock": {
+    "entity_id": "lock.openable_lock",
+    "state": "locked",
+    "attributes": {
+      "friendly_name": "Openable Lock",
+      "supported_features": 1
+    },
+    "last_changed": "2018-07-19T10:44:46.282949+00:00",
+    "last_updated": "2018-07-19T10:44:46.282949+00:00",
+    "_entityDisplay": "Openable Lock"
+  },
+  "lock.kitchen_door": {
+    "entity_id": "lock.kitchen_door",
+    "state": "unlocked",
+    "attributes": {
+      "friendly_name": "Kitchen Door"
+    },
+    "last_changed": "2018-07-19T10:44:46.283175+00:00",
+    "last_updated": "2018-07-19T10:44:46.283175+00:00",
+    "_entityDisplay": "Kitchen Door"
+  },
+  "lock.front_door": {
+    "entity_id": "lock.front_door",
+    "state": "locked",
+    "attributes": {
+      "friendly_name": "Front Door"
+    },
+    "last_changed": "2018-07-19T10:44:46.283396+00:00",
+    "last_updated": "2018-07-19T10:44:46.283396+00:00",
+    "_entityDisplay": "Front Door"
+  },
+  "switch.decorative_lights": {
+    "entity_id": "switch.decorative_lights",
+    "state": "on",
+    "attributes": {
+      "current_power_w": 100,
+      "today_energy_kwh": 15,
+      "friendly_name": "Decorative Lights",
+      "assumed_state": true
+    },
+    "last_changed": "2018-07-19T11:33:15.735386+00:00",
+    "last_updated": "2018-07-19T11:33:15.735386+00:00",
+    "_entityDisplay": "Decorative Lights"
+  },
+  "switch.ac": {
+    "entity_id": "switch.ac",
+    "state": "off",
+    "attributes": {
+      "today_energy_kwh": 15,
+      "friendly_name": "AC",
+      "icon": "mdi:air-conditioner"
+    },
+    "last_changed": "2018-07-19T10:44:46.283901+00:00",
+    "last_updated": "2018-07-19T10:44:46.283901+00:00",
+    "_entityDisplay": "AC"
+  },
+  "device_tracker.demo_paulus": {
+    "entity_id": "device_tracker.demo_paulus",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "gps",
+      "latitude": 32.877105,
+      "longitude": 117.232185,
+      "gps_accuracy": 91,
+      "battery": 71,
+      "friendly_name": "Paulus"
+    },
+    "last_changed": "2018-07-19T10:44:46.287874+00:00",
+    "last_updated": "2018-07-19T10:44:46.287874+00:00",
+    "_stateDisplay": "Away",
+    "_entityDisplay": "Paulus"
+  },
+  "device_tracker.demo_anne_therese": {
+    "entity_id": "device_tracker.demo_anne_therese",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "gps",
+      "latitude": 32.876194999999996,
+      "longitude": 117.236015,
+      "gps_accuracy": 63,
+      "battery": 33,
+      "friendly_name": "Anne Therese"
+    },
+    "last_changed": "2018-07-19T10:44:46.288213+00:00",
+    "last_updated": "2018-07-19T10:44:46.288213+00:00",
+    "_stateDisplay": "Away",
+    "_entityDisplay": "Anne Therese"
+  },
+  "device_tracker.demo_home_boy": {
+    "entity_id": "device_tracker.demo_home_boy",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "gps",
+      "latitude": 32.87334,
+      "longitude": 117.22745,
+      "gps_accuracy": 20,
+      "battery": 53,
+      "friendly_name": "Home Boy"
+    },
+    "last_changed": "2018-07-19T10:44:46.288533+00:00",
+    "last_updated": "2018-07-19T10:44:46.288533+00:00",
+    "_stateDisplay": "Away",
+    "_entityDisplay": "Home Boy"
+  },
+  "calendar.calendar_2": {
+    "entity_id": "calendar.calendar_2",
+    "state": "off",
+    "attributes": {
+      "message": "",
+      "all_day": false,
+      "offset_reached": false,
+      "start_time": null,
+      "end_time": null,
+      "location": null,
+      "description": null,
+      "friendly_name": "Calendar 2"
+    },
+    "last_changed": "2018-07-19T11:27:25.017141+00:00",
+    "last_updated": "2018-07-19T11:27:25.017141+00:00",
+    "_stateDisplay": "Off",
+    "_entityDisplay": "Calendar 2"
+  },
+  "calendar.calendar_1": {
+    "entity_id": "calendar.calendar_1",
+    "state": "off",
+    "attributes": {
+      "message": "",
+      "all_day": false,
+      "offset_reached": false,
+      "start_time": null,
+      "end_time": null,
+      "location": null,
+      "description": null,
+      "friendly_name": "Calendar 1"
+    },
+    "last_changed": "2018-07-19T12:15:21.378222+00:00",
+    "last_updated": "2018-07-19T12:15:21.378222+00:00",
+    "_stateDisplay": "Off",
+    "_entityDisplay": "Calendar 1"
+  },
+  "group.all_covers": {
+    "entity_id": "group.all_covers",
+    "state": "open",
+    "attributes": {
+      "entity_id": [
+        "cover.garage_door",
+        "cover.hall_window",
+        "cover.kitchen_window",
+        "cover.living_room_window"
+      ],
+      "order": 1,
+      "auto": true,
+      "friendly_name": "all covers",
+      "hidden": true
+    },
+    "last_changed": "2018-07-19T10:44:46.430361+00:00",
+    "last_updated": "2018-07-19T10:44:46.430361+00:00"
+  },
+  "group.all_fans": {
+    "entity_id": "group.all_fans",
+    "state": "off",
+    "attributes": {
+      "entity_id": [
+        "fan.ceiling_fan",
+        "fan.living_room_fan"
+      ],
+      "order": 1,
+      "auto": true,
+      "friendly_name": "all fans",
+      "hidden": true
+    },
+    "last_changed": "2018-07-19T10:44:46.430643+00:00",
+    "last_updated": "2018-07-19T10:44:46.430643+00:00"
+  },
+  "group.all_lights": {
+    "entity_id": "group.all_lights",
+    "state": "on",
+    "attributes": {
+      "entity_id": [
+        "light.bed_light",
+        "light.ceiling_lights",
+        "light.kitchen_lights"
+      ],
+      "order": 1,
+      "auto": true,
+      "friendly_name": "all lights",
+      "hidden": true
+    },
+    "last_changed": "2018-07-19T10:44:46.430879+00:00",
+    "last_updated": "2018-07-19T10:44:46.430879+00:00"
+  },
+  "group.all_locks": {
+    "entity_id": "group.all_locks",
+    "state": "locked",
+    "attributes": {
+      "entity_id": [
+        "lock.front_door",
+        "lock.kitchen_door",
+        "lock.openable_lock"
+      ],
+      "order": 1,
+      "auto": true,
+      "friendly_name": "all locks",
+      "hidden": true
+    },
+    "last_changed": "2018-07-19T10:44:46.431112+00:00",
+    "last_updated": "2018-07-19T10:44:46.431112+00:00"
+  },
+  "group.all_switches": {
+    "entity_id": "group.all_switches",
+    "state": "on",
+    "attributes": {
+      "entity_id": [
+        "switch.ac",
+        "switch.decorative_lights"
+      ],
+      "order": 1,
+      "auto": true,
+      "friendly_name": "all switches",
+      "hidden": true,
+      "assumed_state": true
+    },
+    "last_changed": "2018-07-19T11:33:15.736167+00:00",
+    "last_updated": "2018-07-19T11:33:15.736167+00:00"
+  },
+  "group.calendar": {
+    "entity_id": "group.calendar",
+    "state": "off",
+    "attributes": {
+      "entity_id": [
+        "calendar.calendar_1",
+        "calendar.calendar_2"
+      ],
+      "order": 6,
+      "auto": true,
+      "friendly_name": "calendar",
+      "hidden": true
+    },
+    "last_changed": "2018-07-19T12:15:21.378971+00:00",
+    "last_updated": "2018-07-19T12:15:21.378971+00:00"
+  },
+  "group.all_devices": {
+    "entity_id": "group.all_devices",
+    "state": "not_home",
+    "attributes": {
+      "entity_id": [
+        "device_tracker.demo_paulus",
+        "device_tracker.demo_anne_therese",
+        "device_tracker.demo_home_boy"
+      ],
+      "order": 6,
+      "auto": true,
+      "friendly_name": "all devices",
+      "hidden": true
+    },
+    "last_changed": "2018-07-19T10:44:46.435615+00:00",
+    "last_updated": "2018-07-19T10:44:46.435615+00:00"
+  },
+  "image_processing.demo_alpr": {
+    "entity_id": "image_processing.demo_alpr",
+    "state": "AC3829",
+    "attributes": {
+      "plates": {
+        "AC3829": 98.3,
+        "BE392034": 95.5,
+        "CD02394": 93.4,
+        "DF923043": 90.8
+      },
+      "vehicles": 1,
+      "friendly_name": "Demo Alpr",
+      "device_class": "alpr"
+    },
+    "last_changed": "2018-07-19T10:44:56.654838+00:00",
+    "last_updated": "2018-07-19T10:44:56.654838+00:00",
+    "_stateDisplay": "AC3829",
+    "_entityDisplay": "Demo Alpr"
+  },
+  "image_processing.demo_face": {
+    "entity_id": "image_processing.demo_face",
+    "state": "Hans",
+    "attributes": {
+      "faces": [
+        {
+          "confidence": 98.34,
+          "name": "Hans",
+          "age": 16,
+          "gender": "male",
+          "entity_id": "image_processing.demo_face"
+        },
+        {
+          "name": "Helena",
+          "age": 28,
+          "gender": "female",
+          "entity_id": "image_processing.demo_face"
+        },
+        {
+          "confidence": 62.53,
+          "name": "Luna"
+        }
+      ],
+      "total_faces": 4,
+      "friendly_name": "Demo Face",
+      "device_class": "face"
+    },
+    "last_changed": "2018-07-19T10:44:56.641372+00:00",
+    "last_updated": "2018-07-19T10:44:56.641372+00:00",
+    "_stateDisplay": "Hans",
+    "_entityDisplay": "Demo Face"
+  },
+  "persistent_notification.notification_2": {
+    "entity_id": "persistent_notification.notification_2",
+    "state": "notifying",
+    "attributes": {
+      "title": "Example Notification",
+      "message": "This is an example of a persistent notification."
+    },
+    "last_changed": "2018-07-19T10:44:46.442972+00:00",
+    "last_updated": "2018-07-19T10:44:46.442972+00:00"
+  },
+  "group.living_room": {
+    "entity_id": "group.living_room",
+    "state": "on",
+    "attributes": {
+      "entity_id": [
+        "light.ceiling_lights",
+        "switch.ac",
+        "input_select.living_room_preset",
+        "cover.living_room_window",
+        "media_player.living_room",
+        "scene.romantic_lights"
+      ],
+      "order": 8,
+      "friendly_name": "Living Room"
+    },
+    "last_changed": "2018-07-19T10:44:46.453731+00:00",
+    "last_updated": "2018-07-19T10:44:46.453731+00:00",
+    "_entityDisplay": "Living Room"
+  },
+  "group.bedroom": {
+    "entity_id": "group.bedroom",
+    "state": "on",
+    "attributes": {
+      "entity_id": [
+        "light.bed_light",
+        "switch.decorative_lights",
+        "media_player.bedroom",
+        "input_number.noise_allowance"
+      ],
+      "order": 8,
+      "friendly_name": "Bedroom",
+      "assumed_state": true
+    },
+    "last_changed": "2018-07-19T11:33:15.736625+00:00",
+    "last_updated": "2018-07-19T11:33:15.736625+00:00",
+    "_entityDisplay": "Bedroom"
+  },
+  "group.kitchen": {
+    "entity_id": "group.kitchen",
+    "state": "on",
+    "attributes": {
+      "entity_id": [
+        "light.kitchen_lights",
+        "cover.kitchen_window",
+        "lock.kitchen_door"
+      ],
+      "order": 8,
+      "friendly_name": "Kitchen"
+    },
+    "last_changed": "2018-07-19T10:44:46.455730+00:00",
+    "last_updated": "2018-07-19T10:44:46.455730+00:00",
+    "_entityDisplay": "Kitchen"
+  },
+  "group.doors": {
+    "entity_id": "group.doors",
+    "state": "locked",
+    "attributes": {
+      "entity_id": [
+        "lock.front_door",
+        "lock.kitchen_door",
+        "garage_door.right_garage_door",
+        "garage_door.left_garage_door"
+      ],
+      "order": 8,
+      "friendly_name": "Doors"
+    },
+    "last_changed": "2018-07-19T10:44:46.509528+00:00",
+    "last_updated": "2018-07-19T10:44:46.509528+00:00",
+    "_entityDisplay": "Doors"
+  },
+  "group.automations": {
+    "entity_id": "group.automations",
+    "state": "off",
+    "attributes": {
+      "entity_id": [
+        "input_select.who_cooks",
+        "input_boolean.notify"
+      ],
+      "order": 8,
+      "friendly_name": "Automations"
+    },
+    "last_changed": "2018-07-19T10:44:46.509900+00:00",
+    "last_updated": "2018-07-19T10:44:46.509900+00:00",
+    "_entityDisplay": "Automations"
+  },
+  "group.people": {
+    "entity_id": "group.people",
+    "state": "not_home",
+    "attributes": {
+      "entity_id": [
+        "device_tracker.demo_anne_therese",
+        "device_tracker.demo_home_boy",
+        "device_tracker.demo_paulus"
+      ],
+      "order": 8,
+      "friendly_name": "People"
+    },
+    "last_changed": "2018-07-19T10:44:46.510172+00:00",
+    "last_updated": "2018-07-19T10:44:46.510172+00:00",
+    "_entityDisplay": "People"
+  },
+  "group.downstairs": {
+    "entity_id": "group.downstairs",
+    "state": "on",
+    "attributes": {
+      "entity_id": [
+        "group.living_room",
+        "group.kitchen",
+        "scene.romantic_lights",
+        "cover.kitchen_window",
+        "cover.living_room_window",
+        "group.doors",
+        "climate.ecobee"
+      ],
+      "order": 8,
+      "view": true,
+      "friendly_name": "Downstairs",
+      "hidden": true
+    },
+    "last_changed": "2018-07-19T10:44:46.510448+00:00",
+    "last_updated": "2018-07-19T10:44:46.510448+00:00",
+    "_entityDisplay": "Downstairs"
+  },
+  "history_graph.recent_switches": {
+    "entity_id": "history_graph.recent_switches",
+    "state": "unknown",
+    "attributes": {
+      "hours_to_show": 1,
+      "refresh": 60,
+      "entity_id": [
+        "switch.ac",
+        "switch.decorative_lights"
+      ],
+      "friendly_name": "Recent Switches"
+    },
+    "last_changed": "2018-07-19T10:44:46.512351+00:00",
+    "last_updated": "2018-07-19T10:44:46.512351+00:00"
+  },
+  "scene.switch_on_and_off": {
+    "entity_id": "scene.switch_on_and_off",
+    "state": "scening",
+    "attributes": {
+      "entity_id": [
+        "switch.ac",
+        "switch.decorative_lights"
+      ],
+      "friendly_name": "Switch on and off"
+    },
+    "last_changed": "2018-07-19T10:44:46.512674+00:00",
+    "last_updated": "2018-07-19T10:44:46.512674+00:00",
+    "_entityDisplay": "Switch on and off"
+  },
+  "scene.romantic_lights": {
+    "entity_id": "scene.romantic_lights",
+    "state": "scening",
+    "attributes": {
+      "entity_id": [
+        "light.bed_light",
+        "light.ceiling_lights"
+      ],
+      "friendly_name": "Romantic lights"
+    },
+    "last_changed": "2018-07-19T10:44:46.512985+00:00",
+    "last_updated": "2018-07-19T10:44:46.512985+00:00",
+    "_entityDisplay": "Romantic lights"
+  },
+  "configurator.philips_hue": {
+    "entity_id": "configurator.philips_hue",
+    "state": "configure",
+    "attributes": {
+      "configure_id": "4596919600-1",
+      "fields": [
+        {
+          "id": "username",
+          "name": "Username"
+        }
+      ],
+      "friendly_name": "Philips Hue",
+      "entity_picture": null,
+      "description": "Press the button on the bridge to register Philips Hue with Home Assistant.\n\n![Description image](/static/images/config_philips_hue.jpg)",
+      "submit_caption": "I have pressed the button"
+    },
+    "last_changed": "2018-07-19T10:44:46.515160+00:00",
+    "last_updated": "2018-07-19T10:44:46.515160+00:00",
+    "_entityDisplay": "Philips Hue"
+  }
+}

--- a/gallery/src/data/demo_dump.js
+++ b/gallery/src/data/demo_dump.js
@@ -1,1314 +1,1314 @@
 export default {
-  "sun.sun": {
-    "entity_id": "sun.sun",
-    "state": "below_horizon",
-    "attributes": {
-      "next_dawn": "2018-07-19T20:48:47+00:00",
-      "next_dusk": "2018-07-20T11:46:06+00:00",
-      "next_midnight": "2018-07-19T16:17:28+00:00",
-      "next_noon": "2018-07-20T04:17:26+00:00",
-      "next_rising": "2018-07-19T21:16:31+00:00",
-      "next_setting": "2018-07-20T11:18:22+00:00",
-      "elevation": 67.69,
-      "azimuth": 338.55,
-      "friendly_name": "Sun"
+  'sun.sun': {
+    entity_id: 'sun.sun',
+    state: 'below_horizon',
+    attributes: {
+      next_dawn: '2018-07-19T20:48:47+00:00',
+      next_dusk: '2018-07-20T11:46:06+00:00',
+      next_midnight: '2018-07-19T16:17:28+00:00',
+      next_noon: '2018-07-20T04:17:26+00:00',
+      next_rising: '2018-07-19T21:16:31+00:00',
+      next_setting: '2018-07-20T11:18:22+00:00',
+      elevation: 67.69,
+      azimuth: 338.55,
+      friendly_name: 'Sun'
     },
-    "last_changed": "2018-07-19T12:06:18.384550+00:00",
-    "last_updated": "2018-07-19T12:40:30.374858+00:00",
-    "_entityDisplay": "Sun"
+    last_changed: '2018-07-19T12:06:18.384550+00:00',
+    last_updated: '2018-07-19T12:40:30.374858+00:00',
+    _entityDisplay: 'Sun'
   },
-  "zone.home": {
-    "entity_id": "zone.home",
-    "state": "zoning",
-    "attributes": {
-      "hidden": true,
-      "latitude": 0,
-      "longitude": 0,
-      "radius": 100,
-      "friendly_name": "Home",
-      "icon": "mdi:home"
+  'zone.home': {
+    entity_id: 'zone.home',
+    state: 'zoning',
+    attributes: {
+      hidden: true,
+      latitude: 0,
+      longitude: 0,
+      radius: 100,
+      friendly_name: 'Home',
+      icon: 'mdi:home'
     },
-    "last_changed": "2018-07-19T10:44:45.811040+00:00",
-    "last_updated": "2018-07-19T10:44:45.811040+00:00"
+    last_changed: '2018-07-19T10:44:45.811040+00:00',
+    last_updated: '2018-07-19T10:44:45.811040+00:00'
   },
-  "persistent_notification.notification": {
-    "entity_id": "persistent_notification.notification",
-    "state": "notifying",
-    "attributes": {
-      "title": "Welcome Home!",
-      "message": "Here are some resources to get started:\n\n - [Configuring Home Assistant](https://home-assistant.io/getting-started/configuration/)\n - [Available components](https://home-assistant.io/components/)\n - [Troubleshooting your configuration](https://home-assistant.io/docs/configuration/troubleshooting/)\n - [Getting help](https://home-assistant.io/help/)\n\nTo not see this card popup in the future, edit your config in\n`configuration.yaml` and disable the `introduction` component."
+  'persistent_notification.notification': {
+    entity_id: 'persistent_notification.notification',
+    state: 'notifying',
+    attributes: {
+      title: 'Welcome Home!',
+      message: 'Here are some resources to get started:\n\n - [Configuring Home Assistant](https://home-assistant.io/getting-started/configuration/)\n - [Available components](https://home-assistant.io/components/)\n - [Troubleshooting your configuration](https://home-assistant.io/docs/configuration/troubleshooting/)\n - [Getting help](https://home-assistant.io/help/)\n\nTo not see this card popup in the future, edit your config in\n`configuration.yaml` and disable the `introduction` component.'
     },
-    "last_changed": "2018-07-19T10:44:45.922241+00:00",
-    "last_updated": "2018-07-19T10:44:45.922241+00:00"
+    last_changed: '2018-07-19T10:44:45.922241+00:00',
+    last_updated: '2018-07-19T10:44:45.922241+00:00'
   },
-  "timer.laundry": {
-    "entity_id": "timer.laundry",
-    "state": "idle",
-    "attributes": {
-      "duration": "0:01:00",
-      "remaining": "0:01:00"
+  'timer.laundry': {
+    entity_id: 'timer.laundry',
+    state: 'idle',
+    attributes: {
+      duration: '0:01:00',
+      remaining: '0:01:00'
     },
-    "last_changed": "2018-07-19T10:44:45.923256+00:00",
-    "last_updated": "2018-07-19T10:44:45.923256+00:00",
-    "_entityDisplay": "laundry"
+    last_changed: '2018-07-19T10:44:45.923256+00:00',
+    last_updated: '2018-07-19T10:44:45.923256+00:00',
+    _entityDisplay: 'laundry'
   },
-  "input_number.box1": {
-    "entity_id": "input_number.box1",
-    "state": "30.0",
-    "attributes": {
-      "min": -20,
-      "max": 35,
-      "step": 1,
-      "mode": "box",
-      "friendly_name": "Numeric Input Box"
+  'input_number.box1': {
+    entity_id: 'input_number.box1',
+    state: '30.0',
+    attributes: {
+      min: -20,
+      max: 35,
+      step: 1,
+      mode: 'box',
+      friendly_name: 'Numeric Input Box'
     },
-    "last_changed": "2018-07-19T10:44:45.923416+00:00",
-    "last_updated": "2018-07-19T10:44:45.923416+00:00",
-    "_entityDisplay": "Numeric Input Box"
+    last_changed: '2018-07-19T10:44:45.923416+00:00',
+    last_updated: '2018-07-19T10:44:45.923416+00:00',
+    _entityDisplay: 'Numeric Input Box'
   },
-  "input_number.slider1": {
-    "entity_id": "input_number.slider1",
-    "state": "30.0",
-    "attributes": {
-      "min": -20,
-      "max": 35,
-      "step": 1,
-      "mode": "slider",
-      "unit_of_measurement": "beers",
-      "friendly_name": "Slider"
+  'input_number.slider1': {
+    entity_id: 'input_number.slider1',
+    state: '30.0',
+    attributes: {
+      min: -20,
+      max: 35,
+      step: 1,
+      mode: 'slider',
+      unit_of_measurement: 'beers',
+      friendly_name: 'Slider'
     },
-    "last_changed": "2018-07-19T10:44:45.923572+00:00",
-    "last_updated": "2018-07-19T10:44:45.923572+00:00",
-    "_entityDisplay": "Slider"
+    last_changed: '2018-07-19T10:44:45.923572+00:00',
+    last_updated: '2018-07-19T10:44:45.923572+00:00',
+    _entityDisplay: 'Slider'
   },
-  "sensor.brightness": {
-    "entity_id": "sensor.brightness",
-    "state": "12",
-    "attributes": {
-      "maximum": 20,
-      "minimum": 0,
-      "friendly_name": "brightness",
-      "icon": "mdi:hanger"
+  'sensor.brightness': {
+    entity_id: 'sensor.brightness',
+    state: '12',
+    attributes: {
+      maximum: 20,
+      minimum: 0,
+      friendly_name: 'brightness',
+      icon: 'mdi:hanger'
     },
-    "last_changed": "2018-07-19T12:40:28.378102+00:00",
-    "last_updated": "2018-07-19T12:40:28.378102+00:00",
-    "_entityDisplay": "brightness"
+    last_changed: '2018-07-19T12:40:28.378102+00:00',
+    last_updated: '2018-07-19T12:40:28.378102+00:00',
+    _entityDisplay: 'brightness'
   },
-  "sensor.battery": {
-    "entity_id": "sensor.battery",
-    "state": "2",
-    "attributes": {
-      "maximum": 20,
-      "minimum": 0,
-      "friendly_name": "battery",
-      "icon": "mdi:hanger"
+  'sensor.battery': {
+    entity_id: 'sensor.battery',
+    state: '2',
+    attributes: {
+      maximum: 20,
+      minimum: 0,
+      friendly_name: 'battery',
+      icon: 'mdi:hanger'
     },
-    "last_changed": "2018-07-19T12:40:28.377758+00:00",
-    "last_updated": "2018-07-19T12:40:28.377758+00:00",
-    "_entityDisplay": "battery"
+    last_changed: '2018-07-19T12:40:28.377758+00:00',
+    last_updated: '2018-07-19T12:40:28.377758+00:00',
+    _entityDisplay: 'battery'
   },
-  "sensor.outside_temperature": {
-    "entity_id": "sensor.outside_temperature",
-    "state": "15.6",
-    "attributes": {
-      "battery_level": 12,
-      "unit_of_measurement": "°C",
-      "friendly_name": "Outside Temperature",
-      "device_class": "temperature"
+  'sensor.outside_temperature': {
+    entity_id: 'sensor.outside_temperature',
+    state: '15.6',
+    attributes: {
+      battery_level: 12,
+      unit_of_measurement: '°C',
+      friendly_name: 'Outside Temperature',
+      device_class: 'temperature'
     },
-    "last_changed": "2018-07-19T10:44:45.924111+00:00",
-    "last_updated": "2018-07-19T10:44:45.924111+00:00",
-    "_entityDisplay": "Outside Temperature"
+    last_changed: '2018-07-19T10:44:45.924111+00:00',
+    last_updated: '2018-07-19T10:44:45.924111+00:00',
+    _entityDisplay: 'Outside Temperature'
   },
-  "sensor.outside_humidity": {
-    "entity_id": "sensor.outside_humidity",
-    "state": "54",
-    "attributes": {
-      "unit_of_measurement": "%",
-      "friendly_name": "Outside Humidity",
-      "device_class": "humidity"
+  'sensor.outside_humidity': {
+    entity_id: 'sensor.outside_humidity',
+    state: '54',
+    attributes: {
+      unit_of_measurement: '%',
+      friendly_name: 'Outside Humidity',
+      device_class: 'humidity'
     },
-    "last_changed": "2018-07-19T10:44:45.924273+00:00",
-    "last_updated": "2018-07-19T10:44:45.924273+00:00",
-    "_entityDisplay": "Outside Humidity"
+    last_changed: '2018-07-19T10:44:45.924273+00:00',
+    last_updated: '2018-07-19T10:44:45.924273+00:00',
+    _entityDisplay: 'Outside Humidity'
   },
-  "sensor.conductivity": {
-    "entity_id": "sensor.conductivity",
-    "state": "1",
-    "attributes": {
-      "maximum": 20,
-      "minimum": 0,
-      "friendly_name": "conductivity",
-      "icon": "mdi:hanger"
+  'sensor.conductivity': {
+    entity_id: 'sensor.conductivity',
+    state: '1',
+    attributes: {
+      maximum: 20,
+      minimum: 0,
+      friendly_name: 'conductivity',
+      icon: 'mdi:hanger'
     },
-    "last_changed": "2018-07-19T12:40:28.377305+00:00",
-    "last_updated": "2018-07-19T12:40:28.377305+00:00",
-    "_entityDisplay": "conductivity"
+    last_changed: '2018-07-19T12:40:28.377305+00:00',
+    last_updated: '2018-07-19T12:40:28.377305+00:00',
+    _entityDisplay: 'conductivity'
   },
-  "weather.demo_weather_south": {
-    "entity_id": "weather.demo_weather_south",
-    "state": "sunny",
-    "attributes": {
-      "temperature": 21.6,
-      "humidity": 92,
-      "pressure": 1099,
-      "wind_speed": 0.5,
-      "attribution": "Powered by Home Assistant",
-      "forecast": [
+  'weather.demo_weather_south': {
+    entity_id: 'weather.demo_weather_south',
+    state: 'sunny',
+    attributes: {
+      temperature: 21.6,
+      humidity: 92,
+      pressure: 1099,
+      wind_speed: 0.5,
+      attribution: 'Powered by Home Assistant',
+      forecast: [
         {
-          "datetime": "2018-07-19T16:00:45.924736",
-          "condition": "rainy",
-          "precipitation": 1,
-          "temperature": 22,
-          "templow": 15
+          datetime: '2018-07-19T16:00:45.924736',
+          condition: 'rainy',
+          precipitation: 1,
+          temperature: 22,
+          templow: 15
         },
         {
-          "datetime": "2018-07-19T20:00:45.924736",
-          "condition": "rainy",
-          "precipitation": 5,
-          "temperature": 19,
-          "templow": 8
+          datetime: '2018-07-19T20:00:45.924736',
+          condition: 'rainy',
+          precipitation: 5,
+          temperature: 19,
+          templow: 8
         },
         {
-          "datetime": "2018-07-20T00:00:45.924736",
-          "condition": "cloudy",
-          "precipitation": 0,
-          "temperature": 15,
-          "templow": 9
+          datetime: '2018-07-20T00:00:45.924736',
+          condition: 'cloudy',
+          precipitation: 0,
+          temperature: 15,
+          templow: 9
         },
         {
-          "datetime": "2018-07-20T04:00:45.924736",
-          "condition": "sunny",
-          "precipitation": 0,
-          "temperature": 12,
-          "templow": 6
+          datetime: '2018-07-20T04:00:45.924736',
+          condition: 'sunny',
+          precipitation: 0,
+          temperature: 12,
+          templow: 6
         },
         {
-          "datetime": "2018-07-20T08:00:45.924736",
-          "condition": "partlycloudy",
-          "precipitation": 2,
-          "temperature": 14,
-          "templow": 7
+          datetime: '2018-07-20T08:00:45.924736',
+          condition: 'partlycloudy',
+          precipitation: 2,
+          temperature: 14,
+          templow: 7
         },
         {
-          "datetime": "2018-07-20T12:00:45.924736",
-          "condition": "rainy",
-          "precipitation": 15,
-          "temperature": 18,
-          "templow": 7
+          datetime: '2018-07-20T12:00:45.924736',
+          condition: 'rainy',
+          precipitation: 15,
+          temperature: 18,
+          templow: 7
         },
         {
-          "datetime": "2018-07-20T16:00:45.924736",
-          "condition": "fog",
-          "precipitation": 0.2,
-          "temperature": 21,
-          "templow": 12
+          datetime: '2018-07-20T16:00:45.924736',
+          condition: 'fog',
+          precipitation: 0.2,
+          temperature: 21,
+          templow: 12
         }
       ],
-      "friendly_name": "Demo Weather South"
+      friendly_name: 'Demo Weather South'
     },
-    "last_changed": "2018-07-19T10:44:45.924818+00:00",
-    "last_updated": "2018-07-19T10:44:45.924818+00:00"
+    last_changed: '2018-07-19T10:44:45.924818+00:00',
+    last_updated: '2018-07-19T10:44:45.924818+00:00'
   },
-  "weather.demo_weather_north": {
-    "entity_id": "weather.demo_weather_north",
-    "state": "rainy",
-    "attributes": {
-      "temperature": -24,
-      "humidity": 54,
-      "pressure": 987,
-      "wind_speed": 4.8,
-      "attribution": "Powered by Home Assistant",
-      "forecast": [
+  'weather.demo_weather_north': {
+    entity_id: 'weather.demo_weather_north',
+    state: 'rainy',
+    attributes: {
+      temperature: -24,
+      humidity: 54,
+      pressure: 987,
+      wind_speed: 4.8,
+      attribution: 'Powered by Home Assistant',
+      forecast: [
         {
-          "datetime": "2018-07-19T16:00:45.925119",
-          "condition": "snowy",
-          "precipitation": 2,
-          "temperature": -23,
-          "templow": -26
+          datetime: '2018-07-19T16:00:45.925119',
+          condition: 'snowy',
+          precipitation: 2,
+          temperature: -23,
+          templow: -26
         },
         {
-          "datetime": "2018-07-19T20:00:45.925119",
-          "condition": "partlycloudy",
-          "precipitation": 1,
-          "temperature": -25,
-          "templow": -26
+          datetime: '2018-07-19T20:00:45.925119',
+          condition: 'partlycloudy',
+          precipitation: 1,
+          temperature: -25,
+          templow: -26
         },
         {
-          "datetime": "2018-07-20T00:00:45.925119",
-          "condition": "sunny",
-          "precipitation": 0,
-          "temperature": -28,
-          "templow": -30
+          datetime: '2018-07-20T00:00:45.925119',
+          condition: 'sunny',
+          precipitation: 0,
+          temperature: -28,
+          templow: -30
         },
         {
-          "datetime": "2018-07-20T04:00:45.925119",
-          "condition": "sunny",
-          "precipitation": 0.1,
-          "temperature": -31,
-          "templow": -31
+          datetime: '2018-07-20T04:00:45.925119',
+          condition: 'sunny',
+          precipitation: 0.1,
+          temperature: -31,
+          templow: -31
         },
         {
-          "datetime": "2018-07-20T08:00:45.925119",
-          "condition": "snowy",
-          "precipitation": 4,
-          "temperature": -28,
-          "templow": -29
+          datetime: '2018-07-20T08:00:45.925119',
+          condition: 'snowy',
+          precipitation: 4,
+          temperature: -28,
+          templow: -29
         },
         {
-          "datetime": "2018-07-20T12:00:45.925119",
-          "condition": "sunny",
-          "precipitation": 0.3,
-          "temperature": -26,
-          "templow": -28
+          datetime: '2018-07-20T12:00:45.925119',
+          condition: 'sunny',
+          precipitation: 0.3,
+          temperature: -26,
+          templow: -28
         },
         {
-          "datetime": "2018-07-20T16:00:45.925119",
-          "condition": "sunny",
-          "precipitation": 0,
-          "temperature": -23,
-          "templow": -24
+          datetime: '2018-07-20T16:00:45.925119',
+          condition: 'sunny',
+          precipitation: 0,
+          temperature: -23,
+          templow: -24
         }
       ],
-      "friendly_name": "Demo Weather North"
+      friendly_name: 'Demo Weather North'
     },
-    "last_changed": "2018-07-19T10:44:45.925197+00:00",
-    "last_updated": "2018-07-19T10:44:45.925197+00:00"
+    last_changed: '2018-07-19T10:44:45.925197+00:00',
+    last_updated: '2018-07-19T10:44:45.925197+00:00'
   },
-  "a.demo_mode": {
-    "entity_id": "a.demo_mode",
-    "state": "Enabled",
-    "attributes": {},
-    "last_changed": "2018-07-19T10:44:45.928682+00:00",
-    "last_updated": "2018-07-19T10:44:45.928682+00:00"
+  'a.demo_mode': {
+    entity_id: 'a.demo_mode',
+    state: 'Enabled',
+    attributes: {},
+    last_changed: '2018-07-19T10:44:45.928682+00:00',
+    last_updated: '2018-07-19T10:44:45.928682+00:00'
   },
-  "plant.bonsai": {
-    "entity_id": "plant.bonsai",
-    "state": "ok",
-    "attributes": {
-      "problem": "none",
-      "sensors": {
-        "moisture": "sensor.outside_humidity",
-        "battery": "sensor.battery",
-        "temperature": "sensor.outside_temperature",
-        "conductivity": "sensor.conductivity",
-        "brightness": "sensor.brightness"
+  'plant.bonsai': {
+    entity_id: 'plant.bonsai',
+    state: 'ok',
+    attributes: {
+      problem: 'none',
+      sensors: {
+        moisture: 'sensor.outside_humidity',
+        battery: 'sensor.battery',
+        temperature: 'sensor.outside_temperature',
+        conductivity: 'sensor.conductivity',
+        brightness: 'sensor.brightness'
       },
-      "unit_of_measurement_dict": {
-        "temperature": "°C",
-        "moisture": "%"
+      unit_of_measurement_dict: {
+        temperature: '°C',
+        moisture: '%'
       },
-      "moisture": 54,
-      "battery": 2,
-      "temperature": 15.6,
-      "conductivity": 1,
-      "brightness": 12,
-      "max_brightness": 20,
-      "friendly_name": "Bonsai"
+      moisture: 54,
+      battery: 2,
+      temperature: 15.6,
+      conductivity: 1,
+      brightness: 12,
+      max_brightness: 20,
+      friendly_name: 'Bonsai'
     },
-    "last_changed": "2018-07-19T10:44:45.939328+00:00",
-    "last_updated": "2018-07-19T12:40:28.379845+00:00"
+    last_changed: '2018-07-19T10:44:45.939328+00:00',
+    last_updated: '2018-07-19T12:40:28.379845+00:00'
   },
-  "media_player.lounge_room": {
-    "entity_id": "media_player.lounge_room",
-    "state": "playing",
-    "attributes": {
-      "volume_level": 1,
-      "is_volume_muted": false,
-      "media_content_id": "house-of-cards-1",
-      "media_content_type": "tvshow",
-      "media_duration": 3600,
-      "media_title": "Chapter 1",
-      "media_series_title": "House of Cards",
-      "media_season": 1,
-      "media_episode": 1,
-      "app_name": "Netflix",
-      "source": "dvd",
-      "sound_mode": "Dummy Music",
-      "sound_mode_list": [
-        "Dummy Music",
-        "Dummy Movie"
+  'media_player.lounge_room': {
+    entity_id: 'media_player.lounge_room',
+    state: 'playing',
+    attributes: {
+      volume_level: 1,
+      is_volume_muted: false,
+      media_content_id: 'house-of-cards-1',
+      media_content_type: 'tvshow',
+      media_duration: 3600,
+      media_title: 'Chapter 1',
+      media_series_title: 'House of Cards',
+      media_season: 1,
+      media_episode: 1,
+      app_name: 'Netflix',
+      source: 'dvd',
+      sound_mode: 'Dummy Music',
+      sound_mode_list: [
+        'Dummy Music',
+        'Dummy Movie'
       ],
-      "shuffle": false,
-      "friendly_name": "Lounge room",
-      "entity_picture": "/api/media_player_proxy/media_player.lounge_room?token=20aea624c9d6c83d44e212e60c0795633d2700cde18d60901c6d74b0d063d6bf&cache=cb9d84451faf9351",
-      "supported_features": 117169
+      shuffle: false,
+      friendly_name: 'Lounge room',
+      entity_picture: '/api/media_player_proxy/media_player.lounge_room?token=20aea624c9d6c83d44e212e60c0795633d2700cde18d60901c6d74b0d063d6bf&cache=cb9d84451faf9351',
+      supported_features: 117169
     },
-    "last_changed": "2018-07-19T10:44:45.935593+00:00",
-    "last_updated": "2018-07-19T10:44:45.935593+00:00",
-    "_entityDisplay": "Lounge room"
+    last_changed: '2018-07-19T10:44:45.935593+00:00',
+    last_updated: '2018-07-19T10:44:45.935593+00:00',
+    _entityDisplay: 'Lounge room'
   },
-  "media_player.bedroom": {
-    "entity_id": "media_player.bedroom",
-    "state": "playing",
-    "attributes": {
-      "volume_level": 1,
-      "is_volume_muted": false,
-      "media_content_id": "kxopViU98Xo",
-      "media_content_type": "movie",
-      "media_duration": 360000,
-      "media_position": 54000.016711,
-      "media_position_updated_at": "2018-07-19T10:44:45.919531+00:00",
-      "media_title": "Epic sax guy 10 hours",
-      "app_name": "YouTube",
-      "sound_mode": "Dummy Music",
-      "sound_mode_list": [
-        "Dummy Music",
-        "Dummy Movie"
+  'media_player.bedroom': {
+    entity_id: 'media_player.bedroom',
+    state: 'playing',
+    attributes: {
+      volume_level: 1,
+      is_volume_muted: false,
+      media_content_id: 'kxopViU98Xo',
+      media_content_type: 'movie',
+      media_duration: 360000,
+      media_position: 54000.016711,
+      media_position_updated_at: '2018-07-19T10:44:45.919531+00:00',
+      media_title: 'Epic sax guy 10 hours',
+      app_name: 'YouTube',
+      sound_mode: 'Dummy Music',
+      sound_mode_list: [
+        'Dummy Music',
+        'Dummy Movie'
       ],
-      "shuffle": false,
-      "friendly_name": "Bedroom",
-      "entity_picture": "/api/media_player_proxy/media_player.bedroom?token=b26ff1a75b0929f6ad578955689815af828229e6cffaf061b8b6fb69c4044976&cache=e4513ed94ec89151",
-      "supported_features": 115597
+      shuffle: false,
+      friendly_name: 'Bedroom',
+      entity_picture: '/api/media_player_proxy/media_player.bedroom?token=b26ff1a75b0929f6ad578955689815af828229e6cffaf061b8b6fb69c4044976&cache=e4513ed94ec89151',
+      supported_features: 115597
     },
-    "last_changed": "2018-07-19T10:44:45.936499+00:00",
-    "last_updated": "2018-07-19T10:44:45.936499+00:00",
-    "_entityDisplay": "Bedroom"
+    last_changed: '2018-07-19T10:44:45.936499+00:00',
+    last_updated: '2018-07-19T10:44:45.936499+00:00',
+    _entityDisplay: 'Bedroom'
   },
-  "media_player.living_room": {
-    "entity_id": "media_player.living_room",
-    "state": "playing",
-    "attributes": {
-      "volume_level": 1,
-      "is_volume_muted": false,
-      "media_content_id": "eyU3bRy2x44",
-      "media_content_type": "movie",
-      "media_duration": 300,
-      "media_position": 45.017773,
-      "media_position_updated_at": "2018-07-19T10:44:45.919514+00:00",
-      "media_title": "♥♥ The Best Fireplace Video (3 hours)",
-      "app_name": "YouTube",
-      "sound_mode": "Dummy Music",
-      "sound_mode_list": [
-        "Dummy Music",
-        "Dummy Movie"
+  'media_player.living_room': {
+    entity_id: 'media_player.living_room',
+    state: 'playing',
+    attributes: {
+      volume_level: 1,
+      is_volume_muted: false,
+      media_content_id: 'eyU3bRy2x44',
+      media_content_type: 'movie',
+      media_duration: 300,
+      media_position: 45.017773,
+      media_position_updated_at: '2018-07-19T10:44:45.919514+00:00',
+      media_title: '♥♥ The Best Fireplace Video (3 hours)',
+      app_name: 'YouTube',
+      sound_mode: 'Dummy Music',
+      sound_mode_list: [
+        'Dummy Music',
+        'Dummy Movie'
       ],
-      "shuffle": false,
-      "friendly_name": "Living Room",
-      "entity_picture": "/api/media_player_proxy/media_player.living_room?token=e925f8db7f7bd1f317e4524dcb8333d60f6019219a3799a22604b5787f243567&cache=bc2ffb49c4f67034",
-      "supported_features": 115597
+      shuffle: false,
+      friendly_name: 'Living Room',
+      entity_picture: '/api/media_player_proxy/media_player.living_room?token=e925f8db7f7bd1f317e4524dcb8333d60f6019219a3799a22604b5787f243567&cache=bc2ffb49c4f67034',
+      supported_features: 115597
     },
-    "last_changed": "2018-07-19T10:44:45.937400+00:00",
-    "last_updated": "2018-07-19T10:44:45.937400+00:00",
-    "_entityDisplay": "Living Room"
+    last_changed: '2018-07-19T10:44:45.937400+00:00',
+    last_updated: '2018-07-19T10:44:45.937400+00:00',
+    _entityDisplay: 'Living Room'
   },
-  "media_player.walkman": {
-    "entity_id": "media_player.walkman",
-    "state": "playing",
-    "attributes": {
-      "volume_level": 1,
-      "is_volume_muted": false,
-      "media_content_id": "bounzz-1",
-      "media_content_type": "music",
-      "media_duration": 213,
-      "media_title": "I Wanna Be A Hippy (Flamman & Abraxas Radio Mix)",
-      "media_artist": "Technohead",
-      "media_album_name": "Bounzz",
-      "media_track": 1,
-      "sound_mode": "Dummy Music",
-      "sound_mode_list": [
-        "Dummy Music",
-        "Dummy Movie"
+  'media_player.walkman': {
+    entity_id: 'media_player.walkman',
+    state: 'playing',
+    attributes: {
+      volume_level: 1,
+      is_volume_muted: false,
+      media_content_id: 'bounzz-1',
+      media_content_type: 'music',
+      media_duration: 213,
+      media_title: 'I Wanna Be A Hippy (Flamman & Abraxas Radio Mix)',
+      media_artist: 'Technohead',
+      media_album_name: 'Bounzz',
+      media_track: 1,
+      sound_mode: 'Dummy Music',
+      sound_mode_list: [
+        'Dummy Music',
+        'Dummy Movie'
       ],
-      "shuffle": false,
-      "friendly_name": "Walkman",
-      "entity_picture": "/api/media_player_proxy/media_player.walkman?token=eda2b56fa513fa80f8d9c641941a3702b83e84e239c9ed82efc665a31e80d8fd&cache=62c0c516acbc53a9",
-      "supported_features": 123325
+      shuffle: false,
+      friendly_name: 'Walkman',
+      entity_picture: '/api/media_player_proxy/media_player.walkman?token=eda2b56fa513fa80f8d9c641941a3702b83e84e239c9ed82efc665a31e80d8fd&cache=62c0c516acbc53a9',
+      supported_features: 123325
     },
-    "last_changed": "2018-07-19T10:44:45.938179+00:00",
-    "last_updated": "2018-07-19T10:44:45.938179+00:00",
-    "_entityDisplay": "Walkman"
+    last_changed: '2018-07-19T10:44:45.938179+00:00',
+    last_updated: '2018-07-19T10:44:45.938179+00:00',
+    _entityDisplay: 'Walkman'
   },
-  "input_select.who_cooks": {
-    "entity_id": "input_select.who_cooks",
-    "state": "Anne Therese",
-    "attributes": {
-      "options": [
-        "Paulus",
-        "Anne Therese"
+  'input_select.who_cooks': {
+    entity_id: 'input_select.who_cooks',
+    state: 'Anne Therese',
+    attributes: {
+      options: [
+        'Paulus',
+        'Anne Therese'
       ],
-      "friendly_name": "Cook today",
-      "icon": "mdi:panda"
+      friendly_name: 'Cook today',
+      icon: 'mdi:panda'
     },
-    "last_changed": "2018-07-19T10:44:46.105361+00:00",
-    "last_updated": "2018-07-19T10:44:46.105361+00:00",
-    "_entityDisplay": "Cook today"
+    last_changed: '2018-07-19T10:44:46.105361+00:00',
+    last_updated: '2018-07-19T10:44:46.105361+00:00',
+    _entityDisplay: 'Cook today'
   },
-  "input_boolean.notify": {
-    "entity_id": "input_boolean.notify",
-    "state": "off",
-    "attributes": {
-      "friendly_name": "Notify Anne Therese is home",
-      "icon": "mdi:car"
+  'input_boolean.notify': {
+    entity_id: 'input_boolean.notify',
+    state: 'off',
+    attributes: {
+      friendly_name: 'Notify Anne Therese is home',
+      icon: 'mdi:car'
     },
-    "last_changed": "2018-07-19T10:44:46.105940+00:00",
-    "last_updated": "2018-07-19T10:44:46.105940+00:00",
-    "_entityDisplay": "Notify Anne Therese is home"
+    last_changed: '2018-07-19T10:44:46.105940+00:00',
+    last_updated: '2018-07-19T10:44:46.105940+00:00',
+    _entityDisplay: 'Notify Anne Therese is home'
   },
-  "weblink.router": {
-    "entity_id": "weblink.router",
-    "state": "http://192.168.1.1",
-    "attributes": {
-      "friendly_name": "Router"
+  'weblink.router': {
+    entity_id: 'weblink.router',
+    state: 'http://192.168.1.1',
+    attributes: {
+      friendly_name: 'Router'
     },
-    "last_changed": "2018-07-19T10:44:46.107286+00:00",
-    "last_updated": "2018-07-19T10:44:46.107286+00:00",
-    "_entityDisplay": "Router"
+    last_changed: '2018-07-19T10:44:46.107286+00:00',
+    last_updated: '2018-07-19T10:44:46.107286+00:00',
+    _entityDisplay: 'Router'
   },
-  "group.all_plants": {
-    "entity_id": "group.all_plants",
-    "state": "ok",
-    "attributes": {
-      "entity_id": [
-        "plant.bonsai"
+  'group.all_plants': {
+    entity_id: 'group.all_plants',
+    state: 'ok',
+    attributes: {
+      entity_id: [
+        'plant.bonsai'
       ],
-      "order": 0,
-      "auto": true,
-      "friendly_name": "all plants",
-      "hidden": true
+      order: 0,
+      auto: true,
+      friendly_name: 'all plants',
+      hidden: true
     },
-    "last_changed": "2018-07-19T10:44:46.193703+00:00",
-    "last_updated": "2018-07-19T10:44:46.193703+00:00"
+    last_changed: '2018-07-19T10:44:46.193703+00:00',
+    last_updated: '2018-07-19T10:44:46.193703+00:00'
   },
-  "alarm_control_panel.alarm": {
-    "entity_id": "alarm_control_panel.alarm",
-    "state": "disarmed",
-    "attributes": {
-      "code_format": "Number",
-      "changed_by": null,
-      "friendly_name": "Alarm"
+  'alarm_control_panel.alarm': {
+    entity_id: 'alarm_control_panel.alarm',
+    state: 'disarmed',
+    attributes: {
+      code_format: 'Number',
+      changed_by: null,
+      friendly_name: 'Alarm'
     },
-    "last_changed": "2018-07-19T10:44:46.198517+00:00",
-    "last_updated": "2018-07-19T10:44:46.198517+00:00",
-    "_entityDisplay": "Alarm"
+    last_changed: '2018-07-19T10:44:46.198517+00:00',
+    last_updated: '2018-07-19T10:44:46.198517+00:00',
+    _entityDisplay: 'Alarm'
   },
-  "binary_sensor.basement_floor_wet": {
-    "entity_id": "binary_sensor.basement_floor_wet",
-    "state": "off",
-    "attributes": {
-      "friendly_name": "Basement Floor Wet",
-      "device_class": "moisture"
+  'binary_sensor.basement_floor_wet': {
+    entity_id: 'binary_sensor.basement_floor_wet',
+    state: 'off',
+    attributes: {
+      friendly_name: 'Basement Floor Wet',
+      device_class: 'moisture'
     },
-    "last_changed": "2018-07-19T10:44:46.198923+00:00",
-    "last_updated": "2018-07-19T10:44:46.198923+00:00",
-    "_entityDisplay": "Basement Floor Wet"
+    last_changed: '2018-07-19T10:44:46.198923+00:00',
+    last_updated: '2018-07-19T10:44:46.198923+00:00',
+    _entityDisplay: 'Basement Floor Wet'
   },
-  "binary_sensor.movement_backyard": {
-    "entity_id": "binary_sensor.movement_backyard",
-    "state": "on",
-    "attributes": {
-      "friendly_name": "Movement Backyard",
-      "device_class": "motion"
+  'binary_sensor.movement_backyard': {
+    entity_id: 'binary_sensor.movement_backyard',
+    state: 'on',
+    attributes: {
+      friendly_name: 'Movement Backyard',
+      device_class: 'motion'
     },
-    "last_changed": "2018-07-19T10:44:46.199163+00:00",
-    "last_updated": "2018-07-19T10:44:46.199163+00:00",
-    "_entityDisplay": "Movement Backyard"
+    last_changed: '2018-07-19T10:44:46.199163+00:00',
+    last_updated: '2018-07-19T10:44:46.199163+00:00',
+    _entityDisplay: 'Movement Backyard'
   },
-  "climate.ecobee": {
-    "entity_id": "climate.ecobee",
-    "state": "auto",
-    "attributes": {
-      "current_temperature": 23,
-      "min_temp": 7,
-      "max_temp": 35,
-      "temperature": null,
-      "target_temp_high": 24,
-      "target_temp_low": 21,
-      "fan_mode": "Auto Low",
-      "fan_list": [
-        "On Low",
-        "On High",
-        "Auto Low",
-        "Auto High",
-        "Off"
+  'climate.ecobee': {
+    entity_id: 'climate.ecobee',
+    state: 'auto',
+    attributes: {
+      current_temperature: 23,
+      min_temp: 7,
+      max_temp: 35,
+      temperature: null,
+      target_temp_high: 24,
+      target_temp_low: 21,
+      fan_mode: 'Auto Low',
+      fan_list: [
+        'On Low',
+        'On High',
+        'Auto Low',
+        'Auto High',
+        'Off'
       ],
-      "operation_mode": "auto",
-      "operation_list": [
-        "heat",
-        "cool",
-        "auto",
-        "off"
+      operation_mode: 'auto',
+      operation_list: [
+        'heat',
+        'cool',
+        'auto',
+        'off'
       ],
-      "hold_mode": "home",
-      "swing_mode": "Auto",
-      "swing_list": [
-        "Auto",
-        "1",
-        "2",
-        "3",
-        "Off"
+      hold_mode: 'home',
+      swing_mode: 'Auto',
+      swing_list: [
+        'Auto',
+        '1',
+        '2',
+        '3',
+        'Off'
       ],
-      "unit_of_measurement": "°C",
-      "friendly_name": "Ecobee",
-      "supported_features": 1014
+      unit_of_measurement: '°C',
+      friendly_name: 'Ecobee',
+      supported_features: 1014
     },
-    "last_changed": "2018-07-19T10:44:46.200333+00:00",
-    "last_updated": "2018-07-19T10:44:46.200333+00:00",
-    "_entityDisplay": "Ecobee"
+    last_changed: '2018-07-19T10:44:46.200333+00:00',
+    last_updated: '2018-07-19T10:44:46.200333+00:00',
+    _entityDisplay: 'Ecobee'
   },
-  "climate.hvac": {
-    "entity_id": "climate.hvac",
-    "state": "cool",
-    "attributes": {
-      "current_temperature": 22,
-      "min_temp": 7,
-      "max_temp": 35,
-      "temperature": 21,
-      "humidity": 67,
-      "current_humidity": 54,
-      "min_humidity": 30,
-      "max_humidity": 99,
-      "fan_mode": "On High",
-      "fan_list": [
-        "On Low",
-        "On High",
-        "Auto Low",
-        "Auto High",
-        "Off"
+  'climate.hvac': {
+    entity_id: 'climate.hvac',
+    state: 'cool',
+    attributes: {
+      current_temperature: 22,
+      min_temp: 7,
+      max_temp: 35,
+      temperature: 21,
+      humidity: 67,
+      current_humidity: 54,
+      min_humidity: 30,
+      max_humidity: 99,
+      fan_mode: 'On High',
+      fan_list: [
+        'On Low',
+        'On High',
+        'Auto Low',
+        'Auto High',
+        'Off'
       ],
-      "operation_mode": "cool",
-      "operation_list": [
-        "heat",
-        "cool",
-        "auto",
-        "off"
+      operation_mode: 'cool',
+      operation_list: [
+        'heat',
+        'cool',
+        'auto',
+        'off'
       ],
-      "swing_mode": "Off",
-      "swing_list": [
-        "Auto",
-        "1",
-        "2",
-        "3",
-        "Off"
+      swing_mode: 'Off',
+      swing_list: [
+        'Auto',
+        '1',
+        '2',
+        '3',
+        'Off'
       ],
-      "away_mode": "on",
-      "aux_heat": "off",
-      "unit_of_measurement": "°C",
-      "friendly_name": "Hvac",
-      "supported_features": 3833
+      away_mode: 'on',
+      aux_heat: 'off',
+      unit_of_measurement: '°C',
+      friendly_name: 'Hvac',
+      supported_features: 3833
     },
-    "last_changed": "2018-07-19T10:44:46.200650+00:00",
-    "last_updated": "2018-07-19T10:44:46.200650+00:00",
-    "_entityDisplay": "Hvac"
+    last_changed: '2018-07-19T10:44:46.200650+00:00',
+    last_updated: '2018-07-19T10:44:46.200650+00:00',
+    _entityDisplay: 'Hvac'
   },
-  "climate.heatpump": {
-    "entity_id": "climate.heatpump",
-    "state": "heat",
-    "attributes": {
-      "current_temperature": 25,
-      "min_temp": 7,
-      "max_temp": 35,
-      "temperature": 20,
-      "operation_mode": "heat",
-      "operation_list": [
-        "heat",
-        "cool",
-        "auto",
-        "off"
+  'climate.heatpump': {
+    entity_id: 'climate.heatpump',
+    state: 'heat',
+    attributes: {
+      current_temperature: 25,
+      min_temp: 7,
+      max_temp: 35,
+      temperature: 20,
+      operation_mode: 'heat',
+      operation_list: [
+        'heat',
+        'cool',
+        'auto',
+        'off'
       ],
-      "unit_of_measurement": "°C",
-      "friendly_name": "HeatPump",
-      "supported_features": 4273
+      unit_of_measurement: '°C',
+      friendly_name: 'HeatPump',
+      supported_features: 4273
     },
-    "last_changed": "2018-07-19T10:44:46.200946+00:00",
-    "last_updated": "2018-07-19T10:44:46.200946+00:00",
-    "_entityDisplay": "HeatPump"
+    last_changed: '2018-07-19T10:44:46.200946+00:00',
+    last_updated: '2018-07-19T10:44:46.200946+00:00',
+    _entityDisplay: 'HeatPump'
   },
-  "mailbox.demomailbox": {
-    "entity_id": "mailbox.demomailbox",
-    "state": "10",
-    "attributes": {
-      "friendly_name": "DemoMailbox"
+  'mailbox.demomailbox': {
+    entity_id: 'mailbox.demomailbox',
+    state: '10',
+    attributes: {
+      friendly_name: 'DemoMailbox'
     },
-    "last_changed": "2018-07-19T10:45:16.555210+00:00",
-    "last_updated": "2018-07-19T10:45:16.555210+00:00",
-    "_entityDisplay": "DemoMailbox"
+    last_changed: '2018-07-19T10:45:16.555210+00:00',
+    last_updated: '2018-07-19T10:45:16.555210+00:00',
+    _entityDisplay: 'DemoMailbox'
   },
-  "input_select.living_room_preset": {
-    "entity_id": "input_select.living_room_preset",
-    "state": "Visitors",
-    "attributes": {
-      "options": [
-        "Visitors",
-        "Visitors with kids",
-        "Home Alone"
+  'input_select.living_room_preset': {
+    entity_id: 'input_select.living_room_preset',
+    state: 'Visitors',
+    attributes: {
+      options: [
+        'Visitors',
+        'Visitors with kids',
+        'Home Alone'
       ]
     },
-    "last_changed": "2018-07-19T10:44:46.211150+00:00",
-    "last_updated": "2018-07-19T10:44:46.211150+00:00",
-    "_entityDisplay": "living room preset"
+    last_changed: '2018-07-19T10:44:46.211150+00:00',
+    last_updated: '2018-07-19T10:44:46.211150+00:00',
+    _entityDisplay: 'living room preset'
   },
-  "camera.demo_camera": {
-    "entity_id": "camera.demo_camera",
-    "state": "idle",
-    "attributes": {
-      "access_token": "2f5bb163fb91cd8770a9494fa5e7eab172d8d34f4aba806eb6b59411b8c720b8",
-      "friendly_name": "Demo camera",
-      "entity_picture": "/api/camera_proxy/camera.demo_camera?token=2f5bb163fb91cd8770a9494fa5e7eab172d8d34f4aba806eb6b59411b8c720b8"
+  'camera.demo_camera': {
+    entity_id: 'camera.demo_camera',
+    state: 'idle',
+    attributes: {
+      access_token: '2f5bb163fb91cd8770a9494fa5e7eab172d8d34f4aba806eb6b59411b8c720b8',
+      friendly_name: 'Demo camera',
+      entity_picture: '/api/camera_proxy/camera.demo_camera?token=2f5bb163fb91cd8770a9494fa5e7eab172d8d34f4aba806eb6b59411b8c720b8'
     },
-    "last_changed": "2018-07-19T10:44:46.217296+00:00",
-    "last_updated": "2018-07-19T12:37:34.378986+00:00"
+    last_changed: '2018-07-19T10:44:46.217296+00:00',
+    last_updated: '2018-07-19T12:37:34.378986+00:00'
   },
-  "cover.garage_door": {
-    "entity_id": "cover.garage_door",
-    "state": "closed",
-    "attributes": {
-      "friendly_name": "Garage Door",
-      "supported_features": 3,
-      "device_class": "garage"
+  'cover.garage_door': {
+    entity_id: 'cover.garage_door',
+    state: 'closed',
+    attributes: {
+      friendly_name: 'Garage Door',
+      supported_features: 3,
+      device_class: 'garage'
     },
-    "last_changed": "2018-07-19T10:44:46.218790+00:00",
-    "last_updated": "2018-07-19T10:44:46.218790+00:00",
-    "_entityDisplay": "Garage Door"
+    last_changed: '2018-07-19T10:44:46.218790+00:00',
+    last_updated: '2018-07-19T10:44:46.218790+00:00',
+    _entityDisplay: 'Garage Door'
   },
-  "cover.living_room_window": {
-    "entity_id": "cover.living_room_window",
-    "state": "open",
-    "attributes": {
-      "current_position": 70,
-      "current_tilt_position": 50,
-      "friendly_name": "Living Room Window",
-      "supported_features": 255
+  'cover.living_room_window': {
+    entity_id: 'cover.living_room_window',
+    state: 'open',
+    attributes: {
+      current_position: 70,
+      current_tilt_position: 50,
+      friendly_name: 'Living Room Window',
+      supported_features: 255
     },
-    "last_changed": "2018-07-19T10:44:46.220347+00:00",
-    "last_updated": "2018-07-19T10:44:46.220347+00:00",
-    "_entityDisplay": "Living Room Window"
+    last_changed: '2018-07-19T10:44:46.220347+00:00',
+    last_updated: '2018-07-19T10:44:46.220347+00:00',
+    _entityDisplay: 'Living Room Window'
   },
-  "cover.hall_window": {
-    "entity_id": "cover.hall_window",
-    "state": "open",
-    "attributes": {
-      "current_position": 10,
-      "friendly_name": "Hall Window",
-      "supported_features": 15
+  'cover.hall_window': {
+    entity_id: 'cover.hall_window',
+    state: 'open',
+    attributes: {
+      current_position: 10,
+      friendly_name: 'Hall Window',
+      supported_features: 15
     },
-    "last_changed": "2018-07-19T10:44:46.281104+00:00",
-    "last_updated": "2018-07-19T10:44:46.281104+00:00",
-    "_entityDisplay": "Hall Window"
+    last_changed: '2018-07-19T10:44:46.281104+00:00',
+    last_updated: '2018-07-19T10:44:46.281104+00:00',
+    _entityDisplay: 'Hall Window'
   },
-  "cover.kitchen_window": {
-    "entity_id": "cover.kitchen_window",
-    "state": "closed",
-    "attributes": {
-      "friendly_name": "Kitchen Window",
-      "supported_features": 11
+  'cover.kitchen_window': {
+    entity_id: 'cover.kitchen_window',
+    state: 'closed',
+    attributes: {
+      friendly_name: 'Kitchen Window',
+      supported_features: 11
     },
-    "last_changed": "2018-07-19T10:44:46.281449+00:00",
-    "last_updated": "2018-07-19T10:44:46.281449+00:00",
-    "_entityDisplay": "Kitchen Window"
+    last_changed: '2018-07-19T10:44:46.281449+00:00',
+    last_updated: '2018-07-19T10:44:46.281449+00:00',
+    _entityDisplay: 'Kitchen Window'
   },
-  "fan.living_room_fan": {
-    "entity_id": "fan.living_room_fan",
-    "state": "off",
-    "attributes": {
-      "speed": "off",
-      "speed_list": [
-        "off",
-        "low",
-        "medium",
-        "high"
+  'fan.living_room_fan': {
+    entity_id: 'fan.living_room_fan',
+    state: 'off',
+    attributes: {
+      speed: 'off',
+      speed_list: [
+        'off',
+        'low',
+        'medium',
+        'high'
       ],
-      "oscillating": false,
-      "direction": "forward",
-      "friendly_name": "Living Room Fan",
-      "supported_features": 7
+      oscillating: false,
+      direction: 'forward',
+      friendly_name: 'Living Room Fan',
+      supported_features: 7
     },
-    "last_changed": "2018-07-19T10:44:46.281761+00:00",
-    "last_updated": "2018-07-19T10:44:46.281761+00:00",
-    "_entityDisplay": "Living Room Fan"
+    last_changed: '2018-07-19T10:44:46.281761+00:00',
+    last_updated: '2018-07-19T10:44:46.281761+00:00',
+    _entityDisplay: 'Living Room Fan'
   },
-  "fan.ceiling_fan": {
-    "entity_id": "fan.ceiling_fan",
-    "state": "off",
-    "attributes": {
-      "speed": "off",
-      "speed_list": [
-        "off",
-        "low",
-        "medium",
-        "high"
+  'fan.ceiling_fan': {
+    entity_id: 'fan.ceiling_fan',
+    state: 'off',
+    attributes: {
+      speed: 'off',
+      speed_list: [
+        'off',
+        'low',
+        'medium',
+        'high'
       ],
-      "friendly_name": "Ceiling Fan",
-      "supported_features": 1
+      friendly_name: 'Ceiling Fan',
+      supported_features: 1
     },
-    "last_changed": "2018-07-19T10:44:46.282008+00:00",
-    "last_updated": "2018-07-19T10:44:46.282008+00:00",
-    "_entityDisplay": "Ceiling Fan"
+    last_changed: '2018-07-19T10:44:46.282008+00:00',
+    last_updated: '2018-07-19T10:44:46.282008+00:00',
+    _entityDisplay: 'Ceiling Fan'
   },
-  "light.kitchen_lights": {
-    "entity_id": "light.kitchen_lights",
-    "state": "on",
-    "attributes": {
-      "min_mireds": 153,
-      "max_mireds": 500,
-      "brightness": 180,
-      "color_temp": 240,
-      "hs_color": [
+  'light.kitchen_lights': {
+    entity_id: 'light.kitchen_lights',
+    state: 'on',
+    attributes: {
+      min_mireds: 153,
+      max_mireds: 500,
+      brightness: 180,
+      color_temp: 240,
+      hs_color: [
         345,
         75
       ],
-      "rgb_color": [
+      rgb_color: [
         255,
         63,
         111
       ],
-      "xy_color": [
+      xy_color: [
         0.59,
         0.274
       ],
-      "white_value": 200,
-      "friendly_name": "Kitchen Lights",
-      "supported_features": 151
+      white_value: 200,
+      friendly_name: 'Kitchen Lights',
+      supported_features: 151
     },
-    "last_changed": "2018-07-19T10:44:46.282257+00:00",
-    "last_updated": "2018-07-19T10:44:46.282257+00:00",
-    "_entityDisplay": "Kitchen Lights"
+    last_changed: '2018-07-19T10:44:46.282257+00:00',
+    last_updated: '2018-07-19T10:44:46.282257+00:00',
+    _entityDisplay: 'Kitchen Lights'
   },
-  "light.bed_light": {
-    "entity_id": "light.bed_light",
-    "state": "off",
-    "attributes": {
-      "min_mireds": 153,
-      "max_mireds": 500,
-      "friendly_name": "Bed Light",
-      "supported_features": 151
+  'light.bed_light': {
+    entity_id: 'light.bed_light',
+    state: 'off',
+    attributes: {
+      min_mireds: 153,
+      max_mireds: 500,
+      friendly_name: 'Bed Light',
+      supported_features: 151
     },
-    "last_changed": "2018-07-19T10:44:46.282478+00:00",
-    "last_updated": "2018-07-19T10:44:46.282478+00:00",
-    "_entityDisplay": "Bed Light"
+    last_changed: '2018-07-19T10:44:46.282478+00:00',
+    last_updated: '2018-07-19T10:44:46.282478+00:00',
+    _entityDisplay: 'Bed Light'
   },
-  "light.ceiling_lights": {
-    "entity_id": "light.ceiling_lights",
-    "state": "on",
-    "attributes": {
-      "min_mireds": 153,
-      "max_mireds": 500,
-      "brightness": 180,
-      "color_temp": 380,
-      "hs_color": [
+  'light.ceiling_lights': {
+    entity_id: 'light.ceiling_lights',
+    state: 'on',
+    attributes: {
+      min_mireds: 153,
+      max_mireds: 500,
+      brightness: 180,
+      color_temp: 380,
+      hs_color: [
         56,
         86
       ],
-      "rgb_color": [
+      rgb_color: [
         255,
         240,
         35
       ],
-      "xy_color": [
+      xy_color: [
         0.459,
         0.496
       ],
-      "white_value": 200,
-      "friendly_name": "Ceiling Lights",
-      "supported_features": 151
+      white_value: 200,
+      friendly_name: 'Ceiling Lights',
+      supported_features: 151
     },
-    "last_changed": "2018-07-19T10:44:46.282696+00:00",
-    "last_updated": "2018-07-19T10:44:46.282696+00:00",
-    "_entityDisplay": "Ceiling Lights"
+    last_changed: '2018-07-19T10:44:46.282696+00:00',
+    last_updated: '2018-07-19T10:44:46.282696+00:00',
+    _entityDisplay: 'Ceiling Lights'
   },
-  "lock.openable_lock": {
-    "entity_id": "lock.openable_lock",
-    "state": "locked",
-    "attributes": {
-      "friendly_name": "Openable Lock",
-      "supported_features": 1
+  'lock.openable_lock': {
+    entity_id: 'lock.openable_lock',
+    state: 'locked',
+    attributes: {
+      friendly_name: 'Openable Lock',
+      supported_features: 1
     },
-    "last_changed": "2018-07-19T10:44:46.282949+00:00",
-    "last_updated": "2018-07-19T10:44:46.282949+00:00",
-    "_entityDisplay": "Openable Lock"
+    last_changed: '2018-07-19T10:44:46.282949+00:00',
+    last_updated: '2018-07-19T10:44:46.282949+00:00',
+    _entityDisplay: 'Openable Lock'
   },
-  "lock.kitchen_door": {
-    "entity_id": "lock.kitchen_door",
-    "state": "unlocked",
-    "attributes": {
-      "friendly_name": "Kitchen Door"
+  'lock.kitchen_door': {
+    entity_id: 'lock.kitchen_door',
+    state: 'unlocked',
+    attributes: {
+      friendly_name: 'Kitchen Door'
     },
-    "last_changed": "2018-07-19T10:44:46.283175+00:00",
-    "last_updated": "2018-07-19T10:44:46.283175+00:00",
-    "_entityDisplay": "Kitchen Door"
+    last_changed: '2018-07-19T10:44:46.283175+00:00',
+    last_updated: '2018-07-19T10:44:46.283175+00:00',
+    _entityDisplay: 'Kitchen Door'
   },
-  "lock.front_door": {
-    "entity_id": "lock.front_door",
-    "state": "locked",
-    "attributes": {
-      "friendly_name": "Front Door"
+  'lock.front_door': {
+    entity_id: 'lock.front_door',
+    state: 'locked',
+    attributes: {
+      friendly_name: 'Front Door'
     },
-    "last_changed": "2018-07-19T10:44:46.283396+00:00",
-    "last_updated": "2018-07-19T10:44:46.283396+00:00",
-    "_entityDisplay": "Front Door"
+    last_changed: '2018-07-19T10:44:46.283396+00:00',
+    last_updated: '2018-07-19T10:44:46.283396+00:00',
+    _entityDisplay: 'Front Door'
   },
-  "switch.decorative_lights": {
-    "entity_id": "switch.decorative_lights",
-    "state": "on",
-    "attributes": {
-      "current_power_w": 100,
-      "today_energy_kwh": 15,
-      "friendly_name": "Decorative Lights",
-      "assumed_state": true
+  'switch.decorative_lights': {
+    entity_id: 'switch.decorative_lights',
+    state: 'on',
+    attributes: {
+      current_power_w: 100,
+      today_energy_kwh: 15,
+      friendly_name: 'Decorative Lights',
+      assumed_state: true
     },
-    "last_changed": "2018-07-19T11:33:15.735386+00:00",
-    "last_updated": "2018-07-19T11:33:15.735386+00:00",
-    "_entityDisplay": "Decorative Lights"
+    last_changed: '2018-07-19T11:33:15.735386+00:00',
+    last_updated: '2018-07-19T11:33:15.735386+00:00',
+    _entityDisplay: 'Decorative Lights'
   },
-  "switch.ac": {
-    "entity_id": "switch.ac",
-    "state": "off",
-    "attributes": {
-      "today_energy_kwh": 15,
-      "friendly_name": "AC",
-      "icon": "mdi:air-conditioner"
+  'switch.ac': {
+    entity_id: 'switch.ac',
+    state: 'off',
+    attributes: {
+      today_energy_kwh: 15,
+      friendly_name: 'AC',
+      icon: 'mdi:air-conditioner'
     },
-    "last_changed": "2018-07-19T10:44:46.283901+00:00",
-    "last_updated": "2018-07-19T10:44:46.283901+00:00",
-    "_entityDisplay": "AC"
+    last_changed: '2018-07-19T10:44:46.283901+00:00',
+    last_updated: '2018-07-19T10:44:46.283901+00:00',
+    _entityDisplay: 'AC'
   },
-  "device_tracker.demo_paulus": {
-    "entity_id": "device_tracker.demo_paulus",
-    "state": "not_home",
-    "attributes": {
-      "source_type": "gps",
-      "latitude": 32.877105,
-      "longitude": 117.232185,
-      "gps_accuracy": 91,
-      "battery": 71,
-      "friendly_name": "Paulus"
+  'device_tracker.demo_paulus': {
+    entity_id: 'device_tracker.demo_paulus',
+    state: 'not_home',
+    attributes: {
+      source_type: 'gps',
+      latitude: 32.877105,
+      longitude: 117.232185,
+      gps_accuracy: 91,
+      battery: 71,
+      friendly_name: 'Paulus'
     },
-    "last_changed": "2018-07-19T10:44:46.287874+00:00",
-    "last_updated": "2018-07-19T10:44:46.287874+00:00",
-    "_stateDisplay": "Away",
-    "_entityDisplay": "Paulus"
+    last_changed: '2018-07-19T10:44:46.287874+00:00',
+    last_updated: '2018-07-19T10:44:46.287874+00:00',
+    _stateDisplay: 'Away',
+    _entityDisplay: 'Paulus'
   },
-  "device_tracker.demo_anne_therese": {
-    "entity_id": "device_tracker.demo_anne_therese",
-    "state": "not_home",
-    "attributes": {
-      "source_type": "gps",
-      "latitude": 32.876194999999996,
-      "longitude": 117.236015,
-      "gps_accuracy": 63,
-      "battery": 33,
-      "friendly_name": "Anne Therese"
+  'device_tracker.demo_anne_therese': {
+    entity_id: 'device_tracker.demo_anne_therese',
+    state: 'not_home',
+    attributes: {
+      source_type: 'gps',
+      latitude: 32.876194999999996,
+      longitude: 117.236015,
+      gps_accuracy: 63,
+      battery: 33,
+      friendly_name: 'Anne Therese'
     },
-    "last_changed": "2018-07-19T10:44:46.288213+00:00",
-    "last_updated": "2018-07-19T10:44:46.288213+00:00",
-    "_stateDisplay": "Away",
-    "_entityDisplay": "Anne Therese"
+    last_changed: '2018-07-19T10:44:46.288213+00:00',
+    last_updated: '2018-07-19T10:44:46.288213+00:00',
+    _stateDisplay: 'Away',
+    _entityDisplay: 'Anne Therese'
   },
-  "device_tracker.demo_home_boy": {
-    "entity_id": "device_tracker.demo_home_boy",
-    "state": "not_home",
-    "attributes": {
-      "source_type": "gps",
-      "latitude": 32.87334,
-      "longitude": 117.22745,
-      "gps_accuracy": 20,
-      "battery": 53,
-      "friendly_name": "Home Boy"
+  'device_tracker.demo_home_boy': {
+    entity_id: 'device_tracker.demo_home_boy',
+    state: 'not_home',
+    attributes: {
+      source_type: 'gps',
+      latitude: 32.87334,
+      longitude: 117.22745,
+      gps_accuracy: 20,
+      battery: 53,
+      friendly_name: 'Home Boy'
     },
-    "last_changed": "2018-07-19T10:44:46.288533+00:00",
-    "last_updated": "2018-07-19T10:44:46.288533+00:00",
-    "_stateDisplay": "Away",
-    "_entityDisplay": "Home Boy"
+    last_changed: '2018-07-19T10:44:46.288533+00:00',
+    last_updated: '2018-07-19T10:44:46.288533+00:00',
+    _stateDisplay: 'Away',
+    _entityDisplay: 'Home Boy'
   },
-  "calendar.calendar_2": {
-    "entity_id": "calendar.calendar_2",
-    "state": "off",
-    "attributes": {
-      "message": "",
-      "all_day": false,
-      "offset_reached": false,
-      "start_time": null,
-      "end_time": null,
-      "location": null,
-      "description": null,
-      "friendly_name": "Calendar 2"
+  'calendar.calendar_2': {
+    entity_id: 'calendar.calendar_2',
+    state: 'off',
+    attributes: {
+      message: '',
+      all_day: false,
+      offset_reached: false,
+      start_time: null,
+      end_time: null,
+      location: null,
+      description: null,
+      friendly_name: 'Calendar 2'
     },
-    "last_changed": "2018-07-19T11:27:25.017141+00:00",
-    "last_updated": "2018-07-19T11:27:25.017141+00:00",
-    "_stateDisplay": "Off",
-    "_entityDisplay": "Calendar 2"
+    last_changed: '2018-07-19T11:27:25.017141+00:00',
+    last_updated: '2018-07-19T11:27:25.017141+00:00',
+    _stateDisplay: 'Off',
+    _entityDisplay: 'Calendar 2'
   },
-  "calendar.calendar_1": {
-    "entity_id": "calendar.calendar_1",
-    "state": "off",
-    "attributes": {
-      "message": "",
-      "all_day": false,
-      "offset_reached": false,
-      "start_time": null,
-      "end_time": null,
-      "location": null,
-      "description": null,
-      "friendly_name": "Calendar 1"
+  'calendar.calendar_1': {
+    entity_id: 'calendar.calendar_1',
+    state: 'off',
+    attributes: {
+      message: '',
+      all_day: false,
+      offset_reached: false,
+      start_time: null,
+      end_time: null,
+      location: null,
+      description: null,
+      friendly_name: 'Calendar 1'
     },
-    "last_changed": "2018-07-19T12:15:21.378222+00:00",
-    "last_updated": "2018-07-19T12:15:21.378222+00:00",
-    "_stateDisplay": "Off",
-    "_entityDisplay": "Calendar 1"
+    last_changed: '2018-07-19T12:15:21.378222+00:00',
+    last_updated: '2018-07-19T12:15:21.378222+00:00',
+    _stateDisplay: 'Off',
+    _entityDisplay: 'Calendar 1'
   },
-  "group.all_covers": {
-    "entity_id": "group.all_covers",
-    "state": "open",
-    "attributes": {
-      "entity_id": [
-        "cover.garage_door",
-        "cover.hall_window",
-        "cover.kitchen_window",
-        "cover.living_room_window"
+  'group.all_covers': {
+    entity_id: 'group.all_covers',
+    state: 'open',
+    attributes: {
+      entity_id: [
+        'cover.garage_door',
+        'cover.hall_window',
+        'cover.kitchen_window',
+        'cover.living_room_window'
       ],
-      "order": 1,
-      "auto": true,
-      "friendly_name": "all covers",
-      "hidden": true
+      order: 1,
+      auto: true,
+      friendly_name: 'all covers',
+      hidden: true
     },
-    "last_changed": "2018-07-19T10:44:46.430361+00:00",
-    "last_updated": "2018-07-19T10:44:46.430361+00:00"
+    last_changed: '2018-07-19T10:44:46.430361+00:00',
+    last_updated: '2018-07-19T10:44:46.430361+00:00'
   },
-  "group.all_fans": {
-    "entity_id": "group.all_fans",
-    "state": "off",
-    "attributes": {
-      "entity_id": [
-        "fan.ceiling_fan",
-        "fan.living_room_fan"
+  'group.all_fans': {
+    entity_id: 'group.all_fans',
+    state: 'off',
+    attributes: {
+      entity_id: [
+        'fan.ceiling_fan',
+        'fan.living_room_fan'
       ],
-      "order": 1,
-      "auto": true,
-      "friendly_name": "all fans",
-      "hidden": true
+      order: 1,
+      auto: true,
+      friendly_name: 'all fans',
+      hidden: true
     },
-    "last_changed": "2018-07-19T10:44:46.430643+00:00",
-    "last_updated": "2018-07-19T10:44:46.430643+00:00"
+    last_changed: '2018-07-19T10:44:46.430643+00:00',
+    last_updated: '2018-07-19T10:44:46.430643+00:00'
   },
-  "group.all_lights": {
-    "entity_id": "group.all_lights",
-    "state": "on",
-    "attributes": {
-      "entity_id": [
-        "light.bed_light",
-        "light.ceiling_lights",
-        "light.kitchen_lights"
+  'group.all_lights': {
+    entity_id: 'group.all_lights',
+    state: 'on',
+    attributes: {
+      entity_id: [
+        'light.bed_light',
+        'light.ceiling_lights',
+        'light.kitchen_lights'
       ],
-      "order": 1,
-      "auto": true,
-      "friendly_name": "all lights",
-      "hidden": true
+      order: 1,
+      auto: true,
+      friendly_name: 'all lights',
+      hidden: true
     },
-    "last_changed": "2018-07-19T10:44:46.430879+00:00",
-    "last_updated": "2018-07-19T10:44:46.430879+00:00"
+    last_changed: '2018-07-19T10:44:46.430879+00:00',
+    last_updated: '2018-07-19T10:44:46.430879+00:00'
   },
-  "group.all_locks": {
-    "entity_id": "group.all_locks",
-    "state": "locked",
-    "attributes": {
-      "entity_id": [
-        "lock.front_door",
-        "lock.kitchen_door",
-        "lock.openable_lock"
+  'group.all_locks': {
+    entity_id: 'group.all_locks',
+    state: 'locked',
+    attributes: {
+      entity_id: [
+        'lock.front_door',
+        'lock.kitchen_door',
+        'lock.openable_lock'
       ],
-      "order": 1,
-      "auto": true,
-      "friendly_name": "all locks",
-      "hidden": true
+      order: 1,
+      auto: true,
+      friendly_name: 'all locks',
+      hidden: true
     },
-    "last_changed": "2018-07-19T10:44:46.431112+00:00",
-    "last_updated": "2018-07-19T10:44:46.431112+00:00"
+    last_changed: '2018-07-19T10:44:46.431112+00:00',
+    last_updated: '2018-07-19T10:44:46.431112+00:00'
   },
-  "group.all_switches": {
-    "entity_id": "group.all_switches",
-    "state": "on",
-    "attributes": {
-      "entity_id": [
-        "switch.ac",
-        "switch.decorative_lights"
+  'group.all_switches': {
+    entity_id: 'group.all_switches',
+    state: 'on',
+    attributes: {
+      entity_id: [
+        'switch.ac',
+        'switch.decorative_lights'
       ],
-      "order": 1,
-      "auto": true,
-      "friendly_name": "all switches",
-      "hidden": true,
-      "assumed_state": true
+      order: 1,
+      auto: true,
+      friendly_name: 'all switches',
+      hidden: true,
+      assumed_state: true
     },
-    "last_changed": "2018-07-19T11:33:15.736167+00:00",
-    "last_updated": "2018-07-19T11:33:15.736167+00:00"
+    last_changed: '2018-07-19T11:33:15.736167+00:00',
+    last_updated: '2018-07-19T11:33:15.736167+00:00'
   },
-  "group.calendar": {
-    "entity_id": "group.calendar",
-    "state": "off",
-    "attributes": {
-      "entity_id": [
-        "calendar.calendar_1",
-        "calendar.calendar_2"
+  'group.calendar': {
+    entity_id: 'group.calendar',
+    state: 'off',
+    attributes: {
+      entity_id: [
+        'calendar.calendar_1',
+        'calendar.calendar_2'
       ],
-      "order": 6,
-      "auto": true,
-      "friendly_name": "calendar",
-      "hidden": true
+      order: 6,
+      auto: true,
+      friendly_name: 'calendar',
+      hidden: true
     },
-    "last_changed": "2018-07-19T12:15:21.378971+00:00",
-    "last_updated": "2018-07-19T12:15:21.378971+00:00"
+    last_changed: '2018-07-19T12:15:21.378971+00:00',
+    last_updated: '2018-07-19T12:15:21.378971+00:00'
   },
-  "group.all_devices": {
-    "entity_id": "group.all_devices",
-    "state": "not_home",
-    "attributes": {
-      "entity_id": [
-        "device_tracker.demo_paulus",
-        "device_tracker.demo_anne_therese",
-        "device_tracker.demo_home_boy"
+  'group.all_devices': {
+    entity_id: 'group.all_devices',
+    state: 'not_home',
+    attributes: {
+      entity_id: [
+        'device_tracker.demo_paulus',
+        'device_tracker.demo_anne_therese',
+        'device_tracker.demo_home_boy'
       ],
-      "order": 6,
-      "auto": true,
-      "friendly_name": "all devices",
-      "hidden": true
+      order: 6,
+      auto: true,
+      friendly_name: 'all devices',
+      hidden: true
     },
-    "last_changed": "2018-07-19T10:44:46.435615+00:00",
-    "last_updated": "2018-07-19T10:44:46.435615+00:00"
+    last_changed: '2018-07-19T10:44:46.435615+00:00',
+    last_updated: '2018-07-19T10:44:46.435615+00:00'
   },
-  "image_processing.demo_alpr": {
-    "entity_id": "image_processing.demo_alpr",
-    "state": "AC3829",
-    "attributes": {
-      "plates": {
-        "AC3829": 98.3,
-        "BE392034": 95.5,
-        "CD02394": 93.4,
-        "DF923043": 90.8
+  'image_processing.demo_alpr': {
+    entity_id: 'image_processing.demo_alpr',
+    state: 'AC3829',
+    attributes: {
+      plates: {
+        AC3829: 98.3,
+        BE392034: 95.5,
+        CD02394: 93.4,
+        DF923043: 90.8
       },
-      "vehicles": 1,
-      "friendly_name": "Demo Alpr",
-      "device_class": "alpr"
+      vehicles: 1,
+      friendly_name: 'Demo Alpr',
+      device_class: 'alpr'
     },
-    "last_changed": "2018-07-19T10:44:56.654838+00:00",
-    "last_updated": "2018-07-19T10:44:56.654838+00:00",
-    "_stateDisplay": "AC3829",
-    "_entityDisplay": "Demo Alpr"
+    last_changed: '2018-07-19T10:44:56.654838+00:00',
+    last_updated: '2018-07-19T10:44:56.654838+00:00',
+    _stateDisplay: 'AC3829',
+    _entityDisplay: 'Demo Alpr'
   },
-  "image_processing.demo_face": {
-    "entity_id": "image_processing.demo_face",
-    "state": "Hans",
-    "attributes": {
-      "faces": [
+  'image_processing.demo_face': {
+    entity_id: 'image_processing.demo_face',
+    state: 'Hans',
+    attributes: {
+      faces: [
         {
-          "confidence": 98.34,
-          "name": "Hans",
-          "age": 16,
-          "gender": "male",
-          "entity_id": "image_processing.demo_face"
+          confidence: 98.34,
+          name: 'Hans',
+          age: 16,
+          gender: 'male',
+          entity_id: 'image_processing.demo_face'
         },
         {
-          "name": "Helena",
-          "age": 28,
-          "gender": "female",
-          "entity_id": "image_processing.demo_face"
+          name: 'Helena',
+          age: 28,
+          gender: 'female',
+          entity_id: 'image_processing.demo_face'
         },
         {
-          "confidence": 62.53,
-          "name": "Luna"
+          confidence: 62.53,
+          name: 'Luna'
         }
       ],
-      "total_faces": 4,
-      "friendly_name": "Demo Face",
-      "device_class": "face"
+      total_faces: 4,
+      friendly_name: 'Demo Face',
+      device_class: 'face'
     },
-    "last_changed": "2018-07-19T10:44:56.641372+00:00",
-    "last_updated": "2018-07-19T10:44:56.641372+00:00",
-    "_stateDisplay": "Hans",
-    "_entityDisplay": "Demo Face"
+    last_changed: '2018-07-19T10:44:56.641372+00:00',
+    last_updated: '2018-07-19T10:44:56.641372+00:00',
+    _stateDisplay: 'Hans',
+    _entityDisplay: 'Demo Face'
   },
-  "persistent_notification.notification_2": {
-    "entity_id": "persistent_notification.notification_2",
-    "state": "notifying",
-    "attributes": {
-      "title": "Example Notification",
-      "message": "This is an example of a persistent notification."
+  'persistent_notification.notification_2': {
+    entity_id: 'persistent_notification.notification_2',
+    state: 'notifying',
+    attributes: {
+      title: 'Example Notification',
+      message: 'This is an example of a persistent notification.'
     },
-    "last_changed": "2018-07-19T10:44:46.442972+00:00",
-    "last_updated": "2018-07-19T10:44:46.442972+00:00"
+    last_changed: '2018-07-19T10:44:46.442972+00:00',
+    last_updated: '2018-07-19T10:44:46.442972+00:00'
   },
-  "group.living_room": {
-    "entity_id": "group.living_room",
-    "state": "on",
-    "attributes": {
-      "entity_id": [
-        "light.ceiling_lights",
-        "switch.ac",
-        "input_select.living_room_preset",
-        "cover.living_room_window",
-        "media_player.living_room",
-        "scene.romantic_lights"
+  'group.living_room': {
+    entity_id: 'group.living_room',
+    state: 'on',
+    attributes: {
+      entity_id: [
+        'light.ceiling_lights',
+        'switch.ac',
+        'input_select.living_room_preset',
+        'cover.living_room_window',
+        'media_player.living_room',
+        'scene.romantic_lights'
       ],
-      "order": 8,
-      "friendly_name": "Living Room"
+      order: 8,
+      friendly_name: 'Living Room'
     },
-    "last_changed": "2018-07-19T10:44:46.453731+00:00",
-    "last_updated": "2018-07-19T10:44:46.453731+00:00",
-    "_entityDisplay": "Living Room"
+    last_changed: '2018-07-19T10:44:46.453731+00:00',
+    last_updated: '2018-07-19T10:44:46.453731+00:00',
+    _entityDisplay: 'Living Room'
   },
-  "group.bedroom": {
-    "entity_id": "group.bedroom",
-    "state": "on",
-    "attributes": {
-      "entity_id": [
-        "light.bed_light",
-        "switch.decorative_lights",
-        "media_player.bedroom",
-        "input_number.noise_allowance"
+  'group.bedroom': {
+    entity_id: 'group.bedroom',
+    state: 'on',
+    attributes: {
+      entity_id: [
+        'light.bed_light',
+        'switch.decorative_lights',
+        'media_player.bedroom',
+        'input_number.noise_allowance'
       ],
-      "order": 8,
-      "friendly_name": "Bedroom",
-      "assumed_state": true
+      order: 8,
+      friendly_name: 'Bedroom',
+      assumed_state: true
     },
-    "last_changed": "2018-07-19T11:33:15.736625+00:00",
-    "last_updated": "2018-07-19T11:33:15.736625+00:00",
-    "_entityDisplay": "Bedroom"
+    last_changed: '2018-07-19T11:33:15.736625+00:00',
+    last_updated: '2018-07-19T11:33:15.736625+00:00',
+    _entityDisplay: 'Bedroom'
   },
-  "group.kitchen": {
-    "entity_id": "group.kitchen",
-    "state": "on",
-    "attributes": {
-      "entity_id": [
-        "light.kitchen_lights",
-        "cover.kitchen_window",
-        "lock.kitchen_door"
+  'group.kitchen': {
+    entity_id: 'group.kitchen',
+    state: 'on',
+    attributes: {
+      entity_id: [
+        'light.kitchen_lights',
+        'cover.kitchen_window',
+        'lock.kitchen_door'
       ],
-      "order": 8,
-      "friendly_name": "Kitchen"
+      order: 8,
+      friendly_name: 'Kitchen'
     },
-    "last_changed": "2018-07-19T10:44:46.455730+00:00",
-    "last_updated": "2018-07-19T10:44:46.455730+00:00",
-    "_entityDisplay": "Kitchen"
+    last_changed: '2018-07-19T10:44:46.455730+00:00',
+    last_updated: '2018-07-19T10:44:46.455730+00:00',
+    _entityDisplay: 'Kitchen'
   },
-  "group.doors": {
-    "entity_id": "group.doors",
-    "state": "locked",
-    "attributes": {
-      "entity_id": [
-        "lock.front_door",
-        "lock.kitchen_door",
-        "garage_door.right_garage_door",
-        "garage_door.left_garage_door"
+  'group.doors': {
+    entity_id: 'group.doors',
+    state: 'locked',
+    attributes: {
+      entity_id: [
+        'lock.front_door',
+        'lock.kitchen_door',
+        'garage_door.right_garage_door',
+        'garage_door.left_garage_door'
       ],
-      "order": 8,
-      "friendly_name": "Doors"
+      order: 8,
+      friendly_name: 'Doors'
     },
-    "last_changed": "2018-07-19T10:44:46.509528+00:00",
-    "last_updated": "2018-07-19T10:44:46.509528+00:00",
-    "_entityDisplay": "Doors"
+    last_changed: '2018-07-19T10:44:46.509528+00:00',
+    last_updated: '2018-07-19T10:44:46.509528+00:00',
+    _entityDisplay: 'Doors'
   },
-  "group.automations": {
-    "entity_id": "group.automations",
-    "state": "off",
-    "attributes": {
-      "entity_id": [
-        "input_select.who_cooks",
-        "input_boolean.notify"
+  'group.automations': {
+    entity_id: 'group.automations',
+    state: 'off',
+    attributes: {
+      entity_id: [
+        'input_select.who_cooks',
+        'input_boolean.notify'
       ],
-      "order": 8,
-      "friendly_name": "Automations"
+      order: 8,
+      friendly_name: 'Automations'
     },
-    "last_changed": "2018-07-19T10:44:46.509900+00:00",
-    "last_updated": "2018-07-19T10:44:46.509900+00:00",
-    "_entityDisplay": "Automations"
+    last_changed: '2018-07-19T10:44:46.509900+00:00',
+    last_updated: '2018-07-19T10:44:46.509900+00:00',
+    _entityDisplay: 'Automations'
   },
-  "group.people": {
-    "entity_id": "group.people",
-    "state": "not_home",
-    "attributes": {
-      "entity_id": [
-        "device_tracker.demo_anne_therese",
-        "device_tracker.demo_home_boy",
-        "device_tracker.demo_paulus"
+  'group.people': {
+    entity_id: 'group.people',
+    state: 'not_home',
+    attributes: {
+      entity_id: [
+        'device_tracker.demo_anne_therese',
+        'device_tracker.demo_home_boy',
+        'device_tracker.demo_paulus'
       ],
-      "order": 8,
-      "friendly_name": "People"
+      order: 8,
+      friendly_name: 'People'
     },
-    "last_changed": "2018-07-19T10:44:46.510172+00:00",
-    "last_updated": "2018-07-19T10:44:46.510172+00:00",
-    "_entityDisplay": "People"
+    last_changed: '2018-07-19T10:44:46.510172+00:00',
+    last_updated: '2018-07-19T10:44:46.510172+00:00',
+    _entityDisplay: 'People'
   },
-  "group.downstairs": {
-    "entity_id": "group.downstairs",
-    "state": "on",
-    "attributes": {
-      "entity_id": [
-        "group.living_room",
-        "group.kitchen",
-        "scene.romantic_lights",
-        "cover.kitchen_window",
-        "cover.living_room_window",
-        "group.doors",
-        "climate.ecobee"
+  'group.downstairs': {
+    entity_id: 'group.downstairs',
+    state: 'on',
+    attributes: {
+      entity_id: [
+        'group.living_room',
+        'group.kitchen',
+        'scene.romantic_lights',
+        'cover.kitchen_window',
+        'cover.living_room_window',
+        'group.doors',
+        'climate.ecobee'
       ],
-      "order": 8,
-      "view": true,
-      "friendly_name": "Downstairs",
-      "hidden": true
+      order: 8,
+      view: true,
+      friendly_name: 'Downstairs',
+      hidden: true
     },
-    "last_changed": "2018-07-19T10:44:46.510448+00:00",
-    "last_updated": "2018-07-19T10:44:46.510448+00:00",
-    "_entityDisplay": "Downstairs"
+    last_changed: '2018-07-19T10:44:46.510448+00:00',
+    last_updated: '2018-07-19T10:44:46.510448+00:00',
+    _entityDisplay: 'Downstairs'
   },
-  "history_graph.recent_switches": {
-    "entity_id": "history_graph.recent_switches",
-    "state": "unknown",
-    "attributes": {
-      "hours_to_show": 1,
-      "refresh": 60,
-      "entity_id": [
-        "switch.ac",
-        "switch.decorative_lights"
+  'history_graph.recent_switches': {
+    entity_id: 'history_graph.recent_switches',
+    state: 'unknown',
+    attributes: {
+      hours_to_show: 1,
+      refresh: 60,
+      entity_id: [
+        'switch.ac',
+        'switch.decorative_lights'
       ],
-      "friendly_name": "Recent Switches"
+      friendly_name: 'Recent Switches'
     },
-    "last_changed": "2018-07-19T10:44:46.512351+00:00",
-    "last_updated": "2018-07-19T10:44:46.512351+00:00"
+    last_changed: '2018-07-19T10:44:46.512351+00:00',
+    last_updated: '2018-07-19T10:44:46.512351+00:00'
   },
-  "scene.switch_on_and_off": {
-    "entity_id": "scene.switch_on_and_off",
-    "state": "scening",
-    "attributes": {
-      "entity_id": [
-        "switch.ac",
-        "switch.decorative_lights"
+  'scene.switch_on_and_off': {
+    entity_id: 'scene.switch_on_and_off',
+    state: 'scening',
+    attributes: {
+      entity_id: [
+        'switch.ac',
+        'switch.decorative_lights'
       ],
-      "friendly_name": "Switch on and off"
+      friendly_name: 'Switch on and off'
     },
-    "last_changed": "2018-07-19T10:44:46.512674+00:00",
-    "last_updated": "2018-07-19T10:44:46.512674+00:00",
-    "_entityDisplay": "Switch on and off"
+    last_changed: '2018-07-19T10:44:46.512674+00:00',
+    last_updated: '2018-07-19T10:44:46.512674+00:00',
+    _entityDisplay: 'Switch on and off'
   },
-  "scene.romantic_lights": {
-    "entity_id": "scene.romantic_lights",
-    "state": "scening",
-    "attributes": {
-      "entity_id": [
-        "light.bed_light",
-        "light.ceiling_lights"
+  'scene.romantic_lights': {
+    entity_id: 'scene.romantic_lights',
+    state: 'scening',
+    attributes: {
+      entity_id: [
+        'light.bed_light',
+        'light.ceiling_lights'
       ],
-      "friendly_name": "Romantic lights"
+      friendly_name: 'Romantic lights'
     },
-    "last_changed": "2018-07-19T10:44:46.512985+00:00",
-    "last_updated": "2018-07-19T10:44:46.512985+00:00",
-    "_entityDisplay": "Romantic lights"
+    last_changed: '2018-07-19T10:44:46.512985+00:00',
+    last_updated: '2018-07-19T10:44:46.512985+00:00',
+    _entityDisplay: 'Romantic lights'
   },
-  "configurator.philips_hue": {
-    "entity_id": "configurator.philips_hue",
-    "state": "configure",
-    "attributes": {
-      "configure_id": "4596919600-1",
-      "fields": [
+  'configurator.philips_hue': {
+    entity_id: 'configurator.philips_hue',
+    state: 'configure',
+    attributes: {
+      configure_id: '4596919600-1',
+      fields: [
         {
-          "id": "username",
-          "name": "Username"
+          id: 'username',
+          name: 'Username'
         }
       ],
-      "friendly_name": "Philips Hue",
-      "entity_picture": null,
-      "description": "Press the button on the bridge to register Philips Hue with Home Assistant.\n\n![Description image](/static/images/config_philips_hue.jpg)",
-      "submit_caption": "I have pressed the button"
+      friendly_name: 'Philips Hue',
+      entity_picture: null,
+      description: 'Press the button on the bridge to register Philips Hue with Home Assistant.\n\n![Description image](/static/images/config_philips_hue.jpg)',
+      submit_caption: 'I have pressed the button'
     },
-    "last_changed": "2018-07-19T10:44:46.515160+00:00",
-    "last_updated": "2018-07-19T10:44:46.515160+00:00",
-    "_entityDisplay": "Philips Hue"
+    last_changed: '2018-07-19T10:44:46.515160+00:00',
+    last_updated: '2018-07-19T10:44:46.515160+00:00',
+    _entityDisplay: 'Philips Hue'
   }
-}
+};

--- a/gallery/src/data/hass.js
+++ b/gallery/src/data/hass.js
@@ -1,0 +1,34 @@
+export default class FakeHass {
+  constructor() {
+    this.states = {};
+    this._wsCommands = {};
+  }
+
+  addWSCommand(command, callback) {
+    this._wsCommands[command] = callback;
+  }
+
+  async callService(domain, service, serviceData) {
+    console.log('callService', { domain, service, serviceData });
+    return Promise.resolve();
+  }
+
+  async callWS(msg) {
+    const callback = this._wsCommands[msg.type];
+    return callback ? callback(msg) : Promise.reject({
+      code: 'command_not_mocked',
+      message: 'This command is not implemented in the gallery.',
+    });
+  }
+
+  async sendWS(msg) {
+    const callback = this._wsCommands[msg.type];
+
+    if (callback) {
+      callback(msg);
+    } else {
+      console.error(`Unknown command: ${msg.type}`)
+    }
+    console.log('sendWS', msg);
+  }
+}

--- a/gallery/src/data/hass.js
+++ b/gallery/src/data/hass.js
@@ -27,7 +27,7 @@ export default class FakeHass {
     if (callback) {
       callback(msg);
     } else {
-      console.error(`Unknown command: ${msg.type}`)
+      console.error(`Unknown command: ${msg.type}`);
     }
     console.log('sendWS', msg);
   }

--- a/gallery/src/demos/demo-hui-picture-glance-card.js
+++ b/gallery/src/demos/demo-hui-picture-glance-card.js
@@ -1,0 +1,76 @@
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import '../../../src/panels/lovelace/cards/hui-picture-glance-card.js';
+
+import HomeAssistant from '../data/hass.js';
+import demoStates from '../data/demo_dump.js';
+
+const CONFIGS = [
+  {
+    type: 'picture-glance',
+    image: 'https://images.pexels.com/photos/276724/pexels-photo-276724.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=240&w=495',
+    title: 'Picture glance',
+    entities: [
+      'switch.decorative_lights',
+      'light.ceiling_lights',
+      'binary_sensor.movement_backyard',
+      'binary_sensor.basement_floor_wet',
+    ]
+  },
+  {
+    type: 'picture-glance',
+    image: 'https://images.pexels.com/photos/276724/pexels-photo-276724.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=240&w=495',
+    entities: [
+      'switch.decorative_lights',
+      'light.ceiling_lights',
+      'binary_sensor.movement_backyard',
+      'binary_sensor.basement_floor_wet',
+    ]
+  },
+  {
+    type: 'picture-glance',
+    image: 'https://images.pexels.com/photos/276724/pexels-photo-276724.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=240&w=495',
+    title: 'Picture glance',
+    entities: [
+      'switch.decorative_lights',
+      'light.ceiling_lights',
+    ]
+  },
+]
+
+class DemoPicGlance extends PolymerElement {
+  static get template() {
+    return html`
+      <style>
+        #root {
+        }
+        hui-picture-glance-card {
+          width: 400px;
+          display: inline-block;
+          margin-left: 20px;
+          margin-top: 20px;
+        }
+      </style>
+      <div id='root'>
+      </div>
+    `;
+  }
+
+  ready() {
+    super.ready();
+
+    const root = this.$.root;
+    const hass = new HomeAssistant();
+    hass.states = demoStates;
+    console.log(demoStates);
+    CONFIGS.forEach(config => {
+      const el = document.createElement('hui-picture-glance-card');
+      el.setConfig(config);
+      el.hass = hass;
+      root.appendChild(el);
+    });
+  }
+}
+
+customElements.define('demo-hui-picture-glance-card', DemoPicGlance);

--- a/gallery/src/demos/demo-hui-picture-glance-card.js
+++ b/gallery/src/demos/demo-hui-picture-glance-card.js
@@ -37,7 +37,7 @@ const CONFIGS = [
       'light.ceiling_lights',
     ]
   },
-]
+];
 
 class DemoPicGlance extends PolymerElement {
   static get template() {
@@ -64,7 +64,7 @@ class DemoPicGlance extends PolymerElement {
     const hass = new HomeAssistant();
     hass.states = demoStates;
     console.log(demoStates);
-    CONFIGS.forEach(config => {
+    CONFIGS.forEach((config) => {
       const el = document.createElement('hui-picture-glance-card');
       el.setConfig(config);
       el.hass = hass;

--- a/gallery/src/entrypoint.js
+++ b/gallery/src/entrypoint.js
@@ -1,0 +1,17 @@
+import '@polymer/paper-styles/typography.js';
+
+import '../../src/resources/hass-icons.js';
+import '../../src/resources/ha-style.js';
+// We don't have static mapped yet
+// import '../../src/resources/roboto.js';
+import '../../src/components/ha-iconset-svg.js';
+
+import './ha-gallery.js';
+
+// Temp roboto fix
+const link = document.createElement('link');
+link.href = "https://fonts.googleapis.com/css?family=Roboto";
+link.rel = "stylesheet";
+document.head.appendChild(link);
+
+document.body.appendChild(document.createElement('ha-gallery'));

--- a/gallery/src/entrypoint.js
+++ b/gallery/src/entrypoint.js
@@ -10,8 +10,8 @@ import './ha-gallery.js';
 
 // Temp roboto fix
 const link = document.createElement('link');
-link.href = "https://fonts.googleapis.com/css?family=Roboto";
-link.rel = "stylesheet";
+link.href = 'https://fonts.googleapis.com/css?family=Roboto';
+link.rel = 'stylesheet';
 document.head.appendChild(link);
 
 document.body.appendChild(document.createElement('ha-gallery'));

--- a/gallery/src/ha-gallery.js
+++ b/gallery/src/ha-gallery.js
@@ -1,0 +1,62 @@
+import '@polymer/polymer/lib/elements/dom-if.js';
+import '@polymer/polymer/lib/elements/dom-repeat.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+const demos = require.context("./demos", true, /^(.*\.(js$))[^.]*$/im);
+
+const fixPath = path => path.substr(2, path.length - 5);
+
+class HaGallery extends PolymerElement {
+  static get template() {
+    return html`
+      <div id='demo'></div>
+      <template is='dom-if' if='[[!_demo]]'>
+        <ul>
+          <template is='dom-repeat' items='[[_demos]]'>
+            <li><a href='#[[item]]'>{{ item }}</a></li>
+          </template>
+        </ul>
+      </template>
+    `;
+  }
+
+  static get properties() {
+    return {
+      _demo: {
+        type: Object,
+        value: document.location.hash.substr(1),
+        observer: '_demoChanged',
+      },
+      _demos: {
+        type: Array,
+        value: demos.keys().map(fixPath)
+      }
+    }
+  }
+
+  ready() {
+    super.ready();
+
+    this.addEventListener('hass-more-info', ev => {
+      if (ev.detail.entityId) alert(`Showing more info for ${ev.detail.entityId}`);
+    });
+
+    window.addEventListener(
+      'hashchange', ev => { this._demo = document.location.hash.substr(1); });
+  }
+
+  _demoChanged(demo) {
+    const root = this.$.demo;
+
+    while (root.lastChild) root.removeChild(root.lastChild);
+
+    if (demo) {
+      demos(`./${demo}.js`);
+      const el = document.createElement(demo);
+      root.appendChild(el);
+    }
+  }
+}
+
+customElements.define('ha-gallery', HaGallery);

--- a/gallery/src/ha-gallery.js
+++ b/gallery/src/ha-gallery.js
@@ -3,7 +3,7 @@ import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
-const demos = require.context("./demos", true, /^(.*\.(js$))[^.]*$/im);
+const demos = require.context('./demos', true, /^(.*\.(js$))[^.]*$/im);
 
 const fixPath = path => path.substr(2, path.length - 5);
 
@@ -32,18 +32,17 @@ class HaGallery extends PolymerElement {
         type: Array,
         value: demos.keys().map(fixPath)
       }
-    }
+    };
   }
 
   ready() {
     super.ready();
 
-    this.addEventListener('hass-more-info', ev => {
+    this.addEventListener('hass-more-info', (ev) => {
       if (ev.detail.entityId) alert(`Showing more info for ${ev.detail.entityId}`);
     });
 
-    window.addEventListener(
-      'hashchange', ev => { this._demo = document.location.hash.substr(1); });
+    window.addEventListener('hashchange', () => { this._demo = document.location.hash.substr(1); });
   }
 
   _demoChanged(demo) {

--- a/gallery/webpack.config.js
+++ b/gallery/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-const isProd = process.env.NODE_ENV === 'production'
+const isProd = process.env.NODE_ENV === 'production';
 const chunkFilename = isProd ?
   'chunk.[chunkhash].js' : '[name].chunk.js';
 const buildPath = path.resolve(__dirname, 'dist');
@@ -23,7 +23,7 @@ module.exports = {
           options: {
             plugins: [
               // Only support the syntax, Webpack will handle it.
-              "syntax-dynamic-import",
+              'syntax-dynamic-import',
               [
                 'transform-react-jsx',
                 {

--- a/gallery/webpack.config.js
+++ b/gallery/webpack.config.js
@@ -1,0 +1,81 @@
+const path = require('path');
+const webpack = require('webpack');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const CompressionPlugin = require("compression-webpack-plugin");
+
+const isProd = process.env.NODE_ENV === 'production'
+const chunkFilename = isProd ?
+  'chunk.[chunkhash].js' : '[name].chunk.js';
+const buildPath = path.resolve(__dirname, 'dist');
+const publicPath = isProd ? './' : 'http://localhost:8080/';
+
+module.exports = {
+  mode: isProd ? 'production' : 'development',
+  // Disabled in prod while we make Home Assistant able to serve the right files.
+  // Was source-map
+  devtool: isProd ? 'none' : 'inline-source-map',
+  entry: './src/entrypoint.js',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: [
+              // Only support the syntax, Webpack will handle it.
+              "syntax-dynamic-import",
+              [
+                'transform-react-jsx',
+                {
+                  pragma: 'h'
+                }
+              ],
+
+            ],
+          },
+        },
+      },
+      {
+        test: /\.(html)$/,
+        use: {
+          loader: 'html-loader',
+          options: {
+            exportAsEs6Default: true,
+          }
+        }
+      },
+    ]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      __DEV__: JSON.stringify(!isProd),
+    }),
+    isProd && new UglifyJsPlugin({
+      extractComments: true,
+      sourceMap: true,
+      uglifyOptions: {
+        // Disabling because it broke output
+        mangle: false,
+      }
+    }),
+    isProd && new CompressionPlugin({
+      cache: true,
+      exclude: [
+        /\.js\.map$/,
+        /\.LICENSE$/,
+        /\.py$/,
+        /\.txt$/,
+      ]
+    }),
+  ].filter(Boolean),
+  output: {
+    filename: '[name].js',
+    chunkFilename: chunkFilename,
+    path: buildPath,
+    publicPath,
+  },
+  devServer: {
+    contentBase: './public',
+  }
+};

--- a/gallery/webpack.config.js
+++ b/gallery/webpack.config.js
@@ -1,7 +1,6 @@
 const path = require('path');
-const webpack = require('webpack');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-const CompressionPlugin = require("compression-webpack-plugin");
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const isProd = process.env.NODE_ENV === 'production'
 const chunkFilename = isProd ?
@@ -48,9 +47,7 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.DefinePlugin({
-      __DEV__: JSON.stringify(!isProd),
-    }),
+    new CopyWebpackPlugin(['public']),
     isProd && new UglifyJsPlugin({
       extractComments: true,
       sourceMap: true,
@@ -58,15 +55,6 @@ module.exports = {
         // Disabling because it broke output
         mangle: false,
       }
-    }),
-    isProd && new CompressionPlugin({
-      cache: true,
-      exclude: [
-        /\.js\.map$/,
-        /\.LICENSE$/,
-        /\.py$/,
-        /\.txt$/,
-      ]
     }),
   ].filter(Boolean),
   output: {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "script/build_frontend",
-    "lint": "eslint src hassio/src test-mocha && polymer lint",
+    "lint": "eslint src hassio/src gallery/src test-mocha && polymer lint",
     "mocha": "node_modules/.bin/mocha --opts test-mocha/mocha.opts",
     "test": "npm run lint && npm run mocha"
   },

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "web-component-tester": "^6.7.0",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",
+    "webpack-dev-server": "^3.1.4",
     "workbox-webpack-plugin": "^3.3.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,6 +2035,10 @@ ansi-gray@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
+ansi-html@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
+
 ansi-red@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ansi-red/-/ansi-red-0.1.1.tgz#8c638f9d1080800a353c9c28c8a81ca4705d946c"
@@ -2210,6 +2214,10 @@ array-find@^1.0.0:
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+
+array-flatten@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
 
 array-includes@^3.0.3:
   version "3.0.3"
@@ -3163,6 +3171,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+batch@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -3224,6 +3236,17 @@ body-parser@1.18.2, body-parser@^1.17.2:
     qs "6.5.1"
     raw-body "2.3.2"
     type-is "~1.6.15"
+
+bonjour@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
+  dependencies:
+    array-flatten "^2.1.0"
+    deep-equal "^1.0.1"
+    dns-equal "^1.0.0"
+    dns-txt "^2.0.2"
+    multicast-dns "^6.0.1"
+    multicast-dns-service-types "^1.1.0"
 
 boom@2.x.x:
   version "2.10.1"
@@ -3445,6 +3468,10 @@ buffer-fill@^0.1.0:
 buffer-from@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
+buffer-indexof@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -3728,6 +3755,25 @@ chokidar@^1.7.0:
     readdirp "^2.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
+
+chokidar@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.0"
+    braces "^2.3.0"
+    glob-parent "^3.1.0"
+    inherits "^2.0.1"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    lodash.debounce "^4.0.8"
+    normalize-path "^2.1.1"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.0.0"
+    upath "^1.0.5"
+  optionalDependencies:
+    fsevents "^1.2.2"
 
 chokidar@^2.0.2:
   version "2.0.3"
@@ -4026,6 +4072,12 @@ compressible@~2.0.13:
   dependencies:
     mime-db ">= 1.33.0 < 2"
 
+compressible@~2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.14.tgz#326c5f507fbb055f54116782b969a81b67a29da7"
+  dependencies:
+    mime-db ">= 1.34.0 < 2"
+
 compression-webpack-plugin@^1.1.11:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-1.1.11.tgz#8384c7a6ead1d2e2efb190bdfcdcf35878ed8266"
@@ -4035,6 +4087,18 @@ compression-webpack-plugin@^1.1.11:
     neo-async "^2.5.0"
     serialize-javascript "^1.4.0"
     webpack-sources "^1.0.1"
+
+compression@^1.5.2:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db"
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.14"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
 
 compression@^1.6.2:
   version "1.7.2"
@@ -4101,6 +4165,10 @@ configstore@^3.0.0:
     unique-string "^1.0.0"
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
+
+connect-history-api-fallback@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -4334,6 +4402,12 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dargs@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-5.1.0.tgz#ec7ea50c78564cd36c9d5ec18f66329fade27829"
@@ -4367,7 +4441,7 @@ dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
-debug@2, debug@2.6.9, debug@^2.0.0, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4, debug@~2.6.6, debug@~2.6.9:
+debug@2, debug@2.6.9, debug@^2.0.0, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4, debug@~2.6.6, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -4422,6 +4496,10 @@ deep-eql@^3.0.0:
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
   dependencies:
     type-detect "^4.0.0"
+
+deep-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-extend@^0.4.0, deep-extend@~0.4.1:
   version "0.4.2"
@@ -4598,6 +4676,23 @@ dir-glob@^2.0.0:
   dependencies:
     arrify "^1.0.1"
     path-type "^3.0.0"
+
+dns-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
+
+dns-packet@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
+  dependencies:
+    ip "^1.1.0"
+    safe-buffer "^5.0.1"
+
+dns-txt@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dns-txt/-/dns-txt-2.0.2.tgz#b91d806f5d27188e4ab3e7d107d881a1cc4642b6"
+  dependencies:
+    buffer-indexof "^1.0.0"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -4887,6 +4982,22 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.45"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.45.tgz#0bfdf7b473da5919d5adf3bd25ceb754fccc3653"
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.1"
+    next-tick "1"
+
+es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
 es6-object-assign@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
@@ -4898,6 +5009,13 @@ es6-promise@^2.1.1:
 es6-promise@^4.0.5:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 es6-templates@^0.2.3:
   version "0.2.3"
@@ -5104,6 +5222,12 @@ events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
+eventsource@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232"
+  dependencies:
+    original ">=0.0.5"
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -5198,7 +5322,7 @@ express@^4.15.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^4.8.5:
+express@^4.16.2, express@^4.8.5:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
   dependencies:
@@ -5364,6 +5488,18 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
 fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
+
+faye-websocket@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
+  dependencies:
+    websocket-driver ">=0.5.1"
+
+faye-websocket@~0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
+  dependencies:
+    websocket-driver ">=0.5.1"
 
 fbjs@^0.8.16:
   version "0.8.16"
@@ -5712,7 +5848,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0:
+fsevents@^1.0.0, fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
@@ -6399,6 +6535,10 @@ has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#a045ab383d7b4b2012a00148ab0aa5f290044d4d"
@@ -6534,6 +6674,10 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+html-entities@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
+
 html-loader@^0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.5.5.tgz#6356dbeb0c49756d8ebd5ca327f16ff06ab5faea"
@@ -6619,6 +6763,10 @@ http-errors@~1.6.2:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-parser-js@>=0.4.0:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.13.tgz#3bd6d6fde6e3172c9334c3b33b6c193d80fe1137"
+
 http-proxy-middleware@^0.17.2:
   version "0.17.4"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz#642e8848851d66f09d4f124912846dbaeb41b833"
@@ -6627,6 +6775,15 @@ http-proxy-middleware@^0.17.2:
     is-glob "^3.1.0"
     lodash "^4.17.2"
     micromatch "^2.3.11"
+
+http-proxy-middleware@~0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz#0987e6bb5a5606e5a69168d8f967a87f15dd8aab"
+  dependencies:
+    http-proxy "^1.16.2"
+    is-glob "^4.0.0"
+    lodash "^4.17.5"
+    micromatch "^3.1.9"
 
 http-proxy@^1.16.2:
   version "1.17.0"
@@ -6820,6 +6977,12 @@ inquirer@^6.0.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+internal-ip@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-1.2.0.tgz#ae9fbf93b984878785d50a8de1b356956058cf5c"
+  dependencies:
+    meow "^3.3.0"
+
 interpret@^1.0.0, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
@@ -6847,6 +7010,10 @@ invariant@^2.1.0, invariant@^2.2.0, invariant@^2.2.2:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+ip@^1.1.0, ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
 ipaddr.js@1.6.0:
   version "1.6.0"
@@ -7175,6 +7342,10 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -7298,7 +7469,7 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json3@3.3.2:
+json3@3.3.2, json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
@@ -7352,6 +7523,10 @@ jsx-ast-utils@^2.0.1:
 just-extend@^1.1.27:
   version "1.1.27"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
+killable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
 
 kind-of@^1.1.0:
   version "1.1.0"
@@ -7664,6 +7839,10 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -7872,6 +8051,17 @@ log-symbols@^2.1.0:
   dependencies:
     chalk "^2.0.1"
 
+loglevel@^1.4.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
+
+loglevelnext@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.5.tgz#36fc4f5996d6640f539ff203ba819641680d75a2"
+  dependencies:
+    es6-symbol "^3.1.1"
+    object.assign "^4.1.0"
+
 lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
@@ -7902,7 +8092,7 @@ loose-envify@^1.0.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
-loud-rejection@^1.0.0:
+loud-rejection@^1.0.0, loud-rejection@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
   dependencies:
@@ -8107,7 +8297,7 @@ micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
+micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -8135,6 +8325,10 @@ miller-rabin@^4.0.0:
 "mime-db@>= 1.33.0 < 2", mime-db@^1.28.0, mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+
+"mime-db@>= 1.34.0 < 2":
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
 
 mime-db@~1.30.0:
   version "1.30.0"
@@ -8167,6 +8361,10 @@ mime@1.4.1:
 mime@^1.2.11, mime@^1.3.4:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+
+mime@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -8267,7 +8465,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -8357,6 +8555,17 @@ multer@^1.3.0:
     on-finished "^2.3.0"
     type-is "^1.6.4"
     xtend "^4.0.0"
+
+multicast-dns-service-types@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
+
+multicast-dns@^6.0.1:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.3.tgz#a0ec7bd9055c4282f790c3c82f4e28db3b31b229"
+  dependencies:
+    dns-packet "^1.3.1"
+    thunky "^1.0.2"
 
 multimatch@^2.0.0:
   version "2.1.0"
@@ -8455,6 +8664,10 @@ netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
+next-tick@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+
 nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
@@ -8481,6 +8694,10 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-forge@0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
 
 "node-libs-browser@^1.0.0 || ^2.0.0", node-libs-browser@^2.0.0:
   version "2.1.0"
@@ -8633,6 +8850,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.11:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
@@ -8642,6 +8863,15 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.defaults@^1.1.0:
   version "1.1.0"
@@ -8713,6 +8943,12 @@ opn@^3.0.2:
   dependencies:
     object-assign "^4.0.1"
 
+opn@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.3.0.tgz#64871565c863875f052cfdf53d3e3cb5adb53b1c"
+  dependencies:
+    is-wsl "^1.1.0"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -8749,6 +8985,12 @@ ordered-read-streams@^0.3.0:
   dependencies:
     is-stream "^1.0.1"
     readable-stream "^2.0.1"
+
+original@>=0.0.5:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/original/-/original-1.0.1.tgz#b0a53ff42ba997a8c9cd1fb5daaeb42b9d693190"
+  dependencies:
+    url-parse "~1.4.0"
 
 os-browserify@^0.3.0:
   version "0.3.0"
@@ -9471,6 +9713,14 @@ polyserve@^0.27.11:
     send "^0.14.1"
     spdy "^3.3.3"
 
+portfinder@^1.0.9:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
+  dependencies:
+    async "^1.5.2"
+    debug "^2.2.0"
+    mkdirp "0.5.x"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -9692,6 +9942,10 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+querystringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
+
 randomatic@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"
@@ -9713,13 +9967,13 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
+range-parser@^1.0.3, range-parser@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+
 range-parser@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.0.3.tgz#6872823535c692e2c2a0103826afd82c2e0ff175"
-
-range-parser@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 raw-body@2.3.2:
   version "2.3.2"
@@ -10297,7 +10551,7 @@ safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -10365,6 +10619,12 @@ selenium-standalone@^6.7.0:
     urijs "^1.18.4"
     which "^1.2.12"
     yauzl "^2.5.0"
+
+selfsigned@^1.9.1:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.3.tgz#d628ecf9e3735f84e8bafba936b3cf85bea43823"
+  dependencies:
+    node-forge "0.7.5"
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -10466,6 +10726,18 @@ sequencify@~0.0.7:
 serialize-javascript@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"
+
+serve-index@^1.7.2:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
+  dependencies:
+    accepts "~1.3.4"
+    batch "0.6.1"
+    debug "2.6.9"
+    escape-html "~1.0.3"
+    http-errors "~1.6.2"
+    mime-types "~2.1.17"
+    parseurl "~1.3.2"
 
 serve-static@1.13.1:
   version "1.13.1"
@@ -10710,6 +10982,24 @@ socket.io@^2.0.3:
     socket.io-client "2.0.4"
     socket.io-parser "~3.1.1"
 
+sockjs-client@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.4.tgz#5babe386b775e4cf14e7520911452654016c8b12"
+  dependencies:
+    debug "^2.6.6"
+    eventsource "0.1.6"
+    faye-websocket "~0.11.0"
+    inherits "^2.0.1"
+    json3 "^3.3.2"
+    url-parse "^1.1.8"
+
+sockjs@0.3.19:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.19.tgz#d976bbe800af7bd20ae08598d582393508993c0d"
+  dependencies:
+    faye-websocket "^0.10.0"
+    uuid "^3.0.1"
+
 sort-keys-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sort-keys-length/-/sort-keys-length-1.0.1.tgz#9cb6f4f4e9e48155a6aa0671edd336ff1479a188"
@@ -10805,7 +11095,7 @@ spdy-transport@^2.0.18:
     safe-buffer "^5.0.1"
     wbuf "^1.7.2"
 
-spdy@^3.3.3:
+spdy@^3.3.3, spdy@^3.4.1:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/spdy/-/spdy-3.4.7.tgz#42ff41ece5cc0f99a3a6c28aabb73f5c3b03acbc"
   dependencies:
@@ -11056,7 +11346,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-supports-color@3.1.2, supports-color@5.4.0, supports-color@^0.2.0, supports-color@^2.0.0, supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@3.1.2, supports-color@5.4.0, supports-color@^0.2.0, supports-color@^2.0.0, supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -11277,6 +11567,10 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
 through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+thunky@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.2.tgz#a862e018e3fb1ea2ec3fce5d55605cf57f247371"
 
 tildify@^1.0.0:
   version "1.2.0"
@@ -11651,6 +11945,10 @@ upath@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.5.tgz#02cab9ecebe95bbec6d5fc2566325725ab6d1a73"
 
+upath@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
+
 update-notifier@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-1.0.3.tgz#8f92c515482bd6831b7c93013e70f87552c7cf5a"
@@ -11717,11 +12015,22 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
+url-join@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
+
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
+
+url-parse@^1.1.8, url-parse@~1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.1.tgz#4dec9dad3dc8585f862fed461d2e19bbf623df30"
+  dependencies:
+    querystringify "^2.0.0"
+    requires-port "^1.0.0"
 
 url-to-options@^1.0.1:
   version "1.0.1"
@@ -11765,6 +12074,10 @@ uuid@^2.0.1:
 uuid@^3.0.0, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.0.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 uws@~0.14.4:
   version "0.14.5"
@@ -12070,6 +12383,60 @@ webpack-cli@^3.0.8:
     v8-compile-cache "^2.0.0"
     yargs "^11.1.0"
 
+webpack-dev-middleware@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz#8b32aa43da9ae79368c1bf1183f2b6cf5e1f39ed"
+  dependencies:
+    loud-rejection "^1.6.0"
+    memory-fs "~0.4.1"
+    mime "^2.1.0"
+    path-is-absolute "^1.0.0"
+    range-parser "^1.0.3"
+    url-join "^4.0.0"
+    webpack-log "^1.0.1"
+
+webpack-dev-server@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.1.4.tgz#9a08d13c4addd1e3b6d8ace116e86715094ad5b4"
+  dependencies:
+    ansi-html "0.0.7"
+    array-includes "^3.0.3"
+    bonjour "^3.5.0"
+    chokidar "^2.0.0"
+    compression "^1.5.2"
+    connect-history-api-fallback "^1.3.0"
+    debug "^3.1.0"
+    del "^3.0.0"
+    express "^4.16.2"
+    html-entities "^1.2.0"
+    http-proxy-middleware "~0.18.0"
+    import-local "^1.0.0"
+    internal-ip "1.2.0"
+    ip "^1.1.5"
+    killable "^1.0.0"
+    loglevel "^1.4.1"
+    opn "^5.1.0"
+    portfinder "^1.0.9"
+    selfsigned "^1.9.1"
+    serve-index "^1.7.2"
+    sockjs "0.3.19"
+    sockjs-client "1.1.4"
+    spdy "^3.4.1"
+    strip-ansi "^3.0.0"
+    supports-color "^5.1.0"
+    webpack-dev-middleware "3.1.3"
+    webpack-log "^1.1.2"
+    yargs "11.0.0"
+
+webpack-log@^1.0.1, webpack-log@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
+  dependencies:
+    chalk "^2.1.0"
+    log-symbols "^2.1.0"
+    loglevelnext "^1.0.1"
+    uuid "^3.1.0"
+
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
@@ -12106,6 +12473,17 @@ webpack@^4.12.0:
     uglifyjs-webpack-plugin "^1.2.4"
     watchpack "^1.5.0"
     webpack-sources "^1.0.1"
+
+websocket-driver@>=0.5.1:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"
+  dependencies:
+    http-parser-js ">=0.4.0"
+    websocket-extensions ">=0.1.1"
+
+websocket-extensions@>=0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
@@ -12406,6 +12784,23 @@ yargs-parser@^9.0.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
   dependencies:
     camelcase "^4.1.0"
+
+yargs@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^11.1.0:
   version "11.1.0"


### PR DESCRIPTION
Time to get out of the dark ages.

This is a gallery that allows us to develop all variations of cards at once. Comes preloaded with the demo component states.

Once checked out, run `yarn` once to install new dependencies.

```
cd gallery
script/develop_gallery
```

Now open http://localhost:8080/#demo-hui-picture-glance-card

![image](https://user-images.githubusercontent.com/1444314/42943815-2b6a69f4-8b64-11e8-93e4-b50b93d44c0c.png)

Pick a demo and…

![image](https://user-images.githubusercontent.com/1444314/42943829-34d970b6-8b64-11e8-8f33-8cc9f4178875.png)


Currently tested on Chrome only. Just wanted to get something working so we can add all different permutations of cards. Makes talking about design very easy.

Will also add Netlify so that we can generate a gallery for EACH PR.