### PR TITLE
Reduce device registry card height

### DIFF
--- a/src/panels/config/config-entries/ha-device-card.js
+++ b/src/panels/config/config-entries/ha-device-card.js
@@ -26,7 +26,7 @@ class HaDeviceCard extends EventsMixin(LocalizeMixin(PolymerElement)) {
     return html`
     <style>
       :host(:not([narrow])) .device-entities {
-        max-height: 400px;
+        max-height: 225px;
         overflow: auto;
       }
       paper-card {


### PR DESCRIPTION
Reduces height of device registry cards to only show 4 entities before scrolling, based on chatter in #beta on Discord.