### PR TITLE
Fix undefined on plant/weather card

### DIFF
--- a/src/cards/ha-plant-card.js
+++ b/src/cards/ha-plant-card.js
@@ -119,7 +119,7 @@ class HaPlantCard extends EventsMixin(PolymerElement) {
   }
 
   computeTitle(stateObj) {
-    return this.config.name || computeStateName(stateObj);
+    return (this.config && this.config.name) || computeStateName(stateObj);
   }
 
   computeAttributes(data) {

--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -39,6 +39,7 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
           opacity: var(--dark-primary-opacity);
           padding: 24px 16px 16px;
           display: flex;
+          align-items: baseline;
         }
 
         .name {
@@ -195,6 +196,7 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   static get properties() {
     return {
       hass: Object,
+      config: Object,
       stateObj: Object,
       forecast: {
         type: Array,
@@ -274,7 +276,7 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
   }
 
   computeName(stateObj) {
-    return this.config.name || computeStateName(stateObj);
+    return (this.config && this.config.name) || computeStateName(stateObj);
   }
 
   showWeatherIcon(condition) {


### PR DESCRIPTION
When we added name support to the weather and plant card, we made the incorrect assumption that the config object would be passed in. This is not the case as that's a Lovelace object and this card is from the legacy UI.

Fixes #2301
Fixes #2294
Fixes #2297
Fixes #2318