### PR TITLE
Add support for CSS imports

### DIFF
--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -27,9 +27,9 @@ import debounce from '../../common/util/debounce.js';
 
 import createCardElement from './common/create-card-element.js';
 
-// JS should only be imported once. Modules and HTML are safe.
-const JS_CACHE = {};
+// CSS and JS should only be imported once. Modules and HTML are safe.
 const CSS_CACHE = {};
+const JS_CACHE = {};
 
 class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
   static get template() {

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -20,7 +20,7 @@ import NavigateMixin from '../../mixins/navigate-mixin.js';
 import '../../layouts/ha-app-layout.js';
 import '../../components/ha-start-voice-button.js';
 import '../../components/ha-icon.js';
-import { loadModule, loadJS } from '../../common/dom/load_resource.js';
+import { loadModule, loadCSS, loadJS } from '../../common/dom/load_resource.js';
 import './hui-unused-entities.js';
 import './hui-view.js';
 import debounce from '../../common/util/debounce.js';
@@ -29,6 +29,7 @@ import createCardElement from './common/create-card-element.js';
 
 // JS should only be imported once. Modules and HTML are safe.
 const JS_CACHE = {};
+const CSS_CACHE = {};
 
 class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
   static get template() {
@@ -258,6 +259,11 @@ class HUIRoot extends NavigateMixin(EventsMixin(PolymerElement)) {
   _loadResources(resources) {
     resources.forEach((resource) => {
       switch (resource.type) {
+        case 'css':
+          if (resource.url in CSS_CACHE) break;
+          CSS_CACHE[resource.url] = loadCSS(resource.url);
+          break;
+
         case 'js':
           if (resource.url in JS_CACHE) break;
           JS_CACHE[resource.url] = loadJS(resource.url);


### PR DESCRIPTION
feels stupid to implement stuff that balloob already explained in the issue...
only wanted to get the issue closed :stuck_out_tongue_closed_eyes: 

```yaml
resources:
  - url: /local/ha-tiles.js
    type: js
  - url: /local/css/minecraft-webfont.css
    type: css
views:
  - title: Picture elements
    cards:
      - type: picture-elements
        image: https://images.pexels.com/photos/316465/pexels-photo-316465.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260
        elements:
          - type: state-label
            entity: media_player.mini
            style:
              top: 10%
              left: 30%
              "font-family": Minecraft
```

fix: https://github.com/home-assistant/ui-schema/issues/115