### PR TITLE
Revert hiding keypad unless it's Number

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -138,46 +138,32 @@ class HuiAlarmPanelCard extends hassLocalizeLitMixin(LitElement)
             })
           }
         </div>
-        ${
-          !stateObj.attributes.code_format
-            ? html``
-            : html`
-                <paper-input
-                  label="Alarm Code"
-                  type="password"
-                  .value="${this._code}"
-                ></paper-input>
-              `
-        }
-        ${
-          stateObj.attributes.code_format !== "Number"
-            ? html``
-            : html`
-                <div id="keypad">
-                  ${
-                    BUTTONS.map((value) => {
-                      return value === ""
-                        ? html`
-                            <paper-button disabled></paper-button>
-                          `
-                        : html`
-                            <paper-button
-                              noink
-                              raised
-                              .value="${value}"
-                              @click="${this._handlePadClick}"
-                              >${
-                                value === "clear"
-                                  ? this._label("clear_code")
-                                  : value
-                              }</paper-button
-                            >
-                          `;
-                    })
-                  }
-                </div>
-              `
-        }
+        <paper-input
+          label="Alarm Code"
+          type="password"
+          .value="${this._code}"
+        ></paper-input>
+        <div id="keypad">
+          ${
+            BUTTONS.map((value) => {
+              return value === ""
+                ? html`
+                    <paper-button disabled></paper-button>
+                  `
+                : html`
+                    <paper-button
+                      noink
+                      raised
+                      .value="${value}"
+                      @click="${this._handlePadClick}"
+                      >${
+                        value === "clear" ? this._label("clear_code") : value
+                      }</paper-button
+                    >
+                  `;
+            })
+          }
+        </div>
       </ha-card>
     `;
   }


### PR DESCRIPTION
Revert #2379

In #2379 we introduced that we hid the keypad unless code format value is `Number`. However, the docs of code format describe it as "Regex for code format or None if no code is required.". So that is wrong and we are hiding it in too many cases, breaking the UI for people.

Fixes #2450

If people want to hide the keypad, let's open an architecture issue to correctly implement how code format works across alarm control panels. No shortcuts.