### PR TITLE
Lovelace: Automatically detect plants

### DIFF
--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -52,6 +52,11 @@ const computeCards = (
         type: "media-control",
         entity: entityId,
       });
+    } else if (domain === "plant") {
+      cards.push({
+        type: "plant-status",
+        entity: entityId,
+      });
     } else if (domain === "weather") {
       cards.push({
         type: "weather-forecast",


### PR DESCRIPTION
When automatically generating the config, we didn't map plant entities to plant status cards. This fixes it.