### PR TITLE
Geolocation source configurable in map editor

### DIFF
--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -13,6 +13,7 @@ import { EditorTarget } from "../editor/types";
 
 export class HuiInputListEditor extends LitElement {
   protected hass?: HomeAssistant;
+  public value?: string;
   protected heading?: string;
   protected inputLabel?: string;
   protected entries?: string[];
@@ -20,6 +21,7 @@ export class HuiInputListEditor extends LitElement {
   static get properties(): PropertyDeclarations {
     return {
       hass: {},
+      value: {},
       heading: {},
       inputLabel: {},
       entries: {},
@@ -62,8 +64,8 @@ export class HuiInputListEditor extends LitElement {
     const newEntries = this.entries!.concat(target.value as string);
     target.value = "";
     this.value = newEntries;
-    fireEvent(this, "entries-changed");
-    target.blur();
+    fireEvent(this, "value-changed");
+    ev.target.blur();
   }
 
   private _valueChanged(ev: Event): void {
@@ -77,7 +79,7 @@ export class HuiInputListEditor extends LitElement {
     }
 
     this.value = newEntries;
-    fireEvent(this, "entries-changed");
+    fireEvent(this, "value-changed");
   }
 
   private renderStyle(): TemplateResult {

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -1,0 +1,94 @@
+import {
+  html,
+  LitElement,
+  PropertyDeclarations,
+  TemplateResult,
+} from "lit-element";
+import "@polymer/paper-input/paper-input";
+
+import { HomeAssistant } from "../../../types";
+import { fireEvent } from "../../../common/dom/fire_event";
+
+import { EditorTarget } from "../editor/types";
+
+export class HuiInputListEditor extends LitElement {
+  protected hass?: HomeAssistant;
+  protected heading?: string;
+  protected entries?: string[];
+
+  static get properties(): PropertyDeclarations {
+    return {
+      hass: {},
+      heading: {},
+      entries: {},
+    };
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this.entries) {
+      return html``;
+    }
+
+    return html`
+      ${this.renderStyle()}
+      <h3>${this.heading}</h3>
+      <div class="entries">
+        ${this.entries.map((listEntry, index) => {
+          return html`
+            <paper-input
+              label="Source"
+              .value="${listEntry}"
+              .configValue="${"entry"}"
+              .index="${index}"
+              @value-changed="${this._valueChanged}"
+            ></paper-input>
+          `;
+        })}
+        <paper-input @value-changed="${this._addEntity}"></paper-input>
+      </div>
+    `;
+  }
+
+  private _addEntity(ev: Event): void {
+    const target = ev.target! as EditorTarget;
+    if (target.value === "") {
+      return;
+    }
+    const newConfigEntries = this.entries!.concat(target.value as string);
+    target.value = "";
+    this.value = newConfigEntries;
+    fireEvent(this, "entries-changed");
+  }
+
+  private _valueChanged(ev: Event): void {
+    const target = ev.target! as EditorTarget;
+    const newConfigEntries = this.entries!.concat();
+
+    if (target.value === "") {
+      newConfigEntries.splice(target.index!, 1);
+    } else {
+      newConfigEntries[target.index!] = target.value!;
+    }
+
+    this.value = newConfigEntries;
+    fireEvent(this, "entries-changed");
+  }
+
+  private renderStyle(): TemplateResult {
+    return html`
+      <style>
+        .entries {
+          padding-left: 20px;
+        }
+      </style>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-input-list-editor": HuiInputListEditor;
+  }
+}
+
+customElements.define("hui-input-list-editor", HuiInputListEditor);

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -1,4 +1,11 @@
-import { html, LitElement, property, TemplateResult } from "lit-element";
+import {
+  html,
+  css,
+  LitElement,
+  property,
+  TemplateResult,
+  CSSResult,
+} from "lit-element";
 import "@polymer/paper-input/paper-input";
 
 import { HomeAssistant } from "../../../types";
@@ -25,17 +32,26 @@ export class HuiInputListEditor extends LitElement {
             .configValue="${"entry"}"
             .index="${index}"
             @value-changed="${this._valueChanged}"
-          ></paper-input>
+            @blur="${this._consolidateEntries}"
+            ><paper-icon-button
+              slot="suffix"
+              class="clear-button"
+              icon="hass:close"
+              no-ripple
+              @click="${this._removeEntry}"
+              >Clear</paper-icon-button
+            ></paper-input
+          >
         `;
       })}
       <paper-input
         label="${this.inputLabel}"
-        @change="${this._addEntity}"
+        @change="${this._addEntry}"
       ></paper-input>
     `;
   }
 
-  private _addEntity(ev: Event): void {
+  private _addEntry(ev: Event): void {
     const target = ev.target! as EditorTarget;
     if (target.value === "") {
       return;
@@ -52,15 +68,42 @@ export class HuiInputListEditor extends LitElement {
     ev.stopPropagation();
     const target = ev.target! as EditorTarget;
     const newEntries = this.value!.concat();
-
-    if (target.value === "") {
-      newEntries.splice(target.index!, 1);
-    } else {
-      newEntries[target.index!] = target.value!;
-    }
+    newEntries[target.index!] = target.value!;
     fireEvent(this, "value-changed", {
       value: newEntries,
     });
+  }
+
+  private _consolidateEntries(ev: Event): void {
+    const target = ev.target! as EditorTarget;
+    if (target.value === "") {
+      const newEntries = this.value!.concat();
+      newEntries.splice(target.index!, 1);
+      fireEvent(this, "value-changed", {
+        value: newEntries,
+      });
+    }
+  }
+
+  private _removeEntry(ev: Event): void {
+    const target = ev.target! as EditorTarget;
+    const parent = target.parentElement;
+    const newEntries = this.value!.concat();
+    newEntries.splice(parent.index!, 1);
+    fireEvent(this, "value-changed", {
+      value: newEntries,
+    });
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      paper-input > paper-icon-button {
+        width: 24px;
+        height: 24px;
+        padding: 2px;
+        color: var(--secondary-text-color);
+      }
+    `;
   }
 }
 

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -12,8 +12,8 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { EditorTarget } from "../editor/types";
 
 export class HuiInputListEditor extends LitElement {
-  protected hass?: HomeAssistant;
   public value?: string;
+  protected hass?: HomeAssistant;
   protected heading?: string;
   protected inputLabel?: string;
   protected entries?: string[];

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -86,8 +86,7 @@ export class HuiInputListEditor extends LitElement {
   }
 
   private _removeEntry(ev: Event): void {
-    const target = ev.target! as EditorTarget;
-    const parent = target.parentElement;
+    const parent = (ev.currentTarget as any).parentElement;
     const newEntries = this.value!.concat();
     newEntries.splice(parent.index!, 1);
     fireEvent(this, "value-changed", {

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -1,9 +1,4 @@
-import {
-  html,
-  LitElement,
-  PropertyDeclarations,
-  TemplateResult,
-} from "lit-element";
+import { html, LitElement, property, TemplateResult } from "lit-element";
 import "@polymer/paper-input/paper-input";
 
 import { HomeAssistant } from "../../../types";
@@ -12,19 +7,10 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { EditorTarget } from "../editor/types";
 
 export class HuiInputListEditor extends LitElement {
-  protected value?: string[];
-  protected hass?: HomeAssistant;
-  protected heading?: string;
-  protected inputLabel?: string;
-
-  static get properties(): PropertyDeclarations {
-    return {
-      hass: {},
-      value: {},
-      heading: {},
-      inputLabel: {},
-    };
-  }
+  @property() protected value?: string[];
+  @property() protected hass?: HomeAssistant;
+  @property() protected heading?: string;
+  @property() protected inputLabel?: string;
 
   protected render(): TemplateResult | void {
     if (!this.value) {

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -46,7 +46,10 @@ export class HuiInputListEditor extends LitElement {
             ></paper-input>
           `;
         })}
-        <paper-input @value-changed="${this._addEntity}"></paper-input>
+        <paper-input
+          label="${this.inputLabel}"
+          @change="${this._addEntity}"
+        ></paper-input>
       </div>
     `;
   }
@@ -60,6 +63,7 @@ export class HuiInputListEditor extends LitElement {
     target.value = "";
     this.value = newEntries;
     fireEvent(this, "entries-changed");
+    target.blur();
   }
 
   private _valueChanged(ev: Event): void {

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -1,11 +1,4 @@
-import {
-  html,
-  css,
-  LitElement,
-  property,
-  TemplateResult,
-  CSSResult,
-} from "lit-element";
+import { html, LitElement, property, TemplateResult } from "lit-element";
 import "@polymer/paper-input/paper-input";
 
 import { HomeAssistant } from "../../../types";
@@ -24,23 +17,21 @@ export class HuiInputListEditor extends LitElement {
     }
 
     return html`
-      <div class="entries">
-        ${this.value.map((listEntry, index) => {
-          return html`
-            <paper-input
-              label="${this.inputLabel}"
-              .value="${listEntry}"
-              .configValue="${"entry"}"
-              .index="${index}"
-              @value-changed="${this._valueChanged}"
-            ></paper-input>
-          `;
-        })}
-        <paper-input
-          label="${this.inputLabel}"
-          @change="${this._addEntity}"
-        ></paper-input>
-      </div>
+      ${this.value.map((listEntry, index) => {
+        return html`
+          <paper-input
+            label="${this.inputLabel}"
+            .value="${listEntry}"
+            .configValue="${"entry"}"
+            .index="${index}"
+            @value-changed="${this._valueChanged}"
+          ></paper-input>
+        `;
+      })}
+      <paper-input
+        label="${this.inputLabel}"
+        @change="${this._addEntity}"
+      ></paper-input>
     `;
   }
 
@@ -68,14 +59,6 @@ export class HuiInputListEditor extends LitElement {
 
     this.value = newEntries;
     fireEvent(this, "value-changed");
-  }
-
-  static get styles(): CSSResult {
-    return css`
-      .entries {
-        padding-left: 20px;
-      }
-    `;
   }
 }
 

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -42,8 +42,9 @@ export class HuiInputListEditor extends LitElement {
     }
     const newEntries = this.value!.concat(target.value as string);
     target.value = "";
-    this.value = newEntries;
-    fireEvent(this, "value-changed");
+    fireEvent(this, "value-changed", {
+      value: newEntries,
+    });
     (ev.target! as LitElement).blur();
   }
 
@@ -57,9 +58,9 @@ export class HuiInputListEditor extends LitElement {
     } else {
       newEntries[target.index!] = target.value!;
     }
-
-    this.value = newEntries;
-    fireEvent(this, "value-changed");
+    fireEvent(this, "value-changed", {
+      value: newEntries,
+    });
   }
 }
 

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -1,4 +1,11 @@
-import { html, LitElement, property, TemplateResult } from "lit-element";
+import {
+  html,
+  css,
+  LitElement,
+  property,
+  TemplateResult,
+  CSSResult,
+} from "lit-element";
 import "@polymer/paper-input/paper-input";
 
 import { HomeAssistant } from "../../../types";
@@ -18,7 +25,6 @@ export class HuiInputListEditor extends LitElement {
     }
 
     return html`
-      ${this.renderStyle()}
       <h3>${this.heading}</h3>
       <div class="entries">
         ${this.value.map((listEntry, index) => {
@@ -66,13 +72,11 @@ export class HuiInputListEditor extends LitElement {
     fireEvent(this, "value-changed");
   }
 
-  private renderStyle(): TemplateResult {
-    return html`
-      <style>
-        .entries {
-          padding-left: 20px;
-        }
-      </style>
+  static get styles(): CSSResult {
+    return css`
+      .entries {
+        padding-left: 20px;
+      }
     `;
   }
 }

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -63,7 +63,7 @@ export class HuiInputListEditor extends LitElement {
     target.value = "";
     this.value = newEntries;
     fireEvent(this, "value-changed");
-    ev.target.blur();
+    (ev.target! as LitElement).blur();
   }
 
   private _valueChanged(ev: Event): void {

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -48,6 +48,7 @@ export class HuiInputListEditor extends LitElement {
   }
 
   private _valueChanged(ev: Event): void {
+    ev.stopPropagation();
     const target = ev.target! as EditorTarget;
     const newEntries = this.value!.concat();
 

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -5,6 +5,7 @@ import {
   property,
   TemplateResult,
   CSSResult,
+  customElement,
 } from "lit-element";
 import "@polymer/paper-input/paper-input";
 
@@ -13,6 +14,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 
 import { EditorTarget } from "../editor/types";
 
+@customElement("hui-input-list-editor")
 export class HuiInputListEditor extends LitElement {
   @property() protected value?: string[];
   @property() protected hass?: HomeAssistant;
@@ -111,5 +113,3 @@ declare global {
     "hui-input-list-editor": HuiInputListEditor;
   }
 }
-
-customElements.define("hui-input-list-editor", HuiInputListEditor);

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -14,12 +14,14 @@ import { EditorTarget } from "../editor/types";
 export class HuiInputListEditor extends LitElement {
   protected hass?: HomeAssistant;
   protected heading?: string;
+  protected inputLabel?: string;
   protected entries?: string[];
 
   static get properties(): PropertyDeclarations {
     return {
       hass: {},
       heading: {},
+      inputLabel: {},
       entries: {},
     };
   }
@@ -36,7 +38,7 @@ export class HuiInputListEditor extends LitElement {
         ${this.entries.map((listEntry, index) => {
           return html`
             <paper-input
-              label="Source"
+              label="${this.inputLabel}"
               .value="${listEntry}"
               .configValue="${"entry"}"
               .index="${index}"
@@ -54,23 +56,23 @@ export class HuiInputListEditor extends LitElement {
     if (target.value === "") {
       return;
     }
-    const newConfigEntries = this.entries!.concat(target.value as string);
+    const newEntries = this.entries!.concat(target.value as string);
     target.value = "";
-    this.value = newConfigEntries;
+    this.value = newEntries;
     fireEvent(this, "entries-changed");
   }
 
   private _valueChanged(ev: Event): void {
     const target = ev.target! as EditorTarget;
-    const newConfigEntries = this.entries!.concat();
+    const newEntries = this.entries!.concat();
 
     if (target.value === "") {
-      newConfigEntries.splice(target.index!, 1);
+      newEntries.splice(target.index!, 1);
     } else {
-      newConfigEntries[target.index!] = target.value!;
+      newEntries[target.index!] = target.value!;
     }
 
-    this.value = newConfigEntries;
+    this.value = newEntries;
     fireEvent(this, "entries-changed");
   }
 

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -12,11 +12,10 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { EditorTarget } from "../editor/types";
 
 export class HuiInputListEditor extends LitElement {
-  public value?: string;
+  protected value?: string[];
   protected hass?: HomeAssistant;
   protected heading?: string;
   protected inputLabel?: string;
-  protected entries?: string[];
 
   static get properties(): PropertyDeclarations {
     return {
@@ -24,12 +23,11 @@ export class HuiInputListEditor extends LitElement {
       value: {},
       heading: {},
       inputLabel: {},
-      entries: {},
     };
   }
 
   protected render(): TemplateResult | void {
-    if (!this.entries) {
+    if (!this.value) {
       return html``;
     }
 
@@ -37,7 +35,7 @@ export class HuiInputListEditor extends LitElement {
       ${this.renderStyle()}
       <h3>${this.heading}</h3>
       <div class="entries">
-        ${this.entries.map((listEntry, index) => {
+        ${this.value.map((listEntry, index) => {
           return html`
             <paper-input
               label="${this.inputLabel}"
@@ -61,7 +59,7 @@ export class HuiInputListEditor extends LitElement {
     if (target.value === "") {
       return;
     }
-    const newEntries = this.entries!.concat(target.value as string);
+    const newEntries = this.value!.concat(target.value as string);
     target.value = "";
     this.value = newEntries;
     fireEvent(this, "value-changed");
@@ -70,7 +68,7 @@ export class HuiInputListEditor extends LitElement {
 
   private _valueChanged(ev: Event): void {
     const target = ev.target! as EditorTarget;
-    const newEntries = this.entries!.concat();
+    const newEntries = this.value!.concat();
 
     if (target.value === "") {
       newEntries.splice(target.index!, 1);

--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -16,7 +16,6 @@ import { EditorTarget } from "../editor/types";
 export class HuiInputListEditor extends LitElement {
   @property() protected value?: string[];
   @property() protected hass?: HomeAssistant;
-  @property() protected heading?: string;
   @property() protected inputLabel?: string;
 
   protected render(): TemplateResult | void {
@@ -25,7 +24,6 @@ export class HuiInputListEditor extends LitElement {
     }
 
     return html`
-      <h3>${this.heading}</h3>
       <div class="entries">
         ${this.value.map((listEntry, index) => {
           return html`

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -110,7 +110,7 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
           .hass="${this.hass}"
           .entries="${this._geo_location_sources}"
           .configValue="${"geo_location_sources"}"
-          @entries-changed="${this._valueChanged}"
+          @value-changed="${this._valueChanged}"
         ></hui-input-list-editor>
       </div>
     `;

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -28,12 +28,19 @@ const entitiesConfigStruct = struct.union([
   "entity-id",
 ]);
 
+const SOURCES = [
+  "geo_json_events",
+  "nsw_rural_fire_service_feed",
+  "usgs_earthquakes_feed",
+];
+
 const cardConfigStruct = struct({
   type: "string",
   title: "string?",
   aspect_ratio: "string?",
   default_zoom: "number?",
   entities: [entitiesConfigStruct],
+  geo_location_sources: [""],
 });
 
 @customElement("hui-map-card-editor")
@@ -43,6 +50,8 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
   @property() private _config?: MapCardConfig;
 
   @property() private _configEntities?: EntityConfig[];
+
+  @property() private _geolocationSources?: string[];
 
   public setConfig(config: MapCardConfig): void {
     config = cardConfigStruct(config);
@@ -60,6 +69,10 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
 
   get _default_zoom(): number {
     return this._config!.default_zoom || NaN;
+  }
+
+  get _geo_location_sources(): string[] {
+    return this._config!.geo_location_sources || [];
   }
 
   protected render(): TemplateResult | void {
@@ -96,6 +109,25 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
           .entities="${this._configEntities}"
           @entities-changed="${this._valueChanged}"
         ></hui-entity-editor>
+        <paper-card heading="Geolocation Sources">
+          <paper-listbox
+            id="geo_location_sources"
+            multi
+            on-selected-items-changed="_fetchData"
+            selected-values="{{selectedSources}}"
+            attr-for-selected="item-name"
+          >
+            <template is="dom-repeat" items="[[geo_location_sources]]">
+              <paper-item item-name="[[item.entity_id]]">
+                <span
+                  class="calendar_color"
+                  style$="background-color: [[item.color]]"
+                ></span>
+                <span class="calendar_color_spacer"></span> [[item.name]]
+              </paper-item>
+            </template>
+          </paper-listbox>
+        </paper-card>
       </div>
     `;
   }

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -18,6 +18,7 @@ import { processEditorEntities } from "../process-editor-entities";
 import { EntityConfig } from "../../entity-rows/types";
 
 import "../../components/hui-entity-editor";
+import "../../components/hui-input-list-editor";
 
 const entitiesConfigStruct = struct.union([
   {
@@ -28,19 +29,13 @@ const entitiesConfigStruct = struct.union([
   "entity-id",
 ]);
 
-const SOURCES = [
-  "geo_json_events",
-  "nsw_rural_fire_service_feed",
-  "usgs_earthquakes_feed",
-];
-
 const cardConfigStruct = struct({
   type: "string",
   title: "string?",
   aspect_ratio: "string?",
   default_zoom: "number?",
   entities: [entitiesConfigStruct],
-  geo_location_sources: [""],
+  geo_location_sources: "array?",
 });
 
 @customElement("hui-map-card-editor")
@@ -109,25 +104,14 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
           .entities="${this._configEntities}"
           @entities-changed="${this._valueChanged}"
         ></hui-entity-editor>
-        <paper-card heading="Geolocation Sources">
-          <paper-listbox
-            id="geo_location_sources"
-            multi
-            on-selected-items-changed="_fetchData"
-            selected-values="{{selectedSources}}"
-            attr-for-selected="item-name"
-          >
-            <template is="dom-repeat" items="[[geo_location_sources]]">
-              <paper-item item-name="[[item.entity_id]]">
-                <span
-                  class="calendar_color"
-                  style$="background-color: [[item.color]]"
-                ></span>
-                <span class="calendar_color_spacer"></span> [[item.name]]
-              </paper-item>
-            </template>
-          </paper-listbox>
-        </paper-card>
+        <hui-input-list-editor
+          id="geo_location_sources"
+          heading="Geolocation Sources"
+          .hass="${this.hass}"
+          .entries="${this._geo_location_sources}"
+          .configValue="${"geo_location_sources"}"
+          @entries-changed="${this._valueChanged}"
+        ></hui-input-list-editor>
       </div>
     `;
   }

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -108,7 +108,7 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
           heading="Geolocation Sources"
           inputLabel="Source"
           .hass="${this.hass}"
-          .entries="${this._geo_location_sources}"
+          .value="${this._geo_location_sources}"
           .configValue="${"geo_location_sources"}"
           @value-changed="${this._valueChanged}"
         ></hui-input-list-editor>

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -104,7 +104,7 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
         <hui-entity-editor
           .hass="${this.hass}"
           .entities="${this._configEntities}"
-          @entities-changed="${this._valueChanged}"
+          @entities-changed="${this._entitiesValueChanged}"
         ></hui-entity-editor>
         <h3>Geolocation Sources</h3>
         <div class="geo_location_sources">
@@ -120,7 +120,19 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     `;
   }
 
-  private _valueChanged(ev: EntitiesEditorEvent): void {
+  private _entitiesValueChanged(ev: EntitiesEditorEvent): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+    const target = ev.target! as EditorTarget;
+    if (ev.detail && ev.detail.entities) {
+      this._config.entities = ev.detail.entities;
+      this._configEntities = processEditorEntities(this._config.entities);
+      fireEvent(this, "config-changed", { config: this._config });
+    }
+  }
+
+  private _valueChanged(ev: Event): void {
     if (!this._config || !this.hass) {
       return;
     }
@@ -132,10 +144,7 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     ) {
       return;
     }
-    if (ev.detail && ev.detail.entities) {
-      this._config.entities = ev.detail.entities;
-      this._configEntities = processEditorEntities(this._config.entities);
-    } else if (target.configValue && ev.detail) {
+    if (target.configValue && ev.detail) {
       if (
         ev.detail.value === "" ||
         (target.type === "number" && isNaN(Number(ev.detail.value)))

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -1,9 +1,11 @@
 import {
   html,
+  css,
   LitElement,
   TemplateResult,
   customElement,
   property,
+  CSSResult,
 } from "lit-element";
 import "@polymer/paper-input/paper-input";
 
@@ -105,13 +107,15 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
           @entities-changed="${this._valueChanged}"
         ></hui-entity-editor>
         <h3>Geolocation Sources</h3>
-        <hui-input-list-editor
-          inputLabel="Source"
-          .hass="${this.hass}"
-          .value="${this._geo_location_sources}"
-          .configValue="${"geo_location_sources"}"
-          @value-changed="${this._valueChanged}"
-        ></hui-input-list-editor>
+        <div class="geo_location_sources">
+          <hui-input-list-editor
+            inputLabel="Source"
+            .hass="${this.hass}"
+            .value="${this._geo_location_sources}"
+            .configValue="${"geo_location_sources"}"
+            @value-changed="${this._valueChanged}"
+          ></hui-input-list-editor>
+        </div>
       </div>
     `;
   }
@@ -145,6 +149,14 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      .geo_location_sources {
+        padding-left: 20px;
+      }
+    `;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -125,20 +125,24 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
       return;
     }
     const target = ev.target! as EditorTarget;
-    if (target.configValue && this[`_${target.configValue}`] === target.value) {
+    if (
+      target.configValue &&
+      ev.detail &&
+      this[`_${target.configValue}`] === ev.detail.value
+    ) {
       return;
     }
     if (ev.detail && ev.detail.entities) {
       this._config.entities = ev.detail.entities;
       this._configEntities = processEditorEntities(this._config.entities);
-    } else if (target.configValue) {
+    } else if (target.configValue && ev.detail) {
       if (
-        target.value === "" ||
-        (target.type === "number" && isNaN(Number(target.value)))
+        ev.detail.value === "" ||
+        (target.type === "number" && isNaN(Number(ev.detail.value)))
       ) {
         delete this._config[target.configValue!];
       } else {
-        let value: any = target.value;
+        let value: any = ev.detail.value;
         if (target.type === "number") {
           value = Number(value);
         }

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -49,8 +49,6 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
 
   @property() private _configEntities?: EntityConfig[];
 
-  @property() private _geolocationSources?: string[];
-
   public setConfig(config: MapCardConfig): void {
     config = cardConfigStruct(config);
     this._config = config;

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -105,8 +105,8 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
           @entities-changed="${this._valueChanged}"
         ></hui-entity-editor>
         <hui-input-list-editor
-          id="geo_location_sources"
           heading="Geolocation Sources"
+          inputLabel="Source"
           .hass="${this.hass}"
           .entries="${this._geo_location_sources}"
           .configValue="${"geo_location_sources"}"

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -18,6 +18,7 @@ import { MapCardConfig } from "../../cards/hui-map-card";
 import { configElementStyle } from "./config-elements-style";
 import { processEditorEntities } from "../process-editor-entities";
 import { EntityConfig } from "../../entity-rows/types";
+import { PolymerChangedEvent } from "../../../../polymer-types";
 
 import "../../components/hui-entity-editor";
 import "../../components/hui-input-list-editor";
@@ -124,7 +125,6 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     if (!this._config || !this.hass) {
       return;
     }
-    const target = ev.target! as EditorTarget;
     if (ev.detail && ev.detail.entities) {
       this._config.entities = ev.detail.entities;
       this._configEntities = processEditorEntities(this._config.entities);
@@ -132,7 +132,7 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     }
   }
 
-  private _valueChanged(ev: Event): void {
+  private _valueChanged(ev: PolymerChangedEvent<any>): void {
     if (!this._config || !this.hass) {
       return;
     }

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -104,8 +104,8 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
           .entities="${this._configEntities}"
           @entities-changed="${this._valueChanged}"
         ></hui-entity-editor>
+        <h3>Geolocation Sources</h3>
         <hui-input-list-editor
-          heading="Geolocation Sources"
           inputLabel="Source"
           .hass="${this.hass}"
           .value="${this._geo_location_sources}"


### PR DESCRIPTION
This will complete the map editor by making the geolocation source configurable in the UI. To achieve this, I implemented a simple list editor (`HuiInputListEditor`) which presents each source in a separate input field, with an additional empty input field at the end of the list for adding a new value.

<img width="997" alt="map-editor-with-geolocation-source-support" src="https://user-images.githubusercontent.com/4704260/52838062-6a73f700-3145-11e9-8227-6d3b940b69cc.png">

The `HuiInputListEditor` is fairly generic and could later be extended, for example to support editing a list of integers or a list of floats, but in this version it only support editing strings.