### PR TITLE
Speed things up

### DIFF
--- a/src/common/util/render-status.ts
+++ b/src/common/util/render-status.ts
@@ -1,0 +1,3 @@
+export const afterNextRender = (cb: () => void): void => {
+  requestAnimationFrame(() => setTimeout(cb, 0));
+};

--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -84,7 +84,9 @@ export class HaStateLabelBadge extends hassLocalizeLitMixin(LitElement) {
     super.firstUpdated(changedProperties);
     this.addEventListener("click", (ev) => {
       ev.stopPropagation();
-      fireEvent(this, "hass-more-info", { entityId: this.state!.entity_id });
+      if (this.state) {
+        fireEvent(this, "hass-more-info", { entityId: this.state.entity_id });
+      }
     });
   }
 

--- a/src/mixins/lit-localize-mixin.ts
+++ b/src/mixins/lit-localize-mixin.ts
@@ -37,13 +37,15 @@ export const hassLocalizeLitMixin = <T extends LitElement>(
     public connectedCallback(): void {
       super.connectedCallback();
 
-      let language;
-      let resources;
-      if (this.hass) {
-        language = this.hass.language;
-        resources = this.hass.resources;
+      if (this.localize === empty) {
+        let language;
+        let resources;
+        if (this.hass) {
+          language = this.hass.language;
+          resources = this.hass.resources;
+        }
+        this.localize = this.__computeLocalize(language, resources);
       }
-      this.localize = this.__computeLocalize(language, resources);
     }
 
     public updated(changedProperties: PropertyValues) {

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -152,15 +152,21 @@ export class HuiThermostatCard extends hassLocalizeLitMixin(LitElement)
   }
 
   protected updated(changedProps: PropertyValues): void {
-    if (!this._config || !this.hass || !this._jQuery) {
+    if (!this._config || !this.hass || !changedProps.has("hass")) {
       return;
     }
 
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+
+    if (!oldHass || oldHass.themes !== this.hass.themes) {
+      applyThemesOnElement(this, this.hass.themes, this._config.theme);
+    }
+
     const stateObj = this.hass.states[this._config.entity] as ClimateEntity;
 
-    // If jQuery changed, we just rendered in firstUpdated
     if (
+      this._jQuery &&
+      // If jQuery changed, we just rendered in firstUpdated
       !changedProps.has("_jQuery") &&
       (!oldHass || oldHass.states[this._config.entity] !== stateObj)
     ) {
@@ -170,10 +176,6 @@ export class HuiThermostatCard extends hassLocalizeLitMixin(LitElement)
         value: sliderValue,
       });
       this._updateSetTemp(uiValue);
-    }
-
-    if (!oldHass || oldHass.themes !== this.hass.themes) {
-      applyThemesOnElement(this, this.hass.themes, this._config.theme);
     }
   }
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -550,7 +550,6 @@ class HUIRoot extends hassLocalizeLitMixin(LitElement) {
       } else {
         view = document.createElement("hui-view");
         view.lovelace = this.lovelace;
-        view.config = viewConfig;
         view.columns = this.columns;
         view.index = viewIndex;
       }

--- a/src/panels/lovelace/hui-view.ts
+++ b/src/panels/lovelace/hui-view.ts
@@ -24,6 +24,24 @@ import { showEditCardDialog } from "./editor/card-editor/show-edit-card-dialog";
 
 let editCodeLoaded = false;
 
+// Find column with < 5 entities, else column with lowest count
+const getColumnIndex = (columnEntityCount: number[], size: number) => {
+  let minIndex = 0;
+  for (let i = 0; i < columnEntityCount.length; i++) {
+    if (columnEntityCount[i] < 5) {
+      minIndex = i;
+      break;
+    }
+    if (columnEntityCount[i] < columnEntityCount[minIndex]) {
+      minIndex = i;
+    }
+  }
+
+  columnEntityCount[minIndex] += size;
+
+  return minIndex;
+};
+
 export class HUIView extends hassLocalizeLitMixin(LitElement) {
   public hass?: HomeAssistant;
   public lovelace?: Lovelace;
@@ -245,28 +263,12 @@ export class HUIView extends hassLocalizeLitMixin(LitElement) {
       columnEntityCount.push(0);
     }
 
-    // Find column with < 5 entities, else column with lowest count
-    function getColumnIndex(size) {
-      let minIndex = 0;
-      for (let i = 0; i < columnEntityCount.length; i++) {
-        if (columnEntityCount[i] < 5) {
-          minIndex = i;
-          break;
-        }
-        if (columnEntityCount[i] < columnEntityCount[minIndex]) {
-          minIndex = i;
-        }
-      }
-
-      columnEntityCount[minIndex] += size;
-
-      return minIndex;
-    }
-
     elements.forEach((el, index) => {
       const cardSize = computeCardSize(el);
       // Element to append might be the wrapped card when we're editing.
-      columns[getColumnIndex(cardSize)].push(elementsToAppend[index]);
+      columns[getColumnIndex(columnEntityCount, cardSize)].push(
+        elementsToAppend[index]
+      );
     });
 
     // Remove empty columns


### PR DESCRIPTION
- `<hui-root>` will no longer create `<hui-view>` twice on startup
- `<hui-root>` will now cache created views
- `<hui-root>` will now wait till next render to create a view, allowing the event that triggered the change of view to complete their work (ie render a ripple on tab select)
- `<hui-thermostat-card>` will now also wait till next render to draw the slider
- `<hui-thermostat-card>` will now not render the slider on initialization twice
- Lit Localize Mixin will no longer always compute a localize function on connectCallback, only the first time.