### PR TITLE
Fix panels with subpaths

### DIFF
--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -177,10 +177,16 @@ class PartialPanelResolver extends LitElement {
       // Manual splitting
       const route = this.route!;
       const dividerPos = route.path.indexOf("/", 1);
-      this._routeTail = {
-        prefix: route.path.substr(0, dividerPos),
-        path: route.path.substr(dividerPos),
-      };
+      this._routeTail =
+        dividerPos === -1
+          ? {
+              prefix: route.path,
+              path: "",
+            }
+          : {
+              prefix: route.path.substr(0, dividerPos),
+              path: route.path.substr(dividerPos),
+            };
 
       // If just route changed, no need to process further.
       if (changedProps.size === 1) {


### PR DESCRIPTION
Only looked at route parsing if the url was `/lovelace/something`. Didn't account for when panels just have `/lovelace` 