### PR TITLE
Handle mouse events on touchscreens. Fix #2085

### DIFF
--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -41,7 +41,8 @@ class LongPress extends HTMLElement implements LongPress {
     this.ripple.primary = true;
 
     [
-      isTouch ? "touchcancel" : "mouseout",
+      "touchcancel",
+      "mouseout",
       "mouseup",
       "touchmove",
       "mousewheel",
@@ -80,6 +81,9 @@ class LongPress extends HTMLElement implements LongPress {
     });
 
     const clickStart = (ev: Event) => {
+      if (ev instanceof TouchEvent) {
+        ev.preventDefault();
+      }
       this.held = false;
       let x;
       let y;
@@ -96,7 +100,10 @@ class LongPress extends HTMLElement implements LongPress {
       }, this.holdTime);
     };
 
-    const clickEnd = () => {
+    const clickEnd = (ev: Event) => {
+      if (ev instanceof TouchEvent) {
+        ev.preventDefault();
+      }
       clearTimeout(this.timer);
       this.stopAnimation();
       if (isTouch && this.timer === undefined) {
@@ -110,14 +117,11 @@ class LongPress extends HTMLElement implements LongPress {
       }
     };
 
-    if (isTouch) {
-      element.addEventListener("touchstart", clickStart, { passive: true });
-      element.addEventListener("touchend", clickEnd);
-      element.addEventListener("touchcancel", clickEnd);
-    } else {
-      element.addEventListener("mousedown", clickStart, { passive: true });
-      element.addEventListener("click", clickEnd);
-    }
+    element.addEventListener("touchstart", clickStart, { passive: true });
+    element.addEventListener("touchend", clickEnd);
+    element.addEventListener("touchcancel", clickEnd);
+    element.addEventListener("mousedown", clickStart, { passive: true });
+    element.addEventListener("click", clickEnd);
   }
 
   private startAnimation(x: number, y: number) {

--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -101,13 +101,13 @@ class LongPress extends HTMLElement implements LongPress {
     };
 
     const clickEnd = (ev: Event) => {
-      if (ev instanceof TouchEvent) {
-        ev.preventDefault();
-      }
       clearTimeout(this.timer);
       this.stopAnimation();
-      if (isTouch && this.timer === undefined) {
-        return;
+      if (ev instanceof TouchEvent) {
+        ev.preventDefault();
+        if (this.timer === undefined) {
+          return;
+        }
       }
       this.timer = undefined;
       if (this.held) {
@@ -117,10 +117,10 @@ class LongPress extends HTMLElement implements LongPress {
       }
     };
 
-    element.addEventListener("touchstart", clickStart, { passive: true });
+    element.addEventListener("touchstart", clickStart);
     element.addEventListener("touchend", clickEnd);
     element.addEventListener("touchcancel", clickEnd);
-    element.addEventListener("mousedown", clickStart, { passive: true });
+    element.addEventListener("mousedown", clickStart);
     element.addEventListener("click", clickEnd);
   }
 

--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -81,7 +81,7 @@ class LongPress extends HTMLElement implements LongPress {
     });
 
     const clickStart = (ev: Event) => {
-      if (ev instanceof TouchEvent) {
+      if (ev instanceof TouchEvent && ev.cancelable) {
         ev.preventDefault();
       }
       this.held = false;
@@ -104,7 +104,9 @@ class LongPress extends HTMLElement implements LongPress {
       clearTimeout(this.timer);
       this.stopAnimation();
       if (ev instanceof TouchEvent) {
-        ev.preventDefault();
+        if (ev.cancelable) {
+          ev.preventDefault();
+        }
         if (this.timer === undefined) {
           return;
         }

--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -107,7 +107,7 @@ class LongPress extends HTMLElement implements LongPress {
       window.setTimeout(() => (this.cooldownStart = false), 100);
     };
 
-    const clickEnd = (ev: Event) => {
+    const clickEnd = () => {
       if (this.cooldownEnd) {
         return;
       }
@@ -123,10 +123,10 @@ class LongPress extends HTMLElement implements LongPress {
       window.setTimeout(() => (this.cooldownEnd = false), 100);
     };
 
-    element.addEventListener("touchstart", clickStart);
+    element.addEventListener("touchstart", clickStart, { passive: true });
     element.addEventListener("touchend", clickEnd);
     element.addEventListener("touchcancel", clickEnd);
-    element.addEventListener("mousedown", clickStart);
+    element.addEventListener("mousedown", clickStart, { passive: true });
     element.addEventListener("click", clickEnd);
   }
 

--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -107,8 +107,11 @@ class LongPress extends HTMLElement implements LongPress {
       window.setTimeout(() => (this.cooldownStart = false), 100);
     };
 
-    const clickEnd = () => {
-      if (this.cooldownEnd) {
+    const clickEnd = (ev: Event) => {
+      if (
+        this.cooldownEnd ||
+        (ev instanceof TouchEvent && this.timer === undefined)
+      ) {
         return;
       }
       clearTimeout(this.timer);


### PR DESCRIPTION
I think this does it.

Before merging I would want someone to test on:

- [X] Chrome for Android
- [X] Windows 10 pc with touchscreen (mouse)
- [X] Windows 10 pc with touchscreen (touch)
- [X] Safari on iphone