### PR TITLE
Adding margin-top to sensor badges

### DIFF
--- a/src/cards/ha-badges-card.js
+++ b/src/cards/ha-badges-card.js
@@ -10,6 +10,7 @@ class HaBadgesCard extends PolymerElement {
       ha-state-label-badge {
         display: inline-block;
         margin-bottom: var(--ha-state-label-badge-margin-bottom, 16px);
+        margin-top: var(--ha-state-label-badge-margin-top, 16px);
       }
     </style>
     <template is="dom-repeat" items="[[states]]">


### PR DESCRIPTION
Fixes  #1753
Sensor Badges looking less "wonky". 