### PR TITLE
Add loaded components popup to dev-info

### DIFF
--- a/src/panels/dev-info/ha-loaded-components.js
+++ b/src/panels/dev-info/ha-loaded-components.js
@@ -1,0 +1,59 @@
+import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
+import '@polymer/paper-dialog/paper-dialog.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import '../../resources/ha-style.js';
+
+import EventsMixin from '../../mixins/events-mixin.js';
+
+/*
+ * @appliesMixin EventsMixin
+ */
+class HaLoadedComponents extends EventsMixin(PolymerElement) {
+  static get template() {
+    return html`
+    <style include="ha-style-dialog">
+      paper-dialog {
+        max-width: 500px;
+      }
+    </style>
+    <paper-dialog id="dialog" with-backdrop="" opened="{{_opened}}">
+      <h2>Loaded Components</h2>
+      <paper-dialog-scrollable id="scrollable">
+       <p>The following components are currently loaded:</p>
+       <ul>
+        <template is='dom-repeat' items='[[_components]]'>
+          <li>[[item]]</li>
+        </template>
+       </ul>
+      </paper-dialog-scrollable>
+    </paper-dialog>
+    `;
+  }
+
+  static get properties() {
+    return {
+      _hass: Object,
+      _components: Array,
+
+      _opened: {
+        type: Boolean,
+        value: false,
+      },
+    };
+  }
+
+  ready() {
+    super.ready();
+  }
+
+  showDialog({ hass }) {
+    this.hass = hass;
+    this._opened = true;
+    this._components = this.hass.config.components.sort();
+    setTimeout(() => this.$.dialog.center(), 0);
+  }
+}
+
+customElements.define('ha-loaded-components', HaLoadedComponents);

--- a/src/panels/dev-info/ha-panel-dev-info.js
+++ b/src/panels/dev-info/ha-panel-dev-info.js
@@ -126,6 +126,7 @@ class HaPanelDevInfo extends PolymerElement {
           </p>
           <p>
             Path to configuration.yaml: [[hass.config.config_dir]]
+            <br><a href="#" on-click="_showComponents">[[loadedComponents.length]] Loaded Components</a>
           </p>
           <p class='develop'>
             <a href='https://www.home-assistant.io/developers/credits/' target='_blank'>
@@ -220,6 +221,18 @@ class HaPanelDevInfo extends PolymerElement {
         </template>
       </paper-dialog-scrollable>
     </paper-dialog>
+
+    <paper-dialog with-backdrop id="showcomponents">
+      <h2>Loaded Components</h2>
+      <paper-dialog-scrollable id="scrollable">
+       <p>The following components are currently loaded:</p>
+       <ul>
+        <template is='dom-repeat' items='[[loadedComponents]]'>
+          <li>[[item]]</li>
+        </template>
+       </ul>
+      </paper-dialog-scrollable>
+    </paper-dialog>
     `;
   }
 
@@ -263,6 +276,11 @@ class HaPanelDevInfo extends PolymerElement {
         type: Array,
         value: window.CUSTOM_UI_LIST || [],
       },
+
+      loadedComponents: {
+        type: Array,
+        value: [],
+      }
     };
   }
 
@@ -271,6 +289,11 @@ class HaPanelDevInfo extends PolymerElement {
     this.addEventListener('hass-service-called', ev => this.serviceCalled(ev));
     // Fix for overlay showing on top of dialog.
     this.$.showlog.addEventListener('iron-overlay-opened', (ev) => {
+      if (ev.target.withBackdrop) {
+        ev.target.parentNode.insertBefore(ev.target.backdropElement, ev.target);
+      }
+    });
+    this.$.showcomponents.addEventListener('iron-overlay-opened', (ev) => {
       if (ev.target.withBackdrop) {
         ev.target.parentNode.insertBefore(ev.target.backdropElement, ev.target);
       }
@@ -291,6 +314,7 @@ class HaPanelDevInfo extends PolymerElement {
     super.connectedCallback();
     this.$.scrollable.dialogElement = this.$.showlog;
     this._fetchData();
+    this.loadedComponents = this._computeLoadedComponents();
     if (!window.CUSTOM_UI_LIST) {
       // Give custom UI an opportunity to load.
       setTimeout(() => {
@@ -350,6 +374,14 @@ class HaPanelDevInfo extends PolymerElement {
       localStorage.defaultPage = 'lovelace';
     }
     this.$.love.innerText = this._defaultPageText();
+  }
+
+  _computeLoadedComponents() {
+    return this.hass.config.components.sort();
+  }
+
+  _showComponents() {
+    this.$.showcomponents.open();
   }
 }
 


### PR DESCRIPTION
Adds a link to dev-info that pops up a list of loaded components from hass.config.components.

Fixes #1347 

![image](https://user-images.githubusercontent.com/7545841/45521078-6a349180-b78a-11e8-8035-872d7f799881.png)
![image](https://user-images.githubusercontent.com/7545841/45521091-7b7d9e00-b78a-11e8-9975-664ce436cf89.png)
