### PR TITLE
Make edit-dialog look ok on mobile

### DIFF
--- a/src/dialogs/ha-more-info-dialog.js
+++ b/src/dialogs/ha-more-info-dialog.js
@@ -52,7 +52,10 @@ class HaMoreInfoDialog extends DialogMixin(PolymerElement) {
             --more-info-header-color: var(--text-primary-color);
           }
           :host {
-            @apply --ha-dialog-fullscreen;
+            width: 100% !important;
+            border-radius: 0px;
+            position: fixed !important;
+            margin: 0;
           }
           :host::before {
             content: "";

--- a/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
@@ -83,11 +83,9 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
 
   static get styles(): CSSResult[] {
     return [
+      haStyleDialog,
       css`
         @media all and (max-width: 450px), all and (max-height: 500px) {
-          :host {
-            @apply --ha-dialog-fullscreen;
-          }
           :host::before {
             content: "";
             position: fixed;
@@ -98,6 +96,7 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
             bottom: 0px;
             background-color: inherit;
           }
+          /* overrule the ha-style-dialog max-height on small screens */
           paper-dialog {
             max-height: 100%;
             height: 100%;
@@ -212,9 +211,6 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
     }
 
     return html`
-      <style>
-        ${haStyleDialog.cssText}
-      </style>
       <paper-dialog
         with-backdrop
         opened

--- a/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
@@ -1,12 +1,16 @@
 import {
   html,
+  css,
   LitElement,
   PropertyDeclarations,
   PropertyValues,
   TemplateResult,
+  CSSResult,
 } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 import yaml from "js-yaml";
+
+import { haStyleDialog } from "../../../../resources/ha-style";
 
 import "@polymer/paper-spinner/paper-spinner";
 import "@polymer/paper-dialog/paper-dialog";
@@ -77,6 +81,76 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
     };
   }
 
+  static get styles(): CSSResult[] {
+    return [
+      css`
+        @media all and (max-width: 450px), all and (max-height: 500px) {
+          :host {
+            @apply --ha-dialog-fullscreen;
+          }
+          :host::before {
+            content: "";
+            position: fixed;
+            z-index: -1;
+            top: 0px;
+            left: 0px;
+            right: 0px;
+            bottom: 0px;
+            background-color: inherit;
+          }
+          paper-dialog {
+            max-height: 100%;
+            height: 100%;
+          }
+        }
+
+        paper-dialog {
+          max-width: 650px;
+        }
+        .center {
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .margin-bot {
+          margin-bottom: 24px;
+        }
+        paper-button paper-spinner {
+          width: 14px;
+          height: 14px;
+          margin-right: 20px;
+        }
+        paper-spinner {
+          display: none;
+        }
+        paper-spinner[active] {
+          display: block;
+        }
+        .hidden {
+          display: none;
+        }
+        .element-editor {
+          margin-bottom: 8px;
+        }
+        .error {
+          color: #ef5350;
+          border-bottom: 1px solid #ef5350;
+        }
+        hr {
+          color: #000;
+          opacity: 0.12;
+        }
+        hui-card-preview {
+          padding-top: 8px;
+          margin-bottom: 4px;
+          display: block;
+        }
+        .toggle-button {
+          margin-right: auto;
+        }
+      `,
+    ];
+  }
+
   private get _dialog(): PaperDialogElement {
     return this.shadowRoot!.querySelector("paper-dialog")!;
   }
@@ -131,7 +205,9 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
     }
 
     return html`
-      ${this.renderStyle()}
+      <style>
+        ${haStyleDialog.cssText}
+      </style>
       <paper-dialog
         with-backdrop
         opened
@@ -191,56 +267,6 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
             : ""
         }
       </paper-dialog>
-    `;
-  }
-
-  private renderStyle(): TemplateResult {
-    return html`
-      <style>
-        paper-dialog {
-          width: 650px;
-        }
-        .center {
-          margin-left: auto;
-          margin-right: auto;
-        }
-        .margin-bot {
-          margin-bottom: 24px;
-        }
-        paper-button paper-spinner {
-          width: 14px;
-          height: 14px;
-          margin-right: 20px;
-        }
-        paper-spinner {
-          display: none;
-        }
-        paper-spinner[active] {
-          display: block;
-        }
-        .hidden {
-          display: none;
-        }
-        .element-editor {
-          margin-bottom: 8px;
-        }
-        .error {
-          color: #ef5350;
-          border-bottom: 1px solid #ef5350;
-        }
-        hr {
-          color: #000;
-          opacity: 0.12;
-        }
-        hui-card-preview {
-          padding-top: 8px;
-          margin-bottom: 4px;
-          display: block;
-        }
-        .toggle-button {
-          margin-right: auto;
-        }
-      </style>
     `;
   }
 

--- a/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
@@ -104,9 +104,16 @@ export class HuiEditCard extends hassLocalizeLitMixin(LitElement) {
           }
         }
 
+        @media all and (min-width: 660px) {
+          paper-dialog {
+            width: 650px;
+          }
+        }
+
         paper-dialog {
           max-width: 650px;
         }
+
         .center {
           margin-left: auto;
           margin-right: auto;

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -63,20 +63,6 @@ export const haStyle = css`
   }
 `;
 
-const haDialogNarrow = css`
-  margin: 0;
-  width: 100% !important;
-  max-height: calc(100% - 64px);
-
-  position: fixed !important;
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
-  overflow: scroll;
-  border-bottom-left-radius: 0px;
-  border-bottom-right-radius: 0px;
-`;
-
 export const haStyleDialog = css`
   /* prevent clipping of positioned elements */
   paper-dialog-scrollable {
@@ -94,7 +80,17 @@ export const haStyleDialog = css`
 
   @media all and (max-width: 450px), all and (max-height: 500px) {
     paper-dialog {
-      ${haDialogNarrow}
+      margin: 0;
+      width: 100% !important;
+      max-height: calc(100% - 64px);
+
+      position: fixed !important;
+      bottom: 0px;
+      left: 0px;
+      right: 0px;
+      overflow: scroll;
+      border-bottom-left-radius: 0px;
+      border-bottom-right-radius: 0px;
     }
   }
 `;

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -63,30 +63,21 @@ export const haStyle = css`
   }
 `;
 
+const haDialogNarrow = css`
+  margin: 0;
+  width: 100% !important;
+  max-height: calc(100% - 64px);
+
+  position: fixed !important;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
+  overflow: scroll;
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
+`;
+
 export const haStyleDialog = css`
-  :host {
-    --ha-dialog-narrow: {
-      margin: 0;
-      width: 100% !important;
-      max-height: calc(100% - 64px);
-
-      position: fixed !important;
-      bottom: 0px;
-      left: 0px;
-      right: 0px;
-      overflow: scroll;
-      border-bottom-left-radius: 0px;
-      border-bottom-right-radius: 0px;
-    }
-
-    --ha-dialog-fullscreen: {
-      width: 100% !important;
-      border-radius: 0px;
-      position: fixed !important;
-      margin: 0;
-    }
-  }
-
   /* prevent clipping of positioned elements */
   paper-dialog-scrollable {
     --paper-dialog-scrollable: {
@@ -103,7 +94,7 @@ export const haStyleDialog = css`
 
   @media all and (max-width: 450px), all and (max-height: 500px) {
     paper-dialog {
-      @apply (--ha-dialog-narrow);
+      ${haDialogNarrow}
     }
   }
 `;


### PR DESCRIPTION
I might be doing something wrong, but putting `haStyleDialog` in `styles()` doesn't seem to work with CSS variables and mixins...

This might not give the best UX, but it is a lot better than it is now...
When approved will do the rest of the dialogs.

Before:
![image](https://user-images.githubusercontent.com/5662298/51343764-68137400-1a97-11e9-952f-ccea1fa0a52f.png)

After:
![image](https://user-images.githubusercontent.com/5662298/51343666-2a165000-1a97-11e9-8d4d-9116b935c5a4.png)
