### PR TITLE
paper-slider RTL fix

### DIFF
--- a/src/components/ha-slider.js
+++ b/src/components/ha-slider.js
@@ -1,8 +1,28 @@
 import "@polymer/paper-slider";
 
 const PaperSliderClass = customElements.get("paper-slider");
+let subTemplate;
 
 class HaSlider extends PaperSliderClass {
+  static get template() {
+    if (!subTemplate) {
+      subTemplate = PaperSliderClass.template.cloneNode(true);
+
+      const superStyle = subTemplate.content.querySelector("style");
+
+      // append style to add mirroring of pin in RTL
+      superStyle.appendChild(
+        document.createTextNode(
+          "#sliderContainer.pin.expand > .slider-knob > .slider-knob-inner::after { " +
+            "  -webkit-transform: scale(1) translate(0, -17px) scaleX(-1) !important;" +
+            "  transform: scale(1) translate(0, -17px) scaleX(-1) !important;" +
+            " }"
+        )
+      );
+    }
+    return subTemplate;
+  }
+
   _calcStep(value) {
     if (!this.step) {
       return parseFloat(value);

--- a/src/components/ha-slider.js
+++ b/src/components/ha-slider.js
@@ -13,7 +13,7 @@ class HaSlider extends PaperSliderClass {
       // append style to add mirroring of pin in RTL
       superStyle.appendChild(
         document.createTextNode(`
-          #sliderContainer.pin.expand > .slider-knob > .slider-knob-inner::after {
+          :host([dir="rtl"]) #sliderContainer.pin.expand > .slider-knob > .slider-knob-inner::after {
             -webkit-transform: scale(1) translate(0, -17px) scaleX(-1) !important;
             transform: scale(1) translate(0, -17px) scaleX(-1) !important;
             }

--- a/src/components/ha-slider.js
+++ b/src/components/ha-slider.js
@@ -12,12 +12,12 @@ class HaSlider extends PaperSliderClass {
 
       // append style to add mirroring of pin in RTL
       superStyle.appendChild(
-        document.createTextNode(
-          "#sliderContainer.pin.expand > .slider-knob > .slider-knob-inner::after { " +
-            "  -webkit-transform: scale(1) translate(0, -17px) scaleX(-1) !important;" +
-            "  transform: scale(1) translate(0, -17px) scaleX(-1) !important;" +
-            " }"
-        )
+        document.createTextNode(`
+          #sliderContainer.pin.expand > .slider-knob > .slider-knob-inner::after {
+            -webkit-transform: scale(1) translate(0, -17px) scaleX(-1) !important;
+            transform: scale(1) translate(0, -17px) scaleX(-1) !important;
+            }
+        `)
       );
     }
     return subTemplate;

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.js
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.js
@@ -107,7 +107,6 @@ class HuiInputNumberEntityRow extends mixinBehaviors(
       _value: Number,
       _rtl: {
         type: String,
-        reflectToAttribute: true,
         computed: "_computeRTLDirection(hass)",
       },
     };

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.js
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.js
@@ -6,6 +6,7 @@ import { mixinBehaviors } from "@polymer/polymer/lib/legacy/class";
 
 import "../components/hui-generic-entity-row";
 import "../../../components/ha-slider";
+import { computeRTL } from "../../../common/util/compute_rtl";
 
 class HuiInputNumberEntityRow extends mixinBehaviors(
   [IronResizableBehavior],
@@ -51,6 +52,7 @@ class HuiInputNumberEntityRow extends mixinBehaviors(
         >
           <div class="flex">
             <ha-slider
+              dir="[[_rtl]]"
               min="[[_min]]"
               max="[[_max]]"
               value="{{_value}}"
@@ -103,6 +105,11 @@ class HuiInputNumberEntityRow extends mixinBehaviors(
       },
       _step: Number,
       _value: Number,
+      _rtl: {
+        type: String,
+        reflectToAttribute: true,
+        computed: "_computeRTLDirection(hass)",
+      },
     };
   }
 
@@ -173,6 +180,10 @@ class HuiInputNumberEntityRow extends mixinBehaviors(
       value: this._value,
       entity_id: this._stateObj.entity_id,
     });
+  }
+
+  _computeRTLDirection(hass) {
+    return computeRTL(hass) ? "rtl" : "ltr";
   }
 }
 customElements.define("hui-input-number-entity-row", HuiInputNumberEntityRow);


### PR DESCRIPTION
Before fix you had to drag knob to the other direction to make it increase.
After forcing dir="RTL" on the ha-slider, the pin was mirrored:
<img width="375" alt="slider-pin-before" src="https://user-images.githubusercontent.com/37745463/51103892-06c87800-17ed-11e9-851a-e8c8243c4994.png">

After both fixes (ignore the number mismatch below - it's because of the screen cap)
<img width="374" alt="slider-pin-after" src="https://user-images.githubusercontent.com/37745463/51106734-47c48a80-17f5-11e9-8dd2-6e9ba3d90713.png">


