### PR TITLE
Remove turn_off from brightness slider

### DIFF
--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -93,7 +93,7 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
   <div class$="[[computeClassNames(stateObj)]]">
 
     <div class="control brightness">
-      <ha-labeled-slider caption="[[localize('ui.card.light.brightness')]]" icon="hass:brightness-5" max="255" value="{{brightnessSliderValue}}" on-change="brightnessSliderChanged"></ha-labeled-slider>
+      <ha-labeled-slider caption="[[localize('ui.card.light.brightness')]]" icon="hass:brightness-5" min="1" max="255" value="{{brightnessSliderValue}}" on-change="brightnessSliderChanged"></ha-labeled-slider>
     </div>
 
     <div class="control color_temp">
@@ -221,16 +221,10 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
     if (isNaN(bri)) return;
 
-    if (bri === 0) {
-      this.hass.callService('light', 'turn_off', {
-        entity_id: this.stateObj.entity_id,
-      });
-    } else {
-      this.hass.callService('light', 'turn_on', {
-        entity_id: this.stateObj.entity_id,
-        brightness: bri,
-      });
-    }
+    this.hass.callService('light', 'turn_on', {
+      entity_id: this.stateObj.entity_id,
+      brightness: bri,
+    });
   }
 
   ctSliderChanged(ev) {


### PR DESCRIPTION
This makes it easier to set low brightness values by making the slider work only as a dimmer. Power must then be controlled by the switch.

The minimum is set to 1 because some bulbs will turn off with zero brightness.