### PR TITLE
Add prefix and suffix for state-label

### DIFF
--- a/src/panels/lovelace/elements/hui-state-label-element.js
+++ b/src/panels/lovelace/elements/hui-state-label-element.js
@@ -25,7 +25,7 @@ class HuiStateLabelElement extends LocalizeMixin(ElementClickMixin(PolymerElemen
         }
       </style>
       <div class="state-label" title$="[[computeTooltip(hass, _config)]]">
-        [[_computeStateDisplay(_stateObj)]]
+        [[_config.prefix]][[_computeStateDisplay(_stateObj)]][[_config.suffix]]
       </div>
     `;
   }
@@ -59,9 +59,7 @@ class HuiStateLabelElement extends LocalizeMixin(ElementClickMixin(PolymerElemen
   }
 
   _computeStateDisplay(stateObj) {
-    const state = stateObj ? computeStateDisplay(this.localize, stateObj) : '-';
-    const config = this._config;
-    return `${config.prefix || ''}${state}${config.suffix || ''}`;
+    return stateObj ? computeStateDisplay(this.localize, stateObj) : '-';
   }
 }
 customElements.define('hui-state-label-element', HuiStateLabelElement);

--- a/src/panels/lovelace/elements/hui-state-label-element.js
+++ b/src/panels/lovelace/elements/hui-state-label-element.js
@@ -17,14 +17,14 @@ class HuiStateLabelElement extends LocalizeMixin(ElementClickMixin(PolymerElemen
     return html`
       <style>
         :host {
-          cursor: pointer; 
-        } 
+          cursor: pointer;
+        }
         .state-label {
           padding: 8px;
           white-space: nowrap;
         }
       </style>
-      <div class="state-label" title$="[[computeTooltip(hass, _config)]]"> 
+      <div class="state-label" title$="[[computeTooltip(hass, _config)]]">
         [[_computeStateDisplay(_stateObj)]]
       </div>
     `;
@@ -59,7 +59,9 @@ class HuiStateLabelElement extends LocalizeMixin(ElementClickMixin(PolymerElemen
   }
 
   _computeStateDisplay(stateObj) {
-    return stateObj && computeStateDisplay(this.localize, stateObj);
+    const state = stateObj ? computeStateDisplay(this.localize, stateObj) : '-';
+    const config = this._config;
+    return `${config.prefix || ''}${state}${config.suffix || ''}`;
   }
 }
 customElements.define('hui-state-label-element', HuiStateLabelElement);


### PR DESCRIPTION
```yaml
        elements:
          - type: state-label
            entity: sensor.outside_temperature
            prefix: "Outside: "
            suffix: " ¯ \\_(ツ)_/¯"
            style:
              top: 40%
              left: 30%
```
![image](https://user-images.githubusercontent.com/11984118/43098743-4f8963b2-8ec0-11e8-8432-be39584bb328.png)
