### PR TITLE
Edited the delete message when deleting a person to match the resource type

### DIFF
--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -180,9 +180,9 @@ class HaConfigPerson extends LitElement {
       },
       removeEntry: async () => {
         if (
-          !confirm(`Are you sure you want to delete this area?
+          !confirm(`Are you sure you want to delete this person?
 
-All devices in this area will become unassigned.`)
+All devices belonging to this person will become unassigned.`)
         ) {
           return false;
         }


### PR DESCRIPTION
The alert message when deleting a person was refering to an 'area'; changed it to match the resource type being deleted.

![image](https://user-images.githubusercontent.com/1231669/54859312-788bd900-4cea-11e9-8409-9918fc29b148.png)
