### PR TITLE
Hide entity config option for user group

### DIFF
--- a/src/dialogs/ha-more-info-dialog.js
+++ b/src/dialogs/ha-more-info-dialog.js
@@ -176,14 +176,16 @@ class HaMoreInfoDialog extends DialogMixin(PolymerElement) {
       return;
     }
 
-    try {
-      const info = await this.hass.callWS({
-        type: "config/entity_registry/get",
-        entity_id: newVal.entity_id,
-      });
-      this._registryInfo = info;
-    } catch (err) {
-      this._registryInfo = null;
+    if (this.hass.user.is_admin) {
+      try {
+        const info = await this.hass.callWS({
+          type: "config/entity_registry/get",
+          entity_id: newVal.entity_id,
+        });
+        this._registryInfo = info;
+      } catch (err) {
+        this._registryInfo = null;
+      }
     }
   }
 


### PR DESCRIPTION
For users, hide the settings icon to change entity settings.

The settings icon that users won't see:

![image](https://user-images.githubusercontent.com/1444314/54466799-b9aa4900-473e-11e9-8fd6-46b2311c7d0d.png)
