### PR TITLE
Revert lovelace as default

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -7,6 +7,9 @@
 /** Icon to use when no icon specified for domain. */
 export const DEFAULT_DOMAIN_ICON = "hass:bookmark";
 
+/** Panel to show when no panel is picked. */
+export const DEFAULT_PANEL = "states";
+
 /** Domains that have a state card. */
 export const DOMAINS_WITH_CARD = [
   "climate",

--- a/src/layouts/app/home-assistant.js
+++ b/src/layouts/app/home-assistant.js
@@ -10,6 +10,7 @@ import "../home-assistant-main";
 import "../ha-init-page";
 import "../../resources/ha-style";
 import registerServiceWorker from "../../util/register-service-worker";
+import { DEFAULT_PANEL } from "../../common/const";
 
 import HassBaseMixin from "./hass-base-mixin";
 import AuthMixin from "./auth-mixin";
@@ -94,7 +95,7 @@ class HomeAssistant extends ext(PolymerElement, [
   }
 
   computePanelUrl(routeData) {
-    return (routeData && routeData.panel) || "lovelace";
+    return (routeData && routeData.panel) || DEFAULT_PANEL;
   }
 
   panelUrlChanged(newPanelUrl) {

--- a/src/layouts/home-assistant-main.js
+++ b/src/layouts/home-assistant-main.js
@@ -11,6 +11,7 @@ import "./partial-panel-resolver";
 import EventsMixin from "../mixins/events-mixin";
 import NavigateMixin from "../mixins/navigate-mixin";
 import { computeRTL } from "../common/util/compute_rtl";
+import { DEFAULT_PANEL } from "../common/const";
 
 import(/* webpackChunkName: "ha-sidebar" */ "../components/ha-sidebar");
 import(/* webpackChunkName: "voice-command-dialog" */ "../dialogs/ha-voice-command-dialog");
@@ -98,7 +99,7 @@ class HomeAssistantMain extends NavigateMixin(EventsMixin(PolymerElement)) {
 
   ready() {
     super.ready();
-    this._defaultPage = localStorage.defaultPage || "lovelace";
+    this._defaultPage = localStorage.defaultPage || DEFAULT_PANEL;
     this.addEventListener("hass-open-menu", () => this.handleOpenMenu());
     this.addEventListener("hass-close-menu", () => this.handleCloseMenu());
     this.addEventListener("hass-start-voice", (ev) =>
@@ -135,7 +136,7 @@ class HomeAssistantMain extends NavigateMixin(EventsMixin(PolymerElement)) {
   connectedCallback() {
     super.connectedCallback();
     if (document.location.pathname === "/") {
-      this.navigate(`/${localStorage.defaultPage || "lovelace"}`, true);
+      this.navigate(`/${localStorage.defaultPage || DEFAULT_PANEL}`, true);
     }
   }
 

--- a/src/panels/dev-info/ha-panel-dev-info.js
+++ b/src/panels/dev-info/ha-panel-dev-info.js
@@ -366,7 +366,7 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
   _defaultPageText() {
     return `>> ${
       localStorage.defaultPage === OPT_IN_PANEL ? "Remove" : "Set"
-    } as default page on this device <<`;
+    } ${OPT_IN_PANEL} as default page on this device <<`;
   }
 
   _toggleDefaultPage() {

--- a/src/panels/dev-info/ha-panel-dev-info.js
+++ b/src/panels/dev-info/ha-panel-dev-info.js
@@ -20,6 +20,7 @@ import formatTime from "../../common/datetime/format_time";
 import EventsMixin from "../../mixins/events-mixin";
 import LocalizeMixin from "../../mixins/localize-mixin";
 
+const OPT_IN_PANEL = "lovelace";
 let registeredDialog = false;
 
 class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
@@ -164,7 +165,7 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
             </template>
           </p>
           <p>
-            <a href='/states'>Go back to the old states page</a>
+            <a href='/lovelace'>Try out the new Lovelace UI</a>
             <div id="love" style="cursor:pointer;" on-click="_toggleDefaultPage">[[_defaultPageText()]]</div
           </p>
         </div>
@@ -364,15 +365,15 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
   _defaultPageText() {
     return `>> ${
-      localStorage.defaultPage === "states" ? "Remove" : "Set"
-    } the old states as default page on this device <<`;
+      localStorage.defaultPage === OPT_IN_PANEL ? "Remove" : "Set"
+    } as default page on this device <<`;
   }
 
   _toggleDefaultPage() {
-    if (localStorage.defaultPage === "states") {
+    if (localStorage.defaultPage === OPT_IN_PANEL) {
       delete localStorage.defaultPage;
     } else {
-      localStorage.defaultPage = "states";
+      localStorage.defaultPage = OPT_IN_PANEL;
     }
     this.$.love.innerText = this._defaultPageText();
   }


### PR DESCRIPTION
This reverts Lovelace as the default panel until we have been able to get a better grip at the current UI feature set.

Fixes #2236