### PR TITLE
Set entity-button defaults

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -44,8 +44,8 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
 
   public static getStubConfig(): object {
     return {
-      tap_action: { action: "more-info" },
-      hold_action: { action: "none" },
+      tap_action: { action: "toggle" },
+      hold_action: { action: "more-info" },
     };
   }
 
@@ -62,7 +62,12 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
       throw new Error("Invalid Entity");
     }
 
-    this._config = { theme: "default", ...config };
+    this._config = {
+      theme: "default",
+      tap_action: { action: "toggle" },
+      hold_action: { action: "more-info" },
+      ...config,
+    };
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -20,6 +20,7 @@ import stateIcon from "../../../common/entity/state_icon";
 import computeStateDomain from "../../../common/entity/compute_state_domain";
 import computeStateName from "../../../common/entity/compute_state_name";
 import applyThemesOnElement from "../../../common/dom/apply_themes_on_element";
+import computeDomain from "../../../common/entity/compute_domain";
 import { HomeAssistant, LightEntity } from "../../../types";
 import { LovelaceCard, LovelaceCardEditor } from "../types";
 import { LovelaceCardConfig, ActionConfig } from "../../../data/lovelace";
@@ -65,14 +66,25 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
 
     this._config = {
       theme: "default",
-      tap_action: {
-        action: DOMAINS_TOGGLE.has(config.entity.split(".", 1)[0])
-          ? "toggle"
-          : "more-info",
-      },
       hold_action: { action: "more-info" },
       ...config,
     };
+
+    if (DOMAINS_TOGGLE.has(computeDomain(config.entity))) {
+      this._config = {
+        tap_action: {
+          action: "toggle",
+        },
+        ...this._config,
+      };
+    } else {
+      this._config = {
+        tap_action: {
+          action: "more-info",
+        },
+        ...this._config,
+      };
+    }
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -25,6 +25,7 @@ import { LovelaceCard, LovelaceCardEditor } from "../types";
 import { LovelaceCardConfig, ActionConfig } from "../../../data/lovelace";
 import { longPress } from "../common/directives/long-press-directive";
 import { handleClick } from "../common/handle-click";
+import { DOMAINS_TOGGLE } from "../../../common/const";
 
 export interface Config extends LovelaceCardConfig {
   entity: string;
@@ -64,7 +65,11 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
 
     this._config = {
       theme: "default",
-      tap_action: { action: "toggle" },
+      tap_action: {
+        action: DOMAINS_TOGGLE.has(config.entity.split(".", 1)[0])
+          ? "toggle"
+          : "more-info",
+      },
       hold_action: { action: "more-info" },
       ...config,
     };


### PR DESCRIPTION
tap_action: toggle
hold_action: more-info

I think this makes a lot more sense as defaults for this card

Partial fix for https://github.com/home-assistant/ui-schema/issues/234