### PR TITLE
Fixes the rendering of the weather card

### DIFF
--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -196,6 +196,7 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
     return {
       hass: Object,
       stateObj: Object,
+      config: Object,
       forecast: {
         type: Array,
         computed: "computeForecast(stateObj.attributes.forecast)",


### PR DESCRIPTION
This was reported in #2294 and caused by an undefined variable. This variable is removed with this commit.