### PR TITLE
Remove isValidObject function

### DIFF
--- a/src/panels/lovelace/common/is-valid-object.js
+++ b/src/panels/lovelace/common/is-valid-object.js
@@ -1,9 +1,0 @@
-// Check if given obj is a JS object and optionally contains all required keys
-export default function isValidObject(obj, requiredKeys = []) {
-  return (
-    obj &&
-    typeof obj === "object" &&
-    !Array.isArray(obj) &&
-    requiredKeys.every((k) => k in obj)
-  );
-}


### PR DESCRIPTION
This is not used in the codebase and can be removed unless anyone can think of a reason to keep it around for future use.