### PR TITLE
remove unnecessary editor types

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -30,8 +30,7 @@ export class HuiAlarmPanelCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
-    this._config = { type: "alarm-panel", ...config };
+    this._config = config;
   }
 
   static get properties(): PropertyDeclarations {

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -58,8 +58,7 @@ export class HuiEntitiesCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
-    this._config = { type: "entities", ...config };
+    this._config = config;
     this._configEntities = processEditorEntities(config.entities);
   }
 

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -34,13 +34,8 @@ export class HuiGaugeCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
     this._useSeverity = config.severity ? true : false;
-
-    this._config = {
-      type: "gauge",
-      ...config,
-    };
+    this._config = config;
   }
 
   static get properties(): PropertyDeclarations {

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -48,8 +48,7 @@ export class HuiGlanceCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
-    this._config = { type: "glance", ...config };
+    this._config = config;
     this._configEntities = processEditorEntities(config.entities);
   }
 

--- a/src/panels/lovelace/editor/config-elements/hui-iframe-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-iframe-card-editor.ts
@@ -25,8 +25,7 @@ export class HuiIframeCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
-    this._config = { type: "iframe", ...config };
+    this._config = config;
   }
 
   static get properties(): PropertyDeclarations {

--- a/src/panels/lovelace/editor/config-elements/hui-light-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-light-card-editor.ts
@@ -28,8 +28,7 @@ export class HuiLightCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
-    this._config = { type: "light", ...config };
+    this._config = config;
   }
 
   static get properties(): PropertyDeclarations {

--- a/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
@@ -25,8 +25,7 @@ export class HuiMarkdownCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
-    this._config = { type: "markdown", ...config };
+    this._config = config;
   }
 
   static get properties(): PropertyDeclarations {

--- a/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
@@ -36,8 +36,7 @@ export class HuiSensorCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
-    this._config = { type: "sensor", ...config };
+    this._config = config;
   }
 
   static get properties(): PropertyDeclarations {

--- a/src/panels/lovelace/editor/config-elements/hui-shopping-list-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-shopping-list-editor.ts
@@ -22,8 +22,7 @@ export class HuiShoppingListEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-
-    this._config = { type: "shopping-list", ...config };
+    this._config = config;
   }
 
   static get properties(): PropertyDeclarations {

--- a/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
@@ -28,7 +28,7 @@ export class HuiThermostatCardEditor extends hassLocalizeLitMixin(LitElement)
 
   public setConfig(config: Config): void {
     config = cardConfigStruct(config);
-    this._config = { type: "thermostat", ...config };
+    this._config = config;
   }
 
   static get properties(): PropertyDeclarations {


### PR DESCRIPTION
Adding `type` to configs in the editor is unnecessary and does nothing