### PR TITLE
Swap naming of error and system log on Dev Info panel

### DIFF
--- a/src/data/error_log.ts
+++ b/src/data/error_log.ts
@@ -1,4 +1,13 @@
 import { HomeAssistant } from "../types";
 
+export interface LoggedError {
+  message: string;
+  level: string;
+  source: string;
+  // unix timestamp in seconds
+  timestamp: number;
+  exception: string;
+}
+
 export const fetchErrorLog = (hass: HomeAssistant) =>
-  hass.callApi<string>("GET", "error_log");
+  hass.callApi<LoggedError[]>("GET", "error/all");

--- a/src/data/system_log.ts
+++ b/src/data/system_log.ts
@@ -1,13 +1,4 @@
 import { HomeAssistant } from "../types";
 
-export interface LoggedError {
-  message: string;
-  level: string;
-  source: string;
-  // unix timestamp in seconds
-  timestamp: number;
-  exception: string;
-}
-
 export const fetchSystemLog = (hass: HomeAssistant) =>
-  hass.callApi<LoggedError[]>("GET", "error/all");
+  hass.callApi<string>("GET", "error_log");

--- a/src/panels/dev-info/dialog-error-log-detail.ts
+++ b/src/panels/dev-info/dialog-error-log-detail.ts
@@ -9,12 +9,12 @@ import {
 import "@polymer/paper-dialog/paper-dialog";
 import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
 
-import { SystemLogDetailDialogParams } from "./show-dialog-system-log-detail";
+import { ErrorLogDetailDialogParams } from "./show-dialog-error-log-detail";
 import { PolymerChangedEvent } from "../../polymer-types";
 import { haStyleDialog } from "../../resources/ha-style";
 
-class DialogSystemLogDetail extends LitElement {
-  private _params?: SystemLogDetailDialogParams;
+class DialogErrorLogDetail extends LitElement {
+  private _params?: ErrorLogDetailDialogParams;
 
   static get properties(): PropertyDeclarations {
     return {
@@ -22,7 +22,7 @@ class DialogSystemLogDetail extends LitElement {
     };
   }
 
-  public async showDialog(params: SystemLogDetailDialogParams): Promise<void> {
+  public async showDialog(params: ErrorLogDetailDialogParams): Promise<void> {
     this._params = params;
     await this.updateComplete;
   }
@@ -70,8 +70,8 @@ class DialogSystemLogDetail extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "dialog-system-log-detail": DialogSystemLogDetail;
+    "dialog-error-log-detail": DialogErrorLogDetail;
   }
 }
 
-customElements.define("dialog-system-log-detail", DialogSystemLogDetail);
+customElements.define("dialog-error-log-detail", DialogErrorLogDetail);

--- a/src/panels/dev-info/ha-panel-dev-info.ts
+++ b/src/panels/dev-info/ha-panel-dev-info.ts
@@ -14,9 +14,9 @@ import "../../components/ha-menu-button";
 import { HomeAssistant } from "../../types";
 import { haStyle } from "../../resources/ha-style";
 
-import "./system-log-card";
-import "./error-log-card";
 import "./system-health-card";
+import "./error-log-card";
+import "./system-log-card";
 
 const JS_VERSION = __BUILD__;
 const OPT_IN_PANEL = "states";
@@ -144,8 +144,8 @@ class HaPanelDevInfo extends LitElement {
             </p>
           </div>
           <system-health-card .hass=${this.hass}></system-health-card>
-          <system-log-card .hass=${this.hass}></system-log-card>
           <error-log-card .hass=${this.hass}></error-log-card>
+          <system-log-card .hass=${this.hass}></system-log-card>
         </div>
       </app-header-layout>
     `;

--- a/src/panels/dev-info/show-dialog-error-log-detail.ts
+++ b/src/panels/dev-info/show-dialog-error-log-detail.ts
@@ -1,18 +1,18 @@
 import { fireEvent } from "../../common/dom/fire_event";
-import { LoggedError } from "../../data/system_log";
+import { LoggedError } from "../../data/error_log";
 
 declare global {
   // for fire event
   interface HASSDomEvents {
-    "show-dialog-system-log-detail": SystemLogDetailDialogParams;
+    "show-dialog-error-log-detail": ErrorLogDetailDialogParams;
   }
 }
 
 let registeredDialog = false;
-const dialogShowEvent = "show-dialog-system-log-detail";
-const dialogTag = "dialog-system-log-detail";
+const dialogShowEvent = "show-dialog-error-log-detail";
+const dialogTag = "dialog-error-log-detail";
 
-export interface SystemLogDetailDialogParams {
+export interface ErrorLogDetailDialogParams {
   item: LoggedError;
 }
 
@@ -21,12 +21,12 @@ const registerDialog = (element: HTMLElement) =>
     dialogShowEvent,
     dialogTag,
     dialogImport: () =>
-      import(/* webpackChunkName: "system-log-detail-dialog" */ "./dialog-system-log-detail"),
+      import(/* webpackChunkName: "error-log-detail-dialog" */ "./dialog-error-log-detail"),
   });
 
-export const showSystemLogDetailDialog = (
+export const showErrorLogDetailDialog = (
   element: HTMLElement,
-  systemLogDetailParams: SystemLogDetailDialogParams
+  systemLogDetailParams: ErrorLogDetailDialogParams
 ): void => {
   if (!registeredDialog) {
     registeredDialog = true;

--- a/src/panels/dev-info/system-log-card.ts
+++ b/src/panels/dev-info/system-log-card.ts
@@ -6,142 +6,67 @@ import {
   PropertyDeclarations,
   TemplateResult,
 } from "lit-element";
-import "@polymer/paper-card/paper-card";
 import "@polymer/paper-icon-button/paper-icon-button";
-import "@polymer/paper-item/paper-item-body";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-spinner/paper-spinner";
-import "../../components/buttons/ha-call-service-button";
-import "../../components/buttons/ha-progress-button";
+import "@polymer/paper-button/paper-button";
+
 import { HomeAssistant } from "../../types";
-import { LoggedError, fetchSystemLog } from "../../data/system_log";
-import formatDateTime from "../../common/datetime/format_date_time";
-import formatTime from "../../common/datetime/format_time";
-import { showSystemLogDetailDialog } from "./show-dialog-system-log-detail";
-
-const formatLogTime = (date, language: string) => {
-  const today = new Date().setHours(0, 0, 0, 0);
-  const dateTime = new Date(date * 1000);
-  const dateTimeDay = new Date(date * 1000).setHours(0, 0, 0, 0);
-
-  return dateTimeDay < today
-    ? formatDateTime(dateTime, language)
-    : formatTime(dateTime, language);
-};
+import { fetchSystemLog } from "../../data/system_log";
 
 class SystemLogCard extends LitElement {
   public hass?: HomeAssistant;
-  private _items?: LoggedError[];
+  private _systemLog?: string;
 
   static get properties(): PropertyDeclarations {
     return {
       hass: {},
-      _items: {},
+      _systemLog: {},
     };
   }
 
   protected render(): TemplateResult | void {
     return html`
-      <div class="system-log-intro">
-        <paper-card>
-          ${this._items === undefined
-            ? html`
-                <div class="loading-container">
-                  <paper-spinner active></paper-spinner>
-                </div>
-              `
-            : html`
-                ${this._items.length === 0
-                  ? html`
-                      <div class="card-content">There are no new issues!</div>
-                    `
-                  : this._items.map(
-                      (item) => html`
-                        <paper-item @click=${this._openLog} .logItem=${item}>
-                          <paper-item-body two-line>
-                            <div class="row">
-                              ${item.message}
-                            </div>
-                            <div secondary>
-                              ${formatLogTime(
-                                item.timestamp,
-                                this.hass!.language
-                              )}
-                              ${item.source} (${item.level})
-                            </div>
-                          </paper-item-body>
-                        </paper-item>
-                      `
-                    )}
-
-                <div class="card-actions">
-                  <ha-call-service-button
-                    .hass=${this.hass}
-                    domain="system_log"
-                    service="clear"
-                    >Clear</ha-call-service-button
-                  >
-                  <ha-progress-button @click=${this._fetchData}
-                    >Refresh</ha-progress-button
-                  >
-                </div>
-              `}
-        </paper-card>
-      </div>
+      <p class="system-log-intro">
+        ${this._systemLog
+          ? html`
+              <paper-icon-button
+                icon="hass:refresh"
+                @click=${this._refreshSystemLog}
+              ></paper-icon-button>
+            `
+          : html`
+              <paper-button raised @click=${this._refreshSystemLog}>
+                Load Full Home Assistant Log
+              </paper-button>
+            `}
+      </p>
+      <div class="system-log">${this._systemLog}</div>
     `;
-  }
-
-  protected firstUpdated(changedProps): void {
-    super.firstUpdated(changedProps);
-    this._fetchData();
-    this.addEventListener("hass-service-called", (ev) =>
-      this.serviceCalled(ev)
-    );
-  }
-
-  protected serviceCalled(ev): void {
-    // Check if this is for us
-    if (ev.detail.success && ev.detail.domain === "system_log") {
-      // Do the right thing depending on service
-      if (ev.detail.service === "clear") {
-        this._items = [];
-      }
-    }
-  }
-
-  private async _fetchData(): Promise<void> {
-    this._items = undefined;
-    this._items = await fetchSystemLog(this.hass!);
-  }
-
-  private _openLog(ev: Event): void {
-    const item = (ev.currentTarget as any).logItem;
-    showSystemLogDetailDialog(this, { item });
   }
 
   static get styles(): CSSResult {
     return css`
-      paper-card {
-        display: block;
-        padding-top: 16px;
-      }
-
-      paper-item {
-        cursor: pointer;
-      }
-
       .system-log-intro {
+        text-align: center;
         margin: 16px;
-        border-top: 1px solid var(--light-primary-color);
-        padding-top: 16px;
       }
 
-      .loading-container {
-        @apply --layout-vertical;
-        @apply --layout-center-center;
-        height: 100px;
+      paper-icon-button {
+        float: right;
+      }
+
+      .system-log {
+        @apply --paper-font-code)
+          clear: both;
+        white-space: pre-wrap;
+        margin: 16px;
       }
     `;
+  }
+
+  private async _refreshSystemLog(): Promise<void> {
+    this._systemLog = "Loading full system log…";
+    const log = await fetchSystemLog(this.hass!);
+    this._systemLog = log || "No log at this time.";
   }
 }
 


### PR DESCRIPTION
### Current Problem

On the Dev Info panel user is shown the error log (in a `<paper-card>`) and then the "full system log" can be loaded underneath that.

However in the code these seem to be the other way around (the error log is called "system log" and the system log is called "error log").

There is also confusing copy such as referring to the error log when loading the system log:

![screenshot](https://i.imgur.com/2yippYX.png)

### Solution

This swaps the naming around of these two panels in the code to reflect what they do. I've also added a heading to the error log card to make this clear:

![screenshot](https://i.imgur.com/XUlVw9m.png)