### PR TITLE
Fix version extract

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const zopfli = require("@gfx/zopfli");
 const translationMetadata = require("./build-translations/translationMetadata.json");
 const { babelLoaderConfig } = require("./config/babel.js");
 
-const version = fs.readFileSync("setup.py", "utf8").match(/\d{8}[^']*/);
+const version = fs.readFileSync("setup.py", "utf8").match(/\d{8}\.\d+/);
 if (!version) {
   throw Error("Version not found");
 }


### PR DESCRIPTION
Fix version extraction regex. We were accidentally including half setup.py:

Bug happened because I have "format on save" enabled for the polymer workspace in my editor, and so it formatted `setup.py` with Black, swapping single quotes for double quotes. The regex was looking for a single quote…

![image](https://user-images.githubusercontent.com/1444314/47588993-35f6e800-d968-11e8-8d9c-ee8ca4e4d987.png)
