### PR TITLE
Update Store Auth card to use primary-text-color

### DIFF
--- a/src/dialogs/ha-store-auth-card.js
+++ b/src/dialogs/ha-store-auth-card.js
@@ -18,6 +18,10 @@ class HaStoreAuth extends LocalizeMixin(PolymerElement) {
           right: 16px;
         }
 
+        .card-content {
+          color: var(--primary-text-color);
+        }
+
         .card-actions {
           text-align: right;
           border-top: 0;


### PR DESCRIPTION
The card that prompts to save login currently uses black text instead of using a theme variable.