### PR TITLE
Warn when remote UI cannot be turned on

### DIFF
--- a/src/panels/config/cloud/cloud-remote-pref.ts
+++ b/src/panels/config/cloud/cloud-remote-pref.ts
@@ -104,6 +104,7 @@ export class CloudRemotePref extends LitElement {
       }
       fireEvent(this, "ha-refresh-cloud-status");
     } catch (err) {
+      alert(err.message);
       toggle.checked = !toggle.checked;
     }
   }

--- a/src/panels/lovelace/hui-view.ts
+++ b/src/panels/lovelace/hui-view.ts
@@ -66,7 +66,6 @@ export class HUIView extends LitElement {
 
   constructor() {
     super();
-    console.log("CONSTRUCT HUI-VIEW");
     this._cards = [];
     this._badges = [];
   }


### PR DESCRIPTION
Fixes #2966 not as elegantly as suggested, but at least tells the user something went wrong.