### PR TITLE
Resolve auto generated Lovelace Card L10N issue

### DIFF
--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -120,6 +120,18 @@ class LovelacePanel extends LitElement {
     this._updateColumns();
   }
 
+  public connectedCallback(): void {
+    super.connectedCallback();
+    if (
+      this.lovelace &&
+      this.hass &&
+      this.lovelace.language !== this.hass.language
+    ) {
+      // language has been changed, rebuild UI
+      this._fetchConfig(false);
+    }
+  }
+
   private _closeEditor() {
     this._state = "loaded";
   }
@@ -163,6 +175,7 @@ class LovelacePanel extends LitElement {
       config: conf,
       editMode: this.lovelace ? this.lovelace.editMode : false,
       mode: confMode,
+      language: this.hass!.language,
       enableFullEditMode: () => {
         if (!editorLoaded) {
           editorLoaded = true;

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -12,6 +12,7 @@ export interface Lovelace {
   config: LovelaceConfig;
   editMode: boolean;
   mode: "generated" | "yaml" | "storage";
+  language: string;
   enableFullEditMode: () => void;
   setEditMode: (editMode: boolean) => void;
   saveConfig: (newConfig: LovelaceConfig) => Promise<void>;


### PR DESCRIPTION
Add `language` to Lovelace model and reload Lovelace config if user changed language

fixes #2795