### PR TITLE
Fix overflow of image elements.

### DIFF
--- a/src/panels/lovelace/elements/hui-image-element.js
+++ b/src/panels/lovelace/elements/hui-image-element.js
@@ -14,10 +14,10 @@ class HuiImageElement extends ElementClickMixin(PolymerElement) {
       <style>
         :host(.clickable) {
           cursor: pointer;
+          overflow: hidden;
           -webkit-touch-callout: none !important;
         }
         hui-image {
-          overflow-y: hidden;
           -webkit-user-select: none !important;
         }
       </style>

--- a/src/panels/lovelace/mixins/element-click-mixin.js
+++ b/src/panels/lovelace/mixins/element-click-mixin.js
@@ -21,13 +21,13 @@ export default dedupingMixin(
 
         let ripple = null;
         const rippleWrapper = document.createElement("div");
-        this.shadowRoot.appendChild(rippleWrapper);
+        this.parentElement.appendChild(rippleWrapper);
         Object.assign(rippleWrapper.style, {
           position: "absolute",
           width: isTouch ? "100px" : "50px",
           height: isTouch ? "100px" : "50px",
-          top: "50%",
-          left: "50%",
+          top: this.style.top,
+          left: this.style.left,
           transform: "translate(-50%, -50%)",
           pointerEvents: "none",
         });

--- a/src/panels/lovelace/mixins/element-click-mixin.js
+++ b/src/panels/lovelace/mixins/element-click-mixin.js
@@ -23,11 +23,13 @@ export default dedupingMixin(
         const rippleWrapper = document.createElement("div");
         this.parentElement.appendChild(rippleWrapper);
         Object.assign(rippleWrapper.style, {
-          position: "absolute",
+          position: this.style.position || "absolute",
           width: isTouch ? "100px" : "50px",
           height: isTouch ? "100px" : "50px",
           top: this.style.top,
           left: this.style.left,
+          bottom: this.style.bottom,
+          right: this.style.right,
           transform: "translate(-50%, -50%)",
           pointerEvents: "none",
         });


### PR DESCRIPTION
To get the ripple to look right I removed `overflow: hidden` for image elements. That meant they couldn't have rounded corners anymore (see #1810).

This restores the overflow property, and instead puts the ripple in a div that's a sibling of the clicked element rather than a child.

Fixes #1810