### PR TITLE
Simplify Lovelace mode

### DIFF
--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -4,8 +4,7 @@ import { LovelaceCardConfig, LovelaceConfig } from "../../data/lovelace";
 export interface Lovelace {
   config: LovelaceConfig;
   editMode: boolean;
-  autoGen: boolean;
-  mode: "yaml" | "storage";
+  mode: "generated" | "yaml" | "storage";
   setEditMode: (editMode: boolean) => void;
   saveConfig: (newConfig: LovelaceConfig) => Promise<void>;
 }


### PR DESCRIPTION
Remove autoGen boolean on Lovelace object and instead incorporate into mode. Mode of Lovelace can now be "generated", "yaml" or "storage".