### PR TITLE
UI Editor for `alarm-panel` card

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -22,7 +22,7 @@ const Icons = {
 };
 
 export const Config = {
-  title: "",
+  name: "",
   entity: "",
   states: "",
 };

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.js
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.js
@@ -21,7 +21,22 @@ const Icons = {
   triggered: "hass:bell-ring",
 };
 
+export const Config = {
+  title: "",
+  entity: "",
+  states: "",
+};
+
 class HuiAlarmPanelCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
+  static async getConfigElement() {
+    await import("../editor/config-elements/hui-alarm-panel-card-editor");
+    return document.createElement("hui-alarm-panel-card-editor");
+  }
+
+  static getStubConfig() {
+    return { states: ["arm_home", "arm_away"] };
+  }
+
   static get template() {
     return html`
     <style>

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -18,7 +18,6 @@ import "../../../../components/ha-icon";
 
 const cardConfigStruct = struct({
   type: "string",
-  id: "string|number",
   entity: "string?",
   name: "string?",
   states: "array?",

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -19,11 +19,9 @@ import "../../components/hui-theme-select-editor";
 import "../../components/hui-entity-editor";
 import "../../../../components/ha-card";
 import "../../../../components/ha-icon";
-import { repeat } from "lit-html/directives/repeat";
 
 const cardConfigStruct = struct({
   type: "string",
-  id: "string|number",
   entity: "string?",
   name: "string?",
   states: "array?",
@@ -62,10 +60,6 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
     }
 
     const states = ["arm_home", "arm_away", "arm_night", "arm_custom_bypass"];
-    const availableStates = states.filter((state) => {
-      return this._states.indexOf(state) === -1;
-    });
-    console.log(this._states);
 
     return html`
       ${configElementStyle} ${this.renderStyle()}
@@ -104,15 +98,13 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
         }
         <paper-dropdown-menu
           label="Available States"
-          dynamic-align
-          close-on-activate
           @value-changed="${this._stateAdded}"
         >
           <paper-listbox slot="dropdown-content">
             ${
-              availableStates.map((state) => {
+              states.map((state) => {
                 return html`
-                  <paper-item .value="${state}">${state}</paper-item>
+                  <paper-item>${state}</paper-item>
                 `;
               })
             }
@@ -162,13 +154,11 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
       return;
     }
     const target = ev.target! as EditorTarget;
-    console.log(target.value);
-    if (!target.value) {
+    if (!target.value || this._states.indexOf(target.value) >= 0) {
       return;
     }
     const newStates = this._states;
     newStates.push(target.value);
-    console.log(newStates);
     this._config = {
       ...this._config,
       states: newStates,
@@ -182,7 +172,6 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
       return;
     }
     const target = ev.target! as EditorTarget;
-
     if (this[`_${target.configValue}`] === target.value) {
       return;
     }

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -61,12 +61,11 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
       return html``;
     }
 
-    const availableStates = [
-      "arm_home",
-      "arm_away",
-      "arm_night",
-      "arm_custom_bypass",
-    ];
+    const states = ["arm_home", "arm_away", "arm_night", "arm_custom_bypass"];
+    const availableStates = states.filter((state) => {
+      return this._states.indexOf(state) === -1;
+    });
+    console.log(this._states);
 
     return html`
       ${configElementStyle}
@@ -88,16 +87,11 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
           ></ha-entity-picker>
         </div>
         <span>Used States</span> ${
-          repeat(
-            this._states!,
-            (item) =>
-              html`
-                <paper-item>
-                  <ha-icon .icon="hass:close"</ha-icon>
-                  <div>${item}</div>
-                </paper-item>
-              `
-          )
+          this._states.map((state, index) => {
+            return html`
+              <paper-item .index="${index}">${state}</paper-item>
+            `;
+          })
         }
         <paper-dropdown-menu
           label="Available States"
@@ -126,14 +120,14 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
     if (!target.value || this._states.indexOf(target.value) >= 0) {
       return;
     }
-    const states = this._states;
-    states.push(target.value);
-    if (target.configValue) {
-      this._config = {
-        ...this._config,
-        states,
-      };
-    }
+    const newStates = this._states;
+    newStates.push(target.value);
+    console.log(newStates);
+    this._config = {
+      ...this._config,
+      states: newStates,
+    };
+    target.value = "";
     fireEvent(this, "config-changed", { config: this._config });
   }
 

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -4,7 +4,6 @@ import { struct } from "../../common/structs/struct";
 import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
-import "@polymer/paper-input/paper-input";
 
 import { EntitiesEditorEvent, EditorTarget } from "../types";
 import { hassLocalizeLitMixin } from "../../../../mixins/lit-localize-mixin";
@@ -14,14 +13,12 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import { Config } from "../../cards/hui-alarm-panel-card";
 import { configElementStyle } from "./config-elements-style";
 
-import "../../../../components/entity/state-badge";
-import "../../components/hui-theme-select-editor";
-import "../../components/hui-entity-editor";
-import "../../../../components/ha-card";
+import "../../../../components/entity/ha-entity-picker";
 import "../../../../components/ha-icon";
 
 const cardConfigStruct = struct({
   type: "string",
+  id: "string|number",
   entity: "string?",
   name: "string?",
   states: "array?",
@@ -85,13 +82,12 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
             return html`
               <div class="states">
                 <paper-item>${state}</paper-item>
-                <paper-icon-button
+                <ha-icon
                   class="deleteState"
-                  slot="item-icon"
                   .value="${index}"
                   icon="hass:close"
                   @click=${this._stateRemoved}
-                ></paper-icon-button>
+                ></ha-icon>
               </div>
             `;
           })
@@ -126,6 +122,9 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
         }
         .states:hover > .deleteState {
           visibility: visible;
+        }
+        ha-icon {
+          padding-top: 12px;
         }
       </style>
     `;

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-editor.ts
@@ -1,0 +1,165 @@
+import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
+import { TemplateResult } from "lit-html";
+import { struct } from "../../common/structs/struct";
+import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
+import "@polymer/paper-item/paper-item";
+import "@polymer/paper-listbox/paper-listbox";
+import "@polymer/paper-input/paper-input";
+
+import { EntitiesEditorEvent, EditorTarget } from "../types";
+import { hassLocalizeLitMixin } from "../../../../mixins/lit-localize-mixin";
+import { HomeAssistant } from "../../../../types";
+import { LovelaceCardEditor } from "../../types";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { Config } from "../../cards/hui-alarm-panel-card";
+import { configElementStyle } from "./config-elements-style";
+
+import "../../../../components/entity/state-badge";
+import "../../components/hui-theme-select-editor";
+import "../../components/hui-entity-editor";
+import "../../../../components/ha-card";
+import "../../../../components/ha-icon";
+import { repeat } from "lit-html/directives/repeat";
+
+const cardConfigStruct = struct({
+  type: "string",
+  id: "string|number",
+  entity: "string?",
+  name: "string?",
+  states: "array?",
+});
+
+export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
+  implements LovelaceCardEditor {
+  public hass?: HomeAssistant;
+  private _config?: Config;
+
+  public setConfig(config: Config): void {
+    config = cardConfigStruct(config);
+
+    this._config = { type: "alarm-panel", ...config };
+  }
+
+  static get properties(): PropertyDeclarations {
+    return { hass: {}, _config: {} };
+  }
+
+  get _entity(): string {
+    return this._config!.entity || "";
+  }
+
+  get _name(): string {
+    return this._config!.name || "";
+  }
+
+  get _states(): string[] {
+    return this._config!.states || ["arm_home", "arm_away"];
+  }
+
+  protected render(): TemplateResult {
+    if (!this.hass) {
+      return html``;
+    }
+
+    const availableStates = [
+      "arm_home",
+      "arm_away",
+      "arm_night",
+      "arm_custom_bypass",
+    ];
+
+    return html`
+      ${configElementStyle}
+      <div class="card-config">
+        <div class="side-by-side">
+          <paper-input
+            label="Name"
+            value="${this._name}"
+            .configValue="${"name"}"
+            @value-changed="${this._valueChanged}"
+          ></paper-input>
+          <ha-entity-picker
+            .hass="${this.hass}"
+            .value="${this._entity}"
+            .configValue=${"entity"}
+            .domainFilter=${"alarm_control_panel"}
+            @change="${this._valueChanged}"
+            allow-custom-entity
+          ></ha-entity-picker>
+        </div>
+        <span>Used States</span> ${
+          repeat(
+            this._states!,
+            (item) =>
+              html`
+                <paper-item>
+                  <ha-icon .icon="hass:close"</ha-icon>
+                  <div>${item}</div>
+                </paper-item>
+              `
+          )
+        }
+        <paper-dropdown-menu
+          label="Available States"
+          dynamic-align
+          @value-changed="${this._stateAdded}"
+        >
+          <paper-listbox slot="dropdown-content">
+            ${
+              availableStates.map((state) => {
+                return html`
+                  <paper-item theme="${state}">${state}</paper-item>
+                `;
+              })
+            }
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </div>
+    `;
+  }
+
+  private _stateAdded(ev: EntitiesEditorEvent): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+    const target = ev.target! as EditorTarget;
+    if (!target.value || this._states.indexOf(target.value) >= 0) {
+      return;
+    }
+    const states = this._states;
+    states.push(target.value);
+    if (target.configValue) {
+      this._config = {
+        ...this._config,
+        states,
+      };
+    }
+    fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  private _valueChanged(ev: EntitiesEditorEvent): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+    const target = ev.target! as EditorTarget;
+
+    if (this[`_${target.configValue}`] === target.value) {
+      return;
+    }
+    if (target.configValue) {
+      this._config = {
+        ...this._config,
+        [target.configValue!]: target.value,
+      };
+    }
+    fireEvent(this, "config-changed", { config: this._config });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-alarm-panel-card-editor": HuiAlarmPanelCardEditor;
+  }
+}
+
+customElements.define("hui-alarm-panel-card-editor", HuiAlarmPanelCardEditor);


### PR DESCRIPTION
I wanted to make the available states a list that was filtered but had issues where when only one item was remaining, it would not recognize it as being a value change even when a default selected was not set. I found some issues reported against it in the paper repo with some potential workarounds but this is probably fine for now.

The title seems to be slow to load, probably because it is Polymer and not Lit? Not sure.

![alarm-editor](https://user-images.githubusercontent.com/1287159/49778790-8afa7d80-fccc-11e8-98e3-dd8b8e36eff5.gif)
