### PR TITLE
Support for geolocation trigger

### DIFF
--- a/src/panels/config/js/trigger/geo_location.js
+++ b/src/panels/config/js/trigger/geo_location.js
@@ -22,12 +22,15 @@ export default class GeolocationTrigger extends Component {
   }
 
   sourcePicked(ev) {
-    this.props.onChange(
-      this.props.index,
-      Object.assign({}, this.props.trigger, {
-        source: ev.target.selectedItem.attributes.source.value,
-      })
-    );
+    const newSource = ev.target.selectedItem.attributes.source.value;
+    const oldSource = this.props.trigger.source;
+
+    if (oldSource !== newSource) {
+      this.props.onChange(
+        this.props.index,
+        Object.assign({}, this.props.trigger, { source: newSource })
+      );
+    }
   }
 
   zonePicked(ev) {

--- a/src/panels/config/js/trigger/geo_location.js
+++ b/src/panels/config/js/trigger/geo_location.js
@@ -1,0 +1,123 @@
+import { h, Component } from "preact";
+import "@polymer/paper-radio-button/paper-radio-button";
+import "@polymer/paper-radio-group/paper-radio-group";
+import "../../../../components/entity/ha-entity-picker";
+
+import { onChangeEvent } from "../../../../common/preact/event";
+import hasLocation from "../../../../common/entity/has_location";
+import computeStateDomain from "../../../../common/entity/compute_state_domain";
+
+const SOURCES = {
+  geo_json_events: "GeoJSON Events",
+  nsw_rural_fire_service_feed: "NSW Rural Fire Service Incidents",
+  usgs_earthquakes_feed: "U.S. Geological Survey Earthquake Hazards Program",
+};
+//const SOURCES = [
+//  { key: "geo_json_events", label: "GeoJSON Events" },
+//  { key: "nsw_rural_fire_service_feed", label: "NSW Rural Fire Service Incidents" },
+//  { key: "usgs_earthquakes_feed", label: "U.S. Geological Survey Earthquake Hazards Program" },
+//];
+
+const OPTIONS = Object.keys(SOURCES).sort();
+
+function zoneAndLocationFilter(stateObj) {
+  return hasLocation(stateObj) && computeStateDomain(stateObj) !== "zone";
+}
+
+export default class GeolocationTrigger extends Component {
+  constructor() {
+    super();
+
+    this.onChange = onChangeEvent.bind(this, "trigger");
+    this.sourcePicked = this.sourcePicked.bind(this);
+    this.zonePicked = this.zonePicked.bind(this);
+    this.radioGroupPicked = this.radioGroupPicked.bind(this);
+  }
+
+  sourcePicked(ev) {
+    this.props.onChange(
+      this.props.index,
+      Object.assign({}, this.props.trigger, {
+        source: ev.target.selectedItem.attributes.source.value,
+      })
+    );
+  }
+
+  zonePicked(ev) {
+    this.props.onChange(
+      this.props.index,
+      Object.assign({}, this.props.trigger, { zone: ev.target.value })
+    );
+  }
+
+  radioGroupPicked(ev) {
+    this.props.onChange(
+      this.props.index,
+      Object.assign({}, this.props.trigger, { event: ev.target.selected })
+    );
+  }
+
+  /* eslint-disable camelcase */
+  render({ index, trigger, onChange, hass, localize }) {
+    const { source, zone, event } = trigger;
+    const selected = OPTIONS.indexOf(trigger.source);
+
+    return (
+      <div>
+        <paper-dropdown-menu
+          label={localize(
+            "ui.panel.config.automation.editor.triggers.type.geo_location.source"
+          )}
+          no-animations
+        >
+          <paper-listbox
+            slot="dropdown-content"
+            selected={selected}
+            oniron-select={this.sourcePicked}
+          >
+            {OPTIONS.map((opt) => (
+              <paper-item source={opt}>{SOURCES[opt]}</paper-item>
+            ))}
+          </paper-listbox>
+        </paper-dropdown-menu>
+        <ha-entity-picker
+          label={localize(
+            "ui.panel.config.automation.editor.triggers.type.geo_location.zone"
+          )}
+          value={zone}
+          onChange={this.zonePicked}
+          hass={hass}
+          allowCustomEntity
+          domainFilter="zone"
+        />
+        <label id="eventlabel">
+          {localize(
+            "ui.panel.config.automation.editor.triggers.type.geo_location.event"
+          )}
+        </label>
+        <paper-radio-group
+          selected={event}
+          aria-labelledby="eventlabel"
+          onpaper-radio-group-changed={this.radioGroupPicked}
+        >
+          <paper-radio-button name="enter">
+            {localize(
+              "ui.panel.config.automation.editor.triggers.type.geo_location.enter"
+            )}
+          </paper-radio-button>
+          <paper-radio-button name="leave">
+            {localize(
+              "ui.panel.config.automation.editor.triggers.type.geo_location.leave"
+            )}
+          </paper-radio-button>
+        </paper-radio-group>
+      </div>
+    );
+  }
+}
+
+GeolocationTrigger.defaultConfig = {
+  source: "",
+  zone: "",
+  event: "enter",
+};

--- a/src/panels/config/js/trigger/geo_location.js
+++ b/src/panels/config/js/trigger/geo_location.js
@@ -3,31 +3,15 @@ import "@polymer/paper-radio-button/paper-radio-button";
 import "@polymer/paper-radio-group/paper-radio-group";
 import "../../../../components/entity/ha-entity-picker";
 
-const SOURCES = [
-  "geo_json_events",
-  "nsw_rural_fire_service_feed",
-  "usgs_earthquakes_feed",
-];
+import { onChangeEvent } from "../../../../common/preact/event";
 
 export default class GeolocationTrigger extends Component {
   constructor() {
     super();
 
-    this.sourcePicked = this.sourcePicked.bind(this);
+    this.onChange = onChangeEvent.bind(this, "trigger");
     this.zonePicked = this.zonePicked.bind(this);
     this.radioGroupPicked = this.radioGroupPicked.bind(this);
-  }
-
-  sourcePicked(ev) {
-    const newSource = ev.target.selectedItem.attributes.source.value;
-    const oldSource = this.props.trigger.source;
-
-    if (oldSource !== newSource) {
-      this.props.onChange(
-        this.props.index,
-        Object.assign({}, this.props.trigger, { source: newSource })
-      );
-    }
   }
 
   zonePicked(ev) {
@@ -46,31 +30,18 @@ export default class GeolocationTrigger extends Component {
 
   /* eslint-disable camelcase */
   render({ trigger, hass, localize }) {
-    const { zone, event } = trigger;
-    const selected = SOURCES.indexOf(trigger.source);
+    const { source, zone, event } = trigger;
 
     return (
       <div>
-        <paper-dropdown-menu
+        <paper-input
           label={localize(
             "ui.panel.config.automation.editor.triggers.type.geo_location.source"
           )}
-          no-animations
-        >
-          <paper-listbox
-            slot="dropdown-content"
-            selected={selected}
-            oniron-select={this.sourcePicked}
-          >
-            {SOURCES.map((opt) => (
-              <paper-item source={opt}>
-                {localize(
-                  `ui.panel.config.automation.editor.triggers.type.geo_location.sources.${opt}`
-                )}
-              </paper-item>
-            ))}
-          </paper-listbox>
-        </paper-dropdown-menu>
+          name="source"
+          value={source}
+          onvalue-changed={this.onChange}
+        />
         <ha-entity-picker
           label={localize(
             "ui.panel.config.automation.editor.triggers.type.geo_location.zone"

--- a/src/panels/config/js/trigger/geo_location.js
+++ b/src/panels/config/js/trigger/geo_location.js
@@ -3,8 +3,6 @@ import "@polymer/paper-radio-button/paper-radio-button";
 import "@polymer/paper-radio-group/paper-radio-group";
 import "../../../../components/entity/ha-entity-picker";
 
-import { onChangeEvent } from "../../../../common/preact/event";
-
 const SOURCES = [
   "geo_json_events",
   "nsw_rural_fire_service_feed",

--- a/src/panels/config/js/trigger/geo_location.js
+++ b/src/panels/config/js/trigger/geo_location.js
@@ -4,8 +4,6 @@ import "@polymer/paper-radio-group/paper-radio-group";
 import "../../../../components/entity/ha-entity-picker";
 
 import { onChangeEvent } from "../../../../common/preact/event";
-import hasLocation from "../../../../common/entity/has_location";
-import computeStateDomain from "../../../../common/entity/compute_state_domain";
 
 const SOURCES = {
   geo_json_events: "GeoJSON Events",
@@ -14,10 +12,6 @@ const SOURCES = {
 };
 
 const OPTIONS = Object.keys(SOURCES).sort();
-
-function zoneAndLocationFilter(stateObj) {
-  return hasLocation(stateObj) && computeStateDomain(stateObj) !== "zone";
-}
 
 export default class GeolocationTrigger extends Component {
   constructor() {

--- a/src/panels/config/js/trigger/geo_location.js
+++ b/src/panels/config/js/trigger/geo_location.js
@@ -15,7 +15,6 @@ export default class GeolocationTrigger extends Component {
   constructor() {
     super();
 
-    this.onChange = onChangeEvent.bind(this, "trigger");
     this.sourcePicked = this.sourcePicked.bind(this);
     this.zonePicked = this.zonePicked.bind(this);
     this.radioGroupPicked = this.radioGroupPicked.bind(this);
@@ -48,8 +47,8 @@ export default class GeolocationTrigger extends Component {
   }
 
   /* eslint-disable camelcase */
-  render({ index, trigger, onChange, hass, localize }) {
-    const { source, zone, event } = trigger;
+  render({ trigger, hass, localize }) {
+    const { zone, event } = trigger;
     const selected = SOURCES.indexOf(trigger.source);
 
     return (

--- a/src/panels/config/js/trigger/geo_location.js
+++ b/src/panels/config/js/trigger/geo_location.js
@@ -12,11 +12,6 @@ const SOURCES = {
   nsw_rural_fire_service_feed: "NSW Rural Fire Service Incidents",
   usgs_earthquakes_feed: "U.S. Geological Survey Earthquake Hazards Program",
 };
-//const SOURCES = [
-//  { key: "geo_json_events", label: "GeoJSON Events" },
-//  { key: "nsw_rural_fire_service_feed", label: "NSW Rural Fire Service Incidents" },
-//  { key: "usgs_earthquakes_feed", label: "U.S. Geological Survey Earthquake Hazards Program" },
-//];
 
 const OPTIONS = Object.keys(SOURCES).sort();
 

--- a/src/panels/config/js/trigger/geo_location.js
+++ b/src/panels/config/js/trigger/geo_location.js
@@ -5,13 +5,11 @@ import "../../../../components/entity/ha-entity-picker";
 
 import { onChangeEvent } from "../../../../common/preact/event";
 
-const SOURCES = {
-  geo_json_events: "GeoJSON Events",
-  nsw_rural_fire_service_feed: "NSW Rural Fire Service Incidents",
-  usgs_earthquakes_feed: "U.S. Geological Survey Earthquake Hazards Program",
-};
-
-const OPTIONS = Object.keys(SOURCES).sort();
+const SOURCES = [
+  "geo_json_events",
+  "nsw_rural_fire_service_feed",
+  "usgs_earthquakes_feed",
+];
 
 export default class GeolocationTrigger extends Component {
   constructor() {
@@ -49,7 +47,7 @@ export default class GeolocationTrigger extends Component {
   /* eslint-disable camelcase */
   render({ index, trigger, onChange, hass, localize }) {
     const { source, zone, event } = trigger;
-    const selected = OPTIONS.indexOf(trigger.source);
+    const selected = SOURCES.indexOf(trigger.source);
 
     return (
       <div>
@@ -64,8 +62,12 @@ export default class GeolocationTrigger extends Component {
             selected={selected}
             oniron-select={this.sourcePicked}
           >
-            {OPTIONS.map((opt) => (
-              <paper-item source={opt}>{SOURCES[opt]}</paper-item>
+            {SOURCES.map((opt) => (
+              <paper-item source={opt}>
+                {localize(
+                  `ui.panel.config.automation.editor.triggers.type.geo_location.sources.${opt}`
+                )}
+              </paper-item>
             ))}
           </paper-listbox>
         </paper-dropdown-menu>

--- a/src/panels/config/js/trigger/trigger_edit.js
+++ b/src/panels/config/js/trigger/trigger_edit.js
@@ -5,6 +5,7 @@ import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 
 import EventTrigger from "./event";
+import GeolocationTrigger from "./geo_location";
 import HassTrigger from "./homeassistant";
 import MQTTTrigger from "./mqtt";
 import NumericStateTrigger from "./numeric_state";
@@ -19,6 +20,7 @@ import ZoneTrigger from "./zone";
 const TYPES = {
   event: EventTrigger,
   state: StateTrigger,
+  geo_location: GeolocationTrigger,
   homeassistant: HassTrigger,
   mqtt: MQTTTrigger,
   numeric_state: NumericStateTrigger,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -593,11 +593,6 @@
                 "geo_location": {
                   "label": "Geolocation",
                   "source": "Source",
-                  "sources": {
-                    "geo_json_events": "GeoJSON Events",
-                    "nsw_rural_fire_service_feed": "NSW Rural Fire Service Incidents",
-                    "usgs_earthquakes_feed": "U.S. Geological Survey Earthquake Hazards Program"
-                  },
                   "zone": "Zone",
                   "event": "Event:",
                   "enter": "Enter",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -590,6 +590,19 @@
                   "event_type": "Event type",
                   "event_data": "Event data"
                 },
+                "geo_location": {
+                  "label": "Geolocation",
+                  "source": "Source",
+                  "sources": {
+                    "geo_json_events": "GeoJSON Events",
+                    "nsw_rural_fire_service_feed": "NSW Rural Fire Service Incidents",
+                    "usgs_earthquakes_feed": "U.S. Geological Survey Earthquake Hazards Program"
+                  },
+                  "zone": "Zone",
+                  "event": "Event:",
+                  "enter": "Enter",
+                  "leave": "Leave"
+                },
                 "state": {
                   "label": "State",
                   "from": "From",

--- a/translations/en.json
+++ b/translations/en.json
@@ -378,6 +378,19 @@
                                     "event_type": "Event type",
                                     "event_data": "Event data"
                                 },
+                                "geo_location": {
+                                    "label": "Geolocation",
+                                    "source": "Source",
+                                    "sources": {
+                                        "geo_json_events": "GeoJSON Events",
+                                        "nsw_rural_fire_service_feed": "NSW Rural Fire Service Incidents",
+                                        "usgs_earthquakes_feed": "U.S. Geological Survey Earthquake Hazards Program"
+                                    },
+                                    "zone": "Zone",
+                                    "event": "Event:",
+                                    "enter": "Enter",
+                                    "leave": "Leave"
+                                },
                                 "state": {
                                     "label": "State",
                                     "from": "From",

--- a/translations/en.json
+++ b/translations/en.json
@@ -381,11 +381,6 @@
                                 "geo_location": {
                                     "label": "Geolocation",
                                     "source": "Source",
-                                    "sources": {
-                                        "geo_json_events": "GeoJSON Events",
-                                        "nsw_rural_fire_service_feed": "NSW Rural Fire Service Incidents",
-                                        "usgs_earthquakes_feed": "U.S. Geological Survey Earthquake Hazards Program"
-                                    },
                                     "zone": "Zone",
                                     "event": "Event:",
                                     "enter": "Enter",


### PR DESCRIPTION
This adds the ability to define a geolocation trigger when configuring an automation.

The geolocation source is currently a simple text input field. In a future change, this could be amended with some sort of input validation, or transformed into a dropdown box - given that the valid values are determined by the backend components loaded.

<img width="1058" alt="geolocation_trigger_example_2" src="https://user-images.githubusercontent.com/4704260/51947473-8f414c80-246c-11e9-8add-bc8c43041424.png">
