### PR TITLE
Allow custom UI on "card" entities

### DIFF
--- a/src/components/ha-cards.js
+++ b/src/components/ha-cards.js
@@ -251,7 +251,10 @@ class HaCards extends PolymerElement {
       entities.forEach((entity) => {
         const domain = computeStateDomain(entity);
 
-        if (domain in DOMAINS_WITH_CARD) {
+        if (
+          domain in DOMAINS_WITH_CARD &&
+          !entity.attributes.custom_ui_state_card
+        ) {
           owncard.push(entity);
           size += DOMAINS_WITH_CARD[domain];
         } else {


### PR DESCRIPTION
This will always render entities with `custom_ui_state_card` attribute set in `entities` state card. Fixes custom UI on `media_player` objects.

This PR came out of my annoyance with whole https://community.home-assistant.io/t/custom-ui-mini-media-player/40135 topic. With this patch applied it'll be no longer necessary to add dummy `input_text` entity and hide original `media_player`. (This is especially troubling with autodetected media players)