### PR TITLE
Remove styleMap for base-unit

### DIFF
--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -104,10 +104,7 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
 
     return html`
       ${this.renderStyle()}
-      <ha-card
-        @click="${this._handleClick}"
-        style="${styleMap({ "--base-unit": this._computeBaseUnit() })}"
-      >
+      <ha-card @click="${this._handleClick}">
         ${
           error
             ? html`
@@ -148,6 +145,15 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     return hasConfigOrEntityChanged(this, changedProps);
+  }
+
+  protected firstUpdated(): void {
+    (this.shadowRoot!.querySelector(
+      "ha-card"
+    )! as HTMLElement).style.setProperty(
+      "--base-unit",
+      this._computeBaseUnit()
+    );
   }
 
   protected updated(changedProps: PropertyValues): void {


### PR DESCRIPTION
Setting css variables with styleMap was introduced in lit-html 0.14, we are still on lit-html 0.12