### PR TITLE
Corrected some Italian translations related to "sun".

### DIFF
--- a/translations/it.json
+++ b/translations/it.json
@@ -1036,9 +1036,9 @@
                     "last_action": "Ultima azione"
                 },
                 "sun": {
-                    "elevation": "Alba",
-                    "rising": "Tramonto",
-                    "setting": "Impostazione"
+                    "elevation": "Altezza",
+                    "rising": "Alba",
+                    "setting": "Tramonto"
                 },
                 "updater": {
                     "title": "Aggiorna istruzioni"


### PR DESCRIPTION
The current translations are simply wrong.

Signed-off-by: Roberto Bonacina <roby.bonacina@gmail.com>