### PR TITLE
Fix fetch translation

### DIFF
--- a/src/data/frontend.ts
+++ b/src/data/frontend.ts
@@ -1,38 +1,36 @@
 import { HomeAssistant } from "../types";
 
-export interface FrontendUserData {
-  language: string;
+declare global {
+  // tslint:disable-next-line
+  interface FrontendUserData {}
 }
 
-export const fetchFrontendUserData = async (
+export type ValidUserDataKey = keyof FrontendUserData;
+
+export const fetchFrontendUserData = async <
+  UserDataKey extends ValidUserDataKey
+>(
   hass: HomeAssistant,
-  key: string
-): Promise<FrontendUserData> => {
-  const result = await hass.callWS<{ value: FrontendUserData }>({
+  key: UserDataKey
+): Promise<FrontendUserData[UserDataKey] | null> => {
+  const result = await hass.callWS<{
+    value: FrontendUserData[UserDataKey] | null;
+  }>({
     type: "frontend/get_user_data",
     key,
   });
   return result.value;
 };
 
-export const saveFrontendUserData = async (
+export const saveFrontendUserData = async <
+  UserDataKey extends ValidUserDataKey
+>(
   hass: HomeAssistant,
-  key: string,
-  value: FrontendUserData
+  key: UserDataKey,
+  value: FrontendUserData[UserDataKey]
 ): Promise<void> =>
   hass.callWS<void>({
     type: "frontend/set_user_data",
     key,
     value,
   });
-
-export const getHassTranslations = async (
-  hass: HomeAssistant,
-  language: string
-): Promise<{}> => {
-  const result = await hass.callWS<{ resources: {} }>({
-    type: "frontend/get_translations",
-    language,
-  });
-  return result.resources;
-};

--- a/src/data/translation.ts
+++ b/src/data/translation.ts
@@ -1,0 +1,31 @@
+import { HomeAssistant } from "../types";
+import { fetchFrontendUserData, saveFrontendUserData } from "./frontend";
+
+export interface FrontendTranslationData {
+  language: string;
+}
+
+declare global {
+  interface FrontendUserData {
+    language: FrontendTranslationData;
+  }
+}
+
+export const fetchTranslationPreferences = (hass: HomeAssistant) =>
+  fetchFrontendUserData(hass, "language");
+
+export const saveTranslationPreferences = (
+  hass: HomeAssistant,
+  data: FrontendTranslationData
+) => saveFrontendUserData(hass, "language", data);
+
+export const getHassTranslations = async (
+  hass: HomeAssistant,
+  language: string
+): Promise<{}> => {
+  const result = await hass.callWS<{ resources: {} }>({
+    type: "frontend/get_translations",
+    language,
+  });
+  return result.resources;
+};

--- a/src/layouts/app/translations-mixin.ts
+++ b/src/layouts/app/translations-mixin.ts
@@ -9,8 +9,9 @@ import { HassBaseEl } from "./hass-base-mixin";
 import { computeLocalize } from "../../common/translations/localize";
 import { computeRTL } from "../../common/util/compute_rtl";
 import { HomeAssistant } from "../../types";
-import { saveFrontendUserData, getHassTranslations } from "../../data/frontend";
+import { saveFrontendUserData } from "../../data/frontend";
 import { storeState } from "../../util/ha-pref-storage";
+import { getHassTranslations } from "../../data/translation";
 
 /*
  * superClass needs to contain `this.hass` and `this._updateHass`.

--- a/src/util/hass-translation.ts
+++ b/src/util/hass-translation.ts
@@ -43,7 +43,8 @@ function findAvailableLanguage(language: string) {
  * Get user selected language from backend
  */
 export async function getUserLanguage(hass: HomeAssistant) {
-  const { language } = await fetchFrontendUserData(hass, "language");
+  const result = await fetchFrontendUserData(hass, "language");
+  const language = result ? result.language : null;
   if (language) {
     const availableLanguage = findAvailableLanguage(language);
     if (availableLanguage) {


### PR DESCRIPTION
Fetching a translation could return in `null` being returned when the user has never set a language, this was raising an error. This fixes it, and also fixes the underlying types to be better in warning us ahead of time.

CC @awarecan 