### PR TITLE
Add feature to rename multiple related entities at once

### DIFF
--- a/src/panels/config/entity_registry/ha-config-entity-registry.ts
+++ b/src/panels/config/entity_registry/ha-config-entity-registry.ts
@@ -123,16 +123,28 @@ class HaConfigEntityRegistry extends LitElement {
 
   private _openEditEntry(ev: MouseEvent): void {
     const entry = (ev.currentTarget! as any).entry;
+    const entryName = computeEntityRegistryName(this.hass!, entry);
+    const entityIdPattern = entry.entity_id.split(".").pop();
+
+    const matchingEntities = this._items.filter((e) => {
+      const en = computeEntityRegistryName(this.hass!, e);
+      return (e !== entry &&
+        en.indexOf(entryName) === 0 &&
+        e.entity_id.indexOf(entityIdPattern) !== -1
+      );
+    });
+
     showEntityRegistryDetailDialog(this, {
       entry,
-      updateEntry: async (updates) => {
+      matchingEntities,
+      updateEntry: async (entityId, updates) => {
         const updated = await updateEntityRegistryEntry(
           this.hass!,
-          entry.entity_id,
+          entityId,
           updates
         );
         this._items = this._items!.map((ent) =>
-          ent === entry ? updated : ent
+          ent.entity_id === entityId ? updated : ent
         );
       },
       removeEntry: async () => {

--- a/src/panels/config/entity_registry/show-dialog-entity-registry-detail.ts
+++ b/src/panels/config/entity_registry/show-dialog-entity-registry-detail.ts
@@ -6,7 +6,9 @@ import {
 
 export interface EntityRegistryDetailDialogParams {
   entry: EntityRegistryEntry;
+  matchingEntities: EntityRegistryEntry[];
   updateEntry: (
+    entityId: string,
     updates: Partial<EntityRegistryEntryUpdateParams>
   ) => Promise<unknown>;
   removeEntry: () => Promise<boolean>;


### PR DESCRIPTION
After installing some fibaro switches, I wanted to more conveniently rename them (each switch generates a ton of entities - zwave, switch/light, sensors). According to forum threads (e.g., https://community.home-assistant.io/t/what-is-the-preferred-way-to-rename-z-wave-entities/64329/151), it seemed like the entity registry was the preferred route to go. So I added a small feature where, when one edits a device, a heuristic is applied to find related entities and offer a way to rename all related entities at once. The heuristic for matching entities is:
- Friendly name of clicked device is a prefix of matching entity's friendly name
- Suffix of entity_id (after last period) is a substring of entity_id of matching entity

Demo gif: https://gfycat.com/HospitableCluelessGoldenmantledgroundsquirrel

Apologies for the questionable code quality, think of this more as a feature request with a proof-of-concept PR. I don't normally do much javascript/frontend, and this was my first time encountering typescript and polymer, so there's a fair bit of cargo culting in this PR. In particular, the way I handle clicks on checkboxes feels far from optimal, and I didn't find a good container to surround matching entities with, so they jump around a bit when editing.