### PR TITLE
Fix overlapping device cards

### DIFF
--- a/src/panels/config/config-entries/ha-config-entry-page.js
+++ b/src/panels/config/config-entries/ha-config-entry-page.js
@@ -29,6 +29,7 @@ class HaConfigEntryPage extends NavigateMixin(
       box-sizing: border-box;
       display: flex;
       flex: 1 0 300px;
+      min-width: 0;
       max-width: 500px;
       padding: 8px;
     }

--- a/src/panels/config/config-entries/ha-device-card.js
+++ b/src/panels/config/config-entries/ha-device-card.js
@@ -32,6 +32,7 @@ class HaDeviceCard extends EventsMixin(LocalizeMixin(PolymerElement)) {
       paper-card {
         flex: 1 0 100%;
         padding-bottom: 10px;
+        min-width: 0;
       }
       .device {
         width: 30%;


### PR DESCRIPTION
Prevents device cards in config entries to become bigger.

Fixes: https://github.com/home-assistant/home-assistant-polymer/issues/1869

Before:
![image](https://user-images.githubusercontent.com/5662298/47819854-0414c580-dd5c-11e8-998c-813b28b73d16.png)

After:
![image](https://user-images.githubusercontent.com/5662298/47819644-6f11cc80-dd5b-11e8-8a65-d5ad0982f1dc.png)
