### PR TITLE
allow 'same-origin' credentials for fetch()

### DIFF
--- a/src/auth/ha-auth-flow.js
+++ b/src/auth/ha-auth-flow.js
@@ -72,6 +72,7 @@ class HaAuthFlow extends EventsMixin(PolymerElement) {
 
     fetch('/auth/login_flow', {
       method: 'POST',
+      credentials: 'same-origin',
       body: JSON.stringify({
         client_id: this.clientId,
         handler: [this.authProvider.type, this.authProvider.id],
@@ -111,6 +112,7 @@ class HaAuthFlow extends EventsMixin(PolymerElement) {
 
     fetch(`/auth/login_flow/${this._step.flow_id}`, {
       method: 'POST',
+      credentials: 'same-origin',
       body: JSON.stringify(postData)
     }).then((response) => {
       if (!response.ok) throw new Error();

--- a/src/auth/ha-pick-auth-provider.js
+++ b/src/auth/ha-pick-auth-provider.js
@@ -53,7 +53,7 @@ class HaPickAuthProvider extends EventsMixin(PolymerElement) {
   connectedCallback() {
     super.connectedCallback();
 
-    fetch('/auth/providers').then((response) => {
+    fetch('/auth/providers', { credentials: 'same-origin' }).then((response) => {
       if (!response.ok) throw new Error();
       return response.json();
     }).then((authProviders) => {

--- a/src/common/auth/fetch_token.js
+++ b/src/common/auth/fetch_token.js
@@ -4,6 +4,7 @@ export default function fetchToken(clientId, code) {
   data.append('grant_type', 'authorization_code');
   data.append('code', code);
   return fetch('/auth/token', {
+    credentials: 'same-origin',
     method: 'POST',
     body: data,
   }).then((resp) => {

--- a/src/common/auth/refresh_token.js
+++ b/src/common/auth/refresh_token.js
@@ -4,6 +4,7 @@ export default function refreshAccessToken(clientId, refreshToken) {
   data.append('grant_type', 'refresh_token');
   data.append('refresh_token', refreshToken);
   return fetch('/auth/token', {
+    credentials: 'same-origin',
     method: 'POST',
     body: data,
   }).then((resp) => {

--- a/src/entrypoints/service-worker-hass.js
+++ b/src/entrypoints/service-worker-hass.js
@@ -41,6 +41,7 @@ function initPushNotifications() {
       delete payload.data;
     }
     fetch('/api/notify.html5/callback', {
+      credentials: 'same-origin',
       method: 'POST',
       headers: new Headers({ 'Content-Type': 'application/json',
         Authorization: 'Bearer ' + jwt }),

--- a/src/util/hass-translation.js
+++ b/src/util/hass-translation.js
@@ -80,7 +80,7 @@ export function getTranslation(fragment, translationInput) {
   // Create a promise to fetch translation from the server
   if (!translations[translationFingerprint]) {
     translations[translationFingerprint] =
-      fetch(`/static/translations/${translationFingerprint}`, { credentials: 'include' })
+      fetch(`/static/translations/${translationFingerprint}`, { credentials: 'same-origin' })
         .then(response => response.json()).then(data => ({
           language: translation,
           data: data,


### PR DESCRIPTION
when using nginx + oauth2_proxy, user authentication is broken, because fetch() request do not supply authentication cookie. This fix allows browser to provide cookie with the request, as long as it within same origin. In latest google chrome 68.0.3440 this is on by default (as per https://github.com/whatwg/fetch/pull/585) , but some older browser like on the mobile devices haven't been updated yet.
More details are in https://community.home-assistant.io/t/nginx-oauth2-proxy-and-home-assistant-user-authentication/61651/4