### PR TITLE
Lovelace: Allow glance card to assume theme colors

### DIFF
--- a/gallery/src/demos/demo-hui-glance-card.js
+++ b/gallery/src/demos/demo-hui-glance-card.js
@@ -142,6 +142,21 @@ const CONFIGS = [
     - light.kitchen_lights
     `
   },
+  {
+    heading: 'Primary theme',
+    config: `
+- type: glance
+  theming: primary
+  entities:
+    - device_tracker.demo_paulus
+    - media_player.living_room
+    - sun.sun
+    - cover.kitchen_window
+    - light.kitchen_lights
+    - lock.kitchen_door
+    - light.ceiling_lights
+    `
+  },
 ];
 
 class DemoPicEntity extends PolymerElement {

--- a/src/panels/lovelace/cards/hui-glance-card.js
+++ b/src/panels/lovelace/cards/hui-glance-card.js
@@ -22,11 +22,12 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   static get template() {
     return html`
       <style>
-        :host(.themed) {
+        :host(.theme-primary) {
           --paper-card-background-color:var(--primary-color);
           --paper-item-icon-color:var(--text-primary-color);
           color:var(--text-primary-color);
         }
+        :host(.theme-default) {}
         .entities {
           display: flex;
           padding: 0 16px 4px;
@@ -95,7 +96,11 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   setConfig(config) {
     this._config = config;
     this.updateStyles({ '--glance-column-width': (config && config.column_width) || '20%' });
-    if (config && config.themed) this.classList.add('themed');
+
+    if (config && config.theming && typeof (config.theming) === 'string') {
+      this.classList.add(`theme-${config.theming || 'default'}`);
+    }
+
     this._configEntities = processConfigEntities(config.entities);
   }
 

--- a/src/panels/lovelace/cards/hui-glance-card.js
+++ b/src/panels/lovelace/cards/hui-glance-card.js
@@ -22,6 +22,11 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   static get template() {
     return html`
       <style>
+        :host(.themed) {
+          --paper-card-background-color:var(--primary-color);
+          --paper-item-icon-color:var(--text-primary-color);
+          color:var(--text-primary-color);
+        }
         .entities {
           display: flex;
           padding: 0 16px 4px;
@@ -90,6 +95,7 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   setConfig(config) {
     this._config = config;
     this.updateStyles({ '--glance-column-width': (config && config.column_width) || '20%' });
+    if (config && config.themed) this.classList.add('themed');
     this._configEntities = processConfigEntities(config.entities);
   }
 

--- a/src/panels/lovelace/cards/hui-glance-card.js
+++ b/src/panels/lovelace/cards/hui-glance-card.js
@@ -27,7 +27,6 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
           --paper-item-icon-color:var(--text-primary-color);
           color:var(--text-primary-color);
         }
-        :host(.theme-default) {}
         .entities {
           display: flex;
           padding: 0 16px 4px;
@@ -97,8 +96,11 @@ class HuiGlanceCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this._config = config;
     this.updateStyles({ '--glance-column-width': (config && config.column_width) || '20%' });
 
-    if (config && config.theming && typeof (config.theming) === 'string') {
-      this.classList.add(`theme-${config.theming || 'default'}`);
+    if (config && config.theming) {
+      if (typeof (config.theming) !== 'string') {
+        throw new Error('Incorrect theming config.');
+      }
+      this.classList.add(`theme-${config.theming}`);
     }
 
     this._configEntities = processConfigEntities(config.entities);


### PR DESCRIPTION
**Edit**: Documentation added: home-assistant/home-assistant.io#6506

This change lets the glance card act like [color-glance-card](https://github.com/thomasloven/lovelace-color-glance-card).

For now a sample config looks like this:
```yaml
- type: glance
  themed: true
  entities:
    - light.bed_light
```

I'm not sure about the name of the config variable, though, and as @balloob pointed out in discord, making it a boolean means values can't be added later.

Posting this as a WIP, hoping for ideas and advice.