### PR TITLE
Don't include some UI elements from base bundle

### DIFF
--- a/src/layouts/ha-init-page.ts
+++ b/src/layouts/ha-init-page.ts
@@ -1,4 +1,3 @@
-import "@polymer/paper-button/paper-button";
 import "@polymer/paper-spinner/paper-spinner-lite";
 
 import {
@@ -60,6 +59,13 @@ class HaInitPage extends LitElement {
         color: var(--primary-color);
       }
     `;
+  }
+
+  protected updated(changedProps) {
+    super.updated(changedProps);
+    if (changedProps.has("error") && this.error) {
+      import(/* webpackChunkName: "paper-button" */ "@polymer/paper-button/paper-button");
+    }
   }
 
   private _retry() {

--- a/src/layouts/hass-loading-screen.js
+++ b/src/layouts/hass-loading-screen.js
@@ -1,6 +1,6 @@
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import "@polymer/iron-flex-layout/iron-flex-layout-classes";
-import "@polymer/paper-spinner/paper-spinner";
+import "@polymer/paper-spinner/paper-spinner-lite";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 
@@ -25,10 +25,10 @@ class HassLoadingScreen extends PolymerElement {
             narrow="[[narrow]]"
             show-menu="[[showMenu]]"
           ></ha-menu-button>
-          <div main-title="">[[title]]</div>
+          <div main-title>[[title]]</div>
         </app-toolbar>
         <div class="layout horizontal center-center">
-          <paper-spinner active=""></paper-spinner>
+          <paper-spinner-lite active></paper-spinner-lite>
         </div>
       </div>
     `;

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -6,7 +6,6 @@ import {
 } from "lit-element";
 
 import "./hass-loading-screen";
-import "./hass-error-screen";
 import { HomeAssistant, Panel, PanelElement, Route } from "../types";
 
 // Cache of panel loading promises.
@@ -168,7 +167,15 @@ class PartialPanelResolver extends LitElement {
     `;
   }
 
+  protected firstUpdated(changedProps: PropertyValues) {
+    super.firstUpdated(changedProps);
+    // Load it before it's needed, because it will be shown if user is offline
+    // and a panel has to be loaded.
+    import(/* webpackChunkName: "hass-error-screen" */ "./hass-error-screen");
+  }
+
   protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
     if (!this.hass) {
       return;
     }


### PR DESCRIPTION
Defer loading some of the UI elements for error states instead of being part of the main bundle.