### PR TITLE
Add schema validating Lovelace config

### DIFF
--- a/gulp/tasks/gen-lovelace-schema.js
+++ b/gulp/tasks/gen-lovelace-schema.js
@@ -1,0 +1,21 @@
+const Ajv = require('ajv');
+const ajv = new Ajv({sourceCode: true}); // this option is required
+const pack = require('ajv-pack');
+const path = require('path');
+const fs = require('fs');
+const gulp = require('gulp');
+
+const OUTPUT_DIR = path.resolve(__dirname, '../../build');
+const MDI_OUTPUT_PATH = path.resolve(OUTPUT_DIR, 'mdi.html');
+const HASS_OUTPUT_PATH = path.resolve(OUTPUT_DIR, 'hass-icons.html');
+const SCHEMA_LOCATION = path.resolve(__dirname, '../../src/panels/lovelace/schema.json');
+
+function generateSchema() {
+  fs.existsSync(OUTPUT_DIR) || fs.mkdirSync(OUTPUT_DIR);
+  const schema = require(SCHEMA_LOCATION);
+  const validate = ajv.compile(schema);
+  const moduleCode = pack(ajv, validate);
+  fs.writeFileSync(path.join(OUTPUT_DIR, '/lovelace_schema.js'), moduleCode);
+}
+
+gulp.task('gen-lovelace-schema', generateSchema);

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "xss": "^1.0.3"
   },
   "devDependencies": {
+    "ajv-pack": "^0.3.1",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.1.4",

--- a/script/build_frontend
+++ b/script/build_frontend
@@ -14,7 +14,7 @@ OUTPUT_DIR_ES5=hass_frontend_es5
 rm -rf $OUTPUT_DIR $OUTPUT_DIR_ES5 $BUILD_DIR $BUILD_TRANSLATIONS_DIR
 
 # Build frontend
-./node_modules/.bin/gulp build-translations gen-icons
+./node_modules/.bin/gulp build-translations gen-icons gen-lovelace-schema
 NODE_ENV=production ./node_modules/.bin/webpack
 
 # Temp for Hass.io

--- a/script/develop
+++ b/script/develop
@@ -13,7 +13,7 @@ mkdir $OUTPUT_DIR $OUTPUT_DIR_ES5
 # Needed in case frontend repo installed with pip3 install -e
 cp -r public/__init__.py $OUTPUT_DIR_ES5/
 
-./node_modules/.bin/gulp build-translations gen-icons
+./node_modules/.bin/gulp build-translations gen-icons gen-lovelace-schema
 cp src/authorize.html $OUTPUT_DIR
 cp src/onboarding.html $OUTPUT_DIR
 

--- a/src/panels/lovelace/ha-panel-lovelace.js
+++ b/src/panels/lovelace/ha-panel-lovelace.js
@@ -5,6 +5,7 @@ import '@polymer/paper-button/paper-button.js';
 import '../../layouts/hass-loading-screen.js';
 import '../../layouts/hass-error-screen.js';
 import './hui-root.js';
+import validate from '../../../build/lovelace_schema.js'
 
 class Lovelace extends PolymerElement {
   static get template() {
@@ -102,9 +103,18 @@ class Lovelace extends PolymerElement {
     this._columns = Math.max(1, matchColumns - (!this.narrow && this.showMenu));
   }
 
+  _parseErrors(errors) {
+    return errors.map(error => `${error.dataPath} ${error.message}`).join(' ');
+  }
+
   async _fetchConfig() {
     try {
       const conf = await this.hass.callWS({ type: 'frontend/lovelace_config' });
+      const valid = validate(conf);
+      if (!valid) {
+        throw new Error(
+          `Configuration error: ${this._parseErrors(validate.errors)}`);
+      }
       this.setProperties({
         _config: conf,
         _state: 'loaded',

--- a/src/panels/lovelace/ha-panel-lovelace.js
+++ b/src/panels/lovelace/ha-panel-lovelace.js
@@ -5,7 +5,7 @@ import '@polymer/paper-button/paper-button.js';
 import '../../layouts/hass-loading-screen.js';
 import '../../layouts/hass-error-screen.js';
 import './hui-root.js';
-import validate from '../../../build/lovelace_schema.js'
+import validate from '../../../build/lovelace_schema.js';
 
 class Lovelace extends PolymerElement {
   static get template() {
@@ -112,8 +112,7 @@ class Lovelace extends PolymerElement {
       const conf = await this.hass.callWS({ type: 'frontend/lovelace_config' });
       const valid = validate(conf);
       if (!valid) {
-        throw new Error(
-          `Configuration error: ${this._parseErrors(validate.errors)}`);
+        throw new Error(`Configuration error: ${this._parseErrors(validate.errors)}`);
       }
       this.setProperties({
         _config: conf,

--- a/src/panels/lovelace/schema.json
+++ b/src/panels/lovelace/schema.json
@@ -1,0 +1,38 @@
+{
+  "title": "Home Assistant UI Schema",
+  "description": "With Home Assistant UI, people can define a user interface to render their entities.",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "views": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/ViewType" }
+    }
+  },
+  "required": ["views"],
+  "definitions": {
+    "ViewType": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Title of the view. Used for the tab of this view if no icon specified."
+        },
+        "icon": {
+          "type": "string",
+          "description": "Icon to use for the tab."
+        },
+        "columnWidth": {
+          "type": "number",
+          "description": "Specifying the width of the column in pixels.",
+          "notes": [
+            "Not implemented"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test-mocha/schema_test.js
+++ b/test-mocha/schema_test.js
@@ -1,0 +1,20 @@
+import Ajv from 'ajv';
+import pack from 'ajv-pack';
+import schema from '../src/panels/lovelace/schema.json';
+
+describe('Lovelace schema', () => {
+  let ajv;
+
+  beforeEach(() => {
+    ajv = new Ajv({ sourceCode: true });
+  });
+
+  it('valid by ajv', () => {
+    ajv.compile(schema);
+  });
+
+  it('valid by ajv-pack', () => {
+    const validate = ajv.compile(schema);
+    pack(ajv, validate);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1961,6 +1961,13 @@ ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
+ajv-pack@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/ajv-pack/-/ajv-pack-0.3.1.tgz#b72c4d4219e3928e62842d742ded93bf50796560"
+  dependencies:
+    js-beautify "^1.6.4"
+    require-from-string "^1.2.0"
+
 ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -3214,7 +3221,7 @@ blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
 
-bluebird@^3.5.1:
+bluebird@^3.0.5, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -4141,6 +4148,13 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+config-chain@~1.1.5:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
+
 configstore@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-2.1.0.tgz#737a3a7036e9886102aa6099e47bb33ab1aba1a1"
@@ -4823,6 +4837,16 @@ ecc-jsbn@~0.1.1:
 editions@^1.3.3:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
+
+editorconfig@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.3.tgz#e5219e587951d60958fd94ea9a9a008cdeff1b34"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    semver "^5.1.0"
+    sigmund "^1.0.1"
 
 ee-first@1.1.0:
   version "1.1.0"
@@ -7416,6 +7440,15 @@ joi@^11.1.1:
     isemail "3.x.x"
     topo "2.x.x"
 
+js-beautify@^1.6.4:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.7.5.tgz#69d9651ef60dbb649f65527b53674950138a7919"
+  dependencies:
+    config-chain "~1.1.5"
+    editorconfig "^0.13.2"
+    mkdirp "~0.5.0"
+    nopt "~3.0.1"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -8124,6 +8157,12 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
+
 lru-cache@^4.0.1, lru-cache@^4.0.2, lru-cache@^4.1.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
@@ -8787,6 +8826,12 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@~3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
@@ -9855,6 +9900,10 @@ prop-types@^15.6.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+
 proxy-addr@~2.0.2, proxy-addr@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
@@ -9866,7 +9915,7 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
-pseudomap@^1.0.2:
+pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
@@ -10393,6 +10442,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -10843,7 +10896,7 @@ shelljs@^0.8.0:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-sigmund@~1.0.0:
+sigmund@^1.0.1, sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 


### PR DESCRIPTION
Currently the Lovelace config is not validated.
If we want Lovelace to be frontend-only we can't use backend `voluptuous` schemas, so this PR adds frontend JSON schema.

This PR only adds a basic schema.

This PR increased Lovelace panel JS by 4k (2k compressed)

Also in this PR:
 - Add a test that will validate that the schema itself is valid

TODO in future PRs:
 - Extend the schema to everything in home-assistant/ui-schema/schema.md
 - Add JSON example(s) of Lovelace config and add tests that will validate them.
 - Auto-generate `schema.md` based on the schema.