### PR TITLE
don't compress for CI runs

### DIFF
--- a/hassio/webpack.config.js
+++ b/hassio/webpack.config.js
@@ -4,6 +4,7 @@ const config = require("./config.js");
 const { babelLoaderConfig } = require("../config/babel.js");
 
 const isProdBuild = process.env.NODE_ENV === "production";
+const isCI = process.env.CI === "true";
 const chunkFilename = isProdBuild ? "chunk.[chunkhash].js" : "[name].chunk.js";
 
 module.exports = {
@@ -37,6 +38,7 @@ module.exports = {
         },
       }),
     isProdBuild &&
+      isCI &&
       new CompressionPlugin({
         cache: true,
         exclude: [/\.js\.map$/, /\.LICENSE$/, /\.py$/, /\.txt$/],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ if (!version) {
   throw Error("Version not found");
 }
 const VERSION = version[0];
+const isCI = process.env.CI === "true";
 
 const generateJSPage = (entrypoint, latestBuild) => {
   return new HtmlWebpackPlugin({
@@ -159,6 +160,7 @@ function createConfig(isProdBuild, latestBuild) {
         path.resolve(__dirname, "src/util/empty.js")
       ),
       isProdBuild &&
+        !isCI &&
         new CompressionPlugin({
           cache: true,
           exclude: [/\.js\.map$/, /\.LICENSE$/, /\.py$/, /\.txt$/],


### PR DESCRIPTION
The compression plugin is effective but also slows down builds a lot. No need to run compression on each CI build, so disabling it on CI.

- Old runtime of CI: 13m12s
- New runtime of CI: 8m25s