### PR TITLE
RTL support for arrows in scrolable tabs

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -244,6 +244,7 @@ class HUIRoot extends LitElement {
                     scrollable
                     .selected="${this._curView}"
                     @iron-activate="${this._handleViewSelected}"
+                    dir="${computeRTL(this.hass!) ? "rtl" : "ltr"}"
                   >
                     ${this.lovelace!.config.views.map(
                       (view) => html`

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -49,7 +49,7 @@ import { showEditLovelaceDialog } from "./editor/lovelace-editor/show-edit-lovel
 import { Lovelace } from "./types";
 import { afterNextRender } from "../../common/util/render-status";
 import { haStyle } from "../../resources/ha-style";
-import { computeRTL } from "../../common/util/compute_rtl";
+import { computeRTL, computeRTLDirection } from "../../common/util/compute_rtl";
 
 // CSS and JS should only be imported once. Modules and HTML are safe.
 const CSS_CACHE = {};
@@ -244,7 +244,7 @@ class HUIRoot extends LitElement {
                     scrollable
                     .selected="${this._curView}"
                     @iron-activate="${this._handleViewSelected}"
-                    dir="${computeRTL(this.hass!) ? "rtl" : "ltr"}"
+                    dir="${computeRTLDirection(this.hass!)}"
                   >
                     ${this.lovelace!.config.views.map(
                       (view) => html`


### PR DESCRIPTION
Fixes the arrow orientation on the sides when there are scrolable tabs. 

We may end up reverting this since they have a bug where they persistently show the back arrow but it's probably still better. Let's start with this.