### PR TITLE
Ask "save login" after hass connected

### DIFF
--- a/src/layouts/app/auth-mixin.js
+++ b/src/layouts/app/auth-mixin.js
@@ -11,6 +11,11 @@ export default superClass => class extends superClass {
     // HACK :( We don't have a way yet to trigger an update of `subscribeUser`
     this.addEventListener('hass-refresh-current-user', () =>
       getUser(this.hass.connection).then(user => this._updateHass({ user })));
+  }
+
+  hassConnected() {
+    super.hassConnected();
+    subscribeUser(this.hass.connection, user => this._updateHass({ user }));
 
     afterNextRender(null, () => {
       if (askWrite()) {
@@ -20,11 +25,6 @@ export default superClass => class extends superClass {
         import(/* webpackChunkName: "ha-store-auth-card" */ '../../dialogs/ha-store-auth-card.js');
       }
     });
-  }
-
-  hassConnected() {
-    super.hassConnected();
-    subscribeUser(this.hass.connection, user => this._updateHass({ user }));
   }
 
   _handleLogout() {


### PR DESCRIPTION
askWrite() should be called only hassConnection established, e.g., authentication passed. 

Fixes: home-assistant/home-assistant#16347

Lots of users report that they never seen "save login" dialog. I finally can reproduce this issue by using Firefox (showdom==False) access my production box through external network. After some investigation, I found out that sometime `askWrite()` will be called before HAWS called `saveTokens()`, therefore `askWrite()` will return false, the "save login" dialog didn't show up.

Move `askWrite(`) into `hassConnected` from `ready` should resolve it.