### PR TITLE
Fix lint error for longPress directive

### DIFF
--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -160,6 +160,7 @@ export const longPressBind = (element: LongPressElement) => {
   longpress.bind(element);
 };
 
-export const longPress = directive(() => (part: PropertyPart) => {
-  longPressBind(part.committer.element);
-});
+export const longPress = () =>
+  directive((part: PropertyPart) => {
+    longPressBind(part.committer.element);
+  });


### PR DESCRIPTION
Cards/Elements using longPress directive are not working since upgrading Lit. This PR is to address the new lint errors, but does not fix the underlying functionality issue, so hoping to spark investigation on what the issue may be.

Referenced this PR: https://github.com/Polymer/lit-html/pull/615/files