### PR TITLE
Fix navigation stack for integrations page

### DIFF
--- a/src/panels/config/area_registry/ha-config-area-registry.ts
+++ b/src/panels/config/area_registry/ha-config-area-registry.ts
@@ -66,7 +66,7 @@ class HaConfigAreaRegistry extends LitElement {
                 "ui.panel.config.area_registry.picker.introduction2"
               )}
             </p>
-            <a href="/config/integrations">
+            <a href="/config/integrations/dashboard">
               ${this.hass.localize(
                 "ui.panel.config.area_registry.picker.integrations_page"
               )}


### PR DESCRIPTION
This fixes the back action when clicking back after going into an integration. The error occurs after following the link to the integrations page from the area registry. 

See this video for what this corrects: 


![ezgif-3-9cd25ccafffd](https://user-images.githubusercontent.com/1335687/54490874-4ca6c880-4890-11e9-8b6a-5bad5e92d955.gif)
