### PR TITLE
Added translation for two strings used in MAX! thermostats

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -139,6 +139,8 @@
             "dry": "Entfeuchten",
             "fan_only": "Nur Ventilator",
             "eco": "Sparmodus",
+            "boost": 'Boost',
+            "comfort": 'Komfort',
             "electric": "Elektrisch",
             "performance": "Leistung",
             "high_demand": "Hoher Verbrauch",


### PR DESCRIPTION
They get used in MAX! eQ-3 thermostats and most probably in other devices from eQ-3 too. "boost" opens the valve, while "comfort" is used to set the temperature to the configured "comfortTemperature"-value in wall thermostats.