### PR TITLE
Guard cloud info being null

### DIFF
--- a/src/panels/config/cloud/ha-config-cloud.js
+++ b/src/panels/config/cloud/ha-config-cloud.js
@@ -107,8 +107,9 @@ class HaConfigCloud extends NavigateMixin(PolymerElement) {
       timeOut.after(0),
       () => {
         if (
-          !this.cloudStatus.logged_in &&
-          !NOT_LOGGED_IN_URLS.includes(route.path)
+          !this.cloudStatus ||
+          (!this.cloudStatus.logged_in &&
+            !NOT_LOGGED_IN_URLS.includes(route.path))
         ) {
           this.navigate("/config/cloud/login", true);
         } else if (


### PR DESCRIPTION
If a user is linked to the cloud page from a persistent notification, the `cloudStatus` object can be undefined.