### PR TITLE
Handle defaults, required and optional fields

### DIFF
--- a/src/panels/config/config-entries/ha-config-flow.js
+++ b/src/panels/config/config-entries/ha-config-flow.js
@@ -236,7 +236,7 @@ class HaConfigFlow extends
         if ('default' in field) {
           data[field.name] = field.default;
         }
-      })
+      });
       this._stepData = data;
     }
   }


### PR DESCRIPTION
 - Disable submit button if not all required fields filled in
 - Do not send empty optional fields to the server. Fixes #1472
 - Set defaults

Realized that the foundation of dealing with `ha-form` needs to be abstracted, as I now only fix it for config entries, not for MFA or Authorize.
