### PR TITLE
Fixes Color not being overwritten by themes for cards

### DIFF
--- a/src/components/ha-card.js
+++ b/src/components/ha-card.js
@@ -12,6 +12,7 @@ class HaCard extends PolymerElement {
           border-radius: 2px;
           transition: all 0.3s ease-out;
           background-color: var(--paper-card-background-color, white);
+          color: var(--primary-text-color);
         }
         .header {
           @apply --paper-font-headline;


### PR DESCRIPTION
This allows card themes to overwrite the color using `--primary-text-color` 