### PR TITLE
exporation: Use indexes for editing

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -7,14 +7,16 @@ import { showEditCardDialog } from "../editor/show-edit-card-dialog";
 import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
 import { confDeleteCard } from "../editor/delete-card";
 import { HomeAssistant } from "../../../types";
-import { LovelaceCardConfig } from "../../../data/lovelace";
+import { LovelaceCardConfig, LovelaceConfig } from "../../../data/lovelace";
 
 export class HuiCardOptions extends hassLocalizeLitMixin(LitElement) {
   public cardConfig?: LovelaceCardConfig;
   protected hass?: HomeAssistant;
+  protected path?: [number, number];
+  protected config?: LovelaceConfig;
 
   static get properties(): PropertyDeclarations {
-    return { hass: {} };
+    return { hass: {}, path: {}, config: {} };
   }
 
   protected render() {
@@ -58,7 +60,8 @@ export class HuiCardOptions extends hassLocalizeLitMixin(LitElement) {
       return;
     }
     showEditCardDialog(this, {
-      cardConfig: this.cardConfig,
+      path: this.path!,
+      config: this.config!,
       add: false,
       reloadLovelace: () => fireEvent(this, "config-refresh"),
     });

--- a/src/panels/lovelace/editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/hui-dialog-edit-card.ts
@@ -41,8 +41,8 @@ export class HuiDialogEditCard extends LitElement {
     return html`
       <hui-edit-card
         .hass="${this.hass}"
-        .viewIndex="${this._params.viewIndex}"
-        .cardConfig="${this._params.cardConfig}"
+        .config="${this._params.config}"
+        .path="${this._params.path}"
         .add="${this._params.add}"
         @reload-lovelace="${this._params.reloadLovelace}"
         @cancel-edit-card="${this._cancel}"
@@ -52,11 +52,7 @@ export class HuiDialogEditCard extends LitElement {
   }
 
   private _cancel() {
-    this._params = {
-      reloadLovelace: () => {
-        return;
-      },
-    };
+    this._params = undefined;
   }
 }
 

--- a/src/panels/lovelace/editor/show-edit-card-dialog.ts
+++ b/src/panels/lovelace/editor/show-edit-card-dialog.ts
@@ -1,4 +1,4 @@
-import { LovelaceCardConfig } from "../../../data/lovelace";
+import { LovelaceCardConfig, LovelaceConfig } from "../../../data/lovelace";
 import { fireEvent } from "../../../common/dom/fire_event";
 
 declare global {
@@ -13,8 +13,8 @@ const dialogShowEvent = "show-edit-card";
 const dialogTag = "hui-dialog-edit-card";
 
 export interface EditCardDialogParams {
-  cardConfig?: LovelaceCardConfig;
-  viewIndex?: number;
+  config: LovelaceConfig;
+  path: [number, number];
   add?: boolean;
   reloadLovelace: () => void;
 }

--- a/src/panels/lovelace/ha-panel-lovelace.js
+++ b/src/panels/lovelace/ha-panel-lovelace.js
@@ -120,11 +120,8 @@ class Lovelace extends localizeMixin(PolymerElement) {
   async _fetchConfig(force) {
     try {
       const conf = await fetchConfig(this.hass, force);
-      const {
-        formatLovelaceConfig,
-      } = await import("./common/format-lovelace-config");
       this.setProperties({
-        _config: formatLovelaceConfig(conf),
+        _config: conf,
         _state: "loaded",
       });
     } catch (err) {

--- a/src/panels/lovelace/hui-root.js
+++ b/src/panels/lovelace/hui-root.js
@@ -393,9 +393,11 @@ class HUIRoot extends NavigateMixin(
         view.editMode = this._editMode;
       } else {
         view = document.createElement("hui-view");
+        view.lovelaceConfig = this.config;
         view.config = viewConfig;
         view.columns = this.columns;
         view.editMode = this._editMode;
+        view.index = viewIndex;
       }
       if (viewConfig.background) background = viewConfig.background;
     }

--- a/src/panels/lovelace/hui-view.js
+++ b/src/panels/lovelace/hui-view.js
@@ -97,9 +97,11 @@ class HUIView extends localizeMixin(EventsMixin(PolymerElement)) {
         type: Object,
         observer: "_hassChanged",
       },
+      lovelaceConfig: Object,
       config: Object,
       columns: Number,
       editMode: Boolean,
+      index: Number,
     };
   }
 
@@ -169,23 +171,24 @@ class HUIView extends localizeMixin(EventsMixin(PolymerElement)) {
 
     const elements = [];
     const elementsToAppend = [];
-    for (const cardConfig of config.cards) {
+    config.cards.forEach((cardConfig, cardIndex) => {
       const element = createCardElement(cardConfig);
       element.hass = this.hass;
       elements.push(element);
 
       if (!this.editMode) {
         elementsToAppend.push(element);
-        continue;
+        return;
       }
 
       const wrapper = document.createElement("hui-card-options");
       wrapper.hass = this.hass;
-      wrapper.cardConfig = cardConfig;
+      wrapper.config = this.lovelaceConfig;
       wrapper.editMode = this.editMode;
+      wrapper.path = [this.index, cardIndex];
       wrapper.appendChild(element);
       elementsToAppend.push(wrapper);
-    }
+    });
 
     let columns = [];
     const columnEntityCount = [];


### PR DESCRIPTION
This is an exploration to convert refering to cards being edited by an index path `[viewIndex, cardIndex]` instead of cardConfig, as that fits better with doing mutation on frontend.

Work done on top of #2228

Not for merging.