### PR TITLE
Fix calculation of size of glance card

### DIFF
--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -51,8 +51,11 @@ export class HuiGlanceCard extends hassLocalizeLitMixin(LitElement)
   }
 
   public getCardSize() {
+    const columns =
+      this.config!.columns || Math.min(this.config!.entities.length, 5);
     return (
-      (this.config!.title ? 1 : 0) + Math.ceil(this.configEntities!.length / 5)
+      (this.config!.title ? 1 : 0) +
+      2 * Math.ceil(this.configEntities!.length / columns)
     );
   }
 


### PR DESCRIPTION
A glance card is between 88 and 128 pixels high per row depending on settings. I rounded that to about 100 pixels.