### PR TITLE
Add Program Modes (Heat, Cool, Auto) to Thermostat Card

### DIFF
--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -227,7 +227,9 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
                   items="[[stateObj.attributes.fan_list]]"
                   on-dom-change="handleFanListUpdate"
                 >
-                  <paper-item>[[item]]</paper-item>
+                  <paper-item
+                    >[[_localizeOperationMode(localize, item)]]</paper-item
+                  >
                 </template>
               </paper-listbox>
             </paper-dropdown-menu>

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -43,6 +43,9 @@ const modeIcons = {
   eco: "hass:leaf",
   dry: "hass:water-percent",
   idle: "hass:power-sleep",
+  program_auto: "hass:calendar-clock",
+  program_cool: "hass:calendar-import",
+  program_heat: "hass:calendar-export",
 };
 
 export interface Config extends LovelaceCardConfig {
@@ -419,6 +422,15 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
         }
         .idle {
           --mode-color: var(--idle-color);
+        }
+        .program_auto {
+          --mode-color: var(--auto-color);
+        }
+        .program_cool {
+          --mode-color: var(--cool-color);
+        }
+        .program_heat {
+          --mode-color: var(--heat-color);
         }
         .unknown-mode {
           --mode-color: var(--unknown-color);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -188,7 +188,10 @@
       "high_demand": "High demand",
       "heat_pump": "Heat pump",
       "gas": "Gas",
-      "manual": "Manual"
+      "manual": "Manual",
+      "program_auto": "Program Auto",
+      "program_cool": "Program Cool",
+      "program_heat": "Program Heat"
     },
     "configurator": {
       "configure": "Configure",

--- a/translations/en.json
+++ b/translations/en.json
@@ -145,7 +145,10 @@
             "high_demand": "High demand",
             "heat_pump": "Heat pump",
             "gas": "Gas",
-            "manual": "Manual"
+            "manual": "Manual",
+            "program_auto": "Program Auto",
+            "program_cool": "Program Cool",
+            "program_heat": "Program Heat"
         },
         "configurator": {
             "configure": "Configure",


### PR DESCRIPTION
This change is to add separate "Program Auto" "Program Heat" and "Program Cool" modes for the thermostat card, as well as fix the missing localization on the Fan Mode drop down.

This change is in support of an upcoming PR to the `home-assistant` code which will include support for Insteon and Z-Wave Thermostats via the `ISY994` platform.  These thermostats have separate modes for "Auto/Cool/Heat" and "Program Auto/Program Cool/Program Heat" (e.g.  manual set vs. scheduled).  This is separate from the normal "Hold" and "Energy/Leaf" modes.

Upcoming Changes are on this branch: https://github.com/shbatm/home-assistant/tree/isy994-climate-support