### PR TITLE
Allow push notifications to suggest its device name

### DIFF
--- a/src/components/ha-push-notifications-toggle.js
+++ b/src/components/ha-push-notifications-toggle.js
@@ -20,6 +20,7 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
       <paper-toggle-button
         disabled="[[_compDisabled(disabled, loading)]]"
         checked="{{pushChecked}}"
+        on-change="handlePushChange"
       ></paper-toggle-button>
     `;
   }
@@ -35,7 +36,6 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
         type: Boolean,
         value:
           "Notification" in window && Notification.permission === "granted",
-        observer: "handlePushChange",
       },
       loading: {
         type: Boolean,
@@ -63,12 +63,12 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
     }
   }
 
-  handlePushChange(pushChecked) {
+  handlePushChange(event) {
     // Somehow this is triggered on Safari on page load causing
     // it to get into a loop and crash the page.
     if (!pushSupported) return;
 
-    if (pushChecked) {
+    if (event.target.checked) {
       this.subscribePushNotifications();
     } else {
       this.unsubscribePushNotifications();
@@ -77,10 +77,9 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
 
   async subscribePushNotifications() {
     const reg = await navigator.serviceWorker.ready;
+    let sub;
 
     try {
-      const sub = await reg.pushManager.subscribe({ userVisibleOnly: true });
-
       let browserName;
       if (navigator.userAgent.toLowerCase().indexOf("firefox") > -1) {
         browserName = "firefox";
@@ -88,12 +87,24 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
         browserName = "chrome";
       }
 
+      let name = prompt("What should this device be called ?");
+      if (name == null) {
+        this.pushChecked = false;
+        return;
+      }
+
+      sub = await reg.pushManager.subscribe({ userVisibleOnly: true });
+
       await this.hass.callApi("POST", "notify.html5", {
         subscription: sub,
         browser: browserName,
+        name,
       });
     } catch (err) {
       const message = err.message || "Notification registration failed.";
+      if (sub) {
+        await sub.unsubscribe();
+      }
 
       // eslint-disable-next-line
       console.error(err);

--- a/src/components/ha-push-notifications-toggle.js
+++ b/src/components/ha-push-notifications-toggle.js
@@ -87,7 +87,7 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
         browserName = "chrome";
       }
 
-      let name = prompt("What should this device be called ?");
+      const name = prompt("What should this device be called ?");
       if (name == null) {
         this.pushChecked = false;
         return;


### PR DESCRIPTION
Prompts the user for a name when enabling html5 push notifications.
Companion PR for home-assistant: https://github.com/home-assistant/home-assistant/pull/19965
