### PR TITLE
Add preview to edit LL card

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -21,8 +21,8 @@ export class HuiCardOptions extends LitElement {
       registeredDialog = true;
       fireEvent(this, "register-dialog", {
         dialogShowEvent: "show-edit-card",
-        dialogTag: "ha-dialog-edit-card",
-        dialogImport: () => import("./ha-dialog-edit-card"),
+        dialogTag: "hui-dialog-edit-card",
+        dialogImport: () => import("../editor/hui-dialog-edit-card"),
       });
     }
   }

--- a/src/panels/lovelace/editor/hui-yaml-card-preview.ts
+++ b/src/panels/lovelace/editor/hui-yaml-card-preview.ts
@@ -1,0 +1,52 @@
+import yaml from "js-yaml";
+
+import "@polymer/paper-input/paper-textarea.js";
+
+import createCardElement from "../common/create-card-element";
+import createErrorCardConfig from "../common/create-error-card-config";
+import { HomeAssistant } from "../../../types";
+import { LovelaceCard } from "../types";
+
+export class HuiYAMLCardPreview extends HTMLElement {
+  private _hass?: HomeAssistant;
+
+  set hass(value: HomeAssistant) {
+    this._hass = value;
+    if (this.lastChild) {
+      (this.lastChild as LovelaceCard).hass = value;
+    }
+  }
+
+  set yaml(value: string) {
+    if (this.lastChild) {
+      this.removeChild(this.lastChild);
+    }
+
+    if (value === "") {
+      return;
+    }
+
+    let conf;
+    try {
+      conf = yaml.safeLoad(value);
+    } catch (err) {
+      conf = createErrorCardConfig(`Invalid YAML: ${err.message}`, undefined);
+    }
+
+    const element = createCardElement(conf);
+
+    if (this._hass) {
+      element.hass = this._hass;
+    }
+
+    this.appendChild(element);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-yaml-card-preview": HuiYAMLCardPreview;
+  }
+}
+
+customElements.define("hui-yaml-card-preview", HuiYAMLCardPreview);

--- a/src/panels/lovelace/editor/hui-yaml-editor.ts
+++ b/src/panels/lovelace/editor/hui-yaml-editor.ts
@@ -1,0 +1,41 @@
+import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
+import { fireEvent } from "../../../common/dom/fire_event.js";
+
+import "@polymer/paper-input/paper-textarea.js";
+
+export class HuiYAMLEditor extends LitElement {
+  public yaml?: string;
+
+  static get properties(): PropertyDeclarations {
+    return {
+      yaml: {},
+    };
+  }
+
+  protected render() {
+    return html`
+      <style>
+        paper-textarea {
+          --paper-input-container-shared-input-style_-_font-family: monospace;
+        }
+      </style>
+      <paper-textarea
+        value="${this.yaml}"
+        @value-changed="${this._valueChanged}"
+      ></paper-textarea>
+    `;
+  }
+
+  private _valueChanged(ev) {
+    this.yaml = ev.target.value;
+    fireEvent(this, "yaml-changed", { yaml: ev.target.value });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-yaml-editor": HuiYAMLEditor;
+  }
+}
+
+customElements.define("hui-yaml-editor", HuiYAMLEditor);


### PR DESCRIPTION
Show real-time preview of the config. When you make a YAML error, will show that too.

One downside: we re-create the card on every config change. If you're developing a sensor card, it will fetch history on every key stroke. For thermostat card it will do the loading animation on each load. We need to tweak the preview logic (in future PR), that will look at type of existing card element and if the type is the same, will just call `setConfig`.

![localhost_8123_lovelace_example 1](https://user-images.githubusercontent.com/1444314/47718820-b0b25280-dc49-11e8-853d-f6f50e06301c.png)

YAML Error:
![image](https://user-images.githubusercontent.com/1444314/47718891-e6573b80-dc49-11e8-874d-0414a0d5e5fe.png)

Config error:
![image](https://user-images.githubusercontent.com/1444314/47718919-f2db9400-dc49-11e8-8794-687e4e947b81.png)
