### PR TITLE
Update external auth

### DIFF
--- a/src/common/auth/external_auth.js
+++ b/src/common/auth/external_auth.js
@@ -23,7 +23,9 @@ export default class ExternalAuth extends Auth {
   }
 
   async refreshAccessToken() {
-    const responseProm = new Promise((resolve) => { window[CALLBACK_SET_TOKEN] = resolve; });
+    const responseProm = new Promise((resolve, reject) => {
+      window[CALLBACK_SET_TOKEN] = (success, data) => success ? resolve(data) : reject(data);
+    });
 
     // Allow promise to set resolve on window object.
     await 0;
@@ -48,7 +50,9 @@ export default class ExternalAuth extends Auth {
   }
 
   async revoke() {
-    const responseProm = new Promise((resolve) => { window[CALLBACK_REVOKE_TOKEN] = resolve; });
+    const responseProm = new Promise((resolve, reject) => {
+      window[CALLBACK_REVOKE_TOKEN] = (success, data) => success ? resolve(data) : reject(data);
+    });
 
     // Allow promise to set resolve on window object.
     await 0;

--- a/src/common/auth/external_auth.js
+++ b/src/common/auth/external_auth.js
@@ -24,7 +24,7 @@ export default class ExternalAuth extends Auth {
 
   async refreshAccessToken() {
     const responseProm = new Promise((resolve, reject) => {
-      window[CALLBACK_SET_TOKEN] = (success, data) => success ? resolve(data) : reject(data);
+      window[CALLBACK_SET_TOKEN] = (success, data) => (success ? resolve(data) : reject(data));
     });
 
     // Allow promise to set resolve on window object.
@@ -51,7 +51,7 @@ export default class ExternalAuth extends Auth {
 
   async revoke() {
     const responseProm = new Promise((resolve, reject) => {
-      window[CALLBACK_REVOKE_TOKEN] = (success, data) => success ? resolve(data) : reject(data);
+      window[CALLBACK_REVOKE_TOKEN] = (success, data) => (success ? resolve(data) : reject(data));
     });
 
     // Allow promise to set resolve on window object.


### PR DESCRIPTION
Update external auth so it can reject.

Updates external auth callbacks to be called from external from:

```javascript
externalAuthSetToken(newToken)
```

to

```javascript
externalAuthSetToken(true, newToken)
// or if it fails
externalAuthSetToken(false, errorObj)
```

Docs PR: https://github.com/home-assistant/developers.home-assistant/pull/83

CC @blackgold9 