### PR TITLE
Add getElementConfig to Glance + Add Form UI for updating YAML

### DIFF
--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -89,6 +89,28 @@ export class HuiGlanceCard extends hassLocalizeLitMixin(LitElement)
     }
   }
 
+  public getElementConfig(config: any, hass: HomeAssistant): TemplateResult {
+    if (!config || !hass) {
+      return html``;
+    }
+    return html`
+      <paper-input label="Title" value="${config.title}"></paper-input>
+      ${config.entities.map((entityConf) => {
+        return html`
+          <ha-entity-picker
+            hass="${hass}"
+            value="${entityConf.entity || entityConf}"
+            allow-custom-entity
+          ></ha-entity-picker>
+        `;
+      })}
+      <paper-checkbox ?checked="${config.show_name !==
+        false}">Show Entity's Name?</paper-checkbox>
+      <paper-checkbox ?checked="${config.show_state !==
+        false}">Show Entity's state-text?</paper-checkbox>
+    `;
+  }
+
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     if (changedProps.has("_config")) {
       return true;

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -23,7 +23,7 @@ import "../../../components/entity/state-badge";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
 
-interface EntityConfig {
+export interface EntityConfig {
   name: string;
   icon: string;
   entity: string;
@@ -33,7 +33,7 @@ interface EntityConfig {
   service_data?: object;
 }
 
-interface Config extends LovelaceConfig {
+export interface Config extends LovelaceConfig {
   show_name?: boolean;
   show_state?: boolean;
   title?: string;
@@ -44,7 +44,7 @@ interface Config extends LovelaceConfig {
 
 export class HuiGlanceCard extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCard {
-  public static async getElementConfig(): Promise<LovelaceCardEditor> {
+  public static async getConfigElement(): Promise<LovelaceCardEditor> {
     await import("../editor/hui-glance-card-editor");
     return document.createElement("hui-glance-card-editor");
   }

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -7,22 +7,21 @@ import {
 import { TemplateResult } from "lit-html";
 import { classMap } from "lit-html/directives/classMap";
 
-import computeStateDisplay from "../../../common/entity/compute_state_display";
-import computeStateName from "../../../common/entity/compute_state_name";
-import processConfigEntities from "../common/process-config-entities";
-import applyThemesOnElement from "../../../common/dom/apply_themes_on_element";
+import { fireEvent } from "../../../common/dom/fire_event.js";
+import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
+import { HomeAssistant } from "../../../types.js";
+import { LovelaceCard, LovelaceConfig, LovelaceCardEditor } from "../types.js";
+import { longPress } from "../common/directives/long-press-directive";
 
-import toggleEntity from "../common/entity/toggle-entity";
+import computeStateDisplay from "../../../common/entity/compute_state_display.js";
+import computeStateName from "../../../common/entity/compute_state_name.js";
+import processConfigEntities from "../common/process-config-entities";
+import applyThemesOnElement from "../../../common/dom/apply_themes_on_element.js";
+import toggleEntity from "../common/entity/toggle-entity.js";
 
 import "../../../components/entity/state-badge";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
-
-import { fireEvent } from "../../../common/dom/fire_event";
-import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
-import { HomeAssistant } from "../../../types";
-import { LovelaceCard, LovelaceConfig } from "../types";
-import { longPress } from "../common/directives/long-press-directive";
 
 interface EntityConfig {
   name: string;
@@ -45,6 +44,11 @@ interface Config extends LovelaceConfig {
 
 export class HuiGlanceCard extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCard {
+  public static async getElementConfig(): Promise<LovelaceCardEditor> {
+    await import("../editor/hui-glance-card-editor");
+    return document.createElement("hui-glance-card-editor");
+  }
+
   public hass?: HomeAssistant;
   private _config?: Config;
   private _configEntities?: EntityConfig[];

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -93,28 +93,6 @@ export class HuiGlanceCard extends hassLocalizeLitMixin(LitElement)
     }
   }
 
-  public getElementConfig(config: any, hass: HomeAssistant): TemplateResult {
-    if (!config || !hass) {
-      return html``;
-    }
-    return html`
-      <paper-input label="Title" value="${config.title}"></paper-input>
-      ${config.entities.map((entityConf) => {
-        return html`
-          <ha-entity-picker
-            hass="${hass}"
-            value="${entityConf.entity || entityConf}"
-            allow-custom-entity
-          ></ha-entity-picker>
-        `;
-      })}
-      <paper-checkbox ?checked="${config.show_name !==
-        false}">Show Entity's Name?</paper-checkbox>
-      <paper-checkbox ?checked="${config.show_state !==
-        false}">Show Entity's state-text?</paper-checkbox>
-    `;
-  }
-
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     if (changedProps.has("_config")) {
       return true;

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -1,27 +1,33 @@
 import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
-import { fireEvent } from "../../../common/dom/fire_event";
+import { fireEvent } from "../../../common/dom/fire_event.js";
+import yaml from "js-yaml";
 
-import "@polymer/paper-button/paper-button";
-import "@polymer/paper-input/paper-textarea";
-import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
-import "@polymer/paper-dialog/paper-dialog";
+import "@polymer/paper-checkbox/paper-checkbox.js";
+import "@polymer/paper-button/paper-button.js";
+import "@polymer/paper-input/paper-textarea.js";
+import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js";
+import "@polymer/paper-dialog/paper-dialog.js";
 // This is not a duplicate import, one is for types, one is for element.
 // tslint:disable-next-line
 import { PaperDialogElement } from "@polymer/paper-dialog/paper-dialog";
 import { HomeAssistant } from "../../../types";
 import { getCardConfig, updateCardConfig } from "../common/data";
 
+import "../../../components/entity/ha-entity-picker";
 import "./hui-yaml-editor";
 import "./hui-yaml-card-preview";
 // This is not a duplicate import, one is for types, one is for element.
 // tslint:disable-next-line
 import { HuiYAMLCardPreview } from "./hui-yaml-card-preview";
+import { TemplateResult } from "lit-html";
 
 export class HuiDialogEditCard extends LitElement {
   protected hass?: HomeAssistant;
   private _cardId?: string;
   private _cardConfig?: string;
+  private _elementConfig?: TemplateResult;
   private _reloadLovelace?: () => void;
+  private _showUIEditor?: boolean;
 
   static get properties(): PropertyDeclarations {
     return {
@@ -31,6 +37,7 @@ export class HuiDialogEditCard extends LitElement {
       },
       _cardConfig: {},
       _dialogClosedCallback: {},
+      _showUIEditor: {},
     };
   }
 
@@ -39,6 +46,7 @@ export class HuiDialogEditCard extends LitElement {
     this._cardId = cardId;
     this._reloadLovelace = reloadLovelace;
     this._cardConfig = "";
+    this._showUIEditor = true;
     this._loadConfig();
     // Wait till dialog is rendered.
     await this.updateComplete;
@@ -59,20 +67,31 @@ export class HuiDialogEditCard extends LitElement {
         paper-dialog {
           width: 650px;
         }
+        .element-editor {
+          margin-bottom: 16px;
+        }
       </style>
       <paper-dialog with-backdrop>
         <h2>Card Configuration</h2>
         <paper-dialog-scrollable>
-          <hui-yaml-editor
-            .yaml="${this._cardConfig}"
-            @yaml-changed="${this._handleYamlChanged}"
-          ></hui-yaml-editor>
+          ${
+            this._showUIEditor
+              ? html`<div class="element-editor">${this._elementConfig}</div>`
+              : html`
+              <hui-yaml-editor
+                .yaml="${this._cardConfig}"
+                @yaml-changed="${this._handleYamlChanged}"
+              ></hui-yaml-editor>`
+          }
           <hui-yaml-card-preview
             .hass="${this.hass}"
             .yaml="${this._cardConfig}"
           ></hui-yaml-card-preview>
         </paper-dialog-scrollable>
         <div class="paper-dialog-buttons">
+          <paper-button @click="${
+            this._toggleEditor
+          }">Toggle Editor</paper-button>
           <paper-button @click="${this._closeDialog}">Cancel</paper-button>
           <paper-button @click="${this._updateConfig}">Save</paper-button>
         </div>
@@ -88,11 +107,38 @@ export class HuiDialogEditCard extends LitElement {
     this._dialog.close();
   }
 
+  private _toggleEditor() {
+    if (!this._elementConfig) {
+      return;
+    }
+    this._showUIEditor = !this._showUIEditor;
+    // This will center the dialog with the updated config
+    fireEvent(this._dialog, "iron-resize");
+  }
+
   private async _loadConfig() {
     this._cardConfig = await getCardConfig(this.hass!, this._cardId!);
+    this._loadElementConfig();
     await this.updateComplete;
     // This will center the dialog with the updated config
     fireEvent(this._dialog, "iron-resize");
+  }
+
+  private async _loadElementConfig() {
+    const conf = yaml.safeLoad(this._cardConfig);
+    const elClass = customElements.get(`hui-${conf.type}-card`);
+    const element = document.createElement(`hui-${conf.type}-card`);
+
+    try {
+      console.log(this.hass);
+      console.log(conf);
+
+      this._elementConfig = (element as any).getElementConfig(conf, this.hass);
+    } catch (err) {
+      // No Element Config Function on Element
+      this._showUIEditor = false;
+      return;
+    }
   }
 
   private async _updateConfig() {

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -105,7 +105,7 @@ export class HuiDialogEditCard extends LitElement {
             @click="${this._closeDialog}"
           >Cancel</paper-button>
           <paper-button
-            @click="${this._UpdateConfigInBackend}"'
+            @click="${this._updateConfigInBackend}"'
           >Save</paper-button>
         </div>
       </paper-dialog>
@@ -173,6 +173,7 @@ export class HuiDialogEditCard extends LitElement {
       configElement = await elClass.getConfigElement();
     } catch (err) {
       this._configElement = null;
+      return;
     }
 
     configElement.setConfig(conf);
@@ -187,7 +188,7 @@ export class HuiDialogEditCard extends LitElement {
     fireEvent(this._dialog, "iron-resize");
   }
 
-  private async _UpdateConfigInBackend(): Promise<void> {
+  private async _updateConfigInBackend(): Promise<void> {
     if (this._configValue!.format === "js") {
       this._configValue = {
         format: "yaml",

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -168,22 +168,20 @@ export class HuiDialogEditCard extends LitElement {
 
     const elClass = customElements.get(tag);
     let configElement;
+
     try {
       configElement = await elClass.getConfigElement();
-      configElement.setConfig(conf);
-      configElement.hass = this.hass;
-      configElement.addEventListener("config-changed", (ev) =>
-        this._handleJSConfigChanged(ev.detail.config)
-      );
-      this._configValue = { format: "js", value: conf };
-      this._configElement = configElement;
     } catch (err) {
-      if (!(err instanceof TypeError)) {
-        // tslint:disable-next-line:no-console
-        console.error(err);
-      }
       this._configElement = null;
     }
+
+    configElement.setConfig(conf);
+    configElement.hass = this.hass;
+    configElement.addEventListener("config-changed", (ev) =>
+      this._handleJSConfigChanged(ev.detail.config)
+    );
+    this._configValue = { format: "js", value: conf };
+    this._configElement = configElement;
 
     // This will center the dialog with the updated config Element
     fireEvent(this._dialog, "iron-resize");

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -1,7 +1,7 @@
 import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
 import yaml from "js-yaml";
+import { until } from "lit-html/directives/until";
 
-import "@polymer/paper-checkbox/paper-checkbox.js";
 import "@polymer/paper-button/paper-button.js";
 import "@polymer/paper-input/paper-textarea.js";
 import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable.js";
@@ -103,6 +103,16 @@ export class HuiDialogEditCard extends LitElement {
     this._previewEl.yaml = ev.detail.yaml;
   }
 
+  private _handleConfigChanged(ev) {
+    console.log("Config Changed");
+
+    if (!this._previewEl) {
+      return;
+    }
+
+    this._previewEl.config = ev.detail.config;
+  }
+
   private _closeDialog() {
     this._dialog.close();
   }
@@ -139,8 +149,11 @@ export class HuiDialogEditCard extends LitElement {
       this._showUIEditor = false;
       return;
     }
-    this._elementConfig!.setConfig(conf);
-    this._elementConfig!.hass = this.hass;
+    this._elementConfig.setConfig(conf);
+    this._elementConfig.hass = this.hass;
+    this._elementConfig.addEventListener("config-changed", (ev) =>
+      this._handleConfigChanged(ev)
+    );
   }
 
   private async _updateConfig() {

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -19,6 +19,7 @@ import "./hui-yaml-card-preview";
 // tslint:disable-next-line
 import { HuiYAMLCardPreview } from "./hui-yaml-card-preview";
 import { LovelaceCardEditor, LovelaceConfig } from "../types";
+import { TemplateResult } from "lit-html";
 
 export class HuiDialogEditCard extends LitElement {
   protected hass?: HomeAssistant;
@@ -62,7 +63,7 @@ export class HuiDialogEditCard extends LitElement {
     return this.shadowRoot!.querySelector("hui-yaml-card-preview")!;
   }
 
-  protected render() {
+  protected render(): TemplateResult {
     return html`
       <style>
         paper-dialog {
@@ -108,13 +109,13 @@ export class HuiDialogEditCard extends LitElement {
     `;
   }
 
-  protected updated() {
+  protected updated(): void {
     // This will center the dialog with the updated config
     fireEvent(this._dialog, "iron-resize");
   }
 
-  private _handleYamlChanged(ev) {
-    this._handleConfigChanged("yaml", ev.detail.yaml);
+  private _handleYamlChanged(ev: MouseEvent): void {
+    this._handleConfigChanged("yaml", (ev.detail as any).yaml);
   }
 
   private _handleConfigChanged(
@@ -177,7 +178,7 @@ export class HuiDialogEditCard extends LitElement {
     this._elementConfig = elementConfig;
   }
 
-  private async _updateConfig() {
+  private async _updateConfig(): Promise<void> {
     try {
       await updateCardConfig(this.hass!, this._cardId!, this._cardConfig);
       this._dialog.close();

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -178,16 +178,6 @@ export class HuiDialogEditCard extends LitElement {
   }
 
   private async _updateConfig() {
-    const newCardConfig = this.shadowRoot!.querySelector("hui-yaml-editor")!
-      .yaml;
-
-    // if (this._cardConfig === newCardConfig) {
-    //   this._dialog.close();
-    //   return;
-    // }
-    console.log(this._cardConfig);
-    console.log(newCardConfig);
-
     try {
       await updateCardConfig(this.hass!, this._cardId!, this._cardConfig);
       this._dialog.close();

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -48,17 +48,17 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
       ></paper-input>
       ${this._configEntities!.map((entityConf) =>
         this.renderEntity(entityConf)
-      )}
+      )}<br>
       <paper-checkbox
         id="show_name"
         @change="${this._valueChanged}"
         ?checked="${this._config.show_name !== false}"
-      >Show Entity's Name?</paper-checkbox>
+      >Show Entity's Name?</paper-checkbox><br><br>
       <paper-checkbox
         id="show_state"
         @change="${this._valueChanged}"
         ?checked="${this._config.show_state !== false}"
-      >Show Entity's state-text?</paper-checkbox>
+      >Show Entity's State Text?</paper-checkbox><br>
     `;
   }
 

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -1,0 +1,85 @@
+import { html, LitElement } from "@polymer/lit-element";
+import processConfigEntities from "../common/process-config-entities";
+
+import "../../../components/entity/state-badge.js";
+import "../../../components/ha-card.js";
+import "../../../components/ha-icon.js";
+
+import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
+import { HomeAssistant } from "../../../types.js";
+import { LovelaceConfig, LovelaceCardEditor } from "../types.js";
+
+interface EntityConfig {
+  name: string;
+  icon: string;
+  entity: string;
+  tap_action: "toggle" | "call-service" | "more-info";
+  hold_action?: "toggle" | "call-service" | "more-info";
+  service?: string;
+  service_data?: object;
+}
+
+interface Config extends LovelaceConfig {
+  show_name?: boolean;
+  show_state?: boolean;
+  title?: string;
+  theme?: string;
+  entities: EntityConfig[];
+  columns?: number;
+}
+
+export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
+  implements LovelaceCardEditor {
+  public hass?: HomeAssistant;
+  protected _config?: Config;
+  protected _configEntities?: EntityConfig[];
+
+  static get properties() {
+    return {
+      hass: {},
+      _config: {},
+    };
+  }
+
+  public setConfig(config: Config) {
+    this._config = config;
+    const entities = processConfigEntities(config.entities);
+
+    this._configEntities = entities;
+  }
+
+  protected render() {
+    if (!this._config || !this.hass) {
+      return html``;
+    }
+
+    return html`
+      <paper-input label="Title" value="${this._config.title}"></paper-input>
+      ${this._configEntities!.map((entityConf) =>
+        this.renderEntity(entityConf)
+      )}
+      <paper-checkbox ?checked="${this._config.show_name !==
+        false}">Show Entity's Name?</paper-checkbox>
+      <paper-checkbox ?checked="${this._config.show_state !==
+        false}">Show Entity's state-text?</paper-checkbox>
+    `;
+  }
+
+  private renderEntity(entityConf) {
+    return html`
+        <ha-entity-picker
+            hass="${this.hass}"
+            value="${entityConf.entity || entityConf}"
+            allow-custom-entity
+        ></ha-entity-picker>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-glance-card-editor": HuiGlanceCardEditor;
+  }
+}
+
+customElements.define("hui-glance-card-editor", HuiGlanceCardEditor);

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -79,7 +79,6 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
 
     const target = ev.target! as any;
 
-    // Paper-checkbox's use Checked, Their value is always "on" /shrug
     const newValue =
       target.checked !== undefined ? target.checked : target.value;
 

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -1,13 +1,15 @@
 import { html, LitElement } from "@polymer/lit-element";
+import "@polymer/paper-checkbox/paper-checkbox.js";
+
 import processConfigEntities from "../common/process-config-entities";
+import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
+import { HomeAssistant } from "../../../types.js";
+import { LovelaceConfig, LovelaceCardEditor } from "../types.js";
+import { fireEvent } from "../../../common/dom/fire_event.js";
 
 import "../../../components/entity/state-badge.js";
 import "../../../components/ha-card.js";
 import "../../../components/ha-icon.js";
-
-import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
-import { HomeAssistant } from "../../../types.js";
-import { LovelaceConfig, LovelaceCardEditor } from "../types.js";
 
 interface EntityConfig {
   name: string;
@@ -54,25 +56,53 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     }
 
     return html`
-      <paper-input label="Title" value="${this._config.title}"></paper-input>
+      <paper-input
+        id="title"
+        @value-changed="${this._valueChanged}"
+        label="Title"
+        value="${this._config.title}"
+      ></paper-input>
       ${this._configEntities!.map((entityConf) =>
         this.renderEntity(entityConf)
       )}
-      <paper-checkbox ?checked="${this._config.show_name !==
-        false}">Show Entity's Name?</paper-checkbox>
-      <paper-checkbox ?checked="${this._config.show_state !==
-        false}">Show Entity's state-text?</paper-checkbox>
+      <paper-checkbox
+        id="show_name"
+        @change="${this._valueChanged}"
+        ?checked="${this._config.show_name !== false}"
+      >Show Entity's Name?</paper-checkbox>
+      <paper-checkbox
+        id="show_state"
+        @change="${this._valueChanged}"
+        ?checked="${this._config.show_state !== false}"
+      >Show Entity's state-text?</paper-checkbox>
     `;
   }
 
   private renderEntity(entityConf) {
     return html`
-        <ha-entity-picker
-            hass="${this.hass}"
-            value="${entityConf.entity || entityConf}"
-            allow-custom-entity
-        ></ha-entity-picker>
+      <ha-entity-picker
+        hass="${this.hass}"
+        value="${entityConf.entity || entityConf}"
+        allow-custom-entity
+      ></ha-entity-picker>
     `;
+  }
+
+  private _valueChanged(ev) {
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    // Paper-checkbox's use Checked, Their value is always "on" /shrug
+    const newValue =
+      ev.target.checked !== undefined ? ev.target.checked : ev.target.value;
+
+    // Unsure why I could not grab a propery value ".configValue='show_name'" and ev.target.configValue wasnt working
+    this._config[ev.target.id] = newValue;
+
+    fireEvent(this, "config-changed", {
+      config: this._config,
+    });
   }
 }
 

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement } from "@polymer/lit-element";
+import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
 import "@polymer/paper-checkbox/paper-checkbox.js";
 
 import processConfigEntities from "../common/process-config-entities";
@@ -12,6 +12,7 @@ import "../../../components/entity/state-badge.js";
 import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-card.js";
 import "../../../components/ha-icon.js";
+import { TemplateResult } from "lit-html";
 
 export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCardEditor {
@@ -19,21 +20,21 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
   private _config?: Config;
   private _configEntities?: EntityConfig[];
 
-  static get properties() {
+  static get properties(): PropertyDeclarations {
     return {
       hass: {},
       _config: {},
     };
   }
 
-  public setConfig(config: Config) {
+  public setConfig(config: Config): void {
     this._config = config;
     const entities = processConfigEntities(config.entities);
 
     this._configEntities = entities;
   }
 
-  protected render() {
+  protected render(): TemplateResult {
     if (!this._config || !this.hass) {
       return html``;
     }
@@ -61,7 +62,7 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     `;
   }
 
-  private renderEntity(entityConf) {
+  private renderEntity(entityConf: EntityConfig): TemplateResult {
     return html`
       <ha-entity-picker
         hass="${this.hass}"
@@ -71,17 +72,19 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     `;
   }
 
-  private _valueChanged(ev) {
+  private _valueChanged(ev: MouseEvent): void {
     if (!this._config || !this.hass) {
       return;
     }
 
+    const target = ev.target! as any;
+
     // Paper-checkbox's use Checked, Their value is always "on" /shrug
     const newValue =
-      ev.target.checked !== undefined ? ev.target.checked : ev.target.value;
+      target.checked !== undefined ? target.checked : target.value;
 
     // Unsure why I could not grab a propery value ".configValue='show_name'" and ev.target.configValue wasnt working
-    this._config[ev.target.id] = newValue;
+    this._config[target.id] = newValue;
 
     fireEvent(this, "config-changed", {
       config: this._config,

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -1,24 +1,22 @@
 import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
+import { TemplateResult } from "lit-html";
 import "@polymer/paper-checkbox/paper-checkbox.js";
 
-import processConfigEntities from "../common/process-config-entities";
 import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
 import { HomeAssistant } from "../../../types.js";
 import { LovelaceCardEditor } from "../types.js";
 import { fireEvent } from "../../../common/dom/fire_event.js";
-import { Config, EntityConfig } from "../cards/hui-glance-card";
+import { Config } from "../cards/hui-glance-card";
 
 import "../../../components/entity/state-badge.js";
 import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-card.js";
 import "../../../components/ha-icon.js";
-import { TemplateResult } from "lit-html";
 
 export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCardEditor {
   public hass?: HomeAssistant;
   private _config?: Config;
-  private _configEntities?: EntityConfig[];
 
   static get properties(): PropertyDeclarations {
     return {
@@ -28,47 +26,31 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
   }
 
   public setConfig(config: Config): void {
-    this._config = config;
-    const entities = processConfigEntities(config.entities);
-
-    this._configEntities = entities;
+    this._config = { type: "glance", ...config };
   }
 
   protected render(): TemplateResult {
-    if (!this._config || !this.hass) {
+    if (!this.hass) {
       return html``;
     }
 
     return html`
       <paper-input
-        id="title"
-        @value-changed="${this._valueChanged}"
         label="Title"
-        value="${this._config.title}"
-      ></paper-input>
-      ${this._configEntities!.map((entityConf) =>
-        this.renderEntity(entityConf)
-      )}<br>
+        value="${this._config!.title}"
+        .configValue=${"title"}
+        @value-changed="${this._valueChanged}"
+      ></paper-input><br>
       <paper-checkbox
-        id="show_name"
+        ?checked="${this._config!.show_name !== false}"
+        .configValue=${"show_name"}
         @change="${this._valueChanged}"
-        ?checked="${this._config.show_name !== false}"
       >Show Entity's Name?</paper-checkbox><br><br>
       <paper-checkbox
-        id="show_state"
+        ?checked="${this._config!.show_state !== false}"
+        .configValue=${"show_state"}
         @change="${this._valueChanged}"
-        ?checked="${this._config.show_state !== false}"
       >Show Entity's State Text?</paper-checkbox><br>
-    `;
-  }
-
-  private renderEntity(entityConf: EntityConfig): TemplateResult {
-    return html`
-      <ha-entity-picker
-        hass="${this.hass}"
-        value="${entityConf.entity || entityConf}"
-        allow-custom-entity
-      ></ha-entity-picker>
     `;
   }
 
@@ -82,11 +64,8 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     const newValue =
       target.checked !== undefined ? target.checked : target.value;
 
-    // Unsure why I could not grab a propery value ".configValue='show_name'" and ev.target.configValue wasnt working
-    this._config[target.id] = newValue;
-
     fireEvent(this, "config-changed", {
-      config: this._config,
+      config: { ...this._config, [target.configValue]: newValue },
     });
   }
 }

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -4,37 +4,19 @@ import "@polymer/paper-checkbox/paper-checkbox.js";
 import processConfigEntities from "../common/process-config-entities";
 import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
 import { HomeAssistant } from "../../../types.js";
-import { LovelaceConfig, LovelaceCardEditor } from "../types.js";
+import { LovelaceCardEditor } from "../types.js";
 import { fireEvent } from "../../../common/dom/fire_event.js";
+import { Config, EntityConfig } from "../cards/hui-glance-card";
 
 import "../../../components/entity/state-badge.js";
 import "../../../components/ha-card.js";
 import "../../../components/ha-icon.js";
 
-interface EntityConfig {
-  name: string;
-  icon: string;
-  entity: string;
-  tap_action: "toggle" | "call-service" | "more-info";
-  hold_action?: "toggle" | "call-service" | "more-info";
-  service?: string;
-  service_data?: object;
-}
-
-interface Config extends LovelaceConfig {
-  show_name?: boolean;
-  show_state?: boolean;
-  title?: string;
-  theme?: string;
-  entities: EntityConfig[];
-  columns?: number;
-}
-
 export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCardEditor {
   public hass?: HomeAssistant;
-  protected _config?: Config;
-  protected _configEntities?: EntityConfig[];
+  private _config?: Config;
+  private _configEntities?: EntityConfig[];
 
   static get properties() {
     return {

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -9,6 +9,7 @@ import { fireEvent } from "../../../common/dom/fire_event.js";
 import { Config, EntityConfig } from "../cards/hui-glance-card";
 
 import "../../../components/entity/state-badge.js";
+import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-card.js";
 import "../../../components/ha-icon.js";
 

--- a/src/panels/lovelace/editor/hui-yaml-card-preview.ts
+++ b/src/panels/lovelace/editor/hui-yaml-card-preview.ts
@@ -41,6 +41,25 @@ export class HuiYAMLCardPreview extends HTMLElement {
 
     this.appendChild(element);
   }
+
+  // Set to type any for now. Need to add Config type
+  set config(config: any) {
+    if (!config) {
+      return;
+    }
+
+    if (this.lastChild) {
+      this.removeChild(this.lastChild);
+    }
+
+    const element = createCardElement(config);
+
+    if (this._hass) {
+      element.hass = this._hass;
+    }
+
+    this.appendChild(element);
+  }
 }
 
 declare global {

--- a/src/panels/lovelace/editor/hui-yaml-card-preview.ts
+++ b/src/panels/lovelace/editor/hui-yaml-card-preview.ts
@@ -1,13 +1,12 @@
-import yaml from "js-yaml";
 import "@polymer/paper-input/paper-textarea";
 
 import createCardElement from "../common/create-card-element";
-import createErrorCardConfig from "../common/create-error-card-config";
 import { HomeAssistant } from "../../../types";
-import { LovelaceCard } from "../types";
+import { LovelaceCard, LovelaceConfig } from "../types";
 
 export class HuiYAMLCardPreview extends HTMLElement {
   private _hass?: HomeAssistant;
+  private _config?: LovelaceConfig;
 
   set hass(value: HomeAssistant) {
     this._hass = value;
@@ -16,29 +15,27 @@ export class HuiYAMLCardPreview extends HTMLElement {
     }
   }
 
-  set yaml(value: string) {
+  set config(config: LovelaceConfig) {
     if (this.lastChild) {
       this.removeChild(this.lastChild);
     }
 
-    if (value === "") {
+    if (!config) {
       return;
     }
 
-    let conf;
-    try {
-      conf = yaml.safeLoad(value);
-    } catch (err) {
-      conf = createErrorCardConfig(`Invalid YAML: ${err.message}`, undefined);
-    }
-
-    const element = createCardElement(conf);
+    const element = createCardElement(config);
 
     if (this._hass) {
       element.hass = this._hass;
     }
 
     this.appendChild(element);
+    this._config = config;
+  }
+
+  get config() {
+    return this._config!;
   }
 }
 

--- a/src/panels/lovelace/editor/hui-yaml-card-preview.ts
+++ b/src/panels/lovelace/editor/hui-yaml-card-preview.ts
@@ -1,12 +1,15 @@
+import yaml from "js-yaml";
+
 import "@polymer/paper-input/paper-textarea";
 
 import createCardElement from "../common/create-card-element";
+import createErrorCardConfig from "../common/create-error-card-config";
 import { HomeAssistant } from "../../../types";
-import { LovelaceCard, LovelaceConfig } from "../types";
+import { LovelaceCard } from "../types";
+import { ConfigValue } from "./types";
 
 export class HuiYAMLCardPreview extends HTMLElement {
   private _hass?: HomeAssistant;
-  private _config?: LovelaceConfig;
 
   set hass(value: HomeAssistant) {
     this._hass = value;
@@ -15,27 +18,33 @@ export class HuiYAMLCardPreview extends HTMLElement {
     }
   }
 
-  set config(config: LovelaceConfig) {
+  set value(configValue: ConfigValue) {
     if (this.lastChild) {
       this.removeChild(this.lastChild);
     }
 
-    if (!config) {
+    if (!configValue.value || configValue.value === "") {
       return;
     }
 
-    const element = createCardElement(config);
+    let conf;
+    if (configValue.format === "yaml") {
+      try {
+        conf = yaml.safeLoad(configValue.value);
+      } catch (err) {
+        conf = createErrorCardConfig(`Invalid YAML: ${err.message}`, undefined);
+      }
+    } else {
+      conf = configValue.value;
+    }
+
+    const element = createCardElement(conf);
 
     if (this._hass) {
       element.hass = this._hass;
     }
 
     this.appendChild(element);
-    this._config = config;
-  }
-
-  get config() {
-    return this._config!;
   }
 }
 

--- a/src/panels/lovelace/editor/hui-yaml-card-preview.ts
+++ b/src/panels/lovelace/editor/hui-yaml-card-preview.ts
@@ -1,12 +1,10 @@
 import yaml from "js-yaml";
-
 import "@polymer/paper-input/paper-textarea";
 
 import createCardElement from "../common/create-card-element";
 import createErrorCardConfig from "../common/create-error-card-config";
 import { HomeAssistant } from "../../../types";
 import { LovelaceCard } from "../types";
-import { ConfigValue } from "./types";
 
 export class HuiYAMLCardPreview extends HTMLElement {
   private _hass?: HomeAssistant;
@@ -18,24 +16,20 @@ export class HuiYAMLCardPreview extends HTMLElement {
     }
   }
 
-  set value(configValue: ConfigValue) {
+  set yaml(value: string) {
     if (this.lastChild) {
       this.removeChild(this.lastChild);
     }
 
-    if (configValue.value === "") {
+    if (value === "") {
       return;
     }
 
     let conf;
-    if (configValue.format === "yaml") {
-      try {
-        conf = yaml.safeLoad(configValue.value);
-      } catch (err) {
-        conf = createErrorCardConfig(`Invalid YAML: ${err.message}`, undefined);
-      }
-    } else {
-      conf = configValue.value;
+    try {
+      conf = yaml.safeLoad(value);
+    } catch (err) {
+      conf = createErrorCardConfig(`Invalid YAML: ${err.message}`, undefined);
     }
 
     const element = createCardElement(conf);

--- a/src/panels/lovelace/editor/hui-yaml-card-preview.ts
+++ b/src/panels/lovelace/editor/hui-yaml-card-preview.ts
@@ -7,6 +7,11 @@ import createErrorCardConfig from "../common/create-error-card-config";
 import { HomeAssistant } from "../../../types";
 import { LovelaceCard } from "../types";
 
+interface ConfigValue {
+  format: string;
+  value: any;
+}
+
 export class HuiYAMLCardPreview extends HTMLElement {
   private _hass?: HomeAssistant;
 
@@ -53,6 +58,35 @@ export class HuiYAMLCardPreview extends HTMLElement {
     }
 
     const element = createCardElement(config);
+
+    if (this._hass) {
+      element.hass = this._hass;
+    }
+
+    this.appendChild(element);
+  }
+
+  set value(configValue: ConfigValue) {
+    if (this.lastChild) {
+      this.removeChild(this.lastChild);
+    }
+
+    if (configValue.value === "") {
+      return;
+    }
+
+    let conf;
+    if (configValue.format === "yaml") {
+      try {
+        conf = yaml.safeLoad(configValue.value);
+      } catch (err) {
+        conf = createErrorCardConfig(`Invalid YAML: ${err.message}`, undefined);
+      }
+    } else {
+      conf = configValue.value;
+    }
+
+    const element = createCardElement(conf);
 
     if (this._hass) {
       element.hass = this._hass;

--- a/src/panels/lovelace/editor/hui-yaml-card-preview.ts
+++ b/src/panels/lovelace/editor/hui-yaml-card-preview.ts
@@ -6,11 +6,7 @@ import createCardElement from "../common/create-card-element";
 import createErrorCardConfig from "../common/create-error-card-config";
 import { HomeAssistant } from "../../../types";
 import { LovelaceCard } from "../types";
-
-interface ConfigValue {
-  format: string;
-  value: any;
-}
+import { ConfigValue } from "./types";
 
 export class HuiYAMLCardPreview extends HTMLElement {
   private _hass?: HomeAssistant;
@@ -20,50 +16,6 @@ export class HuiYAMLCardPreview extends HTMLElement {
     if (this.lastChild) {
       (this.lastChild as LovelaceCard).hass = value;
     }
-  }
-
-  set yaml(value: string) {
-    if (this.lastChild) {
-      this.removeChild(this.lastChild);
-    }
-
-    if (value === "") {
-      return;
-    }
-
-    let conf;
-    try {
-      conf = yaml.safeLoad(value);
-    } catch (err) {
-      conf = createErrorCardConfig(`Invalid YAML: ${err.message}`, undefined);
-    }
-
-    const element = createCardElement(conf);
-
-    if (this._hass) {
-      element.hass = this._hass;
-    }
-
-    this.appendChild(element);
-  }
-
-  // Set to type any for now. Need to add Config type
-  set config(config: any) {
-    if (!config) {
-      return;
-    }
-
-    if (this.lastChild) {
-      this.removeChild(this.lastChild);
-    }
-
-    const element = createCardElement(config);
-
-    if (this._hass) {
-      element.hass = this._hass;
-    }
-
-    this.appendChild(element);
   }
 
   set value(configValue: ConfigValue) {

--- a/src/panels/lovelace/editor/hui-yaml-editor.ts
+++ b/src/panels/lovelace/editor/hui-yaml-editor.ts
@@ -2,6 +2,7 @@ import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
 import { fireEvent } from "../../../common/dom/fire_event";
 
 import "@polymer/paper-input/paper-textarea";
+import { TemplateResult } from "lit-html";
 
 export class HuiYAMLEditor extends LitElement {
   public yaml?: string;
@@ -12,7 +13,7 @@ export class HuiYAMLEditor extends LitElement {
     };
   }
 
-  protected render() {
+  protected render(): TemplateResult {
     return html`
       <style>
         paper-textarea {
@@ -26,9 +27,10 @@ export class HuiYAMLEditor extends LitElement {
     `;
   }
 
-  private _valueChanged(ev) {
-    this.yaml = ev.target.value;
-    fireEvent(this, "yaml-changed", { yaml: ev.target.value });
+  private _valueChanged(ev: MouseEvent): void {
+    const target = ev.target! as any;
+    this.yaml = target.value;
+    fireEvent(this, "yaml-changed", { yaml: target.value });
   }
 }
 

--- a/src/panels/lovelace/editor/hui-yaml-editor.ts
+++ b/src/panels/lovelace/editor/hui-yaml-editor.ts
@@ -1,8 +1,8 @@
 import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
-import { fireEvent } from "../../../common/dom/fire_event";
-
-import "@polymer/paper-input/paper-textarea";
 import { TemplateResult } from "lit-html";
+import "@polymer/paper-input/paper-textarea";
+
+import { fireEvent } from "../../../common/dom/fire_event";
 
 export class HuiYAMLEditor extends LitElement {
   public yaml?: string;
@@ -21,6 +21,7 @@ export class HuiYAMLEditor extends LitElement {
         }
       </style>
       <paper-textarea
+        max-rows=10
         value="${this.yaml}"
         @value-changed="${this._valueChanged}"
       ></paper-textarea>

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -1,5 +1,12 @@
+import { LovelaceConfig } from "../types";
+
 export interface YamlChangedEvent extends Event {
   detail: {
     yaml: string;
   };
+}
+
+export interface ConfigValue {
+  format: "js" | "yaml";
+  value: string | LovelaceConfig;
 }

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -1,0 +1,4 @@
+export interface ConfigValue {
+  format: string;
+  value: any;
+}

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -1,4 +1,5 @@
-export interface ConfigValue {
-  format: string;
-  value: any;
+export interface YamlChangedEvent extends Event {
+  detail: {
+    yaml: string;
+  };
 }

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -9,3 +9,8 @@ export interface LovelaceCard extends HTMLElement {
   getCardSize(): number;
   setConfig(config: LovelaceConfig): void;
 }
+
+export interface LovelaceCardEditor extends HTMLElement {
+  hass?: HomeAssistant;
+  setConfig(config: LovelaceConfig): void;
+}


### PR DESCRIPTION
This is a work in progress and my next step is creating Entity Element. That shows a List Box of entities, Delete Entity button, show options button that then gives options for entities (icon, name, etc)

Creating the PR now so that the implementation can be critiqued. I am going to work on the different Elements for now. Just want to know if I am going about this the correct way. 

- [ ] Add Entity Config Element
    - [ ] Create List box of entities
    - [ ] Add Ability to delete entity
    - [ ] Add Show options toggle
- [ ] Add Theme Config Element
- [x] When Form UI is changed, Update Preview and Config

![Working Example](https://i.gyazo.com/1e8481eebb3fd4a1d11a4beb33edc444.gif)

Fixes #1951 
Fixes #1952 
Fixes #1953 