### PR TITLE
Fix sensor card error when only one state history entry.

### DIFF
--- a/src/panels/lovelace/cards/hui-sensor-card.js
+++ b/src/panels/lovelace/cards/hui-sensor-card.js
@@ -120,6 +120,8 @@ class HuiSensorCard extends EventsMixin(LitElement) {
     const min = Math.floor(Math.min.apply(null, values) * 0.95);
     const max = Math.ceil(Math.max.apply(null, values) * 1.05);
 
+    if (values.length === 1) values.push(values[0]);
+
     const yRatio = (max - min) / height;
     const xRatio = width / (values.length - 1);
 


### PR DESCRIPTION
Fixes console error/missing graph if state history only has one entry (sensor that hasn't yet had a state change). This just copies the first value so that we at least get a straight line graph