### PR TITLE
Add Z-Wave Entity Information/more-info button

### DIFF
--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -231,6 +231,7 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
                service="refresh_entity"
                hidden$="[[!showHelp]]">
              </ha-service-description>
+             <paper-button on-click="_entityMoreInfo">Entity Information</paper-button>
            </div>
            <div class="form-group">
              <paper-checkbox checked="{{entityIgnored}}" class="form-control">
@@ -252,18 +253,6 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
                service-data="[[computePollIntensityServiceData(entityPollingIntensity)]]">
                Save
              </ha-call-service-button>
-           </div>
-           <div class="content">
-             <div class="card-actions">
-               <paper-button toggles="" raised="" noink="" active="{{entityInfoActive}}">Entity Attributes</paper-button>
-             </div>
-             <template is="dom-if" if="{{entityInfoActive}}">
-               <template is="dom-repeat" items="[[selectedEntityAttrs]]" as="state">
-                 <div class="node-info">
-                   <span>[[state]]</span>
-                 </div>
-               </template>
-             </template>
            </div>
 
            </template>
@@ -561,6 +550,9 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   _nodeMoreInfo() {
     this.fire('hass-more-info', { entityId: this.nodes[this.selectedNode].entity_id });
+  }
+  _entityMoreInfo() {
+    this.fire('hass-more-info', { entityId: this.entities[this.selectedEntity].entity_id });
   }
 
   _saveEntity() {

--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -345,17 +345,10 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
         computed: 'computeEntities(selectedNode)',
       },
 
-      entityInfoActive: Boolean,
-
       selectedEntity: {
         type: Number,
         value: -1,
         observer: 'selectedEntityChanged',
-      },
-
-      selectedEntityAttrs: {
-        type: Array,
-        computed: 'computeSelectedEntityAttrs(selectedEntity)'
       },
 
       values: {
@@ -492,16 +485,6 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
           entityPollingIntensity: this.values[valueIndex].value.poll_intensity
         });
       });
-  }
-
-  computeSelectedEntityAttrs(selectedEntity) {
-    if (selectedEntity === -1) return 'No entity selected';
-    const entityAttrs = this.entities[selectedEntity].attributes;
-    const att = [];
-    Object.keys(entityAttrs).forEach((key) => {
-      att.push(key + ': ' + entityAttrs[key]);
-    });
-    return att.sort();
   }
 
   computeSelectCaption(stateObj) {


### PR DESCRIPTION
Removed the "Entity Attributes" button that only showed attributes of select zwave entities and added an "Entity Information" button that will open the complete more-info popup for the selected entity, allowing easier renaming & less duplication of code.

![image](https://user-images.githubusercontent.com/7545841/45508039-b7503d80-b761-11e8-87b5-51ead3ad2a3e.png)
