### PR TITLE
Adding Theme option to Glance and Button Cards

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -1,4 +1,4 @@
-import { html, LitElement } from "@polymer/lit-element";
+import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
 import { fireEvent } from "../../../common/dom/fire_event.js";
 
 import "../../../components/ha-card.js";
@@ -24,12 +24,12 @@ interface Config extends LovelaceConfig {
   service_data?: object;
 }
 
-export class HuiEntityButtonCard extends HassLocalizeLitMixin(LitElement)
+class HuiEntityButtonCard extends HassLocalizeLitMixin(LitElement)
   implements LovelaceCard {
   protected hass?: HomeAssistant;
   protected config?: Config;
 
-  static get properties() {
+  static get properties(): PropertyDeclarations {
     return {
       hass: {},
       config: {},
@@ -45,7 +45,7 @@ export class HuiEntityButtonCard extends HassLocalizeLitMixin(LitElement)
       throw new Error("Invalid Entity");
     }
 
-    this.config = config;
+    this.config = { theme: "default", ...config };
 
     if (this.hass) {
       this.requestUpdate();
@@ -58,9 +58,7 @@ export class HuiEntityButtonCard extends HassLocalizeLitMixin(LitElement)
     }
     const stateObj = this.hass!.states[this.config.entity];
 
-    if (this.config.theme) {
-      applyThemesOnElement(this, this.hass!.themes, this.config.theme);
-    }
+    applyThemesOnElement(this, this.hass!.themes, this.config.theme);
 
     return html`
       ${this.renderStyle()}

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -8,6 +8,7 @@ import isValidEntityId from "../../../common/entity/valid_entity_id.js";
 import stateIcon from "../../../common/entity/state_icon.js";
 import computeStateDomain from "../../../common/entity/compute_state_domain.js";
 import computeStateName from "../../../common/entity/compute_state_name.js";
+import applyThemesOnElement from "../../../common/dom/apply_themes_on_element.js";
 import { styleMap } from "lit-html/directives/styleMap.js";
 import { HomeAssistant } from "../../../types.js";
 import { HassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
@@ -17,6 +18,7 @@ interface Config extends LovelaceConfig {
   entity: string;
   name?: string;
   icon?: string;
+  theme?: string;
   tap_action?: "toggle" | "call-service" | "more-info";
   service?: string;
   service_data?: object;
@@ -55,6 +57,10 @@ export class HuiEntityButtonCard extends HassLocalizeLitMixin(LitElement)
       return html``;
     }
     const stateObj = this.hass!.states[this.config.entity];
+
+    if (this.config.theme) {
+      applyThemesOnElement(this, this.hass!.themes, this.config.theme);
+    }
 
     return html`
       ${this.renderStyle()}

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -54,7 +54,7 @@ export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
   }
 
   public setConfig(config: Config) {
-    this.config = config;
+    this.config = { theme: "default", ...config };
     const entities = processConfigEntities(config.entities);
 
     for (const entity of entities) {
@@ -87,9 +87,7 @@ export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
       (conf) => conf.entity in states
     );
 
-    if(this.config.theme) {
-      applyThemesOnElement(this, this.hass!.themes, this.config.theme)
-    }
+    applyThemesOnElement(this, this.hass!.themes, this.config.theme);
 
     return html`
       ${this.renderStyle()}
@@ -155,9 +153,9 @@ export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
         ${
           this.config!.show_name !== false
             ? html`<div class="name">${
-                "name" in entityConf
-                  ? entityConf.name
-                  : computeStateName(stateObj)
+              "name" in entityConf
+                ? entityConf.name
+                : computeStateName(stateObj)
               }</div>`
             : ""
         }

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -153,9 +153,9 @@ export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
         ${
           this.config!.show_name !== false
             ? html`<div class="name">${
-              "name" in entityConf
-                ? entityConf.name
-                : computeStateName(stateObj)
+                "name" in entityConf
+                  ? entityConf.name
+                  : computeStateName(stateObj)
               }</div>`
             : ""
         }

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -5,6 +5,7 @@ import { repeat } from "lit-html/directives/repeat";
 import computeStateDisplay from "../../../common/entity/compute_state_display.js";
 import computeStateName from "../../../common/entity/compute_state_name.js";
 import processConfigEntities from "../common/process-config-entities";
+import applyThemesOnElement from "../../../common/dom/apply_themes_on_element.js";
 
 import toggleEntity from "../common/entity/toggle-entity.js";
 
@@ -31,7 +32,7 @@ interface Config extends LovelaceConfig {
   show_state?: boolean;
   title?: string;
   column_width?: string;
-  theming?: "primary";
+  theme?: string;
   entities: EntityConfig[];
 }
 
@@ -69,13 +70,6 @@ export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
       config.column_width || "20%"
     );
 
-    if (config.theming) {
-      if (typeof config.theming !== "string") {
-        throw new Error("Incorrect theming config.");
-      }
-      this.classList.add(`theme-${config.theming}`);
-    }
-
     this.configEntities = entities;
 
     if (this.hass) {
@@ -92,6 +86,10 @@ export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
     const entities = this.configEntities!.filter(
       (conf) => conf.entity in states
     );
+
+    if(this.config.theme) {
+      applyThemesOnElement(this, this.hass!.themes, this.config.theme)
+    }
 
     return html`
       ${this.renderStyle()}
@@ -110,11 +108,6 @@ export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
   private renderStyle() {
     return html`
       <style>
-        :host(.theme-primary) {
-          --paper-card-background-color:var(--primary-color);
-          --paper-item-icon-color:var(--text-primary-color);
-          color:var(--text-primary-color);
-        }
         .entities {
           display: flex;
           padding: 0 16px 4px;


### PR DESCRIPTION
This adds the option to set a theme per card.

Deletes `theming` option of Glance Card

ui-lovelace.yaml:
```yaml
- type: glance
  theme: glance-card
  entities: ...
- type: entity-button
  theme: button-card
  entity: ...
```

themes.yaml:
```yaml
glance-card:
    paper-card-background-color: 'blue'
    primary-text-color: '#FFF'
button-card:
    paper-card-background-color: 'pink'
```

Frontend View:
![Example](https://i.gyazo.com/55c10717d5b1709cf1d0437d7a73b56e.png)