### PR TITLE
Enforce prettier for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-eslint-rules": "^5.4.0",
+    "tslint-plugin-prettier": "^2.0.0",
     "typescript": "3.1.3",
     "wct-browser-legacy": "^1.0.1",
     "web-component-tester": "^6.8.0",
@@ -166,7 +167,7 @@
   },
   "lint-staged": {
     "linters": {
-      "*.{js,json,css,md}": [
+      "*.{js,ts,json,css,md}": [
         "prettier --write",
         "git add"
       ]

--- a/src/panels/lovelace/cards/hui-conditional-card.ts
+++ b/src/panels/lovelace/cards/hui-conditional-card.ts
@@ -19,7 +19,7 @@ class HuiConditionalCard extends HTMLElement implements LovelaceCard {
   protected card?: LovelaceCard;
 
   public setConfig(config) {
-    if(
+    if (
       !config.card ||
       !config.conditions ||
       !Array.isArray(config.conditions) ||
@@ -37,22 +37,28 @@ class HuiConditionalCard extends HTMLElement implements LovelaceCard {
   }
 
   set hass(hass: HomeAssistant) {
-    const visible = this.config &&
+    const visible =
+      this.config &&
       this.config.conditions.every((c) => {
-      if (!(c.entity in hass.states)) { return false; }
-      if (c.state) { return hass.states[c.entity].state === c.state; }
-      return hass.states[c.entity].state !== c.state_not;
-    });
+        if (!(c.entity in hass.states)) {
+          return false;
+        }
+        if (c.state) {
+          return hass.states[c.entity].state === c.state;
+        }
+        return hass.states[c.entity].state !== c.state_not;
+      });
 
-    if (visible && this.card) { this.card.hass = hass; }
+    if (visible && this.card) {
+      this.card.hass = hass;
+    }
 
-    this.style.setProperty("display", visible? "" : "none");
+    this.style.setProperty("display", visible ? "" : "none");
   }
 
   public getCardSize() {
     return computeCardSize(this.card);
   }
-
 }
 
 declare global {

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -11,8 +11,7 @@ interface Config extends LovelaceConfig {
   title?: string;
 }
 
-export class HuiMarkdownCard extends LitElement
-  implements LovelaceCard {
+export class HuiMarkdownCard extends LitElement implements LovelaceCard {
   protected config?: Config;
 
   static get properties() {

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,12 @@
 {
-  "extends": ["tslint:latest", "tslint-eslint-rules", "tslint-config-prettier"],
+  "extends": [
+    "tslint-plugin-prettier",
+    "tslint:latest",
+    "tslint-eslint-rules",
+    "tslint-config-prettier"
+  ],
   "rules": {
+    "prettier": true,
     "interface-name": false,
     "no-submodule-imports": false,
     "ordered-imports": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6291,6 +6291,14 @@ eslint-plugin-import@^2.14.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
+eslint-plugin-prettier@^2.2.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz#b4312dcf2c1d965379d7f9d5b5f8aaadc6a45904"
+  integrity sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 eslint-plugin-prettier@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz#f6b823e065f8c36529918cdb766d7a0e975ec30c"
@@ -6763,6 +6771,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-diff@^1.1.2:
   version "1.1.2"
@@ -9055,6 +9068,11 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
+
+jest-docblock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+  integrity sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==
 
 jest-get-type@^22.1.0:
   version "22.4.3"
@@ -14223,7 +14241,7 @@ tslib@1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
   integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -14241,6 +14259,14 @@ tslint-eslint-rules@^5.4.0:
     doctrine "0.7.2"
     tslib "1.9.0"
     tsutils "^3.0.0"
+
+tslint-plugin-prettier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.0.tgz#ade328b26c71f37418d4d01187dca232a7447b49"
+  integrity sha512-nA8yM+1tS9dylirSajTxxFV6jCQrIMQ0Ykl//jjRgqmwwmGp3hqodG+rtr16S/OUwyQBfoFScFDK7nuHYPd4Gw==
+  dependencies:
+    eslint-plugin-prettier "^2.2.0"
+    tslib "^1.7.1"
 
 tslint@^5.11.0:
   version "5.11.0"


### PR DESCRIPTION
- Run prettier on typescript files in the pre-commit hook
- Fail CI if a TS file is not formatted with prettier.
- Format the violating TS files with prettier