### PR TITLE
Fix styling of raw config save button

### DIFF
--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -53,14 +53,16 @@ class LovelaceFullConfigEditor extends LitElement {
               @click="${this._closeEditor}"
             ></paper-icon-button>
             <div main-title>Edit Config</div>
-            <mwc-button raised @click="${this._handleSave}">Save</mwc-button>
-            <ha-icon
-              class="save-button
+            <mwc-button raised @click="${this._handleSave}"
+              >Save
+              <ha-icon
+                class="save-button
             ${classMap({
-                saved: this._saving! === false || this._changed === true,
-              })}"
-              icon="${this._changed ? "hass:circle-medium" : "hass:check"}"
-            ></ha-icon>
+                  saved: this._saving! === false || this._changed === true,
+                })}"
+                icon="${this._changed ? "hass:circle-medium" : "hass:check"}"
+              ></ha-icon
+            ></mwc-button>
           </app-toolbar>
         </app-header>
         <div class="content">
@@ -113,11 +115,12 @@ class LovelaceFullConfigEditor extends LitElement {
         .save-button {
           opacity: 0;
           margin-left: -21px;
-          margin-top: -1px;
-          transition: opacity 1.5s;
+          transition: all 1.5s;
         }
 
         .saved {
+          margin-left: initial;
+          margin-right: -8px;
           opacity: 1;
         }
       `,


### PR DESCRIPTION
The icon would be over the button text 
Before:
![image](https://user-images.githubusercontent.com/5662298/52814600-ce8eb080-309c-11e9-903d-3b70535bd8ff.png)
After:
![image](https://user-images.githubusercontent.com/5662298/52814616-d9494580-309c-11e9-9a18-517e02b1df73.png)

