### PR TITLE
Glance Card Editor

### DIFF
--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -24,10 +24,10 @@ import "../../../components/ha-card";
 import "../../../components/ha-icon";
 
 export interface EntityConfig {
-  name: string;
-  icon: string;
+  name?: string;
+  icon?: string;
   entity: string;
-  tap_action: "toggle" | "call-service" | "more-info";
+  tap_action?: "toggle" | "call-service" | "more-info";
   hold_action?: "toggle" | "call-service" | "more-info";
   service?: string;
   service_data?: object;

--- a/src/panels/lovelace/components/hui-entity-editor.ts
+++ b/src/panels/lovelace/components/hui-entity-editor.ts
@@ -7,6 +7,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { EntityConfig } from "../entity-rows/types";
 
 import "../../../components/entity/ha-entity-picker";
+import { EditorTarget } from "../editor/types";
 
 export class HuiEntityEditor extends LitElement {
   protected hass?: HomeAssistant;
@@ -42,7 +43,6 @@ export class HuiEntityEditor extends LitElement {
           })
         }
       </div>
-      <br />
       <paper-button noink raised @click="${this._addEntity}"
         >Add Entity</paper-button
       >
@@ -50,21 +50,22 @@ export class HuiEntityEditor extends LitElement {
   }
 
   private _addEntity() {
-    const newConfigEntities = this.entities!.concat();
-
-    newConfigEntities.push({ entity: "" });
+    const newConfigEntities = this.entities!.concat({ entity: "" });
 
     fireEvent(this, "change", { entities: newConfigEntities });
   }
 
-  private _valueChanged(ev): void {
-    const target = ev.target! as any;
+  private _valueChanged(ev: Event): void {
+    const target = ev.target! as EditorTarget;
     const newConfigEntities = this.entities!.concat();
 
     if (target.value === "") {
-      newConfigEntities.splice(target.index, 1);
+      newConfigEntities.splice(target.index!, 1);
     } else {
-      newConfigEntities[target.index].entity = target.value;
+      newConfigEntities[target.index!] = {
+        ...newConfigEntities[target.index!],
+        entity: target.value!,
+      };
     }
 
     fireEvent(this, "change", { entities: newConfigEntities });
@@ -75,6 +76,9 @@ export class HuiEntityEditor extends LitElement {
       <style>
         .entities {
           padding-left: 20px;
+        }
+        paper-button {
+          margin: 8px 0;
         }
       </style>
     `;

--- a/src/panels/lovelace/components/hui-entity-editor.ts
+++ b/src/panels/lovelace/components/hui-entity-editor.ts
@@ -1,0 +1,91 @@
+import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
+import "@polymer/paper-button/paper-button";
+import { TemplateResult } from "lit-html";
+
+import { HomeAssistant } from "../../../types";
+import { fireEvent } from "../../../common/dom/fire_event";
+import { EntityConfig } from "../entity-rows/types";
+
+import "../../../components/entity/ha-entity-picker";
+
+export class HuiEntityEditor extends LitElement {
+  protected hass?: HomeAssistant;
+  protected entities?: EntityConfig[];
+
+  static get properties(): PropertyDeclarations {
+    return {
+      hass: {},
+      entities: {},
+    };
+  }
+
+  protected render(): TemplateResult {
+    if (!this.entities) {
+      return html``;
+    }
+
+    return html`
+      ${this.renderStyle()}
+      <h3>Entities</h3>
+      <div class="entities">
+        ${
+          this.entities.map((entityConf, index) => {
+            return html`
+              <ha-entity-picker
+                .hass="${this.hass}"
+                .value="${entityConf.entity}"
+                .index="${index}"
+                @change="${this._valueChanged}"
+                allow-custom-entity
+              ></ha-entity-picker>
+            `;
+          })
+        }
+      </div>
+      <br />
+      <paper-button noink raised @click="${this._addEntity}"
+        >Add Entity</paper-button
+      >
+    `;
+  }
+
+  private _addEntity() {
+    const newConfigEntities = this.entities!.concat();
+
+    newConfigEntities.push({ entity: " " });
+    this.entities = newConfigEntities;
+
+    fireEvent(this, "change", { entities: newConfigEntities });
+  }
+
+  private _valueChanged(ev): void {
+    const target = ev.target! as any;
+    const newConfigEntities = this.entities!.concat();
+
+    if (target.value === "") {
+      newConfigEntities.splice(target.index, 1);
+    } else {
+      newConfigEntities[target.index].entity = target.value;
+    }
+
+    fireEvent(this, "change", { entities: newConfigEntities });
+  }
+
+  private renderStyle(): TemplateResult {
+    return html`
+      <style>
+        .entities {
+          padding-left: 20px;
+        }
+      </style>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-entity-editor": HuiEntityEditor;
+  }
+}
+
+customElements.define("hui-entity-editor", HuiEntityEditor);

--- a/src/panels/lovelace/components/hui-entity-editor.ts
+++ b/src/panels/lovelace/components/hui-entity-editor.ts
@@ -52,8 +52,7 @@ export class HuiEntityEditor extends LitElement {
   private _addEntity() {
     const newConfigEntities = this.entities!.concat();
 
-    newConfigEntities.push({ entity: " " });
-    this.entities = newConfigEntities;
+    newConfigEntities.push({ entity: "" });
 
     fireEvent(this, "change", { entities: newConfigEntities });
   }

--- a/src/panels/lovelace/components/hui-theme-select-editor.ts
+++ b/src/panels/lovelace/components/hui-theme-select-editor.ts
@@ -24,13 +24,12 @@ export class HuiThemeSelectionEditor extends hassLocalizeLitMixin(LitElement) {
     return html`
       ${this.renderStyle()}
       <paper-dropdown-menu
-        label="${this.localize("ui.panel.profile.themes.dropdown_label")}"
         dynamic-align
-        @value-changed="${this._changed}"
+        @value-changed=${this._changed}
       >
         <paper-listbox
           slot="dropdown-content"
-          selected="${this.value || "Backend-selected"}"
+          selected=${this.value || "Backend-selected"}
           attr-for-selected="theme"
         >
           ${themes.map((theme) => {

--- a/src/panels/lovelace/components/hui-theme-select-editor.ts
+++ b/src/panels/lovelace/components/hui-theme-select-editor.ts
@@ -7,8 +7,8 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
 
 export class HuiThemeSelectionEditor extends hassLocalizeLitMixin(LitElement) {
+  public value?: string;
   protected hass?: HomeAssistant;
-  private value?: string;
 
   static get properties(): PropertyDeclarations {
     return {
@@ -21,9 +21,11 @@ export class HuiThemeSelectionEditor extends hassLocalizeLitMixin(LitElement) {
     const themes = ["Backend-selected", "default"].concat(
       Object.keys(this.hass!.themes.themes).sort()
     );
+
     return html`
       ${this.renderStyle()}
       <paper-dropdown-menu
+        label="Theme"
         dynamic-align
         @value-changed=${this._changed}
       >

--- a/src/panels/lovelace/components/hui-theme-select-editor.ts
+++ b/src/panels/lovelace/components/hui-theme-select-editor.ts
@@ -1,0 +1,66 @@
+import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
+import "@polymer/paper-button/paper-button";
+import { TemplateResult } from "lit-html";
+
+import { HomeAssistant } from "../../../types";
+import { fireEvent } from "../../../common/dom/fire_event";
+import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
+
+export class HuiThemeSelectionEditor extends hassLocalizeLitMixin(LitElement) {
+  protected hass?: HomeAssistant;
+  private value?: string;
+
+  static get properties(): PropertyDeclarations {
+    return {
+      hass: {},
+      value: {},
+    };
+  }
+
+  protected render(): TemplateResult {
+    const themes = ["Backend-selected", "default"].concat(
+      Object.keys(this.hass!.themes.themes).sort()
+    );
+    return html`
+      ${this.renderStyle()}
+      <paper-dropdown-menu
+        label="${this.localize("ui.panel.profile.themes.dropdown_label")}"
+        dynamic-align
+        @value-changed="${this._changed}"
+      >
+        <paper-listbox
+          slot="dropdown-content"
+          selected="${this.value || "Backend-selected"}"
+          attr-for-selected="theme"
+        >
+          ${themes.map((theme) => {
+            return html`<paper-item .theme=${theme}>${theme}</paper-item>`;
+          })}
+        </paper-listbox>
+      </paper-dropdown-menu>
+    `;
+  }
+
+  private renderStyle(): TemplateResult {
+    return html`
+      <style>
+        paper-dropdown-menu {
+          width: 100%;
+        }
+      </style>
+    `;
+  }
+
+  private _changed(ev): void {
+    this.value = ev.target.value;
+    fireEvent(this, "change");
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-theme-select-editor": HuiThemeSelectionEditor;
+  }
+}
+
+customElements.define("hui-theme-select-editor", HuiThemeSelectionEditor);

--- a/src/panels/lovelace/components/hui-theme-select-editor.ts
+++ b/src/panels/lovelace/components/hui-theme-select-editor.ts
@@ -31,13 +31,13 @@ export class HuiThemeSelectionEditor extends hassLocalizeLitMixin(LitElement) {
       >
         <paper-listbox
           slot="dropdown-content"
-          .sselected="${this.value || "Backend-selected"}"
-          .attrForSelected="theme"
+          .selected="${this.value || "Backend-selected"}"
+          attr-for-selected="theme"
         >
           ${
             themes.map((theme) => {
               return html`
-                <paper-item .theme="${theme}">${theme}</paper-item>
+                <paper-item theme="${theme}">${theme}</paper-item>
               `;
             })
           }

--- a/src/panels/lovelace/components/hui-theme-select-editor.ts
+++ b/src/panels/lovelace/components/hui-theme-select-editor.ts
@@ -27,16 +27,20 @@ export class HuiThemeSelectionEditor extends hassLocalizeLitMixin(LitElement) {
       <paper-dropdown-menu
         label="Theme"
         dynamic-align
-        @value-changed=${this._changed}
+        @value-changed="${this._changed}"
       >
         <paper-listbox
           slot="dropdown-content"
-          selected=${this.value || "Backend-selected"}
+          selected="${this.value || "Backend-selected"}"
           attr-for-selected="theme"
         >
-          ${themes.map((theme) => {
-            return html`<paper-item .theme=${theme}>${theme}</paper-item>`;
-          })}
+          ${
+            themes.map((theme) => {
+              return html`
+                <paper-item .theme="${theme}">${theme}</paper-item>
+              `;
+            })
+          }
         </paper-listbox>
       </paper-dropdown-menu>
     `;

--- a/src/panels/lovelace/components/hui-theme-select-editor.ts
+++ b/src/panels/lovelace/components/hui-theme-select-editor.ts
@@ -31,8 +31,8 @@ export class HuiThemeSelectionEditor extends hassLocalizeLitMixin(LitElement) {
       >
         <paper-listbox
           slot="dropdown-content"
-          selected="${this.value || "Backend-selected"}"
-          attr-for-selected="theme"
+          .sselected="${this.value || "Backend-selected"}"
+          .attrForSelected="theme"
         >
           ${
             themes.map((theme) => {

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -83,14 +83,16 @@ export class HuiDialogEditCard extends LitElement {
             this._editorToggle && this._configElement !== null
               ? html`
                   <div class="element-editor">
-                    ${when(
-                      this._configElement,
-                      () => this._configElement,
-                      () =>
-                        html`
+                    ${
+                      when(
+                        this._configElement,
+                        () => this._configElement,
+                        () =>
+                          html`
                             Loading...
                           `
-                    )}
+                      )
+                    }
                   </div>
                 `
               : html`
@@ -101,20 +103,18 @@ export class HuiDialogEditCard extends LitElement {
                 `
           }
           <hui-yaml-card-preview
-            .hass=${this.hass}
-            .value=${this._configValue}
+            .hass="${this.hass}"
+            .value="${this._configValue}"
           ></hui-yaml-card-preview>
         </paper-dialog-scrollable>
         <div class="paper-dialog-buttons">
-          <paper-button
-            @click=${this._toggleEditor}
-          >Toggle Editor</paper-button>
-          <paper-button
-            @click=${this._closeDialog}
-          >Cancel</paper-button>
-          <paper-button
-            @click=${this._updateConfigInBackend}
-          >Save</paper-button>
+          <paper-button @click="${this._toggleEditor}"
+            >Toggle Editor</paper-button
+          >
+          <paper-button @click="${this._closeDialog}">Cancel</paper-button>
+          <paper-button @click="${this._updateConfigInBackend}"
+            >Save</paper-button
+          >
         </div>
       </paper-dialog>
     `;

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -83,16 +83,14 @@ export class HuiDialogEditCard extends LitElement {
             this._editorToggle && this._configElement !== null
               ? html`
                   <div class="element-editor">
-                    ${
-                      when(
-                        this._configElement,
-                        () => this._configElement,
-                        () =>
-                          html`
+                    ${when(
+                      this._configElement,
+                      () => this._configElement,
+                      () =>
+                        html`
                             Loading...
                           `
-                      )
-                    }
+                    )}
                   </div>
                 `
               : html`
@@ -103,19 +101,19 @@ export class HuiDialogEditCard extends LitElement {
                 `
           }
           <hui-yaml-card-preview
-            .hass="${this.hass}"
-            .value="${this._configValue}"
+            .hass=${this.hass}
+            .value=${this._configValue}
           ></hui-yaml-card-preview>
         </paper-dialog-scrollable>
         <div class="paper-dialog-buttons">
           <paper-button
-            @click="${this._toggleEditor}"
+            @click=${this._toggleEditor}
           >Toggle Editor</paper-button>
           <paper-button
-            @click="${this._closeDialog}"
+            @click=${this._closeDialog}
           >Cancel</paper-button>
           <paper-button
-            @click="${this._updateConfigInBackend}"'
+            @click=${this._updateConfigInBackend}
           >Save</paper-button>
         </div>
       </paper-dialog>
@@ -167,6 +165,9 @@ export class HuiDialogEditCard extends LitElement {
       value: cardConfig,
     };
     this._originalConfigYaml = cardConfig;
+
+    // This will center the dialog with the updated config Element
+    fireEvent(this._dialog, "iron-resize");
   }
 
   private async _loadConfigElement(): Promise<void> {

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -6,7 +6,7 @@ import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 
 import { processEditorEntities } from "./process-editor-entities";
-import { EditorEvent } from "./types";
+import { EntitiesEditorEvent, EditorTarget } from "./types";
 import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
 import { HomeAssistant } from "../../../types";
 import { LovelaceCardEditor } from "../types";
@@ -44,26 +44,23 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     }
 
     return html`
+      ${this.renderStyle()}
       <paper-input
         label="Title"
         value="${this._config!.title}"
         .configValue="${"title"}"
-        .type="${"input"}"
         @value-changed="${this._valueChanged}"
       ></paper-input>
       <hui-theme-select-editor
         .hass="${this.hass}"
         .value="${this._config!.theme}"
-        .type="${"input"}"
         .configValue="${"theme"}"
         @change="${this._valueChanged}"
-      ></hui-theme-select-editor
-      ><br />
+      ></hui-theme-select-editor>
       <paper-input
         label="Columns"
         value="${this._config!.columns || ""}"
         .configValue="${"columns"}"
-        .type="${"input"}"
         @value-changed="${this._valueChanged}"
       ></paper-input>
       <hui-entity-editor
@@ -71,30 +68,27 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
         .entities="${this._configEntities}"
         @change="${this._valueChanged}"
       ></hui-entity-editor>
-      <br /><br />
       <paper-checkbox
         ?checked="${this._config!.show_name !== false}"
         .configValue="${"show_name"}"
-        .type="${"checkbox"}"
         @change="${this._valueChanged}"
         >Show Entity's Name?</paper-checkbox
-      ><br /><br />
+      >
       <paper-checkbox
         ?checked="${this._config!.show_state !== false}"
         .configValue="${"show_state"}"
-        .type="${"checkbox"}"
         @change="${this._valueChanged}"
         >Show Entity's State Text?</paper-checkbox
-      ><br />
+      >
     `;
   }
 
-  private _valueChanged(ev: EditorEvent): void {
+  private _valueChanged(ev: EntitiesEditorEvent): void {
     if (!this._config || !this.hass) {
       return;
     }
 
-    const target = ev.target! as any;
+    const target = ev.target! as EditorTarget;
     let newConfig = this._config;
 
     if (ev.detail && ev.detail.entities) {
@@ -102,7 +96,7 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     } else {
       newConfig = {
         ...this._config,
-        [target.configValue]:
+        [target.configValue!]:
           target.checked !== undefined ? target.checked : target.value,
       };
     }
@@ -110,6 +104,17 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     fireEvent(this, "config-changed", {
       config: newConfig,
     });
+  }
+
+  private renderStyle(): TemplateResult {
+    return html`
+      <style>
+        paper-checkbox {
+          display: block;
+          padding-top: 16px;
+        }
+      </style>
+    `;
   }
 }
 

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -18,6 +18,7 @@ import "../components/hui-entity-editor";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
 import { processEditorEntities } from "./process-editor-entities";
+import { EditorEvent } from "./types";
 
 export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCardEditor {
@@ -89,7 +90,7 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     `;
   }
 
-  private _valueChanged(ev: MouseEvent): void {
+  private _valueChanged(ev: EditorEvent): void {
     if (!this._config || !this.hass) {
       return;
     }
@@ -97,14 +98,14 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     const target = ev.target! as any;
     let newConfig = this._config;
 
-    if (!target.entities) {
+    if (ev.detail && ev.detail.entities) {
+      newConfig.entities = ev.detail.entities;
+    } else {
       newConfig = {
         ...this._config,
         [target.configValue]:
           target.checked !== undefined ? target.checked : target.value,
       };
-    } else {
-      newConfig.entities = target.entities;
     }
 
     fireEvent(this, "config-changed", {

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -1,15 +1,20 @@
 import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
 import { TemplateResult } from "lit-html";
 import "@polymer/paper-checkbox/paper-checkbox";
+import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
+import "@polymer/paper-item/paper-item";
+import "@polymer/paper-listbox/paper-listbox";
 
+import processConfigEntities from "../common/process-config-entities";
 import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
 import { HomeAssistant } from "../../../types";
 import { LovelaceCardEditor } from "../types";
 import { fireEvent } from "../../../common/dom/fire_event";
-import { Config } from "../cards/hui-glance-card";
+import { Config, EntityConfig } from "../cards/hui-glance-card";
 
 import "../../../components/entity/state-badge";
 import "../../../components/entity/ha-entity-picker";
+import "../components/hui-theme-select-editor";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
 
@@ -17,16 +22,21 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCardEditor {
   public hass?: HomeAssistant;
   private _config?: Config;
+  private _configEntities?: EntityConfig[];
 
   static get properties(): PropertyDeclarations {
     return {
       hass: {},
       _config: {},
+      _configEntities: {},
     };
   }
 
   public setConfig(config: Config): void {
     this._config = { type: "glance", ...config };
+    const entities = processConfigEntities(config.entities);
+
+    this._configEntities = entities;
   }
 
   protected render(): TemplateResult {
@@ -35,26 +45,92 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     }
 
     return html`
+      ${this.renderStyle()}
       <paper-input
         label="Title"
         value="${this._config!.title}"
-        .configValue="${"title"}"
+        .configValue=${"title"}
+        .type=${"input"}
         @value-changed="${this._valueChanged}"
-      ></paper-input
-      ><br />
+      ></paper-input>
+      <hui-theme-select-editor
+        .hass=${this.hass}
+        .value=${this._config!.theme}
+        .type=${"input"}
+        .configValue=${"theme"}
+        @change=${this._valueChanged}
+      ></hui-theme-select-editor><br>
+      <paper-input
+        label="Columns"
+        value="${this._config!.columns || ""}"
+        .configValue=${"columns"}
+        .type=${"input"}
+        @value-changed="${this._valueChanged}"
+      ></paper-input>
+      <h4>Entities</h4>
+      <div class="entities">
+        ${this._configEntities!.map((entityConf, index) => {
+          return this.renderEntity(entityConf, index!);
+        })}
+      </div><br>
+      <paper-button
+        noink
+        raised
+        @click=${this.addEntity}
+      >Add Entity</paper-button>
+      <br><br>
       <paper-checkbox
         ?checked="${this._config!.show_name !== false}"
-        .configValue="${"show_name"}"
+        .configValue=${"show_name"}
+        .type=${"checkbox"}
         @change="${this._valueChanged}"
         >Show Entity's Name?</paper-checkbox
       ><br /><br />
       <paper-checkbox
         ?checked="${this._config!.show_state !== false}"
-        .configValue="${"show_state"}"
+        .configValue=${"show_state"}
+        .type=${"checkbox"}
         @change="${this._valueChanged}"
         >Show Entity's State Text?</paper-checkbox
       ><br />
     `;
+  }
+
+  private renderStyle(): TemplateResult {
+    return html`
+      <style>
+        .entities {
+          padding-left: 20px;
+        }
+      </style>
+    `;
+  }
+
+  private renderEntity(
+    entityConf: EntityConfig,
+    index: number
+  ): TemplateResult {
+    return html`
+      <ha-entity-picker
+        .hass="${this.hass}"
+        .value="${entityConf.entity || entityConf}"
+        .type=${"entity"}
+        .index="${index}"
+        @change="${this._valueChanged}"
+      ></ha-entity-picker>
+    `;
+  }
+
+  private addEntity() {
+    const newConfig = this._config!;
+    const newConfigEntites = this._configEntities!;
+
+    newConfigEntites.push(newConfigEntites[0].entity);
+    newConfig.entities = newConfigEntites;
+
+    fireEvent(this, "config-changed", {
+      config: newConfig,
+    });
   }
 
   private _valueChanged(ev: MouseEvent): void {
@@ -63,12 +139,30 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
     }
 
     const target = ev.target! as any;
+    let newConfig = this._config;
+    const newConfigEntites = this._configEntities!;
 
-    const newValue =
-      target.checked !== undefined ? target.checked : target.value;
+    switch (target.type) {
+      case "input":
+        newConfig = { ...this._config, [target.configValue]: target.value };
+        break;
+
+      case "checkbox":
+        newConfig = { ...this._config, [target.configValue]: target.checked };
+        break;
+
+      case "entity":
+        if (target.value === "") {
+          newConfigEntites.splice(target.index, 1);
+        } else {
+          newConfigEntites[target.index].entity = target.value;
+        }
+        newConfig.entities = newConfigEntites;
+        break;
+    }
 
     fireEvent(this, "config-changed", {
-      config: { ...this._config, [target.configValue]: newValue },
+      config: newConfig,
     });
   }
 }

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -49,47 +49,49 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
       <paper-input
         label="Title"
         value="${this._config!.title}"
-        .configValue=${"title"}
-        .type=${"input"}
+        .configValue="${"title"}"
+        .type="${"input"}"
         @value-changed="${this._valueChanged}"
       ></paper-input>
       <hui-theme-select-editor
-        .hass=${this.hass}
-        .value=${this._config!.theme}
-        .type=${"input"}
-        .configValue=${"theme"}
-        @change=${this._valueChanged}
-      ></hui-theme-select-editor><br>
+        .hass="${this.hass}"
+        .value="${this._config!.theme}"
+        .type="${"input"}"
+        .configValue="${"theme"}"
+        @change="${this._valueChanged}"
+      ></hui-theme-select-editor
+      ><br />
       <paper-input
         label="Columns"
         value="${this._config!.columns || ""}"
-        .configValue=${"columns"}
-        .type=${"input"}
+        .configValue="${"columns"}"
+        .type="${"input"}"
         @value-changed="${this._valueChanged}"
       ></paper-input>
       <h4>Entities</h4>
       <div class="entities">
-        ${this._configEntities!.map((entityConf, index) => {
-          return this.renderEntity(entityConf, index!);
-        })}
-      </div><br>
-      <paper-button
-        noink
-        raised
-        @click=${this.addEntity}
-      >Add Entity</paper-button>
-      <br><br>
+        ${
+          this._configEntities!.map((entityConf, index) => {
+            return this.renderEntity(entityConf, index!);
+          })
+        }
+      </div>
+      <br />
+      <paper-button noink raised @click="${this.addEntity}"
+        >Add Entity</paper-button
+      >
+      <br /><br />
       <paper-checkbox
         ?checked="${this._config!.show_name !== false}"
-        .configValue=${"show_name"}
-        .type=${"checkbox"}
+        .configValue="${"show_name"}"
+        .type="${"checkbox"}"
         @change="${this._valueChanged}"
         >Show Entity's Name?</paper-checkbox
       ><br /><br />
       <paper-checkbox
         ?checked="${this._config!.show_state !== false}"
-        .configValue=${"show_state"}
-        .type=${"checkbox"}
+        .configValue="${"show_state"}"
+        .type="${"checkbox"}"
         @change="${this._valueChanged}"
         >Show Entity's State Text?</paper-checkbox
       ><br />
@@ -114,7 +116,7 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
       <ha-entity-picker
         .hass="${this.hass}"
         .value="${entityConf.entity || entityConf}"
-        .type=${"entity"}
+        .type="${"entity"}"
         .index="${index}"
         @change="${this._valueChanged}"
       ></ha-entity-picker>

--- a/src/panels/lovelace/editor/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/hui-glance-card-editor.ts
@@ -5,7 +5,8 @@ import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 
-import processConfigEntities from "../common/process-config-entities";
+import { processEditorEntities } from "./process-editor-entities";
+import { EditorEvent } from "./types";
 import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
 import { HomeAssistant } from "../../../types";
 import { LovelaceCardEditor } from "../types";
@@ -17,8 +18,6 @@ import "../components/hui-theme-select-editor";
 import "../components/hui-entity-editor";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
-import { processEditorEntities } from "./process-editor-entities";
-import { EditorEvent } from "./types";
 
 export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCardEditor {

--- a/src/panels/lovelace/editor/process-editor-entities.ts
+++ b/src/panels/lovelace/editor/process-editor-entities.ts
@@ -1,0 +1,10 @@
+import { EntityConfig } from "../entity-rows/types";
+
+export function processEditorEntities(entities): EntityConfig[] {
+  return entities.map((entityConf) => {
+    if (typeof entityConf === "string") {
+      return { entity: entityConf };
+    }
+    return entityConf;
+  });
+}

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -1,4 +1,5 @@
 import { LovelaceConfig } from "../types";
+import { EntityConfig } from "../entity-rows/types";
 
 export interface YamlChangedEvent extends Event {
   detail: {
@@ -9,4 +10,11 @@ export interface YamlChangedEvent extends Event {
 export interface ConfigValue {
   format: "js" | "yaml";
   value: string | LovelaceConfig;
+}
+
+export interface EditorEvent {
+  detail?: {
+    entities?: EntityConfig[];
+  };
+  target?: EventTarget;
 }

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -12,9 +12,16 @@ export interface ConfigValue {
   value: string | LovelaceConfig;
 }
 
-export interface EditorEvent {
+export interface EntitiesEditorEvent {
   detail?: {
     entities?: EntityConfig[];
   };
   target?: EventTarget;
+}
+
+export interface EditorTarget extends EventTarget {
+  value?: string;
+  index?: number;
+  checked?: boolean;
+  configValue?: string;
 }

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -2,8 +2,9 @@ import { HomeAssistant } from "../../../types";
 
 export interface EntityConfig {
   entity: string;
-  name: string;
-  icon: string;
+  type?: string;
+  name?: string;
+  icon?: string;
 }
 export interface DividerConfig {
   style: string;


### PR DESCRIPTION
Add A better editor for the Glance Card.

Ideas on the Next PR to improve on this are:

 * Add an edit button next to each entity and and bring up a second modal with Entity Config

 * Add a checkbox `show options` next to each entity that show under each entity the entity config options

We can discuss this further.

![image](https://user-images.githubusercontent.com/18730868/48106173-5a747f00-e208-11e8-9d2a-d5d3b4a13af7.png)
