### PR TITLE
Adding Alarm Panel to Lovelace 

### DIFF
--- a/gallery/src/demos/demo-hui-alarm-panel-card.js
+++ b/gallery/src/demos/demo-hui-alarm-panel-card.js
@@ -1,0 +1,75 @@
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import getEntity from '../data/entity.js';
+import provideHass from '../data/provide_hass.js';
+import '../components/demo-cards.js';
+
+const ENTITIES = [
+  getEntity('alarm_control_panel', 'alarm', 'disarmed', {
+    friendly_name: 'Alarm',
+  }),
+  getEntity('alarm_control_panel', 'alarm_armed', 'armed_home', {
+    friendly_name: 'Alarm',
+  }),
+];
+
+const CONFIGS = [
+  {
+    heading: 'Basic Example',
+    config: `
+- type: alarm-panel
+  entity: alarm_control_panel.alarm
+    `
+  },
+  {
+    heading: 'With Title',
+    config: `
+- type: alarm-panel
+  entity: alarm_control_panel.alarm_armed
+  title: My Alarm
+    `
+  },
+  {
+    heading: 'Using only Arm_Home State',
+    config: `
+- type: alarm-panel
+  entity: alarm_control_panel.alarm
+  states:
+    - arm_home
+    `
+  },
+  {
+    heading: 'Invalid Entity',
+    config: `
+- type: alarm-panel
+  entity: alarm_control_panel.alarm1
+    `
+  },
+];
+
+class DemoAlarmPanelEntity extends PolymerElement {
+  static get template() {
+    return html`
+      <demo-cards id='demos' hass='[[hass]]' configs="[[_configs]]"></demo-cards>
+    `;
+  }
+
+  static get properties() {
+    return {
+      _configs: {
+        type: Object,
+        value: CONFIGS
+      },
+      hass: Object,
+    };
+  }
+
+  ready() {
+    super.ready();
+    const hass = provideHass(this.$.demos);
+    hass.addEntities(ENTITIES);
+  }
+}
+
+customElements.define('demo-hui-alarm-panel-card', DemoAlarmPanelEntity);

--- a/gallery/src/demos/demo-hui-alarm-panel-card.js
+++ b/gallery/src/demos/demo-hui-alarm-panel-card.js
@@ -1,50 +1,50 @@
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { html } from "@polymer/polymer/lib/utils/html-tag.js";
+import { PolymerElement } from "@polymer/polymer/polymer-element.js";
 
-import getEntity from '../data/entity.js';
-import provideHass from '../data/provide_hass.js';
-import '../components/demo-cards.js';
+import getEntity from "../data/entity.js";
+import provideHass from "../data/provide_hass.js";
+import "../components/demo-cards.js";
 
 const ENTITIES = [
-  getEntity('alarm_control_panel', 'alarm', 'disarmed', {
-    friendly_name: 'Alarm',
+  getEntity("alarm_control_panel", "alarm", "disarmed", {
+    friendly_name: "Alarm",
   }),
-  getEntity('alarm_control_panel', 'alarm_armed', 'armed_home', {
-    friendly_name: 'Alarm',
+  getEntity("alarm_control_panel", "alarm_armed", "armed_home", {
+    friendly_name: "Alarm",
   }),
 ];
 
 const CONFIGS = [
   {
-    heading: 'Basic Example',
+    heading: "Basic Example",
     config: `
 - type: alarm-panel
   entity: alarm_control_panel.alarm
-    `
+    `,
   },
   {
-    heading: 'With Title',
+    heading: "With Title",
     config: `
 - type: alarm-panel
   entity: alarm_control_panel.alarm_armed
   title: My Alarm
-    `
+    `,
   },
   {
-    heading: 'Using only Arm_Home State',
+    heading: "Using only Arm_Home State",
     config: `
 - type: alarm-panel
   entity: alarm_control_panel.alarm
   states:
     - arm_home
-    `
+    `,
   },
   {
-    heading: 'Invalid Entity',
+    heading: "Invalid Entity",
     config: `
 - type: alarm-panel
   entity: alarm_control_panel.alarm1
-    `
+    `,
   },
 ];
 
@@ -59,7 +59,7 @@ class DemoAlarmPanelEntity extends PolymerElement {
     return {
       _configs: {
         type: Object,
-        value: CONFIGS
+        value: CONFIGS,
       },
       hass: Object,
     };
@@ -72,4 +72,4 @@ class DemoAlarmPanelEntity extends PolymerElement {
   }
 }
 
-customElements.define('demo-hui-alarm-panel-card', DemoAlarmPanelEntity);
+customElements.define("demo-hui-alarm-panel-card", DemoAlarmPanelEntity);

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -214,7 +214,7 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
   }
 
   _handlePadClick(e) {
-    e.target.getAttribute('value') === 'clear' ? this._value = '' : this._value += e.target.getAttribute('value');
+    this._value = e.target.getAttribute('value') === 'clear' ? '' : this._value + e.target.getAttribute('value');
   }
 
   _handleActionClick(e) {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -4,6 +4,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../../../components/ha-card.js';
 
 import EventsMixin from '../../../mixins/events-mixin.js';
+import '../../../components/ha-label-badge.js';
 
 /*
  * @appliesMixin EventsMixin
@@ -24,14 +25,14 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
         --base-unit: 15px;
         font-size: calc(var(--base-unit));
       }
-      ha-icon {
+      ha-label-badge {
+        --ha-label-badge-color:  var(--alarm-state-color);
+        --label-badge-text-color: var(--alarm-state-color);
         color: var(--alarm-state-color);
         position: absolute;
-        right: 20px;
-        top: 20px;
+        right: 10px;
+        top: 10px;
         padding: 10px;
-        border: 2px solid var(--alarm-state-color);
-        border-radius: 50%;
       }
       .disarmed {
         --alarm-state-color: var(--alarm-color-disarmed);
@@ -50,10 +51,10 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
       }
       @keyframes pulse {
         0% {
-          border: 2px solid var(--alarm-state-color);
+          --ha-label-badge-color: var(--alarm-state-color);
         }
         100% {
-          border: 2px solid rgba(255, 153, 0, 0.3);
+          --ha-label-badge-color: rgba(255, 153, 0, 0.3);
         }
       }
       paper-input {
@@ -105,41 +106,38 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
     </style>
     <ha-card header$='[[_computeHeader(_stateObj)]]' class$='[[_computeClassName(_stateObj)]]'>
       <template is='dom-if' if='[[_stateObj]]'>
-        <div id='AlarmPanel'>
-          <ha-icon id='Icon' icon='[[_computeIcon(_stateObj)]]' class$='[[_stateObj.state]]'></ha-icon>
-          <div id='StateText' class$='state [[_stateObj.state]]'>[[_computeStateText(_stateObj)]]</div>
-          <template is='dom-if' if='[[_showActionToggle(_stateObj.state)]]'>
-            <div id='ArmActions' class='actions'>
-              <template is='dom-repeat' items='[[_config.states]]'>
-                <paper-button noink raised id='[[item]]' on-click='_handleActionClick'>[[_label(item)]]</paper-button>
-              </template>
-            </div>
-          </template>
-          <template is='dom-if' if='[[!_showActionToggle(_stateObj.state)]]'>
-            <div id='DisarmActions' class='actions'>
-              <paper-button noink raised id='disarm' on-click='_handleActionClick'>[[_label('disarm')]]</paper-button>
-            </div>
-          </template>
-          <paper-input id='Input' label='Alarm Code' type='password' value='[[_value]]'></paper-input>
-          <div id='Keypad'>
-              <div id='ButtonSection1'>
-                <paper-button noink raised value='1' on-click='_handlePadClick'>1</paper-button>
-                <paper-button noink raised value='4' on-click='_handlePadClick'>4</paper-button>
-                <paper-button noink raised value='7' on-click='_handlePadClick'>7</paper-button>
-              </div>
-              <div id='ButtonSection2'>
-                <paper-button noink raised value='2' on-click='_handlePadClick'>2</paper-button>
-                <paper-button noink raised value='5' on-click='_handlePadClick'>5</paper-button>
-                <paper-button noink raised value='8' on-click='_handlePadClick'>8</paper-button>
-                <paper-button noink raised value='0' on-click='_handlePadClick'>0</paper-button>
-              </div>
-              <div id='ButtonSection3'>
-                <paper-button noink raised value='3' on-click='_handlePadClick'>3</paper-button>
-                <paper-button noink raised value='6' on-click='_handlePadClick'>6</paper-button>
-                <paper-button noink raised value='9' on-click='_handlePadClick'>9</paper-button>
-                <paper-button noink raised value='clear' on-click='_handlePadClick'>CLEAR</paper-button>
-              </div>
-        </div>
+        <ha-label-badge class$="[[_stateObj.state]]" icon="[[_computeIcon(_stateObj)]]" label="[[_stateIconLabel(_stateObj.state)]]"></ha-label-badge>
+        <template is='dom-if' if='[[_showActionToggle(_stateObj.state)]]'>
+          <div id='ArmActions' class='actions'>
+            <template is='dom-repeat' items='[[_config.states]]'>
+              <paper-button noink raised id='[[item]]' on-click='_handleActionClick'>[[_label(item)]]</paper-button>
+            </template>
+          </div>
+        </template>
+        <template is='dom-if' if='[[!_showActionToggle(_stateObj.state)]]'>
+          <div id='DisarmActions' class='actions'>
+            <paper-button noink raised id='disarm' on-click='_handleActionClick'>[[_label('disarm')]]</paper-button>
+          </div>
+        </template>
+        <paper-input label='Alarm Code' type='password' value='[[_value]]'></paper-input>
+        <div id='Keypad'>
+          <div>
+            <paper-button noink raised value='1' on-click='_handlePadClick'>1</paper-button>
+            <paper-button noink raised value='4' on-click='_handlePadClick'>4</paper-button>
+            <paper-button noink raised value='7' on-click='_handlePadClick'>7</paper-button>
+          </div>
+          <div>
+            <paper-button noink raised value='2' on-click='_handlePadClick'>2</paper-button>
+            <paper-button noink raised value='5' on-click='_handlePadClick'>5</paper-button>
+            <paper-button noink raised value='8' on-click='_handlePadClick'>8</paper-button>
+            <paper-button noink raised value='0' on-click='_handlePadClick'>0</paper-button>
+          </div>
+          <div>
+            <paper-button noink raised value='3' on-click='_handlePadClick'>3</paper-button>
+            <paper-button noink raised value='6' on-click='_handlePadClick'>6</paper-button>
+            <paper-button noink raised value='9' on-click='_handlePadClick'>9</paper-button>
+            <paper-button noink raised value='clear' on-click='_handlePadClick'>CLEAR</paper-button>
+          </div>
       </template>
       <template is='dom-if' if='[[!_stateObj]]'>
         <div>Entity not available: [[_config.entity]]</div>
@@ -197,11 +195,16 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
   }
 
   _computeIcon(stateObj) {
-    return this._icons[stateObj.state] || 'mdi:shield-outline';
+    return this._icons[stateObj.state] || 'hass:shield-outline';
   }
 
   _label(state) {
     return state.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
+  }
+
+  _stateIconLabel(state) {
+    const stateLabel = state.split('_').pop();
+    return stateLabel === 'disarmed' || stateLabel === 'triggered' ? '' : stateLabel;
   }
 
   _showActionToggle(state) {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -1,15 +1,16 @@
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { html } from "@polymer/polymer/lib/utils/html-tag.js";
+import { PolymerElement } from "@polymer/polymer/polymer-element.js";
 
-import '../../../components/ha-card.js';
+import "../../../components/ha-card.js";
 
-import EventsMixin from '../../../mixins/events-mixin.js';
-import '../../../components/ha-label-badge.js';
+import EventsMixin from "../../../mixins/events-mixin.js";
+import LocalizeMixin from "../../../mixins/localize-mixin.js";
+import "../../../components/ha-label-badge.js";
 
 /*
  * @appliesMixin EventsMixin
  */
-class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
+class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   static get template() {
     return html`
     <style>
@@ -70,15 +71,15 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
         color: var(--alarm-state-color);
         animation: none;
       }
-      #Keypad {
+      #keypad {
         display: flex;
         justify-content: center;
       }
-      #Keypad div {
+      #keypad div {
         display: flex;
         flex-direction: column;
       }
-      #Keypad paper-button {
+      #keypad paper-button {
         margin-bottom: 10%;
         position: relative;
         padding: calc(var(--base-unit));
@@ -104,42 +105,49 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
         padding: 8px;
       }
     </style>
-    <ha-card header$='[[_computeHeader(_stateObj)]]' class$='[[_computeClassName(_stateObj)]]'>
-      <template is='dom-if' if='[[_stateObj]]'>
-        <ha-label-badge class$="[[_stateObj.state]]" icon="[[_computeIcon(_stateObj)]]" label="[[_stateIconLabel(_stateObj.state)]]"></ha-label-badge>
-        <template is='dom-if' if='[[_showActionToggle(_stateObj.state)]]'>
-          <div id='ArmActions' class='actions'>
-            <template is='dom-repeat' items='[[_config.states]]'>
-              <paper-button noink raised id='[[item]]' on-click='_handleActionClick'>[[_label(item)]]</paper-button>
+    <ha-card
+      header$="[[_computeHeader(localize, _stateObj)]]"
+      class$="[[_computeClassName(_stateObj)]]"
+    >
+      <template is="dom-if" if="[[_stateObj]]">
+        <ha-label-badge
+          class$="[[_stateObj.state]]"
+          icon="[[_computeIcon(_stateObj)]]"
+          label="[[_stateIconLabel(_stateObj.state)]]"
+        ></ha-label-badge>
+        <template is="dom-if" if="[[_showActionToggle(_stateObj.state)]]">
+          <div id="armActions" class="actions">
+            <template is="dom-repeat" items="[[_config.states]]">
+              <paper-button noink raised id="[[item]]" on-click="_handleActionClick">[[_label(localize, item)]]</paper-button>
             </template>
           </div>
         </template>
-        <template is='dom-if' if='[[!_showActionToggle(_stateObj.state)]]'>
-          <div id='DisarmActions' class='actions'>
-            <paper-button noink raised id='disarm' on-click='_handleActionClick'>[[_label('disarm')]]</paper-button>
+        <template is="dom-if" if="[[!_showActionToggle(_stateObj.state)]]">
+          <div id="disarmActions" class="actions">
+            <paper-button noink raised id="disarm" on-click="_handleActionClick">[[_label(localize, "disarm")]]</paper-button>
           </div>
         </template>
-        <paper-input label='Alarm Code' type='password' value='[[_value]]'></paper-input>
-        <div id='Keypad'>
+        <paper-input label="Alarm Code" type="password" value="[[_value]]"></paper-input>
+        <div id="keypad">
           <div>
-            <paper-button noink raised value='1' on-click='_handlePadClick'>1</paper-button>
-            <paper-button noink raised value='4' on-click='_handlePadClick'>4</paper-button>
-            <paper-button noink raised value='7' on-click='_handlePadClick'>7</paper-button>
+            <paper-button noink raised value="1" on-click="_handlePadClick">1</paper-button>
+            <paper-button noink raised value="4" on-click="_handlePadClick">4</paper-button>
+            <paper-button noink raised value="7" on-click="_handlePadClick">7</paper-button>
           </div>
           <div>
-            <paper-button noink raised value='2' on-click='_handlePadClick'>2</paper-button>
-            <paper-button noink raised value='5' on-click='_handlePadClick'>5</paper-button>
-            <paper-button noink raised value='8' on-click='_handlePadClick'>8</paper-button>
-            <paper-button noink raised value='0' on-click='_handlePadClick'>0</paper-button>
+            <paper-button noink raised value="2" on-click="_handlePadClick">2</paper-button>
+            <paper-button noink raised value="5" on-click="_handlePadClick">5</paper-button>
+            <paper-button noink raised value="8" on-click="_handlePadClick">8</paper-button>
+            <paper-button noink raised value="0" on-click="_handlePadClick">0</paper-button>
           </div>
           <div>
-            <paper-button noink raised value='3' on-click='_handlePadClick'>3</paper-button>
-            <paper-button noink raised value='6' on-click='_handlePadClick'>6</paper-button>
-            <paper-button noink raised value='9' on-click='_handlePadClick'>9</paper-button>
-            <paper-button noink raised value='clear' on-click='_handlePadClick'>CLEAR</paper-button>
+            <paper-button noink raised value="3" on-click="_handlePadClick">3</paper-button>
+            <paper-button noink raised value="6" on-click="_handlePadClick">6</paper-button>
+            <paper-button noink raised value="9" on-click="_handlePadClick">9</paper-button>
+            <paper-button noink raised value="clear" on-click="_handlePadClick">CLEAR</paper-button>
           </div>
       </template>
-      <template is='dom-if' if='[[!_stateObj]]'>
+      <template is="dom-if" if="[[!_stateObj]]">
         <div>Entity not available: [[_config.entity]]</div>
       </template>
     </ha-card>
@@ -149,16 +157,16 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
   static get properties() {
     return {
       hass: {
-        type: Object
+        type: Object,
       },
       _config: Object,
       _stateObj: {
         type: Object,
-        computed: '_computeStateObj(hass.states, _config.entity)',
+        computed: "_computeStateObj(hass.states, _config.entity)",
       },
       _value: {
         type: String,
-        value: ''
+        value: "",
       },
     };
   }
@@ -168,16 +176,21 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
   }
 
   setConfig(config) {
-    if (!config || !config.entity || config.entity.split('.')[0] !== 'alarm_control_panel') throw new Error('Invalid card configuration');
-    this._config = Object.assign({ states: ['arm_away', 'arm_home'] }, config);
+    if (
+      !config ||
+      !config.entity ||
+      config.entity.split(".")[0] !== "alarm_control_panel"
+    )
+      throw new Error("Invalid card configuration");
+    this._config = Object.assign({ states: ["arm_away", "arm_home"] }, config);
     this._icons = {
-      armed_away: 'hass:security-lock',
-      armed_custom_bypass: 'hass:security',
-      armed_home: 'hass:security-home',
-      armed_night: 'hass:security-home',
-      disarmed: 'hass:verified',
-      pending: 'hass:shield-outline',
-      triggered: 'hass:bell-ring',
+      armed_away: "hass:security-lock",
+      armed_custom_bypass: "hass:security",
+      armed_home: "hass:security-home",
+      armed_night: "hass:security-home",
+      disarmed: "hass:verified",
+      pending: "hass:shield-outline",
+      triggered: "hass:bell-ring",
     };
   }
 
@@ -185,48 +198,49 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
     return states && entityId in states ? states[entityId] : null;
   }
 
-  _computeHeader(stateObj) {
-    if (!stateObj) return '';
-    return this._config.title ? this._config.title : this._label(stateObj.state);
-  }
-
-  _computeStateText(stateObj) {
-    return this._config.title ? this._label(stateObj.state) : '';
+  _computeHeader(localize, stateObj) {
+    if (!stateObj) return "";
+    return this._config.title
+      ? this._config.title
+      : this._label(localize, stateObj.state);
   }
 
   _computeIcon(stateObj) {
-    return this._icons[stateObj.state] || 'hass:shield-outline';
+    return this._icons[stateObj.state] || "hass:shield-outline";
   }
 
-  _label(state) {
-    return state.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
+  _label(localize, state) {
+    return localize(`component.alarm_control_panel.state.${state}`) || state;
   }
 
   _stateIconLabel(state) {
-    const stateLabel = state.split('_').pop();
-    return stateLabel === 'disarmed' || stateLabel === 'triggered' ? '' : stateLabel;
+    const stateLabel = state.split("_").pop();
+    return stateLabel === "disarmed" || stateLabel === "triggered"
+      ? ""
+      : stateLabel;
   }
 
   _showActionToggle(state) {
-    return state === 'disarmed';
+    return state === "disarmed";
   }
 
   _computeClassName(stateObj) {
-    if (!stateObj) return 'not-found';
-    return '';
+    if (!stateObj) return "not-found";
+    return "";
   }
 
   _handlePadClick(e) {
-    this._value = e.target.getAttribute('value') === 'clear' ? '' : this._value + e.target.getAttribute('value');
+    const val = e.target.getAttribute("value");
+    this._value = val === "clear" ? "" : this._value + val;
   }
 
   _handleActionClick(e) {
-    this.hass.callService('alarm_control_panel', 'alarm_' + e.target.id, {
+    this.hass.callService("alarm_control_panel", "alarm_" + e.target.id, {
       entity_id: this._stateObj.entity_id,
       code: this._value,
     });
-    this._value = '';
+    this._value = "";
   }
 }
 
-customElements.define('hui-alarm-panel-card', HuiAlarmPanelCard);
+customElements.define("hui-alarm-panel-card", HuiAlarmPanelCard);

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -155,7 +155,7 @@ class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
             <paper-button noink raised value="3" on-click="_handlePadClick">3</paper-button>
             <paper-button noink raised value="6" on-click="_handlePadClick">6</paper-button>
             <paper-button noink raised value="9" on-click="_handlePadClick">9</paper-button>
-            <paper-button noink raised value="clear" on-click="_handlePadClick">CLEAR</paper-button>
+            <paper-button noink raised value="clear" on-click="_handlePadClick">[[_label(localize, "clear_code")]]</paper-button>
           </div>
       </template>
       <template is="dom-if" if="[[!_stateObj]]">
@@ -219,7 +219,10 @@ class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   }
 
   _label(localize, state) {
-    return localize(`component.alarm_control_panel.state.${state}`) || state;
+    return (
+      localize(`state.alarm_control_panel.${state}`) ||
+      localize(`ui.card.alarm_control_panel.${state}`)
+    );
   }
 
   _stateIconLabel(state) {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -10,6 +10,17 @@ import "../../../components/ha-label-badge.js";
 /*
  * @appliesMixin EventsMixin
  */
+
+const Icons = {
+  armed_away: "hass:security-lock",
+  armed_custom_bypass: "hass:security",
+  armed_home: "hass:security-home",
+  armed_night: "hass:security-home",
+  disarmed: "hass:verified",
+  pending: "hass:shield-outline",
+  triggered: "hass:bell-ring",
+};
+
 class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   static get template() {
     return html`
@@ -31,9 +42,8 @@ class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
         --label-badge-text-color: var(--alarm-state-color);
         color: var(--alarm-state-color);
         position: absolute;
-        right: 10px;
-        top: 10px;
-        padding: 10px;
+        right: 12px;
+        top: 12px;
       }
       .disarmed {
         --alarm-state-color: var(--alarm-color-disarmed);
@@ -87,7 +97,7 @@ class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
       }
       .actions {
         margin: 0 8px;
-        padding-top: 20px; 
+        padding-top: 20px;
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
@@ -181,18 +191,16 @@ class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
       !config ||
       !config.entity ||
       config.entity.split(".")[0] !== "alarm_control_panel"
-    )
+    ) {
       throw new Error("Invalid card configuration");
-    this._config = Object.assign({ states: ["arm_away", "arm_home"] }, config);
-    this._icons = {
-      armed_away: "hass:security-lock",
-      armed_custom_bypass: "hass:security",
-      armed_home: "hass:security-home",
-      armed_night: "hass:security-home",
-      disarmed: "hass:verified",
-      pending: "hass:shield-outline",
-      triggered: "hass:bell-ring",
+    }
+
+    const defaults = {
+      states: ["arm_away", "arm_home"],
     };
+
+    this._config = { ...defaults, ...config };
+    this._icons = Icons;
   }
 
   _computeStateObj(states, entityId) {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -1,0 +1,229 @@
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+import '../../../components/ha-card.js';
+
+import EventsMixin from '../../../mixins/events-mixin.js';
+
+/*
+ * @appliesMixin EventsMixin
+ */
+class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
+  static get template() {
+    return html`
+    <style>
+      ha-card {
+        padding-bottom: 16px;
+        position: relative;
+        --alarm-color-disarmed: var(--label-badge-green);
+        --alarm-color-pending: var(--label-badge-yellow);
+        --alarm-color-triggered: var(--label-badge-red);
+        --alarm-color-armed: var(--label-badge-red);
+        --alarm-color-autoarm: rgba(0, 153, 255, .1);
+        --alarm-state-color: var(--alarm-color-armed);
+        --base-unit: 15px;
+        font-size: calc(var(--base-unit));
+      }
+      ha-icon {
+        color: var(--alarm-state-color);
+        position: absolute;
+        right: 20px;
+        top: 20px;
+        padding: 10px;
+        border: 2px solid var(--alarm-state-color);
+        border-radius: 50%;
+      }
+      .disarmed {
+        --alarm-state-color: var(--alarm-color-disarmed);
+      }
+      .triggered {
+        --alarm-state-color: var(--alarm-color-triggered);
+        animation: pulse 1s infinite;
+      }
+      .arming {
+        --alarm-state-color: var(--alarm-color-pending);
+        animation: pulse 1s infinite;
+      }
+      .pending {
+        --alarm-state-color: var(--alarm-color-pending);
+        animation: pulse 1s infinite;
+      }
+      @keyframes pulse {
+        0% {
+          border: 2px solid var(--alarm-state-color);
+        }
+        100% {
+          border: 2px solid rgba(255, 153, 0, 0.3);
+        }
+      }
+      paper-input {
+        margin: auto;
+        max-width: 200px;
+        font-size: calc(var(--base-unit));
+      }
+      .state {
+        margin-left: 20px;
+        font-size: calc(var(--base-unit) * 0.9);
+        position: relative;
+        bottom: 16px;
+        color: var(--alarm-state-color);
+        animation: none;
+      }
+      #Keypad {
+        display: flex;
+        justify-content: center;
+      }
+      #Keypad div {
+        display: flex;
+        flex-direction: column;
+      }
+      #Keypad paper-button {
+        margin-bottom: 10%;
+        position: relative;
+        padding: calc(var(--base-unit));
+        font-size: calc(var(--base-unit) * 1.1);
+      }
+      .actions {
+        margin: 0 8px;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        font-size: calc(var(--base-unit) * 1);
+      }
+      .actions paper-button {
+        min-width: calc(var(--base-unit) * 9);
+        color: var(--primary-color);
+      }
+      paper-button#disarm {
+        color: var(--google-red-500);
+      }
+      .not-found {
+        flex: 1;
+        background-color: yellow;
+        padding: 8px;
+      }
+    </style>
+    <ha-card header$='[[_computeHeader(_stateObj)]]' class$='[[_computeClassName(_stateObj)]]'>
+      <template is='dom-if' if='[[_stateObj]]'>
+        <div id='AlarmPanel'>
+          <ha-icon id='Icon' icon='[[_computeIcon(_stateObj)]]' class$='[[_stateObj.state]]'></ha-icon>
+          <div id='StateText' class$='state [[_stateObj.state]]'>[[_computeStateText(_stateObj)]]</div>
+          <template is='dom-if' if='[[_showActionToggle(_stateObj.state)]]'>
+            <div id='ArmActions' class='actions'>
+              <template is='dom-repeat' items='[[_config.states]]'>
+                <paper-button noink raised id='[[item]]' on-click='_handleActionClick'>[[_label(item)]]</paper-button>
+              </template>
+            </div>
+          </template>
+          <template is='dom-if' if='[[!_showActionToggle(_stateObj.state)]]'>
+            <div id='DisarmActions' class='actions'>
+              <paper-button noink raised id='disarm' on-click='_handleActionClick'>[[_label('disarm')]]</paper-button>
+            </div>
+          </template>
+          <paper-input id='Input' label='Alarm Code' type='password' value='[[_value]]'></paper-input>
+          <div id='Keypad'>
+              <div id='ButtonSection1'>
+                <paper-button noink raised value='1' on-click='_handlePadClick'>1</paper-button>
+                <paper-button noink raised value='4' on-click='_handlePadClick'>4</paper-button>
+                <paper-button noink raised value='7' on-click='_handlePadClick'>7</paper-button>
+              </div>
+              <div id='ButtonSection2'>
+                <paper-button noink raised value='2' on-click='_handlePadClick'>2</paper-button>
+                <paper-button noink raised value='5' on-click='_handlePadClick'>5</paper-button>
+                <paper-button noink raised value='8' on-click='_handlePadClick'>8</paper-button>
+                <paper-button noink raised value='0' on-click='_handlePadClick'>0</paper-button>
+              </div>
+              <div id='ButtonSection3'>
+                <paper-button noink raised value='3' on-click='_handlePadClick'>3</paper-button>
+                <paper-button noink raised value='6' on-click='_handlePadClick'>6</paper-button>
+                <paper-button noink raised value='9' on-click='_handlePadClick'>9</paper-button>
+                <paper-button noink raised value='clear' on-click='_handlePadClick'>CLEAR</paper-button>
+              </div>
+        </div>
+      </template>
+      <template is='dom-if' if='[[!_stateObj]]'>
+        <div>Entity not available: [[_config.entity]]</div>
+      </template>
+    </ha-card>
+    `;
+  }
+
+  static get properties() {
+    return {
+      hass: {
+        type: Object
+      },
+      _config: Object,
+      _stateObj: {
+        type: Object,
+        computed: '_computeStateObj(hass.states, _config.entity)',
+      },
+      _value: {
+        type: String,
+        value: ''
+      },
+    };
+  }
+
+  getCardSize() {
+    return 1;
+  }
+
+  setConfig(config) {
+    if (!config || !config.entity || config.entity.split('.')[0] !== 'alarm_control_panel') throw new Error('Invalid card configuration');
+    this._config = Object.assign({ states: ['arm_away', 'arm_home'] }, config);
+    this._icons = {
+      armed_away: 'mdi:security-lock',
+      armed_custom_bypass: 'mdi:security',
+      armed_home: 'mdi:security-home',
+      armed_night: 'mdi:security-home',
+      disarmed: 'mdi:verified',
+      pending: 'mdi:shield-outline',
+      triggered: 'hass:bell-ring',
+    };
+  }
+
+  _computeStateObj(states, entityId) {
+    return states && entityId in states ? states[entityId] : null;
+  }
+
+  _computeHeader(stateObj) {
+    if (!stateObj) return '';
+    return this._config.title ? this._config.title : this._label(stateObj.state);
+  }
+
+  _computeStateText(stateObj) {
+    return this._config.title ? this._label(stateObj.state) : '';
+  }
+
+  _computeIcon(stateObj) {
+    return this._icons[stateObj.state] || 'mdi:shield-outline';
+  }
+
+  _label(state) {
+    return state.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
+  }
+
+  _showActionToggle(state) {
+    return state === 'disarmed';
+  }
+
+  _computeClassName(stateObj) {
+    if (!stateObj) return 'not-found';
+    return '';
+  }
+
+  _handlePadClick(e) {
+    e.target.getAttribute('value') === 'clear' ? this._value = '' : this._value += e.target.getAttribute('value');
+  }
+
+  _handleActionClick(e) {
+    this.hass.callService('alarm_control_panel', 'alarm_' + e.target.id, {
+      entity_id: this._stateObj.entity_id,
+      code: this._value,
+    });
+    this._value = '';
+  }
+}
+
+customElements.define('hui-alarm-panel-card', HuiAlarmPanelCard);

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -62,7 +62,7 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
         font-size: calc(var(--base-unit));
       }
       .state {
-        margin-left: 20px;
+        margin-left: 16px;
         font-size: calc(var(--base-unit) * 0.9);
         position: relative;
         bottom: 16px;
@@ -166,19 +166,19 @@ class HuiAlarmPanelCard extends EventsMixin(PolymerElement) {
   }
 
   getCardSize() {
-    return 1;
+    return 4;
   }
 
   setConfig(config) {
     if (!config || !config.entity || config.entity.split('.')[0] !== 'alarm_control_panel') throw new Error('Invalid card configuration');
     this._config = Object.assign({ states: ['arm_away', 'arm_home'] }, config);
     this._icons = {
-      armed_away: 'mdi:security-lock',
-      armed_custom_bypass: 'mdi:security',
-      armed_home: 'mdi:security-home',
-      armed_night: 'mdi:security-home',
-      disarmed: 'mdi:verified',
-      pending: 'mdi:shield-outline',
+      armed_away: 'hass:security-lock',
+      armed_custom_bypass: 'hass:security',
+      armed_home: 'hass:security-home',
+      armed_night: 'hass:security-home',
+      disarmed: 'hass:verified',
+      pending: 'hass:shield-outline',
       triggered: 'hass:bell-ring',
     };
   }

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -87,6 +87,7 @@ class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
       }
       .actions {
         margin: 0 8px;
+        padding-top: 20px; 
         display: flex;
         flex-wrap: wrap;
         justify-content: center;

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -1,5 +1,6 @@
 import { fireEvent } from "../../../common/dom/fire_event.js";
 
+import "../cards/hui-alarm-panel-card.js";
 import "../cards/hui-conditional-card.js";
 import "../cards/hui-entities-card.js";
 import "../cards/hui-entity-filter-card.js";
@@ -24,6 +25,7 @@ import "../cards/hui-gauge-card.js";
 import createErrorCardConfig from "./create-error-card-config.js";
 
 const CARD_TYPES = new Set([
+  "alarm-panel",
   "conditional",
   "entities",
   "entity-filter",


### PR DESCRIPTION
Adds a new card type `alarm-panel` to the available cards

Card uses the Previously made Custom Card located [here](https://github.com/ciotlosm/custom-lovelace/tree/master/alarm_control_panel-card)

## Configuration Variables

| Name | Type | Default | Description
| ---- | ---- | ------- | -----------
| type | string | **Required** | `alarm-panel`
| entity | string | **Required** | An entity_id from alarm_control_panel domain. Example: `alarm_control_panel.alarm`
| title | string | Current Arm State | Card Title
| states | list | arm_home, arm_away | A list of possible arm buttons. Supports `arm_home`, `arm_away`, `arm_night`, `arm_custom_bypass`.

## Example

```yaml
- type: alarm-panel
  entity: alarm_control_panel.alarm
```

```yaml
- type: alarm-panel
  entity: alarm_control_panel.alarm
  title: House Alarm
  states:
    - arm_home
```

![Example](https://i.gyazo.com/327f54cf30f1e5712d017c5ae678906d.gif)