### PR TITLE
Improve lovelace template inheritance - custom_ui

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
@@ -31,7 +31,7 @@ class HuiClimateEntityRow extends LitElement implements EntityRow {
       return html``;
     }
 
-    return renderTemplate();
+    return this.renderTemplate();
   }
 
   protected renderTemplate(): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
@@ -31,6 +31,10 @@ class HuiClimateEntityRow extends LitElement implements EntityRow {
       return html``;
     }
 
+    return renderTemplate();
+  }
+
+  protected renderTemplate(): TemplateResult {
     return html`
       ${this.renderStyle()}
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
@@ -42,7 +46,7 @@ class HuiClimateEntityRow extends LitElement implements EntityRow {
     `;
   }
 
-  private renderStyle(): TemplateResult {
+  protected renderStyle(): TemplateResult {
     return html`
       <style>
         ha-climate-state {

--- a/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
@@ -43,7 +43,7 @@ class HuiCoverEntityRow extends LitElement implements EntityRow {
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
@@ -43,29 +43,19 @@ class HuiCoverEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       ${this.renderStyle()}
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
-        ${
-          isTiltOnly(stateObj)
-            ? html`
-                <ha-cover-tilt-controls
-                  .hass="${this.hass}"
-                  .stateObj="${stateObj}"
-                ></ha-cover-tilt-controls>
-              `
-            : html`
-                <ha-cover-controls
-                  .hass="${this.hass}"
-                  .stateObj="${stateObj}"
-                ></ha-cover-controls>
-              `
-        }
+        ${this.renderCoverControl(stateObj)}
       </hui-generic-entity-row>
     `;
   }
 
-  private renderStyle(): TemplateResult {
+  protected renderStyle(): TemplateResult {
     return html`
       <style>
         ha-cover-controls,
@@ -73,6 +63,26 @@ class HuiCoverEntityRow extends LitElement implements EntityRow {
           margin-right: -0.57em;
         }
       </style>
+    `;
+  }
+
+  protected renderCoverControl(stateObj): TemplateResult {
+    return html`
+      ${
+        isTiltOnly(stateObj)
+          ? html`
+              <ha-cover-tilt-controls
+                .hass="${this.hass}"
+                .stateObj="${stateObj}"
+              ></ha-cover-tilt-controls>
+            `
+          : html`
+              <ha-cover-controls
+                .hass="${this.hass}"
+                .stateObj="${stateObj}"
+              ></ha-cover-controls>
+            `
+      }
     `;
   }
 }

--- a/src/panels/lovelace/entity-rows/hui-error-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-error-entity-row.ts
@@ -19,7 +19,7 @@ class HuiErrorEntityRow extends LitElement {
     `;
   }
 
-  private renderStyle(): TemplateResult {
+  protected renderStyle(): TemplateResult {
     return html`
       <style>
         :host {

--- a/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
@@ -45,7 +45,7 @@ class HuiGroupEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
@@ -45,6 +45,10 @@ class HuiGroupEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         ${

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -47,7 +47,7 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -47,6 +47,10 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       ${this.renderStyle()}
       <state-badge .stateObj="${stateObj}"></state-badge>
@@ -73,7 +77,7 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
     `;
   }
 
-  private renderStyle(): TemplateResult {
+  protected renderStyle(): TemplateResult {
     return html`
       <style>
         :host {

--- a/src/panels/lovelace/entity-rows/hui-input-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-text-entity-row.ts
@@ -42,7 +42,7 @@ class HuiInputTextEntityRow extends LitElement implements EntityRow {
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-input-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-text-entity-row.ts
@@ -42,6 +42,10 @@ class HuiInputTextEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         <paper-input

--- a/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
@@ -42,6 +42,10 @@ class HuiLockEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       ${this.renderStyle()}
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">

--- a/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
@@ -42,7 +42,7 @@ class HuiLockEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
@@ -43,7 +43,7 @@ class HuiSceneEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
@@ -43,6 +43,10 @@ class HuiSceneEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       ${this.renderStyle()}
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">

--- a/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
@@ -43,6 +43,10 @@ class HuiScriptEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       ${this.renderStyle()}
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">

--- a/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
@@ -43,7 +43,7 @@ class HuiScriptEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -45,7 +45,7 @@ class HuiSensorEntityRow extends LitElement implements EntityRow {
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -45,6 +45,10 @@ class HuiSensorEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       ${this.renderStyle()}
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
@@ -65,7 +69,7 @@ class HuiSensorEntityRow extends LitElement implements EntityRow {
     `;
   }
 
-  private renderStyle(): TemplateResult {
+  protected renderStyle(): TemplateResult {
     return html`
       <style>
         div {

--- a/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
@@ -43,7 +43,7 @@ class HuiTextEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {

--- a/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
@@ -43,6 +43,10 @@ class HuiTextEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       ${this.renderStyle()}
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
@@ -53,7 +57,7 @@ class HuiTextEntityRow extends hassLocalizeLitMixin(LitElement)
     `;
   }
 
-  private renderStyle(): TemplateResult {
+  protected renderStyle(): TemplateResult {
     return html`
       <style>
         div {

--- a/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
@@ -44,6 +44,10 @@ class HuiToggleEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
+    return renderTemplate(stateObj);
+  }
+
+  protected renderTemplate(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         ${

--- a/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
@@ -44,7 +44,7 @@ class HuiToggleEntityRow extends hassLocalizeLitMixin(LitElement)
       `;
     }
 
-    return renderTemplate(stateObj);
+    return this.renderTemplate(stateObj);
   }
 
   protected renderTemplate(stateObj): TemplateResult {


### PR DESCRIPTION
With the move to `lit-html`, we lost some simplicity for custom_ui and template inheritance (first introduced with #1230), since the render method now contains additional values and checks that had been separate before.

To solve this, I would suggest extracting the `template` section from the `render` function.
The advantage for `custom_ui` would be that **only** the `renderTemplate` itself would need to be overridden and not the variable definitions and checks. Vars (if any) could be passed as argument to the function.

#### Example
```js
// HuiCoverEntityRow

protected render(): TemplateResult {
 if (!this._config || !this.hass) {
   return html``;
 }
 const stateObj = this.hass.states[this._config.entity];
 if (!stateObj) {
   return html`
     <hui-error-entity-row
       .entity="${this._config.entity}"
     ></hui-error-entity-row>
  `;
  }

  return renderTemplate(stateObj);
}


protected renderTemplate(stateObj): TemplateResult {
  return html`
    ...
  `;
}
```