### PR TITLE
Trim overflow in picture-elements card

### DIFF
--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -26,6 +26,7 @@ class HaCard extends LitElement {
         );
         color: var(--primary-text-color);
         display: block;
+        overflow: hidden;
         transition: all 0.3s ease-out;
       }
       .header:not(:empty) {

--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -26,7 +26,6 @@ class HaCard extends LitElement {
         );
         color: var(--primary-text-color);
         display: block;
-        overflow: hidden;
         transition: all 0.3s ease-out;
       }
       .header:not(:empty) {

--- a/src/panels/lovelace/cards/hui-picture-elements-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.ts
@@ -84,11 +84,13 @@ class HuiPictureElementsCard extends LitElement implements LovelaceCard {
       <style>
         #root {
           position: relative;
-          overflow: hidden;
         }
         .element {
           position: absolute;
           transform: translate(-50%, -50%);
+        }
+        ha-card {
+          overflow: hidden;
         }
       </style>
     `;


### PR DESCRIPTION
Some lovelace cards (picture-entities and some custom ones) have elements that could overflow the card boundaries. This is most apparent when cards have rounded corners.

Before:
![before](https://user-images.githubusercontent.com/1299821/53562257-3a6b2180-3b51-11e9-83b3-edb3e9319bfd.jpg)

After:
![after](https://user-images.githubusercontent.com/1299821/53562265-3e973f00-3b51-11e9-92de-5e9e0a59e597.jpg)

