### PR TITLE
Lovelace Custom ui fallback

### DIFF
--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -62,20 +62,17 @@ function _createErrorElement(error, config) {
 }
 
 export default function createCardElement(config) {
-  let tag;
-
   if (!config || typeof config !== 'object' || !config.type) {
     return _createErrorElement('No card type configured.', config);
   }
 
   if (config.type.startsWith(CUSTOM_TYPE_PREFIX)) {
-    tag = config.type.substr(CUSTOM_TYPE_PREFIX.length);
+    const tag = config.type.substr(CUSTOM_TYPE_PREFIX.length);
 
     if (customElements.get(tag)) {
       return _createElement(tag, config);
     }
-
-    const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);
+    const element = _createElement(`hui-${config.type}-card`, config);
 
     customElements.whenDefined(tag)
       .then(() => fireEvent(element, 'rebuild-view'));

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -41,8 +41,8 @@ const CARD_TYPES = new Set([
   'vertical-stack',
   'weather-forecast'
 ]);
-
 const CUSTOM_TYPE_PREFIX = 'custom:';
+const TIMEOUT = 2000;
 
 function _createElement(tag, config) {
   const element = document.createElement(tag);
@@ -61,6 +61,11 @@ function _createErrorElement(error, config) {
   return _createElement('hui-error-card', createErrorCardConfig(error, config));
 }
 
+function _hideErrorElement(element) {
+  element.style.display = 'None';
+  return window.setTimeout(() => { element.style.display = ''; }, TIMEOUT);
+}
+
 export default function createCardElement(config) {
   if (!config || typeof config !== 'object' || !config.type) {
     return _createErrorElement('No card type configured.', config);
@@ -72,10 +77,13 @@ export default function createCardElement(config) {
     if (customElements.get(tag)) {
       return _createElement(tag, config);
     }
-    const element = _createElement(`hui-${config.type}-card`, config);
+    const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);
+    const timer = _hideErrorElement(element);
 
-    customElements.whenDefined(tag)
-      .then(() => fireEvent(element, 'rebuild-view'));
+    customElements.whenDefined(tag).then(() => {
+      clearTimeout(timer);
+      fireEvent(element, 'rebuild-view');
+    });
 
     return element;
   }

--- a/src/panels/lovelace/common/create-hui-element.js
+++ b/src/panels/lovelace/common/create-hui-element.js
@@ -17,6 +17,7 @@ const ELEMENT_TYPES = new Set([
   'state-icon',
   'state-label',
 ]);
+const TIMEOUT = 2000;
 
 function _createElement(tag, config) {
   const element = document.createElement(tag);
@@ -35,6 +36,11 @@ function _createErrorElement(error, config) {
   return _createElement('hui-error-card', createErrorCardConfig(error, config));
 }
 
+function _hideErrorElement(element) {
+  element.style.display = 'None';
+  return window.setTimeout(() => { element.style.display = ''; }, TIMEOUT);
+}
+
 export default function createHuiElement(config) {
   if (!config || typeof config !== 'object' || !config.type) {
     return _createErrorElement('No element type configured.', config);
@@ -46,10 +52,13 @@ export default function createHuiElement(config) {
     if (customElements.get(tag)) {
       return _createElement(tag, config);
     }
-    const element = _createElement(`hui-${config.type}-element`, config);
+    const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);
+    const timer = _hideErrorElement(element);
 
-    customElements.whenDefined(tag)
-      .then(() => fireEvent(element, 'rebuild-view'));
+    customElements.whenDefined(tag).then(() => {
+      clearTimeout(timer);
+      fireEvent(element, 'rebuild-view');
+    });
 
     return element;
   }

--- a/src/panels/lovelace/common/create-hui-element.js
+++ b/src/panels/lovelace/common/create-hui-element.js
@@ -46,8 +46,7 @@ export default function createHuiElement(config) {
     if (customElements.get(tag)) {
       return _createElement(tag, config);
     }
-
-    const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);
+    const element = _createElement(`hui-${config.type}-element`, config);
 
     customElements.whenDefined(tag)
       .then(() => fireEvent(element, 'rebuild-view'));

--- a/src/panels/lovelace/common/create-row-element.js
+++ b/src/panels/lovelace/common/create-row-element.js
@@ -63,8 +63,6 @@ function _createErrorElement(error, config) {
 }
 
 export default function createRowElement(config) {
-  let tag;
-
   if (!config || typeof config !== 'object' || (!config.entity && !config.type)) {
     return _createErrorElement('Invalid config given.', config);
   }
@@ -74,22 +72,22 @@ export default function createRowElement(config) {
     return _createElement(`hui-${type}-row`, config);
   }
 
+  const domain = config.entity.split('.', 1)[0];
+  const tag = `hui-${DOMAIN_TO_ELEMENT_TYPE[domain] || 'text'}-entity-row`;
+
   if (type.startsWith(CUSTOM_TYPE_PREFIX)) {
-    tag = type.substr(CUSTOM_TYPE_PREFIX.length);
+    const custom_tag = type.substr(CUSTOM_TYPE_PREFIX.length);
 
-    if (customElements.get(tag)) {
-      return _createElement(tag, config);
+    if (customElements.get(custom_tag)) {
+      return _createElement(custom_tag, config);
     }
-    const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);
+    const element = _createElement(tag, config);
 
-    customElements.whenDefined(tag)
+    customElements.whenDefined(custom_tag)
       .then(() => fireEvent(element, 'rebuild-view'));
 
     return element;
   }
-
-  const domain = config.entity.split('.', 1)[0];
-  tag = `hui-${DOMAIN_TO_ELEMENT_TYPE[domain] || 'text'}-entity-row`;
 
   return _createElement(tag, config);
 }

--- a/src/panels/lovelace/common/create-row-element.js
+++ b/src/panels/lovelace/common/create-row-element.js
@@ -76,14 +76,14 @@ export default function createRowElement(config) {
   const tag = `hui-${DOMAIN_TO_ELEMENT_TYPE[domain] || 'text'}-entity-row`;
 
   if (type.startsWith(CUSTOM_TYPE_PREFIX)) {
-    const custom_tag = type.substr(CUSTOM_TYPE_PREFIX.length);
+    const customTag = type.substr(CUSTOM_TYPE_PREFIX.length);
 
-    if (customElements.get(custom_tag)) {
-      return _createElement(custom_tag, config);
+    if (customElements.get(customTag)) {
+      return _createElement(customTag, config);
     }
     const element = _createElement(tag, config);
 
-    customElements.whenDefined(custom_tag)
+    customElements.whenDefined(customTag)
       .then(() => fireEvent(element, 'rebuild-view'));
 
     return element;


### PR DESCRIPTION
This PR hides an error that occurs if the lovelace UI is loaded before all custom elements are. For a short moment the UI will display an error that the `custom element doesn't exist` before reloading the page correctly.

I think that in most cases it would be ok and less intrusive to just display the `default element` instead. The error `custom element doesn't exist` normally only happens during development and testing, so it would be quite easy to notice IMO even without the flashy warning.

See also: https://community.home-assistant.io/t/lovelace-custom-ui/65026