### PR TITLE
Proper RTL support in weather forecast card

### DIFF
--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -103,11 +103,11 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
           top: 4px;
         }
 
-        .unit {
+        .measurand {
           display: inline-block;
         }
 
-        :host([rtl]) .unit {
+        :host([rtl]) .measurand {
           direction: ltr;
         }
 
@@ -165,9 +165,9 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <div>
                   [[localize('ui.card.weather.attributes.air_pressure')]]:
-                  <div class="unit">
+                  <span class="measurand">
                     [[stateObj.attributes.pressure]] [[getUnit('air_pressure')]]
-                  </div>
+                  </span>
                 </div>
               </template>
               <template
@@ -176,7 +176,9 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <div>
                   [[localize('ui.card.weather.attributes.humidity')]]:
-                  <div class="unit">[[stateObj.attributes.humidity]] %</div>
+                  <span class="measurand"
+                    >[[stateObj.attributes.humidity]] %</span
+                  >
                 </div>
               </template>
               <template
@@ -185,9 +187,9 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <div>
                   [[localize('ui.card.weather.attributes.wind_speed')]]:
-                  <div class="unit">
+                  <span class="measurand">
                     [[getWindSpeed(stateObj.attributes.wind_speed)]]
-                  </div>
+                  </span>
                   [[getWindBearing(stateObj.attributes.wind_bearing, localize)]]
                 </div>
               </template>

--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -8,6 +8,7 @@ import "../components/ha-icon";
 
 import EventsMixin from "../mixins/events-mixin";
 import LocalizeMixin from "../mixins/localize-mixin";
+import { computeRTL } from "../common/util/compute_rtl";
 
 /*
  * @appliesMixin LocalizeMixin
@@ -52,6 +53,11 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
           color: var(--secondary-text-color);
         }
 
+        :host([rtl]) .name {
+          margin-left: 0px;
+          margin-right: 16px;
+        }
+
         .now {
           display: flex;
           justify-content: space-between;
@@ -65,10 +71,18 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
           margin-right: 32px;
         }
 
+        :host([rtl]) .main {
+          margin-right: 0px;
+        }
+
         .main ha-icon {
           --iron-icon-height: 72px;
           --iron-icon-width: 72px;
           margin-right: 8px;
+        }
+
+        :host([rtl]) .main ha-icon {
+          margin-right: 0px;
         }
 
         .main .temp {
@@ -77,11 +91,24 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
           position: relative;
         }
 
+        :host([rtl]) .main .temp {
+          direction: ltr;
+          margin-right: 28px;
+        }
+
         .main .temp span {
           font-size: 24px;
           line-height: 1em;
           position: absolute;
           top: 4px;
+        }
+
+        .unit {
+          display: inline-block;
+        }
+
+        :host([rtl]) .unit {
+          direction: ltr;
         }
 
         .forecast {
@@ -98,6 +125,10 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
         .forecast .icon {
           margin: 4px 0;
           text-align: center;
+        }
+
+        :host([rtl]) .forecast .temp {
+          direction: ltr;
         }
 
         .weekday {
@@ -134,7 +165,9 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <div>
                   [[localize('ui.card.weather.attributes.air_pressure')]]:
-                  [[stateObj.attributes.pressure]] [[getUnit('air_pressure')]]
+                  <div class="unit">
+                    [[stateObj.attributes.pressure]] [[getUnit('air_pressure')]]
+                  </div>
                 </div>
               </template>
               <template
@@ -143,7 +176,7 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <div>
                   [[localize('ui.card.weather.attributes.humidity')]]:
-                  [[stateObj.attributes.humidity]] %
+                  <div class="unit">[[stateObj.attributes.humidity]] %</div>
                 </div>
               </template>
               <template
@@ -152,8 +185,10 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <div>
                   [[localize('ui.card.weather.attributes.wind_speed')]]:
-                  [[getWind(stateObj.attributes.wind_speed,
-                  stateObj.attributes.wind_bearing, localize)]]
+                  <div class="unit">
+                    [[getWindSpeed(stateObj.attributes.wind_speed)]]
+                  </div>
+                  [[getWindBearing(stateObj.attributes.wind_bearing, localize)]]
                 </div>
               </template>
             </div>
@@ -205,6 +240,11 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
       forecast: {
         type: Array,
         computed: "computeForecast(stateObj.attributes.forecast)",
+      },
+      rtl: {
+        type: Boolean,
+        reflectToAttribute: true,
+        computed: "_computeRTL(hass)",
       },
     };
   }
@@ -299,14 +339,18 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
     return degree;
   }
 
-  getWind(speed, bearing, localize) {
+  getWindSpeed(speed) {
+    return `${speed} ${this.getUnit("length")}/h`;
+  }
+
+  getWindBearing(bearing, localize) {
     if (bearing != null) {
       const cardinalDirection = this.windBearingToText(bearing);
-      return `${speed} ${this.getUnit("length")}/h (${localize(
+      return `(${localize(
         `ui.card.weather.cardinal_direction.${cardinalDirection.toLowerCase()}`
       ) || cardinalDirection})`;
     }
-    return `${speed} ${this.getUnit("length")}/h`;
+    return ``;
   }
 
   _showValue(item) {
@@ -327,6 +371,10 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
       this.hass.selectedLanguage || this.hass.language,
       { hour: "numeric" }
     );
+  }
+
+  _computeRTL(hass) {
+    return computeRTL(hass);
   }
 }
 customElements.define("ha-weather-card", HaWeatherCard);

--- a/src/panels/dev-state/ha-panel-dev-state.js
+++ b/src/panels/dev-state/ha-panel-dev-state.js
@@ -28,6 +28,7 @@ class HaPanelDevState extends EventsMixin(PolymerElement) {
 
         .content {
           padding: 16px;
+          direction: ltr;
         }
 
         ha-entity-picker,


### PR DESCRIPTION
Weather  - before - all messed up and degrees on wrong side of number...
<img width="990" alt="weather-before" src="https://user-images.githubusercontent.com/37745463/50784942-ddbd5a00-12b7-11e9-9f4a-22ac83a919d3.PNG">

After:
<img width="990" alt="weather-after" src="https://user-images.githubusercontent.com/37745463/50784944-df871d80-12b7-11e9-850d-1476ed283dc5.PNG">
