### PR TITLE
Fix custom panel doctype

### DIFF
--- a/src/panels/custom/ha-panel-custom.js
+++ b/src/panels/custom/ha-panel-custom.js
@@ -98,7 +98,9 @@ It will have access to all data in Home Assistant.
     `.trim();
     const iframeDoc = this.querySelector("iframe").contentWindow.document;
     iframeDoc.open();
-    iframeDoc.write(`<script src='${window.customPanelJS}'></script>`);
+    iframeDoc.write(
+      `<!doctype html><script src='${window.customPanelJS}'></script>`
+    );
     iframeDoc.close();
   }
 


### PR DESCRIPTION
The custom panel was running under quirksmode, which caused content shown in tables to always have black text, regardless of the defined CSS color.

Fixes:
![image](https://user-images.githubusercontent.com/1444314/54649759-bd084200-4a68-11e9-8160-a9cc5b66a89e.png)

Reported by @SeanPM5 