### PR TITLE
Add `last-triggered` as `secondary_info` (useful for automation)

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -22,7 +22,7 @@ import applyThemesOnElement from "../../../common/dom/apply_themes_on_element";
 
 export interface ConfigEntity extends EntityConfig {
   type?: string;
-  secondary_info?: "entity-id" | "last-changed";
+  secondary_info?: "entity-id" | "last-changed" | "last-triggered";
   action_name?: string;
   service?: string;
   service_data?: object;

--- a/src/panels/lovelace/components/hui-generic-entity-row.js
+++ b/src/panels/lovelace/components/hui-generic-entity-row.js
@@ -99,6 +99,15 @@ class HuiGenericEntityRow extends PolymerElement {
                 datetime="[[_stateObj.last_changed]]"
               ></ha-relative-time>
             </template>
+            <template
+              is="dom-if"
+              if="[[_equals(config.secondary_info, 'last-triggered')]]"
+            >
+              <ha-relative-time
+                hass="[[hass]]"
+                datetime="[[_stateObj.last_triggered]]"
+              ></ha-relative-time>
+            </template>
           </template>
           <template is="dom-if" if="[[!showSecondary]">
             <slot name="secondary"></slot>


### PR DESCRIPTION
I felt like this was a common nice-to-have feature. And in my scenario, it is needed for some automations I have in the frontend.

Mainly, this PR should add support for:

      - entity: automation.<name_of_automation>
        secondary_info: last-triggered

and it will show the `last_triggered` attribute of the automation, which tends to be a useful metric --much more useful than the `last_changed`, at least for common always-on automations.