### PR TITLE
Hash translation files

### DIFF
--- a/gulp/tasks/translations.js
+++ b/gulp/tasks/translations.js
@@ -104,7 +104,7 @@ function lokalise_transform(data, original) {
 
 let taskName = "clean-translations";
 gulp.task(taskName, function() {
-  return del([`${workDir}/**`]);
+  return del([`${outDir}/**/*.json`]);
 });
 tasks.push(taskName);
 

--- a/gulp/tasks/translations.js
+++ b/gulp/tasks/translations.js
@@ -1,19 +1,26 @@
+const del = require("del");
 const path = require("path");
 const gulp = require("gulp");
 const foreach = require("gulp-foreach");
 const hash = require("gulp-hash");
+const hashFilename = require("gulp-hash-filename");
 const merge = require("gulp-merge-json");
 const minify = require("gulp-jsonminify");
 const rename = require("gulp-rename");
 const transform = require("gulp-json-transform");
-
-const isDemo = process.env.DEMO === "1";
 
 const inDir = "translations";
 const workDir = "build-translations";
 const fullDir = workDir + "/full";
 const coreDir = workDir + "/core";
 const outDir = workDir + "/output";
+
+String.prototype.rsplit = function(sep, maxsplit) {
+  var split = this.split(sep);
+  return maxsplit
+    ? [split.slice(0, -maxsplit).join(sep)].concat(split.slice(-maxsplit))
+    : split;
+};
 
 // Panel translations which should be split from the core translations. These
 // should mirror the fragment definitions in polymer.json, so that we load
@@ -95,6 +102,12 @@ function lokalise_transform(data, original) {
   return output;
 }
 
+let taskName = "clean-translations";
+gulp.task(taskName, function() {
+  return del([`${workDir}/**`]);
+});
+tasks.push(taskName);
+
 /**
  * This task will build a master translation file, to be used as the base for
  * all languages. This starts with src/translations/en.json, and replaces all
@@ -104,8 +117,8 @@ function lokalise_transform(data, original) {
  * project is buildable immediately after merging new translation keys, since
  * the Lokalise update to translations/en.json will not happen immediately.
  */
-let taskName = "build-master-translation";
-gulp.task(taskName, function() {
+taskName = "build-master-translation";
+gulp.task(taskName, ["clean-translations"], function() {
   return gulp
     .src("src/translations/en.json")
     .pipe(
@@ -207,6 +220,7 @@ gulp.task(taskName, splitTasks, function() {
       })
     )
     .pipe(minify())
+    .pipe(hashFilename())
     .pipe(
       rename((filePath) => {
         if (filePath.dirname === "core") {
@@ -231,7 +245,7 @@ gulp.task(taskName, ["build-flattened-translations"], function() {
       hash({
         algorithm: "md5",
         hashLength: 32,
-        template: isDemo ? "<%= name %>.json" : "<%= name %>-<%= hash %>.json",
+        template: "<%= name %>.json",
       })
     )
     .pipe(hash.manifest("translationFingerprints.json"))
@@ -241,8 +255,10 @@ gulp.task(taskName, ["build-flattened-translations"], function() {
         // all translation fragment fingerprints under the translation name key
         const newData = {};
         Object.entries(data).forEach(([key, value]) => {
-          const parts = key.split("/");
-          let translation = key;
+          const [path, _md5] = key.rsplit("-", 1);
+          // let translation = key;
+          let translation = path;
+          const parts = translation.split("/");
           if (parts.length === 2) {
             translation = parts[1];
           }
@@ -251,7 +267,7 @@ gulp.task(taskName, ["build-flattened-translations"], function() {
               fingerprints: {},
             };
           }
-          newData[translation].fingerprints[key] = value;
+          newData[translation].fingerprints[path] = value;
         });
         return newData;
       })

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "es6-object-assign": "^1.1.0",
     "eslint-import-resolver-webpack": "^0.10.1",
     "fecha": "^3.0.0",
+    "gulp-hash-filename": "^2.0.1",
     "home-assistant-js-websocket": "^3.2.4",
     "intl-messageformat": "^2.2.0",
     "jquery": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7019,6 +7019,11 @@ gulp-foreach@^0.1.0:
     gulp-util "~2.2.14"
     through2 "~0.6.3"
 
+gulp-hash-filename@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/gulp-hash-filename/-/gulp-hash-filename-2.0.1.tgz#c30656261a9b622d636766e48b8297125b4ddde8"
+  integrity sha512-pMg5owb8Dt0wqjgPx/TFbU3c5ckD16rrgo0BTm9PQ3pVC1Zsgw7AYx1+DP2t31JoUTeN1/dPuXNWnCNvN/wj7A==
+
 gulp-hash@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/gulp-hash/-/gulp-hash-4.2.2.tgz#2cf4ad081ef7a65393a51e3df58f514f388f4523"


### PR DESCRIPTION
Store the translation files with hashes in the filename. This were the last files that was still using the fake fingerprinting that the backed had integrated. We can drop that now.