### PR TITLE
Fix minify fail

### DIFF
--- a/src/panels/lovelace/cards/hui-error-card.js
+++ b/src/panels/lovelace/cards/hui-error-card.js
@@ -7,9 +7,10 @@ class HuiErrorCard extends PolymerElement {
       <style>
         :host {
           display: block;
-          background-color: red;
+          background-color: #ef5350;
           color: white;
           padding: 8px;
+          font-weight: 500;
         }
       </style>
       [[_config.error]]

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -61,11 +61,6 @@ function _createErrorElement(error, config) {
   return _createElement('hui-error-card', createErrorCardConfig(error, config));
 }
 
-function _hideErrorElement(element) {
-  element.style.display = 'None';
-  return window.setTimeout(() => { element.style.display = ''; }, TIMEOUT);
-}
-
 export default function createCardElement(config) {
   if (!config || typeof config !== 'object' || !config.type) {
     return _createErrorElement('No card type configured.', config);
@@ -78,7 +73,8 @@ export default function createCardElement(config) {
       return _createElement(tag, config);
     }
     const element = _createErrorElement(`Custom element doesn't exist: ${tag}.`, config);
-    const timer = _hideErrorElement(element);
+    element.style.display = 'None';
+    const timer = window.setTimeout(() => { element.style.display = ''; }, TIMEOUT);
 
     customElements.whenDefined(tag).then(() => {
       clearTimeout(timer);


### PR DESCRIPTION
Minification tried to inline a function, causing a const assignment.

First tried to update the minification plugin. However, we use uglify-es which is no longer maintained. It's being dropped by the new release of uglify-webpack-plugin. However uglify-js only supports ES5. uglify-es was forked as Terser, but that had the same error.

I tried Babel Minify too, but it made Webpack choke on source maps. The issue has been open for a long time so I decide to just simplify the code and voila, minifaction works again.

Also threw in a nicer red for the error card.

![image](https://user-images.githubusercontent.com/1444314/45743570-9e7dd700-bbfc-11e8-9159-16d05461c56b.png)

Fixes #1671