### PR TITLE
Fix attribute-prop mapping

### DIFF
--- a/src/components/entity/ha-entities-picker.ts
+++ b/src/components/entity/ha-entities-picker.ts
@@ -22,9 +22,10 @@ import { HassEntity } from "home-assistant-js-websocket";
 class HaEntitiesPickerLight extends LitElement {
   @property() public hass?: HomeAssistant;
   @property() public value?: string[];
-  @property() public domainFilter?: string;
-  @property() public pickedEntityLabel?: string;
-  @property() public pickEntityLabel?: string;
+  @property({ attribute: "domain-filter" }) public domainFilter?: string;
+  @property({ attribute: "picked-entity-label" })
+  public pickedEntityLabel?: string;
+  @property({ attribute: "pick-entity-label" }) public pickEntityLabel?: string;
 
   protected render(): TemplateResult | void {
     if (!this.hass) {

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -55,11 +55,12 @@ const rowRenderer = (
 class HaEntityPicker extends LitElement {
   @property({ type: Boolean }) public autofocus?: boolean;
   @property({ type: Boolean }) public disabled?: boolean;
-  @property({ type: Boolean }) public allowCustomEntity;
+  @property({ type: Boolean, attribute: "allow-custom-entity" })
+  public allowCustomEntity;
   @property() public hass?: HomeAssistant;
   @property() public label?: string;
   @property() public value?: string;
-  @property() public domainFilter?: string;
+  @property({ attribute: "domain-filter" }) public domainFilter?: string;
   @property() public entityFilter?: HaEntityPickerEntityFilterFunc;
   @property({ type: Boolean }) private _opened?: boolean;
   @property() private _hass?: HomeAssistant;


### PR DESCRIPTION
When I converted ha-entity-picker from Polymer to Lit, I didn't migrate the attribute to prop mapping. Lit defaults to lowercasing it, while Polymer would convert from camel to kebabcase. So in Lit, the attribute for `domainFilter` became `domainfilter`, while in Polymer it was `domain-filter`. This fixes it.

Don't feel like going through the code and find all occurrences of ha-entity-picker so just use the Lit property options to make the attributes be like the Polymer ones.