### PR TITLE
add min-width to childeren of horizontal stack

### DIFF
--- a/src/panels/lovelace/cards/hui-horizontal-stack-card.js
+++ b/src/panels/lovelace/cards/hui-horizontal-stack-card.js
@@ -14,6 +14,7 @@ class HuiHorizontalStackCard extends PolymerElement {
         #root > * {
           flex: 1 1 0;
           margin: 0 4px;
+          min-width: 0;
         }
         #root > *:first-child {
           margin-left: 0;


### PR DESCRIPTION
To prevent layout screwup by a card that doesn't plays nice and forces the entire flex parent element too wide.
See: https://drafts.csswg.org/css-flexbox/#min-size-auto
and https://css-tricks.com/flexbox-truncated-text/