### PR TITLE
Disable XSS filter in flow step description markdown

### DIFF
--- a/src/components/ha-markdown.js
+++ b/src/components/ha-markdown.js
@@ -12,7 +12,11 @@ class HaMarkdown extends EventsMixin(PolymerElement) {
       content: {
         type: String,
         observer: '_render',
-      }
+      },
+      disableXssFilter: {
+        type: Boolean,
+        value: false,
+      },
     };
   }
 
@@ -29,7 +33,7 @@ class HaMarkdown extends EventsMixin(PolymerElement) {
     loaded.then(
       ({ marked, filterXSS }) => {
         this.marked = marked;
-        this.filterXSS = filterXSS;
+        this.filterXSS = this.disableXssFilter ? c => c : filterXSS;
         this._scriptLoaded = 1;
       },
       () => { this._scriptLoaded = 2; },

--- a/src/panels/config/config-entries/ha-config-flow.js
+++ b/src/panels/config/config-entries/ha-config-flow.js
@@ -71,7 +71,7 @@ class HaConfigFlow extends
 
           <template is="dom-if" if="[[_equals(_step.type, 'form')]]">
             <template is="dom-if" if="[[_computeStepDescription(localize, _step)]]">
-              <ha-markdown content="[[_computeStepDescription(localize, _step)]]"></ha-markdown>
+              <ha-markdown content="[[_computeStepDescription(localize, _step)]]" disable-xss-filter></ha-markdown>
             </template>
 
             <ha-form

--- a/src/panels/profile/ha-mfa-module-setup-flow.js
+++ b/src/panels/profile/ha-mfa-module-setup-flow.js
@@ -71,7 +71,7 @@ class HaMfaModuleSetupFlow extends
 
           <template is="dom-if" if="[[_equals(_step.type, 'form')]]">
             <template is="dom-if" if="[[_computeStepDescription(localize, _step)]]">
-              <ha-markdown content="[[_computeStepDescription(localize, _step)]]"></ha-markdown>
+              <ha-markdown content="[[_computeStepDescription(localize, _step)]]" disable-xss-filter></ha-markdown>
             </template>
 
             <ha-form


### PR DESCRIPTION
XSS filter will filter out `data:image` in `<image>` `src` attribute. Disable the XSS filter allow us to use embedded image in description placeholder. Since we are fully control the  step description placeholder, the XSS will not be the concern.

See: https://github.com/home-assistant/home-assistant/pull/16129#issuecomment-415991096