### PR TITLE
Fixed conditional card state on 1st render

### DIFF
--- a/src/panels/lovelace/cards/hui-conditional-card.js
+++ b/src/panels/lovelace/cards/hui-conditional-card.js
@@ -29,7 +29,6 @@ class HuiConditionalCard extends PolymerElement {
   ready() {
     super.ready();
     if (this._config) this._buildConfig();
-    if (this.hass) this._hassChanged(this.hass);
   }
 
   setConfig(config) {
@@ -52,6 +51,7 @@ class HuiConditionalCard extends PolymerElement {
     const element = createCardElement(config.card);
     element.hass = this.hass;
     root.appendChild(element);
+    if (this.hass) this._hassChanged(this.hass);
   }
 
   getCardSize() {

--- a/src/panels/lovelace/cards/hui-conditional-card.js
+++ b/src/panels/lovelace/cards/hui-conditional-card.js
@@ -29,6 +29,7 @@ class HuiConditionalCard extends PolymerElement {
   ready() {
     super.ready();
     if (this._config) this._buildConfig();
+    if (this.hass) this._hassChanged(this.hass);
   }
 
   setConfig(config) {


### PR DESCRIPTION
Using the below with `light.bed_light` set to `off` will still show the card until 1st hass update.

```yaml
      - type: conditional
        conditions:
          - entity: light.bed_light
            state: 'on'
        card:
          type: entities
          entities:
            - device_tracker.demo_paulus
            - cover.kitchen_window
            - group.kitchen
            - lock.kitchen_door
            - light.bed_light
```

I just tested the suggestion from Discord by balloob. 