### PR TITLE
Fix localize lite mixin types

### DIFF
--- a/src/auth/ha-authorize.ts
+++ b/src/auth/ha-authorize.ts
@@ -61,7 +61,7 @@ class HaAuthorize extends litLocalizeLiteMixin(LitElement) {
     // So we sanitize the translation with innerText and then inject
     // the name with a bold tag.
     const loggingInWith = document.createElement("div");
-    loggingInWith.innerText = this.hass!.localize(
+    loggingInWith.innerText = this.localize(
       "ui.panel.page-authorize.logging_in_with",
       "authProviderName",
       "NAME"
@@ -78,7 +78,7 @@ class HaAuthorize extends litLocalizeLiteMixin(LitElement) {
     return html`
       ${this.renderStyle()}
       <p>
-        ${this.hass!.localize(
+        ${this.localize(
           "ui.panel.page-authorize.authorizing_client",
           "clientId",
           this.clientId

--- a/src/mixins/lit-localize-lite-mixin.ts
+++ b/src/mixins/lit-localize-lite-mixin.ts
@@ -6,8 +6,7 @@ import {
 } from "lit-element";
 import { getActiveTranslation } from "../util/hass-translation";
 import { localizeLiteBaseMixin } from "./localize-lite-base-mixin";
-import { computeLocalize } from "../common/translations/localize";
-import { LocalizeMixin } from "../types";
+import { computeLocalize, LocalizeFunc } from "../common/translations/localize";
 
 const empty = () => "";
 
@@ -15,11 +14,12 @@ interface LitLocalizeLiteMixin {
   language: string;
   resources: {};
   translationFragment: string;
+  localize: LocalizeFunc;
 }
 
 export const litLocalizeLiteMixin = <T extends LitElement>(
   superClass: Constructor<T>
-): Constructor<T & LocalizeMixin & LitLocalizeLiteMixin> =>
+): Constructor<T & LitLocalizeLiteMixin> =>
   // @ts-ignore
   class extends localizeLiteBaseMixin(superClass) {
     static get properties(): PropertyDeclarations {


### PR DESCRIPTION
The localize Lite mixin type was wrong. Fixed it and fixed resulting typing errors.

Thanks to @dmulcahey for finding.