### PR TITLE
standardize more-info-weather and add hourly/daily

### DIFF
--- a/src/dialogs/more-info/controls/more-info-weather.js
+++ b/src/dialogs/more-info/controls/more-info-weather.js
@@ -105,8 +105,11 @@ class MoreInfoWeather extends LocalizeMixin(PolymerElement) {
             <template is="dom-if" if="[[_showValue(item.condition)]]">
               <iron-icon icon="[[getWeatherIcon(item.condition)]]"></iron-icon>
             </template>
-            <div class="main">[[computeDateTime(item.datetime)]]</div>
+            <template is="dom-if" if="[[!_showValue(item.templow)]]">
+              <div class="main">[[computeDateTime(item.datetime)]]</div>
+            </template>
             <template is="dom-if" if="[[_showValue(item.templow)]]">
+              <div class="main">[[computeDate(item.datetime)]]</div>
               <div class="templow">
                 [[item.templow]] [[getUnit('temperature')]]
               </div>
@@ -170,25 +173,20 @@ class MoreInfoWeather extends LocalizeMixin(PolymerElement) {
     };
   }
 
-  computeDateTime(data) {
+  computeDate(data) {
     const date = new Date(data);
-    const provider = this.stateObj.attributes.attribution;
-    if (
-      provider === "Powered by Dark Sky" ||
-      provider === "Data provided by OpenWeatherMap"
-    ) {
-      if (new Date().getDay() === date.getDay()) {
-        return date.toLocaleTimeString(this.hass.language, { hour: "numeric" });
-      }
-      return date.toLocaleDateString(this.hass.language, {
-        weekday: "long",
-        hour: "numeric",
-      });
-    }
     return date.toLocaleDateString(this.hass.language, {
       weekday: "long",
       month: "short",
       day: "numeric",
+    });
+  }
+
+  computeDateTime(data) {
+    const date = new Date(data);
+    return date.toLocaleDateString(this.hass.language, {
+      weekday: "long",
+      hour: "numeric",
     });
   }
 


### PR DESCRIPTION
Fixes #2764 .  

Standardizes dates for more info weather card to be platform agnostic.  Adds daily and hourly mode similar to the weather card.

Daily mode behavior:
![screenshot_20190216-103207](https://user-images.githubusercontent.com/39341281/52901817-267d0280-31d6-11e9-90a0-c55dcf25bdb2.png)

Hourly mode behavior:
![screenshot_20190216-103027](https://user-images.githubusercontent.com/39341281/52901794-ea49a200-31d5-11e9-9b3a-2a3ca508af73.png)
