### PR TITLE
Make yaml editor scrollabel in RTL mode

### DIFF
--- a/src/panels/lovelace/components/hui-yaml-editor.ts
+++ b/src/panels/lovelace/components/hui-yaml-editor.ts
@@ -47,7 +47,7 @@ export class HuiYamlEditor extends HTMLElement {
                 color: var(--paper-dialog-color, var(--primary-text-color));
               }
 
-              .CodeMirror-vscrollbar-RTL {
+              .CodeMirror-vscrollbar.rtl {
                 right: auto;
                 left: 0px;
               }
@@ -122,9 +122,9 @@ export class HuiYamlEditor extends HTMLElement {
     const scroll = this.shadowRoot.querySelector(".CodeMirror-vscrollbar");
     if (scroll) {
       if (computeRTL(hass)) {
-        scroll.classList.add("CodeMirror-vscrollbar-RTL");
+        scroll.classList.add("rtl");
       } else {
-        scroll.classList.remove("CodeMirror-vscrollbar-RTL");
+        scroll.classList.remove("rtl");
       }
     }
   }

--- a/src/panels/lovelace/components/hui-yaml-editor.ts
+++ b/src/panels/lovelace/components/hui-yaml-editor.ts
@@ -47,7 +47,7 @@ export class HuiYamlEditor extends HTMLElement {
                 color: var(--paper-dialog-color, var(--primary-text-color));
               }
 
-              .CodeMirror-vscrollbar.rtl {
+              .rtl .CodeMirror-vscrollbar {
                 right: auto;
                 left: 0px;
               }
@@ -58,13 +58,10 @@ export class HuiYamlEditor extends HTMLElement {
   }
 
   set hass(hass: HomeAssistant) {
-    if (
-      (!this._hass || this._hass.language !== hass.language) &&
-      this.shadowRoot
-    ) {
-      this.setScrollBarDirection(hass);
-    }
     this._hass = hass;
+    if (this._hass) {
+      this.setScrollBarDirection();
+    }
   }
 
   set value(value: string) {
@@ -103,7 +100,7 @@ export class HuiYamlEditor extends HTMLElement {
             ? ["rtl-gutter", "CodeMirror-linenumbers"]
             : [],
       });
-      this.setScrollBarDirection(this._hass!);
+      this.setScrollBarDirection();
       this.codemirror.on("changes", () => this._onChange());
     } else {
       this.codemirror.refresh();
@@ -114,15 +111,14 @@ export class HuiYamlEditor extends HTMLElement {
     fireEvent(this, "yaml-changed", { value: this.codemirror.getValue() });
   }
 
-  private setScrollBarDirection(hass: HomeAssistant) {
-    if (!this.shadowRoot) {
+  private setScrollBarDirection() {
+    if (!this.codemirror) {
       return;
     }
 
-    const scroll = this.shadowRoot.querySelector(".CodeMirror-vscrollbar");
-    if (scroll) {
-      scroll.classList.toggle("rtl", computeRTL(hass));
-    }
+    this.codemirror
+      .getWrapperElement()
+      .classList.toggle("rtl", computeRTL(this._hass!));
   }
 }
 

--- a/src/panels/lovelace/components/hui-yaml-editor.ts
+++ b/src/panels/lovelace/components/hui-yaml-editor.ts
@@ -3,7 +3,7 @@ import CodeMirror from "codemirror";
 import "codemirror/mode/yaml/yaml";
 // @ts-ignore
 import codeMirrorCSS from "codemirror/lib/codemirror.css";
-import { HomeAssistant } from "../../../../types";
+import { HomeAssistant } from "../../../types";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeRTL } from "../../../common/util/compute_rtl";
 
@@ -99,11 +99,11 @@ export class HuiYamlEditor extends HTMLElement {
           },
         },
         gutters:
-          this._hass && computeRTL(this._hass)
+          this._hass && computeRTL(this._hass!)
             ? ["rtl-gutter", "CodeMirror-linenumbers"]
             : [],
       });
-      this.setScrollBarDirection(this._hass);
+      this.setScrollBarDirection(this._hass!);
       this.codemirror.on("changes", () => this._onChange());
     } else {
       this.codemirror.refresh();

--- a/src/panels/lovelace/components/hui-yaml-editor.ts
+++ b/src/panels/lovelace/components/hui-yaml-editor.ts
@@ -121,11 +121,7 @@ export class HuiYamlEditor extends HTMLElement {
 
     const scroll = this.shadowRoot.querySelector(".CodeMirror-vscrollbar");
     if (scroll) {
-      if (computeRTL(hass)) {
-        scroll.classList.add("rtl");
-      } else {
-        scroll.classList.remove("rtl");
-      }
+      scroll.classList.toggle("rtl", computeRTL(hass));
     }
   }
 }

--- a/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
@@ -119,6 +119,7 @@ export class HuiEditCard extends LitElement {
             ? this._configElement
             : html`
                 <hui-yaml-editor
+                  .hass="${this.hass}"
                   .value="${this._configValue!.value}"
                   @yaml-changed="${this._handleYamlChanged}"
                   @yaml-save="${this._save}"

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -95,6 +95,7 @@ class LovelacePanel extends LitElement {
     if (state === "yaml-editor") {
       return html`
         <hui-editor
+          .hass="${this.hass}"
           .lovelace="${this.lovelace}"
           .closeEditor="${this._closeEditor}"
         ></hui-editor>

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -18,6 +18,7 @@ import "./components/hui-yaml-editor";
 // This is not a duplicate import, one is for types, one is for element.
 // tslint:disable-next-line
 import { HuiYamlEditor } from "./components/hui-yaml-editor";
+import { HomeAssistant } from "../../types";
 
 const lovelaceStruct = struct.interface({
   title: "string?",
@@ -26,6 +27,7 @@ const lovelaceStruct = struct.interface({
 });
 
 class LovelaceFullConfigEditor extends LitElement {
+  public hass?: HomeAssistant;
   public lovelace?: Lovelace;
   public closeEditor?: () => void;
   private _saving?: boolean;
@@ -34,6 +36,7 @@ class LovelaceFullConfigEditor extends LitElement {
 
   static get properties() {
     return {
+      hass: {},
       lovelace: {},
       _saving: {},
       _changed: {},
@@ -62,6 +65,7 @@ class LovelaceFullConfigEditor extends LitElement {
         </app-header>
         <div class="content">
           <hui-yaml-editor
+            .hass="${this.hass}"
             @yaml-changed="${this._yamlChanged}"
             @yaml-save="${this._handleSave}"
           >
@@ -102,7 +106,6 @@ class LovelaceFullConfigEditor extends LitElement {
 
         .content {
           height: calc(100vh - 68px);
-          direction: ltr;
         }
 
         hui-code-editor {


### PR DESCRIPTION
The CodeMirror scrollbar is obstructed by the app-drawer swipe placeholder so scrolling is impossible. And CodeMirror's RTL support does not handle the scrollbar position.
I've added gutter/style to push scrollbar to the other side and still keep line number proper.

Please review