### PR TITLE
Use core temperature units for climate entities.

### DIFF
--- a/src/components/ha-climate-state.js
+++ b/src/components/ha-climate-state.js
@@ -35,7 +35,7 @@ class HaClimateState extends LocalizeMixin(PolymerElement) {
       <span class="state-label">
         [[_localizeState(stateObj.state)]]
       </span>
-      [[computeTarget(stateObj)]]
+      [[computeTarget(hass, stateObj)]]
     </div>
 
     <template is="dom-if" if="[[currentStatus]]">
@@ -52,33 +52,35 @@ class HaClimateState extends LocalizeMixin(PolymerElement) {
       stateObj: Object,
       currentStatus: {
         type: String,
-        computed: 'computeCurrentStatus(stateObj)',
+        computed: 'computeCurrentStatus(hass, stateObj)',
       },
     };
   }
 
-  computeCurrentStatus(stateObj) {
+  computeCurrentStatus(hass, stateObj) {
+    if (!hass || !stateObj) return null;
     if (stateObj.attributes.current_temperature != null) {
-      return `${stateObj.attributes.current_temperature} ${stateObj.attributes.unit_of_measurement}`;
+      return `${stateObj.attributes.current_temperature} ${hass.config.core.unit_system.temperature}`;
     }
     if (stateObj.attributes.current_humidity != null) {
-      return `${stateObj.attributes.current_humidity} ${stateObj.attributes.unit_of_measurement}`;
+      return `${stateObj.attributes.current_humidity} %`;
     }
     return null;
   }
 
-  computeTarget(stateObj) {
+  computeTarget(hass, stateObj) {
+    if (!hass || !stateObj) return null;
     // We're using "!= null" on purpose so that we match both null and undefined.
     if (stateObj.attributes.target_temp_low != null &&
         stateObj.attributes.target_temp_high != null) {
-      return `${stateObj.attributes.target_temp_low} - ${stateObj.attributes.target_temp_high} ${stateObj.attributes.unit_of_measurement}`;
+      return `${stateObj.attributes.target_temp_low} - ${stateObj.attributes.target_temp_high} ${hass.config.core.unit_system.temperature}`;
     } else if (stateObj.attributes.temperature != null) {
-      return `${stateObj.attributes.temperature} ${stateObj.attributes.unit_of_measurement}`;
+      return `${stateObj.attributes.temperature} ${hass.config.core.unit_system.temperature}`;
     } else if (stateObj.attributes.target_humidity_low != null &&
                stateObj.attributes.target_humidity_high != null) {
-      return `${stateObj.attributes.target_humidity_low} - ${stateObj.attributes.target_humidity_high} ${stateObj.attributes.unit_of_measurement}`;
+      return `${stateObj.attributes.target_humidity_low} - ${stateObj.attributes.target_humidity_high} %`;
     } else if (stateObj.attributes.humidity != null) {
-      return `${stateObj.attributes.humidity} ${stateObj.attributes.unit_of_measurement}`;
+      return `${stateObj.attributes.humidity} %`;
     }
 
     return '';

--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -125,13 +125,13 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
         <div class$="[[stateObj.attributes.operation_mode]]">
           <div hidden$="[[!supportsTemperatureControls(stateObj)]]">[[localize('ui.card.climate.target_temperature')]]</div>
           <template is="dom-if" if="[[supportsTemperature(stateObj)]]">
-            <ha-climate-control value="[[stateObj.attributes.temperature]]" units="[[stateObj.attributes.unit_of_measurement]]" step="[[computeTemperatureStepSize(stateObj)]]" min="[[stateObj.attributes.min_temp]]" max="[[stateObj.attributes.max_temp]]" on-change="targetTemperatureChanged">
+            <ha-climate-control value="[[stateObj.attributes.temperature]]" units="[[hass.config.core.unit_system.temperature]]" step="[[computeTemperatureStepSize(hass, stateObj)]]" min="[[stateObj.attributes.min_temp]]" max="[[stateObj.attributes.max_temp]]" on-change="targetTemperatureChanged">
             </ha-climate-control>
           </template>
           <template is="dom-if" if="[[supportsTemperatureRange(stateObj)]]">
-            <ha-climate-control value="[[stateObj.attributes.target_temp_low]]" units="[[stateObj.attributes.unit_of_measurement]]" step="[[computeTemperatureStepSize(stateObj)]]" min="[[stateObj.attributes.min_temp]]" max="[[stateObj.attributes.target_temp_high]]" class="range-control-left" on-change="targetTemperatureLowChanged">
+            <ha-climate-control value="[[stateObj.attributes.target_temp_low]]" units="[[hass.config.core.unit_system.temperature]]" step="[[computeTemperatureStepSize(hass, stateObj)]]" min="[[stateObj.attributes.min_temp]]" max="[[stateObj.attributes.target_temp_high]]" class="range-control-left" on-change="targetTemperatureLowChanged">
             </ha-climate-control>
-            <ha-climate-control value="[[stateObj.attributes.target_temp_high]]" units="[[stateObj.attributes.unit_of_measurement]]" step="[[computeTemperatureStepSize(stateObj)]]" min="[[stateObj.attributes.target_temp_low]]" max="[[stateObj.attributes.max_temp]]" class="range-control-right" on-change="targetTemperatureHighChanged">
+            <ha-climate-control value="[[stateObj.attributes.target_temp_high]]" units="[[hass.config.core.unit_system.temperature]]" step="[[computeTemperatureStepSize(hass, stateObj)]]" min="[[stateObj.attributes.target_temp_low]]" max="[[stateObj.attributes.max_temp]]" class="range-control-right" on-change="targetTemperatureHighChanged">
             </ha-climate-control>
           </template>
         </div>
@@ -290,10 +290,10 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
     }
   }
 
-  computeTemperatureStepSize(stateObj) {
+  computeTemperatureStepSize(hass, stateObj) {
     if (stateObj.attributes.target_temp_step) {
       return stateObj.attributes.target_temp_step;
-    } else if (stateObj.attributes.unit_of_measurement.indexOf('F') !== -1) {
+    } else if (hass.config.core.unit_system.temperature.indexOf('F') !== -1) {
       return 1;
     }
     return 0.5;


### PR DESCRIPTION
Use core temperature units instead of `unit_of_measurement` for climate entities.

**Must be merged before https://github.com/home-assistant/home-assistant/pull/16012**

Architecture discussion: https://github.com/home-assistant/architecture/issues/48

Related issues: 
- https://github.com/home-assistant/ui-schema/issues/137
- https://github.com/home-assistant/ui-schema/issues/148