### PR TITLE
Fix sidebar when user is slow to load

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -26,19 +26,13 @@ const computePanels = (hass: HomeAssistant) => {
   if (!panels) {
     return [];
   }
-  const isAdmin = hass.user.is_admin;
+
   const sortValue = {
     map: 1,
     logbook: 2,
     history: 3,
   };
-  const result: Panel[] = [];
-
-  Object.values(panels).forEach((panel) => {
-    if (panel.title && (panel.component_name !== "config" || isAdmin)) {
-      result.push(panel);
-    }
-  });
+  const result: Panel[] = Object.values(panels).filter((panel) => panel.title);
 
   result.sort((a, b) => {
     const aBuiltIn = a.component_name in sortValue;
@@ -133,9 +127,8 @@ class HaSidebar extends LitElement {
           : html``}
       </paper-listbox>
 
-      ${!hass.user.is_admin
-        ? ""
-        : html`
+      ${hass.user && hass.user.is_admin
+        ? html`
             <div>
               <div class="divider"></div>
 
@@ -192,7 +185,8 @@ class HaSidebar extends LitElement {
                 </a>
               </div>
             </div>
-          `}
+          `
+        : ""}
     `;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export interface HomeAssistant {
 
   dockedSidebar: boolean;
   moreInfoEntityId: string;
-  user: CurrentUser;
+  user?: CurrentUser;
   callService: (
     domain: string,
     service: string,


### PR DESCRIPTION
The sidebar would crash if the command to fetch the user was slower than fetching the states/services.

I am removing the admin check from the sidebar, as that is now fixed in the backend with https://github.com/home-assistant/home-assistant/pull/22272