### PR TITLE
Add entity attribute support in secondary_info entities card

### DIFF
--- a/src/panels/lovelace/components/hui-generic-entity-row.js
+++ b/src/panels/lovelace/components/hui-generic-entity-row.js
@@ -98,6 +98,9 @@ class HuiGenericEntityRow extends PolymerElement {
                 datetime="[[_stateObj.last_changed]]"
               ></ha-relative-time>
             </template>
+            <template is="dom-if" if="[[_isStateAttribute(config.secondary_info, _stateObj)]]">
+              [[_stateObj.attributes[config.secondary_info]]]
+            </template>
           </template>
           <template is="dom-if" if="[[!showSecondary]">
             <slot name="secondary"></slot>
@@ -124,6 +127,10 @@ class HuiGenericEntityRow extends PolymerElement {
 
   _equals(a, b) {
     return a === b;
+  }
+
+  _isStateAttribute(attribute, stateObj) {
+    return attribute in stateObj.attributes;
   }
 
   _computeStateObj(states, entityId) {

--- a/src/panels/lovelace/components/hui-generic-entity-row.js
+++ b/src/panels/lovelace/components/hui-generic-entity-row.js
@@ -98,8 +98,8 @@ class HuiGenericEntityRow extends PolymerElement {
                 datetime="[[_stateObj.last_changed]]"
               ></ha-relative-time>
             </template>
-            <template is="dom-if" if="[[_isStateAttribute(config.secondary_info, _stateObj)]]">
-              [[_stateObj.attributes[config.secondary_info]]]
+            <template is="dom-if" if="[[_isAttribute(config.secondary_info)]]">
+              [[_getAttribute(config.secondary_info, _stateObj)]]
             </template>
           </template>
           <template is="dom-if" if="[[!showSecondary]">
@@ -129,8 +129,13 @@ class HuiGenericEntityRow extends PolymerElement {
     return a === b;
   }
 
-  _isStateAttribute(attribute, stateObj) {
-    return attribute in stateObj.attributes;
+  _isAttribute(secInfo, stateObj) {
+    return secInfo.startsWith('attribute(') && secInfo.endsWith(')');
+  }
+  
+  _getAttribute(secInfo, stateObj) {
+    const attr = secInfo.slice(10, -1);
+    return stateObj.attributes[attr];
   }
 
   _computeStateObj(states, entityId) {

--- a/src/panels/lovelace/components/hui-generic-entity-row.js
+++ b/src/panels/lovelace/components/hui-generic-entity-row.js
@@ -129,7 +129,7 @@ class HuiGenericEntityRow extends PolymerElement {
     return a === b;
   }
 
-  _isAttribute(secInfo, stateObj) {
+  _isAttribute(secInfo) {
     return secInfo.startsWith('attribute(') && secInfo.endsWith(')');
   }
 

--- a/src/panels/lovelace/components/hui-generic-entity-row.js
+++ b/src/panels/lovelace/components/hui-generic-entity-row.js
@@ -132,7 +132,7 @@ class HuiGenericEntityRow extends PolymerElement {
   _isAttribute(secInfo, stateObj) {
     return secInfo.startsWith('attribute(') && secInfo.endsWith(')');
   }
-  
+
   _getAttribute(secInfo, stateObj) {
     const attr = secInfo.slice(10, -1);
     return stateObj.attributes[attr];

--- a/src/panels/lovelace/components/hui-generic-entity-row.js
+++ b/src/panels/lovelace/components/hui-generic-entity-row.js
@@ -130,7 +130,7 @@ class HuiGenericEntityRow extends PolymerElement {
   }
 
   _isAttribute(secInfo) {
-    return secInfo.startsWith('attribute(') && secInfo.endsWith(')');
+    return secInfo && secInfo.startsWith('attribute(') && secInfo.endsWith(')');
   }
 
   _getAttribute(secInfo, stateObj) {


### PR DESCRIPTION
example:
- entity: vacuum.mqtt_roomba
  secondary_info: status
- entity: calendar.mycal
  secondary_info: message