### PR TITLE
Lovelace: Don't show badge entities in unused list

### DIFF
--- a/src/panels/lovelace/common/compute-unused-entities.js
+++ b/src/panels/lovelace/common/compute-unused-entities.js
@@ -18,6 +18,7 @@ function computeUsedEntities(config) {
     if (obj.entities) obj.entities.forEach(entity => addEntityId(entity));
     if (obj.card) addEntities(obj.card);
     if (obj.cards) obj.cards.forEach(card => addEntities(card));
+    if (obj.badges) obj.badges.forEach(badge => addEntityId(badge));
   }
 
   config.views.forEach(view => addEntities(view));


### PR DESCRIPTION
For the Lovelace UI
This one-liner prevents entities that are only listed in a 'badges' section from showing up in the 'Unused Entities' page

Resolves:
https://github.com/home-assistant/home-assistant/issues/16230

