### PR TITLE
Fix ll-rebuild only keeps the card that should be deleted

### DIFF
--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -75,14 +75,13 @@ export abstract class HuiStackCard extends LitElement implements LovelaceCard {
   }
 
   private _rebuildCard(
-    element: LovelaceCard,
+    cardElToReplace: LovelaceCard,
     config: LovelaceCardConfig
   ): void {
-    const newCard = this._createCardElement(config);
-    element.replaceWith(newCard);
-
-    const newCardList = this._cards!.slice(0);
-    newCardList[this._cards.indexOf(element)] = newCard;
-    this._cards = newCardList;
+    const newCardEl = this._createCardElement(config);
+    cardElToReplace.parentElement!.replaceChild(newCardEl, cardElToReplace);
+    this._cards = this._cards!.map((curCardEl) =>
+      curCardEl === cardElToReplace ? newCardEl : curCardEl
+    );
   }
 }

--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -80,6 +80,9 @@ export abstract class HuiStackCard extends LitElement implements LovelaceCard {
   ): void {
     const newCard = this._createCardElement(config);
     element.replaceWith(newCard);
-    this._cards!.splice(this._cards!.indexOf(element), 1, newCard);
+
+    const newCardList = this._cards!.slice(0);
+    newCardList[this._cards.indexOf(element)] = newCard;
+    this._cards = newCardList;
   }
 }

--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -80,10 +80,6 @@ export abstract class HuiStackCard extends LitElement implements LovelaceCard {
   ): void {
     const newCard = this._createCardElement(config);
     element.replaceWith(newCard);
-    this._cards = this._cards!.splice(
-      this._cards!.indexOf(element),
-      1,
-      newCard
-    );
+    this._cards!.splice(this._cards!.indexOf(element), 1, newCard);
   }
 }

--- a/src/panels/lovelace/hui-view.ts
+++ b/src/panels/lovelace/hui-view.ts
@@ -306,15 +306,14 @@ export class HUIView extends hassLocalizeLitMixin(LitElement) {
   }
 
   private _rebuildCard(
-    element: LovelaceCard,
+    cardElToReplace: LovelaceCard,
     config: LovelaceCardConfig
   ): void {
-    const newCard = this._createCardElement(config);
-    element.parentElement!.replaceChild(newCard, element);
-
-    const newCardList = this._cards!.slice(0);
-    newCardList[this._cards.indexOf(element)] = newCard;
-    this._cards = newCardList;
+    const newCardEl = this._createCardElement(config);
+    cardElToReplace.parentElement!.replaceChild(newCardEl, cardElToReplace);
+    this._cards = this._cards!.map((curCardEl) =>
+      curCardEl === cardElToReplace ? newCardEl : curCardEl
+    );
   }
 }
 

--- a/src/panels/lovelace/hui-view.ts
+++ b/src/panels/lovelace/hui-view.ts
@@ -311,7 +311,7 @@ export class HUIView extends hassLocalizeLitMixin(LitElement) {
   ): void {
     const newCard = this._createCardElement(config);
     element.parentElement!.replaceChild(newCard, element);
-    this._cards = this._cards.splice(this._cards.indexOf(element), 1, newCard);
+    this._cards.splice(this._cards.indexOf(element), 1, newCard);
   }
 }
 

--- a/src/panels/lovelace/hui-view.ts
+++ b/src/panels/lovelace/hui-view.ts
@@ -311,7 +311,10 @@ export class HUIView extends hassLocalizeLitMixin(LitElement) {
   ): void {
     const newCard = this._createCardElement(config);
     element.parentElement!.replaceChild(newCard, element);
-    this._cards.splice(this._cards.indexOf(element), 1, newCard);
+
+    const newCardList = this._cards!.slice(0);
+    newCardList[this._cards.indexOf(element)] = newCard;
+    this._cards = newCardList;
   }
 }
 


### PR DESCRIPTION
Apparently splice doesn't return the new array, but instead the elements that were removed...