### PR TITLE
Fix the way calls are made over the javascript bridge

### DIFF
--- a/src/common/auth/external_auth.js
+++ b/src/common/auth/external_auth.js
@@ -27,7 +27,7 @@ export default class ExternalAuth extends Auth {
     // Allow promise to set resolve on window object.
     await 0;
 
-    const callbackPayload = { callback: CALLBACK_METHOD }
+    const callbackPayload = { callback: CALLBACK_METHOD };
 
     if (window.externalApp) {
       window.externalApp.getExternalAuth(callbackPayload);

--- a/src/common/auth/external_auth.js
+++ b/src/common/auth/external_auth.js
@@ -22,16 +22,18 @@ export default class ExternalAuth extends Auth {
   }
 
   async refreshAccessToken() {
-    const meth = window.externalApp ?
-      window.externalApp.getExternalAuth :
-      window.webkit.messageHandlers.getExternalAuth.postMessage;
-
     const responseProm = new Promise((resolve) => { window[CALLBACK_METHOD] = resolve; });
 
     // Allow promise to set resolve on window object.
     await 0;
 
-    meth({ callback: CALLBACK_METHOD });
+    const callbackPayload = { callback: CALLBACK_METHOD }
+
+    if (window.externalApp) {
+      window.externalApp.getExternalAuth(callbackPayload);
+    } else {
+      window.webkit.messageHandlers.getExternalAuth.postMessage(callbackPayload);
+    }
 
     // Response we expect back:
     // {


### PR DESCRIPTION
Not sure why the original way would not succeed, but changing it to this slightly more verbose way works perfectly.