### PR TITLE
Ignore weblinks that don't exist when converting groups to lovelace config

### DIFF
--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -70,15 +70,17 @@ const computeCards = (
         entity: entityId,
       });
     } else if (domain === "weblink") {
-      const conf: WeblinkConfig = {
-        type: "weblink",
-        url: stateObj.state,
-        name: computeStateName(stateObj),
-      };
-      if ("icon" in stateObj.attributes) {
-        conf.icon = stateObj.attributes.icon;
+      if (stateObj) {
+        const conf: WeblinkConfig = {
+          type: "weblink",
+          url: stateObj.state,
+          name: computeStateName(stateObj),
+        };
+        if ("icon" in stateObj.attributes) {
+          conf.icon = stateObj.attributes.icon;
+        }
+        entities.push(conf);
       }
-      entities.push(conf);
     } else {
       entities.push(entityId);
     }

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -69,18 +69,16 @@ const computeCards = (
         type: "weather-forecast",
         entity: entityId,
       });
-    } else if (domain === "weblink") {
-      if (stateObj) {
-        const conf: WeblinkConfig = {
-          type: "weblink",
-          url: stateObj.state,
-          name: computeStateName(stateObj),
-        };
-        if ("icon" in stateObj.attributes) {
-          conf.icon = stateObj.attributes.icon;
-        }
-        entities.push(conf);
+    } else if (domain === "weblink" && stateObj) {
+      const conf: WeblinkConfig = {
+        type: "weblink",
+        url: stateObj.state,
+        name: computeStateName(stateObj),
+      };
+      if ("icon" in stateObj.attributes) {
+        conf.icon = stateObj.attributes.icon;
       }
+      entities.push(conf);
     } else {
       entities.push(entityId);
     }


### PR DESCRIPTION
```yaml
weblink:
  entities:
    - name: Only existing links
      url: www.i-am-defined.com

group:
  my_group:
    entities:
      - weblink.this_does_not_exist
```

Lovelace autogen will throw an error and stop. Blue spinner of death, etc.