### PR TITLE
Use correct keys for localization.

### DIFF
--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -217,7 +217,7 @@ class HaWeatherCard extends
   }
 
   computeState(state, localize) {
-    return localize(`state.weather.${state.replace('-', '_')}`) || state;
+    return localize(`state.weather.${state}`) || state;
   }
 
   showWeatherIcon(condition) {


### PR DESCRIPTION
The weather localization keys are equal to the state, which uses a `-`

dev docs: https://developers.home-assistant.io/docs/en/entity_weather.html#recommended-values-for-state-and-condition