### PR TITLE
Adding Gauge Card to Lovelace

### DIFF
--- a/gallery/src/demos/demo-hui-gauge-card.js
+++ b/gallery/src/demos/demo-hui-gauge-card.js
@@ -27,7 +27,7 @@ const CONFIGS = [
 - type: gauge
   entity: climate.ecobee
   attribute: current_temperature
-  unit_of_measurement: Degrees
+  unit_of_measurement: C
     `
   },
   {
@@ -50,6 +50,22 @@ const CONFIGS = [
   attribute: current_temperature
   min: 0
   max: 38
+    `
+  },
+  {
+    heading: 'Invalid Entity',
+    config: `
+- type: gauge
+  entity: climate.invalid_entity
+  min: 0
+  max: 38
+    `
+  },
+  {
+    heading: 'Non-Numeric Value',
+    config: `
+- type: gauge
+  entity: plant.bonsai
     `
   },
 ];

--- a/gallery/src/demos/demo-hui-gauge-card.js
+++ b/gallery/src/demos/demo-hui-gauge-card.js
@@ -8,7 +8,7 @@ const CONFIGS = [
     heading: 'Basic example',
     config: `
 - type: gauge
-  entity: climate.ecobee
+  entity: climate.ecobee.current_temperature
     `
   },
   {
@@ -16,14 +16,14 @@ const CONFIGS = [
     config: `
 - type: gauge
   title: Temperature
-  entity: climate.ecobee
+  entity: climate.ecobee.current_temperature
     `
   },
   {
     heading: 'Custom Unit of Measurement',
     config: `
 - type: gauge
-  entity: climate.ecobee
+  entity: climate.ecobee.current_temperature
   unit_of_measurement: Degrees
     `
   },
@@ -31,7 +31,7 @@ const CONFIGS = [
     heading: 'Setting Severity Levels',
     config: `
 - type: gauge
-  entity: climate.ecobee
+  entity: climate.ecobee.current_temperature
   severity:
     red: 32
     green: 0
@@ -42,7 +42,7 @@ const CONFIGS = [
     heading: 'Setting Min and Max Values',
     config: `
 - type: gauge
-  entity: climate.ecobee
+  entity: climate.ecobee.current_temperature
   min: 0
   max: 38
     `

--- a/gallery/src/demos/demo-hui-gauge-card.js
+++ b/gallery/src/demos/demo-hui-gauge-card.js
@@ -1,0 +1,69 @@
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import '../components/demo-cards.js';
+
+const CONFIGS = [
+  {
+    heading: 'Basic example',
+    config: `
+- type: gauge
+  entity: climate.ecobee
+    `
+  },
+  {
+    heading: 'With title',
+    config: `
+- type: gauge
+  title: Temperature
+  entity: climate.ecobee
+    `
+  },
+  {
+    heading: 'Custom Unit of Measurement',
+    config: `
+- type: gauge
+  entity: climate.ecobee
+  unit_of_measurement: Degrees
+    `
+  },
+  {
+    heading: 'Setting Severity Levels',
+    config: `
+- type: gauge
+  entity: climate.ecobee
+  severity:
+    red: 32
+    green: 0
+    amber: 23
+    `
+  },
+  {
+    heading: 'Setting Min and Max Values',
+    config: `
+- type: gauge
+  entity: climate.ecobee
+  min: 0
+  max: 38
+    `
+  },
+];
+
+class DemoGaugeEntity extends PolymerElement {
+  static get template() {
+    return html`
+      <demo-cards configs="[[_configs]]"></demo-cards>
+    `;
+  }
+
+  static get properties() {
+    return {
+      _configs: {
+        type: Object,
+        value: CONFIGS
+      }
+    };
+  }
+}
+
+customElements.define('demo-hui-gauge-card', DemoGaugeEntity);

--- a/gallery/src/demos/demo-hui-gauge-card.js
+++ b/gallery/src/demos/demo-hui-gauge-card.js
@@ -8,25 +8,22 @@ const CONFIGS = [
     heading: 'Basic example',
     config: `
 - type: gauge
-  entity: climate.ecobee
-  attribute: current_temperature
+  entity: sensor.brightness
     `
   },
   {
     heading: 'With title',
     config: `
 - type: gauge
-  title: Temperature
-  entity: climate.ecobee
-  attribute: current_temperature
+  title: Humidity
+  entity: sensor.outside_humidity
     `
   },
   {
     heading: 'Custom Unit of Measurement',
     config: `
 - type: gauge
-  entity: climate.ecobee
-  attribute: current_temperature
+  entity: sensor.outside_temperature
   unit_of_measurement: C
     `
   },
@@ -34,20 +31,18 @@ const CONFIGS = [
     heading: 'Setting Severity Levels',
     config: `
 - type: gauge
-  entity: climate.ecobee
-  attribute: current_temperature
+  entity: sensor.brightness
   severity:
     red: 32
     green: 0
-    amber: 23
+    yellow: 23
     `
   },
   {
     heading: 'Setting Min and Max Values',
     config: `
 - type: gauge
-  entity: climate.ecobee
-  attribute: current_temperature
+  entity: sensor.brightness
   min: 0
   max: 38
     `
@@ -56,9 +51,7 @@ const CONFIGS = [
     heading: 'Invalid Entity',
     config: `
 - type: gauge
-  entity: climate.invalid_entity
-  min: 0
-  max: 38
+  entity: sensor.invalid_entity
     `
   },
   {

--- a/gallery/src/demos/demo-hui-gauge-card.js
+++ b/gallery/src/demos/demo-hui-gauge-card.js
@@ -8,7 +8,8 @@ const CONFIGS = [
     heading: 'Basic example',
     config: `
 - type: gauge
-  entity: climate.ecobee.current_temperature
+  entity: climate.ecobee
+  attribute: current_temperature
     `
   },
   {
@@ -16,14 +17,16 @@ const CONFIGS = [
     config: `
 - type: gauge
   title: Temperature
-  entity: climate.ecobee.current_temperature
+  entity: climate.ecobee
+  attribute: current_temperature
     `
   },
   {
     heading: 'Custom Unit of Measurement',
     config: `
 - type: gauge
-  entity: climate.ecobee.current_temperature
+  entity: climate.ecobee
+  attribute: current_temperature
   unit_of_measurement: Degrees
     `
   },
@@ -31,7 +34,8 @@ const CONFIGS = [
     heading: 'Setting Severity Levels',
     config: `
 - type: gauge
-  entity: climate.ecobee.current_temperature
+  entity: climate.ecobee
+  attribute: current_temperature
   severity:
     red: 32
     green: 0
@@ -42,7 +46,8 @@ const CONFIGS = [
     heading: 'Setting Min and Max Values',
     config: `
 - type: gauge
-  entity: climate.ecobee.current_temperature
+  entity: climate.ecobee
+  attribute: current_temperature
   min: 0
   max: 38
     `

--- a/src/panels/lovelace/cards/hui-gauge-card.js
+++ b/src/panels/lovelace/cards/hui-gauge-card.js
@@ -16,6 +16,7 @@ class HuiGaugeCard extends EventsMixin(PolymerElement) {
           --base-unit: 50px;
           height: calc(var(--base-unit)*3);
           position: relative;
+          cursor: pointer;
         }
         .container{
           width: calc(var(--base-unit) * 4);
@@ -151,6 +152,7 @@ class HuiGaugeCard extends EventsMixin(PolymerElement) {
       this.$.title.className = 'not-found';
       return 'Entity is non-numeric: ' + this._config.entity;
     }
+    this.$.title.className = '';
     return this._config.title;
   }
 

--- a/src/panels/lovelace/cards/hui-gauge-card.js
+++ b/src/panels/lovelace/cards/hui-gauge-card.js
@@ -113,17 +113,12 @@ class HuiGaugeCard extends EventsMixin(PolymerElement) {
     };
   }
 
-  ready() {
-    super.ready();
-  }
-
   getCardSize() {
     return 1;
   }
 
   setConfig(config) {
     if (!config || !config.entity) throw new Error('Invalid card configuration');
-
     this._config = Object.assign({ min: 0, max: 100 }, config);
   }
 
@@ -132,16 +127,17 @@ class HuiGaugeCard extends EventsMixin(PolymerElement) {
   }
 
   _stateObjChanged(stateObj) {
-    if (!stateObj) return;
-    const config = this._config;
+    if (!stateObj || isNaN(stateObj.state)) return;
 
+    const config = this._config;
     const turn = this._translateTurn(stateObj.state, config) / 10;
+
     this.$.gauge.style.transform = `rotate(${turn}turn)`;
     this.$.gauge.style.backgroundColor = this._computeSeverity(stateObj.state, config.severity);
   }
 
   _computeStateDisplay(stateObj) {
-    if (!stateObj || isNaN(stateObj.state)) return null;
+    if (!stateObj || isNaN(stateObj.state)) return '';
     const unitOfMeasurement = this._config.unit_of_measurement || stateObj.attributes.unit_of_measurement || '';
     return `${stateObj.state} ${unitOfMeasurement}`;
   }
@@ -166,10 +162,12 @@ class HuiGaugeCard extends EventsMixin(PolymerElement) {
       yellow: 'var(--label-badge-yellow)',
       normal: 'var(--label-badge-blue)',
     };
-    if (!sections) return severityMap.normal;
-    const sectionsArray = Object.keys(sections);
 
+    if (!sections) return severityMap.normal;
+
+    const sectionsArray = Object.keys(sections);
     const sortable = sectionsArray.map(severity => [severity, sections[severity]]);
+
     for (var i = 0; i < sortable.length; i++) {
       if (severityMap[sortable[i][0]] == null || isNaN(sortable[i][1])) {
         return severityMap.normal;

--- a/src/panels/lovelace/cards/hui-gauge-card.js
+++ b/src/panels/lovelace/cards/hui-gauge-card.js
@@ -1,0 +1,182 @@
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import '../../../components/ha-card.js';
+
+import EventsMixin from '../../../mixins/events-mixin.js';
+
+/*
+ * @appliesMixin EventsMixin
+ */
+class HuiGaugeCard extends EventsMixin(PolymerElement) {
+  static get template() {
+    return html`
+      <style>
+        ha-card {
+          --base-unit: 50px;
+          height: calc(var(--base-unit)*3);
+          position: relative;
+        }
+        .container{
+          width: calc(var(--base-unit) * 4);
+          height: calc(var(--base-unit) * 2);
+          position: absolute;
+          top: calc(var(--base-unit)*1.5);
+          left: 50%;
+          overflow: hidden;
+          text-align: center;
+          transform: translate(-50%, -50%);
+        }
+        .gauge-a{
+          z-index: 1;
+          position: absolute;
+          background-color: var(--primary-background-color);
+          width: calc(var(--base-unit) * 4);
+          height: calc(var(--base-unit) * 2);
+          top: 0%;
+          border-radius:calc(var(--base-unit) * 2.5) calc(var(--base-unit) * 2.5) 0px 0px ;
+        }
+        .gauge-b{
+          z-index: 3;
+          position: absolute;
+          background-color: var(--paper-card-background-color);
+          width: calc(var(--base-unit) * 2.5);
+          height: calc(var(--base-unit) * 1.25);
+          top: calc(var(--base-unit) * 0.75);
+          margin-left: calc(var(--base-unit) * 0.75);
+          margin-right: auto;
+          border-radius: calc(var(--base-unit) * 2.5) calc(var(--base-unit) * 2.5) 0px 0px ;
+        }
+        .gauge-c{
+          z-index: 2;
+          position: absolute;
+          background-color: var(--label-badge-yellow);
+          width: calc(var(--base-unit) * 4);
+          height: calc(var(--base-unit) * 2);
+          top: calc(var(--base-unit) * 2);
+          margin-left: auto;
+          margin-right: auto;
+          border-radius: 0px 0px calc(var(--base-unit) * 2) calc(var(--base-unit) * 2) ;
+          transform-origin: center top;
+          transition: all 1.3s ease-in-out;
+        }
+        .gauge-data{
+          z-index: 4;
+          color: var(--primary-text-color);
+          line-height: calc(var(--base-unit) * 0.3);
+          position: absolute;
+          width: calc(var(--base-unit) * 4);
+          height: calc(var(--base-unit) * 2.1);
+          top: calc(var(--base-unit) * 1.2);
+          margin-left: auto;
+          margin-right: auto;
+          transition: all 1s ease-out;
+        }
+        .gauge-data #percent{
+          font-size: calc(var(--base-unit) * 0.55);
+        }
+        .gauge-data #title{
+          padding-top: calc(var(--base-unit) * 0.15);
+          font-size: calc(var(--base-unit) * 0.30);
+        }
+      </style>
+      <ha-card on-click='_handleClick'>
+        <div class='container'>
+          <div class='gauge-a'></div>
+          <div class='gauge-b'></div>
+          <div class='gauge-c' id='gauge'></div>
+          <div class='gauge-data'><div id='percent'></div><div id='title'></div></div>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  static get properties() {
+    return {
+      hass: {
+        type: Object,
+        observer: '_hassChanged'
+      },
+      _config: Object,
+    };
+  }
+
+  ready() {
+    super.ready();
+    if (this._config) this._buildConfig();
+  }
+
+  getCardSize() {
+    return 1;
+  }
+
+  setConfig(config) {
+    this._config = Object.assign({ min: 0, max: 100 }, config);
+    if (!config || !config.entity) throw new Error('Invalid card configuration');
+
+    if (this.$) this._buildConfig();
+    if (this.hass) this._hassChanged(this.hass);
+  }
+
+  _buildConfig() {
+    const entityStateObj = this.hass.states[this._config.entity];
+    const unitOfMeasurement = this._config.unit_of_measurement || entityStateObj.attributes.unit_of_measurement || '';
+    const root = this.shadowRoot;
+
+    if (!this.entityStateObj || entityStateObj.state !== this._entityState.state) {
+      root.getElementById('percent').textContent = `${entityStateObj.state} ${unitOfMeasurement}`;
+      root.getElementById('title').textContent = this._config.title;
+      const turn = this._translateTurn(entityStateObj.state, this._config) / 10;
+      root.getElementById('gauge').style.transform = `rotate(${turn}turn)`;
+      root.getElementById('gauge').style.backgroundColor = this._computeSeverity(entityStateObj.state, this._config.severity);
+      this._entityStateObj = entityStateObj;
+    }
+  }
+
+  _hassChanged(hass) {
+    this.hass = hass;
+    this._buildConfig();
+  }
+
+  _computeSeverity(stateValue, sections) {
+    const numberValue = Number(stateValue);
+    const severityMap = {
+      red: 'var(--label-badge-red)',
+      green: 'var(--label-badge-green)',
+      amber: 'var(--label-badge-yellow)',
+      normal: 'var(--label-badge-blue)',
+    };
+    if (!sections) return severityMap.normal;
+    const sortable = [];
+    Object.keys(sections).forEach((severity) => {
+      sortable.push([severity, sections[severity]]);
+    });
+    sortable.sort((a, b) => a[1] - b[1]);
+
+    if (numberValue >= sortable[0][1] && numberValue < sortable[1][1]) {
+      return severityMap[sortable[0][0]];
+    }
+    if (numberValue >= sortable[1][1] && numberValue < sortable[2][1]) {
+      return severityMap[sortable[1][0]];
+    }
+    if (numberValue >= sortable[2][1]) {
+      return severityMap[sortable[2][0]];
+    }
+    return severityMap.normal;
+  }
+
+  _translateTurn(value, config) {
+    return 5 * (value - config.min) / (config.max - config.min);
+  }
+
+  _computeClasses(hasHeader) {
+    return `entities ${hasHeader ? '' : 'no-header'}`;
+  }
+
+  _handleClick() {
+    const entityId = this._config.entity;
+    this.fire('hass-more-info', { entityId });
+  }
+}
+
+customElements.define('hui-gauge-card', HuiGaugeCard);

--- a/src/panels/lovelace/cards/hui-gauge-card.js
+++ b/src/panels/lovelace/cards/hui-gauge-card.js
@@ -125,7 +125,6 @@ class HuiGaugeCard extends EventsMixin(PolymerElement) {
     if (!config || !config.entity) throw new Error('Invalid card configuration');
 
     this._config = Object.assign({ min: 0, max: 100 }, config);
-    if (this.$) this._buildConfig();
   }
 
   _computeStateObj(states, entityId) {

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -27,6 +27,7 @@ const CARD_TYPES = new Set([
   'entities',
   'entity-filter',
   'error',
+  'gauge',
   'glance',
   'history-graph',
   'horizontal-stack',
@@ -40,8 +41,7 @@ const CARD_TYPES = new Set([
   'picture-glance',
   'plant-status',
   'vertical-stack',
-  'weather-forecast',
-  'gauge'
+  'weather-forecast'
 ]);
 const CUSTOM_TYPE_PREFIX = 'custom:';
 const TIMEOUT = 2000;

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -18,6 +18,7 @@ import '../cards/hui-picture-glance-card';
 import '../cards/hui-plant-status-card.js';
 import '../cards/hui-vertical-stack-card.js';
 import '../cards/hui-weather-forecast-card';
+import '../cards/hui-gauge-card.js';
 
 import createErrorCardConfig from './create-error-card-config.js';
 
@@ -39,7 +40,8 @@ const CARD_TYPES = new Set([
   'picture-glance',
   'plant-status',
   'vertical-stack',
-  'weather-forecast'
+  'weather-forecast',
+  'gauge'
 ]);
 const CUSTOM_TYPE_PREFIX = 'custom:';
 const TIMEOUT = 2000;


### PR DESCRIPTION
Adds a new card type `gauge` to the available cards

Card uses the Previously made Custom Card located [here](https://github.com/ciotlosm/custom-lovelace/tree/master/gauge-card)

## Configuration Variables

| Name | Type | Default | Description
| ---- | ---- | ------- | -----------
| type | string | **Required** | `gauge`
| entity | string | **Required** | `sensor.my_temperature`
| title | string | optional | Name to display on card
| unit_of_measurement | string | optional | If not set, uses the unit_of_measurement on the entity
| min | number | 0 | Minimum value for graph
| max | number | 100 | Maximum value for graph
| severity | object | optional | Severity object. See below

### Severity Variables

| Name | Type | Default | Description
| ---- | ---- | ------- | -----------
| red | number | **Required** | Value from which to start red color
| green | number | **Required** | Value from which to start green color
| yellow | number | **Required** | Value from which to start amber color

## Example

```yaml
- type: gauge
  title: Testing
  entity: input_number.slider1
  unit_of_measurement: '%'
  min: 0
  max: 100
  severity:
    red: 85
    green: 0
    amber: 45
```

Open to any advice on more efficient code and changes to the card. First pull request to any Repo.