### PR TITLE
Catch translation errors

### DIFF
--- a/src/mixins/localize-base-mixin.ts
+++ b/src/mixins/localize-base-mixin.ts
@@ -88,7 +88,11 @@ export const localizeBaseMixin = (superClass) =>
           argObject[args[i]] = args[i + 1];
         }
 
-        return translatedMessage.format(argObject);
+        try {
+          return translatedMessage.format(argObject);
+        } catch (err) {
+          return "Translation " + err;
+        }
       };
     }
 


### PR DESCRIPTION
No longer fails the entire page when a placeholder is translated, or translation fails.

Fixes: https://github.com/home-assistant/home-assistant-polymer/issues/1917