### PR TITLE
Fix group more-info dialog

### DIFF
--- a/src/dialogs/more-info/controls/more-info-group.js
+++ b/src/dialogs/more-info/controls/more-info-group.js
@@ -55,7 +55,7 @@ class MoreInfoGroup extends PolymerElement {
 
   computeStates(stateObj, hass) {
     var states = [];
-    var entIds = stateObj.attributes.entity_id;
+    var entIds = stateObj.attributes.entity_id || [];
 
     for (var i = 0; i < entIds.length; i++) {
       var state = hass.states[entIds[i]];


### PR DESCRIPTION
When click to open more-info-group dialog on Climate group, stateObj.attributes.entity_id is null and cause JavaScript error. fixes: #1466 