### PR TITLE
Fix for expanded more-info graphs

### DIFF
--- a/src/dialogs/more-info/more-info-controls.js
+++ b/src/dialogs/more-info/more-info-controls.js
@@ -78,7 +78,7 @@ class MoreInfoControls extends EventsMixin(PolymerElement) {
   <paper-dialog-scrollable dialog-element="[[dialogElement]]">
     <template is="dom-if" if="[[_computeShowHistoryComponent(hass, stateObj)]]" restamp="">
       <ha-state-history-data hass="[[hass]]" filter-type="recent-entity" entity-id="[[stateObj.entity_id]]" data="{{_stateHistory}}" is-loading="{{_stateHistoryLoading}}" cache-config="[[_cacheConfig]]"></ha-state-history-data>
-      <state-history-charts hass="[[hass]]" history-data="[[_stateHistory]]" is-loading-data="[[_stateHistoryLoading]]" up-to-now no-single="[[large]]"></state-history-charts>
+      <state-history-charts hass="[[hass]]" history-data="[[_stateHistory]]" is-loading-data="[[_stateHistoryLoading]]" up-to-now></state-history-charts>
     </template>
     <more-info-content state-obj="[[stateObj]]" hass="[[hass]]"></more-info-content>
   </paper-dialog-scrollable>


### PR DESCRIPTION
When the more-info popup is expanded with a line graph, the legend is included in the graph and causes the bottom of the graph to be cut off. This gets rid of `no-single="[[large]]"` on more-info state-history-charts since more-info is for a single entity.

Tested in Chrome and Edge on Windows.

Fixes #1543