### PR TITLE
Fix non-working zwave log andriod PWA

### DIFF
--- a/src/common/config/is_pwa.js
+++ b/src/common/config/is_pwa.js
@@ -1,0 +1,4 @@
+/** Return if the displaymode is in standalone mode (PWA). */
+export default function isPwa() {
+  return (window.matchMedia('(display-mode: standalone)').matches);
+}

--- a/src/panels/config/zwave/zwave-log-dialog.js
+++ b/src/panels/config/zwave/zwave-log-dialog.js
@@ -1,0 +1,61 @@
+import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
+import '@polymer/paper-dialog/paper-dialog.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import '../../../resources/ha-style.js';
+
+import EventsMixin from '../../../mixins/events-mixin.js';
+
+class ZwaveLogDialog extends EventsMixin(PolymerElement) {
+  static get template() {
+    return html`
+    <style include="ha-style-dialog">
+    </style>
+      <paper-dialog id="pwaDialog" with-backdrop="" opened="{{_opened}}">
+        <h2>OpenZwave internal logfile</h2>
+        <paper-dialog-scrollable>
+          <pre>[[_ozwLog]]</pre>
+        <paper-dialog-scrollable>
+      </paper-dialog>
+      `;
+  }
+
+  static get properties() {
+    return {
+      _ozwLog: String,
+
+      _dialogClosedCallback: Function,
+
+      _opened: {
+        type: Boolean,
+        value: false,
+      },
+    };
+  }
+
+  ready() {
+    super.ready();
+    this.addEventListener('iron-overlay-closed', ev => this._dialogClosed(ev));
+  }
+
+  showDialog({ _ozwLog, dialogClosedCallback }) {
+    console.log('showDialog');
+    this._ozwLog = _ozwLog;
+    this._opened = true;
+    this._dialogClosedCallback = dialogClosedCallback;
+    setTimeout(() => this.$.pwaDialog.center(), 0);
+  }
+
+  _dialogClosed(ev) {
+    console.log('_dialogClosed', ev.target.nodeName);
+    if (ev.target.nodeId === 'ZWAVE-LOG-DIALOG') {
+      this._opened = false;
+      const closedEvent = true;
+      this._dialogClosedCallback({ closedEvent });
+      this._dialogClosedCallback = null;
+    }
+  }
+}
+
+customElements.define('zwave-log-dialog', ZwaveLogDialog);

--- a/src/panels/config/zwave/zwave-log.js
+++ b/src/panels/config/zwave/zwave-log.js
@@ -73,11 +73,6 @@ class OzwLog extends EventsMixin(PolymerElement) {
 
       _intervalId: String,
 
-      _pwaDialogClosed: {
-        type: Boolean,
-        value: true
-      },
-
       tail: Boolean,
 
     };
@@ -141,12 +136,10 @@ class OzwLog extends EventsMixin(PolymerElement) {
       _tail: this.tail,
       dialogClosedCallback: () => this._dialogClosed()
     });
-    this.setProperties({ _pwaDialogClosed: false });
   }
 
   _dialogClosed() {
     this.setProperties({
-      _pwaDialogClosed: true,
       tail: false
     });
   }

--- a/src/panels/config/zwave/zwave-log.js
+++ b/src/panels/config/zwave/zwave-log.js
@@ -2,6 +2,8 @@ import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-card/paper-card.js';
 import '@polymer/paper-checkbox/paper-checkbox.js';
 import '@polymer/paper-input/paper-input.js';
+import '@polymer/paper-dialog/paper-dialog.js';
+import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -39,6 +41,12 @@ class OzwLog extends PolymerElement {
           <paper-button raised="true" on-click="_openLogWindow">Load</paper-button>   
           <paper-button raised="true" on-click="_tailLog" disabled="{{_completeLog}}">Tail</paper-button>
       </paper-card>
+      <paper-dialog id="pwaDialog">
+        <h2>OpenZwave internal logfile</h2>
+        <paper-dialog-scrollable>
+          <pre>[[_ozwLogs]]</pre>
+        <paper-dialog-scrollable>
+      </paper-dialog>
     </ha-config-section>
 `;
   }
@@ -78,9 +86,12 @@ class OzwLog extends PolymerElement {
   async _openLogWindow() {
     const info = await this.hass.callApi('GET', 'zwave/ozwlog?lines=' + this._numLogLines);
     this.setProperties({ _ozwLogs: info });
-    const ozwWindow = window.open('', 'OpenZwave internal log', 'toolbar');
-    ozwWindow.document.title = 'OpenZwave internal logfile';
-    ozwWindow.document.body.innerText = this._ozwLogs;
+    if (window.matchMedia('(display-mode: standalone)').matches) {
+      this.$.pwaDialog.open();
+      return -1;
+    }
+    const ozwWindow = open('', 'ozwLog', 'toolbar');
+    ozwWindow.document.body.innerHTML = `<pre>${this._ozwLogs}</pre>`;
     return ozwWindow;
   }
 
@@ -91,7 +102,10 @@ class OzwLog extends PolymerElement {
     } else {
       const info = await this.hass.callApi('GET', 'zwave/ozwlog?lines=' + this._numLogLines);
       this.setProperties({ _ozwLogs: info });
-      ozwWindow.document.body.innerText = this._ozwLogs;
+      if (window.matchMedia('(display-mode: standalone)').matches) {
+        return;
+      }
+      ozwWindow.document.body.innerHTML = `<pre>${this._ozwLogs}</pre>`;
     }
   }
 

--- a/src/panels/config/zwave/zwave-log.js
+++ b/src/panels/config/zwave/zwave-log.js
@@ -86,7 +86,7 @@ class OzwLog extends PolymerElement {
   async _openLogWindow() {
     const info = await this.hass.callApi('GET', 'zwave/ozwlog?lines=' + this._numLogLines);
     this.setProperties({ _ozwLogs: info });
-    if (window.matchMedia('(display-mode: standalone)').matches) {
+    if (this._isPwa()) {
       this.$.pwaDialog.open();
       return -1;
     }
@@ -96,13 +96,13 @@ class OzwLog extends PolymerElement {
   }
 
   async _refreshLog(ozwWindow) {
-    if (ozwWindow.closed === true || this.$.pwaDialog.opened === false) {
+    if (ozwWindow.closed === true || (this._isPwa() && this.$.pwaDialog.opened === false)) {
       clearInterval(this._intervalId);
       this.setProperties({ _intervalId: null });
     } else {
       const info = await this.hass.callApi('GET', 'zwave/ozwlog?lines=' + this._numLogLines);
       this.setProperties({ _ozwLogs: info });
-      if (window.matchMedia('(display-mode: standalone)').matches) {
+      if (this._isPwa()) {
         return;
       }
       ozwWindow.document.body.innerHTML = `<pre>${this._ozwLogs}</pre>`;
@@ -113,6 +113,10 @@ class OzwLog extends PolymerElement {
     if (this._numLogLines !== '0') {
       this.setProperties({ _completeLog: false });
     } else { this.setProperties({ _completeLog: true }); }
+  }
+
+  _isPwa() {
+    return (window.matchMedia('(display-mode: standalone)').matches);
   }
 }
 customElements.define('ozw-log', OzwLog);

--- a/src/panels/config/zwave/zwave-log.js
+++ b/src/panels/config/zwave/zwave-log.js
@@ -6,6 +6,7 @@ import '@polymer/paper-dialog/paper-dialog.js';
 import '@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import isPwa from '../../../common/config/is_pwa.js';
 
 import '../ha-config-section.js';
 
@@ -86,7 +87,7 @@ class OzwLog extends PolymerElement {
   async _openLogWindow() {
     const info = await this.hass.callApi('GET', 'zwave/ozwlog?lines=' + this._numLogLines);
     this.setProperties({ _ozwLogs: info });
-    if (this._isPwa()) {
+    if (isPwa()) {
       this.$.pwaDialog.open();
       return -1;
     }
@@ -96,13 +97,13 @@ class OzwLog extends PolymerElement {
   }
 
   async _refreshLog(ozwWindow) {
-    if (ozwWindow.closed === true || (this._isPwa() && this.$.pwaDialog.opened === false)) {
+    if (ozwWindow.closed === true || (isPwa() && this.$.pwaDialog.opened === false)) {
       clearInterval(this._intervalId);
       this.setProperties({ _intervalId: null });
     } else {
       const info = await this.hass.callApi('GET', 'zwave/ozwlog?lines=' + this._numLogLines);
       this.setProperties({ _ozwLogs: info });
-      if (this._isPwa()) {
+      if (isPwa()) {
         return;
       }
       ozwWindow.document.body.innerHTML = `<pre>${this._ozwLogs}</pre>`;
@@ -113,10 +114,6 @@ class OzwLog extends PolymerElement {
     if (this._numLogLines !== '0') {
       this.setProperties({ _completeLog: false });
     } else { this.setProperties({ _completeLog: true }); }
-  }
-
-  _isPwa() {
-    return (window.matchMedia('(display-mode: standalone)').matches);
   }
 }
 customElements.define('ozw-log', OzwLog);

--- a/src/panels/config/zwave/zwave-log.js
+++ b/src/panels/config/zwave/zwave-log.js
@@ -96,7 +96,7 @@ class OzwLog extends PolymerElement {
   }
 
   async _refreshLog(ozwWindow) {
-    if (ozwWindow.closed === true) {
+    if (ozwWindow.closed === true || this.$.pwaDialog.opened === false) {
       clearInterval(this._intervalId);
       this.setProperties({ _intervalId: null });
     } else {


### PR DESCRIPTION
This fixes #1681 
Workaround to keep all features intact is to add dialog to PWA(standalone mode) and use window in browser mode.