### PR TITLE
Unused entities to respect tap/hold action

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -5,7 +5,6 @@ export interface LovelaceConfig {
   views: LovelaceViewConfig[];
   background?: string;
   resources?: Array<{ type: "css" | "js" | "module" | "html"; url: string }>;
-  excluded_entities?: string[];
 }
 
 export interface LovelaceViewConfig {
@@ -34,7 +33,10 @@ export interface ToggleActionConfig {
 export interface CallServiceActionConfig {
   action: "call-service";
   service: string;
-  service_data?: { [key: string]: any };
+  service_data?: {
+    entity_id?: string | [string];
+    [key: string]: any;
+  };
 }
 
 export interface NavigateActionConfig {

--- a/src/panels/lovelace/common/handle-click.ts
+++ b/src/panels/lovelace/common/handle-click.ts
@@ -33,7 +33,7 @@ export const handleClick = (
     case "more-info":
       if (config.entity || config.camera_image) {
         fireEvent(node, "hass-more-info", {
-          entityId: config.entity ? config.entity! : config.camera_image!,
+          entityId: config.entity ? config.entity : config.camera_image!,
         });
       }
       break;

--- a/src/panels/lovelace/hui-unused-entities.ts
+++ b/src/panels/lovelace/hui-unused-entities.ts
@@ -64,7 +64,7 @@ export class HuiUnusedEntities extends LitElement {
         hui-entities-card {
           max-width: 400px;
           padding: 4px;
-          flex: 1;
+          flex: 1 auto;
         }
       </style>
     `;


### PR DESCRIPTION
Respect tap/hold action when computing unused actions.

Removed `excluded_entities`. This is not a page that people should frequent, nor should we have config options to make it more pleasant.