### PR TITLE
HaForm: auto-focus on the first string input field

### DIFF
--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -60,6 +60,7 @@ class HaForm extends EventsMixin(PolymerElement) {
         </template>
         <template is="dom-if" if="[[!_includes(schema.name, &quot;password&quot;)]]" restamp="">
           <paper-input
+            autofocus
             label="[[computeLabel(schema)]]"
             value="{{data}}"
             required="[[schema.required]]"


### PR DESCRIPTION
Form fields are not auto-focussed for 
- login form
- TOTP form.

This pull request enables `autofocus` for input fields that are created by the `HaForm` component.