### PR TITLE
Add support for wildcards and state filters in badges

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -11,13 +11,18 @@ export interface LovelaceConfig {
 export interface LovelaceViewConfig {
   index?: number;
   title?: string;
-  badges?: string[];
+  badges?: (string | LovelaceBadgeConfig)[];
   cards?: LovelaceCardConfig[];
   path?: string;
   icon?: string;
   theme?: string;
   panel?: boolean;
   background?: string;
+}
+
+export interface LovelaceBadgeConfig {
+  entity: string;
+  state_filter?: any[];
 }
 
 export interface LovelaceCardConfig {


### PR DESCRIPTION
One of the things blocking my migration from the old states UI to Lovelace is the very limited set of options Lovelace has when it comes to badges. In my specific case, I have the very common use case of showing all people at home (and not those away) as badges.

This PR adds support for global wildcards (`*`) and domain wildcards (`domain.*`) in Lovelace badges. Additionally, it supports setting state filters in the same way as [Entity Filter](https://www.home-assistant.io/lovelace/entity-filter).

Configs like this are now accepted as badge items in `badges`:

```yaml
badges:
  # single entity, existing behavior
  - 'device_tracker.rui'
  # expands to all tracked devices
  - 'device_tracker.*'
  # expands to all entities
  - '*'

  # equivalent to first item
  - entity: 'device_tracker.rui'
  # expands to all devices with state 'home'
  - entity: 'device_tracker.*'
    state_filter: ['home']           
```

Semantically, each `badges` entry is expanded to zero or more entity IDs, which are then treated exactly like they would if they were written explicitly.

Let me know if I need to update any documentation together with this.