### PR TITLE
Show person as badges

### DIFF
--- a/src/components/ha-cards.js
+++ b/src/components/ha-cards.js
@@ -36,12 +36,13 @@ const PRIORITY = {
   // badges have priority >= 0
   updater: 0,
   sun: 1,
-  device_tracker: 2,
-  alarm_control_panel: 3,
-  timer: 4,
-  sensor: 5,
-  binary_sensor: 6,
-  mailbox: 7,
+  person: 2,
+  device_tracker: 3,
+  alarm_control_panel: 4,
+  timer: 5,
+  sensor: 6,
+  binary_sensor: 7,
+  mailbox: 8,
 };
 
 const getPriority = (domain) => (domain in PRIORITY ? PRIORITY[domain] : 100);

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -19,6 +19,7 @@ import { LocalizeFunc } from "../../../common/translations/localize";
 const DEFAULT_VIEW_ENTITY_ID = "group.default_view";
 const DOMAINS_BADGES = [
   "binary_sensor",
+  "person",
   "device_tracker",
   "mailbox",
   "sensor",


### PR DESCRIPTION
In auto generated Lovelace config and legacy states, show person component as a badge.

Fixes #2816