### PR TITLE
RFC: Change LL default view to group by device

### DIFF
--- a/src/common/entity/group_by_area_and_device.ts
+++ b/src/common/entity/group_by_area_and_device.ts
@@ -1,0 +1,33 @@
+import { HassEntities, HassEntity } from "home-assistant-js-websocket";
+
+export const NULL = "__NULL__";
+
+export interface AreaDeviceEntitiesMap {
+  [areaId: string]: { [deviceId: string]: HassEntity[] };
+}
+
+// Group entities by area_id, device_id
+// "__NULL__" used as the key for null area_id or device_id
+export function groupByAreaAndDevice(
+  entities: HassEntities
+): AreaDeviceEntitiesMap {
+  const groups: AreaDeviceEntitiesMap = {};
+
+  Object.keys(entities).forEach((entityId) => {
+    const entity = entities[entityId];
+
+    const areaId = entity.area_id || NULL;
+    if (!groups[areaId]) {
+      groups[areaId] = {};
+    }
+    const areaMap = groups[areaId];
+    const deviceId = entity.device_id || NULL;
+    if (!areaMap[deviceId]) {
+      areaMap[deviceId] = [entity];
+    } else {
+      areaMap[deviceId].push(entity);
+    }
+  });
+
+  return groups;
+}


### PR DESCRIPTION
This is draft PR, it depends on simple changes in backend and home-assistant-js-websocket, which I haven't submitted yet.

The current default LL view is backward compatible with states UI, however, I feel that we can use `device` to better organize it

After:
![image](https://user-images.githubusercontent.com/7366491/53351944-cd4c5780-38d6-11e9-9b6a-b5a07e01fb08.png)
![image](https://user-images.githubusercontent.com/7366491/53352006-e7863580-38d6-11e9-85cb-c8915d6141ed.png)

Before:
![image](https://user-images.githubusercontent.com/7366491/53352116-12708980-38d7-11e9-9ef0-c4e55597e2e1.png)
