### PR TITLE
Do not fire command if we know component not loaded

### DIFF
--- a/src/panels/config/cloud/cloud-webhooks.ts
+++ b/src/panels/config/cloud/cloud-webhooks.ts
@@ -20,7 +20,6 @@ import {
   deleteCloudhook,
   CloudWebhook,
 } from "../../../data/cloud";
-import { ERR_UNKNOWN_COMMAND } from "../../../data/websocket_api";
 
 declare global {
   // for fire event
@@ -196,15 +195,10 @@ export class CloudWebhooks extends LitElement {
   }
 
   private async _fetchData() {
-    try {
-      this._localHooks = await fetchWebhooks(this.hass!);
-    } catch (err) {
-      if (err.code === ERR_UNKNOWN_COMMAND) {
-        this._localHooks = [];
-      } else {
-        throw err;
-      }
-    }
+    this._localHooks =
+      "webhook" in this.hass!.config.components
+        ? await fetchWebhooks(this.hass!)
+        : [];
   }
 
   private renderStyle() {


### PR DESCRIPTION
Don't try to fetch if we know the component is not loaded. Although we handled the error, it also got logged.

Prevents `Received invalid command: webhook/list`