### PR TITLE
Display Effect dropdown for turned off lights

### DIFF
--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -57,7 +57,7 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
           transition: max-height 0.5s ease-in;
         }
 
-        .has-effect_list.is-on .effect_list,
+        .has-effect_list .effect_list,
         .has-brightness .brightness,
         .has-color_temp.is-on .color_temp,
         .has-white_value.is-on .white_value {


### PR DESCRIPTION
## Description:

**Related issue:** fixes https://github.com/home-assistant/home-assistant/issues/20583

Display Effect dropdown for all lights regardless of state (not only for turned on lights).

Related PR into `home-assistant` repo: https://github.com/home-assistant/home-assistant/pull/20750