### PR TITLE
Remove zwave rename functions

### DIFF
--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -138,12 +138,6 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
             <ha-call-service-button hass="[[hass]]" domain="zwave" service="test_node" service-data="[[computeNodeServiceData(selectedNode)]]">Test Node</ha-call-service-button>
             <ha-service-description hass="[[hass]]" domain="zwave" service="test_node" hidden$="[[!showHelp]]"></ha-service-description>
           </div>
-          <div class="card-actions">
-            <paper-input float-label="New node name" type="text" value="{{newNodeNameInput}}" placeholder="[[computeGetNodeName(selectedNode)]]">
-            </paper-input>
-            <ha-call-service-button hass="[[hass]]" domain="zwave" service="rename_node" service-data="[[computeNodeNameServiceData(newNodeNameInput)]]">Rename Node</ha-call-service-button>
-            <ha-service-description hass="[[hass]]" domain="zwave" service="rename_node" hidden$="[[!showHelp]]"></ha-service-description>
-           </div>
 
            <div class="device-picker">
             <paper-dropdown-menu label="Entities of this node" dynamic-align="" class="flex">
@@ -302,10 +296,6 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
         type: Array,
       },
 
-      newNodeNameInput: {
-        type: String,
-      },
-
       userCodes: {
         type: Array,
         value: function () {
@@ -384,8 +374,6 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
   }
 
   selectedNodeChanged(selectedNode) {
-    this.newNodeNameInput = '';
-
     if (selectedNode === -1) return;
     this.selectedConfigParameter = -1;
     this.selectedConfigParameterValue = -1;
@@ -475,19 +463,6 @@ class HaConfigZwave extends LocalizeMixin(PolymerElement) {
     return {
       node_id: this.nodes[selectedNode].attributes.node_id,
       return_routes: true
-    };
-  }
-
-  computeGetNodeName(selectedNode) {
-    if (this.selectedNode === -1 ||
-      !this.nodes[selectedNode].entity_id) return -1;
-    return this.nodes[selectedNode].attributes.node_name;
-  }
-
-  computeNodeNameServiceData(newNodeNameInput) {
-    return {
-      node_id: this.nodes[this.selectedNode].attributes.node_id,
-      name: newNodeNameInput
     };
   }
 

--- a/src/panels/config/zwave/zwave-values.js
+++ b/src/panels/config/zwave/zwave-values.js
@@ -45,14 +45,6 @@ class ZwaveValues extends PolymerElement {
           </paper-listbox>
         </paper-dropdown-menu>
         </div>
-        <template is="dom-if" if="[[!computeIsValueSelected(selectedValue)]]">
-          <div class="card-actions">
-            <paper-input float-label="Value Name" type="text" value="{{newValueNameInput}}" placeholder="[[computeGetValueName(selectedValue)]]">
-            </paper-input>
-            <ha-call-service-button hass="[[hass]]" domain="zwave" service="rename_value" service-data="[[computeValueNameServiceData(newValueNameInput)]]">Rename Value</ha-call-service-button>
-
-          </div>
-        </template>
       </paper-card>
     </div>
 `;
@@ -102,14 +94,6 @@ class ZwaveValues extends PolymerElement {
     return item.value.label + ' (Instance: ' + item.value.instance + ', Index: ' + item.value.index + ')';
   }
 
-  computeGetValueName(selectedValue) {
-    return this.values[selectedValue].value.label;
-  }
-
-  computeIsValueSelected(selectedValue) {
-    return (!this.nodes || this.selectedNode === -1 || selectedValue === -1);
-  }
-
   refreshValues(selectedNode) {
     var valueData = [];
     this.hass.callApi('GET', 'zwave/values/' + this.nodes[selectedNode].attributes.node_id).then(function (values) {
@@ -122,15 +106,6 @@ class ZwaveValues extends PolymerElement {
       this.values = valueData;
       this.selectedValueChanged(this.selectedValue);
     }.bind(this));
-  }
-
-  computeValueNameServiceData(newValueNameInput) {
-    if (!this.selectedNode === -1 || this.selectedValue === -1) return -1;
-    return {
-      node_id: this.nodes[this.selectedNode].attributes.node_id,
-      value_id: this.values[this.selectedValue].key,
-      name: newValueNameInput,
-    };
   }
 
   selectedValueChanged(selectedValue) {


### PR DESCRIPTION
Remove Zwave rename_node and rename_value from the UI.

Release Note: 
The `rename_node` and `rename_value` services of Z-Wave have been removed from the UI.
The renaming is now following the standard way of renaming, through the UI options or the entity_registry. This will also mean that there is no need for a restart after adding a node or renaming.
For advanced users, the services are still available through the dev-service menu.

Fixes #https://github.com/home-assistant/home-assistant/issues/12430
Docs: https://github.com/home-assistant/home-assistant.io/pull/5976