### PR TITLE
History+logbook positioning update + RTL fixes + label refactor

### DIFF
--- a/src/panels/history/ha-panel-history.js
+++ b/src/panels/history/ha-panel-history.js
@@ -18,6 +18,7 @@ import "../../resources/ha-style";
 
 import formatDate from "../../common/datetime/format_date";
 import LocalizeMixin from "../../mixins/localize-mixin";
+import { computeRTL } from "../../common/util/compute_rtl";
 
 /*
  * @appliesMixin LocalizeMixin
@@ -37,6 +38,15 @@ class HaPanelHistory extends LocalizeMixin(PolymerElement) {
 
         paper-dropdown-menu {
           max-width: 100px;
+          margin-top: 13px;
+          margin-right: 16px;
+          --paper-input-container-label-floating: {
+            padding-bottom: 10px;
+          }
+        }
+
+        :host([rtl]) paper-dropdown-menu {
+          text-align: right;
         }
 
         paper-item {
@@ -158,6 +168,12 @@ class HaPanelHistory extends LocalizeMixin(PolymerElement) {
         type: String,
         value: "date",
       },
+
+      rtl: {
+        type: Boolean,
+        reflectToAttribute: true,
+        computed: "_computeRTL(hass)",
+      },
     };
   }
 
@@ -197,6 +213,10 @@ class HaPanelHistory extends LocalizeMixin(PolymerElement) {
       default:
         return 1;
     }
+  }
+
+  _computeRTL(hass) {
+    return computeRTL(hass);
   }
 }
 

--- a/src/panels/logbook/ha-panel-logbook.js
+++ b/src/panels/logbook/ha-panel-logbook.js
@@ -18,6 +18,7 @@ import "./ha-logbook";
 
 import formatDate from "../../common/datetime/format_date";
 import LocalizeMixin from "../../mixins/localize-mixin";
+import { computeRTL } from "../../common/util/compute_rtl";
 
 /*
  * @appliesMixin LocalizeMixin
@@ -52,6 +53,13 @@ class HaPanelLogbook extends LocalizeMixin(PolymerElement) {
         paper-dropdown-menu {
           max-width: 100px;
           margin-right: 16px;
+          --paper-input-container-label-floating: {
+            padding-bottom: 10px;
+          }
+        }
+
+        :host([rtl]) paper-dropdown-menu {
+          text-align: right;
         }
 
         paper-item {
@@ -205,6 +213,12 @@ class HaPanelLogbook extends LocalizeMixin(PolymerElement) {
       datePicker: {
         type: Object,
       },
+
+      rtl: {
+        type: Boolean,
+        reflectToAttribute: true,
+        computed: "_computeRTL(hass)",
+      },
     };
   }
 
@@ -241,6 +255,10 @@ class HaPanelLogbook extends LocalizeMixin(PolymerElement) {
 
   refreshLogbook() {
     this.shadowRoot.querySelector("ha-logbook-data").refreshLogbook();
+  }
+
+  _computeRTL(hass) {
+    return computeRTL(hass);
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -808,7 +808,8 @@
         "period": "Period"
       },
       "logbook": {
-        "showing_entries": "[%key:ui::panel::history::showing_entries%]"
+        "showing_entries": "[%key:ui::panel::history::showing_entries%]",
+        "period": "Period"
       },
       "lovelace": {
         "cards": {


### PR DESCRIPTION
Had to include RTL because of known paper-input bugs in RTL (open since 2017 and doesn't look like they're going to fix it).


History - LTR - before:
<img width="472" alt="history - before" src="https://user-images.githubusercontent.com/37745463/52168402-b0d35a00-2732-11e9-862c-abd60fe2a764.PNG">


History - LTR - after:
<img width="473" alt="history - after" src="https://user-images.githubusercontent.com/37745463/52168403-b92b9500-2732-11e9-9a27-8769822a2082.PNG">


History - RTL - before
<img width="445" alt="history - rtl - before" src="https://user-images.githubusercontent.com/37745463/52168405-c6488400-2732-11e9-95d0-d04afadadcce.PNG">


History - RTL - after
<img width="448" alt="history - rtl - after" src="https://user-images.githubusercontent.com/37745463/52168409-ca74a180-2732-11e9-93ea-a0905ba7588a.PNG">


Logbook - LTR - before
<img width="572" alt="logbook - before" src="https://user-images.githubusercontent.com/37745463/52168415-e5471600-2732-11e9-8cbd-45d42ef8b284.PNG">


Logbook - LTR - after
<img width="616" alt="logbook - after" src="https://user-images.githubusercontent.com/37745463/52168418-ea0bca00-2732-11e9-8d90-3856fc6cb55c.PNG">


Logbook - RTL - before
<img width="441" alt="logbook - rtl - before" src="https://user-images.githubusercontent.com/37745463/52168412-d7919080-2732-11e9-9302-e6629dce7447.PNG">



Logbook - RTL - after
<img width="459" alt="logbook - rtl - after" src="https://user-images.githubusercontent.com/37745463/52168410-d3fe0980-2732-11e9-9712-d425764e2860.PNG">

