### PR TITLE
 RTL fixes for raw config editor and card editor -> card preview

### DIFF
--- a/src/common/util/compute_rtl.ts
+++ b/src/common/util/compute_rtl.ts
@@ -7,3 +7,7 @@ export function computeRTL(hass: HomeAssistant) {
   }
   return false;
 }
+
+export function computeRTLDirection(hass: HomeAssistant) {
+  return computeRTL(hass) ? "rtl" : "ltr";
+}

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -1,11 +1,3 @@
-import {
-  LitElement,
-  PropertyDeclarations,
-  PropertyValues,
-  TemplateResult,
-  html,
-} from "lit-element";
-
 import "@polymer/paper-input/paper-textarea";
 
 import deepClone from "deep-clone-simple";
@@ -17,34 +9,20 @@ import { LovelaceCard } from "../../types";
 import { ConfigError } from "../types";
 import { getCardElementTag } from "../../common/get-card-element-tag";
 import { createErrorCardConfig } from "../../cards/hui-error-card";
-import { computeRTLDirection } from "../../../../common/util/compute_rtl";
+import { computeRTL } from "../../../../common/util/compute_rtl";
 
-export class HuiCardPreview extends LitElement {
+export class HuiCardPreview extends HTMLElement {
   private _hass?: HomeAssistant;
   private _element?: LovelaceCard;
 
-  static get properties(): PropertyDeclarations {
-    return {
-      _hass: {},
-      _element: {},
-    };
-  }
-
-  protected updated(changedProperties: PropertyValues): void {
-    super.updated(changedProperties);
-    if (
-      this._hass &&
-      (!this.style.direction ||
-        this.style.direction !== computeRTLDirection(this._hass))
-    ) {
-      this.style.direction = computeRTLDirection(this._hass);
-    }
-  }
-
-  set hass(hass: HomeAssistant) {
-    this._hass = hass;
+  set hass(value: HomeAssistant) {
+    this._hass = value;
     if (this._element) {
-      this._element.hass = this._hass;
+      this._element.hass = value;
+    }
+
+    if (this._hass && computeRTL(this._hass)) {
+      this.style.direction = "rtl";
     }
   }
 
@@ -80,22 +58,18 @@ export class HuiCardPreview extends LitElement {
     }
   }
 
-  protected render(): TemplateResult | void {
-    if (!this._element) {
-      return html``;
+  private _createCard(configValue: LovelaceCardConfig): void {
+    if (this._element) {
+      this.removeChild(this._element);
     }
 
-    return html`
-      ${this._element}
-    `;
-  }
-
-  private _createCard(configValue: LovelaceCardConfig): void {
     this._element = createCardElement(configValue);
 
     if (this._hass) {
       this._element!.hass = this._hass;
     }
+
+    this.appendChild(this._element!);
   }
 }
 

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -15,14 +15,14 @@ export class HuiCardPreview extends HTMLElement {
   private _hass?: HomeAssistant;
   private _element?: LovelaceCard;
 
-  set hass(value: HomeAssistant) {
-    this._hass = value;
-    if (this._element) {
-      this._element.hass = value;
+  set hass(hass: HomeAssistant) {
+    if (!this._hass || this._hass.language !== hass.language) {
+      this.style.direction = computeRTL(hass) ? "rtl" : "ltr";
     }
 
-    if (this._hass && computeRTL(this._hass)) {
-      this.style.direction = "rtl";
+    this._hass = hass;
+    if (this._element) {
+      this._element.hass = hass;
     }
   }
 

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -36,7 +36,9 @@ export class HuiCardPreview extends HTMLElement {
       return;
     }
 
-    if (this._hass && computeRTL(this._hass)) this.style.direction = "rtl";
+    if (this._hass && computeRTL(this._hass)) {
+      this.style.direction = "rtl";
+    }
 
     if (!this._element) {
       this._createCard(configValue);

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -1,6 +1,7 @@
 import {
   LitElement,
   PropertyDeclarations,
+  PropertyValues,
   TemplateResult,
   html,
 } from "lit-element";

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -65,7 +65,9 @@ export class HuiCardPreview extends HTMLElement {
 
     this._element = createCardElement(configValue);
 
-    if (this._hass) this._element!.hass = this._hass;
+    if (this._hass) {
+      this._element!.hass = this._hass;
+    }
 
     this.appendChild(this._element!);
   }

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -9,6 +9,7 @@ import { LovelaceCard } from "../../types";
 import { ConfigError } from "../types";
 import { getCardElementTag } from "../../common/get-card-element-tag";
 import { createErrorCardConfig } from "../../cards/hui-error-card";
+import { computeRTL } from "../../../../common/util/compute_rtl";
 
 export class HuiCardPreview extends HTMLElement {
   private _hass?: HomeAssistant;
@@ -35,6 +36,8 @@ export class HuiCardPreview extends HTMLElement {
       return;
     }
 
+    if (this._hass && computeRTL(this._hass)) this.style.direction = "rtl";
+
     if (!this._element) {
       this._createCard(configValue);
       return;
@@ -60,9 +63,7 @@ export class HuiCardPreview extends HTMLElement {
 
     this._element = createCardElement(configValue);
 
-    if (this._hass) {
-      this._element!.hass = this._hass;
-    }
+    if (this._hass) this._element!.hass = this._hass;
 
     this.appendChild(this._element!);
   }

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -1,3 +1,10 @@
+import {
+  LitElement,
+  PropertyDeclarations,
+  TemplateResult,
+  html,
+} from "lit-element";
+
 import "@polymer/paper-input/paper-textarea";
 
 import deepClone from "deep-clone-simple";
@@ -11,14 +18,32 @@ import { getCardElementTag } from "../../common/get-card-element-tag";
 import { createErrorCardConfig } from "../../cards/hui-error-card";
 import { computeRTL } from "../../../../common/util/compute_rtl";
 
-export class HuiCardPreview extends HTMLElement {
+export class HuiCardPreview extends LitElement {
   private _hass?: HomeAssistant;
   private _element?: LovelaceCard;
 
-  set hass(value: HomeAssistant) {
-    this._hass = value;
+  static get properties(): PropertyDeclarations {
+    return {
+      _hass: {},
+      _element: {},
+    };
+  }
+
+  protected updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    if (
+      this._hass &&
+      computeRTL(this._hass) &&
+      (!this.style.direction || this.style.direction == "ltr")
+    ) {
+      this.style.direction = "rtl";
+    }
+  }
+
+  set hass(hass: HomeAssistant) {
+    this._hass = hass;
     if (this._element) {
-      this._element.hass = value;
+      this._element.hass = this._hass;
     }
   }
 
@@ -34,10 +59,6 @@ export class HuiCardPreview extends HTMLElement {
   set config(configValue: LovelaceCardConfig) {
     if (!configValue) {
       return;
-    }
-
-    if (this._hass && computeRTL(this._hass)) {
-      this.style.direction = "rtl";
     }
 
     if (!this._element) {
@@ -58,18 +79,22 @@ export class HuiCardPreview extends HTMLElement {
     }
   }
 
-  private _createCard(configValue: LovelaceCardConfig): void {
-    if (this._element) {
-      this.removeChild(this._element);
+  protected render(): TemplateResult | void {
+    if (!this._element) {
+      return html``;
     }
 
+    return html`
+      ${this._element}
+    `;
+  }
+
+  private _createCard(configValue: LovelaceCardConfig): void {
     this._element = createCardElement(configValue);
 
     if (this._hass) {
       this._element!.hass = this._hass;
     }
-
-    this.appendChild(this._element!);
   }
 }
 

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -16,7 +16,7 @@ import { LovelaceCard } from "../../types";
 import { ConfigError } from "../types";
 import { getCardElementTag } from "../../common/get-card-element-tag";
 import { createErrorCardConfig } from "../../cards/hui-error-card";
-import { computeRTL } from "../../../../common/util/compute_rtl";
+import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 
 export class HuiCardPreview extends LitElement {
   private _hass?: HomeAssistant;
@@ -33,10 +33,10 @@ export class HuiCardPreview extends LitElement {
     super.updated(changedProperties);
     if (
       this._hass &&
-      computeRTL(this._hass) &&
-      (!this.style.direction || this.style.direction == "ltr")
+      (!this.style.direction ||
+        this.style.direction !== computeRTLDirection(this._hass))
     ) {
-      this.style.direction = "rtl";
+      this.style.direction = computeRTLDirection(this._hass);
     }
   }
 

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -135,6 +135,7 @@ class LovelaceFullConfigEditor extends hassLocalizeLitMixin(LitElement) {
 
         .content {
           height: calc(100vh - 68px);
+          direction: ltr;
         }
 
         textarea {


### PR DESCRIPTION
1. Editor before:
<img width="1086" alt="editor-before" src="https://user-images.githubusercontent.com/37745463/51555809-2dd41900-1e81-11e9-950c-d322f014faf4.PNG">

Editor after:
<img width="1095" alt="editor-after" src="https://user-images.githubusercontent.com/37745463/51555870-52c88c00-1e81-11e9-9954-8f3950c3e1c8.PNG">

2. Card preview in card editor - did not obey RTL setting of current language
<img width="640" alt="capture" src="https://user-images.githubusercontent.com/37745463/51556774-bd7ac700-1e83-11e9-9260-17d943464dca.PNG">

After:
<img width="491" alt="capture-after" src="https://user-images.githubusercontent.com/37745463/51556798-d1262d80-1e83-11e9-8141-a9a84be71fd0.PNG">
