### PR TITLE
Force LTR on error popup in dev-info panel

### DIFF
--- a/src/panels/dev-info/dialog-system-log-detail.ts
+++ b/src/panels/dev-info/dialog-system-log-detail.ts
@@ -64,7 +64,14 @@ class DialogSystemLogDetail extends LitElement {
   }
 
   static get styles(): CSSResult[] {
-    return [haStyleDialog, css``];
+    return [
+      haStyleDialog,
+      css`
+        paper-dialog {
+          direction: ltr;
+        }
+      `,
+    ];
   }
 }
 


### PR DESCRIPTION
This was previously working and got broken. Without this it's unreadable in RTL.