### PR TITLE
Fix link color for Hass.io update panel

### DIFF
--- a/hassio/src/dashboard/hassio-hass-update.js
+++ b/hassio/src/dashboard/hassio-hass-update.js
@@ -19,6 +19,9 @@ class HassioHassUpdate extends PolymerElement {
         color: var(--google-red-500);
         margin-top: 16px;
       }
+      a {
+        color: var(--primary-color);
+      }
     </style>
     <template is="dom-if" if="[[computeUpdateAvailable(hassInfo)]]">
       <div class="content">


### PR DESCRIPTION
The link was not showing the correct color, making it hardly visible.