### PR TITLE
migrate long press to paper ripple

### DIFF
--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -1,4 +1,6 @@
 import { directive, PropertyPart } from "lit-html";
+// See https://github.com/home-assistant/home-assistant-polymer/pull/2457
+// on how to undo mwc -> paper migration
 // import "@material/mwc-ripple";
 import "@polymer/paper-ripple";
 

--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -1,5 +1,6 @@
 import { directive, PropertyPart } from "lit-html";
-import "@material/mwc-ripple";
+// import "@material/mwc-ripple";
+import "@polymer/paper-ripple";
 
 const isTouch =
   "ontouchstart" in window ||
@@ -25,7 +26,7 @@ class LongPress extends HTMLElement implements LongPress {
   constructor() {
     super();
     this.holdTime = 500;
-    this.ripple = document.createElement("mwc-ripple");
+    this.ripple = document.createElement("paper-ripple");
     this.timer = undefined;
     this.held = false;
     this.cooldownStart = false;
@@ -34,6 +35,7 @@ class LongPress extends HTMLElement implements LongPress {
 
   public connectedCallback() {
     Object.assign(this.style, {
+      borderRadius: "50%", // paper-ripple
       position: "absolute",
       width: isTouch ? "100px" : "50px",
       height: isTouch ? "100px" : "50px",
@@ -42,7 +44,9 @@ class LongPress extends HTMLElement implements LongPress {
     });
 
     this.appendChild(this.ripple);
-    this.ripple.primary = true;
+    this.ripple.style.color = "#03a9f4"; // paper-ripple
+    this.ripple.style.color = "var(--primary-color)"; // paper-ripple
+    // this.ripple.primary = true;
 
     [
       "touchcancel",
@@ -140,14 +144,17 @@ class LongPress extends HTMLElement implements LongPress {
       top: `${y}px`,
       display: null,
     });
-    this.ripple.disabled = false;
-    this.ripple.active = true;
-    this.ripple.unbounded = true;
+    this.ripple.holdDown = true; // paper-ripple
+    this.ripple.simulatedRipple(); // paper-ripple
+    // this.ripple.disabled = false;
+    // this.ripple.active = true;
+    // this.ripple.unbounded = true;
   }
 
   private stopAnimation() {
-    this.ripple.active = false;
-    this.ripple.disabled = true;
+    this.ripple.holdDown = false; // paper-ripple
+    // this.ripple.active = false;
+    // this.ripple.disabled = true;
     this.style.display = "none";
   }
 }


### PR DESCRIPTION
Migrate long press directive to use paper-ripple. We will revert once mwc uses the latest lit-element 