### PR TITLE
Remove _hiddenState method.

### DIFF
--- a/gallery/src/demos/demo-hui-entities-card.js
+++ b/gallery/src/demos/demo-hui-entities-card.js
@@ -55,6 +55,15 @@ const ENTITIES = [
     unit_of_measurement: '°F',
     friendly_name: 'Ecobee',
     supported_features: 1014
+  }),
+  getEntity('input_number', 'noise_allowance', 5, {
+    min: 0,
+    max: 10,
+    step: 1,
+    mode: 'slider',
+    unit_of_measurement: 'dB',
+    friendly_name: 'Allowed Noise',
+    icon: 'mdi:bell-ring'
   })
 ];
 
@@ -72,6 +81,7 @@ const CONFIGS = [
     - light.bed_light
     - light.non_existing
     - climate.ecobee
+    - input_number.noise_allowance
     `
   },
   {
@@ -86,6 +96,7 @@ const CONFIGS = [
     - lock.kitchen_door
     - light.bed_light
     - climate.ecobee
+    - input_number.noise_allowance
   title: Random group
     `
   },
@@ -101,6 +112,7 @@ const CONFIGS = [
     - lock.kitchen_door
     - light.bed_light
     - climate.ecobee
+    - input_number.noise_allowance
   title: Random group
   show_header_toggle: false
     `
@@ -130,6 +142,7 @@ const CONFIGS = [
     - lock.kitchen_door
     - light.bed_light
     - climate.ecobee
+    - input_number.noise_allowance
   title: Random group
   show_header_toggle: false
     `

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.js
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.js
@@ -40,7 +40,7 @@ class HuiInputNumberEntityRow extends mixinBehaviors([IronResizableBehavior], Po
                 on-change="_selectedValueChanged"
                 ignore-bar-touch
               ></paper-slider>
-              <div class="state">[[_value]] [[_stateObj.attributes.unit_of_measurement]]</div>
+              <span class="state">[[_value]] [[_stateObj.attributes.unit_of_measurement]]</span>
             </div>
           </template>
           <template is="dom-if" if="[[_equals(_stateObj.attributes.mode, 'box')]]">
@@ -83,20 +83,6 @@ class HuiInputNumberEntityRow extends mixinBehaviors([IronResizableBehavior], Po
     };
   }
 
-  ready() {
-    super.ready();
-    if (typeof ResizeObserver === 'function') {
-      const ro = new ResizeObserver((entries) => {
-        entries.forEach(() => {
-          this._hiddenState();
-        });
-      });
-      ro.observe(this.$.input_number_card);
-    } else {
-      this.addEventListener('iron-resize', this._hiddenState);
-    }
-  }
-
   _equals(a, b) {
     return a === b;
   }
@@ -112,27 +98,13 @@ class HuiInputNumberEntityRow extends mixinBehaviors([IronResizableBehavior], Po
     this._config = config;
   }
 
-  _hiddenState() {
-    if (this._stateObj.attributes.mode !== 'slider') return;
-    const sliderwidth = this.shadowRoot.querySelector('paper-slider').offsetWidth;
-    const stateElement = this.shadowRoot.querySelector('.state');
-    if (sliderwidth < 100) {
-      stateElement.style.display = 'none';
-    } else if (sliderwidth >= 145) {
-      stateElement.style.display = 'inline';
-    }
-  }
-
-  _stateObjChanged(stateObj, oldStateObj) {
+  _stateObjChanged(stateObj) {
     this.setProperties({
       _min: Number(stateObj.attributes.min),
       _max: Number(stateObj.attributes.max),
       _step: Number(stateObj.attributes.step),
       _value: Number(stateObj.state)
     });
-    if (oldStateObj && stateObj.attributes.mode === 'slider' && oldStateObj.attributes.mode !== 'slider') {
-      this._hiddenState();
-    }
   }
 
   _selectedValueChanged() {

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.js
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.js
@@ -83,6 +83,20 @@ class HuiInputNumberEntityRow extends mixinBehaviors([IronResizableBehavior], Po
     };
   }
 
+  ready() {
+    super.ready();
+    if (typeof ResizeObserver === 'function') {
+      const ro = new ResizeObserver((entries) => {
+        entries.forEach(() => {
+          this._hiddenState();
+        });
+      });
+      ro.observe(this.$.input_number_card);
+    } else {
+      this.addEventListener('iron-resize', this._hiddenState);
+    }
+  }
+
   _equals(a, b) {
     return a === b;
   }
@@ -98,13 +112,24 @@ class HuiInputNumberEntityRow extends mixinBehaviors([IronResizableBehavior], Po
     this._config = config;
   }
 
-  _stateObjChanged(stateObj) {
+  _hiddenState() {
+    if (!this.$ || this._stateObj.attributes.mode !== 'slider') return;
+    const width = this.$.input_number_card.offsetWidth;
+    const stateEl = this.shadowRoot.querySelector('.state');
+    if (!stateEl) return;
+    stateEl.hidden = width <= 350;
+  }
+
+  _stateObjChanged(stateObj, oldStateObj) {
     this.setProperties({
       _min: Number(stateObj.attributes.min),
       _max: Number(stateObj.attributes.max),
       _step: Number(stateObj.attributes.step),
       _value: Number(stateObj.state)
     });
+    if (oldStateObj && stateObj.attributes.mode === 'slider' && oldStateObj.attributes.mode !== 'slider') {
+      this._hiddenState();
+    }
   }
 
   _selectedValueChanged() {


### PR DESCRIPTION
Removed `_hiddenState()` method from `hui-input-number-entity-row` since it always has the same result. `<paper-slider>` has hardcoded width so `sliderWidth` is always 200. Also changed the `.state` div to a span since it was always getting `display: inline` anyway

cc @c727 Do you know what the purpose of this method was? I can't see how it was having any effect

Fixes https://github.com/home-assistant/ui-schema/issues/151 since the `querySelector` calls were sometimes returning `null` in Safari