### PR TITLE
Honor group control hidden setting

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -21,7 +21,7 @@ import { createRowElement } from "../common/create-row-element";
 import computeDomain from "../../../common/entity/compute_domain";
 import applyThemesOnElement from "../../../common/dom/apply_themes_on_element";
 
-export interface ConfigEntity extends EntityConfig {
+export interface EntitiesCardEntityConfig extends EntityConfig {
   type?: string;
   secondary_info?: "entity-id" | "last-changed";
   action_name?: string;
@@ -30,10 +30,10 @@ export interface ConfigEntity extends EntityConfig {
   url?: string;
 }
 
-export interface Config extends LovelaceCardConfig {
+export interface EntitiesCardConfig extends LovelaceCardConfig {
   show_header_toggle?: boolean;
   title?: string;
-  entities: ConfigEntity[];
+  entities: EntitiesCardEntityConfig[];
   theme?: string;
 }
 
@@ -49,8 +49,8 @@ class HuiEntitiesCard extends hassLocalizeLitMixin(LitElement)
   }
 
   protected _hass?: HomeAssistant;
-  protected _config?: Config;
-  protected _configEntities?: ConfigEntity[];
+  protected _config?: EntitiesCardConfig;
+  protected _configEntities?: EntitiesCardEntityConfig[];
 
   set hass(hass: HomeAssistant) {
     this._hass = hass;
@@ -81,7 +81,7 @@ class HuiEntitiesCard extends hassLocalizeLitMixin(LitElement)
     return (this._config.title ? 1 : 0) + this._config.entities.length;
   }
 
-  public setConfig(config: Config): void {
+  public setConfig(config: EntitiesCardConfig): void {
     const entities = processConfigEntities(config.entities);
 
     this._config = { theme: "default", ...config };
@@ -171,7 +171,7 @@ class HuiEntitiesCard extends hassLocalizeLitMixin(LitElement)
     `;
   }
 
-  private renderEntity(entityConf: ConfigEntity): TemplateResult {
+  private renderEntity(entityConf: EntitiesCardEntityConfig): TemplateResult {
     const element = createRowElement(entityConf);
     if (this._hass) {
       element.hass = this._hass;
@@ -189,7 +189,7 @@ class HuiEntitiesCard extends hassLocalizeLitMixin(LitElement)
     `;
   }
 
-  private _handleClick(entityConf: ConfigEntity): void {
+  private _handleClick(entityConf: EntitiesCardEntityConfig): void {
     const entityId = entityConf.entity;
     fireEvent(this, "hass-more-info", { entityId });
   }

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -14,6 +14,7 @@ import computeStateDomain from "../../../common/entity/compute_state_domain";
 import { LocalizeFunc } from "../../../mixins/localize-base-mixin";
 import computeDomain from "../../../common/entity/compute_domain";
 import { EntityRowConfig, WeblinkConfig } from "../entity-rows/types";
+import { EntitiesCardConfig } from "../cards/hui-entities-card";
 
 const DEFAULT_VIEW_ENTITY_ID = "group.default_view";
 const DOMAINS_BADGES = [
@@ -27,8 +28,8 @@ const DOMAINS_BADGES = [
 const HIDE_DOMAIN = new Set(["persistent_notification", "configurator"]);
 
 const computeCards = (
-  title: string,
-  states: Array<[string, HassEntity]>
+  states: Array<[string, HassEntity]>,
+  entityCardOptions: Partial<EntitiesCardConfig>
 ): LovelaceCardConfig[] => {
   const cards: LovelaceCardConfig[] = [];
 
@@ -85,9 +86,9 @@ const computeCards = (
 
   if (entities.length > 0) {
     cards.unshift({
-      title,
       type: "entities",
       entities,
+      ...entityCardOptions,
     });
   }
 
@@ -152,10 +153,13 @@ const generateViewConfig = (
   splitted.groups.forEach((groupEntity) => {
     cards = cards.concat(
       computeCards(
-        computeStateName(groupEntity),
         groupEntity.attributes.entity_id.map(
           (entityId): [string, HassEntity] => [entityId, entities[entityId]]
-        )
+        ),
+        {
+          title: computeStateName(groupEntity),
+          show_header_toggle: groupEntity.attributes.control !== "hidden",
+        }
       )
     );
   });
@@ -165,10 +169,12 @@ const generateViewConfig = (
     .forEach((domain) => {
       cards = cards.concat(
         computeCards(
-          localize(`domain.${domain}`),
           ungroupedEntitites[domain].map(
             (entityId): [string, HassEntity] => [entityId, entities[entityId]]
-          )
+          ),
+          {
+            title: localize(`domain.${domain}`),
+          }
         )
       );
     });

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -16,7 +16,10 @@ import { hassLocalizeLitMixin } from "../../../../mixins/lit-localize-mixin";
 import { HomeAssistant } from "../../../../types";
 import { LovelaceCardEditor } from "../../types";
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { Config, ConfigEntity } from "../../cards/hui-entities-card";
+import {
+  EntitiesCardConfig,
+  EntitiesCardEntityConfig,
+} from "../../cards/hui-entities-card";
 import { configElementStyle } from "./config-elements-style";
 
 import "../../../../components/entity/state-badge";
@@ -57,10 +60,10 @@ export class HuiEntitiesCardEditor extends hassLocalizeLitMixin(LitElement)
   }
 
   public hass?: HomeAssistant;
-  private _config?: Config;
-  private _configEntities?: ConfigEntity[];
+  private _config?: EntitiesCardConfig;
+  private _configEntities?: EntitiesCardEntityConfig[];
 
-  public setConfig(config: Config): void {
+  public setConfig(config: EntitiesCardConfig): void {
     config = cardConfigStruct(config);
     this._config = config;
     this._configEntities = processEditorEntities(config.entities);


### PR DESCRIPTION
When generating Lovelace config, honor the group "control: hidden" attribute.

Fixes #2377