### PR TITLE
Fix Google Assistant skill link

### DIFF
--- a/src/panels/config/cloud/cloud-google-pref.ts
+++ b/src/panels/config/cloud/cloud-google-pref.ts
@@ -50,7 +50,7 @@ export class CloudGooglePref extends LitElement {
           <ul>
             <li>
               <a
-                href="https://assistant.google.com/services/a/uid/00000091fd5fb875"
+                href="https://assistant.google.com/services/a/uid/00000091fd5fb875?hl=en-US"
                 target="_blank"
               >
                 Activate the Home Assistant skill for Google Assistant


### PR DESCRIPTION
Original URL: https://assistant.google.com/services/a/uid/00000091fd5fb875
Fixed URL: https://assistant.google.com/services/a/uid/00000091fd5fb875?hl=en-US
Broken for FR: https://assistant.google.com/services/a/uid/00000091fd5fb875?hl=fr-FR

Without `hl=en-US` set, with my non-us account, the target page says (translated): 
```
We can't find what you're looking for at the moment. Please try again later.
```