### PR TITLE
Make edit card only close with cancel or save

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-edit-card.ts
@@ -138,6 +138,7 @@ export class HuiEditCard extends LitElement {
       <paper-dialog
         with-backdrop
         opened
+        modal
         @opened-changed="${this._openedChanged}"
       >
         <h2>


### PR DESCRIPTION
## Description

Stops dialog from closing when accidentally clicking outside of the dialog. This makes sure either cancel or save (or refresh of course) be the only way to close the dialog.

## Checklist

- [x] Code is tested and works on my devices
- [x] All other functionality works as it should
