### PR TITLE
Hide name or state in picture entity

### DIFF
--- a/gallery/src/demos/demo-hui-picture-entity-card.js
+++ b/gallery/src/demos/demo-hui-picture-entity-card.js
@@ -36,12 +36,31 @@ const CONFIGS = [
     `
   },
   {
-    heading: 'Hidden info',
+    heading: 'Hidden name',
     config: `
 - type: picture-entity
   image: /images/kitchen.png
   entity: light.kitchen_lights
-  show_info: false
+  show_name: false
+    `
+  },
+  {
+    heading: 'Hidden state',
+    config: `
+- type: picture-entity
+  image: /images/kitchen.png
+  entity: light.kitchen_lights
+  show_state: false
+    `
+  },
+  {
+    heading: 'Both hidden',
+    config: `
+- type: picture-entity
+  image: /images/kitchen.png
+  entity: light.kitchen_lights
+  show_name: false
+  show_state: false
     `
   },
 ];

--- a/src/panels/lovelace/cards/hui-picture-entity-card.js
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.js
@@ -148,7 +148,7 @@ class HuiPictureEntityCard extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
   _showNameAndState(config) {
     return config.show_name !== false && config.show_state !== false;
-    }
+  }
 
   _showName(config) {
     return config.show_name !== false && config.show_state === false;


### PR DESCRIPTION
```yaml
- type: picture-entity
  image: /images/kitchen.png
  entity: light.kitchen_lights
  show_name: false
  show_state: false
```

fix: https://github.com/home-assistant/ui-schema/issues/114