### PR TITLE
Don't delete system generated user

### DIFF
--- a/src/panels/config/users/ha-user-editor.js
+++ b/src/panels/config/users/ha-user-editor.js
@@ -29,9 +29,6 @@ class HaUserEditor extends EventsMixin(NavigateMixin(LocalizeMixin(PolymerElemen
     paper-card:last-child {
       margin-bottom: 16px;
     }
-    paper-button {
-      display: block;
-    }
   </style>
 
   <hass-subpage header="View user">
@@ -57,9 +54,12 @@ class HaUserEditor extends EventsMixin(NavigateMixin(LocalizeMixin(PolymerElemen
     </paper-card>
     <paper-card>
       <div class='card-actions'>
-        <paper-button on-click='_deleteUser'>
+        <paper-button on-click='_deleteUser' disabled='[[user.system_generated]]'>
           [[localize('ui.panel.config.users.editor.delete_user')]]
         </paper-button>
+        <template is='dom-if' if='[[user.system_generated]]'>
+          Unable to remove system generated users.
+        </template>
       </div>
     </paper-card>
   </hass-subpage>

--- a/src/panels/config/users/ha-user-picker.js
+++ b/src/panels/config/users/ha-user-picker.js
@@ -50,7 +50,12 @@ class HaUserPicker extends EventsMixin(NavigateMixin(LocalizeMixin(PolymerElemen
           <paper-item>
             <paper-item-body two-line>
               <div>[[_withDefault(user.name, 'Unnamed User')]]</div>
-              <div secondary="">[[user.id]]</div>
+              <div secondary="">
+                [[user.id]]
+                <template is='dom-if' if='[[user.system_generated]]'>
+                - System Generated
+                </template>
+              </div>
             </paper-item-body>
             <iron-icon icon="hass:chevron-right"></iron-icon>
           </paper-item>


### PR DESCRIPTION
- Prevent user from deleting system generated users.
- Indicate in the frontend that a user is system generated.