### PR TITLE
Fix router

### DIFF
--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -96,7 +96,8 @@
     </style>
   </head>
   <body>
-    <ha-demo><div id="ha-init-skeleton"></div></ha-demo>
+    <div id="ha-init-skeleton"></div>
+    <ha-demo></ha-demo>
     <script>
       var _gaq = [["_setAccount", "UA-57927901-5"], ["_trackPageview"]];
       (function(d, t) {

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -40,8 +40,8 @@
     </script>
   </head>
   <body>
+    <div id='ha-init-skeleton'></div>
     <home-assistant>
-      <div id='ha-init-skeleton'></div>
     </home-assistant>
     <% if (!latestBuild) { %>
       <script src="/static/custom-elements-es5-adapter.js"></script>

--- a/src/layouts/app/home-assistant.ts
+++ b/src/layouts/app/home-assistant.ts
@@ -54,7 +54,7 @@ export class HomeAssistantAppEl extends ext(HassBaseMixin(LitElement), [
       ></app-location>
       ${this._panelUrl === undefined || this._route === undefined
         ? ""
-        : hass && hass.states && hass.config && hass.panels && hass.services
+        : hass && hass.states && hass.config && hass.services
         ? html`
             <home-assistant-main
               .hass=${this.hass}

--- a/src/layouts/hass-loading-screen.ts
+++ b/src/layouts/hass-loading-screen.ts
@@ -15,12 +15,12 @@ import { haStyle } from "../resources/styles";
 
 @customElement("hass-loading-screen")
 class HassLoadingScreen extends LitElement {
-  @property() public isRoot? = false;
+  @property({ type: Boolean }) public rootnav? = false;
 
   protected render(): TemplateResult | void {
     return html`
       <app-toolbar>
-        ${this.isRoot
+        ${this.rootnav
           ? html`
               <ha-menu-button></ha-menu-button>
             `

--- a/src/layouts/hass-router-page.ts
+++ b/src/layouts/hass-router-page.ts
@@ -74,17 +74,17 @@ export class HassRouterPage extends UpdatingElement {
       return;
     }
 
-    this._currentPage = newPage;
-
     const routeOptions = routerOptions.routes[newPage];
 
     if (!routeOptions) {
+      this._currentPage = "";
       if (this.lastChild) {
         this.removeChild(this.lastChild);
       }
       return;
     }
 
+    this._currentPage = newPage;
     const loadProm = routeOptions.load();
 
     // Check when loading the page source failed.

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -1,4 +1,9 @@
-import { property, customElement, PropertyValues } from "lit-element";
+import {
+  property,
+  customElement,
+  PropertyValues,
+  LitElement,
+} from "lit-element";
 import { PolymerElement } from "@polymer/polymer";
 
 import { HomeAssistant, Panels } from "../types";
@@ -80,8 +85,7 @@ class PartialPanelResolver extends HassRouterPage {
     const oldHass = changedProps.get("hass") as this["hass"];
 
     if (!oldHass || oldHass.panels !== this.hass!.panels) {
-      this.routerOptions = getRoutes(this.hass!.panels);
-      this.rebuild();
+      this._updateRoutes();
     }
   }
 
@@ -107,6 +111,17 @@ class PartialPanelResolver extends HassRouterPage {
       el.narrow = this.narrow;
       el.route = this.routeTail;
       el.panel = hass.panels[hass.panelUrl];
+    }
+  }
+
+  private async _updateRoutes() {
+    this.routerOptions = getRoutes(this.hass!.panels);
+    await this.rebuild();
+    await this.pageRendered;
+
+    const initEl = document.getElementById("ha-init-skeleton");
+    if (initEl) {
+      initEl.parentElement!.removeChild(initEl);
     }
   }
 }

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -1,118 +1,97 @@
-import { property, customElement } from "lit-element";
+import { property, customElement, PropertyValues } from "lit-element";
 import { PolymerElement } from "@polymer/polymer";
 
-import { HomeAssistant } from "../types";
-import { HassRouterPage, RouterOptions } from "./hass-router-page";
+import { HomeAssistant, Panels } from "../types";
+import {
+  HassRouterPage,
+  RouterOptions,
+  RouteOptions,
+} from "./hass-router-page";
+
+const CACHE_COMPONENTS = ["lovelace", "states"];
+const COMPONENTS = {
+  calendar: () =>
+    import(/* webpackChunkName: "panel-calendar" */ "../panels/calendar/ha-panel-calendar"),
+  config: () =>
+    import(/* webpackChunkName: "panel-config" */ "../panels/config/ha-panel-config"),
+  custom: () =>
+    import(/* webpackChunkName: "panel-custom" */ "../panels/custom/ha-panel-custom"),
+  "dev-event": () =>
+    import(/* webpackChunkName: "panel-dev-event" */ "../panels/dev-event/ha-panel-dev-event"),
+  "dev-info": () =>
+    import(/* webpackChunkName: "panel-dev-info" */ "../panels/dev-info/ha-panel-dev-info"),
+  "dev-mqtt": () =>
+    import(/* webpackChunkName: "panel-dev-mqtt" */ "../panels/dev-mqtt/ha-panel-dev-mqtt"),
+  "dev-service": () =>
+    import(/* webpackChunkName: "panel-dev-service" */ "../panels/dev-service/ha-panel-dev-service"),
+  "dev-state": () =>
+    import(/* webpackChunkName: "panel-dev-state" */ "../panels/dev-state/ha-panel-dev-state"),
+  "dev-template": () =>
+    import(/* webpackChunkName: "panel-dev-template" */ "../panels/dev-template/ha-panel-dev-template"),
+  lovelace: () =>
+    import(/* webpackChunkName: "panel-lovelace" */ "../panels/lovelace/ha-panel-lovelace"),
+  states: () =>
+    import(/* webpackChunkName: "panel-states" */ "../panels/states/ha-panel-states"),
+  history: () =>
+    import(/* webpackChunkName: "panel-history" */ "../panels/history/ha-panel-history"),
+  iframe: () =>
+    import(/* webpackChunkName: "panel-iframe" */ "../panels/iframe/ha-panel-iframe"),
+  kiosk: () =>
+    import(/* webpackChunkName: "panel-kiosk" */ "../panels/kiosk/ha-panel-kiosk"),
+  logbook: () =>
+    import(/* webpackChunkName: "panel-logbook" */ "../panels/logbook/ha-panel-logbook"),
+  mailbox: () =>
+    import(/* webpackChunkName: "panel-mailbox" */ "../panels/mailbox/ha-panel-mailbox"),
+  map: () =>
+    import(/* webpackChunkName: "panel-map" */ "../panels/map/ha-panel-map"),
+  profile: () =>
+    import(/* webpackChunkName: "panel-profile" */ "../panels/profile/ha-panel-profile"),
+  "shopping-list": () =>
+    import(/* webpackChunkName: "panel-shopping-list" */ "../panels/shopping-list/ha-panel-shopping-list"),
+};
+
+const getRoutes = (panels: Panels): RouterOptions => {
+  const routes: { [route: string]: RouteOptions } = {};
+
+  Object.values(panels).forEach((panel) => {
+    routes[panel.url_path] = {
+      load: COMPONENTS[panel.component_name],
+      tag: `ha-panel-${panel.component_name}`,
+      cache: CACHE_COMPONENTS.includes(panel.component_name),
+    };
+  });
+
+  return {
+    showLoading: true,
+    routes,
+  };
+};
 
 @customElement("partial-panel-resolver")
 class PartialPanelResolver extends HassRouterPage {
-  protected static routerOptions: RouterOptions = {
-    isRoot: true,
-    showLoading: true,
-    routes: {
-      calendar: {
-        tag: "ha-panel-calendar",
-        load: () =>
-          import(/* webpackChunkName: "panel-calendar" */ "../panels/calendar/ha-panel-calendar"),
-      },
-      config: {
-        tag: "ha-panel-config",
-        load: () =>
-          import(/* webpackChunkName: "panel-config" */ "../panels/config/ha-panel-config"),
-      },
-      custom: {
-        tag: "ha-panel-custom",
-        load: () =>
-          import(/* webpackChunkName: "panel-custom" */ "../panels/custom/ha-panel-custom"),
-      },
-      "dev-event": {
-        tag: "ha-panel-dev-event",
-        load: () =>
-          import(/* webpackChunkName: "panel-dev-event" */ "../panels/dev-event/ha-panel-dev-event"),
-      },
-      "dev-info": {
-        tag: "ha-panel-dev-info",
-        load: () =>
-          import(/* webpackChunkName: "panel-dev-info" */ "../panels/dev-info/ha-panel-dev-info"),
-      },
-      "dev-mqtt": {
-        tag: "ha-panel-dev-mqtt",
-        load: () =>
-          import(/* webpackChunkName: "panel-dev-mqtt" */ "../panels/dev-mqtt/ha-panel-dev-mqtt"),
-      },
-      "dev-service": {
-        tag: "ha-panel-dev-service",
-        load: () =>
-          import(/* webpackChunkName: "panel-dev-service" */ "../panels/dev-service/ha-panel-dev-service"),
-      },
-      "dev-state": {
-        tag: "ha-panel-dev-state",
-        load: () =>
-          import(/* webpackChunkName: "panel-dev-state" */ "../panels/dev-state/ha-panel-dev-state"),
-      },
-      "dev-template": {
-        tag: "ha-panel-dev-template",
-        load: () =>
-          import(/* webpackChunkName: "panel-dev-template" */ "../panels/dev-template/ha-panel-dev-template"),
-      },
-      lovelace: {
-        cache: true,
-        tag: "ha-panel-lovelace",
-        load: () =>
-          import(/* webpackChunkName: "panel-lovelace" */ "../panels/lovelace/ha-panel-lovelace"),
-      },
-      states: {
-        cache: true,
-        tag: "ha-panel-states",
-        load: () =>
-          import(/* webpackChunkName: "panel-states" */ "../panels/states/ha-panel-states"),
-      },
-      history: {
-        tag: "ha-panel-history",
-        load: () =>
-          import(/* webpackChunkName: "panel-history" */ "../panels/history/ha-panel-history"),
-      },
-      iframe: {
-        tag: "ha-panel-iframe",
-        load: () =>
-          import(/* webpackChunkName: "panel-iframe" */ "../panels/iframe/ha-panel-iframe"),
-      },
-      kiosk: {
-        tag: "ha-panel-kiosk",
-        load: () =>
-          import(/* webpackChunkName: "panel-kiosk" */ "../panels/kiosk/ha-panel-kiosk"),
-      },
-      logbook: {
-        tag: "ha-panel-logbook",
-        load: () =>
-          import(/* webpackChunkName: "panel-logbook" */ "../panels/logbook/ha-panel-logbook"),
-      },
-      mailbox: {
-        tag: "ha-panel-mailbox",
-        load: () =>
-          import(/* webpackChunkName: "panel-mailbox" */ "../panels/mailbox/ha-panel-mailbox"),
-      },
-      map: {
-        tag: "ha-panel-map",
-        load: () =>
-          import(/* webpackChunkName: "panel-map" */ "../panels/map/ha-panel-map"),
-      },
-      profile: {
-        tag: "ha-panel-profile",
-        load: () =>
-          import(/* webpackChunkName: "panel-profile" */ "../panels/profile/ha-panel-profile"),
-      },
-      "shopping-list": {
-        tag: "ha-panel-shopping-list",
-        load: () =>
-          import(/* webpackChunkName: "panel-shopping-list" */ "../panels/shopping-list/ha-panel-shopping-list"),
-      },
-    },
-  };
   @property() public hass?: HomeAssistant;
   @property() public narrow?: boolean;
 
-  protected _updatePageEl(el) {
+  protected updated(changedProps: PropertyValues) {
+    if (!changedProps.has("hass")) {
+      return;
+    }
+
+    const oldHass = changedProps.get("hass") as this["hass"];
+
+    if (!oldHass || oldHass.panels !== this.hass!.panels) {
+      this.routerOptions = getRoutes(this.hass!.panels);
+      this.rebuild();
+    }
+  }
+
+  protected createLoadingScreen() {
+    const el = super.createLoadingScreen();
+    el.rootnav = true;
+    return el;
+  }
+
+  protected updatePageEl(el) {
     const hass = this.hass!;
 
     if ("setProperties" in el) {

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -1,9 +1,4 @@
-import {
-  property,
-  customElement,
-  PropertyValues,
-  LitElement,
-} from "lit-element";
+import { property, customElement, PropertyValues } from "lit-element";
 import { PolymerElement } from "@polymer/polymer";
 
 import { HomeAssistant, Panels } from "../types";

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -8,7 +8,11 @@ import { HassRouterPage, RouterOptions } from "../../layouts/hass-router-page";
 
 @customElement("ha-panel-config")
 class HaPanelConfig extends HassRouterPage {
-  protected static routerOptions: RouterOptions = {
+  @property() public hass!: HomeAssistant;
+  @property() public _wideSidebar: boolean = false;
+  @property() public _wide: boolean = false;
+
+  protected routerOptions: RouterOptions = {
     defaultPage: "dashboard",
     cacheAll: true,
     preloadAll: true,
@@ -81,9 +85,6 @@ class HaPanelConfig extends HassRouterPage {
     },
   };
 
-  @property() public hass!: HomeAssistant;
-  @property() public _wideSidebar: boolean = false;
-  @property() public _wide: boolean = false;
   @property() private _cloudStatus?: CloudStatus;
 
   private _listeners: Array<() => void> = [];
@@ -119,7 +120,7 @@ class HaPanelConfig extends HassRouterPage {
     );
   }
 
-  protected _updatePageEl(el) {
+  protected updatePageEl(el) {
     el.route = this.route;
     el.hass = this.hass;
     el.isWide = this.hass.dockedSidebar ? this._wideSidebar : this._wide;

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -85,7 +85,7 @@ class LovelacePanel extends LitElement {
     }
 
     return html`
-      <hass-loading-screen></hass-loading-screen>
+      <hass-loading-screen rootnav></hass-loading-screen>
     `;
   }
 


### PR DESCRIPTION
The router was assuming url_path == component_name for partial panel resolver, this is not the case.

This also showed that we should be able to dynamically define routes, so ditched the static routes in favor of dynamic. When you change the dynamic routes, it's up to the updater to also call `this.rebuild()`.

Bonus: because we now update the router when panels change, we are no longer relying on the panels existing before we render the main UI shell ⚡️ 