### PR TITLE
ADD: State to group icon

### DIFF
--- a/src/components/entity/state-badge.js
+++ b/src/components/entity/state-badge.js
@@ -26,6 +26,7 @@ class StateBadge extends PolymerElement {
         }
 
         /* Color the icon if light or sun is on */
+        ha-icon[data-domain="group"][data-state="on"],
         ha-icon[data-domain="light"][data-state="on"],
         ha-icon[data-domain="switch"][data-state="on"],
         ha-icon[data-domain="binary_sensor"][data-state="on"],

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -148,6 +148,7 @@ class HuiEntityButtonCard extends hassLocalizeLitMixin(LitElement)
           height: 40%;
           color: var(--paper-item-icon-color, #44739e);
         }
+        ha-icon[data-domain="group"][data-state="on"],
         ha-icon[data-domain="light"][data-state="on"],
         ha-icon[data-domain="switch"][data-state="on"],
         ha-icon[data-domain="binary_sensor"][data-state="on"],


### PR DESCRIPTION
Bear with me, I barely know what I'm doing ;)

As groups have state, this reflects it on the icon, at least in lovelace entity-button, which is the result I was looking for.