### PR TITLE
Allow changing entity id

### DIFF
--- a/src/dialogs/more-info/more-info-settings.js
+++ b/src/dialogs/more-info/more-info-settings.js
@@ -92,11 +92,15 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   _registryInfoChanged(newVal) {
     if (newVal) {
-      this._name = newVal.name;
-      this._entityId = newVal.entity_id;
+      this.setProperties({
+        _name: newVal.name,
+        _entityId: newVal.entity_id,
+      });
     } else {
-      this._name = '';
-      this._entityId = '';
+      this.setProperties({
+        _name: '',
+        _entityId: '',
+      });
     }
   }
 

--- a/src/dialogs/more-info/more-info-settings.js
+++ b/src/dialogs/more-info/more-info-settings.js
@@ -48,7 +48,14 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
     </app-toolbar>
 
     <div class="form">
-      <paper-input value="{{_name}}" label="[[localize('ui.dialogs.more_info_settings.name')]]"></paper-input>
+      <paper-input
+        value="{{_name}}"
+        label="[[localize('ui.dialogs.more_info_settings.name')]]"
+      ></paper-input>
+      <paper-input
+        value="{{_entity_id}}"
+        label="[[localize('ui.dialogs.more_info_settings.entity_id')]]"
+      ></paper-input>
     </div>
 `;
   }
@@ -70,6 +77,7 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
       },
 
       _name: String,
+      _entity_id: String,
     };
   }
 
@@ -85,8 +93,10 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
   _registryInfoChanged(newVal) {
     if (newVal) {
       this._name = newVal.name;
+      this._entity_id = newVal.entity_id;
     } else {
       this._name = '';
+      this._entity_id = '';
     }
   }
 
@@ -100,10 +110,17 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
         type: 'config/entity_registry/update',
         entity_id: this.stateObj.entity_id,
         name: this._name,
+        new_entity_id: this._entity_id,
       });
+
       this.registryInfo = info;
+
+      // Keep the more info dialog open at the new entity.
+      if (this.stateObj.entity_id !== this._entity_id) {
+        this.fire('hass-more-info', { entityId: this._entity_id });
+      }
     } catch (err) {
-      alert('save failed!');
+      alert(`save failed: ${err.message}`);
     }
   }
 }

--- a/src/dialogs/more-info/more-info-settings.js
+++ b/src/dialogs/more-info/more-info-settings.js
@@ -53,7 +53,7 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
         label="[[localize('ui.dialogs.more_info_settings.name')]]"
       ></paper-input>
       <paper-input
-        value="{{_entity_id}}"
+        value="{{_entityId}}"
         label="[[localize('ui.dialogs.more_info_settings.entity_id')]]"
       ></paper-input>
     </div>
@@ -77,7 +77,7 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
       },
 
       _name: String,
-      _entity_id: String,
+      _entityId: String,
     };
   }
 
@@ -93,10 +93,10 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
   _registryInfoChanged(newVal) {
     if (newVal) {
       this._name = newVal.name;
-      this._entity_id = newVal.entity_id;
+      this._entityId = newVal.entity_id;
     } else {
       this._name = '';
-      this._entity_id = '';
+      this._entityId = '';
     }
   }
 
@@ -110,14 +110,14 @@ class MoreInfoSettings extends LocalizeMixin(EventsMixin(PolymerElement)) {
         type: 'config/entity_registry/update',
         entity_id: this.stateObj.entity_id,
         name: this._name,
-        new_entity_id: this._entity_id,
+        new_entity_id: this._entityId,
       });
 
       this.registryInfo = info;
 
       // Keep the more info dialog open at the new entity.
-      if (this.stateObj.entity_id !== this._entity_id) {
-        this.fire('hass-more-info', { entityId: this._entity_id });
+      if (this.stateObj.entity_id !== this._entityId) {
+        this.fire('hass-more-info', { entityId: this._entityId });
       }
     } catch (err) {
       alert(`save failed: ${err.message}`);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -437,7 +437,8 @@
     "dialogs": {
       "more_info_settings": {
         "save": "Save",
-        "name": "Name"
+        "name": "Name",
+        "entity_id": "Entity ID"
       }
     },
     "duration": {


### PR DESCRIPTION
Requires https://github.com/home-assistant/home-assistant/pull/15637

Allows a user to change the entity ID of entities with unique IDs.

![image](https://user-images.githubusercontent.com/1444314/43097355-2aa70e22-8ebc-11e8-92cc-9616b0177c83.png)
