### PR TITLE
Remove last used from long lived access token list.

### DIFF
--- a/src/panels/profile/ha-long-lived-access-tokens-card.js
+++ b/src/panels/profile/ha-long-lived-access-tokens-card.js
@@ -44,10 +44,9 @@ class HaLongLivedTokens extends LocalizeMixin(EventsMixin(PolymerElement)) {
         </template>
       </div>
       <template is='dom-repeat' items='[[_tokens]]'>
-        <ha-settings-row three-line>
+        <ha-settings-row two-line>
           <span slot='heading'>[[item.client_name]]</span>
           <div slot='description'>[[_formatCreatedAt(item.created_at)]]</div>
-          <div slot='description'>[[_formatLastUsed(item)]]</div>
           <paper-icon-button icon="hass:delete" on-click='_handleDelete'></paper-icon-button>
         </ha-settings-row>
       </template>
@@ -87,14 +86,6 @@ class HaLongLivedTokens extends LocalizeMixin(EventsMixin(PolymerElement)) {
       'ui.panel.profile.long_lived_access_tokens.created_at',
       'date', formatDateTime(new Date(created), this.language)
     );
-  }
-
-  _formatLastUsed(item) {
-    return item.last_used_at ? this.localize(
-      'ui.panel.profile.refresh_tokens.last_used',
-      'date', formatDateTime(new Date(item.last_used_at), this.language),
-      'location', item.last_used_ip
-    ) : this.localize('ui.panel.profile.refresh_tokens.not_used');
   }
 
   async _handleCreate() {


### PR DESCRIPTION
We are showing the refresh token last used info under each long lived access token. This will never be updated and creates incorrect idea that it would track access token last used.

Fixes https://github.com/home-assistant/home-assistant-polymer/issues/1726