### PR TITLE
Lovelace: Remove margin from conditional if not shown

### DIFF
--- a/src/panels/lovelace/cards/hui-conditional-card.js
+++ b/src/panels/lovelace/cards/hui-conditional-card.js
@@ -74,6 +74,7 @@ class HuiConditionalCard extends PolymerElement {
       return false;
     });
     root.classList.toggle('hidden', !visible);
+    this.style.setProperty('margin', (!visible) ? '0' : null);
   }
 }
 customElements.define('hui-conditional-card', HuiConditionalCard);


### PR DESCRIPTION
A [conditional card](https://www.home-assistant.io/lovelace/conditional/) which is currently showing no content may still have margins (e.g. if placed in a [vertical-stack](https://www.home-assistant.io/lovelace/vertical-stack/).

Example:
![conditional fix](https://user-images.githubusercontent.com/1299821/46434002-a25c3e00-c752-11e8-9f58-cea80f5ebc5f.png)
Notice how the curenly hidden conditional in the right column leaves an empty space (marked with red).

This change sets the margin to 0 if the card is currently not showing.

This is not a fix for #1686.
