### PR TITLE
transpile mjs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,7 @@ function createConfig(isProdBuild, latestBuild) {
     module: {
       rules: [
         {
-          test: /\.js$/,
+          test: /\.m?js$/,
           use: {
             loader: 'babel-loader',
             options: {


### PR DESCRIPTION
Unfetch decided to ship their code with the mjs extension. This caused it not to be picked up by our transpiler for ES5.

This fixes it and thus fixes #1743