### PR TITLE
Fix setting aspect ratio in percentage

### DIFF
--- a/src/common/util/parse-aspect-ratio.ts
+++ b/src/common/util/parse-aspect-ratio.ts
@@ -13,7 +13,7 @@ export default function parseAspectRatio(input: string) {
     return null;
   }
   try {
-    if (input.substr(input.length - 1) === "%") {
+    if (input.endsWith("%")) {
       return { w: 100, h: parseOrThrow(input.substr(0, input.length - 1)) };
     }
 

--- a/src/common/util/parse-aspect-ratio.ts
+++ b/src/common/util/parse-aspect-ratio.ts
@@ -1,24 +1,30 @@
-export default function parseAspectRatio(input) {
-  // Handle 16x9, 16:9, 1.78x1, 1.78:1, 1.78
-  // Ignore everything else
-  function parseOrThrow(num) {
-    const parsed = parseFloat(num);
-    if (isNaN(parsed)) {
-      throw new Error(`${num} is not a number`);
-    }
-    return parsed;
+// Handle 16x9, 16:9, 1.78x1, 1.78:1, 1.78
+// Ignore everything else
+const parseOrThrow = (num) => {
+  const parsed = parseFloat(num);
+  if (isNaN(parsed)) {
+    throw new Error(`${num} is not a number`);
+  }
+  return parsed;
+};
+
+export default function parseAspectRatio(input: string) {
+  if (!input) {
+    return null;
   }
   try {
-    if (input) {
-      const arr = input.replace(":", "x").split("x");
-      if (arr.length === 0) {
-        return null;
-      }
-
-      return arr.length === 1
-        ? { w: parseOrThrow(arr[0]), h: 1 }
-        : { w: parseOrThrow(arr[0]), h: parseOrThrow(arr[1]) };
+    if (input.substr(input.length - 1) === "%") {
+      return { w: 100, h: parseOrThrow(input.substr(0, input.length - 1)) };
     }
+
+    const arr = input.replace(":", "x").split("x");
+    if (arr.length === 0) {
+      return null;
+    }
+
+    return arr.length === 1
+      ? { w: parseOrThrow(arr[0]), h: 1 }
+      : { w: parseOrThrow(arr[0]), h: parseOrThrow(arr[1]) };
   } catch (err) {
     // Ignore the error
   }

--- a/test-mocha/common/util/parse_aspect_ratio_test.ts
+++ b/test-mocha/common/util/parse_aspect_ratio_test.ts
@@ -31,6 +31,11 @@ describe("parseAspectRatio", () => {
     assert.deepEqual(r, ratio178);
   });
 
+  it("Parses 23%", () => {
+    const r = parseAspectRatio("23%");
+    assert.deepEqual(r, { w: 100, h: 23 });
+  });
+
   it("Skips null states", () => {
     const r = parseAspectRatio(null);
     assert.equal(r, null);

--- a/test-mocha/common/util/parse_aspect_ratio_test.ts
+++ b/test-mocha/common/util/parse_aspect_ratio_test.ts
@@ -36,11 +36,6 @@ describe("parseAspectRatio", () => {
     assert.deepEqual(r, { w: 100, h: 23 });
   });
 
-  it("Skips null states", () => {
-    const r = parseAspectRatio(null);
-    assert.equal(r, null);
-  });
-
   it("Skips empty states", () => {
     const r = parseAspectRatio("   ");
     assert.equal(r, null);


### PR DESCRIPTION
We did not support setting aspect ration in `%`, I think this used to work as at least the map example in the Lovelace Gallery uses it.

Broken in 3rd example at https://home-assistant-lovelace-gallery.netlify.com/#demo-hui-map-card

Fixed in `<pending netlify>`