### PR TITLE
[WIP] Allow ordering of entities in entities card

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -34,6 +34,7 @@ export interface EntitiesCardConfig extends LovelaceCardConfig {
   title?: string;
   entities: EntitiesCardEntityConfig[];
   theme?: string;
+  orderBy?: string;
 }
 
 class HuiEntitiesCard extends LitElement implements LovelaceCard {
@@ -80,7 +81,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: EntitiesCardConfig): void {
-    const entities = processConfigEntities(config.entities);
+    const entities = processConfigEntities(config.entities, config.orderBy);
 
     this._config = { theme: "default", ...config };
     this._configEntities = entities;
@@ -102,23 +103,27 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     return html`
       ${this.renderStyle()}
       <ha-card>
-        ${!title && !show_header_toggle
-          ? html``
-          : html`
+        ${
+          !title && !show_header_toggle
+            ? html``
+            : html`
               <div class="header">
                 <div class="name">${title}</div>
-                ${show_header_toggle === false
-                  ? html``
-                  : html`
+                ${
+                  show_header_toggle === false
+                    ? html``
+                    : html`
                       <hui-entities-toggle
                         .hass="${this._hass}"
                         .entities="${this._configEntities!.map(
                           (conf) => conf.entity
                         )}"
                       ></hui-entities-toggle>
-                    `}
+                    `
+                }
               </div>
-            `}
+            `
+        }
         <div id="states">
           ${this._configEntities!.map((entityConf) =>
             this.renderEntity(entityConf)

--- a/src/panels/lovelace/common/process-config-entities.ts
+++ b/src/panels/lovelace/common/process-config-entities.ts
@@ -3,13 +3,14 @@ import isValidEntityId from "../../../common/entity/valid_entity_id";
 import { EntityConfig } from "../entity-rows/types";
 
 export const processConfigEntities = <T extends EntityConfig>(
-  entities: Array<T | string>
+  entities: Array<T | string>,
+  orderBy?: string
 ): T[] => {
   if (!entities || !Array.isArray(entities)) {
     throw new Error("Entities need to be an array");
   }
 
-  return entities.map(
+  let mappedEntities = entities.map(
     (entityConf, index): T => {
       if (
         typeof entityConf === "object" &&
@@ -44,4 +45,18 @@ export const processConfigEntities = <T extends EntityConfig>(
       return config;
     }
   );
+
+  if (typeof orderBy === "string" && orderBy.length) {
+    mappedEntities = mappedEntities.sort((a, b) => {
+      if (a[orderBy] < b[orderBy]) {
+        return -1;
+      }
+      if (a[orderBy] > b[orderBy]) {
+        return 1;
+      }
+      return 0;
+    });
+  }
+
+  return mappedEntities;
 };


### PR DESCRIPTION
This allows to specify a custom order in the lovelace `entities` card, and make it possible to use by other cards which processes an entities array.

**Use case**
The use case for this is an entities card which displays the pickup dates of the different trash types:
![screenshot_2](https://user-images.githubusercontent.com/9316480/52347015-3bf96c00-2a21-11e9-9afc-d4d44919a8e8.png)
