### PR TITLE
Only send auth/current_user if new auth is enabled

### DIFF
--- a/src/entrypoints/app.js
+++ b/src/entrypoints/app.js
@@ -333,9 +333,12 @@ class HomeAssistant extends LocalizeMixin(PolymerElement) {
       );
     });
 
-    this.hass.callWS({
-      type: 'auth/current_user',
-    }).then(user => this._updateHass({ user }), () => {});
+    // only for new auth
+    if (conn.options.accessToken) {
+      this.hass.callWS({
+        type: 'auth/current_user',
+      }).then(user => this._updateHass({ user }), () => {});
+    }
 
     conn.subscribeEvents((event) => {
       this._updateHass({ themes: event.data });


### PR DESCRIPTION
Fix the issue reported in dev channel.

```
2018-07-19 21:56:38 DEBUG (MainThread) [homeassistant.components.websocket_api] WS 140119349557400: Received {'type': 'auth/current_user', 'id': 12}
2018-07-19 21:56:38 ERROR (MainThread) [homeassistant.components.websocket_api] WS 140119349557400: Received invalid command: auth/current_user
```
auth/current_user command was registered by `auth` component, we should only sent it to backend if new auth is enabled.