### PR TITLE
Fix history graphs not loading

### DIFF
--- a/src/data/ha-state-history-data.js
+++ b/src/data/ha-state-history-data.js
@@ -168,7 +168,7 @@ class HaStateHistoryData extends LocalizeMixin(PolymerElement) {
       this.endTime,
       this.cacheConfig,
       this.localize,
-      this.language
+      this.hass.language
     );
   }
 
@@ -189,7 +189,7 @@ class HaStateHistoryData extends LocalizeMixin(PolymerElement) {
         this.endTime,
         this.cacheConfig,
         this.localize,
-        this.language
+        this.hass.language
       );
     }
   }


### PR DESCRIPTION
History graphs are not displaying since update to 0.80.2.

It seems `src/data/ha-state-history-data.js` still uses `this.language` which used to be provided by the localize-mixin.

This change makes history graphs show up for me in more-info dialogs.
I haven't tested history-graphs cards etc. yet.