### PR TITLE
✨ option to hide view from tabs

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -18,6 +18,7 @@ export interface LovelaceViewConfig {
   theme?: string;
   panel?: boolean;
   background?: string;
+  hidden?: boolean;
 }
 
 export interface LovelaceCardConfig {

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -52,6 +52,13 @@ export class HuiViewEditor extends hassLocalizeLitMixin(LitElement) {
     return this._config.theme || "Backend-selected";
   }
 
+  get _hidden(): boolean {
+    if (!this._config) {
+      return false;
+    }
+    return this._config.hidden || false;
+  }
+
   public hass?: HomeAssistant;
   private _config?: LovelaceViewConfig;
 
@@ -73,12 +80,20 @@ export class HuiViewEditor extends hassLocalizeLitMixin(LitElement) {
           .configValue="${"title"}"
           @value-changed="${this._valueChanged}"
         ></paper-input>
-        <paper-input
-          label="Icon"
-          .value="${this._icon}"
-          .configValue="${"icon"}"
-          @value-changed="${this._valueChanged}"
-        ></paper-input>
+        <div class="side-by-side">
+          <paper-toggle-button
+            ?checked="${this._hidden !== false}"
+            .configValue="${"hidden"}"
+            @change="${this._valueChanged}"
+            >Hide Tab?</paper-toggle-button
+          >
+          <paper-input
+            label="Icon"
+            .value="${this._icon}"
+            .configValue="${"icon"}"
+            @value-changed="${this._valueChanged}"
+          ></paper-input>
+        </div>
         <paper-input
           label="URL Path"
           .value="${this._path}"

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -1,6 +1,7 @@
 import { html, LitElement, PropertyDeclarations } from "@polymer/lit-element";
 import { TemplateResult } from "lit-html";
 import "@polymer/paper-input/paper-input";
+import "@polymer/paper-toggle-button/paper-toggle-button";
 
 import { EditorTarget } from "../types";
 import { hassLocalizeLitMixin } from "../../../../mixins/lit-localize-mixin";
@@ -52,18 +53,11 @@ export class HuiViewEditor extends hassLocalizeLitMixin(LitElement) {
     return this._config.theme || "Backend-selected";
   }
 
-  get _hidden(): boolean {
-    if (!this._config) {
-      return false;
-    }
-    return this._config.hidden || false;
-  }
-
   public hass?: HomeAssistant;
   private _config?: LovelaceViewConfig;
 
   set config(config: LovelaceViewConfig) {
-    this._config = config;
+    this._config = { hidden: false, ...config };
   }
 
   protected render(): TemplateResult {
@@ -82,7 +76,7 @@ export class HuiViewEditor extends hassLocalizeLitMixin(LitElement) {
         ></paper-input>
         <div class="side-by-side">
           <paper-toggle-button
-            ?checked="${this._hidden !== false}"
+            ?checked="${this._config!.hidden !== false}"
             .configValue="${"hidden"}"
             @change="${this._valueChanged}"
             >Hide Tab?</paper-toggle-button
@@ -126,7 +120,8 @@ export class HuiViewEditor extends hassLocalizeLitMixin(LitElement) {
     if (target.configValue) {
       newConfig = {
         ...this._config,
-        [target.configValue]: target.value,
+        [target.configValue!]:
+          target.checked !== undefined ? target.checked : target.value,
       };
     }
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -243,32 +243,34 @@ class HUIRoot extends hassLocalizeLitMixin(LitElement) {
                     @iron-activate="${this._handleViewSelected}"
                   >
                     ${
-                      this.lovelace!.config.views.map(
-                        (view) => html`
-                          <paper-tab>
-                            ${
-                              view.icon
-                                ? html`
-                                    <ha-icon
-                                      title="${view.title}"
-                                      .icon="${view.icon}"
-                                    ></ha-icon>
-                                  `
-                                : view.title || "Unnamed view"
-                            }
-                            ${
-                              this._editMode
-                                ? html`
-                                    <ha-icon
-                                      class="edit-icon view"
-                                      @click="${this._editView}"
-                                      icon="hass:pencil"
-                                    ></ha-icon>
-                                  `
-                                : ""
-                            }
-                          </paper-tab>
-                        `
+                      this.lovelace!.config.views.map((view) =>
+                        view.hidden && view.path && !this._editMode
+                          ? ""
+                          : html`
+                              <paper-tab>
+                                ${
+                                  view.icon
+                                    ? html`
+                                        <ha-icon
+                                          title="${view.title}"
+                                          .icon="${view.icon}"
+                                        ></ha-icon>
+                                      `
+                                    : view.title || "Unnamed view"
+                                }
+                                ${
+                                  this._editMode
+                                    ? html`
+                                        <ha-icon
+                                          class="edit-icon view"
+                                          @click="${this._editView}"
+                                          icon="hass:pencil"
+                                        ></ha-icon>
+                                      `
+                                    : ""
+                                }
+                              </paper-tab>
+                            `
                       )
                     }
                     ${

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -244,7 +244,7 @@ class HUIRoot extends hassLocalizeLitMixin(LitElement) {
                   >
                     ${
                       this.lovelace!.config.views.map((view) =>
-                        view.hidden && view.path && !this._editMode
+                        view.hidden && !this._editMode
                           ? ""
                           : html`
                               <paper-tab>


### PR DESCRIPTION
https://community.home-assistant.io/t/lovelace-ui-ability-to-hide-views/82353

Adds boolean option `hidden` to views that will remove it from the tab set when set to `true` but still visible when in edit mode. ~~Requires that a path be set hidden.~~

~~Thinking I should make path required before saving a config if hidden selected. Thoughts?~~