### PR TITLE
fix dockerfile for new setups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9-alpine
+FROM node:8.11.1-alpine
 
 # install yarn
 ENV PATH /root/.yarn/bin:$PATH


### PR DESCRIPTION
Creating the initial docker image failed to install the npm dependencies. This updates it to match the specified NVM version