### PR TITLE
Remove default export fire event

### DIFF
--- a/gallery/src/data/provide_hass.js
+++ b/gallery/src/data/provide_hass.js
@@ -1,4 +1,4 @@
-import fireEvent from "../../../src/common/dom/fire_event.js";
+import { fireEvent } from "../../../src/common/dom/fire_event.js";
 
 import demoConfig from "./demo_config.js";
 import demoResources from "./demo_resources.js";

--- a/src/common/dom/fire_event.js
+++ b/src/common/dom/fire_event.js
@@ -43,7 +43,7 @@
   *  `node` on which to fire the event (HTMLElement, defaults to `this`).
   * @return {Event} The new event that was fired.
   */
-export default function fire(node, type, detail, options) {
+export const fireEvent = (node, type, detail, options) => {
   options = options || {};
   detail = detail === null || detail === undefined ? {} : detail;
   const event = new Event(type, {
@@ -54,4 +54,4 @@ export default function fire(node, type, detail, options) {
   event.detail = detail;
   node.dispatchEvent(event);
   return event;
-}
+};

--- a/src/components/buttons/ha-call-api-button.js
+++ b/src/components/buttons/ha-call-api-button.js
@@ -1,7 +1,7 @@
 import { LitElement, html } from "@polymer/lit-element";
 
 import "./ha-progress-button.js";
-import fireEvent from "../../common/dom/fire_event.js";
+import { fireEvent } from "../../common/dom/fire_event.js";
 
 class HaCallApiButton extends LitElement {
   render() {

--- a/src/mixins/events-mixin.js
+++ b/src/mixins/events-mixin.js
@@ -1,6 +1,6 @@
 import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
 
-import fireEvent from "../common/dom/fire_event.js";
+import { fireEvent } from "../common/dom/fire_event.js";
 
 // Polymer legacy event helpers used courtesy of the Polymer project.
 //

--- a/src/panels/lovelace/common/create-card-element.js
+++ b/src/panels/lovelace/common/create-card-element.js
@@ -1,4 +1,4 @@
-import fireEvent from "../../../common/dom/fire_event.js";
+import { fireEvent } from "../../../common/dom/fire_event.js";
 
 import "../cards/hui-conditional-card.js";
 import "../cards/hui-entities-card.js";

--- a/src/panels/lovelace/common/create-hui-element.js
+++ b/src/panels/lovelace/common/create-hui-element.js
@@ -5,7 +5,7 @@ import "../elements/hui-state-badge-element.js";
 import "../elements/hui-state-icon-element.js";
 import "../elements/hui-state-label-element.js";
 
-import fireEvent from "../../../common/dom/fire_event.js";
+import { fireEvent } from "../../../common/dom/fire_event.js";
 import createErrorCardConfig from "./create-error-card-config.js";
 
 const CUSTOM_TYPE_PREFIX = "custom:";

--- a/src/panels/lovelace/common/create-row-element.js
+++ b/src/panels/lovelace/common/create-row-element.js
@@ -1,4 +1,4 @@
-import fireEvent from "../../../common/dom/fire_event.js";
+import { fireEvent } from "../../../common/dom/fire_event.js";
 
 import "../entity-rows/hui-climate-entity-row.js";
 import "../entity-rows/hui-cover-entity-row.js";


### PR DESCRIPTION
This converts fire event function from default export to named export.

Moving forward, we should no longer use default exports:

 - The defining file should define the name, not the importing file. This ensures the name is the same in all files it is used, making it easier for readers of the code.
 - It makes it not look stupid if a 2nd export is added to a file with default export, no more `import bla, { blub } from './X';`
 - VS Code will be able to auto-complete the function name and add the appropriate import automatically
 - VS Code will be able to rename the symbol name across all files at once

Semi-related sidenote: we should remove EventsMixin. Instead code should use this method instead.