### PR TITLE
Fix incorrect state display being cached

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -5,87 +5,82 @@ import formatDate from "../datetime/format_date";
 import formatTime from "../datetime/format_time";
 import { LocalizeFunc } from "../../mixins/localize-base-mixin";
 
-type CachedDisplayEntity = HassEntity & {
-  _stateDisplay?: string;
-};
-
-export default function computeStateDisplay(
+export default (
   localize: LocalizeFunc,
   stateObj: HassEntity,
   language: string
-) {
-  const state = stateObj as CachedDisplayEntity;
-  if (!state._stateDisplay) {
-    const domain = computeStateDomain(state);
-    if (domain === "binary_sensor") {
-      // Try device class translation, then default binary sensor translation
-      if (state.attributes.device_class) {
-        state._stateDisplay = localize(
-          `state.${domain}.${state.attributes.device_class}.${state.state}`
-        );
-      }
-      if (!state._stateDisplay) {
-        state._stateDisplay = localize(
-          `state.${domain}.default.${state.state}`
-        );
-      }
-    } else if (
-      state.attributes.unit_of_measurement &&
-      !["unknown", "unavailable"].includes(state.state)
-    ) {
-      state._stateDisplay =
-        state.state + " " + state.attributes.unit_of_measurement;
-    } else if (domain === "input_datetime") {
-      let date: Date;
-      if (!state.attributes.has_time) {
-        date = new Date(
-          state.attributes.year,
-          state.attributes.month - 1,
-          state.attributes.day
-        );
-        state._stateDisplay = formatDate(date, language);
-      } else if (!state.attributes.has_date) {
-        const now = new Date();
-        date = new Date(
-          // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548
-          // don't use artificial 1970 year.
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDay(),
-          state.attributes.hour,
-          state.attributes.minute
-        );
-        state._stateDisplay = formatTime(date, language);
-      } else {
-        date = new Date(
-          state.attributes.year,
-          state.attributes.month - 1,
-          state.attributes.day,
-          state.attributes.hour,
-          state.attributes.minute
-        );
-        state._stateDisplay = formatDateTime(date, language);
-      }
-    } else if (domain === "zwave") {
-      if (["initializing", "dead"].includes(state.state)) {
-        state._stateDisplay = localize(
-          `state.zwave.query_stage.${state.state}`,
-          "query_stage",
-          state.attributes.query_stage
-        );
-      } else {
-        state._stateDisplay = localize(`state.zwave.default.${state.state}`);
-      }
-    } else {
-      state._stateDisplay = localize(`state.${domain}.${state.state}`);
+): string => {
+  let display: string | undefined;
+  const domain = computeStateDomain(stateObj);
+
+  if (domain === "binary_sensor") {
+    // Try device class translation, then default binary sensor translation
+    if (stateObj.attributes.device_class) {
+      display = localize(
+        `state.${domain}.${stateObj.attributes.device_class}.${stateObj.state}`
+      );
     }
-    // Fall back to default, component backend translation, or raw state if nothing else matches.
-    state._stateDisplay =
-      state._stateDisplay ||
-      localize(`state.default.${state.state}`) ||
-      localize(`component.${domain}.state.${state.state}`) ||
-      state.state;
+
+    if (!display) {
+      display = localize(`state.${domain}.default.${stateObj.state}`);
+    }
+  } else if (
+    stateObj.attributes.unit_of_measurement &&
+    !["unknown", "unavailable"].includes(stateObj.state)
+  ) {
+    display = stateObj.state + " " + stateObj.attributes.unit_of_measurement;
+  } else if (domain === "input_datetime") {
+    let date: Date;
+    if (!stateObj.attributes.has_time) {
+      date = new Date(
+        stateObj.attributes.year,
+        stateObj.attributes.month - 1,
+        stateObj.attributes.day
+      );
+      display = formatDate(date, language);
+    } else if (!stateObj.attributes.has_date) {
+      const now = new Date();
+      date = new Date(
+        // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548
+        // don't use artificial 1970 year.
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDay(),
+        stateObj.attributes.hour,
+        stateObj.attributes.minute
+      );
+      display = formatTime(date, language);
+    } else {
+      date = new Date(
+        stateObj.attributes.year,
+        stateObj.attributes.month - 1,
+        stateObj.attributes.day,
+        stateObj.attributes.hour,
+        stateObj.attributes.minute
+      );
+      display = formatDateTime(date, language);
+    }
+  } else if (domain === "zwave") {
+    if (["initializing", "dead"].includes(stateObj.state)) {
+      display = localize(
+        `state.zwave.query_stage.${stateObj.state}`,
+        "query_stage",
+        stateObj.attributes.query_stage
+      );
+    } else {
+      display = localize(`state.zwave.default.${stateObj.state}`);
+    }
+  } else {
+    display = localize(`state.${domain}.${stateObj.state}`);
   }
 
-  return state._stateDisplay;
-}
+  // Fall back to default, component backend translation, or raw state if nothing else matches.
+  if (!display) {
+    display =
+      localize(`state.default.${stateObj.state}`) ||
+      localize(`component.${domain}.state.${stateObj.state}`) ||
+      stateObj.state;
+  }
+
+  return display;
+};

--- a/src/common/entity/compute_state_name.ts
+++ b/src/common/entity/compute_state_name.ts
@@ -1,18 +1,6 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import computeObjectId from "./compute_object_id";
 
-type CachedDisplayEntity = HassEntity & {
-  _entityDisplay?: string;
-};
-
-export default function computeStateName(stateObj: HassEntity) {
-  const state = stateObj as CachedDisplayEntity;
-
-  if (state._entityDisplay === undefined) {
-    state._entityDisplay =
-      state.attributes.friendly_name ||
-      computeObjectId(state.entity_id).replace(/_/g, " ");
-  }
-
-  return state._entityDisplay;
-}
+export default (stateObj: HassEntity): string =>
+  stateObj.attributes.friendly_name ||
+  computeObjectId(stateObj.entity_id).replace(/_/g, " ");

--- a/test-mocha/common/entity/compute_state_display.ts
+++ b/test-mocha/common/entity/compute_state_display.ts
@@ -258,22 +258,4 @@ describe("computeStateDisplay", () => {
       "My Custom State"
     );
   });
-
-  it("Only calculates state display once per immutable state object", () => {
-    const stateObj: any = {
-      entity_id: "cover.test",
-      state: "open",
-      attributes: {},
-    };
-    assert.strictEqual(
-      computeStateDisplay(localize, stateObj, "en"),
-      "state.cover.open"
-    );
-
-    stateObj.state = "closing";
-    assert.strictEqual(
-      computeStateDisplay(localize, stateObj, "en"),
-      "state.cover.open"
-    );
-  });
 });


### PR DESCRIPTION
The UI would render states before `this.hass.resources` was loaded. This caused the rendering of the computed state domain to use the fallback value (the state) and cache that in `stateObj._stateDisplay`. After resources were done loading, we didn't clear this cache and so users would see incorrect translated states until the state would change.

This PR removes the caching in `stateObj._stateDisplay` and `stateObj._entityDisplay`.

This PR is best reviewed by [ignoring whitespace](https://github.com/home-assistant/home-assistant-polymer/pull/2356/files?utf8=%E2%9C%93&diff=unified&w=1)

Fixes #2354

This might break some custom UI that was using the cache to inject their own values. With Lovelace there are now alternative ways to do this with possibilities to inject custom elements as entity rows, cards, views.

CC @andrey-git  