### PR TITLE
more-info icon for light-card

### DIFF
--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -12,7 +12,6 @@ import { HomeAssistant, LightEntity } from "../../../types";
 import { hassLocalizeLitMixin } from "../../../mixins/lit-localize-mixin";
 import { LovelaceCard, LovelaceCardEditor } from "../types";
 import { LovelaceCardConfig } from "../../../data/lovelace";
-import { longPress } from "../common/directives/long-press-directive";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import { loadRoundslider } from "../../../resources/jquery.roundslider.ondemand";
 import { toggleEntity } from "../common/entity/toggle-entity";
@@ -99,26 +98,25 @@ export class HuiLightCard extends hassLocalizeLitMixin(LitElement)
               </div>
             `
           : html`
+              <ha-icon
+                icon="hass:dots-vertical"
+                class="more-info"
+                @click="${this._handleMoreInfo}"
+              ></ha-icon>
               <div id="light"></div>
               <div id="tooltip">
                 <div class="icon-state">
                   <ha-icon
+                    class="light-icon"
                     data-state="${stateObj.state}"
                     .icon="${stateIcon(stateObj)}"
                     style="${styleMap({
                       filter: this._computeBrightness(stateObj),
                       color: this._computeColor(stateObj),
                     })}"
-                    @ha-click="${this._handleTap}"
-                    @ha-hold="${this._handleHold}"
-                    .longPress="${longPress()}"
+                    @click="${this._handleTap}"
                   ></ha-icon>
-                  <div
-                    class="brightness"
-                    @ha-click="${this._handleTap}"
-                    @ha-hold="${this._handleHold}"
-                    .longPress="${longPress()}"
-                  ></div>
+                  <div class="brightness" @ha-click="${this._handleTap}"></div>
                   <div class="name">
                     ${this._config.name || computeStateName(stateObj)}
                   </div>
@@ -249,17 +247,17 @@ export class HuiLightCard extends hassLocalizeLitMixin(LitElement)
         #light .rs-overlay.rs-transition.rs-bg-color {
           background-color: var(--paper-card-background-color, white);
         }
-        ha-icon {
+        .light-icon {
           margin: auto;
           width: 76px;
           height: 76px;
           color: var(--paper-item-icon-color, #44739e);
           cursor: pointer;
         }
-        ha-icon[data-state="on"] {
+        .light-icon[data-state="on"] {
           color: var(--paper-item-icon-active-color, #fdd835);
         }
-        ha-icon[data-state="unavailable"] {
+        .light-icon[data-state="unavailable"] {
           color: var(--state-icon-unavailable-color);
         }
         .name {
@@ -288,6 +286,13 @@ export class HuiLightCard extends hassLocalizeLitMixin(LitElement)
           flex: 1;
           background-color: yellow;
           padding: 8px;
+        }
+        .more-info {
+          float: right;
+          cursor: pointer;
+          padding-top: 16px;
+          padding-right: 16px;
+          z-index: 25;
         }
       </style>
     `;
@@ -342,7 +347,7 @@ export class HuiLightCard extends hassLocalizeLitMixin(LitElement)
     toggleEntity(this.hass!, this._config!.entity!);
   }
 
-  private _handleHold() {
+  private _handleMoreInfo() {
     fireEvent(this, "hass-more-info", {
       entityId: this._config!.entity,
     });

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -293,6 +293,7 @@ export class HuiLightCard extends hassLocalizeLitMixin(LitElement)
           padding-top: 16px;
           padding-right: 16px;
           z-index: 25;
+          color: var(--secondary-text-color);
         }
       </style>
     `;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1287159/51808880-e2927f80-225f-11e9-8fe2-04586a8954cc.png)

Around 231px width it all goes awful. Could obviously float it over, but pretty much is unusable at this size as well. Like the thermo card, should we make this optional?