### PR TITLE
Extract navigate mixin

### DIFF
--- a/src/common/navigate.ts
+++ b/src/common/navigate.ts
@@ -1,0 +1,14 @@
+import { fireEvent } from "./dom/fire_event.js";
+
+export const navigate = (
+  node: HTMLElement,
+  path: string,
+  replace: boolean = false
+) => {
+  if (replace) {
+    history.replaceState(null, "", path);
+  } else {
+    history.pushState(null, "", path);
+  }
+  fireEvent(node, "location-changed");
+};

--- a/src/mixins/navigate-mixin.js
+++ b/src/mixins/navigate-mixin.js
@@ -1,5 +1,5 @@
 import { dedupingMixin } from "@polymer/polymer/lib/utils/mixin.js";
-import EventsMixin from "./events-mixin";
+import { navigate } from "../common/navigate";
 
 /*
  * @polymerMixin
@@ -8,13 +8,8 @@ import EventsMixin from "./events-mixin";
 export default dedupingMixin(
   (superClass) =>
     class extends EventsMixin(superClass) {
-      navigate(path, replace = false) {
-        if (replace) {
-          history.replaceState(null, null, path);
-        } else {
-          history.pushState(null, null, path);
-        }
-        this.fire("location-changed");
+      navigate(...args) {
+        navigate(this, ...args);
       }
     }
 );

--- a/src/mixins/navigate-mixin.js
+++ b/src/mixins/navigate-mixin.js
@@ -7,7 +7,7 @@ import { navigate } from "../common/navigate";
  */
 export default dedupingMixin(
   (superClass) =>
-    class extends EventsMixin(superClass) {
+    class extends superClass {
       navigate(...args) {
         navigate(this, ...args);
       }

--- a/src/panels/config/dashboard/ha-config-dashboard.js
+++ b/src/panels/config/dashboard/ha-config-dashboard.js
@@ -52,7 +52,7 @@ class HaConfigDashboard extends NavigateMixin(LocalizeMixin(PolymerElement)) {
           <template is="dom-if" if="[[computeIsLoaded(hass, 'cloud')]]">
             <paper-card>
               <a href='/config/cloud' tabindex="-1">
-                <paper-item on-click="_navigate">
+                <paper-item>
                   <paper-item-body two-line="">
                     [[localize('ui.panel.config.cloud.caption')]]
                     <template is="dom-if" if="[[cloudStatus.logged_in]]">

--- a/src/panels/config/users/ha-config-users.js
+++ b/src/panels/config/users/ha-config-users.js
@@ -8,6 +8,7 @@ import NavigateMixin from "../../../mixins/navigate-mixin.js";
 
 import "./ha-user-picker.js";
 import "./ha-user-editor.js";
+import { fireEvent } from "../../../common/dom/fire_event.js";
 
 /*
  * @appliesMixin NavigateMixin
@@ -68,8 +69,8 @@ class HaConfigUsers extends NavigateMixin(PolymerElement) {
   _checkRoute(route) {
     if (!route || route.path.substr(0, 6) !== "/users") return;
 
-    // prevent list gettung under toolbar
-    this.fire("iron-resize");
+    // prevent list getting under toolbar
+    fireEvent(this, "iron-resize");
 
     this._debouncer = Debouncer.debounce(
       this._debouncer,


### PR DESCRIPTION
This extracts the navigate mixin into a helper function for use within Lit.

CC @iantrich 

Side effect of this change: if a class incorrectly relied on the eventsmixin being included by the navigate mixin and used `this.fire`, that will raise now.