### PR TITLE
Add line numbers to Lovelace 'Raw Config Editor'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="home-assistant-frontend",
-    version="20190109.0",
+    version="20190109.1",
     description="The Home Assistant frontend",
     url="https://github.com/home-assistant/home-assistant-polymer",
     author="The Home Assistant Authors",

--- a/src/panels/dev-event/ha-panel-dev-event.js
+++ b/src/panels/dev-event/ha-panel-dev-event.js
@@ -30,6 +30,7 @@ class HaPanelDevEvent extends EventsMixin(PolymerElement) {
         .content {
           @apply --paper-font-body1;
           padding: 16px;
+          direction: ltr;
         }
 
         .ha-form {

--- a/src/panels/dev-info/ha-panel-dev-info.js
+++ b/src/panels/dev-info/ha-panel-dev-info.js
@@ -35,6 +35,7 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
       .content {
         padding: 16px 0px 16px 0;
+        direction: ltr;
       }
 
       .about {
@@ -90,6 +91,7 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
       paper-dialog {
         border-radius: 2px;
+        direction: ltr;
       }
 
       @media all and (max-width: 450px), all and (max-height: 500px) {

--- a/src/panels/dev-mqtt/ha-panel-dev-mqtt.js
+++ b/src/panels/dev-mqtt/ha-panel-dev-mqtt.js
@@ -26,6 +26,7 @@ class HaPanelDevMqtt extends PolymerElement {
           padding: 24px 0 32px;
           max-width: 600px;
           margin: 0 auto;
+          direction: ltr;
         }
 
         paper-card {

--- a/src/panels/dev-service/ha-panel-dev-service.js
+++ b/src/panels/dev-service/ha-panel-dev-service.js
@@ -25,6 +25,7 @@ class HaPanelDevService extends PolymerElement {
 
         .content {
           padding: 16px;
+          direction: ltr;
         }
 
         .ha-form {

--- a/src/panels/dev-template/ha-panel-dev-template.js
+++ b/src/panels/dev-template/ha-panel-dev-template.js
@@ -24,6 +24,7 @@ class HaPanelDevTemplate extends PolymerElement {
 
         .content {
           padding: 16px;
+          direction: ltr;
         }
 
         .edit-pane {

--- a/src/panels/logbook/ha-logbook.js
+++ b/src/panels/logbook/ha-logbook.js
@@ -7,6 +7,7 @@ import formatTime from "../../common/datetime/format_time";
 import formatDate from "../../common/datetime/format_date";
 import EventsMixin from "../../mixins/events-mixin";
 import domainIcon from "../../common/entity/domain_icon";
+import { computeRTL } from "../../common/util/compute_rtl";
 
 /*
  * @appliesMixin EventsMixin
@@ -20,6 +21,10 @@ class HaLogbook extends EventsMixin(PolymerElement) {
           display: block;
         }
 
+        :host([rtl]) {
+          direction: ltr;
+        }
+
         .entry {
           @apply --paper-font-body1;
           line-height: 2em;
@@ -29,6 +34,10 @@ class HaLogbook extends EventsMixin(PolymerElement) {
           width: 55px;
           font-size: 0.8em;
           color: var(--secondary-text-color);
+        }
+
+        :host([rtl]) .date {
+          direction: rtl;
         }
 
         iron-icon {
@@ -83,6 +92,11 @@ class HaLogbook extends EventsMixin(PolymerElement) {
         type: Array,
         value: [],
       },
+      rtl: {
+        type: Boolean,
+        reflectToAttribute: true,
+        computed: "_computeRTL(hass)",
+      },
     };
   }
 
@@ -107,6 +121,10 @@ class HaLogbook extends EventsMixin(PolymerElement) {
 
   _computeIcon(domain) {
     return domainIcon(domain);
+  }
+
+  _computeRTL(hass) {
+    return computeRTL(hass);
   }
 
   entityClicked(ev) {

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -13,6 +13,7 @@ import computeObjectId from "../../../common/entity/compute_object_id";
 import computeStateDomain from "../../../common/entity/compute_state_domain";
 import { LocalizeFunc } from "../../../mixins/localize-base-mixin";
 import computeDomain from "../../../common/entity/compute_domain";
+import { EntityRowConfig, WeblinkConfig } from "../entity-rows/types";
 
 const DEFAULT_VIEW_ENTITY_ID = "group.default_view";
 const DOMAINS_BADGES = [
@@ -32,9 +33,9 @@ const computeCards = (
   const cards: LovelaceCardConfig[] = [];
 
   // For entity card
-  const entities: string[] = [];
+  const entities: Array<string | EntityRowConfig> = [];
 
-  for (const [entityId /*, stateObj */] of states) {
+  for (const [entityId, stateObj] of states) {
     const domain = computeDomain(entityId);
 
     if (domain === "alarm_control_panel") {
@@ -67,6 +68,16 @@ const computeCards = (
         type: "weather-forecast",
         entity: entityId,
       });
+    } else if (domain === "weblink") {
+      const conf: WeblinkConfig = {
+        type: "weblink",
+        url: stateObj.state,
+        name: computeStateName(stateObj),
+      };
+      if ("icon" in stateObj.attributes) {
+        conf.icon = stateObj.attributes.icon;
+      }
+      entities.push(conf);
     } else {
       entities.push(entityId);
     }

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -7,12 +7,15 @@ export interface EntityConfig {
   icon?: string;
 }
 export interface DividerConfig {
+  type: string;
   style: string;
 }
 export interface SectionConfig {
+  type: string;
   label: string;
 }
 export interface WeblinkConfig {
+  type: string;
   name?: string;
   icon?: string;
   url: string;

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -18,9 +18,10 @@ import "../../components/ha-icon";
 
 const TAB_INSERT = "  ";
 
-const lovelaceStruct = struct.partial({
+const lovelaceStruct = struct.interface({
   title: "string?",
   views: ["object"],
+  resources: struct.optional(["object"]),
 });
 
 class LovelaceFullConfigEditor extends hassLocalizeLitMixin(LitElement) {

--- a/src/panels/lovelace/special-rows/hui-weblink-row.ts
+++ b/src/panels/lovelace/special-rows/hui-weblink-row.ts
@@ -35,7 +35,7 @@ class HuiWeblinkRow extends LitElement implements EntityRow {
 
     return html`
       ${this.renderStyle()}
-      <a href="${this._config.url}">
+      <a href="${this._config.url}" target="_blank">
         <ha-icon .icon="${this._config.icon}"></ha-icon>
         <div>${this._config.name}</div>
       </a>


### PR DESCRIPTION
Can we please get line numbers added to the left hand side in the Lovelace 'Raw Config Editor'?  When an error pops up suggesting there is a problem on a specific line its a little difficult to find it without line numbers to reference on the side.