### PR TITLE
Set preferred panel right away

### DIFF
--- a/src/layouts/app/home-assistant.js
+++ b/src/layouts/app/home-assistant.js
@@ -95,7 +95,11 @@ class HomeAssistant extends ext(PolymerElement, [
   }
 
   computePanelUrl(routeData) {
-    return (routeData && routeData.panel) || DEFAULT_PANEL;
+    return (
+      (routeData && routeData.panel) ||
+      localStorage.defaultPage ||
+      DEFAULT_PANEL
+    );
   }
 
   panelUrlChanged(newPanelUrl) {


### PR DESCRIPTION
The fact that we keep track of what default panel is in two places is a bit of a code smell that we should address in another PR.

This PR will correctly extract the default panel when the url is `/`, so that we won't first render the states panel and then the lovelace panel.

Steps to reproduce the flicker: navigate to http://localhost:8123 . You will be redirected to http://localhost:8123/lovelace and then http://localhost:8123/lovelace/<view_id> . The first render would have been the states view if you had lovelace as default.