### PR TITLE
html5 notifications add VAPID support

### DIFF
--- a/src/components/ha-push-notifications-toggle.js
+++ b/src/components/ha-push-notifications-toggle.js
@@ -113,7 +113,9 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
           "notify.html5/applicationServerKey"
         );
         applicationServerKey = res.message;
-      } catch (ex) {}
+      } catch (ex) {
+        applicationServerKey = null;
+      }
 
       if (applicationServerKey) {
         sub = await reg.pushManager.subscribe({

--- a/src/data/notify_html5.ts
+++ b/src/data/notify_html5.ts
@@ -1,0 +1,21 @@
+import { HomeAssistant } from "../types";
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+export const getAppKey = async (hass: HomeAssistant) => {
+  const res = await hass.callWS<string>({
+    type: "notify/html5/appkey",
+  });
+  return res ? urlBase64ToUint8Array(res) : null;
+};


### PR DESCRIPTION
> As of April 10, 2018, Google has deprecated GCM. The GCM server and client APIs are deprecated and will be removed as soon as April 11, 2019. Migrate GCM apps to Firebase Cloud Messaging (FCM), which inherits the reliable and scalable GCM infrastructure, plus many new features. See the migration guide to learn more.

> How will this affect Web APIs (Webpush protocol and chrome.gcm API)?
For Chrome extensions, keep an eye on chrome.gcm API deprecation plans.
For Webpush protocol, start using Voluntary Application Identification when subscribing to PushManager.

This PR add support for VAPID.
Sibling PR for homeassistant: https://github.com/home-assistant/home-assistant/pull/20415
