### PR TITLE
Pin Lit-HTML and Lit-Element

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@polymer/iron-media-query": "^3.0.1",
     "@polymer/iron-pages": "^3.0.1",
     "@polymer/iron-resizable-behavior": "^3.0.1",
-    "@polymer/lit-element": "^0.6.3",
+    "@polymer/lit-element": "0.6.2",
     "@polymer/neon-animation": "^3.0.1",
     "@polymer/paper-button": "^3.0.1",
     "@polymer/paper-card": "^3.0.1",
@@ -78,7 +78,7 @@
     "jquery": "^3.3.1",
     "js-yaml": "^3.12.0",
     "leaflet": "^1.3.4",
-    "lit-html": "^0.13.0",
+    "lit-html": "0.12.0",
     "marked": "^0.5.0",
     "mdn-polyfills": "^5.12.0",
     "moment": "^2.22.2",
@@ -161,7 +161,9 @@
     "@webcomponents/shadycss": "^1.5.2",
     "@vaadin/vaadin-overlay": "3.2.0-alpha3",
     "@vaadin/vaadin-lumo-styles": "1.2.0",
-    "fecha": "https://github.com/taylorhakes/fecha/archive/5e8fe08d982647fdb19fb403459838b02647813c.tar.gz"
+    "fecha": "https://github.com/taylorhakes/fecha/archive/5e8fe08d982647fdb19fb403459838b02647813c.tar.gz",
+    "lit-html": "0.12.0",
+    "@polymer/lit-element": "0.6.2"
   },
   "main": "src/home-assistant.js",
   "husky": {

--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -160,6 +160,7 @@ export const longPressBind = (element: LongPressElement) => {
   longpress.bind(element);
 };
 
-export const longPress = directive(() => (part: PropertyPart) => {
-  longPressBind(part.committer.element);
-});
+export const longPress = () =>
+  directive((part: PropertyPart) => {
+    longPressBind(part.committer.element);
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,12 +1039,12 @@
     "@polymer/iron-meta" "^3.0.0-pre.26"
     "@polymer/polymer" "^3.0.0"
 
-"@polymer/lit-element@^0.6.2", "@polymer/lit-element@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@polymer/lit-element/-/lit-element-0.6.3.tgz#8ac2b82ae24f6306b5df0f2fa0b6deddd3cc4794"
-  integrity sha512-f7MNsgaliRN+g5MFbwKiTWTTWf3GrhYNB/3fAHM7t77TXTSbQ8MXHy2HXfQvPEHwjgen1o2CocaCTSGl/zzJ3g==
+"@polymer/lit-element@0.6.2", "@polymer/lit-element@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@polymer/lit-element/-/lit-element-0.6.2.tgz#589f2fa19e84d23c1debb2c329cbab758ae30581"
+  integrity sha512-4NWvK6SyAyyeW1mQ24ZVR+rtqZNHZ2JWnVTsPF/1iXnmmPwnpLs8mz0HRqz5adyoyt96ed/y2dsDwGBktJYyew==
   dependencies:
-    lit-html "^0.13.0"
+    lit-html "^0.12.0"
 
 "@polymer/neon-animation@^3.0.0-pre.26", "@polymer/neon-animation@^3.0.1":
   version "3.0.1"
@@ -8725,15 +8725,10 @@ listr@^0.14.2:
     p-map "^1.1.1"
     rxjs "^6.1.0"
 
-lit-html@^0.12.0:
+lit-html@0.12.0, lit-html@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-0.12.0.tgz#d994420fda74744f9d4a79401b086de929643e6a"
   integrity sha512-NyFgq8yTlGEjUFQOmNnK/kj+ZdDVJzTwsLunNSewGiOns7SjuJi6ymCCqzZZ81uW2VwEmliMbOlFZc9QmOJPLA==
-
-lit-html@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-0.13.0.tgz#d05e7fe8ade572432120339c451c614669788adf"
-  integrity sha512-p3R2ji/ucNVG5skguy8WufmSYIdMiTTb9ObUVYM2bOuvIXzDnUiePXGwP5BDbKssW1K6fw1Oj/M07FzdPLsTXw==
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This pins Lit-HTML to 0.12.0 and Lit-Element to 0.6.2 (which depends on Lit-HTML 0.12).

Lit HTML had a breaking change in a patch release (how directives are wrapped) and this caused troubles with how they have pinned their deps, pulling in wrong Lit. As we also use MWC, which depends on Lit, and is pulling in the wrong version, things started breaking.

By pinning it, we can work with 0.12.0 until https://github.com/material-components/material-components-web-components/pull/164 is merged and released.