### PR TITLE
Check if config is compatible with UI editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-big-calendar": "^0.19.2",
     "regenerator-runtime": "^0.12.1",
     "round-slider": "^1.3.2",
+    "superstruct": "^0.6.0",
     "unfetch": "^4.0.1",
     "web-animations-js": "^2.3.1",
     "xss": "^1.0.3"

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -41,7 +41,7 @@ export class HuiEntitiesCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     const requiredKeys = ["type", "entities", "id"];
-    const optionalKeys = ["title", "show_header_toggle"];
+    const optionalKeys = ["title", "show_header_toggle", "theme"];
     const allKeys = optionalKeys.concat(requiredKeys);
 
     const requiredEntKeys = ["entity"];

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -43,6 +43,11 @@ export class HuiEntitiesCardEditor extends hassLocalizeLitMixin(LitElement)
     const requiredKeys = ["type", "entities", "id"];
     const optionalKeys = ["title", "show_header_toggle"];
     const allKeys = optionalKeys.concat(requiredKeys);
+
+    const requiredEntKeys = ["entity"];
+    const optionalEntKeys = ["name", "icon"];
+    const allEntKeys = optionalEntKeys.concat(requiredEntKeys);
+
     requiredKeys.forEach((key) => {
       if (!config.hasOwnProperty(key)) {
         throw new Error(`Missing required option: '${key}'`);
@@ -57,14 +62,10 @@ export class HuiEntitiesCardEditor extends hassLocalizeLitMixin(LitElement)
     if (!Array.isArray(config.entities)) {
       throw new Error("Entities need to be an array");
     }
-
     config.entities.forEach((entity) => {
       if (typeof entity === "string") {
         return;
       }
-      const requiredEntKeys = ["entity"];
-      const optionalEntKeys = ["name", "icon"];
-      const allEntKeys = optionalEntKeys.concat(requiredEntKeys);
       requiredEntKeys.forEach((key) => {
         if (!entity.hasOwnProperty(key)) {
           throw new Error(`Missing required entity option: '${key}'`);

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -6,6 +6,7 @@ import "@polymer/paper-listbox/paper-listbox";
 import "@polymer/paper-toggle-button/paper-toggle-button";
 
 import { processEditorEntities } from "../process-editor-entities";
+
 import { EntitiesEditorEvent, EditorTarget } from "../types";
 import { hassLocalizeLitMixin } from "../../../../mixins/lit-localize-mixin";
 import { HomeAssistant } from "../../../../types";
@@ -39,6 +40,43 @@ export class HuiEntitiesCardEditor extends hassLocalizeLitMixin(LitElement)
   }
 
   public setConfig(config: Config): void {
+    const requiredKeys = ["type", "entities", "id"];
+    const optionalKeys = ["title", "show_header_toggle"];
+    const allKeys = optionalKeys.concat(requiredKeys);
+    requiredKeys.forEach((key) => {
+      if (!config.hasOwnProperty(key)) {
+        throw new Error(`Missing required option: '${key}'`);
+      }
+    });
+    Object.keys(config).forEach((key) => {
+      if (allKeys.indexOf(key) === -1) {
+        throw new Error(`Unsupported option: '${key}'`);
+      }
+    });
+
+    if (!Array.isArray(config.entities)) {
+      throw new Error("Entities need to be an array");
+    }
+
+    config.entities.forEach((entity) => {
+      if (typeof entity === "string") {
+        return;
+      }
+      const requiredEntKeys = ["entity"];
+      const optionalEntKeys = ["name", "icon"];
+      const allEntKeys = optionalEntKeys.concat(requiredEntKeys);
+      requiredEntKeys.forEach((key) => {
+        if (!entity.hasOwnProperty(key)) {
+          throw new Error(`Missing required entity option: '${key}'`);
+        }
+      });
+      Object.keys(entity).forEach((key) => {
+        if (allEntKeys.indexOf(key) === -1) {
+          throw new Error(`Unsupported entity option: '${key}'`);
+        }
+      });
+    });
+
     this._config = { type: "entities", ...config };
     this._configEntities = processEditorEntities(config.entities);
   }

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
 import { TemplateResult } from "lit-html";
+import { struct } from "superstruct";
 import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
@@ -21,6 +22,24 @@ import "../../components/hui-entity-editor";
 import "../../../../components/ha-card";
 import "../../../../components/ha-icon";
 
+const entitiesConfigStruct = struct.union([
+  {
+    entity: "string",
+    name: "string?",
+    icon: "string?",
+  },
+  "string",
+]);
+
+const cardConfigStruct = struct({
+  type: "string",
+  id: "string|number",
+  title: "string|number?",
+  theme: "string?",
+  show_header_toggle: "boolean?",
+  entities: [entitiesConfigStruct],
+});
+
 export class HuiEntitiesCardEditor extends hassLocalizeLitMixin(LitElement)
   implements LovelaceCardEditor {
   public hass?: HomeAssistant;
@@ -40,43 +59,7 @@ export class HuiEntitiesCardEditor extends hassLocalizeLitMixin(LitElement)
   }
 
   public setConfig(config: Config): void {
-    const requiredKeys = ["type", "entities", "id"];
-    const optionalKeys = ["title", "show_header_toggle", "theme"];
-    const allKeys = optionalKeys.concat(requiredKeys);
-
-    const requiredEntKeys = ["entity"];
-    const optionalEntKeys = ["name", "icon"];
-    const allEntKeys = optionalEntKeys.concat(requiredEntKeys);
-
-    requiredKeys.forEach((key) => {
-      if (!config.hasOwnProperty(key)) {
-        throw new Error(`Missing required option: '${key}'`);
-      }
-    });
-    Object.keys(config).forEach((key) => {
-      if (allKeys.indexOf(key) === -1) {
-        throw new Error(`Unsupported option: '${key}'`);
-      }
-    });
-
-    if (!Array.isArray(config.entities)) {
-      throw new Error("Entities need to be an array");
-    }
-    config.entities.forEach((entity) => {
-      if (typeof entity === "string") {
-        return;
-      }
-      requiredEntKeys.forEach((key) => {
-        if (!entity.hasOwnProperty(key)) {
-          throw new Error(`Missing required entity option: '${key}'`);
-        }
-      });
-      Object.keys(entity).forEach((key) => {
-        if (allEntKeys.indexOf(key) === -1) {
-          throw new Error(`Unsupported entity option: '${key}'`);
-        }
-      });
-    });
+    config = cardConfigStruct(config);
 
     this._config = { type: "entities", ...config };
     this._configEntities = processEditorEntities(config.entities);

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -20,7 +20,7 @@ declare global {
 }
 
 const dialogShowEvent = "show-edit-card";
-const dialogTag = "hui-dialog-edit-config";
+const dialogTag = "hui-dialog-edit-card";
 
 export interface EditCardDialogParams {
   cardConfig: LovelaceCardConfig;
@@ -81,7 +81,7 @@ export class HuiDialogEditCard extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "hui-dialog-edit-config": HuiDialogEditCard;
+    "hui-dialog-edit-card": HuiDialogEditCard;
   }
 }
 

--- a/src/panels/lovelace/editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-edit-card.ts
@@ -82,7 +82,7 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
     if (String(cardConfig.id) !== this._cardId) {
       this._configValue = { format: "yaml", value: undefined };
       this._configState = "OK";
-      this._uiEditor = false;
+      this._uiEditor = true;
       this._cardId = String(cardConfig.id);
       this._loadConfigElement(cardConfig);
     }
@@ -404,6 +404,7 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
     try {
       configElement = await elClass.getConfigElement();
     } catch (err) {
+      this._uiEditor = false;
       this._configElement = null;
       return;
     }
@@ -415,6 +416,7 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
         Your config is not supported by the UI editor:<br /><b>${err.message}</b
         ><br />Falling back to YAML editor.
       `;
+      this._uiEditor = false;
       this._configElement = null;
       return;
     }
@@ -425,7 +427,6 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
     );
     this._configValue = { format: "json", value: conf };
     this._configElement = configElement;
-    this._uiEditor = true;
     this._isToggleAvailable = true;
     this._updatePreview(conf);
   }

--- a/src/panels/lovelace/editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-edit-card.ts
@@ -415,8 +415,7 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
       configElement.setConfig(conf);
     } catch (err) {
       this._errorMsg = html`
-        Your config is not supported by the UI editor:<br /><b
-          >${err.message}.</b
+        Your config is not supported by the UI editor:<br /><b>${err.message}</b
         ><br />Falling back to YAML editor.
       `;
       this._configElement = null;

--- a/src/panels/lovelace/editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-edit-card.ts
@@ -285,6 +285,7 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
   }
 
   private _closeDialog(): void {
+    this._cardId = undefined;
     this._dialog.close();
   }
 

--- a/src/panels/lovelace/editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-edit-card.ts
@@ -255,16 +255,13 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
         }),
       };
       this._uiEditor = !this._uiEditor;
-      if (
-        (this._configValue!.value! as LovelaceCardConfig).type !==
-        this._cardType
-      ) {
+      const cardConfig = this._configValue!.value! as LovelaceCardConfig;
+      if (cardConfig.type !== this._cardType) {
         await this._loadConfigElement(this._configValue!
           .value! as LovelaceCardConfig);
-        this._cardType = (this._configValue!.value! as LovelaceCardConfig).type;
+        this._cardType = cardConfig.type;
       }
-      this._configElement.setConfig(this._configValue!
-        .value as LovelaceCardConfig);
+      this._configElement.setConfig(cardConfig);
     }
     this._resizeDialog();
   }

--- a/src/panels/lovelace/editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-edit-card.ts
@@ -257,8 +257,7 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
       this._uiEditor = !this._uiEditor;
       const cardConfig = this._configValue!.value! as LovelaceCardConfig;
       if (cardConfig.type !== this._cardType) {
-        await this._loadConfigElement(this._configValue!
-          .value! as LovelaceCardConfig);
+        await this._loadConfigElement(cardConfig);
         this._cardType = cardConfig.type;
       }
       this._configElement.setConfig(cardConfig);

--- a/src/panels/lovelace/editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-edit-card.ts
@@ -105,6 +105,24 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
   }
 
   protected render(): TemplateResult {
+    let content;
+    if (!this._configElement !== undefined) {
+      if (this._uiEditor) {
+        content = html`
+          <div class="element-editor">${this._configElement}</div>
+        `;
+      } else {
+        content = html`
+          <hui-yaml-editor
+            .hass="${this.hass}"
+            .cardId="${this._cardId}"
+            .yaml="${this._configValue!.value}"
+            @yaml-changed="${this._handleYamlChanged}"
+          ></hui-yaml-editor>
+        `;
+      }
+    }
+
     return html`
       ${this.renderStyle()}
       <paper-dialog with-backdrop>
@@ -124,28 +142,7 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
                 `
               : ""
           }
-          ${
-            this._configElement !== undefined
-              ? html`
-                  ${
-                    this._uiEditor
-                      ? html`
-                          <div class="element-editor">
-                            ${this._configElement}
-                          </div>
-                        `
-                      : html`
-                          <hui-yaml-editor
-                            .hass="${this.hass}"
-                            .cardId="${this._cardId}"
-                            .yaml="${this._configValue!.value}"
-                            @yaml-changed="${this._handleYamlChanged}"
-                          ></hui-yaml-editor>
-                        `
-                  }
-                `
-              : ""
-          }
+          ${content}
           <hr />
           <hui-card-preview .hass="${this.hass}"></hui-card-preview>
         </paper-dialog-scrollable>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4226,6 +4226,16 @@ clone-buffer@^1.0.0:
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
   integrity sha1-4+JbIHrE5wGvch4staFnksrD3Fg=
 
+clone-deep@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-2.0.2.tgz#00db3a1e173656730d1188c3d6aced6d7ea97713"
+  integrity sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==
+  dependencies:
+    for-own "^1.0.0"
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.0"
+    shallow-clone "^1.0.0"
+
 clone-stats@^0.0.1, clone-stats@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
@@ -6452,6 +6462,11 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "=3.1.0"
 
+for-in@^0.1.3:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
+  integrity sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -8556,7 +8571,7 @@ kind-of@^5.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^6.0.0, kind-of@^6.0.1, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
@@ -9715,6 +9730,14 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mixin-object@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
+  integrity sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=
+  dependencies:
+    for-in "^0.1.3"
+    is-extendable "^0.1.1"
 
 mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
@@ -12267,6 +12290,15 @@ shady-css-parser@^0.1.0:
   resolved "https://registry.yarnpkg.com/shady-css-parser/-/shady-css-parser-0.1.0.tgz#534dc79c8ca5884c5ed92a4e5a13d6d863bca428"
   integrity sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==
 
+shallow-clone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-1.0.0.tgz#4480cd06e882ef68b2ad88a3ea54832e2c48b571"
+  integrity sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==
+  dependencies:
+    is-extendable "^0.1.1"
+    kind-of "^5.0.0"
+    mixin-object "^2.0.1"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -12902,6 +12934,14 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+superstruct@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.6.0.tgz#20d2073526cf683a57f258695e009c4a19134ad0"
+  integrity sha512-6Y+bh5oFXCMUmGGzcdwd8M2qXMWn9aH3Qu2wV8Cg/Lxu+3fTxJ0dTx54nKd/Sm3lSz3i901xVatzev7c/xN8Lg==
+  dependencies:
+    clone-deep "^2.0.1"
+    kind-of "^6.0.1"
 
 supports-color@3.1.2, supports-color@5.4.0, supports-color@^0.2.0, supports-color@^2.0.0, supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "3.1.2"


### PR DESCRIPTION
Just for the entities editor now.
Extra keys are not allowed:
![image](https://user-images.githubusercontent.com/5662298/49209819-d0a97300-f3bb-11e8-99ef-c14964597cee.png)
Some config is not supported by the UI editor:
![image](https://user-images.githubusercontent.com/5662298/49214692-79a99b00-f3c7-11e8-9f0c-fb968ecda9ba.png)
And missing required elements:
![image](https://user-images.githubusercontent.com/5662298/49215240-a7431400-f3c8-11e8-8b8b-339d5bb01e86.png)

Fixes: https://github.com/home-assistant/home-assistant-polymer/issues/2124