### PR TITLE
Added support for KNX climate devices in Lovelace.

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -183,7 +183,11 @@
       "high_demand": "High demand",
       "heat_pump": "Heat pump",
       "gas": "Gas",
-      "manual": "Manual"
+      "manual": "Manual",
+      "standby": "Standby",
+      "night": "Night",
+      "frost_protection": "Frost Protection",
+      "comfort": "Comfort"
     },
     "configurator": {
       "configure": "Configure",

--- a/translations/de.json
+++ b/translations/de.json
@@ -145,7 +145,11 @@
             "high_demand": "Hoher Verbrauch",
             "heat_pump": "Wärmepumpe",
             "gas": "Gas",
-            "manual": "Manuell"
+            "manual": "Manuell",
+            "standby": "Standby",
+            "night": "Nacht",
+            "frost_protection": "Frostschutz",
+            "comfort": "Komfort"
         },
         "configurator": {
             "configure": "Konfigurieren",


### PR DESCRIPTION
## Description

KNX climate devices are slightly different than other climate devices. One major difference is that the standardised operation modes can contain whitespaces and upper case letters. It's also neccessary to send the correct data back to the KNX bus because otherwise the underlying library will throw exceptions. This PR does the following:

- Formatted the operation_mode before trying to get the translation (remember, the bus will for instance return "Frost Protection") the formatting will simply make it `frost_protection`.
- Added appropriate styling for the new operation modes
- Added translations for the operation modes

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/708887/50387777-bb96da00-0704-11e9-971e-3bc3f3536728.png)

### After

![image](https://user-images.githubusercontent.com/708887/50387783-d49f8b00-0704-11e9-806d-c93e23708316.png)

## How to test

In order to test this you need to have KNX climate devices. Since we changed the overall way operation modes are used it might be useful if anyone who has different kind of climate devices (not KNX) can also test if everything works correctly.