### PR TITLE
Lovelace: Fix margins in vertical-stack

### DIFF
--- a/src/panels/lovelace/cards/hui-vertical-stack-card.js
+++ b/src/panels/lovelace/cards/hui-vertical-stack-card.js
@@ -13,7 +13,7 @@ class HuiVerticalStackCard extends PolymerElement {
           flex-direction: column;
         }
         #root > * {
-          margin: 4px 0 8px 0;
+          margin: 4px 0 4px 0;
         }
         #root > *:first-child {
           margin-top: 0;


### PR DESCRIPTION
Since vertical-stack puts cards in a div with display: flex, the margins don't work in quite the same way as in the normal columns. This change makes them look the same.

```yaml
cards:
  - type: entities
    ...
  - type: entities
    ...
  - type: entities
    ...
  - type: vertical-stack
    cards:
      - type: entities
        ...
      - type: entities
        ...
      - type: entities
        ...
```
  
Before:
![stacks - before](https://user-images.githubusercontent.com/1299821/47080660-e8140e80-d208-11e8-9d5b-ab91c2b183a9.jpg)

After:
![stacks - after](https://user-images.githubusercontent.com/1299821/47080672-ed715900-d208-11e8-9b9a-09a670b4e62f.jpg)
