### PR TITLE
[WIP] Handle dict syntax in state trigger "for"

### DIFF
--- a/src/entrypoints/compatibility.js
+++ b/src/entrypoints/compatibility.js
@@ -10,3 +10,23 @@ if (Object.values === undefined) {
     return Object.keys(target).map(function (key) { return target[key]; });
   };
 }
+
+/* eslint-disable */
+// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
+if (!String.prototype.padStart) {
+    String.prototype.padStart = function padStart(targetLength, padString) {
+        targetLength = targetLength >> 0; //truncate if number, or convert non-number to 0;
+        padString = String(typeof padString !== 'undefined' ? padString : ' ');
+        if (this.length >= targetLength) {
+            return String(this);
+        } else {
+            targetLength = targetLength - this.length;
+            if (targetLength > padString.length) {
+                padString += padString.repeat(targetLength / padString.length); //append to original to ensure we are longer than needed
+            }
+            return padString.slice(0, targetLength) + String(this);
+        }
+    };
+}
+/* eslint-enable */

--- a/src/panels/config/js/trigger/state.js
+++ b/src/panels/config/js/trigger/state.js
@@ -24,7 +24,22 @@ export default class StateTrigger extends Component {
   render({ trigger, hass, localize }) {
     const { entity_id, to } = trigger;
     const trgFrom = trigger.from;
-    const trgFor = trigger.for;
+    let trgFor = trigger.for;
+
+    if (trgFor.hours || trgFor.minutes || trgFor.seconds) {
+      // If the trigger was defined using the yaml dict syntax, convert it to
+      // the equivalent string format
+      let {
+        hours = 0,
+        minutes = 0,
+        seconds = 0,
+      } = trgFor;
+      hours = hours.toString();
+      minutes = minutes.toString().padStart(2, '0');
+      seconds = seconds.toString().padStart(2, '0');
+
+      trgFor = `${hours}:${minutes}:${seconds}`;
+    }
     return (
       <div>
         <ha-entity-picker


### PR DESCRIPTION
## Description
Our `for` configuration in our state trigger currently supports any of the following formats. This PR adds client handling to convert the dict format into string format so it can be rendered and edited in a single text field.
```yaml
for: 30 # seconds
for: '2:15:30' # 2 hours, 15 minutes, 30 seconds
for:
  hours: 2
  minutes: 15
  seconds: 30
```

### Questions
1) Should we even support loading this syntax in the frontend? It'll only be present for converted automations. If not, should we deprecate this syntax, since it's functionally equivalent with the string syntax. It also seems confusing, since it appears very similar to the time interval trigger configuration, but behaves differently, since we're only declaring a delay time, instead of a periodic interval.
2) If we do want to support this, we'll need to roll it out to `numeric_state` as well, so maybe there's somewhere better for this logic to live, or maybe it should even be converted in the backend view.