### PR TITLE
Fixes add-on sorting in add-on store

### DIFF
--- a/hassio/src/addon-store/hassio-addon-repository.js
+++ b/hassio/src/addon-store/hassio-addon-repository.js
@@ -50,14 +50,14 @@ class HassioAddonRepository extends NavigateMixin(PolymerElement) {
   sortAddons(a, b) {
     var addonA = a.name.toUpperCase();
     var addonB = b.name.toUpperCase();
-    
+
     if (addonA < addonB) {
       return -1;
     } else if (addonA > addonB) {
       return 1;
+    } else {
+      return 0;
     }
-
-    return 0;
   }
 
   computeIcon(addon) {

--- a/hassio/src/addon-store/hassio-addon-repository.js
+++ b/hassio/src/addon-store/hassio-addon-repository.js
@@ -50,7 +50,14 @@ class HassioAddonRepository extends NavigateMixin(PolymerElement) {
   sortAddons(a, b) {
     var addonA = a.name.toUpperCase();
     var addonB = b.name.toUpperCase();
-    return (addonA < addonB) ? -1 : (addonA > addonB) ? 1 : 0;
+    
+    if (addonA < addonB) {
+      return -1;
+    } else if (addonA > addonB) {
+      return 1;
+    }
+
+    return 0;
   }
 
   computeIcon(addon) {

--- a/hassio/src/addon-store/hassio-addon-repository.js
+++ b/hassio/src/addon-store/hassio-addon-repository.js
@@ -48,7 +48,9 @@ class HassioAddonRepository extends NavigateMixin(PolymerElement) {
   }
 
   sortAddons(a, b) {
-    return a.name < b.name ? -1 : 1;
+    var addonA = a.name.toUpperCase();
+    var addonB = b.name.toUpperCase();
+    return (addonA < addonB) ? -1 : (addonA > addonB) ? 1 : 0;
   }
 
   computeIcon(addon) {


### PR DESCRIPTION
The order of the add-on in the add-on store, should be alphabetically.
Apparently, it isn't, since recently I've added an add-on that has name that starts with a lower case (`motionEye`).

See the screenshot below for the current result.

This PR changes the sorting, by comparing only uppercase string.
Also added in the case where the add-ons compared are already in the correct position (returning `0`). 

![image](https://user-images.githubusercontent.com/195327/46581151-74694900-ca33-11e8-97c8-afa1e20e2cfa.png)
