### PR TITLE
Flatline fix for Sensor Cards

### DIFF
--- a/src/panels/lovelace/cards/hui-sensor-card.js
+++ b/src/panels/lovelace/cards/hui-sensor-card.js
@@ -180,13 +180,14 @@ class HuiSensorCard extends EventsMixin(LitElement) {
     const history = stateHistory[0];
     const valArray = [history[history.length - 1]];
 
-    let pos = history.length - 1;
-    const accuracy = this._config.accuracy <= pos ? this._config.accuracy : pos;
+    const accuracy = this._config.accuracy <= history.length ? this._config.accuracy : history.length;
     let increment = Math.ceil(history.length / accuracy);
     increment = increment <= 0 ? 1 : increment;
-    for (let i = accuracy; i >= 2; i--) {
+    let pos = history.length - 1;
+    for (let i = accuracy; i >= 1; i--) {
       pos -= increment;
-      valArray.unshift(pos >= 0 ? history[pos] : history[0]);
+      if (pos <= 0) { break; }
+      valArray.unshift(history[pos]);
     }
     this._line = this._getGraph(valArray, 500, this._config.height);
   }

--- a/src/panels/lovelace/cards/hui-sensor-card.js
+++ b/src/panels/lovelace/cards/hui-sensor-card.js
@@ -180,7 +180,8 @@ class HuiSensorCard extends EventsMixin(LitElement) {
     const history = stateHistory[0];
     const valArray = [history[history.length - 1]];
 
-    const accuracy = this._config.accuracy <= history.length
+    const accuracy =
+      this._config.accuracy <= history.length
         ? this._config.accuracy
         : history.length;
     let increment = Math.ceil(history.length / accuracy);

--- a/src/panels/lovelace/cards/hui-sensor-card.js
+++ b/src/panels/lovelace/cards/hui-sensor-card.js
@@ -180,7 +180,9 @@ class HuiSensorCard extends EventsMixin(LitElement) {
     const history = stateHistory[0];
     const valArray = [history[history.length - 1]];
 
-    const accuracy = this._config.accuracy <= history.length ? this._config.accuracy : history.length;
+    const accuracy = this._config.accuracy <= history.length 
+      ? this._config.accuracy 
+      : history.length;
     let increment = Math.ceil(history.length / accuracy);
     increment = increment <= 0 ? 1 : increment;
     let pos = history.length - 1;

--- a/src/panels/lovelace/cards/hui-sensor-card.js
+++ b/src/panels/lovelace/cards/hui-sensor-card.js
@@ -181,16 +181,16 @@ class HuiSensorCard extends EventsMixin(LitElement) {
     const valArray = [history[history.length - 1]];
 
     const accuracy = this._config.accuracy <= history.length 
-      ? this._config.accuracy 
-      : history.length;
+        ? this._config.accuracy 
+        : history.length;
     let increment = Math.ceil(history.length / accuracy);
     increment = increment <= 0 ? 1 : increment;
     let pos = history.length - 1;
     for (let i = accuracy; i >= 1; i--) {
       pos -= increment;
       if (pos >= 0) {
-        valArray.unshift(history[pos]); 
-        }
+        valArray.unshift(history[pos]);
+      }
     }
     this._line = this._getGraph(valArray, 500, this._config.height);
   }

--- a/src/panels/lovelace/cards/hui-sensor-card.js
+++ b/src/panels/lovelace/cards/hui-sensor-card.js
@@ -180,17 +180,15 @@ class HuiSensorCard extends EventsMixin(LitElement) {
     const history = stateHistory[0];
     const valArray = [history[history.length - 1]];
 
-    const accuracy = this._config.accuracy <= history.length 
-        ? this._config.accuracy 
+    const accuracy = this._config.accuracy <= history.length
+        ? this._config.accuracy
         : history.length;
     let increment = Math.ceil(history.length / accuracy);
     increment = increment <= 0 ? 1 : increment;
     let pos = history.length - 1;
     for (let i = accuracy; i >= 1; i--) {
       pos -= increment;
-      if (pos >= 0) {
-        valArray.unshift(history[pos]);
-      }
+      if (pos >= 0) valArray.unshift(history[pos]);
     }
     this._line = this._getGraph(valArray, 500, this._config.height);
   }

--- a/src/panels/lovelace/cards/hui-sensor-card.js
+++ b/src/panels/lovelace/cards/hui-sensor-card.js
@@ -186,8 +186,9 @@ class HuiSensorCard extends EventsMixin(LitElement) {
     let pos = history.length - 1;
     for (let i = accuracy; i >= 1; i--) {
       pos -= increment;
-      if (pos <= 0) { break; }
-      valArray.unshift(history[pos]);
+      if (pos >= 0) {
+        valArray.unshift(history[pos]); 
+        }
     }
     this._line = this._getGraph(valArray, 500, this._config.height);
   }


### PR DESCRIPTION
This fixes issues where the first history item was repeated many times at the start of the graph resulting in a flat line that does not represent the data.

Also, the graph now has the ability to reach a 1 to 1 history graph to sensor graph point representation.  Before 2 to 1 was the highest resolution possible.  This was due to using history.length - 1 as the denominator in cases where the user set the accuracy larger than the total number of points in the history.