### PR TITLE
Set a custom device name for ZHA devices

### DIFF
--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -10,10 +10,12 @@ export interface DeviceRegistryEntry {
   sw_version?: string;
   hub_device_id?: string;
   area_id?: string;
+  name_by_user?: string;
 }
 
 export interface DeviceRegistryEntryMutableParams {
-  area_id: string;
+  area_id?: string;
+  name_by_user?: string;
 }
 
 export const fetchDeviceRegistry = (hass: HomeAssistant) =>

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -14,6 +14,8 @@ export interface ZHADevice {
   quirk_class: string;
   entities: ZHAEntityReference[];
   manufacturer_code: number;
+  device_reg_id: string;
+  user_given_name: string;
 }
 
 export interface Attribute {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -869,7 +869,8 @@
           "caption": "ZHA",
           "description": "Zigbee Home Automation network management",
           "services": {
-            "reconfigure": "Reconfigure ZHA device (heal device). Use this if you are having issues with the device. If the device in question is a battery powered device please ensure it is awake and accepting commands when you use this service."
+            "reconfigure": "Reconfigure ZHA device (heal device). Use this if you are having issues with the device. If the device in question is a battery powered device please ensure it is awake and accepting commands when you use this service.",
+            "updateDeviceName": "Set a custom name for this device in the device registry."
           }
         },
         "zwave": {


### PR DESCRIPTION
This PR allows users to set custom names for ZHA devices so that they are easier to identify in the ZHA configuration panel. There is a small annoyance in this still caused by: https://github.com/PolymerElements/paper-dropdown-menu/issues/159 I want to get this functionality to the users though. I'll come up with a better solution for this when I redesign the UI to support logging and realtime events. 