### PR TITLE
Fix ha-entity-toggle restoring old state

### DIFF
--- a/src/components/entity/ha-entity-toggle.ts
+++ b/src/components/entity/ha-entity-toggle.ts
@@ -110,11 +110,21 @@ class HaEntityToggle extends LitElement {
       entity_id: this.stateObj.entity_id,
     });
 
-    setTimeout(() => {
+    setTimeout(async () => {
       // If after 2 seconds we have not received a state update
       // reset the switch to it's original state.
-      if (this.stateObj === currentState) {
-        this.requestUpdate();
+      if (this.stateObj !== currentState) {
+        return;
+      }
+      // Force a re-render. It's not good enough to just call this.requestUpdate()
+      // because the value has changed outside of Lit's render function, and so Lit
+      // won't update the property again, because it's the same as last update.
+      // So we just temporarily unset the stateObj and set it again.
+      this.stateObj = undefined;
+      await this.updateComplete;
+      // Make sure that a stateObj was not set in between.
+      if (this.stateObj === undefined) {
+        this.stateObj = currentState;
       }
     }, 2000);
   }


### PR DESCRIPTION
Lit renders the `<paper-toggle-button>` in the render method with a value for `checked`. If a user changes the toggle, the `<paper-toggle-button>` will update its own checked value to the new value, making it out of sync in what Lit expects it to be. Now if we don't get a state update from the backend after 2 seconds, we were requesting an update from the Lit Element so it would restore the old state.

However, Lit expected the `checked` value to still be the old value, and the new to-render value is the same as the old value, so Lit won't update the property, even though the property is actually different!

Fixed it by unsetting the state object, waiting for an update and then restoring the state object. This has 1 downside: for 1 frame we will render a disabled paper-toggle from a different template, so Lit will create a new element. Because of that, the slider won't smoothly slide to the old state but instead jump. I want to fix this properly, but not now in the beta.

Fixes https://github.com/home-assistant/home-assistant-polymer/issues/2788