### PR TITLE
Fix for content appearing behind header in hassio and config panels

### DIFF
--- a/hassio/src/hassio-main.js
+++ b/hassio/src/hassio-main.js
@@ -8,9 +8,10 @@ import './hassio-data.js';
 import './hassio-pages-with-tabs.js';
 
 import applyThemesOnElement from '../../src/common/dom/apply_themes_on_element.js';
+import EventsMixin from '../../src/mixins/events-mixin.js';
 import NavigateMixin from '../../src/mixins/navigate-mixin.js';
 
-class HassioMain extends NavigateMixin(PolymerElement) {
+class HassioMain extends EventsMixin(NavigateMixin(PolymerElement)) {
   static get template() {
     return html`
     <app-route route="[[route]]" pattern="/:page" data="{{routeData}}"></app-route>

--- a/hassio/src/hassio-main.js
+++ b/hassio/src/hassio-main.js
@@ -93,6 +93,7 @@ class HassioMain extends NavigateMixin(PolymerElement) {
     if (route.path === '' && route.prefix === '/hassio') {
       this.navigate('/hassio/dashboard', true);
     }
+    this.fire('iron-resize');
   }
 
   equalsAddon(page) {

--- a/src/panels/config/ha-panel-config.js
+++ b/src/panels/config/ha-panel-config.js
@@ -6,6 +6,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../../layouts/hass-error-screen.js';
 
 import isComponentLoaded from '../../common/config/is_component_loaded.js';
+import EventsMixin from '../../mixins/events-mixin.js';
 import NavigateMixin from '../../mixins/navigate-mixin.js';
 
 import(/* webpackChunkName: "panel-config-automation" */ './automation/ha-config-automation.js');
@@ -19,9 +20,10 @@ import(/* webpackChunkName: "panel-config-users" */ './users/ha-config-users.js'
 import(/* webpackChunkName: "panel-config-zwave" */ './zwave/ha-config-zwave.js');
 
 /*
+ * @appliesMixin EventsMixin
  * @appliesMixin NavigateMixin
  */
-class HaPanelConfig extends NavigateMixin(PolymerElement) {
+class HaPanelConfig extends EventsMixin(NavigateMixin(PolymerElement)) {
   static get template() {
     return html`
     <app-route
@@ -170,6 +172,7 @@ class HaPanelConfig extends NavigateMixin(PolymerElement) {
     if (route.path === '' && route.prefix === '/config') {
       this.navigate('/config/dashboard', true);
     }
+    this.fire('iron-resize');
   }
 
   _equals(a, b) {


### PR DESCRIPTION
This fixes the content being drawn behind the header when navigating through the Configuration panel. The same fix was applied to the Hass.io panel, however I don't have Hass.io so I'm unable to test it to confirm. If a Hass.io user could test it out, that would be great.

Fixes #1351
Fixes #1124