### PR TITLE
Check system health loaded

### DIFF
--- a/src/panels/dev-info/system-health-card.ts
+++ b/src/panels/dev-info/system-health-card.ts
@@ -98,6 +98,9 @@ class SystemHealthCard extends LitElement {
 
   private async _fetchInfo() {
     try {
+      if (!("system_health" in this.hass!.config.components)) {
+        throw new Error();
+      }
       this._info = await fetchSystemHealthInfo(this.hass!);
     } catch (err) {
       this._info = {


### PR DESCRIPTION
Check that system health is loaded. Won't change any UI behavior but will prevent an error from being logged about an unknown command.

Fixes https://github.com/home-assistant/home-assistant/issues/20648