### PR TITLE
Add time created to persistent notifications.

### DIFF
--- a/src/panels/lovelace/components/notifications/hui-persistent-notification-item.js
+++ b/src/panels/lovelace/components/notifications/hui-persistent-notification-item.js
@@ -1,5 +1,6 @@
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/paper-tooltip/paper-tooltip.js';
 
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -17,9 +18,8 @@ export class HuiPersistentNotificationItem extends LocalizeMixin(PolymerElement)
   static get template() {
     return html`
     <style>
-      ha-relative-time {
+      #time {
         color: var(--secondary-text-color);
-        display: block;
         margin-top: 6px;
         text-align: right;
       }
@@ -29,10 +29,14 @@ export class HuiPersistentNotificationItem extends LocalizeMixin(PolymerElement)
       
       <ha-markdown content="[[notification.message]]"></ha-markdown>
       
-      <ha-relative-time
-        hass="[[hass]]"
-        datetime="[[notification.created_at]]"
-      ></ha-relative-time>
+      <div id="time">
+        <ha-relative-time
+          id="notificationTime"
+          hass="[[hass]]"
+          datetime="[[notification.created_at]]"
+        ></ha-relative-time>
+        <paper-tooltip for="notificationTime">[[_computeTooltip(hass, notification)]]</paper-tooltip>
+      </div>
 
       <paper-button
         slot="actions"
@@ -58,6 +62,15 @@ export class HuiPersistentNotificationItem extends LocalizeMixin(PolymerElement)
 
   _computeTitle(notification) {
     return notification.title || notification.notification_id;
+  }
+
+  _computeTooltip(hass, notification) {
+    if (!hass || !notification) return null;
+
+    const d = new Date(notification.created_at);
+    return d.toLocaleDateString(hass.language, {
+      year: 'numeric', month: 'short', day: 'numeric', minute: 'numeric', hour: 'numeric'
+    });
   }
 }
 customElements.define(

--- a/src/panels/lovelace/components/notifications/hui-persistent-notification-item.js
+++ b/src/panels/lovelace/components/notifications/hui-persistent-notification-item.js
@@ -19,9 +19,11 @@ export class HuiPersistentNotificationItem extends LocalizeMixin(PolymerElement)
     return html`
     <style>
       #time {
-        color: var(--secondary-text-color);
         margin-top: 6px;
         text-align: right;
+      }
+      ha-relative-time {
+        color: var(--secondary-text-color);
       }
     </style>
     <hui-notification-item-template>

--- a/src/panels/lovelace/components/notifications/hui-persistent-notification-item.js
+++ b/src/panels/lovelace/components/notifications/hui-persistent-notification-item.js
@@ -18,9 +18,10 @@ export class HuiPersistentNotificationItem extends LocalizeMixin(PolymerElement)
   static get template() {
     return html`
     <style>
-      #time {
+      .time {
+        display: flex;
+        justify-content: flex-end;
         margin-top: 6px;
-        text-align: right;
       }
       ha-relative-time {
         color: var(--secondary-text-color);
@@ -31,13 +32,14 @@ export class HuiPersistentNotificationItem extends LocalizeMixin(PolymerElement)
       
       <ha-markdown content="[[notification.message]]"></ha-markdown>
       
-      <div id="time">
-        <ha-relative-time
-          id="notificationTime"
-          hass="[[hass]]"
-          datetime="[[notification.created_at]]"
-        ></ha-relative-time>
-        <paper-tooltip for="notificationTime">[[_computeTooltip(hass, notification)]]</paper-tooltip>
+      <div class="time">
+        <span>
+          <ha-relative-time
+            hass="[[hass]]"
+            datetime="[[notification.created_at]]"
+          ></ha-relative-time>
+          <paper-tooltip>[[_computeTooltip(hass, notification)]]</paper-tooltip>
+        </span>
       </div>
 
       <paper-button

--- a/src/panels/lovelace/components/notifications/hui-persistent-notification-item.js
+++ b/src/panels/lovelace/components/notifications/hui-persistent-notification-item.js
@@ -4,6 +4,7 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
+import '../../../../components/ha-relative-time.js';
 import '../../../../components/ha-markdown.js';
 import './hui-notification-item-template.js';
 
@@ -15,11 +16,24 @@ import LocalizeMixin from '../../../../mixins/localize-mixin.js';
 export class HuiPersistentNotificationItem extends LocalizeMixin(PolymerElement) {
   static get template() {
     return html`
+    <style>
+      ha-relative-time {
+        color: var(--secondary-text-color);
+        display: block;
+        margin-top: 6px;
+        text-align: right;
+      }
+    </style>
     <hui-notification-item-template>
       <span slot="header">[[_computeTitle(notification)]]</span>
       
       <ha-markdown content="[[notification.message]]"></ha-markdown>
       
+      <ha-relative-time
+        hass="[[hass]]"
+        datetime="[[notification.created_at]]"
+      ></ha-relative-time>
+
       <paper-button
         slot="actions"
         class="primary"


### PR DESCRIPTION
Adds relative creation time to persistent notifications in lovelace notification drawer

Depends on https://github.com/home-assistant/home-assistant/pull/17121

Closes https://github.com/home-assistant/ui-schema/issues/170

<img width="400" alt="notification-drawer" src="https://user-images.githubusercontent.com/11150179/46452287-dbdf7a00-c74f-11e8-8336-6757e2689b09.png">
