### PR TITLE
Set input_boolean icon color to active color when on

### DIFF
--- a/src/components/entity/state-badge.js
+++ b/src/components/entity/state-badge.js
@@ -26,11 +26,12 @@ class StateBadge extends PolymerElement {
     }
 
     /* Color the icon if light or sun is on */
-    ha-icon[data-domain=light][data-state=on],
-    ha-icon[data-domain=switch][data-state=on],
     ha-icon[data-domain=binary_sensor][data-state=on],
     ha-icon[data-domain=fan][data-state=on],
-    ha-icon[data-domain=sun][data-state=above_horizon] {
+    ha-icon[data-domain=input_boolean][data-state=on],
+    ha-icon[data-domain=light][data-state=on],
+    ha-icon[data-domain=sun][data-state=above_horizon],
+    ha-icon[data-domain=switch][data-state=on] {
       color: var(--paper-item-icon-active-color, #FDD835);
     }
 


### PR DESCRIPTION
When turning on an input_boolean, the icon is now set to the active color, like binary_sensor, switch, light, and fan entities.

Also re-arranged the style declaration to be in alphabetical order.

Fixes #1673

![image](https://user-images.githubusercontent.com/7545841/46266144-0389d480-c4fb-11e8-82e9-7c427c5a0764.png)
