### PR TITLE
RTL support for history timeline

### DIFF
--- a/src/components/state-history-chart-timeline.js
+++ b/src/components/state-history-chart-timeline.js
@@ -166,9 +166,6 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
       return [state, start, end];
     };
 
-    const isRTL = this.hass.translationMetadata.translations[
-      this.hass.selectedLanguage || this.hass.language
-    ].isRTL;
     const chartOptions = {
       type: "timeline",
       options: {
@@ -192,11 +189,14 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
               afterSetDimensions: (yaxe) => {
                 yaxe.maxWidth = yaxe.chart.width * 0.18;
               },
-              position: isRTL ? "right" : "left",
+              position: this.hass.translationMetadata.translations[
+                this.hass.selectedLanguage || this.hass.language
+              ].isRTL
+                ? "right"
+                : "left",
             },
           ],
         },
-        isRTL: isRTL,
       },
       data: {
         labels: labels,

--- a/src/components/state-history-chart-timeline.js
+++ b/src/components/state-history-chart-timeline.js
@@ -20,6 +20,10 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
         :host([rendered]) {
           opacity: 1;
         }
+
+        ha-chart-base {
+          direction: ltr;
+        }
       </style>
       <ha-chart-base
         data="[[chartData]]"
@@ -162,6 +166,9 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
       return [state, start, end];
     };
 
+    const isRTL = this.hass.translationMetadata.translations[
+      this.hass.selectedLanguage || this.hass.language
+    ].isRTL;
     const chartOptions = {
       type: "timeline",
       options: {
@@ -185,9 +192,11 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
               afterSetDimensions: (yaxe) => {
                 yaxe.maxWidth = yaxe.chart.width * 0.18;
               },
+              position: isRTL ? "right" : "left",
             },
           ],
         },
+        isRTL: isRTL,
       },
       data: {
         labels: labels,


### PR DESCRIPTION
At the end no need to modify the timeline component. Worked around it via CSS.

Before the fix (names on wrong side, labels not within their right time frame)
<img width="365" alt="history-rtl-before" src="https://user-images.githubusercontent.com/37745463/51019796-00d05e00-1585-11e9-923e-51f409141b60.PNG">

After the fix:
<img width="378" alt="history-rtl-after" src="https://user-images.githubusercontent.com/37745463/51019674-7ab41780-1584-11e9-9355-6813aaf42450.PNG">

LTR not affected by fix:
<img width="396" alt="history-after" src="https://user-images.githubusercontent.com/37745463/51019682-843d7f80-1584-11e9-8d40-07aaec6794fc.PNG">
