### PR TITLE
Added translation for two strings used in MAX! thermostats

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -136,6 +136,8 @@
             "cool": "Kühlen",
             "idle": "Untätig",
             "auto": "Automatisch",
+            "boost": "Boost",
+            "comfort": "Komfort",
             "dry": "Entfeuchten",
             "fan_only": "Nur Ventilator",
             "eco": "Sparmodus",


### PR DESCRIPTION
They get used in MAX! eQ-3 thermostats and most probably in other devices from eQ-3 too. "boost" opens the valve, while "comfort" is used to set the temperature to the configured "comfortTemperature"-value in wall thermostats.