### PR TITLE
1813 - Improve Hass.io System cards UI

### DIFF
--- a/hassio/src/system/hassio-host-info.js
+++ b/hassio/src/system/hassio-host-info.js
@@ -31,7 +31,6 @@ class HassioHostInfo extends EventsMixin(PolymerElement) {
       }
       .info {
         width: 100%;
-        margin-bottom: 20px;
       }
       .info td:nth-child(2) {
         text-align: right;
@@ -42,6 +41,9 @@ class HassioHostInfo extends EventsMixin(PolymerElement) {
       }
       paper-button.info {
         max-width: calc(50% - 12px);
+      }
+      table.info {
+        margin-bottom: 10px;
       }
     </style>
     <paper-card>

--- a/hassio/src/system/hassio-host-info.js
+++ b/hassio/src/system/hassio-host-info.js
@@ -26,11 +26,12 @@ class HassioHostInfo extends EventsMixin(PolymerElement) {
           width: 100%;
         }
         .card-content {
-          height: 100%;
+          height: auto;
         }
       }
       .info {
         width: 100%;
+        margin-bottom: 20px;
       }
       .info td:nth-child(2) {
         text-align: right;

--- a/hassio/src/system/hassio-supervisor-info.js
+++ b/hassio/src/system/hassio-supervisor-info.js
@@ -32,9 +32,6 @@ class HassioSupervisorInfo extends EventsMixin(PolymerElement) {
       .info td:nth-child(2) {
         text-align: right;
       }
-      table.info {
-        margin-bottom: 10px;
-      }
       .errors {
         color: var(--google-red-500);
         margin-top: 16px;

--- a/hassio/src/system/hassio-supervisor-info.js
+++ b/hassio/src/system/hassio-supervisor-info.js
@@ -23,7 +23,7 @@ class HassioSupervisorInfo extends EventsMixin(PolymerElement) {
           width: 100%;
         }
         .card-content {
-          height: 100%;
+          height: auto;
         }
       }
       .info {
@@ -31,6 +31,9 @@ class HassioSupervisorInfo extends EventsMixin(PolymerElement) {
       }
       .info td:nth-child(2) {
         text-align: right;
+      }
+      table.info {
+        margin-bottom: 10px;
       }
       .errors {
         color: var(--google-red-500);


### PR DESCRIPTION
Related to #1813 

Improved Hass.io Menu - System Tabs. On mobile, it had some unnecessary spacing on Supervisor and Host info card. Tested on Android and iOS.

<details>

  <summary>Android Chrome</summary>

![screenshot_20181026-120822](https://user-images.githubusercontent.com/11093090/47575488-965e3900-d918-11e8-97df-71df2610672d.jpg)

</details>

<details>

  <summary>iOS Safari</summary>

![img_0394](https://user-images.githubusercontent.com/11093090/47575495-99592980-d918-11e8-8e44-2ec264ad4ca1.PNG)

</details>