### PR TITLE
Media Player: Standardize computePlaybackControlIcon

### DIFF
--- a/src/cards/ha-media_player-card.js
+++ b/src/cards/ha-media_player-card.js
@@ -275,7 +275,10 @@ class HaMediaPlayerCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   computePlaybackControlIcon(playerObj) {
     if (playerObj.isPlaying) {
       return playerObj.supportsPause ? 'hass:pause' : 'hass:stop';
-    } else if (playerObj.isPaused || playerObj.isOff || playerObj.isIdle) {
+    } else if (playerObj.hasMediaControl || playerObj.isOff || playerObj.isIdle) {
+      if (playerObj.hasMediaControl && playerObj.supportsPause && !playerObj.isPaused) {
+        return 'hass:play-pause';
+      }
       return playerObj.supportsPlay ? 'hass:play' : null;
     }
     return '';

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -194,10 +194,15 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
   computePlaybackControlIcon(playerObj) {
     if (playerObj.isPlaying) {
       return playerObj.supportsPause ? 'hass:pause' : 'hass:stop';
+    } else if (playerObj.hasMediaControl || playerObj.isOff || playerObj.isIdle) {
+      if (playerObj.hasMediaControl && playerObj.supportsPause && !playerObj.isPaused) {
+        return 'hass:play-pause';
+      }
+      return playerObj.supportsPlay ? 'hass:play' : null;
     }
-    return playerObj.supportsPlay ? 'hass:play' : null;
+    return '';
   }
-
+  
   computeHidePowerButton(playerObj) {
     return playerObj.isOff ? !playerObj.supportsTurnOn : !playerObj.supportsTurnOff;
   }

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -202,7 +202,7 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
     }
     return '';
   }
-  
+
   computeHidePowerButton(playerObj) {
     return playerObj.isOff ? !playerObj.supportsTurnOn : !playerObj.supportsTurnOff;
   }


### PR DESCRIPTION
The more-info dialog and the card for media player had two separate methods for computing the playback control icon.  This PR addresses those differences so both show under the same circumstances.  I also added support for "unknown" state, as the `MediaPlayerEntity` includes this in the `hasMediaControl` getter.

Finally, I added a play/pause icon for the unknown state where the media is not playing, nor is it paused, but the component still supports pause.  This comes in handy for the Xbox One component I am building which relies on individual apps to have implemented the media state model in the Xbox framework, and for the Xbox smartglass protocol to be communicating properly.  They still support the controls, but sometimes do not relay information about what is playing.  You can see the results in the below screenshots.

<img width="507" alt="screen shot 2018-08-14 at 11 02 39 pm" src="https://user-images.githubusercontent.com/747670/44129903-c63c1612-a018-11e8-8f44-f18923adf7d8.png">

<img width="501" alt="screen shot 2018-08-14 at 11 11 31 pm" src="https://user-images.githubusercontent.com/747670/44129905-c86fc546-a018-11e8-802f-316bc177a70d.png">