### PR TITLE
Fix gauge card gallery demo

### DIFF
--- a/gallery/src/demos/demo-hui-gauge-card.ts
+++ b/gallery/src/demos/demo-hui-gauge-card.ts
@@ -2,6 +2,19 @@ import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 
 import "../components/demo-cards";
+import { getEntity } from "../../../src/fake_data/entity";
+import { provideHass } from "../../../src/fake_data/provide_hass";
+
+const ENTITIES = [
+  getEntity("sensor", "brightness", "12", {}),
+  getEntity("plant", "bonsai", "ok", {}),
+  getEntity("sensor", "outside_humidity", "54", {
+    unit_of_measurement: "%",
+  }),
+  getEntity("sensor", "outside_temperature", "15.6", {
+    unit_of_measurement: "°C",
+  }),
+];
 
 const CONFIGS = [
   {
@@ -66,7 +79,7 @@ const CONFIGS = [
 class DemoGaugeEntity extends PolymerElement {
   static get template() {
     return html`
-      <demo-cards configs="[[_configs]]"></demo-cards>
+      <demo-cards id="demos" configs="[[_configs]]"></demo-cards>
     `;
   }
 
@@ -77,6 +90,12 @@ class DemoGaugeEntity extends PolymerElement {
         value: CONFIGS,
       },
     };
+  }
+
+  public ready() {
+    super.ready();
+    const hass = provideHass(this.$.demos);
+    hass.addEntities(ENTITIES);
   }
 }
 


### PR DESCRIPTION
When we introduced the demo, we broke a few cards in the gallery. The cards that are broken are the ones that don't use `provideHass` yet.

This is an example PR how to fix a card. States are taken from [this file](https://github.com/home-assistant/home-assistant-polymer/blob/dev/gallery/src/data/demo_states.js)