### PR TITLE
Allow mocking websocket commands in the gallery

### DIFF
--- a/gallery/src/data/provide_hass.js
+++ b/gallery/src/data/provide_hass.js
@@ -71,7 +71,7 @@ export default (elements, { initialStates = {} } = {}) => {
     },
 
     async callApi(method, path, parameters) {
-      const path = restResponses[path];
+      const callback = restResponses[path];
 
       return callback
         ? callback(method, path, parameters)

--- a/gallery/src/data/provide_hass.js
+++ b/gallery/src/data/provide_hass.js
@@ -10,6 +10,7 @@ export default (elements, { initialStates = {} } = {}) => {
   elements = ensureArray(elements);
 
   const wsCommands = {};
+  const restResponses = {};
   let hass;
   const entities = {};
 
@@ -69,6 +70,14 @@ export default (elements, { initialStates = {} } = {}) => {
       console.log("sendWS", msg);
     },
 
+    async callApi(method, path, parameters) {
+      const path = restResponses[path];
+
+      return callback
+        ? callback(method, path, parameters)
+        : Promise.reject(`Mock for {path} is not implemented`);
+    },
+
     // Mock functions
     updateHass,
     updateStates(newStates) {
@@ -84,6 +93,12 @@ export default (elements, { initialStates = {} } = {}) => {
         states[ent.entityId] = ent.toState();
       });
       this.updateStates(states);
+    },
+    mockWS(type, callback) {
+      wsCommands[type] = callback;
+    },
+    mockAPI(path, callback) {
+      restResponses[path] = callback;
     },
   });
 


### PR DESCRIPTION
Use in gallery like this:

```ts
  ready() {
    super.ready();
    const hass = provideHass(this.$.demos);
    hass.addEntities(ENTITIES);
    // Mock a WS command
    hass.mockWS('auth/current_user', () => ({ name: 'Paulus' }));
    // Mock a Rest API call
    hass.mockAPI("shopping_list/item/", () => [ { name: "yo", id: 1, complete: false } ]);
  }
```