### PR TITLE
Put geo_events on a map instead of an entities card.

### DIFF
--- a/src/panels/lovelace/cards/hui-map-card.js
+++ b/src/panels/lovelace/cards/hui-map-card.js
@@ -247,7 +247,10 @@ class HuiMapCard extends PolymerElement {
         const stateObj = this.hass.states[entityId];
         if (
           computeStateDomain(stateObj) === "geo_location" &&
-          this._configGeoLocationSources.includes(stateObj.attributes.source)
+          (this._configGeoLocationSources.includes(
+            stateObj.attributes.source
+          ) ||
+            this._configGeoLocationSources.includes("all"))
         ) {
           allEntities.push(entityId);
         }

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -25,7 +25,11 @@ const DOMAINS_BADGES = [
   "sun",
   "timer",
 ];
-const HIDE_DOMAIN = new Set(["persistent_notification", "configurator"]);
+const HIDE_DOMAIN = new Set([
+  "persistent_notification",
+  "configurator",
+  "geo_location",
+]);
 
 const computeCards = (
   states: Array<[string, HassEntity]>,
@@ -242,6 +246,16 @@ export const generateLovelaceConfig = (
         groupOrders
       )
     );
+
+    // Add map of geo locations to default view if loaded
+    if (hass.config.components.includes("geo_location")) {
+      if (views[0] && views[0].cards) {
+        views[0].cards.push({
+          type: "map",
+          geo_location_sources: ["all"],
+        });
+      }
+    }
 
     // Make sure we don't have Home as title and first tab.
     if (views.length > 1 && title === "Home") {


### PR DESCRIPTION
... With the default solution, geo_events are added to a static list - i.e. it doesn't update as new geo_events are added or they are resolved.

This was the best way I could come up with to fix things. Had to add a new magic value to the `geo_event_sources` list for the map card (needs documentation).

Unfortunately the distance to the event is lost.

Before:
![spurious entities](https://user-images.githubusercontent.com/1299821/51248152-91e17380-198f-11e9-9ddf-4fa80d723998.jpg)

After:
![map events](https://user-images.githubusercontent.com/1299821/51248184-a7569d80-198f-11e9-98e1-5b65ebf3820e.jpg)
