### PR TITLE
✨ option to hide toasts for tap/hold actions

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -6,6 +6,7 @@ export interface LovelaceConfig {
   background?: string;
   resources?: Array<{ type: "css" | "js" | "module" | "html"; url: string }>;
   excluded_entities?: string[];
+  toast?: boolean;
 }
 
 export interface LovelaceViewConfig {
@@ -18,6 +19,7 @@ export interface LovelaceViewConfig {
   theme?: string;
   panel?: boolean;
   background?: string;
+  toast?: boolean;
 }
 
 export interface LovelaceCardConfig {
@@ -25,33 +27,30 @@ export interface LovelaceCardConfig {
   view_index?: number;
   type: string;
   [key: string]: any;
+  toast?: boolean;
 }
 
-export interface ToggleActionConfig extends ActionBaseConfig {
+export interface ToggleActionConfig {
   action: "toggle";
 }
 
-export interface CallServiceActionConfig extends ActionBaseConfig {
+export interface CallServiceActionConfig {
   action: "call-service";
   service: string;
   service_data?: { [key: string]: any };
 }
 
-export interface NavigateActionConfig extends ActionBaseConfig {
+export interface NavigateActionConfig {
   action: "navigate";
   navigation_path: string;
 }
 
-export interface MoreInfoActionConfig extends ActionBaseConfig {
+export interface MoreInfoActionConfig {
   action: "more-info";
 }
 
-export interface NoActionConfig extends ActionBaseConfig {
+export interface NoActionConfig {
   action: "none";
-}
-
-export interface ActionBaseConfig {
-  toast?: boolean;
 }
 
 export type ActionConfig =

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -27,27 +27,31 @@ export interface LovelaceCardConfig {
   [key: string]: any;
 }
 
-export interface ToggleActionConfig {
+export interface ToggleActionConfig extends ActionBaseConfig {
   action: "toggle";
 }
 
-export interface CallServiceActionConfig {
+export interface CallServiceActionConfig extends ActionBaseConfig {
   action: "call-service";
   service: string;
   service_data?: { [key: string]: any };
 }
 
-export interface NavigateActionConfig {
+export interface NavigateActionConfig extends ActionBaseConfig {
   action: "navigate";
   navigation_path: string;
 }
 
-export interface MoreInfoActionConfig {
+export interface MoreInfoActionConfig extends ActionBaseConfig {
   action: "more-info";
 }
 
-export interface NoActionConfig {
+export interface NoActionConfig extends ActionBaseConfig {
   action: "none";
+}
+
+export interface ActionBaseConfig {
+  toast?: boolean;
 }
 
 export type ActionConfig =

--- a/src/layouts/app/connection-mixin.js
+++ b/src/layouts/app/connection-mixin.js
@@ -55,7 +55,12 @@ export default (superClass) =>
           translationMetadata: translationMetadata,
           dockedSidebar: false,
           moreInfoEntityId: null,
-          callService: async (domain, service, serviceData = {}) => {
+          callService: async (
+            domain,
+            service,
+            serviceData = {},
+            toast = true
+          ) => {
             if (__DEV__) {
               // eslint-disable-next-line
               console.log("Calling service", domain, service, serviceData);
@@ -93,7 +98,9 @@ export default (superClass) =>
                   `${domain}/${service}`
                 );
               }
-              this.fire("hass-notification", { message });
+              if (toast) {
+                this.fire("hass-notification", { message });
+              }
             } catch (err) {
               if (__DEV__) {
                 // eslint-disable-next-line

--- a/src/panels/lovelace/common/entity/toggle-entity.ts
+++ b/src/panels/lovelace/common/entity/toggle-entity.ts
@@ -3,8 +3,9 @@ import { turnOnOffEntity } from "./turn-on-off-entity";
 import { HomeAssistant } from "../../../../types";
 export const toggleEntity = (
   hass: HomeAssistant,
-  entityId: string
+  entityId: string,
+  toast = true
 ): Promise<void> => {
   const turnOn = STATES_OFF.includes(hass.states[entityId].state);
-  return turnOnOffEntity(hass, entityId, turnOn);
+  return turnOnOffEntity(hass, entityId, turnOn, toast);
 };

--- a/src/panels/lovelace/common/entity/turn-on-off-entity.ts
+++ b/src/panels/lovelace/common/entity/turn-on-off-entity.ts
@@ -4,7 +4,8 @@ import { HomeAssistant } from "../../../../types";
 export const turnOnOffEntity = (
   hass: HomeAssistant,
   entityId: string,
-  turnOn = true
+  turnOn = true,
+  toast = true
 ): Promise<void> => {
   const stateDomain = computeDomain(entityId);
   const serviceDomain = stateDomain === "group" ? "homeassistant" : stateDomain;
@@ -21,5 +22,10 @@ export const turnOnOffEntity = (
       service = turnOn ? "turn_on" : "turn_off";
   }
 
-  return hass.callService(serviceDomain, service, { entity_id: entityId });
+  return hass.callService(
+    serviceDomain,
+    service,
+    { entity_id: entityId },
+    toast
+  );
 };

--- a/src/panels/lovelace/common/handle-click.ts
+++ b/src/panels/lovelace/common/handle-click.ts
@@ -12,6 +12,7 @@ export const handleClick = (
     camera_image?: string;
     hold_action?: ActionConfig;
     tap_action?: ActionConfig;
+    toast?: boolean;
   },
   hold: boolean
 ): void => {
@@ -44,7 +45,7 @@ export const handleClick = (
       break;
     case "toggle":
       if (config.entity) {
-        toggleEntity(hass, config.entity!, actionConfig.toast);
+        toggleEntity(hass, config.entity!, config.toast);
       }
       break;
     case "call-service": {
@@ -56,7 +57,7 @@ export const handleClick = (
         domain,
         service,
         actionConfig.service_data,
-        actionConfig.toast
+        config.toast
       );
     }
   }

--- a/src/panels/lovelace/common/handle-click.ts
+++ b/src/panels/lovelace/common/handle-click.ts
@@ -44,7 +44,7 @@ export const handleClick = (
       break;
     case "toggle":
       if (config.entity) {
-        toggleEntity(hass, config.entity!);
+        toggleEntity(hass, config.entity!, actionConfig.toast);
       }
       break;
     case "call-service": {
@@ -52,7 +52,12 @@ export const handleClick = (
         return;
       }
       const [domain, service] = actionConfig.service.split(".", 2);
-      hass.callService(domain, service, actionConfig.service_data);
+      hass.callService(
+        domain,
+        service,
+        actionConfig.service_data,
+        actionConfig.toast
+      );
     }
   }
 };

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -591,7 +591,10 @@ class HUIRoot extends hassLocalizeLitMixin(LitElement) {
     }
 
     let view;
-    const viewConfig = this.config.views[viewIndex];
+    const viewConfig = {
+      toast: this.config.toast,
+      ...this.config.views[viewIndex],
+    };
 
     if (!viewConfig) {
       this._editModeEnable();

--- a/src/panels/lovelace/hui-view.ts
+++ b/src/panels/lovelace/hui-view.ts
@@ -184,7 +184,10 @@ export class HUIView extends hassLocalizeLitMixin(LitElement) {
     }
 
     if (configChanged || editModeChanged || changedProperties.has("columns")) {
-      this._createCards(lovelace.config.views[this.index!]);
+      this._createCards({
+        toast: lovelace.config.toast,
+        ...lovelace.config.views[this.index!],
+      });
     } else if (changedProperties.has("hass")) {
       this._cards.forEach((element) => {
         element.hass = this.hass;
@@ -239,7 +242,10 @@ export class HUIView extends hassLocalizeLitMixin(LitElement) {
     const elements: LovelaceCard[] = [];
     const elementsToAppend: HTMLElement[] = [];
     config.cards.forEach((cardConfig, cardIndex) => {
-      const element = createCardElement(cardConfig) as LovelaceCard;
+      const element = createCardElement({
+        toast: config.toast,
+        ...cardConfig,
+      }) as LovelaceCard;
       element.hass = this.hass;
       elements.push(element);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,8 @@ export interface HomeAssistant {
   callService: (
     domain: string,
     service: string,
-    serviceData?: { [key: string]: any }
+    serviceData?: { [key: string]: any },
+    toast?: boolean
   ) => Promise<void>;
   callApi: <T>(
     method: "GET" | "POST" | "PUT" | "DELETE",


### PR DESCRIPTION
https://community.home-assistant.io/t/disable-toast-notification-on-ui-switch-actions/76352

```
type: picture-entity
entity: light.bed_light
image: 'https://www.home-assistant.io/images/merchandise/shirt-frontpage.png'
tap_action:
  action: toggle
  toast: false
```

This will become very tedious, very quickly if you wanted all your actions to not produce toasts and you had to set each one to false. Should probably think of a way to provide a more global option, perhaps at the level of view or lovelace as a whole. This is a WIP, so please provide feedback