### PR TITLE
Fix HLS on Android 9.0

### DIFF
--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -61,7 +61,7 @@ class MoreInfoCamera extends UpdatingElement {
     let Hls: HLSModule | undefined;
 
     let hlsSupported =
-      videoEl.canPlayType("application/vnd.apple.mpegurl") !== "";
+      videoEl.canPlayType("application/vnd.apple.mpegurl") === "probably";
 
     if (!hlsSupported) {
       Hls = ((await import(/* webpackChunkName: "hls.js" */ "hls.js")) as any)

--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -58,15 +58,13 @@ class MoreInfoCamera extends UpdatingElement {
     videoEl.muted = true;
 
     // tslint:disable-next-line
-    let Hls: HLSModule | undefined;
-
-    let hlsSupported =
-      videoEl.canPlayType("application/vnd.apple.mpegurl") === "probably";
+    const Hls = ((await import(/* webpackChunkName: "hls.js" */ "hls.js")) as any)
+      .default as HLSModule;
+    let hlsSupported = Hls.isSupported();
 
     if (!hlsSupported) {
-      Hls = ((await import(/* webpackChunkName: "hls.js" */ "hls.js")) as any)
-        .default as HLSModule;
-      hlsSupported = Hls.isSupported();
+      hlsSupported =
+        videoEl.canPlayType("application/vnd.apple.mpegurl") !== "";
     }
 
     if (hlsSupported) {
@@ -76,7 +74,7 @@ class MoreInfoCamera extends UpdatingElement {
           this.stateObj.entity_id
         );
 
-        if (Hls) {
+        if (Hls.isSupported()) {
           this._renderHLSPolyfill(videoEl, Hls, url);
         } else {
           this._renderHLSNative(videoEl, url);


### PR DESCRIPTION
This fixes #2948.  The issue is Chrome on Android 9.0 was returning "maybe" for `canPlayType` ([docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canPlayType#Return_value)), but was unable to actually play the media.  This PR checks HLS.js before "native" support, then falls back to MJPEG.