### PR TITLE
RFC: mwc elements / Add mwc-switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Paulus Schoutsen <Paulus@PaulusSchoutsen.nl> (http://paulusschoutsen.nl)",
   "license": "Apache-2.0",
   "dependencies": {
+    "@material/mwc-switch": "^0.3.0",
     "@mdi/svg": "^2.7.94",
     "@polymer/app-layout": "^3.0.1",
     "@polymer/app-localize-behavior": "^3.0.1",

--- a/src/components/entity/ha-entity-toggle.js
+++ b/src/components/entity/ha-entity-toggle.js
@@ -1,7 +1,7 @@
 import '@polymer/paper-icon-button/paper-icon-button.js';
-import '@polymer/paper-toggle-button/paper-toggle-button.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import '@material/mwc-switch';
 
 import { STATES_OFF } from '../../common/const.js';
 import computeStateDomain from '../../common/entity/compute_state_domain.js';
@@ -10,9 +10,8 @@ class HaEntityToggle extends PolymerElement {
   static get template() {
     return html`
     <style>
-      :host {
+      .buttonWrapper {
         white-space: nowrap;
-        min-width: 38px;
       }
       paper-icon-button {
         color: var(--paper-icon-button-inactive-color, var(--primary-text-color));
@@ -21,20 +20,16 @@ class HaEntityToggle extends PolymerElement {
       paper-icon-button[state-active] {
         color: var(--paper-icon-button-active-color, var(--primary-color));
       }
-      paper-toggle-button {
-        cursor: pointer;
-        --paper-toggle-button-label-spacing: 0;
-        padding: 13px 5px;
-        margin: -4px -5px;
-      }
     </style>
 
     <template is="dom-if" if="[[stateObj.attributes.assumed_state]]">
-      <paper-icon-button icon="hass:flash-off" on-click="turnOff" state-active$="[[!isOn]]"></paper-icon-button>
-      <paper-icon-button icon="hass:flash" on-click="turnOn" state-active$="[[isOn]]"></paper-icon-button>
+      <div class='buttonWrapper'>
+        <paper-icon-button icon="hass:flash-off" on-click="turnOff" state-active$="[[!isOn]]"></paper-icon-button>
+        <paper-icon-button icon="hass:flash" on-click="turnOn" state-active$="[[isOn]]"></paper-icon-button>
+      </div>
     </template>
     <template is="dom-if" if="[[!stateObj.attributes.assumed_state]]">
-      <paper-toggle-button checked="[[toggleChecked]]" on-change="toggleChanged"></paper-toggle-button>
+      <mwc-switch checked="[[toggleChecked]]" on-change="toggleChanged"></mwc-switch>
     </template>
 `;
   }

--- a/src/panels/config/cloud/ha-config-cloud-account.js
+++ b/src/panels/config/cloud/ha-config-cloud-account.js
@@ -1,7 +1,7 @@
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-card/paper-card.js';
 import '@polymer/paper-item/paper-item-body.js';
-import '@polymer/paper-toggle-button/paper-toggle-button.js';
+import '@material/mwc-switch';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -64,10 +64,10 @@ class HaConfigCloudAccount extends EventsMixin(LocalizeMixin(PolymerElement)) {
       a {
         color: var(--primary-color);
       }
-      paper-card > paper-toggle-button {
+      paper-card > mwc-switch {
         position: absolute;
-        right: 8px;
-        top: 16px;
+        right: 16px;
+        top: 18px;
       }
     </style>
     <hass-subpage header="Home Assistant Cloud">
@@ -116,10 +116,10 @@ class HaConfigCloudAccount extends EventsMixin(LocalizeMixin(PolymerElement)) {
           </div>
 
           <paper-card heading="Alexa">
-            <paper-toggle-button
+            <mwc-switch
               checked='[[cloudStatus.alexa_enabled]]'
               on-change='_alexaChanged'
-            ></paper-toggle-button>
+            ></mwc-switch>
             <div class="card-content">
               With the Alexa integration for Home Assistant Cloud you'll be able to control all your Home Assistant devices via any Alexa-enabled device.
               <ul>
@@ -137,10 +137,10 @@ class HaConfigCloudAccount extends EventsMixin(LocalizeMixin(PolymerElement)) {
           </paper-card>
 
           <paper-card heading="Google Assistant">
-            <paper-toggle-button
+            <mwc-switch
               checked='[[cloudStatus.google_enabled]]'
               on-change='_googleChanged'
-            ></paper-toggle-button>
+            ></mwc-switch>
             <div class="card-content">
               With the Google Assistant integration for Home Assistant Cloud you'll be able to control all your Home Assistant devices via any Google Assistant-enabled device.
               <ul>

--- a/src/resources/ha-style.js
+++ b/src/resources/ha-style.js
@@ -4,6 +4,7 @@ import '@polymer/polymer/polymer-legacy.js';
 const documentContainer = document.createElement('template');
 documentContainer.setAttribute('style', 'display: none;');
 
+// https://material.io/tools/color/#!/?view.left=0&view.right=0&primary.color=03a9f4&secondary.color=FBC02D
 documentContainer.innerHTML = `<custom-style>
   <style>
     /*
@@ -25,9 +26,9 @@ documentContainer.innerHTML = `<custom-style>
 
       /* main interface colors */
       --primary-color: #03a9f4;
-      --dark-primary-color: #0288d1;
-      --light-primary-color: #b3e5fC;
-      --accent-color: #ff9800;
+      --dark-primary-color: #007ac1;
+      --light-primary-color: #67daff;
+      --accent-color: #fbc02d;
       --divider-color: rgba(0, 0, 0, .12);
 
       /* states and badges */
@@ -118,6 +119,10 @@ documentContainer.innerHTML = `<custom-style>
       --paper-slider-secondary-color: var(--slider-secondary-color);
       --paper-slider-container-color: var(--slider-bar-color);
       --ha-paper-slider-pin-font-size: 15px;
+
+      /* mdc mapping: https://material.io/develop/web/docs/theming/ */
+      --mdc-theme-primary: var(--primary-color);
+      --mdc-theme-secondary: var(--primary-color);
     }
   </style>
 

--- a/src/state-summary/state-card-script.js
+++ b/src/state-summary/state-card-script.js
@@ -14,8 +14,13 @@ import LocalizeMixin from '../mixins/localize-mixin.js';
 class StateCardScript extends LocalizeMixin(PolymerElement) {
   static get template() {
     return html`
-    <style include="iron-flex iron-flex-alignment"></style>
     <style>
+      :host {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
       paper-button {
         color: var(--primary-color);
         font-weight: 500;
@@ -29,15 +34,13 @@ class StateCardScript extends LocalizeMixin(PolymerElement) {
       }
     </style>
 
-    <div class="horizontal justified layout">
-      ${this.stateInfoTemplate}
-      <template is="dom-if" if="[[stateObj.attributes.can_cancel]]">
-        <ha-entity-toggle state-obj="[[stateObj]]" hass="[[hass]]"></ha-entity-toggle>
-      </template>
-      <template is="dom-if" if="[[!stateObj.attributes.can_cancel]]">
-        <paper-button on-click="fireScript">[[localize('ui.card.script.execute')]]</paper-button>
-      </template>
-    </div>
+    ${this.stateInfoTemplate}
+    <template is="dom-if" if="[[stateObj.attributes.can_cancel]]">
+      <ha-entity-toggle state-obj="[[stateObj]]" hass="[[hass]]"></ha-entity-toggle>
+    </template>
+    <template is="dom-if" if="[[!stateObj.attributes.can_cancel]]">
+      <paper-button on-click="fireScript">[[localize('ui.card.script.execute')]]</paper-button>
+    </template>
 `;
   }
 

--- a/src/state-summary/state-card-toggle.js
+++ b/src/state-summary/state-card-toggle.js
@@ -1,4 +1,3 @@
-import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -8,18 +7,15 @@ import '../components/entity/state-info.js';
 class StateCardToggle extends PolymerElement {
   static get template() {
     return html`
-    <style include="iron-flex iron-flex-alignment"></style>
     <style>
-      ha-entity-toggle {
-        margin: -4px -16px -4px 0;
-        padding: 4px 16px;
+      :host {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
       }
     </style>
-
-    <div class="horizontal justified layout">
-      ${this.stateInfoTemplate}
-      <ha-entity-toggle state-obj="[[stateObj]]" hass="[[hass]]"></ha-entity-toggle>
-    </div>
+    ${this.stateInfoTemplate}
+    <ha-entity-toggle state-obj="[[stateObj]]" hass="[[hass]]"></ha-entity-toggle>
 `;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -663,6 +663,91 @@
   dependencies:
     base64-js "^1.3.0"
 
+"@material/animation@^0.40.1":
+  version "0.40.1"
+  resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.40.1.tgz#c5ff31e7d7e17324a0045e889d3530b150b9fcec"
+  integrity sha512-HtxFUw04EHg4S6pXfTA3Z0wKxnNDNcDhe1Np2Y2geo+lAk2Hb7m8yCL/GaL9o2I/eRYsgUXC0U7+Mk74GCz3zw==
+
+"@material/base@^0.40.1":
+  version "0.40.1"
+  resolved "https://registry.yarnpkg.com/@material/base/-/base-0.40.1.tgz#a0d8e19cee98dae0f96dbf0887a14b3f7acd2aac"
+  integrity sha512-vrbOK8hONVCYgURQ9h7nkXvMdYnZVVNmAfFFijF8fbWQdwnoPcNTdqV6RoQlhBEqHYHQqLNfdUDlznAPKLclGQ==
+
+"@material/elevation@^0.40.1":
+  version "0.40.1"
+  resolved "https://registry.yarnpkg.com/@material/elevation/-/elevation-0.40.1.tgz#beb17eb90bde94459c41cd826c2de13f13b10b25"
+  integrity sha512-VD9ii90WzI+t4df08A9hQIsYLH/N+85a2Mqo10CNVZLZYW5fDOwFH/h7553aNoAuSHKPcGCLdyav9J9oC6TSaQ==
+  dependencies:
+    "@material/animation" "^0.40.1"
+    "@material/theme" "^0.40.1"
+
+"@material/mwc-base@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@material/mwc-base/-/mwc-base-0.3.1.tgz#5e1440aa09e0a83633be36eb8102ff88d3fddae8"
+  integrity sha512-7AdcBu6rxARcUteEBNSJKCen3hP47T/NRsfw+RMn6IedHlEGp2GKwF6YqYDCVSsQbm0IjsJ4ft4+nVXlFVYO2g==
+  dependencies:
+    "@polymer/lit-element" "^0.6.2"
+    lit-html "^0.12.0"
+
+"@material/mwc-ripple@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@material/mwc-ripple/-/mwc-ripple-0.3.1.tgz#da812516d0bd0b15b0c4793b783fbdb9e04cd7a0"
+  integrity sha512-pOdBkP6NJyGz9UftvKjrx8sXvz+yIXMC8q6Qx/LgGw67tgU4qM/1Hy22iePiw1UFNhlqD8ZwtdPLXKVaisGauQ==
+  dependencies:
+    "@material/mwc-base" "^0.3.1"
+    "@material/ripple" "^0.40.0"
+    "@polymer/lit-element" "^0.6.2"
+    lit-html "^0.12.0"
+
+"@material/mwc-switch@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@material/mwc-switch/-/mwc-switch-0.3.1.tgz#2daee64827ca283aad2072af92d07fb9393f54d1"
+  integrity sha512-5r/chZrbcuLh1sLqtpnNodmGzqFCeAlv1fWliQig56TRBbrZjSRY78qm+JOg9/rr3fj92FcI5c2tKaHWoud79g==
+  dependencies:
+    "@material/mwc-base" "^0.3.1"
+    "@material/mwc-ripple" "^0.3.1"
+    "@material/switch" "^0.40.0"
+    "@polymer/lit-element" "^0.6.2"
+
+"@material/ripple@^0.40.0", "@material/ripple@^0.40.1":
+  version "0.40.1"
+  resolved "https://registry.yarnpkg.com/@material/ripple/-/ripple-0.40.1.tgz#57cbc689303b48282229cb9b62556af7442e852a"
+  integrity sha512-sndeTS4VHa0v1UGj7MNcxMCuO9LJ1DjoL1EjE6BH3Lm3M1MnXJHdsBo2CgPbU/FI84tt6+eyHGOYPdPrEDJhCA==
+  dependencies:
+    "@material/animation" "^0.40.1"
+    "@material/base" "^0.40.1"
+    "@material/theme" "^0.40.1"
+
+"@material/rtl@^0.40.1":
+  version "0.40.1"
+  resolved "https://registry.yarnpkg.com/@material/rtl/-/rtl-0.40.1.tgz#5b0d973e3c6f8e2ea3656c06ada37ba2fedfa206"
+  integrity sha512-Pk6Iw1/KrhWZoZtkDsPMDUW0bm7Z1zeXb3MTQRCFmjf1wU5cRxgOTtuoZLcJqlcKGppLAzJL/TJV3E7KEiuL0A==
+
+"@material/selection-control@^0.40.1":
+  version "0.40.1"
+  resolved "https://registry.yarnpkg.com/@material/selection-control/-/selection-control-0.40.1.tgz#501784eb2166bca150b88bb9c09e1a7947e17f96"
+  integrity sha512-BbCmSsRz4mTlBaaA5pmrSEL+F6BKR8hjwvo+XQBh8ICT3FbSGg7mhYwjpsQhNQ8J6l7bnh79VYxKGPY6XjSx6g==
+  dependencies:
+    "@material/ripple" "^0.40.1"
+
+"@material/switch@^0.40.0":
+  version "0.40.1"
+  resolved "https://registry.yarnpkg.com/@material/switch/-/switch-0.40.1.tgz#cea8f1fa2d2241104d23d155b5db29f79d0b9168"
+  integrity sha512-jWskicPUQht7ETlkprF+1fK8I0jKrKN3mnKo6hngbkm+JyZpjfAsN31nhx6sxuuCxWQrQNCEvUz6EolnCPp3zQ==
+  dependencies:
+    "@material/animation" "^0.40.1"
+    "@material/base" "^0.40.1"
+    "@material/elevation" "^0.40.1"
+    "@material/ripple" "^0.40.1"
+    "@material/rtl" "^0.40.1"
+    "@material/selection-control" "^0.40.1"
+    "@material/theme" "^0.40.1"
+
+"@material/theme@^0.40.1":
+  version "0.40.1"
+  resolved "https://registry.yarnpkg.com/@material/theme/-/theme-0.40.1.tgz#3cc3f1bf87ee9581df03e347a1979e53ae617221"
+  integrity sha512-cH1CsGIDisEQ2oroZhLTypV0Ir00x3WIwFXnPo7qv3832tuIDkZY623U3rUax6KNPz4Hh1j0tNpTwgrNZwvwWA==
+
 "@mdi/svg@^2.7.94":
   version "2.7.94"
   resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-2.7.94.tgz#5f2b03c363b10f7e4cf8c8a5fdc81cbd838bf44b"


### PR DESCRIPTION
When Polymer 3 was introduced, they also announced that the paper-* and iron-* elements will no longer be maintained. The reason was two-fold: the elements were based on the Polymer templating engine, which they are phasing out in favor of the smaller and more flexible lit-html. The other reason was that their new [mwc elements](https://github.com/material-components/material-components-web-components) are based on their [vanilla JS material components](https://www.material.io/develop/web/) and so they didn't had to maintain two sets of components.

I've been following the Polymer Slack and they are soon approaching Lit Element 1.0. The current version of lit-html (0.11) is expected to be the final API. MWC elements are still being build on top of this but a couple, including the mwc-switch, are already ready.

Migrating away from Polymer elements to Lit Element based MWC elements has various advantages:
 - Maintained. We've had to fork a couple of components to apply fixes for things that didn't work. That should no longer be the case.
 - Light. The new elements are extremely lightweight. Should make our UI faster to load.
 - Fun! Who doesn't like new tech 💃 

So I went ahead and added mwc-switch to the Cloud page and the ha-entity-toggle.

Before:
![image](https://user-images.githubusercontent.com/1444314/46523457-0cc1cb00-c886-11e8-90bb-d693227b8763.png)

After:
![image](https://user-images.githubusercontent.com/1444314/46523421-f7e53780-c885-11e8-9fc8-065feff3733a.png)
