### PR TITLE
Fix wrong import

### DIFF
--- a/src/panels/lovelace/components/hui-entities-toggle.js
+++ b/src/panels/lovelace/components/hui-entities-toggle.js
@@ -3,7 +3,7 @@ import { PolymerElement } from "@polymer/polymer/polymer-element";
 import "@polymer/paper-toggle-button/paper-toggle-button";
 
 import { DOMAINS_TOGGLE } from "../../../common/const";
-import turnOnOffEntities from "../common/entity/turn-on-off-entities";
+import { turnOnOffEntities } from "../common/entity/turn-on-off-entities";
 
 class HuiEntitiesToggle extends PolymerElement {
   static get template() {


### PR DESCRIPTION
I am not sure why this was a warning and not an error. Probably because it was in JS.

Noticed in webpack build:

```
    WARNING in ./src/panels/lovelace/components/hui-entities-toggle.js 52:4-21
    "export 'default' (imported as 'turnOnOffEntities') was not found in '../common/entity/turn-on-off-entities'
     @ ./src/panels/lovelace/cards/hui-entities-card.ts
     @ ./src/panels/lovelace/hui-unused-entities.js
     @ ./src/panels/lovelace/hui-root.js
     @ ./src/panels/lovelace/ha-panel-lovelace.js
     @ ./src/layouts/partial-panel-resolver.js
     @ ./src/layouts/home-assistant-main.js
     @ ./src/layouts/app/home-assistant.js
     @ ./src/entrypoints/app.js
```