### PR TITLE
Add ha-card-box-shadow css variable for themeing

### DIFF
--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -18,8 +18,12 @@ class HaCard extends LitElement {
           var(--paper-card-background-color, white)
         );
         border-radius: var(--ha-card-border-radius, 2px);
-        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
-          0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
+        box-shadow: var(
+          --ha-card-box-shadow,
+          0 2px 2px 0 rgba(0, 0, 0, 0.14),
+          0 1px 5px 0 rgba(0, 0, 0, 0.12),
+          0 3px 1px -2px rgba(0, 0, 0, 0.2)
+        );
         color: var(--primary-text-color);
         display: block;
         transition: all 0.3s ease-out;


### PR DESCRIPTION
Apparently some themes were overriding parts of the paper css variables like `shadow-elevation-2dp_-_box-shadow` to achieve this effect, and #2701 broke that. So here's an "official" method.