### PR TITLE
Be specific on Danish-Norwegian translation name

### DIFF
--- a/src/translations/translationMetadata.json
+++ b/src/translations/translationMetadata.json
@@ -90,7 +90,7 @@
   "nn": {
     "nativeName": "Norsk Nynorsk"
   },
-  "no": {
+  "nb": {
     "nativeName": "Norsk Bokmål"
   },
   "pl": {

--- a/src/translations/translationMetadata.json
+++ b/src/translations/translationMetadata.json
@@ -87,11 +87,11 @@
   "nl": {
     "nativeName": "Nederlands"
   },
-  "nn": {
-    "nativeName": "Norsk Nynorsk"
-  },
   "nb": {
     "nativeName": "Norsk Bokmål"
+  },
+  "nn": {
+    "nativeName": "Norsk Nynorsk"
   },
   "pl": {
     "nativeName": "Polski"

--- a/src/translations/translationMetadata.json
+++ b/src/translations/translationMetadata.json
@@ -91,7 +91,7 @@
     "nativeName": "Norsk Nynorsk"
   },
   "no": {
-    "nativeName": "Norsk"
+    "nativeName": "Norsk Bokmål"
   },
   "pl": {
     "nativeName": "Polski"


### PR DESCRIPTION
I noticed the names in the translation list was wrong. It says "Norsk" and "Norsk Nynorsk", when it should be "Norsk Bokmål" and "Norsk Nynorsk". In the context of language, there is two languages, "Nynorsk" and "Bokmål". There is no such thing as a written Norwegian language. "Norsk" would only be if it includes both "nn" and "nb". And since it is a translation, this is wrong. :)