### PR TITLE
Update map entity condition

### DIFF
--- a/src/panels/map/ha-panel-map.js
+++ b/src/panels/map/ha-panel-map.js
@@ -114,7 +114,7 @@ class HaPanelMap extends LocalizeMixin(PolymerElement) {
 
       if (
         (entity.attributes.hidden && computeStateDomain(entity) !== "zone") ||
-        entity.state === "home" ||
+        (!entity.attributes.show_always && entity.state === "home") ||
         !("latitude" in entity.attributes) ||
         !("longitude" in entity.attributes)
       ) {


### PR DESCRIPTION
Add a condition to `ha-panel-map` to allow users to configure if an entity should always be shown on the map (even when in the Home Zone)

https://community.home-assistant.io/t/map-always-show-devices/44013/10