### PR TITLE
Support icon_height for entity button

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -132,7 +132,7 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
                   filter: this._computeBrightness(stateObj),
                   color: this._computeColor(stateObj),
                   height: this._config.icon_height
-                    ? `${this._config.icon_height}px`
+                    ? this._config.icon_height
                     : "auto",
                 })}"
               ></ha-icon>

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -131,6 +131,7 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
                 style="${styleMap({
                   filter: this._computeBrightness(stateObj),
                   color: this._computeColor(stateObj),
+                  height: this._config.icon_height,
                 })}"
               ></ha-icon>
             `

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -131,7 +131,9 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
                 style="${styleMap({
                   filter: this._computeBrightness(stateObj),
                   color: this._computeColor(stateObj),
-                  height: this._config.icon_height,
+                  height: this._config.icon_height
+                    ? `${this._config.icon_height}px`
+                    : "auto",
                 })}"
               ></ha-icon>
             `

--- a/src/panels/lovelace/editor/config-elements/config-elements-style.ts
+++ b/src/panels/lovelace/editor/config-elements/config-elements-style.ts
@@ -12,5 +12,8 @@ export const configElementStyle = html`
       flex: 1;
       padding-right: 4px;
     }
+    .suffix {
+      margin: 0 8px;
+    }
   </style>
 `;

--- a/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
@@ -31,6 +31,7 @@ const cardConfigStruct = struct({
   show_name: "boolean?",
   icon: "string?",
   show_icon: "boolean?",
+  icon_height: "string?",
   tap_action: struct.optional(actionConfigStruct),
   hold_action: struct.optional(actionConfigStruct),
   theme: "string?",
@@ -68,6 +69,10 @@ export class HuiEntityButtonCardEditor extends LitElement
     return this._config!.show_icon || true;
   }
 
+  get _icon_height(): string {
+    return this._config!.icon_height || "";
+  }
+
   get _tap_action(): ActionConfig {
     return this._config!.tap_action || { action: "more-info" };
   }
@@ -97,17 +102,23 @@ export class HuiEntityButtonCardEditor extends LitElement
           @change="${this._valueChanged}"
           allow-custom-entity
         ></ha-entity-picker>
+        <paper-input
+          label="Name (Optional)"
+          .value="${this._name}"
+          .configValue="${"name"}"
+          @value-changed="${this._valueChanged}"
+        ></paper-input>
         <div class="side-by-side">
-          <paper-input
-            label="Name (Optional)"
-            .value="${this._name}"
-            .configValue="${"name"}"
-            @value-changed="${this._valueChanged}"
-          ></paper-input>
           <paper-input
             label="Icon (Optional)"
             .value="${this._icon}"
             .configValue="${"icon"}"
+            @value-changed="${this._valueChanged}"
+          ></paper-input>
+          <paper-input
+            label="Icon Height (Optional)"
+            .value="${this._icon_height}"
+            .configValue="${"icon_height"}"
             @value-changed="${this._valueChanged}"
           ></paper-input>
         </div>

--- a/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
@@ -70,7 +70,9 @@ export class HuiEntityButtonCardEditor extends LitElement
   }
 
   get _icon_height(): string {
-    return this._config!.icon_height || "";
+    return this._config!.icon_height && this._config!.icon_height.includes("px")
+      ? String(parseFloat(this._config!.icon_height))
+      : "";
   }
 
   get _tap_action(): ActionConfig {
@@ -102,25 +104,18 @@ export class HuiEntityButtonCardEditor extends LitElement
           @change="${this._valueChanged}"
           allow-custom-entity
         ></ha-entity-picker>
-        <paper-input
-          label="Name (Optional)"
-          .value="${this._name}"
-          .configValue="${"name"}"
-          @value-changed="${this._valueChanged}"
-        ></paper-input>
         <div class="side-by-side">
+          <paper-input
+            label="Name (Optional)"
+            .value="${this._name}"
+            .configValue="${"name"}"
+            @value-changed="${this._valueChanged}"
+          ></paper-input>
           <paper-input
             label="Icon (Optional)"
             .value="${this._icon}"
             .configValue="${"icon"}"
             @value-changed="${this._valueChanged}"
-          ></paper-input>
-          <paper-input
-            label="Icon Height (Optional)"
-            .value="${this._icon_height}"
-            .configValue="${"icon_height"}"
-            @value-changed="${this._valueChanged}"
-            type="number"
           ></paper-input>
         </div>
         <div class="side-by-side">
@@ -137,12 +132,24 @@ export class HuiEntityButtonCardEditor extends LitElement
             >Show Icon?</paper-toggle-button
           >
         </div>
-        <hui-theme-select-editor
-          .hass="${this.hass}"
-          .value="${this._theme}"
-          .configValue="${"theme"}"
-          @theme-changed="${this._valueChanged}"
-        ></hui-theme-select-editor>
+        <div class="side-by-side">
+          <paper-input
+            label="Icon Height (Optional)"
+            .value="${this._icon_height}"
+            .configValue="${"icon_height"}"
+            @value-changed="${this._valueChanged}"
+            type="number"
+          ><div class="suffix" slot="suffix">px</div>
+          </paper-input>
+          <hui-theme-select-editor
+            .hass="${this.hass}"
+            .value="${this._theme}"
+            .configValue="${"theme"}"
+            @theme-changed="${this._valueChanged}"
+          ></hui-theme-select-editor>
+        </paper-input>
+
+        </div>
         <div class="side-by-side">
           <hui-action-editor
             label="Tap Action"
@@ -181,11 +188,20 @@ export class HuiEntityButtonCardEditor extends LitElement
       if (target.value === "") {
         delete this._config[target.configValue!];
       } else {
+        let newValue: string | undefined;
+        if (
+          target.configValue === "icon_height" &&
+          !isNaN(Number(target.value))
+        ) {
+          newValue = `${String(target.value)}px`;
+        }
         this._config = {
           ...this._config,
           [target.configValue!]:
             target.checked !== undefined
               ? target.checked
+              : newValue !== undefined
+              ? newValue
               : target.value
               ? target.value
               : target.config,

--- a/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-button-card-editor.ts
@@ -120,6 +120,7 @@ export class HuiEntityButtonCardEditor extends LitElement
             .value="${this._icon_height}"
             .configValue="${"icon_height"}"
             @value-changed="${this._valueChanged}"
+            type="number"
           ></paper-input>
         </div>
         <div class="side-by-side">


### PR DESCRIPTION
## Description

Adds support for `icon_height` with the `entity-button` card. This allows the user to tweak the height of the icon in the UI. Also added to config UI and moved the `icon` and `icon_height` to a new line.

## Screenshots

![image](https://user-images.githubusercontent.com/28114703/53017970-1caf0580-3449-11e9-940b-9f9c68a90b0f.png)

![image](https://user-images.githubusercontent.com/28114703/57559111-43117c80-7378-11e9-817f-71e7619eab19.png)


![image](https://user-images.githubusercontent.com/28114703/53018099-63046480-3449-11e9-95e0-41193d15963d.png)


## Checklist

- [x] Code is tested and works on my devices
