### PR TITLE
Improve "Full Log" button on Dev Info panel

### DIFF
--- a/src/panels/dev-info/ha-panel-dev-info.js
+++ b/src/panels/dev-info/ha-panel-dev-info.js
@@ -56,6 +56,7 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
       }
 
       .error-log-intro {
+        text-align: center;
         margin: 16px;
       }
 
@@ -210,8 +211,12 @@ class HaPanelDevInfo extends EventsMixin(LocalizeMixin(PolymerElement)) {
           </paper-card>
         </div>
         <p class='error-log-intro'>
-          Press the button to load the full Home Assistant log.
-          <paper-icon-button icon='hass:refresh' on-click='refreshErrorLog'></paper-icon-button>
+          <template is='dom-if' if='[[!errorLog]]'>
+            <paper-button raised on-click='refreshErrorLog'>Load Full Home Assistant Log</paper-button>
+          </template>
+          <template is='dom-if' if='[[errorLog]]'>
+            <paper-icon-button icon='hass:refresh' on-click='refreshErrorLog'></paper-icon-button>
+          </template>
         </p>
         <div class='error-log'>[[errorLog]]</div>
       </div>


### PR DESCRIPTION
A small bugbear for me on my widescreen monitor is the position of the text and button for "full log output" on the Dev Info panel:

![screenshot](https://i.imgur.com/AAbxHLK.png)

This PR makes the initial state just a centre-aligned button, and when the log is shown the same refresh button as before is shown on the far right (which seems to be a rough convention in HA).

**Initial State:**

![screenshot](https://i.imgur.com/82Hyyge.png)

**Expanded State:**

![screenshot](https://i.imgur.com/vii7Ox6.png)