### PR TITLE
Add channel picker in media_player dialog

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -265,7 +265,8 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
         || !this.playerObj.supportsSelectSource
         || this.playerObj.sourceList === undefined
         || sourceIndex < 0
-        || sourceIndex >= this.playerObj.sourceList
+        // In case source list has been updated and a source removed
+        || sourceIndex >= this.playerObj.sourceList.length
         || sourceIndexOld === undefined
     ) {
       return;
@@ -285,7 +286,8 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
     if (!this.playerObj
         || this.playerObj.channelList === undefined
         || channelIndex < 0
-        || channelIndex >= this.playerObj.channelList
+        // In case channel list has been updated and a channel removed
+        || channelIndex >= this.playerObj.channelList.length
         || channelIndexOld === undefined
     ) {
       return;

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -146,7 +146,7 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
         value: 0,
         observer: 'handleSourceChanged',
       },
-      
+
       channelIndex: {
         type: Number,
         value: 0,

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -98,6 +98,17 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
         </paper-listbox>
       </paper-dropdown-menu>
     </div>
+    <!-- CHANNEL PICKER -->
+    <div class="controls layout horizontal justified" hidden$="[[computeHideSelectChannel(playerObj)]]">
+      <iron-icon class="source-input" icon="hass:login-variant"></iron-icon>
+      <paper-dropdown-menu class="flex source-input" dynamic-align="" label-float="" label="[[localize('ui.card.media_player.channel')]]">
+        <paper-listbox slot="dropdown-content" selected="{{channelIndex}}">
+          <template is="dom-repeat" items="[[playerObj.channelList]]">
+            <paper-item>[[item]]</paper-item>
+          </template>
+        </paper-listbox>
+      </paper-dropdown-menu>
+    </div>
     <!-- SOUND MODE PICKER -->
     <template is='dom-if' if='[[!computeHideSelectSoundMode(playerObj)]]'>
       <div class="controls layout horizontal justified">
@@ -135,6 +146,12 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
         value: 0,
         observer: 'handleSourceChanged',
       },
+      
+      channelIndex: {
+        type: Number,
+        value: 0,
+        observer: 'handleChannelChanged',
+      },
 
       SoundModeInput: {
         type: String,
@@ -162,6 +179,10 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
   playerObjChanged(newVal, oldVal) {
     if (newVal && newVal.sourceList !== undefined) {
       this.sourceIndex = newVal.sourceList.indexOf(newVal.source);
+    }
+
+    if (newVal && newVal.channelList !== undefined) {
+      this.channelIndex = newVal.channelList.indexOf(newVal.channel);
     }
 
     if (newVal && newVal.soundModeList !== undefined) {
@@ -204,6 +225,10 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   computeHideSelectSource(playerObj) {
     return playerObj.isOff || !playerObj.supportsSelectSource || !playerObj.sourceList;
+  }
+
+  computeHideSelectChannel(playerObj) {
+    return playerObj.isOff || !playerObj.channelList || !playerObj.channel;
   }
 
   computeHideSelectSoundMode(playerObj) {
@@ -254,6 +279,27 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
     this.playerObj.selectSource(sourceInput);
   }
+
+  handleChannelChanged(channelIndex, channelIndexOld) {
+    // Selected Option will transition to '' before transitioning to new value
+    if (!this.playerObj
+        || this.playerObj.channelList === undefined
+        || channelIndex < 0
+        || channelIndex >= this.playerObj.channelList
+        || channelIndexOld === undefined
+    ) {
+      return;
+    }
+
+    const channelInput = this.playerObj.channelList[channelIndex];
+
+    if (channelInput === this.playerObj.channel) {
+      return;
+    }
+
+    this.playerObj.selectChannel(channelInput);
+  }
+
 
   handleSoundModeChanged(newVal, oldVal) {
     if (oldVal

--- a/src/util/hass-media-player-model.js
+++ b/src/util/hass-media-player-model.js
@@ -145,11 +145,11 @@ export default class MediaPlayerEntity {
   }
 
   get channel() {
-    if (this._attr.media_content_type == 'channel') {
-	return this._attr.media_title;
-    } else {
-        return;
+    if (this._attr.media_content_type === 'channel') {
+      return this._attr.media_title;
     }
+
+    return '';
   }
 
   get channelList() {

--- a/src/util/hass-media-player-model.js
+++ b/src/util/hass-media-player-model.js
@@ -144,6 +144,19 @@ export default class MediaPlayerEntity {
     return this._attr.source_list;
   }
 
+  get channel() {
+    if (this._attr.media_content_type == 'channel') {
+	return this._attr.media_title;
+    } else {
+        return;
+    }
+  }
+
+  get channelList() {
+    return this._attr.channel_list;
+  }
+
+
   get soundMode() {
     return this._attr.sound_mode;
   }
@@ -205,6 +218,10 @@ export default class MediaPlayerEntity {
 
   selectSource(source) {
     this.callService('select_source', { source });
+  }
+
+  selectChannel(channel) {
+    this.callService('play_media', { media_content_id: channel, media_content_type: 'channel' });
   }
 
   selectSoundMode(soundMode) {

--- a/translations/en.json
+++ b/translations/en.json
@@ -632,7 +632,8 @@
             "media_player": {
                 "text_to_speak": "Text to speak",
                 "source": "Source",
-                "sound_mode": "Sound mode"
+                "sound_mode": "Sound mode",
+                "channel": "Channel"
             },
             "climate": {
                 "currently": "Currently",


### PR DESCRIPTION
Allows choosing a channel in a media_player component that supports it

![image](https://user-images.githubusercontent.com/6267124/44030768-18be472e-9f02-11e8-9d29-573746d2a4ad.png)


Need this PR in the backend : https://github.com/home-assistant/home-assistant/pull/15941