### PR TITLE
Image aspect ratio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ lib
 bin
 dist
 
+# vscode
+.vscode
+
 # Secrets
 .lokalise_token
 yarn-error.log

--- a/src/common/util/parse-aspect-ratio.js
+++ b/src/common/util/parse-aspect-ratio.js
@@ -1,16 +1,24 @@
 export default function parseAspectRatio(input) {
-  // Handle 16x9, 16:9, 1.78:1, 1.78
+  // Handle 16x9, 16:9, 1.78x1, 1.78:1, 1.78
   // Ignore everything else
+  function parseOrThrow(number) {
+    const parsed = parseFloat(number);
+    if (isNaN(parsed)) throw new Error(`${number} is not a number`);
+    return parsed;
+  }
   try {
     if (input) {
-      let arr = input.replace(':', 'x').split('x');
-      return arr.length == 0 ?
-        null :
-        arr.length == 1 ?
-          { w: parseFloat(arr[0]), h: 1 } :
-          { w: parseFloat(arr[0]), h: parseFloat(arr[1]) };
+      const arr = input.replace(':', 'x').split('x');
+      if (arr.length === 0) {
+        return null;
+      }
+
+      return arr.length === 1 ?
+        { w: parseOrThrow(arr[0]), h: 1 } :
+        { w: parseOrThrow(arr[0]), h: parseOrThrow(arr[1]) };
     }
+  } catch (err) {
+    // Ignore the error
   }
-  catch(err) {}
   return null;
 }

--- a/src/common/util/parse-aspect-ratio.js
+++ b/src/common/util/parse-aspect-ratio.js
@@ -1,0 +1,14 @@
+export default function parseAspectRatio(input) {
+  try {
+    if (input) {
+      let arr = input.replace(':', 'x').split('x');
+      return arr.length == 0 ?
+        null :
+        arr.length == 1 ?
+          { w: parseFloat(arr[0]), h: 1 } :
+          { w: parseFloat(arr[0]), h: parseFloat(arr[1]) };
+    }
+  }
+  catch(err) {}
+  return null;
+}

--- a/src/common/util/parse-aspect-ratio.js
+++ b/src/common/util/parse-aspect-ratio.js
@@ -1,4 +1,6 @@
 export default function parseAspectRatio(input) {
+  // Handle 16x9, 16:9, 1.78:1, 1.78
+  // Ignore everything else
   try {
     if (input) {
       let arr = input.replace(':', 'x').split('x');

--- a/src/panels/lovelace/cards/hui-picture-entity-card.js
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.js
@@ -58,6 +58,7 @@ class HuiPictureEntityCard extends EventsMixin(LocalizeMixin(PolymerElement)) {
           state-image="[[_config.state_image]]"
           camera-image="[[_getCameraImage(_config)]]"
           entity="[[_config.entity]]"
+          aspect-ratio="[[_config.aspect_ratio]]"
         ></hui-image>
         <template is="dom-if" if="[[_showNameAndState(_config)]]">
           <div class="footer both">

--- a/src/panels/lovelace/cards/hui-picture-glance-card.js
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.js
@@ -78,6 +78,7 @@ class HuiPictureGlanceCard extends NavigateMixin(LocalizeMixin(EventsMixin(Polym
           state-image="[[_config.state_image]]"
           camera-image="[[_config.camera_image]]"
           entity="[[_config.entity]]"
+          aspect-ratio="[[_config.aspect_ratio]]"
         ></hui-image>
         <div class="box">
           <template is="dom-if" if="[[_config.title]]">

--- a/src/panels/lovelace/components/hui-image.js
+++ b/src/panels/lovelace/components/hui-image.js
@@ -122,7 +122,7 @@ class HuiImage extends LocalizeMixin(PolymerElement) {
   _onImageError() {
     this._imageSrc = null;
     this.$.image.classList.add('hidden');
-    if (!this.$wrapper.classList.contains('ratio')) {
+    if (!this.$.wrapper.classList.contains('ratio')) {
       this.$.brokenImage.style.setProperty('height', `${this._lastImageHeight || '100'}px`);
     }
     this.$.brokenImage.classList.remove('hidden');
@@ -131,7 +131,7 @@ class HuiImage extends LocalizeMixin(PolymerElement) {
   _onImageLoad() {
     this.$.image.classList.remove('hidden');
     this.$.brokenImage.classList.add('hidden');
-    if (!this.$wrapper.classList.contains('ratio')) {
+    if (!this.$.wrapper.classList.contains('ratio')) {
       this._lastImageHeight = this.$.image.offsetHeight;
     }
   }

--- a/src/panels/lovelace/components/hui-image.js
+++ b/src/panels/lovelace/components/hui-image.js
@@ -14,7 +14,6 @@ const DEFAULT_FILTER = 'grayscale(100%)';
  * @appliesMixin LocalizeMixin
  */
 class HuiImage extends LocalizeMixin(PolymerElement) {
-
   static get template() {
     return html`
       ${this.styleTemplate}
@@ -104,8 +103,7 @@ class HuiImage extends LocalizeMixin(PolymerElement) {
   }
 
   _configChanged(image, stateImage, cameraImage, aspectRatio) {
-
-    let ratio = parseAspectRatio(aspectRatio);
+    const ratio = parseAspectRatio(aspectRatio);
 
     if (ratio && ratio.w > 0 && ratio.h > 0) {
       this.$.wrapper.style.paddingBottom = `${((100 * ratio.h) / ratio.w).toFixed(2)}%`;

--- a/src/panels/lovelace/elements/hui-image-element.js
+++ b/src/panels/lovelace/elements/hui-image-element.js
@@ -13,11 +13,11 @@ class HuiImageElement extends ElementClickMixin(PolymerElement) {
     return html`
       <style>
         :host(.clickable) {
-          cursor: pointer; 
-        } 
+          cursor: pointer;
+        }
         hui-image {
           overflow-y: hidden;
-        } 
+        }
       </style>
       <hui-image
         hass="[[hass]]"
@@ -28,6 +28,7 @@ class HuiImageElement extends ElementClickMixin(PolymerElement) {
         filter="[[_config.filter]]"
         state-filter="[[_config.state_filter]]"
         title$="[[computeTooltip(hass, _config)]]"
+        aspect-ratio="[[_config.aspect_ratio]]"
       ></hui-image>
     `;
   }

--- a/test-mocha/common/util/parse_aspect_ratio_test.js
+++ b/test-mocha/common/util/parse_aspect_ratio_test.js
@@ -3,42 +3,51 @@ import assert from 'assert';
 import parseAspectRatio from '../../../src/common/util/parse-aspect-ratio.js';
 
 describe('parseAspectRatio', () => {
+  const ratio16by9 = { w: 16, h: 9 };
+  const ratio178 = { w: 1.78, h: 1 };
 
-    const ratio16by9 = { w: 16, h: 9 }
-    const ratio178 = { w: 1.78, h: 1 }
+  it('Parses 16x9', () => {
+    const r = parseAspectRatio('16x9');
+    assert.deepEqual(r, ratio16by9);
+  });
 
-    it('Parses 16x9', () => {
-        const r = parseAspectRatio('16x9');
-        assert.deepEqual(r, ratio16by9);
-    });
+  it('Parses 16:9', () => {
+    const r = parseAspectRatio('16:9');
+    assert.deepEqual(r, ratio16by9);
+  });
 
-    it('Parses 16:9', () => {
-        const r = parseAspectRatio('16:9');
-        assert.deepEqual(r, ratio16by9);
-    });
+  it('Parses 1.78x1', () => {
+    const r = parseAspectRatio('1.78x1');
+    assert.deepEqual(r, ratio178);
+  });
 
-    it('Parses 1.78', () => {
-        const r = parseAspectRatio('1.78');
-        assert.deepEqual(r, ratio178);
-    });
+  it('Parses 1.78:1', () => {
+    const r = parseAspectRatio('1.78:1');
+    assert.deepEqual(r, ratio178);
+  });
 
-    it('Parses 1.78:1', () => {
-        const r = parseAspectRatio('1.78:1');
-        assert.deepEqual(r, ratio178);
-    });
+  it('Parses 1.78', () => {
+    const r = parseAspectRatio('1.78');
+    assert.deepEqual(r, ratio178);
+  });
 
-    it('Skips null states', () => {
-        const r = parseAspectRatio(null);
-        assert.equal(r, null);
-    });
+  it('Skips null states', () => {
+    const r = parseAspectRatio(null);
+    assert.equal(r, null);
+  });
 
-    it('Ignores invalid input', () => {
-        const r = parseAspectRatio('mary had a little lamb');
-        assert.equal(r, null);
-    });
+  it('Skips empty states', () => {
+    const r = parseAspectRatio('   ');
+    assert.equal(r, null);
+  });
 
-    it('Ignores invalid, but close input', () => {
-        const r = parseAspectRatio('mary:lamb');
-        assert.equal(r, null);
-    })
+  it('Skips invalid input', () => {
+    const r = parseAspectRatio('mary had a little lamb');
+    assert.equal(r, null);
+  });
+
+  it('Skips invalid, but close input', () => {
+    const r = parseAspectRatio('mary:lamb');
+    assert.equal(r, null);
+  });
 });

--- a/test-mocha/common/util/parse_aspect_ratio_test.js
+++ b/test-mocha/common/util/parse_aspect_ratio_test.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+
+import parseAspectRatio from '../../../src/common/util/parse-aspect-ratio.js';
+
+describe('parseAspectRatio', () => {
+
+    const ratio16by9 = { w: 16, h: 9 }
+    const ratio178 = { w: 1.78, h: 1 }
+
+    it('Parses 16x9', () => {
+        const r = parseAspectRatio('16x9');
+        assert.deepEqual(r, ratio16by9);
+    });
+
+    it('Parses 16:9', () => {
+        const r = parseAspectRatio('16:9');
+        assert.deepEqual(r, ratio16by9);
+    });
+
+    it('Parses 1.78', () => {
+        const r = parseAspectRatio('1.78');
+        assert.deepEqual(r, ratio178);
+    });
+
+    it('Parses 1.78:1', () => {
+        const r = parseAspectRatio('1.78:1');
+        assert.deepEqual(r, ratio178);
+    });
+
+    it('Skips null states', () => {
+        const r = parseAspectRatio(null);
+        assert.equal(r, null);
+    });
+
+    it('Ignores invalid input', () => {
+        const r = parseAspectRatio('mary had a little lamb');
+        assert.equal(r, null);
+    });
+
+    it('Ignores invalid, but close input', () => {
+        const r = parseAspectRatio('mary:lamb');
+        assert.equal(r, null);
+    })
+});


### PR DESCRIPTION
Allows you to pass in an aspect ratio so the  height of images won't bounce/expand when the image loads (since it might take a second or two after the page is rendered).

I created some tests for the parseAspectRatio method, but I'm not certain if it is being called. ~~I didn't see in the development documentation how to run tests. I'm pretty new at testing.~~

If an aspect ratio is not specified, it should behave exactly the same as as it currently does.

~~Edit: I figured out the test. If I go into the script directory and run npm run test, I see some issues. I'll work on resolving those.~~