### PR TITLE
Fix nl translation

### DIFF
--- a/translations/nl.json
+++ b/translations/nl.json
@@ -545,9 +545,9 @@
                         "no_device": "Entiteiten zonder apparaten",
                         "delete_confirm": "Weet u zeker dat u deze integratie wilt verwijderen?",
                         "restart_confirm": "Herstart Home Assistant om het verwijderen van deze integratie te voltooien",
-                        "manuf": "door {fabrikant}",
+                        "manuf": "door {manufacturer}",
                         "hub": "Verbonden via",
-                        "firmware": "Firmware: {versie}",
+                        "firmware": "Firmware: {version}",
                         "device_unavailable": "apparaat niet beschikbaar",
                         "entity_unavailable": "entiteit niet beschikbaar"
                     }


### PR DESCRIPTION
Previously, you would get the following error:

`https://*******/frontend_latest/app-945b88ed.js:2090:8023 Error: The intl string context variable 'fabrikant' was not provided to the string 'door {fabrikant}'`

I believe this PR should fix this.
