### PR TITLE
Add external auth

### DIFF
--- a/src/common/auth/external_auth.js
+++ b/src/common/auth/external_auth.js
@@ -1,7 +1,7 @@
 /**
  * Auth class that connects to a native app for authentication.
  */
-import { Auth } from "home-assistant-js-websocket";
+import { Auth } from 'home-assistant-js-websocket';
 
 const CALLBACK_METHOD = 'externalAuthSetToken';
 
@@ -14,7 +14,7 @@ export default class ExternalAuth extends Auth {
       access_token: '',
       // This will trigger connection to do a refresh right away
       expires: 0,
-    }
+    };
   }
 
   async refreshAccessToken() {
@@ -22,7 +22,7 @@ export default class ExternalAuth extends Auth {
       window.externalApp.getExternalAuth :
       window.webkit.messageHandlers.getExternalAuth.postMessage;
 
-      const responseProm = new Promise(resolve => { window[CALLBACK_METHOD] = resolve; });
+    const responseProm = new Promise((resolve) => { window[CALLBACK_METHOD] = resolve; });
 
     // Allow promise to set resolve on window object.
     await 0;
@@ -37,6 +37,6 @@ export default class ExternalAuth extends Auth {
     const tokens = await responseProm;
 
     this.data.access_token = tokens.access_token;
-    this.data.expires = tokens.expires_in * 1000 + Date.now();
+    this.data.expires = (tokens.expires_in * 1000) + Date.now();
   }
 }

--- a/src/common/auth/external_auth.js
+++ b/src/common/auth/external_auth.js
@@ -5,6 +5,10 @@ import { Auth } from 'home-assistant-js-websocket';
 
 const CALLBACK_METHOD = 'externalAuthSetToken';
 
+if (!window.externalApp && !window.webkit) {
+  throw new Error('External auth requires either externalApp or webkit defined on Window object.');
+}
+
 export default class ExternalAuth extends Auth {
   constructor(hassUrl) {
     super();

--- a/src/common/auth/external_auth.js
+++ b/src/common/auth/external_auth.js
@@ -1,0 +1,42 @@
+/**
+ * Auth class that connects to a native app for authentication.
+ */
+import { Auth } from "home-assistant-js-websocket";
+
+const CALLBACK_METHOD = 'externalAuthSetToken';
+
+export default class ExternalAuth extends Auth {
+  constructor(hassUrl) {
+    super();
+
+    this.data = {
+      hassUrl,
+      access_token: '',
+      // This will trigger connection to do a refresh right away
+      expires: 0,
+    }
+  }
+
+  async refreshAccessToken() {
+    const meth = window.externalApp ?
+      window.externalApp.getExternalAuth :
+      window.webkit.messageHandlers.getExternalAuth.postMessage;
+
+      const responseProm = new Promise(resolve => { window[CALLBACK_METHOD] = resolve; });
+
+    // Allow promise to set resolve on window object.
+    await 0;
+
+    meth({ callback: CALLBACK_METHOD });
+
+    // Response we expect back:
+    // {
+    //   "access_token": "qwere",
+    //   "expires_in": 1800
+    // }
+    const tokens = await responseProm;
+
+    this.data.access_token = tokens.access_token;
+    this.data.expires = tokens.expires_in * 1000 + Date.now();
+  }
+}

--- a/src/entrypoints/core.js
+++ b/src/entrypoints/core.js
@@ -11,11 +11,18 @@ import { subscribePanels } from '../data/ws-panels.js';
 import { subscribeThemes } from '../data/ws-themes.js';
 import { subscribeUser } from '../data/ws-user.js';
 
-window.hassAuth = getAuth({
-  hassUrl: `${location.protocol}//${location.host}`,
-  saveTokens,
-  loadTokens: () => Promise.resolve(loadTokens()),
-});
+const hassUrl = `${location.protocol}//${location.host}`;
+
+if (location.search.includes('external_auth=1')) {
+  window.hassAuth = import('../common/auth/external_auth.js')
+    .then(mod => new mod.default(hassUrl));
+} else {
+  window.hassAuth = getAuth({
+    hassUrl,
+    saveTokens,
+    loadTokens: () => Promise.resolve(loadTokens()),
+  });
+}
 
 window.hassConnection = window.hassAuth.then((auth) => {
   if (location.search.includes('auth_callback=1')) {


### PR DESCRIPTION
This will allow auth to be provided by an external app. To use external auth, load the frontend with `http://localhost:8123/?external_auth=1`: 

Fixes #1606

API:

External app needs to provide one of either methods:

```js
window.externalApp.getExternalAuth();
// or
window.webkit.messageHandlers.getExternalAuth.postMessage();
```

When an access token is needed, this method will be called with an object that defines the callback to call:

```js
window.webkit.messageHandlers.getExternalAuth.postMessage({
  callback: 'externalAuthSetToken'
});
```

The external app will need to call this method with new tokens:

```js
window.externalAuthSetToken({
  access_token: "ABCDEFH",
  expires_in: 1800,  // seconds that the token is ready
});
```