### PR TITLE
Fix camera image

### DIFF
--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -167,15 +167,14 @@ class HuiImage extends LitElement {
     if (!this.hass || !this.cameraImage) {
       return;
     }
-    if (this._cameraImageSrc) {
-      URL.revokeObjectURL(this._cameraImageSrc);
-      this._cameraImageSrc = undefined;
-    }
     try {
       const { content_type: contentType, content } = await fetchThumbnail(
         this.hass,
         this.cameraImage
       );
+      if (this._cameraImageSrc) {
+        URL.revokeObjectURL(this._cameraImageSrc);
+      }
       this._cameraImageSrc = URL.createObjectURL(
         b64toBlob(content, contentType)
       );


### PR DESCRIPTION
Only revoke the old camera image source after the the new image has been loaded and set as image source.

Fixes #2760