### PR TITLE
Add profile badge to sidebar header

### DIFF
--- a/src/components/ha-menu-button.js
+++ b/src/components/ha-menu-button.js
@@ -10,12 +10,10 @@ import EventsMixin from '../mixins/events-mixin.js';
 class HaMenuButton extends EventsMixin(PolymerElement) {
   static get template() {
     return html`
-    <style>
-      .invisible {
-        visibility: hidden;
-      }
-    </style>
-    <paper-icon-button icon="[[_getIcon(hassio)]]" class$="[[computeMenuButtonClass(narrow, showMenu)]]" on-click="toggleMenu"></paper-icon-button>
+    <paper-icon-button
+      icon="[[_getIcon(hassio)]]"
+      on-click="toggleMenu"
+    ></paper-icon-button>
 `;
   }
 
@@ -38,13 +36,9 @@ class HaMenuButton extends EventsMixin(PolymerElement) {
     };
   }
 
-  computeMenuButtonClass(narrow, showMenu) {
-    return !narrow && showMenu ? 'invisible' : '';
-  }
-
   toggleMenu(ev) {
     ev.stopPropagation();
-    this.fire('hass-open-menu');
+    this.fire(this.showMenu ? 'hass-close-menu' : 'hass-open-menu');
   }
 
   _getIcon(hassio) {

--- a/src/components/ha-sidebar.js
+++ b/src/components/ha-sidebar.js
@@ -240,16 +240,17 @@ class HaSidebar extends LocalizeMixin(PolymerElement) {
 
   _computeUserInitials(name) {
     if (!name) return 'user';
-
+    name = 'J v B';
     return name.trim()
       // Split by space and take first 3 words
       .split(' ').slice(0, 3)
       // Of each word, take first letter
-      .map(s => s.substr(0, 1)).join('');
+      .map(s => s.substr(0, 1))
+      .join('');
   }
 
   _computeBadgeClass(initials) {
-    return `profile-badge ${initials.length > 2 ? 'long': ''}`;
+    return `profile-badge ${initials.length > 2 ? 'long' : ''}`;
   }
 
   _mqttLoaded(hass) {

--- a/src/components/ha-sidebar.js
+++ b/src/components/ha-sidebar.js
@@ -49,12 +49,17 @@ class HaSidebar extends LocalizeMixin(PolymerElement) {
         padding-bottom: 0;
       }
 
-      a paper-icon-item {
+      paper-listbox > a {
+        @apply --sidebar-text;
         text-decoration: none;
 
         --paper-item-icon: {
           color: var(--sidebar-icon-color);
         };
+      }
+
+      paper-icon-item span {
+        @apply --sidebar-text;
       }
 
       a.iron-selected {
@@ -67,11 +72,8 @@ class HaSidebar extends LocalizeMixin(PolymerElement) {
         };
       }
 
-      paper-icon-item .item-text {
-        @apply --sidebar-text;
-      }
       a.iron-selected .item-text {
-          color: var(--sidebar-selected-text-color);
+        color: var(--sidebar-selected-text-color);
       }
 
       paper-icon-item.logout {
@@ -82,10 +84,6 @@ class HaSidebar extends LocalizeMixin(PolymerElement) {
         height: 1px;
         background-color: var(--divider-color);
         margin: 4px 0;
-      }
-
-      .setting {
-        @apply --sidebar-text;
       }
 
       .subheader {
@@ -239,7 +237,6 @@ class HaSidebar extends LocalizeMixin(PolymerElement) {
 
   _computeUserInitials(name) {
     if (!name) return 'user';
-    name = 'J v B';
     return name.trim()
       // Split by space and take first 3 words
       .split(' ').slice(0, 3)

--- a/src/components/ha-sidebar.js
+++ b/src/components/ha-sidebar.js
@@ -1,4 +1,3 @@
-import '@polymer/app-layout/app-header/app-header.js';
 import '@polymer/app-layout/app-toolbar/app-toolbar.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';

--- a/src/panels/profile/ha-change-password-card.js
+++ b/src/panels/profile/ha-change-password-card.js
@@ -40,7 +40,6 @@ class HaChangePasswordCard extends PolymerElement {
             <div class="status">[[_statusMsg]]</div>
           </template>
           <paper-input
-            autofocus
             class='currentPassword'
             label='Current Password'
             type='password'


### PR DESCRIPTION
- Add profile badge to sidebar header
- Make `<ha-menu-button>` always visible and used for toggling menu
- Use `<a>` instead of navigate mixin
- Remove change password card auto focus

![image](https://user-images.githubusercontent.com/1444314/43266925-d72fb7fc-90ec-11e8-9bd1-092ce3c9ea2b.png)

![image](https://user-images.githubusercontent.com/1444314/43266885-c0fcad1e-90ec-11e8-8676-8f204d4040b5.png)

We take up to 3 characters. If 3 characters, we make the font smaller

![image](https://user-images.githubusercontent.com/1444314/43267009-13ba0d80-90ed-11e8-9a7e-cb2366a3c9bc.png)
