### PR TITLE
ha-cover-controls: handle opening/closing states

### DIFF
--- a/src/components/ha-cover-controls.js
+++ b/src/components/ha-cover-controls.js
@@ -43,11 +43,11 @@ class HaCoverControls extends PolymerElement {
   }
   computeOpenDisabled(stateObj, entityObj) {
     var assumedState = stateObj.attributes.assumed_state === true;
-    return (entityObj.isFullyOpen || entity.isOpening) && !assumedState;
+    return (entityObj.isFullyOpen || entityObj.isOpening) && !assumedState;
   }
   computeClosedDisabled(stateObj, entityObj) {
     var assumedState = (stateObj.attributes.assumed_state === true);
-    return (entityObj.isFullyClosed || entity.isClosing) && !assumedState;
+    return (entityObj.isFullyClosed || entityObj.isClosing) && !assumedState;
   }
   onOpenTap(ev) {
     ev.stopPropagation();

--- a/src/components/ha-cover-controls.js
+++ b/src/components/ha-cover-controls.js
@@ -43,11 +43,11 @@ class HaCoverControls extends PolymerElement {
   }
   computeOpenDisabled(stateObj, entityObj) {
     var assumedState = stateObj.attributes.assumed_state === true;
-    return entityObj.isFullyOpen && !assumedState;
+    return (entityObj.isFullyOpen || entity.isOpening) && !assumedState;
   }
   computeClosedDisabled(stateObj, entityObj) {
     var assumedState = (stateObj.attributes.assumed_state === true);
-    return entityObj.isFullyClosed && !assumedState;
+    return (entityObj.isFullyClosed || entity.isClosing) && !assumedState;
   }
   onOpenTap(ev) {
     ev.stopPropagation();

--- a/src/util/cover-model.js
+++ b/src/util/cover-model.js
@@ -30,11 +30,11 @@ export default class CoverEntity {
   }
 
   get isOpening() {
-    return this.stateObj.state === 'opening'
+    return this.stateObj.state === 'opening';
   }
 
   get isClosing() {
-    return this.stateObj.state === 'closing'
+    return this.stateObj.state === 'closing';
   }
 
   /* eslint-disable no-bitwise */

--- a/src/util/cover-model.js
+++ b/src/util/cover-model.js
@@ -29,6 +29,14 @@ export default class CoverEntity {
     return this._attr.current_tilt_position === 0;
   }
 
+  get isOpening() {
+    return this.stateObj.state === 'opening'
+  }
+
+  get isClosing() {
+    return this.stateObj.state === 'closing'
+  }
+
   /* eslint-disable no-bitwise */
 
   get supportsOpen() {


### PR DESCRIPTION
In addition to [STATE_OPEN](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/const.py#L181), [STATE_CLOSED](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/const.py#L183), there is also [STATE_CLOSING](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/const.py#L184), [STATE_OPENING](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/const.py#L182). 

Several covers use these additional states, such as [opengarage.py](https://github.com/home-assistant/home-assistant/blob/b92350fb5588a05a870495753a0c0b3c69d12bd1/homeassistant/components/cover/opengarage.py#L126) and [garadget.py](https://github.com/home-assistant/home-assistant/blob/b92350fb5588a05a870495753a0c0b3c69d12bd1/homeassistant/components/cover/garadget.py#L28).

As an example, lets assume the garage is in the "open" state. On the web ui, the "close" button is enabled and the "open" button is disabled. Before this pull request, upon clicking the "close" button, both "open" and "close" buttons become enabled if the state is `STATE_CLOSING` until the state becomes `STATE_CLOSED`. I find this a bit disorienting. 

I've added logic to also disable the "open" button while the state is `STATE_OPENING` and to also disable the "close" button when the state is `STATE_CLOSING`. If a device does not implement  `STATE_OPENING` or `STATE_CLOSING`, then there is no functional change.