### PR TITLE
Remove extra >

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
@@ -47,7 +47,6 @@ class HuiGroupEntityRow extends hassLocalizeLitMixin(LitElement)
 
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
-        >
         ${
           this._computeCanToggle(stateObj.attributes.entity_id)
             ? html`


### PR DESCRIPTION
Similar to 4407da93649e2b54ad3ae67eecaf2e49143ab378, seems to have been added in 6c44a92e2.

This can be seen on the group row in the gallery for the `entities` card (Kitchen in this case);

<img width="419" alt="Home Assistant Polymer Gallery" src="https://user-images.githubusercontent.com/1843197/48650566-b603f100-e9ee-11e8-820c-ea2888e57618.png">
