### PR TITLE
Add missing localization for Fan Mode in Climate More Info

### DIFF
--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -227,7 +227,9 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
                   items="[[stateObj.attributes.fan_list]]"
                   on-dom-change="handleFanListUpdate"
                 >
-                  <paper-item>[[item]]</paper-item>
+                  <paper-item
+                    >[[_localizeOperationMode(localize, item)]]</paper-item
+                  >
                 </template>
               </paper-listbox>
             </paper-dropdown-menu>

--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -557,7 +557,7 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
   }
 
   _localizeFanMode(localize, mode) {
-    return localize(`state.climate_fan.${mode}`) || mode;
+    return localize(`state_attributes.climate.fan_mode.${mode}`) || mode;
   }
 }
 

--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -227,9 +227,7 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
                   items="[[stateObj.attributes.fan_list]]"
                   on-dom-change="handleFanListUpdate"
                 >
-                  <paper-item
-                    >[[_localizeOperationMode(localize, item)]]</paper-item
-                  >
+                  <paper-item>[[_localizeFanMode(localize, item)]]</paper-item>
                 </template>
               </paper-listbox>
             </paper-dropdown-menu>

--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -555,6 +555,10 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
   _localizeOperationMode(localize, mode) {
     return localize(`state.climate.${mode}`) || mode;
   }
+
+  _localizeFanMode(localize, mode) {
+    return localize(`state.climate_fan.${mode}`) || mode;
+  }
 }
 
 customElements.define("more-info-climate", MoreInfoClimate);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -190,6 +190,11 @@
       "gas": "Gas",
       "manual": "Manual"
     },
+    "climate_fan": {
+      "off": "[%key:state::default::off%]",
+      "on": "[%key:state::default::on%]",
+      "auto": "[%key:state::climate::auto%]"
+    },
     "configurator": {
       "configure": "Configure",
       "configured": "Configured"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -190,11 +190,6 @@
       "gas": "Gas",
       "manual": "Manual"
     },
-    "climate_fan": {
-      "off": "[%key:state::default::off%]",
-      "on": "[%key:state::default::on%]",
-      "auto": "[%key:state::climate::auto%]"
-    },
     "configurator": {
       "configure": "Configure",
       "configured": "Configured"
@@ -312,6 +307,15 @@
       "query_stage": {
         "initializing": "[%key:state::zwave::default::initializing%] ({query_stage})",
         "dead": "[%key:state::zwave::default::dead%] ({query_stage})"
+      }
+    }
+  },
+  "state_attributes": {
+    "climate": {
+      "fan_mode": {
+        "off": "[%key:state::default::off%]",
+        "on": "[%key:state::default::on%]",
+        "auto": "[%key:state::climate::auto%]"
       }
     }
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -147,11 +147,6 @@
             "gas": "Gas",
             "manual": "Manual"
         },
-        "climate_fan": {
-            "off": "Off",
-            "on": "On",
-            "auto": "Auto"
-        },
         "configurator": {
             "configure": "Configure",
             "configured": "Configured"
@@ -270,6 +265,15 @@
             "on": "On",
             "paused": "Paused",
             "returning": "Returning to dock"
+        }
+    },
+    "state_attributes": {
+        "climate": {
+          "fan_mode": {
+            "off": "Off",
+            "on": "On",
+            "auto": "Auto"
+          }
         }
     },
     "state_badge": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -147,6 +147,11 @@
             "gas": "Gas",
             "manual": "Manual"
         },
+        "climate_fan": {
+            "off": "Off",
+            "on": "On",
+            "auto": "Auto"
+        },
         "configurator": {
             "configure": "Configure",
             "configured": "Configured"


### PR DESCRIPTION
The Fan Mode dropdown in Climate More Info dialog does not have any localization applied to it, it just shows the raw "auto" or "on".  Fan Mode appears to use the same values as the Operation Mode, so this uses the Operation Mode localization function to translate these values.