### PR TITLE
Autocapitalization of username field

### DIFF
--- a/src/onboarding/ha-onboarding.js
+++ b/src/onboarding/ha-onboarding.js
@@ -42,6 +42,7 @@ class HaOnboarding extends localizeLiteMixin(PolymerElement) {
         value='{{_name}}'
         required
         auto-validate
+        autocapitalize='words'
         error-message="[[localize('ui.panel.page-onboarding.user.required_field')]]"
         on-blur='_maybePopulateUsername'
       ></paper-input>
@@ -51,6 +52,7 @@ class HaOnboarding extends localizeLiteMixin(PolymerElement) {
         value='{{_username}}'
         required
         auto-validate
+        autocapitalize='none'
         error-message="[[localize('ui.panel.page-onboarding.user.required_field')]]"
       ></paper-input>
 

--- a/src/onboarding/ha-onboarding.js
+++ b/src/onboarding/ha-onboarding.js
@@ -42,7 +42,7 @@ class HaOnboarding extends localizeLiteMixin(PolymerElement) {
         value='{{_name}}'
         required
         auto-validate
-        autocapitalize='words'
+        autocapitalize='on'
         error-message="[[localize('ui.panel.page-onboarding.user.required_field')]]"
         on-blur='_maybePopulateUsername'
       ></paper-input>

--- a/src/panels/config/users/ha-dialog-add-user.js
+++ b/src/panels/config/users/ha-dialog-add-user.js
@@ -37,7 +37,7 @@ class HaDialogAddUser extends LocalizeMixin(PolymerElement) {
           value='{{_name}}'
           required
           auto-validate
-          autocapitalize='words'
+          autocapitalize='on'
           error-message='Required'
           on-blur='_maybePopulateUsername'
         ></paper-input>

--- a/src/panels/config/users/ha-dialog-add-user.js
+++ b/src/panels/config/users/ha-dialog-add-user.js
@@ -37,6 +37,7 @@ class HaDialogAddUser extends LocalizeMixin(PolymerElement) {
           value='{{_name}}'
           required
           auto-validate
+          autocapitalize='words'
           error-message='Required'
           on-blur='_maybePopulateUsername'
         ></paper-input>
@@ -46,6 +47,7 @@ class HaDialogAddUser extends LocalizeMixin(PolymerElement) {
           value='{{_username}}'
           required
           auto-validate
+          autocapitalize='none'
           error-message='Required'
         ></paper-input>
         <paper-input


### PR DESCRIPTION
## Description

Sets `autocapitalize` for username and name fields. This makes sure the username is always lowercase when logging in or creating accounts with mobile devices.

## Related issue this fixes

#1626 
