### PR TITLE
Add html to LitElement.prototype

### DIFF
--- a/src/layouts/app/home-assistant.js
+++ b/src/layouts/app/home-assistant.js
@@ -4,6 +4,7 @@ import "@polymer/iron-flex-layout/iron-flex-layout-classes";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 import { afterNextRender } from "@polymer/polymer/lib/utils/render-status";
+import { html as litHtml, LitElement } from "@polymer/lit-element";
 
 import "../home-assistant-main";
 import "../ha-init-page";
@@ -20,6 +21,8 @@ import { dialogManagerMixin } from "./dialog-manager-mixin";
 import ConnectionMixin from "./connection-mixin";
 import NotificationMixin from "./notification-mixin";
 import DisconnectToastMixin from "./disconnect-toast-mixin";
+
+LitElement.prototype.html = litHtml;
 
 const ext = (baseClass, mixins) =>
   mixins.reduceRight((base, mixin) => mixin(base), baseClass);


### PR DESCRIPTION
This PR maps the `html` function form `lit-html` to `LitElement.prototype.html` to be accessible within custom_ui components when overriding existing class implementation.

I've added the mapping inside `src/layouts/app/home-assistant.js` for now, but am happy to move it if there is a better place for it.

#### Example
```js
const ExistingRow = customElements.get('existing-row');
// 'existing-row' being the name of the customElement

class MyFancyRow extends ExistingRow {
  render() {             // overrides existing render implementation
    return this.html`    // use `this.html`
      ...
    `;
  }
}
```

Fixes: #2107
CC: @balloob