### PR TITLE
Force dev panels to LTR even in RTL language to make it usable. Same for logbook

### DIFF
--- a/src/panels/dev-event/ha-panel-dev-event.js
+++ b/src/panels/dev-event/ha-panel-dev-event.js
@@ -30,6 +30,7 @@ class HaPanelDevEvent extends EventsMixin(PolymerElement) {
         .content {
           @apply --paper-font-body1;
           padding: 16px;
+          direction: ltr;
         }
 
         .ha-form {

--- a/src/panels/dev-info/ha-panel-dev-info.js
+++ b/src/panels/dev-info/ha-panel-dev-info.js
@@ -35,6 +35,7 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
       .content {
         padding: 16px 0px 16px 0;
+        direction: ltr;
       }
 
       .about {
@@ -90,6 +91,7 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
       paper-dialog {
         border-radius: 2px;
+        direction: ltr;
       }
 
       @media all and (max-width: 450px), all and (max-height: 500px) {

--- a/src/panels/dev-mqtt/ha-panel-dev-mqtt.js
+++ b/src/panels/dev-mqtt/ha-panel-dev-mqtt.js
@@ -26,6 +26,7 @@ class HaPanelDevMqtt extends PolymerElement {
           padding: 24px 0 32px;
           max-width: 600px;
           margin: 0 auto;
+          direction: ltr;
         }
 
         paper-card {

--- a/src/panels/dev-service/ha-panel-dev-service.js
+++ b/src/panels/dev-service/ha-panel-dev-service.js
@@ -25,6 +25,7 @@ class HaPanelDevService extends PolymerElement {
 
         .content {
           padding: 16px;
+          direction: ltr;
         }
 
         .ha-form {

--- a/src/panels/dev-template/ha-panel-dev-template.js
+++ b/src/panels/dev-template/ha-panel-dev-template.js
@@ -24,6 +24,7 @@ class HaPanelDevTemplate extends PolymerElement {
 
         .content {
           padding: 16px;
+          direction: ltr;
         }
 
         .edit-pane {

--- a/src/panels/logbook/ha-logbook.js
+++ b/src/panels/logbook/ha-logbook.js
@@ -7,6 +7,7 @@ import formatTime from "../../common/datetime/format_time";
 import formatDate from "../../common/datetime/format_date";
 import EventsMixin from "../../mixins/events-mixin";
 import domainIcon from "../../common/entity/domain_icon";
+import { computeRTL } from "../../common/util/compute_rtl";
 
 /*
  * @appliesMixin EventsMixin
@@ -20,6 +21,10 @@ class HaLogbook extends EventsMixin(PolymerElement) {
           display: block;
         }
 
+        :host([rtl]) {
+          direction: ltr;
+        }
+
         .entry {
           @apply --paper-font-body1;
           line-height: 2em;
@@ -29,6 +34,10 @@ class HaLogbook extends EventsMixin(PolymerElement) {
           width: 55px;
           font-size: 0.8em;
           color: var(--secondary-text-color);
+        }
+
+        :host([rtl]) .date {
+          direction: rtl;
         }
 
         iron-icon {
@@ -83,6 +92,11 @@ class HaLogbook extends EventsMixin(PolymerElement) {
         type: Array,
         value: [],
       },
+      rtl: {
+        type: Boolean,
+        reflectToAttribute: true,
+        computed: "_computeRTL(hass)",
+      },
     };
   }
 
@@ -107,6 +121,10 @@ class HaLogbook extends EventsMixin(PolymerElement) {
 
   _computeIcon(domain) {
     return domainIcon(domain);
+  }
+
+  _computeRTL(hass) {
+    return computeRTL(hass);
   }
 
   entityClicked(ev) {


### PR DESCRIPTION
Dev panels

Devinfo - before - not readable since hebrew and english is not in the right order. Anyway all users would want it to be English since otherwise we need to manually switch to English to make any sense of it.
<img width="990" alt="devinfo-before" src="https://user-images.githubusercontent.com/37745463/50783754-6639fb80-12b4-11e9-9e43-ef8496163e57.PNG">

After:
<img width="990" alt="devinfo-after" src="https://user-images.githubusercontent.com/37745463/50783821-8e295f00-12b4-11e9-8f55-60d2fe5f98c6.PNG">

Events - before - out of order and json can't be used.
<img width="804" alt="events-before" src="https://user-images.githubusercontent.com/37745463/50783840-96819a00-12b4-11e9-9ec4-b30562b5ab81.PNG">

After:
<img width="990" alt="events-after" src="https://user-images.githubusercontent.com/37745463/50783871-aa2d0080-12b4-11e9-9f19-1884a7a5c223.PNG">

Services - before - hard to read service and entity names, JSON impossible...
<img width="804" alt="services-before" src="https://user-images.githubusercontent.com/37745463/50783885-bb760d00-12b4-11e9-87e6-035a10fdf37a.PNG">

After:
<img width="804" alt="services-after" src="https://user-images.githubusercontent.com/37745463/50958483-78d94e00-14c9-11e9-93b3-d487e26bff31.PNG">

Templates - before - you get the idea...
<img width="990" alt="templates-before" src="https://user-images.githubusercontent.com/37745463/50784849-8e772980-12b7-11e9-899d-ff0b1e8830fa.PNG">

After:
<img width="990" alt="templates-after" src="https://user-images.githubusercontent.com/37745463/50784853-920ab080-12b7-11e9-8efc-b681707f1ee5.PNG">

Logbook - before - data in sentences is other way around and also very hard to read and follow
<img width="990" alt="logbook-before" src="https://user-images.githubusercontent.com/37745463/50784886-a8b10780-12b7-11e9-8182-d23aaa8573c4.PNG">

After:
<img width="990" alt="logbook-after" src="https://user-images.githubusercontent.com/37745463/50784909-be263180-12b7-11e9-9639-b419121ae1de.PNG">

MQTT - before - again - payload won't be readable, etc'...
<img width="990" alt="mqtt-before" src="https://user-images.githubusercontent.com/37745463/50785032-19f0ba80-12b8-11e9-9a98-4a326a2697a5.PNG">

After - payload would be readable
<img width="990" alt="mqtt-after" src="https://user-images.githubusercontent.com/37745463/50785180-8370c900-12b8-11e9-9230-0e6239c7b1cb.PNG">
