### PR TITLE
Refresh cloud status if paying sub info comes in

### DIFF
--- a/src/panels/config/cloud/ha-config-cloud-account.js
+++ b/src/panels/config/cloud/ha-config-cloud-account.js
@@ -190,6 +190,9 @@ class HaConfigCloudAccount extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
   async _fetchSubscriptionInfo() {
     this._subscription = await this.hass.callWS({ type: "cloud/subscription" });
+    if (this._subscription.provider && this.cloudStatus.cloud !== "connected") {
+      this.fire("ha-refresh-cloud-status");
+    }
   }
 
   handleLogout() {


### PR DESCRIPTION
When a paying sub info comes in and we're not connected, refresh cloud status.