### PR TITLE
Color picker: dynamic segmentation

### DIFF
--- a/src/components/ha-color-picker.js
+++ b/src/components/ha-color-picker.js
@@ -140,6 +140,7 @@ class HaColorPicker extends EventsMixin(PolymerElement) {
       hueSegments: {
         type: Number,
         value: 0,
+        observer: "segmentationChange",
       },
 
       // the amount segments for the hue
@@ -149,6 +150,7 @@ class HaColorPicker extends EventsMixin(PolymerElement) {
       saturationSegments: {
         type: Number,
         value: 0,
+        observer: "segmentationChange",
       },
 
       // set to true to make the segments purely esthetical
@@ -589,6 +591,12 @@ class HaColorPicker extends EventsMixin(PolymerElement) {
     svgElement.tooltip.setAttribute("cy", TooltipOffsetY);
     this.tooltip = svgElement.tooltip;
     svgElement.appendChild(svgElement.tooltip);
+  }
+
+  segmentationChange() {
+    if (this.backgroundLayer) {
+        this.drawColorWheel();
+    }
   }
 }
 customElements.define("ha-color-picker", HaColorPicker);

--- a/src/components/ha-color-picker.js
+++ b/src/components/ha-color-picker.js
@@ -595,7 +595,7 @@ class HaColorPicker extends EventsMixin(PolymerElement) {
 
   segmentationChange() {
     if (this.backgroundLayer) {
-        this.drawColorWheel();
+      this.drawColorWheel();
     }
   }
 }

--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -341,7 +341,7 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
   }
 
   segmentClick() {
-    if (this.hueSegments == 24 && this.saturationSegments == 8){
+    if (this.hueSegments === 24 && this.saturationSegments === 8) {
       this.hueSegments = 0;
       this.saturationSegments = 0;
     } else {

--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -20,7 +20,6 @@ const FEATURE_CLASS_NAMES = {
   16: "has-color",
   128: "has-white_value",
 };
-
 /*
  * @appliesMixin EventsMixin
  */
@@ -151,7 +150,7 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
           ></ha-labeled-slider>
         </div>
 
-        <div class="white_value">
+        <div class="control white_value">
           <ha-labeled-slider
             caption="[[localize('ui.card.light.white_value')]]"
             icon="hass:file-word-box"

--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -342,9 +342,9 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   segmentClick() {
     if (this.hueSegments === 24 && this.saturationSegments === 8) {
-      this.setProperties({ hueSegments: 0, saturationSegments: 0 })
+      this.setProperties({ hueSegments: 0, saturationSegments: 0 });
     } else {
-      this.setProperties({ hueSegments: 24, saturationSegments: 8 })
+      this.setProperties({ hueSegments: 24, saturationSegments: 8 });
     }
   }
 

--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -64,25 +64,25 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
         .segmentationButton {
           position: absolute;
-          top: 0%;
-          left: 100%;
-          transform: translate(-100%, 0%);
+          top: 11%;
+          transform: translate(0%, 0%);
           padding: 0px;
           max-height: 0px;
-          width: 28px;
-          height: 28px;
+          width: 23px;
+          height: 23px;
+          opacity: var(--dark-secondary-opacity);
           overflow: hidden;
           transition: max-height 0.5s ease-in;
         }
 
         .has-color.is-on .segmentationContainer .segmentationButton {
           position: absolute;
-          top: 0%;
-          left: 100%;
-          transform: translate(-100%, 0%);
-          width: 45px;
-          height: 45px;
-          padding: 8px;
+          top: 11%;
+          transform: translate(0%, 0%);
+          width: 23px;
+          height: 23px;
+          padding: 0px;
+          opacity: var(--dark-secondary-opacity);
         }
 
         .has-effect_list.is-on .effect_list,

--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -342,9 +342,9 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   segmentClick() {
     if (this.hueSegments === 24 && this.saturationSegments === 8) {
-      setProperties({ hueSegments: 0, saturationSegment: 0})
+      this.setProperties({ hueSegments: 0, saturationSegments: 0})
     } else {
-      setProperties({ hueSegments: 24, saturationSegment: 8})
+      this.setProperties({ hueSegments: 24, saturationSegments: 8})
     }
   }
 

--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -342,11 +342,9 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   segmentClick() {
     if (this.hueSegments === 24 && this.saturationSegments === 8) {
-      this.hueSegments = 0;
-      this.saturationSegments = 0;
+      setProperties({ hueSegments: 0, saturationSegment: 0})
     } else {
-      this.hueSegments = 24;
-      this.saturationSegments = 8;
+      setProperties({ hueSegments: 24, saturationSegment: 8})
     }
   }
 

--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -20,6 +20,7 @@ const FEATURE_CLASS_NAMES = {
   16: "has-color",
   128: "has-white_value",
 };
+
 /*
  * @appliesMixin EventsMixin
  */
@@ -48,6 +49,11 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
           --paper-slider-knob-start-border-color: var(--primary-color);
         }
 
+        .segmentationContainer {
+          position: relative;
+          width: 100%;
+        }
+
         ha-color-picker {
           display: block;
           width: 100%;
@@ -55,6 +61,29 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
           max-height: 0px;
           overflow: hidden;
           transition: max-height 0.5s ease-in;
+        }
+
+        .segmentationButton {
+          position: absolute;
+          top: 0%;
+          left: 100%;
+          transform: translate(-100%, 0%);
+          padding: 0px;
+          max-height: 0px;
+          width: 28px;
+          height: 28px;
+          overflow: hidden;
+          transition: max-height 0.5s ease-in;
+        }
+
+        .has-color.is-on .segmentationContainer .segmentationButton {
+          position: absolute;
+          top: 0%;
+          left: 100%;
+          transform: translate(-100%, 0%);
+          width: 45px;
+          height: 45px;
+          padding: 8px;
         }
 
         .has-effect_list.is-on .effect_list,
@@ -73,6 +102,11 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
         .has-color_temp.is-on .color_temp,
         .has-white_value.is-on .white_value {
           padding-top: 16px;
+        }
+
+        .has-color.is-on .segmentationButton {
+          max-height: 100px;
+          overflow: visible;
         }
 
         .has-color.is-on ha-color-picker {
@@ -117,7 +151,7 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
           ></ha-labeled-slider>
         </div>
 
-        <div class="control white_value">
+        <div class="white_value">
           <ha-labeled-slider
             caption="[[localize('ui.card.light.white_value')]]"
             icon="hass:file-word-box"
@@ -126,16 +160,22 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
             on-change="wvSliderChanged"
           ></ha-labeled-slider>
         </div>
-
-        <ha-color-picker
-          class="control color"
-          on-colorselected="colorPicked"
-          desired-hs-color="{{colorPickerColor}}"
-          throttle="500"
-          hue-segments="24"
-          saturation-segments="8"
-        >
-        </ha-color-picker>
+        <div class="segmentationContainer">
+          <ha-color-picker
+            class="control color"
+            on-colorselected="colorPicked"
+            desired-hs-color="{{colorPickerColor}}"
+            throttle="500"
+            hue-segments="{{hueSegments}}"
+            saturation-segments="{{saturationSegments}}"
+          >
+          </ha-color-picker>
+          <paper-icon-button
+            icon="mdi:palette"
+            on-click="segmentClick"
+            class="control segmentationButton"
+          ></paper-icon-button>
+        </div>
 
         <div class="control effect_list">
           <paper-dropdown-menu
@@ -192,6 +232,16 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
       wvSliderValue: {
         type: Number,
         value: 0,
+      },
+
+      hueSegments: {
+        type: Number,
+        value: 24,
+      },
+
+      saturationSegments: {
+        type: Number,
+        value: 8,
       },
 
       colorPickerColor: {
@@ -289,6 +339,16 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
       entity_id: this.stateObj.entity_id,
       white_value: wv,
     });
+  }
+
+  segmentClick() {
+    if (this.hueSegments == 24 && this.saturationSegments == 8){
+      this.hueSegments = 0;
+      this.saturationSegments = 0;
+    } else {
+      this.hueSegments = 24;
+      this.saturationSegments = 8;
+    }
   }
 
   serviceChangeColor(hass, entityId, color) {

--- a/src/dialogs/more-info/controls/more-info-light.js
+++ b/src/dialogs/more-info/controls/more-info-light.js
@@ -342,9 +342,9 @@ class MoreInfoLight extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   segmentClick() {
     if (this.hueSegments === 24 && this.saturationSegments === 8) {
-      this.setProperties({ hueSegments: 0, saturationSegments: 0})
+      this.setProperties({ hueSegments: 0, saturationSegments: 0 })
     } else {
-      this.setProperties({ hueSegments: 24, saturationSegments: 8})
+      this.setProperties({ hueSegments: 24, saturationSegments: 8 })
     }
   }
 


### PR DESCRIPTION
This PR adds a small button to the top left corner of the color picker wheel.
When this button is pressed the segmentation of the color wheel changes from the default: 24 hue segments and 8 saturation segments to a continues color wheel (360 hue segments and 255 saturation segments).
If the button is pressed again it changes back to the default (24 hue, 8 sat) and in this way you can keep togeling the color wheel segmentation.

I find this very helpfull because I love the default segmentation to be able to easily select full saturation and sync diffrent lights to exactly the same color.

However sometimes I want to discover new colors or just play around with my lights and then I like to be able to select all possible colors 360x255 instead of only 24x8 limited color possibilities.

![segmented_color_wheel](https://user-images.githubusercontent.com/14811189/53077234-deb9ec00-34f1-11e9-8dbb-8fc8abdaeade.PNG)
![full_color_wheel](https://user-images.githubusercontent.com/14811189/53077235-deb9ec00-34f1-11e9-833c-bbef37e16f28.PNG)
