### PR TITLE
Include ES5 version of hass-icons

### DIFF
--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -9,7 +9,7 @@
     <link rel='apple-touch-icon' sizes='180x180'
           href='/static/icons/favicon-apple-180x180.png'>
     <link rel="mask-icon" href="/static/icons/mask-icon.svg" color="#3fbbf4">
-    <link rel='preload' href='<%= corejs %>' as='script'/>
+    <link rel='preload' href='<%= coreJS %>' as='script'/>
     <link rel='preload' href='/static/fonts/roboto/Roboto-Regular.ttf' as='font' crossorigin />
     <link rel='preload' href='/static/fonts/roboto/Roboto-Medium.ttf' as='font' crossorigin />
     <meta name='apple-mobile-web-app-capable' content='yes'>
@@ -73,9 +73,9 @@
         }());
       }
     </script>
-    <script src='<%= corejs %>'></script>
-    <script src='<%= appjs %>'></script>
-    <script src='/frontend_latest/hass-icons.js' async></script>
+    <script src='<%= coreJS %>'></script>
+    <script src='<%= appJS %>'></script>
+    <script src='<%= hassIconsJS %>' async></script>
     {% for extra_url in extra_urls -%}
       <link rel='import' href='{{ extra_url }}' async>
     {% endfor -%}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,10 +41,10 @@ function createConfig(isProdBuild, latestBuild) {
     core: './src/entrypoints/core.js',
     compatibility: './src/entrypoints/compatibility.js',
     'custom-panel': './src/entrypoints/custom-panel.js',
+    'hass-icons': './src/entrypoints/hass-icons.js',
   };
 
   if (latestBuild) {
-    entry['hass-icons'] = './src/entrypoints/hass-icons.js';
     entry['service-worker-hass'] = './src/entrypoints/service-worker-hass.js';
   }
 
@@ -188,9 +188,10 @@ function createConfig(isProdBuild, latestBuild) {
         templateParameters: (compilation, assets, option) => ({
           latestBuild,
           compatibility: assets.chunks.compatibility.entry,
-          appjs: assets.chunks.app.entry,
-          corejs: assets.chunks.core.entry,
+          appJS: assets.chunks.app.entry,
+          coreJS: assets.chunks.core.entry,
           customPanelJS: assets.chunks['custom-panel'].entry,
+          hassIconsJS: assets.chunks['hass-icons'].entry,
         }),
         filename: `index.html`,
       }),
@@ -200,9 +201,6 @@ function createConfig(isProdBuild, latestBuild) {
     output: {
       filename: ({ chunk }) => {
         const dontHash = new Set([
-          // Because we don't include it in ES5 build
-          // And so can't reference it there
-          'hass-icons',
           // This is loaded from service-worker-bootstrap.js
           // which is processed by Workbox, not Webpack
           'service-worker-hass',


### PR DESCRIPTION
To save space, we would only build our iconset once. However, then our icon set got some ES5 incompatible code and stuff broke. Removing all the hacks and including hass-icons in ES5 build.

Fixes #1573