### PR TITLE
Upgrade home-assistant-js-websocket to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "deep-clone-simple": "^1.1.1",
     "es6-object-assign": "^1.1.0",
     "fecha": "^3.0.0",
-    "home-assistant-js-websocket": "^3.2.4",
+    "home-assistant-js-websocket": "^3.3.0",
     "intl-messageformat": "^2.2.0",
     "jquery": "^3.3.1",
     "js-yaml": "^3.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7217,10 +7217,10 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-home-assistant-js-websocket@^3.2.4:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-3.2.5.tgz#ac4fa6a7cb5cb48efe2a49390cf24acb5439f51f"
-  integrity sha512-CRlq9WA1WGw9lVzouK4BxEGEP5JqWV2MBBZyiUPVgBLHPR9p3bJL/y+jNhnjqEyb8QNPVboGuAJ+Rylrl7o2dg==
+home-assistant-js-websocket@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-3.3.0.tgz#c8bb211c06ff7f8f9ca8391482b0a5e6c7f78711"
+  integrity sha512-3ObNSMwv9EG+7emcGVOg/QWSTdZ8tCaLTrKCM6LEelefybQPbeZWcW37PzZ5wZxXuTOxSSQhGrvTFS8vubpYfw==
 
 homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This allows using the new method [`connection.subscribeMessage`](https://github.com/home-assistant/home-assistant-js-websocket#connsubscribemessagecallback-subscribemessage).