### PR TITLE
Upgrade HAWS

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "es6-object-assign": "^1.1.0",
     "fecha": "^3.0.0",
     "hls.js": "^0.12.3",
-    "home-assistant-js-websocket": "^3.3.0",
+    "home-assistant-js-websocket": "^3.4.0",
     "intl-messageformat": "^2.2.0",
     "jquery": "^3.3.1",
     "js-yaml": "^3.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7230,10 +7230,10 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-home-assistant-js-websocket@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-3.3.0.tgz#c8bb211c06ff7f8f9ca8391482b0a5e6c7f78711"
-  integrity sha512-3ObNSMwv9EG+7emcGVOg/QWSTdZ8tCaLTrKCM6LEelefybQPbeZWcW37PzZ5wZxXuTOxSSQhGrvTFS8vubpYfw==
+home-assistant-js-websocket@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/home-assistant-js-websocket/-/home-assistant-js-websocket-3.4.0.tgz#3ba47cc8f8b7620619a675e7488d6108e8733a70"
+  integrity sha512-Uq5/KIAh4kF13MKzMyd0efBDoU+pNF0O1CfdGpSmT3La3tpt5h+ykpUYlq/vEBj6WwzU6iv3Czt4UK1o0IJHcA==
 
 homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
https://github.com/home-assistant/home-assistant-js-websocket/releases/tag/3.4.0

Slightly faster connections when the UI hasn't been opened for an hour and the token needs to be refreshed.