### PR TITLE
Fix header padding for history graph card

### DIFF
--- a/src/panels/lovelace/cards/hui-history-graph-card.js
+++ b/src/panels/lovelace/cards/hui-history-graph-card.js
@@ -11,31 +11,33 @@ class HuiHistoryGraphCard extends PolymerElement {
   static get template() {
     return html`
       <style>
-        ha-card {
+        .content {
           padding: 16px;
         }
-        ha-card[header] {
+        [header] .content {
           padding-top: 0;
         }
       </style>
 
       <ha-card header$="[[_config.title]]">
-        <ha-state-history-data
-          hass="[[hass]]"
-          filter-type="recent-entity"
-          entity-id="[[_entities]]"
-          data="{{_stateHistory}}"
-          is-loading="{{_stateHistoryLoading}}"
-          cache-config="[[_cacheConfig]]"
-        ></ha-state-history-data>
-        <state-history-charts
-          hass="[[hass]]"
-          history-data="[[_stateHistory]]"
-          is-loading-data="[[_stateHistoryLoading]]"
-          names="[[_names]]"
-          up-to-now
-          no-single
-        ></state-history-charts>
+        <div class="content">
+          <ha-state-history-data
+            hass="[[hass]]"
+            filter-type="recent-entity"
+            entity-id="[[_entities]]"
+            data="{{_stateHistory}}"
+            is-loading="{{_stateHistoryLoading}}"
+            cache-config="[[_cacheConfig]]"
+          ></ha-state-history-data>
+          <state-history-charts
+            hass="[[hass]]"
+            history-data="[[_stateHistory]]"
+            is-loading-data="[[_stateHistoryLoading]]"
+            names="[[_names]]"
+            up-to-now
+            no-single
+          ></state-history-charts>
+        </div>
       </ha-card>
     `;
   }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1444314/52763663-92dae480-2fd1-11e9-9e65-16af5aa9e616.png)

After:
![image](https://user-images.githubusercontent.com/1444314/52763673-9bcbb600-2fd1-11e9-99c7-c795d32eeae0.png)

Moral of the story: don't apply padding to `<ha-card>` when you're adding a header!