### PR TITLE
Stop MouseEvent from reach parent element

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -145,13 +145,15 @@ class HuiMediaPlayerEntityRow extends hassLocalizeLitMixin(LitElement)
     return prefix && suffix ? `${prefix}: ${suffix}` : prefix || suffix || "";
   }
 
-  private _playPause(): void {
+  private _playPause(ev: MouseEvent): void {
+    ev.stopPropagation();
     this.hass!.callService("media_player", "media_play_pause", {
       entity_id: this._config!.entity,
     });
   }
 
-  private _nextTrack(): void {
+  private _nextTrack(ev: MouseEvent): void {
+    ev.stopPropagation();
     this.hass!.callService("media_player", "media_next_track", {
       entity_id: this._config!.entity,
     });


### PR DESCRIPTION
`more-info` is being displayed on each click of pause/play and next track buttons in the media-row