### PR TITLE
Update demo-hui-glance-card.js

### DIFF
--- a/gallery/src/demos/demo-hui-glance-card.js
+++ b/gallery/src/demos/demo-hui-glance-card.js
@@ -89,7 +89,7 @@ const CONFIGS = [
     `,
   },
   {
-    heading: "Custom column width",
+    heading: "Custom number of columns",
     config: `
 - type: glance
   columns: 7

--- a/gallery/src/demos/demo-hui-glance-card.js
+++ b/gallery/src/demos/demo-hui-glance-card.js
@@ -92,7 +92,7 @@ const CONFIGS = [
     heading: "Custom column width",
     config: `
 - type: glance
-  column_width: calc(100% / 7)
+  columns: 7
   entities:
     - device_tracker.demo_paulus
     - media_player.living_room


### PR DESCRIPTION
Fixed updated syntax
```
calc(100% / 7)
```
vs
```
columns: 7
```
