### PR TITLE
Add custom elements to picture-elements.

### DIFF
--- a/src/panels/lovelace/common/create-hui-element.js
+++ b/src/panels/lovelace/common/create-hui-element.js
@@ -5,8 +5,10 @@ import '../elements/hui-state-badge-element.js';
 import '../elements/hui-state-icon-element.js';
 import '../elements/hui-state-label-element.js';
 
+import fireEvent from '../../../common/dom/fire_event.js';
 import createErrorCardConfig from './create-error-card-config.js';
 
+const CUSTOM_TYPE_PREFIX = 'custom:';
 const ELEMENT_TYPES = new Set([
   'icon',
   'image',
@@ -36,6 +38,21 @@ function _createErrorElement(error, config) {
 export default function createHuiElement(config) {
   if (!config || typeof config !== 'object' || !config.type) {
     return _createErrorElement('No element type configured.', config);
+  }
+
+  if (config.type.startsWith(CUSTOM_TYPE_PREFIX)) {
+    const tag = config.type.substr(CUSTOM_TYPE_PREFIX.length);
+
+    if (customElements.get(tag)) {
+      return _createElement(tag, config);
+    }
+
+    const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);
+
+    customElements.whenDefined(tag)
+      .then(() => fireEvent(element, 'rebuild-view'));
+
+    return element;
   }
 
   if (!ELEMENT_TYPES.has(config.type)) {


### PR DESCRIPTION
Allows adding custom elements to picture-elements cards using `custom:` prefix similar to custom cards.

```yaml
elements:
  - type: custom:circle-sensor-element
    entity: sensor.outside_temperature
    style:
      top: 50%
      left: 50%
```

![screen shot 2018-07-19 at 6 03 09 pm](https://user-images.githubusercontent.com/11150179/42977810-2f0ff8a2-8b7e-11e8-9228-8835ec303785.png)
