### PR TITLE
add history-graph to generated mode

### DIFF
--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -58,6 +58,14 @@ const computeCards = (
         type: "thermostat",
         entity: entityId,
       });
+    } else if (domain === "history_graph" && stateObj) {
+      cards.push({
+        type: "history-graph",
+        entities: stateObj.attributes.entity_id,
+        hours_to_show: stateObj.attributes.hours_to_show,
+        title: stateObj.attributes.friendly_name,
+        refresh_interval: stateObj.attributes.refresh,
+      });
     } else if (domain === "media_player") {
       cards.push({
         type: "media-control",


### PR DESCRIPTION
So we have backend components that are only used to get something on the frontend? With Lovelace they should be removed I guess?

Closes https://github.com/home-assistant/home-assistant-polymer/issues/2562