### PR TITLE
Hass.io: Show ANSI color codes in logs

### DIFF
--- a/hassio/src/addon-view/hassio-addon-logs.js
+++ b/hassio/src/addon-view/hassio-addon-logs.js
@@ -2,6 +2,7 @@ import "@polymer/paper-button/paper-button";
 import "@polymer/paper-card/paper-card";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
+import { ANSI_HTML_STYLE, parseTextToColoredPre } from "../ansi-to-html";
 
 import "../../../src/resources/ha-style";
 
@@ -18,67 +19,8 @@ class HassioAddonLogs extends PolymerElement {
           white-space: pre-wrap;
           overflow-wrap: break-word;
         }
-        .bold {
-          font-weight: bold;
-        }
-        .italic {
-          font-style: italic;
-        }
-        .underline {
-          text-decoration: underline;
-        }
-        .strikethrough {
-          text-decoration: line-through;
-        }
-        .underline.strikethrough {
-          text-decoration: underline line-through;
-        }
-        .fg-red {
-          color: rgb(222, 56, 43);
-        }
-        .fg-green {
-          color: rgb(57, 181, 74);
-        }
-        .fg-yellow {
-          color: rgb(255, 199, 6);
-        }
-        .fg-blue {
-          color: rgb(0, 111, 184);
-        }
-        .fg-magenta {
-          color: rgb(118, 38, 113);
-        }
-        .fg-cyan {
-          color: rgb(44, 181, 233);
-        }
-        .fg-white {
-          color: rgb(204, 204, 204);
-        }
-        .bg-black {
-          background-color: rgb(0, 0, 0);
-        }
-        .bg-red {
-          background-color: rgb(222, 56, 43);
-        }
-        .bg-green {
-          background-color: rgb(57, 181, 74);
-        }
-        .bg-yellow {
-          background-color: rgb(255, 199, 6);
-        }
-        .bg-blue {
-          background-color: rgb(0, 111, 184);
-        }
-        .bg-magenta {
-          background-color: rgb(118, 38, 113);
-        }
-        .bg-cyan {
-          background-color: rgb(44, 181, 233);
-        }
-        .bg-white {
-          background-color: rgb(204, 204, 204);
-        }
       </style>
+      ${ANSI_HTML_STYLE}
       <paper-card heading="Log">
         <div class="card-content" id="content"></div>
         <div class="card-actions">
@@ -109,152 +51,6 @@ class HassioAddonLogs extends PolymerElement {
     this.refresh();
   }
 
-  static parseLogsToPre(text) {
-    const pre = document.createElement("pre");
-    const re = /\033(?:\[(.*?)[@-~]|\].*?(?:\007|\033\\))/g;
-    let i = 0;
-
-    const state = {
-      bold: false,
-      italic: false,
-      underline: false,
-      strikethrough: false,
-      foregroundColor: null,
-      backgroundColor: null,
-    };
-
-    const addSpan = (content) => {
-      const span = document.createElement("span");
-      if (state.bold) {
-        span.classList.add("bold");
-      }
-      if (state.italic) {
-        span.classList.add("italic");
-      }
-      if (state.underline) {
-        span.classList.add("underline");
-      }
-      if (state.strikethrough) {
-        span.classList.add("strikethrough");
-      }
-      if (state.foregroundColor !== null) {
-        span.classList.add(state.foregroundColor);
-      }
-      if (state.backgroundColor !== null) {
-        span.classList.add(state.backgroundColor);
-      }
-      span.appendChild(document.createTextNode(content));
-      pre.appendChild(span);
-    };
-
-    /* eslint-disable no-constant-condition */
-    while (true) {
-      const match = re.exec(text);
-      if (match === null) {
-        break;
-      }
-
-      const j = match.index;
-      addSpan(text.substring(i, j));
-      i = j + match[0].length;
-
-      if (match[1] === undefined) continue;
-
-      for (const colorCode of match[1].split(";")) {
-        switch (parseInt(colorCode)) {
-          case 0:
-            // reset
-            state.bold = false;
-            state.italic = false;
-            state.underline = false;
-            state.strikethrough = false;
-            state.foregroundColor = null;
-            state.backgroundColor = null;
-            break;
-          case 1:
-            state.bold = true;
-            break;
-          case 3:
-            state.italic = true;
-            break;
-          case 4:
-            state.underline = true;
-            break;
-          case 9:
-            state.strikethrough = true;
-            break;
-          case 22:
-            state.bold = false;
-            break;
-          case 23:
-            state.italic = false;
-            break;
-          case 24:
-            state.underline = false;
-            break;
-          case 29:
-            state.strikethrough = false;
-            break;
-          case 31:
-            state.foregroundColor = "fg-red";
-            break;
-          case 32:
-            state.foregroundColor = "fg-green";
-            break;
-          case 33:
-            state.foregroundColor = "fg-yellow";
-            break;
-          case 34:
-            state.foregroundColor = "fg-blue";
-            break;
-          case 35:
-            state.foregroundColor = "fg-magenta";
-            break;
-          case 36:
-            state.foregroundColor = "fg-cyan";
-            break;
-          case 37:
-            state.foregroundColor = "fg-white";
-            break;
-          case 30:
-          case 39:
-            state.foregroundColor = null;
-            break;
-          case 40:
-            state.backgroundColor = "bg-black";
-            break;
-          case 41:
-            state.backgroundColor = "bg-red";
-            break;
-          case 42:
-            state.backgroundColor = "bg-green";
-            break;
-          case 43:
-            state.backgroundColor = "bg-yellow";
-            break;
-          case 44:
-            state.backgroundColor = "bg-blue";
-            break;
-          case 45:
-            state.backgroundColor = "bg-magenta";
-            break;
-          case 46:
-            state.backgroundColor = "bg-cyan";
-            break;
-          case 47:
-            state.backgroundColor = "bg-white";
-            break;
-          case 49:
-            state.backgroundColor = null;
-            break;
-        }
-      }
-    }
-    addSpan(text.substring(i));
-
-    return pre;
-  }
-
   refresh() {
     this.hass
       .callApi("get", `hassio/addons/${this.addonSlug}/logs`)
@@ -262,7 +58,7 @@ class HassioAddonLogs extends PolymerElement {
         while (this.$.content.lastChild) {
           this.$.content.removeChild(this.$.content.lastChild);
         }
-        this.$.content.appendChild(HassioAddonLogs.parseLogsToPre(text));
+        this.$.content.appendChild(parseTextToColoredPre(text));
       });
   }
 }

--- a/hassio/src/addon-view/hassio-addon-logs.js
+++ b/hassio/src/addon-view/hassio-addon-logs.js
@@ -15,10 +15,72 @@ class HassioAddonLogs extends PolymerElement {
         }
         pre {
           overflow-x: auto;
+          white-space: pre-wrap;
+          overflow-wrap: break-word;
+        }
+        .bold {
+          font-weight: bold;
+        }
+        .italic {
+          font-style: italic;
+        }
+        .underline {
+          text-decoration: underline;
+        }
+        .strikethrough {
+          text-decoration: line-through;
+        }
+        .underline.strikethrough {
+          text-decoration: underline line-through;
+        }
+        .fg-red {
+          color: rgb(222, 56, 43);
+        }
+        .fg-green {
+          color: rgb(57, 181, 74);
+        }
+        .fg-yellow {
+          color: rgb(255, 199, 6);
+        }
+        .fg-blue {
+          color: rgb(0, 111, 184);
+        }
+        .fg-magenta {
+          color: rgb(118, 38, 113);
+        }
+        .fg-cyan {
+          color: rgb(44, 181, 233);
+        }
+        .fg-white {
+          color: rgb(204, 204, 204);
+        }
+        .bg-black {
+          background-color: rgb(0, 0, 0);
+        }
+        .bg-red {
+          background-color: rgb(222, 56, 43);
+        }
+        .bg-green {
+          background-color: rgb(57, 181, 74);
+        }
+        .bg-yellow {
+          background-color: rgb(255, 199, 6);
+        }
+        .bg-blue {
+          background-color: rgb(0, 111, 184);
+        }
+        .bg-magenta {
+          background-color: rgb(118, 38, 113);
+        }
+        .bg-cyan {
+          background-color: rgb(44, 181, 233);
+        }
+        .bg-white {
+          background-color: rgb(204, 204, 204);
         }
       </style>
       <paper-card heading="Log">
-        <div class="card-content"><pre>[[log]]</pre></div>
+        <div class="card-content" id="content"></div>
         <div class="card-actions">
           <paper-button on-click="refresh">Refresh</paper-button>
         </div>
@@ -33,7 +95,6 @@ class HassioAddonLogs extends PolymerElement {
         type: String,
         observer: "addonSlugChanged",
       },
-      log: String,
     };
   }
 
@@ -48,11 +109,160 @@ class HassioAddonLogs extends PolymerElement {
     this.refresh();
   }
 
+  static parseLogsToPre(text) {
+    const pre = document.createElement("pre");
+    const re = /\033(?:\[(.*?)[@-~]|\].*?(?:\007|\033\\))/g;
+    let i = 0;
+
+    const state = {
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      foregroundColor: null,
+      backgroundColor: null,
+    };
+
+    const addSpan = (content) => {
+      const span = document.createElement("span");
+      if (state.bold) {
+        span.classList.add("bold");
+      }
+      if (state.italic) {
+        span.classList.add("italic");
+      }
+      if (state.underline) {
+        span.classList.add("underline");
+      }
+      if (state.strikethrough) {
+        span.classList.add("strikethrough");
+      }
+      if (state.foregroundColor !== null) {
+        span.classList.add(state.foregroundColor);
+      }
+      if (state.backgroundColor !== null) {
+        span.classList.add(state.backgroundColor);
+      }
+      span.appendChild(document.createTextNode(content));
+      pre.appendChild(span);
+    };
+
+    /* eslint-disable no-constant-condition */
+    while (true) {
+      const match = re.exec(text);
+      if (match === null) {
+        break;
+      }
+
+      const j = match.index;
+      addSpan(text.substring(i, j));
+      i = j + match[0].length;
+
+      if (match[1] === undefined) continue;
+
+      for (const colorCode of match[1].split(";")) {
+        switch (parseInt(colorCode)) {
+          case 0:
+            // reset
+            state.bold = false;
+            state.italic = false;
+            state.underline = false;
+            state.strikethrough = false;
+            state.foregroundColor = null;
+            state.backgroundColor = null;
+            break;
+          case 1:
+            state.bold = true;
+            break;
+          case 3:
+            state.italic = true;
+            break;
+          case 4:
+            state.underline = true;
+            break;
+          case 9:
+            state.strikethrough = true;
+            break;
+          case 22:
+            state.bold = false;
+            break;
+          case 23:
+            state.italic = false;
+            break;
+          case 24:
+            state.underline = false;
+            break;
+          case 29:
+            state.strikethrough = false;
+            break;
+          case 31:
+            state.foregroundColor = "fg-red";
+            break;
+          case 32:
+            state.foregroundColor = "fg-green";
+            break;
+          case 33:
+            state.foregroundColor = "fg-yellow";
+            break;
+          case 34:
+            state.foregroundColor = "fg-blue";
+            break;
+          case 35:
+            state.foregroundColor = "fg-magenta";
+            break;
+          case 36:
+            state.foregroundColor = "fg-cyan";
+            break;
+          case 37:
+            state.foregroundColor = "fg-white";
+            break;
+          case 30:
+          case 39:
+            state.foregroundColor = null;
+            break;
+          case 40:
+            state.backgroundColor = "bg-black";
+            break;
+          case 41:
+            state.backgroundColor = "bg-red";
+            break;
+          case 42:
+            state.backgroundColor = "bg-green";
+            break;
+          case 43:
+            state.backgroundColor = "bg-yellow";
+            break;
+          case 44:
+            state.backgroundColor = "bg-blue";
+            break;
+          case 45:
+            state.backgroundColor = "bg-magenta";
+            break;
+          case 46:
+            state.backgroundColor = "bg-cyan";
+            break;
+          case 47:
+            state.backgroundColor = "bg-white";
+            break;
+          case 49:
+            state.backgroundColor = null;
+            break;
+        }
+      }
+    }
+    addSpan(text.substring(i));
+
+    return pre;
+  }
+
   refresh() {
     this.hass
       .callApi("get", `hassio/addons/${this.addonSlug}/logs`)
-      .then((info) => {
-        this.log = info;
+      .then((text) => {
+        while (this.$.content.lastChild) {
+          this.$.content.removeChild(this.$.content.lastChild);
+        }
+        this.$.content.appendChild(HassioAddonLogs.parseLogsToPre(text));
       });
   }
 }

--- a/hassio/src/ansi-to-html.js
+++ b/hassio/src/ansi-to-html.js
@@ -81,24 +81,14 @@ export function parseTextToColoredPre(text) {
 
   const addSpan = (content) => {
     const span = document.createElement("span");
-    if (state.bold) {
-      span.classList.add("bold");
-    }
-    if (state.italic) {
-      span.classList.add("italic");
-    }
-    if (state.underline) {
-      span.classList.add("underline");
-    }
-    if (state.strikethrough) {
-      span.classList.add("strikethrough");
-    }
-    if (state.foregroundColor !== null) {
+    if (state.bold) span.classList.add("bold");
+    if (state.italic) span.classList.add("italic");
+    if (state.underline) span.classList.add("underline");
+    if (state.strikethrough) span.classList.add("strikethrough");
+    if (state.foregroundColor !== null)
       span.classList.add(`fg-${state.foregroundColor}`);
-    }
-    if (state.backgroundColor !== null) {
+    if (state.backgroundColor !== null)
       span.classList.add(`bg-${state.backgroundColor}`);
-    }
     span.appendChild(document.createTextNode(content));
     pre.appendChild(span);
   };
@@ -106,9 +96,7 @@ export function parseTextToColoredPre(text) {
   /* eslint-disable no-constant-condition */
   while (true) {
     const match = re.exec(text);
-    if (match === null) {
-      break;
-    }
+    if (match === null) break;
 
     const j = match.index;
     addSpan(text.substring(i, j));
@@ -151,6 +139,10 @@ export function parseTextToColoredPre(text) {
         case 29:
           state.strikethrough = false;
           break;
+        case 30:
+          // foreground black
+          state.foregroundColor = null;
+          break;
         case 31:
           state.foregroundColor = "red";
           break;
@@ -172,8 +164,8 @@ export function parseTextToColoredPre(text) {
         case 37:
           state.foregroundColor = "white";
           break;
-        case 30:
         case 39:
+          // foreground reset
           state.foregroundColor = null;
           break;
         case 40:
@@ -201,6 +193,7 @@ export function parseTextToColoredPre(text) {
           state.backgroundColor = "white";
           break;
         case 49:
+          // background reset
           state.backgroundColor = null;
           break;
       }

--- a/hassio/src/ansi-to-html.js
+++ b/hassio/src/ansi-to-html.js
@@ -1,0 +1,212 @@
+import { html } from "@polymer/polymer/lib/utils/html-tag";
+
+export const ANSI_HTML_STYLE = html`
+  <style>
+    .bold {
+      font-weight: bold;
+    }
+    .italic {
+      font-style: italic;
+    }
+    .underline {
+      text-decoration: underline;
+    }
+    .strikethrough {
+      text-decoration: line-through;
+    }
+    .underline.strikethrough {
+      text-decoration: underline line-through;
+    }
+    .fg-red {
+      color: rgb(222, 56, 43);
+    }
+    .fg-green {
+      color: rgb(57, 181, 74);
+    }
+    .fg-yellow {
+      color: rgb(255, 199, 6);
+    }
+    .fg-blue {
+      color: rgb(0, 111, 184);
+    }
+    .fg-magenta {
+      color: rgb(118, 38, 113);
+    }
+    .fg-cyan {
+      color: rgb(44, 181, 233);
+    }
+    .fg-white {
+      color: rgb(204, 204, 204);
+    }
+    .bg-black {
+      background-color: rgb(0, 0, 0);
+    }
+    .bg-red {
+      background-color: rgb(222, 56, 43);
+    }
+    .bg-green {
+      background-color: rgb(57, 181, 74);
+    }
+    .bg-yellow {
+      background-color: rgb(255, 199, 6);
+    }
+    .bg-blue {
+      background-color: rgb(0, 111, 184);
+    }
+    .bg-magenta {
+      background-color: rgb(118, 38, 113);
+    }
+    .bg-cyan {
+      background-color: rgb(44, 181, 233);
+    }
+    .bg-white {
+      background-color: rgb(204, 204, 204);
+    }
+  </style>
+`;
+
+export function parseTextToColoredPre(text) {
+  const pre = document.createElement("pre");
+  const re = /\033(?:\[(.*?)[@-~]|\].*?(?:\007|\033\\))/g;
+  let i = 0;
+
+  const state = {
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    foregroundColor: null,
+    backgroundColor: null,
+  };
+
+  const addSpan = (content) => {
+    const span = document.createElement("span");
+    if (state.bold) {
+      span.classList.add("bold");
+    }
+    if (state.italic) {
+      span.classList.add("italic");
+    }
+    if (state.underline) {
+      span.classList.add("underline");
+    }
+    if (state.strikethrough) {
+      span.classList.add("strikethrough");
+    }
+    if (state.foregroundColor !== null) {
+      span.classList.add(`fg-${state.foregroundColor}`);
+    }
+    if (state.backgroundColor !== null) {
+      span.classList.add(`bg-${state.backgroundColor}`);
+    }
+    span.appendChild(document.createTextNode(content));
+    pre.appendChild(span);
+  };
+
+  /* eslint-disable no-constant-condition */
+  while (true) {
+    const match = re.exec(text);
+    if (match === null) {
+      break;
+    }
+
+    const j = match.index;
+    addSpan(text.substring(i, j));
+    i = j + match[0].length;
+
+    if (match[1] === undefined) continue;
+
+    for (const colorCode of match[1].split(";")) {
+      switch (parseInt(colorCode)) {
+        case 0:
+          // reset
+          state.bold = false;
+          state.italic = false;
+          state.underline = false;
+          state.strikethrough = false;
+          state.foregroundColor = null;
+          state.backgroundColor = null;
+          break;
+        case 1:
+          state.bold = true;
+          break;
+        case 3:
+          state.italic = true;
+          break;
+        case 4:
+          state.underline = true;
+          break;
+        case 9:
+          state.strikethrough = true;
+          break;
+        case 22:
+          state.bold = false;
+          break;
+        case 23:
+          state.italic = false;
+          break;
+        case 24:
+          state.underline = false;
+          break;
+        case 29:
+          state.strikethrough = false;
+          break;
+        case 31:
+          state.foregroundColor = "red";
+          break;
+        case 32:
+          state.foregroundColor = "green";
+          break;
+        case 33:
+          state.foregroundColor = "yellow";
+          break;
+        case 34:
+          state.foregroundColor = "blue";
+          break;
+        case 35:
+          state.foregroundColor = "magenta";
+          break;
+        case 36:
+          state.foregroundColor = "cyan";
+          break;
+        case 37:
+          state.foregroundColor = "white";
+          break;
+        case 30:
+        case 39:
+          state.foregroundColor = null;
+          break;
+        case 40:
+          state.backgroundColor = "black";
+          break;
+        case 41:
+          state.backgroundColor = "red";
+          break;
+        case 42:
+          state.backgroundColor = "green";
+          break;
+        case 43:
+          state.backgroundColor = "yellow";
+          break;
+        case 44:
+          state.backgroundColor = "blue";
+          break;
+        case 45:
+          state.backgroundColor = "magenta";
+          break;
+        case 46:
+          state.backgroundColor = "cyan";
+          break;
+        case 47:
+          state.backgroundColor = "white";
+          break;
+        case 49:
+          state.backgroundColor = null;
+          break;
+      }
+    }
+  }
+  addSpan(text.substring(i));
+
+  return pre;
+}

--- a/hassio/src/ansi-to-html.js
+++ b/hassio/src/ansi-to-html.js
@@ -93,11 +93,9 @@ export function parseTextToColoredPre(text) {
     pre.appendChild(span);
   };
 
-  /* eslint-disable no-constant-condition */
-  while (true) {
-    const match = re.exec(text);
-    if (match === null) break;
-
+  /* eslint-disable no-cond-assign */
+  let match;
+  while ((match = re.exec(text)) !== null) {
     const j = match.index;
     addSpan(text.substring(i, j));
     i = j + match[0].length;

--- a/hassio/src/system/hassio-supervisor-log.js
+++ b/hassio/src/system/hassio-supervisor-log.js
@@ -16,6 +16,9 @@ class HassioSupervisorLog extends PolymerElement {
           white-space: pre-wrap;
           overflow-wrap: break-word;
         }
+        .fg-green {
+          color: var(--primary-text-color) !important;
+        }
       </style>
       ${ANSI_HTML_STYLE}
       <paper-card>

--- a/hassio/src/system/hassio-supervisor-log.js
+++ b/hassio/src/system/hassio-supervisor-log.js
@@ -12,12 +12,74 @@ class HassioSupervisorLog extends PolymerElement {
         }
         pre {
           overflow-x: auto;
+          white-space: pre-wrap;
+          overflow-wrap: break-word;
+        }
+        .bold {
+          font-weight: bold;
+        }
+        .italic {
+          font-style: italic;
+        }
+        .underline {
+          text-decoration: underline;
+        }
+        .strikethrough {
+          text-decoration: line-through;
+        }
+        .underline.strikethrough {
+          text-decoration: underline line-through;
+        }
+        .fg-red {
+          color: rgb(222, 56, 43);
+        }
+        .fg-green {
+          /* color: rgb(57, 181, 74); */
+        }
+        .fg-yellow {
+          color: rgb(255, 199, 6);
+        }
+        .fg-blue {
+          color: rgb(0, 111, 184);
+        }
+        .fg-magenta {
+          color: rgb(118, 38, 113);
+        }
+        .fg-cyan {
+          color: rgb(44, 181, 233);
+        }
+        .fg-white {
+          color: rgb(204, 204, 204);
+        }
+        .bg-black {
+          background-color: rgb(0, 0, 0);
+        }
+        .bg-red {
+          background-color: rgb(222, 56, 43);
+        }
+        .bg-green {
+          background-color: rgb(57, 181, 74);
+        }
+        .bg-yellow {
+          background-color: rgb(255, 199, 6);
+        }
+        .bg-blue {
+          background-color: rgb(0, 111, 184);
+        }
+        .bg-magenta {
+          background-color: rgb(118, 38, 113);
+        }
+        .bg-cyan {
+          background-color: rgb(44, 181, 233);
+        }
+        .bg-white {
+          background-color: rgb(204, 204, 204);
         }
       </style>
       <paper-card>
-        <div class="card-content"><pre>[[log]]</pre></div>
+        <div class="card-content" id="content"></div>
         <div class="card-actions">
-          <paper-button on-click="refreshTapped">Refresh</paper-button>
+          <paper-button on-click="refresh">Refresh</paper-button>
         </div>
       </paper-card>
     `;
@@ -35,18 +97,172 @@ class HassioSupervisorLog extends PolymerElement {
     this.loadData();
   }
 
+  static parseLogsToPre(text) {
+    const pre = document.createElement("pre");
+    const re = /\033(?:\[(.*?)[@-~]|\].*?(?:\007|\033\\))/g;
+    let i = 0;
+
+    const state = {
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      foregroundColor: null,
+      backgroundColor: null,
+    };
+
+    const addSpan = (content) => {
+      const span = document.createElement("span");
+      if (state.bold) {
+        span.classList.add("bold");
+      }
+      if (state.italic) {
+        span.classList.add("italic");
+      }
+      if (state.underline) {
+        span.classList.add("underline");
+      }
+      if (state.strikethrough) {
+        span.classList.add("strikethrough");
+      }
+      if (state.foregroundColor !== null) {
+        span.classList.add(state.foregroundColor);
+      }
+      if (state.backgroundColor !== null) {
+        span.classList.add(state.backgroundColor);
+      }
+      span.appendChild(document.createTextNode(content));
+      pre.appendChild(span);
+    };
+
+    /* eslint-disable no-constant-condition */
+    while (true) {
+      const match = re.exec(text);
+      if (match === null) {
+        break;
+      }
+
+      const j = match.index;
+      addSpan(text.substring(i, j));
+      i = j + match[0].length;
+
+      if (match[1] === undefined) continue;
+
+      for (const colorCode of match[1].split(";")) {
+        switch (parseInt(colorCode)) {
+          case 0:
+            // reset
+            state.bold = false;
+            state.italic = false;
+            state.underline = false;
+            state.strikethrough = false;
+            state.foregroundColor = null;
+            state.backgroundColor = null;
+            break;
+          case 1:
+            state.bold = true;
+            break;
+          case 3:
+            state.italic = true;
+            break;
+          case 4:
+            state.underline = true;
+            break;
+          case 9:
+            state.strikethrough = true;
+            break;
+          case 22:
+            state.bold = false;
+            break;
+          case 23:
+            state.italic = false;
+            break;
+          case 24:
+            state.underline = false;
+            break;
+          case 29:
+            state.strikethrough = false;
+            break;
+          case 31:
+            state.foregroundColor = "fg-red";
+            break;
+          case 32:
+            state.foregroundColor = "fg-green";
+            break;
+          case 33:
+            state.foregroundColor = "fg-yellow";
+            break;
+          case 34:
+            state.foregroundColor = "fg-blue";
+            break;
+          case 35:
+            state.foregroundColor = "fg-magenta";
+            break;
+          case 36:
+            state.foregroundColor = "fg-cyan";
+            break;
+          case 37:
+            state.foregroundColor = "fg-white";
+            break;
+          case 30:
+          case 39:
+            state.foregroundColor = null;
+            break;
+          case 40:
+            state.backgroundColor = "bg-black";
+            break;
+          case 41:
+            state.backgroundColor = "bg-red";
+            break;
+          case 42:
+            state.backgroundColor = "bg-green";
+            break;
+          case 43:
+            state.backgroundColor = "bg-yellow";
+            break;
+          case 44:
+            state.backgroundColor = "bg-blue";
+            break;
+          case 45:
+            state.backgroundColor = "bg-magenta";
+            break;
+          case 46:
+            state.backgroundColor = "bg-cyan";
+            break;
+          case 47:
+            state.backgroundColor = "bg-white";
+            break;
+          case 49:
+            state.backgroundColor = null;
+            break;
+        }
+      }
+    }
+    addSpan(text.substring(i));
+
+    return pre;
+  }
+
   loadData() {
     this.hass.callApi("get", "hassio/supervisor/logs").then(
-      (info) => {
-        this.log = info;
+      (text) => {
+        while (this.$.content.lastChild) {
+          this.$.content.removeChild(this.$.content.lastChild);
+        }
+        this.$.content.appendChild(HassioSupervisorLog.parseLogsToPre(text));
       },
       () => {
-        this.log = "Error fetching logs";
+        while (this.$.content.lastChild) {
+          this.$.content.removeChild(this.$.content.lastChild);
+        }
+        this.$.content.appendChild(
+          HassioSupervisorLog.parseLogsToPre("Error fetching logs")
+        );
       }
     );
   }
 
-  refreshTapped() {
+  refresh() {
     this.loadData();
   }
 }

--- a/hassio/src/system/hassio-supervisor-log.js
+++ b/hassio/src/system/hassio-supervisor-log.js
@@ -2,6 +2,7 @@ import "@polymer/paper-button/paper-button";
 import "@polymer/paper-card/paper-card";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
+import { ANSI_HTML_STYLE, parseTextToColoredPre } from "../ansi-to-html";
 
 class HassioSupervisorLog extends PolymerElement {
   static get template() {
@@ -15,67 +16,8 @@ class HassioSupervisorLog extends PolymerElement {
           white-space: pre-wrap;
           overflow-wrap: break-word;
         }
-        .bold {
-          font-weight: bold;
-        }
-        .italic {
-          font-style: italic;
-        }
-        .underline {
-          text-decoration: underline;
-        }
-        .strikethrough {
-          text-decoration: line-through;
-        }
-        .underline.strikethrough {
-          text-decoration: underline line-through;
-        }
-        .fg-red {
-          color: rgb(222, 56, 43);
-        }
-        .fg-green {
-          color: rgb(57, 181, 74);
-        }
-        .fg-yellow {
-          color: rgb(255, 199, 6);
-        }
-        .fg-blue {
-          color: rgb(0, 111, 184);
-        }
-        .fg-magenta {
-          color: rgb(118, 38, 113);
-        }
-        .fg-cyan {
-          color: rgb(44, 181, 233);
-        }
-        .fg-white {
-          color: rgb(204, 204, 204);
-        }
-        .bg-black {
-          background-color: rgb(0, 0, 0);
-        }
-        .bg-red {
-          background-color: rgb(222, 56, 43);
-        }
-        .bg-green {
-          background-color: rgb(57, 181, 74);
-        }
-        .bg-yellow {
-          background-color: rgb(255, 199, 6);
-        }
-        .bg-blue {
-          background-color: rgb(0, 111, 184);
-        }
-        .bg-magenta {
-          background-color: rgb(118, 38, 113);
-        }
-        .bg-cyan {
-          background-color: rgb(44, 181, 233);
-        }
-        .bg-white {
-          background-color: rgb(204, 204, 204);
-        }
       </style>
+      ${ANSI_HTML_STYLE}
       <paper-card>
         <div class="card-content" id="content"></div>
         <div class="card-actions">
@@ -88,7 +30,6 @@ class HassioSupervisorLog extends PolymerElement {
   static get properties() {
     return {
       hass: Object,
-      log: String,
     };
   }
 
@@ -97,159 +38,13 @@ class HassioSupervisorLog extends PolymerElement {
     this.loadData();
   }
 
-  static parseLogsToPre(text) {
-    const pre = document.createElement("pre");
-    const re = /\033(?:\[(.*?)[@-~]|\].*?(?:\007|\033\\))/g;
-    let i = 0;
-
-    const state = {
-      bold: false,
-      italic: false,
-      underline: false,
-      strikethrough: false,
-      foregroundColor: null,
-      backgroundColor: null,
-    };
-
-    const addSpan = (content) => {
-      const span = document.createElement("span");
-      if (state.bold) {
-        span.classList.add("bold");
-      }
-      if (state.italic) {
-        span.classList.add("italic");
-      }
-      if (state.underline) {
-        span.classList.add("underline");
-      }
-      if (state.strikethrough) {
-        span.classList.add("strikethrough");
-      }
-      if (state.foregroundColor !== null) {
-        span.classList.add(state.foregroundColor);
-      }
-      if (state.backgroundColor !== null) {
-        span.classList.add(state.backgroundColor);
-      }
-      span.appendChild(document.createTextNode(content));
-      pre.appendChild(span);
-    };
-
-    /* eslint-disable no-constant-condition */
-    while (true) {
-      const match = re.exec(text);
-      if (match === null) {
-        break;
-      }
-
-      const j = match.index;
-      addSpan(text.substring(i, j));
-      i = j + match[0].length;
-
-      if (match[1] === undefined) continue;
-
-      for (const colorCode of match[1].split(";")) {
-        switch (parseInt(colorCode)) {
-          case 0:
-            // reset
-            state.bold = false;
-            state.italic = false;
-            state.underline = false;
-            state.strikethrough = false;
-            state.foregroundColor = null;
-            state.backgroundColor = null;
-            break;
-          case 1:
-            state.bold = true;
-            break;
-          case 3:
-            state.italic = true;
-            break;
-          case 4:
-            state.underline = true;
-            break;
-          case 9:
-            state.strikethrough = true;
-            break;
-          case 22:
-            state.bold = false;
-            break;
-          case 23:
-            state.italic = false;
-            break;
-          case 24:
-            state.underline = false;
-            break;
-          case 29:
-            state.strikethrough = false;
-            break;
-          case 31:
-            state.foregroundColor = "fg-red";
-            break;
-          case 32:
-            state.foregroundColor = "fg-green";
-            break;
-          case 33:
-            state.foregroundColor = "fg-yellow";
-            break;
-          case 34:
-            state.foregroundColor = "fg-blue";
-            break;
-          case 35:
-            state.foregroundColor = "fg-magenta";
-            break;
-          case 36:
-            state.foregroundColor = "fg-cyan";
-            break;
-          case 37:
-            state.foregroundColor = "fg-white";
-            break;
-          case 30:
-          case 39:
-            state.foregroundColor = null;
-            break;
-          case 40:
-            state.backgroundColor = "bg-black";
-            break;
-          case 41:
-            state.backgroundColor = "bg-red";
-            break;
-          case 42:
-            state.backgroundColor = "bg-green";
-            break;
-          case 43:
-            state.backgroundColor = "bg-yellow";
-            break;
-          case 44:
-            state.backgroundColor = "bg-blue";
-            break;
-          case 45:
-            state.backgroundColor = "bg-magenta";
-            break;
-          case 46:
-            state.backgroundColor = "bg-cyan";
-            break;
-          case 47:
-            state.backgroundColor = "bg-white";
-            break;
-          case 49:
-            state.backgroundColor = null;
-            break;
-        }
-      }
-    }
-    addSpan(text.substring(i));
-
-    return pre;
-  }
-
   loadData() {
     this.hass.callApi("get", "hassio/supervisor/logs").then(
       (text) => {
         while (this.$.content.lastChild) {
           this.$.content.removeChild(this.$.content.lastChild);
         }
-        this.$.content.appendChild(HassioSupervisorLog.parseLogsToPre(text));
+        this.$.content.appendChild(parseTextToColoredPre(text));
       },
       () => {
         this.$.content.innerHTML =

--- a/hassio/src/system/hassio-supervisor-log.js
+++ b/hassio/src/system/hassio-supervisor-log.js
@@ -34,7 +34,7 @@ class HassioSupervisorLog extends PolymerElement {
           color: rgb(222, 56, 43);
         }
         .fg-green {
-          /* color: rgb(57, 181, 74); */
+          color: rgb(57, 181, 74);
         }
         .fg-yellow {
           color: rgb(255, 199, 6);
@@ -252,12 +252,8 @@ class HassioSupervisorLog extends PolymerElement {
         this.$.content.appendChild(HassioSupervisorLog.parseLogsToPre(text));
       },
       () => {
-        while (this.$.content.lastChild) {
-          this.$.content.removeChild(this.$.content.lastChild);
-        }
-        this.$.content.appendChild(
-          HassioSupervisorLog.parseLogsToPre("Error fetching logs")
-        );
+        this.$.content.innerHTML =
+          '<span class="fg-red bold">Error fetching logs</span>';
       }
     );
   }


### PR DESCRIPTION
Home-Assistant PR to forward ANSI color codes in HTTP view: https://github.com/home-assistant/home-assistant/pull/18834

Show colors in Hass.io logs. Example:

<img width="613" alt="Hass.io add-on" src="https://user-images.githubusercontent.com/6833237/49281899-0f0f6280-f48e-11e8-8e76-adfe73acaeee.png">

(source: https://gist.github.com/OttoWinter/88ec233c3bd714c00f86cb70018aa7af)

<img width="985" alt="Hass.io supervisor logs" src="https://user-images.githubusercontent.com/6833237/49281913-146cad00-f48e-11e8-8154-69f37d484e5e.png">

- [x] Obviously there's a lot of duplication going on between the supervisor and add-on logs; Of course these should be refactored into one class. However I don't know how to create such a class + I have no idea how imports work here 😅 Help is welcome!
- [x] One problem with refactoring is that the supervisor logs are slightly different. The supervisor uses green for almost all log messages (info), so green is converted to black in the supervisor logs.
- [ ] The colors are not perfect yet. Especially the yellow color is a bit too bright to read. I spent some time trying to find a working color but ultimately failed. The color schema is based on the ubuntu colors here: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
- [x] Probably we could strip down the list of supported ANSI escape codes here. For the initial patch, I just went ahead and implemented all to see how it looks. Probably something like background isn't too necessary, but I'm sure somebody could make some creative design using that.
