### PR TITLE
Display alert entity row as a toggle

### DIFF
--- a/src/panels/lovelace/common/create-row-element.js
+++ b/src/panels/lovelace/common/create-row-element.js
@@ -29,8 +29,8 @@ const SPECIAL_TYPES = new Set([
   "weblink",
 ]);
 const DOMAIN_TO_ELEMENT_TYPE = {
-  automation: "toggle",
   alert: "toggle",
+  automation: "toggle",
   climate: "climate",
   cover: "cover",
   fan: "toggle",

--- a/src/panels/lovelace/common/create-row-element.js
+++ b/src/panels/lovelace/common/create-row-element.js
@@ -30,6 +30,7 @@ const SPECIAL_TYPES = new Set([
 ]);
 const DOMAIN_TO_ELEMENT_TYPE = {
   automation: "toggle",
+  alert: "toggle",
   climate: "climate",
   cover: "cover",
   fan: "toggle",


### PR DESCRIPTION
In the default UI alerts where displayed as toggles, this change makes this also the default behaviour in Lovelace