### PR TITLE
Fix sorting of addons

### DIFF
--- a/hassio/src/addon-store/hassio-addon-repository.js
+++ b/hassio/src/addon-store/hassio-addon-repository.js
@@ -48,7 +48,7 @@ class HassioAddonRepository extends NavigateMixin(PolymerElement) {
   }
 
   sortAddons(a, b) {
-    return a.name < b.name ? -1 : 1;
+    return a.name.toUpperCase() < b.name.toUpperCase() ? -1 : 1;
   }
 
   computeIcon(addon) {

--- a/hassio/src/addon-store/hassio-addon-store.js
+++ b/hassio/src/addon-store/hassio-addon-store.js
@@ -53,7 +53,7 @@ class HassioAddonStore extends PolymerElement {
     if (b.slug === "core") {
       return 1;
     }
-    return a.name < b.name ? -1 : 1;
+    return a.name.toUpperCase() < b.name.toUpperCase() ? -1 : 1;
   }
 
   computeAddons(repo) {


### PR DESCRIPTION
# Description

As requested by @frenck fixes order of sorting as described in his PR here: #1747 

This also sorts the add-ons in the store as well as in the repository by name as uppercase