### PR TITLE
Lovelace alarm panel should respects the code_format

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -138,32 +138,46 @@ class HuiAlarmPanelCard extends hassLocalizeLitMixin(LitElement)
             })
           }
         </div>
-        <paper-input
-          label="Alarm Code"
-          type="password"
-          .value="${this._code}"
-        ></paper-input>
-        <div id="keypad">
-          ${
-            BUTTONS.map((value) => {
-              return value === ""
-                ? html`
-                    <paper-button disabled></paper-button>
-                  `
-                : html`
-                    <paper-button
-                      noink
-                      raised
-                      .value="${value}"
-                      @click="${this._handlePadClick}"
-                      >${
-                        value === "clear" ? this._label("clear_code") : value
-                      }</paper-button
-                    >
-                  `;
-            })
-          }
-        </div>
+        ${
+          !stateObj.attributes.code_format
+            ? html``
+            : html`
+                <paper-input
+                  label="Alarm Code"
+                  type="password"
+                  .value="${this._code}"
+                ></paper-input>
+              `
+        }
+        ${
+          stateObj.attributes.code_format !== "Number"
+            ? html``
+            : html`
+                <div id="keypad">
+                  ${
+                    BUTTONS.map((value) => {
+                      return value === ""
+                        ? html`
+                            <paper-button disabled></paper-button>
+                          `
+                        : html`
+                            <paper-button
+                              noink
+                              raised
+                              .value="${value}"
+                              @click="${this._handlePadClick}"
+                              >${
+                                value === "clear"
+                                  ? this._label("clear_code")
+                                  : value
+                              }</paper-button
+                            >
+                          `;
+                    })
+                  }
+                </div>
+              `
+        }
       </ha-card>
     `;
   }


### PR DESCRIPTION
Alarm entities could have an attribute called "code_format".

```
 @property
    def code_format(self):
        """Regex for code format or None if no code is required."""
        return None
```

The old UI looked at this attribute and displayed the "code field" and/or the keypad based on its value.
Lovelace however doesn't care about this at all. It will always show the code field and the keypad. 
This PR aims to make the lovelace card handle this attribute like the old UI did.

When the _code_format_ value is "Number" it will show the keypad
When the _code_format_ value is anything except for "None" it will show the code field.