### PR TITLE
Fix Icon spacing in Logbook list

### DIFF
--- a/src/panels/logbook/ha-logbook.js
+++ b/src/panels/logbook/ha-logbook.js
@@ -31,7 +31,7 @@ class HaLogbook extends EventsMixin(PolymerElement) {
         color: var(--secondary-text-color);
       }
 
-      domain-icon {
+      iron-icon {
         margin: 0 8px 0 16px;
         color: var(--primary-text-color);
       }


### PR DESCRIPTION
I think this bug was introduced with #1739. The styles for the logbook icons have been lost because the selector has changed.