### PR TITLE
Always define localize func

### DIFF
--- a/src/mixins/lit-localize-mixin.ts
+++ b/src/mixins/lit-localize-mixin.ts
@@ -11,6 +11,8 @@ import {
   LocalizeMixin,
 } from "./localize-base-mixin";
 
+const empty = () => "";
+
 export const HassLocalizeLitMixin = <T extends LitElement>(
   superClass: Constructor<T>
 ): Constructor<T & LocalizeMixin> =>
@@ -24,6 +26,12 @@ export const HassLocalizeLitMixin = <T extends LitElement>(
         hass: {},
         localize: {},
       };
+    }
+
+    constructor() {
+      super();
+      // This will prevent undefined errors if called before connected to DOM.
+      this.localize = empty;
     }
 
     public connectedCallback(): void {


### PR DESCRIPTION
This makes sure that there will always be a `localize` function defined for elements extending the lit localize mixin.

Fixes #1823