### PR TITLE
Fix opening edit dialog twice when closed by clicking on overlay

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -58,6 +58,7 @@ export class HuiDialogEditCard extends LitElement {
         <hui-dialog-pick-card
           .hass="${this.hass}"
           .cardPicked="${this._cardPicked}"
+          .closeDialog="${this._cancel}"
         ></hui-dialog-pick-card>
       `;
     }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-pick-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-pick-card.ts
@@ -11,6 +11,7 @@ import { LovelaceCardConfig } from "../../../../data/lovelace";
 export class HuiDialogPickCard extends hassLocalizeLitMixin(LitElement) {
   public hass?: HomeAssistant;
   public cardPicked?: (cardConf: LovelaceCardConfig) => void;
+  public closeDialog?: () => void;
 
   static get properties(): PropertyDeclarations {
     return {};
@@ -18,7 +19,11 @@ export class HuiDialogPickCard extends hassLocalizeLitMixin(LitElement) {
 
   protected render(): TemplateResult {
     return html`
-      <paper-dialog with-backdrop opened>
+      <paper-dialog
+        with-backdrop
+        opened
+        @opened-changed="${this._openedChanged}"
+      >
         <h2>${this.localize("ui.panel.lovelace.editor.edit_card.header")}</h2>
         <paper-dialog-scrollable>
           <hui-card-picker
@@ -31,6 +36,12 @@ export class HuiDialogPickCard extends hassLocalizeLitMixin(LitElement) {
         </div>
       </paper-dialog>
     `;
+  }
+
+  private _openedChanged(ev) {
+    if (!ev.detail.value) {
+      this.closeDialog!();
+    }
   }
 
   private _skipPick() {

--- a/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
@@ -132,7 +132,11 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
 
     return html`
       ${this.renderStyle()}
-      <paper-dialog with-backdrop opened>
+      <paper-dialog
+        with-backdrop
+        opened
+        @opened-changed="${this._openedChanged}"
+      >
         <h2>${this.localize("ui.panel.lovelace.editor.edit_card.header")}</h2>
         <paper-spinner
           ?active="${this._loading}"
@@ -435,6 +439,12 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
 
   private get _creatingCard(): boolean {
     return this.path!.length === 1;
+  }
+
+  private _openedChanged(ev) {
+    if (!ev.detail.value) {
+      this.closeDialog!();
+    }
   }
 }
 


### PR DESCRIPTION
When the edit dialog was closed by clicking on the overlay, we didn't reset the state of the edit dialog manager. This meant that if we tried to open it again, it would render the same element, which meant it didn't need to change anything, and so also didn't reset `opened`.

Fixing by listening to when dialog is closed and calling cancel.

Fixes #2283