### PR TITLE
Fix entity-button icon color

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -177,7 +177,7 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
     if (!stateObj.attributes.hs_color) {
       return "";
     }
-    const { hue, sat } = stateObj.attributes.hs_color;
+    const [hue, sat] = stateObj.attributes.hs_color;
     if (sat <= 10) {
       return "";
     }


### PR DESCRIPTION
## Description

Fixes color of the icon for `entity_button`s when used with lights which have different colors.

Fixes #2607

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/28114703/53012788-e919ae80-343b-11e9-97b8-1763ec2f65f9.png)

### After

![image](https://user-images.githubusercontent.com/28114703/53012810-f8006100-343b-11e9-8996-e50b3754ebe3.png)

## Checklist

- [x] Code is tested and works on my devices
