### PR TITLE
Extend legacy support (custom ui) to include lit html

### DIFF
--- a/src/util/legacy-support.js
+++ b/src/util/legacy-support.js
@@ -4,8 +4,12 @@
  */
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 import { Polymer } from "@polymer/polymer/polymer-legacy";
-import { html } from "@polymer/polymer/lib/utils/html-tag";
+import { html as polymerHtml } from "@polymer/polymer/lib/utils/html-tag";
+import { html as litHtml, LitElement } from "@polymer/lit-element";
 
 Polymer.Element = PolymerElement;
-Polymer.html = html;
+Polymer.html = polymerHtml;
 window.Polymer = Polymer;
+
+LitElement.html = litHtml;
+window.LitElement = LitElement;


### PR DESCRIPTION
With the change from Polymer to Lit, I would suggest updating the `legacy` support for `custom ui` (#1157) to also include
- `LitElement`
- `LitElement.html`