### PR TITLE
Add background and border-radius to themeable options for ha-card

### DIFF
--- a/src/components/ha-card.js
+++ b/src/components/ha-card.js
@@ -9,9 +9,9 @@ class HaCard extends PolymerElement {
         :host {
           @apply --paper-material-elevation-1;
           display: block;
-          border-radius: var(--paper-card-border-radius, 2px);
+          border-radius: var(--ha-card-border-radius, 2px);
           transition: all 0.3s ease-out;
-          background: var(--paper-card-background, var(--paper-card-background-color, white));
+          background: var(--ha-card-background, var(--paper-card-background-color, white));
           color: var(--primary-text-color);
         }
         .header {

--- a/src/components/ha-card.js
+++ b/src/components/ha-card.js
@@ -9,9 +9,9 @@ class HaCard extends PolymerElement {
         :host {
           @apply --paper-material-elevation-1;
           display: block;
-          border-radius: 2px;
+          border-radius: var(--paper-card-border-radius, 2px);
           transition: all 0.3s ease-out;
-          background-color: var(--paper-card-background-color, white);
+          background: var(--paper-card-background, var(--paper-card-background-color, white));
           color: var(--primary-text-color);
         }
         .header {


### PR DESCRIPTION
[card-modder](https://github.com/thomasloven/lovelace-card-modder) is almost exclusively used for two things; setting a background image for cards and rounding their corners.

This PR adds that option to do that using HA themes.