### PR TITLE
Hide Z-Wave "Remove/Replace Failed Node" Buttons unless nodes are failed

### DIFF
--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -135,6 +135,7 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
               hidden$="[[!showHelp]]">
             </ha-service-description>
 
+            <template is="dom-if" if="[[computeNodeFailed(selectedNode)]]">
             <ha-call-service-button
               hass="[[hass]]"
               domain="zwave"
@@ -162,6 +163,7 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
               service="replace_failed_node"
               hidden$="[[!showHelp]]">
             </ha-service-description>
+            </template>
 
             <ha-call-service-button
               hass="[[hass]]"
@@ -335,6 +337,11 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: "selectedNodeChanged",
       },
 
+      nodeFailed: {
+        type: Boolean,
+        value: false,
+      },
+
       config: {
         type: Array,
         value: () => [],
@@ -490,6 +497,8 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
           this._protectionNode = true;
         }
       });
+
+    this.nodeFailed = this.nodes[selectedNode].attributes.is_failed;
   }
 
   selectedEntityChanged(selectedEntity) {
@@ -546,6 +555,10 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   computeIsEntitySelected(selectedEntity) {
     return selectedEntity === -1;
+  }
+
+  computeNodeFailed(selectedNode) {
+    return this.nodes[selectedNode].attributes.is_failed;
   }
 
   computeNodeServiceData(selectedNode) {

--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -135,7 +135,7 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
               hidden$="[[!showHelp]]">
             </ha-service-description>
 
-            <template is="dom-if" if="[[computeNodeFailed(selectedNode)]]">
+            <template is="dom-if" if="[[nodeFailed]]">
             <ha-call-service-button
               hass="[[hass]]"
               domain="zwave"
@@ -555,10 +555,6 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   computeIsEntitySelected(selectedEntity) {
     return selectedEntity === -1;
-  }
-
-  computeNodeFailed(selectedNode) {
-    return this.nodes[selectedNode].attributes.is_failed;
   }
 
   computeNodeServiceData(selectedNode) {


### PR DESCRIPTION
This hides the Remove Failed Node and Replace Failed Node buttons from the Z-Wave config panel unless the selected node is actually marked `is_failed: true` - The service calls don't do anything if the node isn't marked failed.

You can manually override is_failed from dev-states or manually call the services from the services page if desired.

![image](https://user-images.githubusercontent.com/7545841/46977958-897d5200-d09b-11e8-8ff3-e7524b934b2c.png)

![image](https://user-images.githubusercontent.com/7545841/46977976-9732d780-d09b-11e8-85df-c2c486dd8d24.png)

