### PR TITLE
Added domain icon for homekit

### DIFF
--- a/src/common/entity/domain_icon.js
+++ b/src/common/entity/domain_icon.js
@@ -18,6 +18,7 @@ const fixedIcons = {
   group: "hass:google-circles-communities",
   history_graph: "hass:chart-line",
   homeassistant: "hass:home-assistant",
+  homekit: "hass:home-automation",
   image_processing: "hass:image-filter-frames",
   input_boolean: "hass:drawing",
   input_datetime: "hass:calendar-clock",


### PR DESCRIPTION
Added domain icon home-automation for domain homekit. With PR home-assistant/pull/17180 the homekit component will create entries within logbook. This PR is to set the icon displayed then for those logbook entries to be the home-automation icon.