### PR TITLE
optional `entity` for `more-info` action

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -46,6 +46,7 @@ export interface NavigateActionConfig {
 
 export interface MoreInfoActionConfig {
   action: "more-info";
+  entity?: string;
 }
 
 export interface NoActionConfig {

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -46,7 +46,7 @@ export interface NavigateActionConfig {
 
 export interface MoreInfoActionConfig {
   action: "more-info";
-  entity?: string;
+  entity: string;
 }
 
 export interface NoActionConfig {

--- a/src/panels/lovelace/common/handle-click.ts
+++ b/src/panels/lovelace/common/handle-click.ts
@@ -31,9 +31,12 @@ export const handleClick = (
 
   switch (actionConfig.action) {
     case "more-info":
-      if (config.entity || config.camera_image) {
+      if (config.entity || config.camera_image || actionConfig.entity) {
+        const entityId = (actionConfig.entity ||
+          config.entity ||
+          config.camera_image) as string;
         fireEvent(node, "hass-more-info", {
-          entityId: config.entity ? config.entity : config.camera_image!,
+          entityId,
         });
       }
       break;

--- a/src/panels/lovelace/common/handle-click.ts
+++ b/src/panels/lovelace/common/handle-click.ts
@@ -15,17 +15,16 @@ export const handleClick = (
   },
   hold: boolean
 ): void => {
-  let actionConfig: ActionConfig | undefined;
+  let actionConfig: ActionConfig;
 
   if (hold && config.hold_action) {
     actionConfig = config.hold_action;
   } else if (!hold && config.tap_action) {
     actionConfig = config.tap_action;
-  }
-
-  if (!actionConfig) {
+  } else {
     actionConfig = {
       action: "more-info",
+      entity: config.entity!,
     };
   }
 

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -41,6 +41,8 @@ export class HuiActionEditor extends LitElement {
 
   @property() public actions?: string[];
 
+  @property() public fallbackEntity: string = "";
+
   @property() protected hass?: HomeAssistant;
 
   get _action(): string {
@@ -49,7 +51,7 @@ export class HuiActionEditor extends LitElement {
 
   get _entity(): string {
     const _config = this.config! as MoreInfoActionConfig;
-    return _config.entity || this.entity || "";
+    return _config.entity || this.fallbackEntity;
   }
 
   get _navigation_path(): string {

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -49,7 +49,7 @@ export class HuiActionEditor extends LitElement {
 
   get _entity(): string {
     const _config = this.config! as MoreInfoActionConfig;
-    return _config.entity || "";
+    return _config.entity || this.entity || "";
   }
 
   get _navigation_path(): string {

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -19,6 +19,7 @@ import {
   ActionConfig,
   NavigateActionConfig,
   CallServiceActionConfig,
+  MoreInfoActionConfig,
 } from "../../../data/lovelace";
 
 declare global {
@@ -46,14 +47,19 @@ export class HuiActionEditor extends LitElement {
     return this.config!.action || "";
   }
 
+  get _entity(): string {
+    const _config = this.config! as MoreInfoActionConfig;
+    return _config.entity || "";
+  }
+
   get _navigation_path(): string {
-    const config = this.config! as NavigateActionConfig;
-    return config.navigation_path || "";
+    const _config = this.config! as NavigateActionConfig;
+    return _config.navigation_path || "";
   }
 
   get _service(): string {
-    const config = this.config! as CallServiceActionConfig;
-    return config.service || "";
+    const _config = this.config! as CallServiceActionConfig;
+    return _config.service || "";
   }
 
   protected render(): TemplateResult | void {
@@ -77,6 +83,17 @@ export class HuiActionEditor extends LitElement {
           })}
         </paper-listbox>
       </paper-dropdown-menu>
+      ${this._action === "more-info"
+        ? html`
+            <ha-entity-picker
+              .hass="${this.hass}"
+              .value="${this._entity}"
+              .configValue=${"entity"}
+              @change="${this._valueChanged}"
+              allow-custom-entity
+            ></ha-entity-picker>
+          `
+        : ""}
       ${this._action === "navigate"
         ? html`
             <paper-input

--- a/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
@@ -138,6 +138,7 @@ export class HuiEntityButtonCardEditor extends LitElement
             .config="${this._tap_action}"
             .actions="${actions}"
             .configValue="${"tap_action"}"
+            .entity="${this._entity}"
             @action-changed="${this._valueChanged}"
           ></hui-action-editor>
           <hui-action-editor
@@ -146,6 +147,7 @@ export class HuiEntityButtonCardEditor extends LitElement
             .config="${this._hold_action}"
             .actions="${actions}"
             .configValue="${"hold_action"}"
+            .entity="${this._entity}"
             @action-changed="${this._valueChanged}"
           ></hui-action-editor>
         </div>

--- a/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
@@ -138,7 +138,7 @@ export class HuiEntityButtonCardEditor extends LitElement
             .config="${this._tap_action}"
             .actions="${actions}"
             .configValue="${"tap_action"}"
-            .entity="${this._entity}"
+            .fallbackEntity="${this._entity}"
             @action-changed="${this._valueChanged}"
           ></hui-action-editor>
           <hui-action-editor
@@ -147,7 +147,7 @@ export class HuiEntityButtonCardEditor extends LitElement
             .config="${this._hold_action}"
             .actions="${actions}"
             .configValue="${"hold_action"}"
-            .entity="${this._entity}"
+            .fallbackEntity="${this._entity}"
             @action-changed="${this._valueChanged}"
           ></hui-action-editor>
         </div>

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -51,6 +51,7 @@ export interface CardPickTarget extends EventTarget {
 
 export const actionConfigStruct = struct({
   action: "string",
+  entity: "string?",
   navigation_path: "string?",
   service: "string?",
   service_data: "object?",


### PR DESCRIPTION
Been out of the mix for awhile and trying to get back into the swing of things. Having an issue with saved values not being populated correctly for tap/hold actions.