### PR TITLE
Add revoke token to (external) auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "es6-object-assign": "^1.1.0",
     "eslint-import-resolver-webpack": "^0.10.0",
     "fecha": "^2.3.3",
-    "home-assistant-js-websocket": "^3.0.0",
+    "home-assistant-js-websocket": "^3.1.1",
     "intl-messageformat": "^2.2.0",
     "js-yaml": "^3.12.0",
     "leaflet": "^1.3.1",

--- a/src/common/auth/external_auth.js
+++ b/src/common/auth/external_auth.js
@@ -28,7 +28,7 @@ export default class ExternalAuth extends Auth {
     // Allow promise to set resolve on window object.
     await 0;
 
-    const callbackPayload = { callback: CALLBACK_METHOD };
+    const callbackPayload = { callback: CALLBACK_SET_TOKEN };
 
     if (window.externalApp) {
       window.externalApp.getExternalAuth(callbackPayload);

--- a/src/layouts/app/auth-mixin.js
+++ b/src/layouts/app/auth-mixin.js
@@ -27,9 +27,15 @@ export default superClass => class extends superClass {
     });
   }
 
-  _handleLogout() {
-    this.hass.connection.close();
-    clearState();
-    document.location.href = '/';
+  async _handleLogout() {
+    try {
+      await this.hass.auth.revoke();
+      this.hass.connection.close();
+      clearState();
+      document.location.href = '/';
+    } catch (err) {
+      console.error(err);
+      alert('Log out failed');
+    }
   }
 };

--- a/src/layouts/app/auth-mixin.js
+++ b/src/layouts/app/auth-mixin.js
@@ -34,6 +34,7 @@ export default superClass => class extends superClass {
       clearState();
       document.location.href = '/';
     } catch (err) {
+      // eslint-disable-next-line
       console.error(err);
       alert('Log out failed');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6561,9 +6561,9 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-home-assistant-js-websocket@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-3.0.0.tgz#498828a29827bdd1f3e99cf3b5e152694cededbf"
+home-assistant-js-websocket@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-3.1.1.tgz#264f9efdafdff1053294b07bcaa5629e51a22b73"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Allows revoking the auth token. It will be triggered when the user clicks on the logout button.

Also adds it to the external API. 

Requires https://github.com/home-assistant/home-assistant-js-websocket/pull/53

Documentation external API: https://developers.home-assistant.io/docs/en/next/frontend_external_auth.html

CC @blackgold9