### PR TITLE
Force LTR on configuration validation message so errors are readable also in RTL langauges

### DIFF
--- a/src/panels/config/core/ha-config-section-core.js
+++ b/src/panels/config/core/ha-config-section-core.js
@@ -46,6 +46,7 @@ class HaConfigSectionCore extends LocalizeMixin(PolymerElement) {
 
         .validate-log {
           white-space: pre-wrap;
+          direction: ltr;
         }
       </style>
       <ha-config-section is-wide="[[isWide]]">


### PR DESCRIPTION
Before (not readable):

<img width="736" alt="config-label-fix-before" src="https://user-images.githubusercontent.com/37745463/51792105-78250500-21b5-11e9-8c89-2c99e98c91ef.PNG">

After:

<img width="776" alt="config-label-fix-after" src="https://user-images.githubusercontent.com/37745463/51792108-7e1ae600-21b5-11e9-9fd6-fbcfc32d45ce.PNG">
