### PR TITLE
media_player: only add a separating colon if there is a valid prefix and suffix

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.js
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.js
@@ -103,22 +103,27 @@ class HuiMediaPlayerEntityRow extends LocalizeMixin(PolymerElement) {
   _computeMediaTitle(stateObj) {
     if (!stateObj || this._isOff(stateObj.state)) return null;
 
+    let prefix;
+    let suffix;
+
     switch (stateObj.attributes.media_content_type) {
       case "music":
-        return `${stateObj.attributes.media_artist}: ${
-          stateObj.attributes.media_title
-        }`;
+        prefix = stateObj.attributes.media_artist;
+        suffix = stateObj.attributes.media_title;
+        break;
       case "tvshow":
-        return `${stateObj.attributes.media_series_title}: ${
-          stateObj.attributes.media_title
-        }`;
+        prefix = stateObj.attributes.media_series_title;
+        suffix = stateObj.attributes.media_title;
+        break;
       default:
-        return (
+        prefix =
           stateObj.attributes.media_title ||
           stateObj.attributes.app_name ||
-          stateObj.state
-        );
+          stateObj.state;
+        suffix = "";
     }
+
+    return prefix && suffix ? `${prefix}: ${suffix}` : prefix || suffix || "";
   }
 
   _computeState(state) {


### PR DESCRIPTION
This PR changes the media player entity row to only add a colon separator to the status line when there is both a prefix and a suffix.

This issue affected my Sonos device, displaying a colon when there is nothing playing (and also when using TTS);

| Old | New |
|---|---|
| <img width="402" alt="Media player card displaying erroneous colon" src="https://user-images.githubusercontent.com/1843197/48644216-d8d7da80-e9d9-11e8-9c1b-57f59c6d8d12.png"> | <img width="407" alt="Media player card displaying correctly" src="https://user-images.githubusercontent.com/1843197/48644259-f7d66c80-e9d9-11e8-9dd5-f8a300605c6a.png"> |

This change only affects the Lovelace UI.