### PR TITLE
Add HomeAssistant object hass to LovelaceCard interface

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -26,7 +26,7 @@ interface Config extends LovelaceConfig {
 
 class HuiEntityButtonCard extends HassLocalizeLitMixin(LitElement)
   implements LovelaceCard {
-  protected hass?: HomeAssistant;
+  public hass?: HomeAssistant;
   protected config?: Config;
 
   static get properties(): PropertyDeclarations {

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -37,7 +37,7 @@ interface Config extends LovelaceConfig {
 
 export class HuiGlanceCard extends HassLocalizeLitMixin(LitElement)
   implements LovelaceCard {
-  protected hass?: HomeAssistant;
+  public hass?: HomeAssistant;
   protected config?: Config;
   protected configEntities?: EntityConfig[];
 

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -1,8 +1,11 @@
+import { HomeAssistant } from "../../types.js";
+
 export interface LovelaceConfig {
   type: string;
 }
 
-export interface LovelaceCard {
+export interface LovelaceCard extends HTMLElement {
+  hass?: HomeAssistant;
   getCardSize(): number;
   setConfig(config: LovelaceConfig): void;
 }


### PR DESCRIPTION
Makes LovelaceCard usable as Node, and adds the hass object to the public interface.