### PR TITLE
Make conditional not take up space in stacks when hidden

### DIFF
--- a/src/panels/lovelace/cards/hui-conditional-card.ts
+++ b/src/panels/lovelace/cards/hui-conditional-card.ts
@@ -67,6 +67,7 @@ class HuiConditionalCard extends HTMLElement implements LovelaceCard {
     } else if (this._card.parentElement) {
       this.removeChild(this._card);
     }
+    this.style.setProperty("display", visible ? "" : "none");
   }
 
   public getCardSize() {

--- a/src/panels/lovelace/cards/hui-conditional-card.ts
+++ b/src/panels/lovelace/cards/hui-conditional-card.ts
@@ -67,6 +67,7 @@ class HuiConditionalCard extends HTMLElement implements LovelaceCard {
     } else if (this._card.parentElement) {
       this.removeChild(this._card);
     }
+    // This will hide the complete card so it won't get styled by parent
     this.style.setProperty("display", visible ? "" : "none");
   }
 


### PR DESCRIPTION
Conditional left a gap between cards when hidden if in a vertical-stack.
Restoring old solution.