### PR TITLE
Add option to pick number of columns for glance card

### DIFF
--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -32,6 +32,7 @@ interface Config extends LovelaceConfig {
   title?: string;
   theme?: string;
   entities: EntityConfig[];
+  columns?: number;
 }
 
 export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
@@ -63,10 +64,8 @@ export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
       }
     }
 
-    const columnWidth =
-      config.entities.length > 4 ? "20%" : `${100 / config.entities.length}%`;
-
-    this.style.setProperty("--glance-column-width", columnWidth);
+    const columns = config.columns || Math.min(config.entities.length, 5);
+    this.style.setProperty("--glance-column-width", `${100 / columns}%`);
 
     this.configEntities = entities;
 


### PR DESCRIPTION
This adds an optional `columns:` option to glance card to force the number of columns to display.

## Documentation
home-assistant/home-assistant.io#7014