### PR TITLE
Set isHuiElement property on custom elements.

### DIFF
--- a/src/panels/lovelace/common/create-hui-element.js
+++ b/src/panels/lovelace/common/create-hui-element.js
@@ -44,7 +44,9 @@ export default function createHuiElement(config) {
     const tag = config.type.substr(CUSTOM_TYPE_PREFIX.length);
 
     if (customElements.get(tag)) {
-      return _createElement(tag, config);
+      const el = _createElement(tag, config);
+      el.isHuiElement = true;
+      return el;
     }
 
     const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);


### PR DESCRIPTION
This will allow custom ui components to know if they are being rendered as a card or as an element on a picture-elements card.