### PR TITLE
secondary-info attributes

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -25,7 +25,7 @@ import applyThemesOnElement from "../../../common/dom/apply_themes_on_element";
 
 export interface EntitiesCardEntityConfig extends EntityConfig {
   type?: string;
-  secondary_info?: "entity-id" | "last-changed";
+  secondary_info?: string;
   action_name?: string;
   service?: string;
   service_data?: object;

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -45,9 +45,6 @@ class HuiGenericEntityRow extends LitElement {
       `;
     }
 
-    console.log(stateObj);
-    console.log(this.config.secondary_info);
-
     return html`
       <state-badge
         .stateObj="${stateObj}"

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -45,6 +45,9 @@ class HuiGenericEntityRow extends LitElement {
       `;
     }
 
+    console.log(stateObj);
+    console.log(this.config.secondary_info);
+
     return html`
       <state-badge
         .stateObj="${stateObj}"
@@ -58,15 +61,19 @@ class HuiGenericEntityRow extends LitElement {
               ? html`
                   <slot name="secondary"></slot>
                 `
-              : this.config.secondary_info === "entity-id"
-              ? stateObj.entity_id
-              : this.config.secondary_info === "last-changed"
-              ? html`
-                  <ha-relative-time
-                    .hass="${this.hass}"
-                    .datetime="${stateObj.last_changed}"
-                  ></ha-relative-time>
-                `
+              : this.config.secondary_info !== undefined
+              ? this.config.secondary_info === "last_changed"
+                ? html`
+                    <ha-relative-time
+                      .hass="${this.hass}"
+                      .datetime="${stateObj.last_changed}"
+                    ></ha-relative-time>
+                  `
+                : this.config.secondary_info!.startsWith("attributes")
+                ? stateObj.attributes[
+                    this.config.secondary_info!.split(".", 2)[1]
+                  ]
+                : stateObj[this.config.secondary_info!]
               : ""}
           </div>
         </div>


### PR DESCRIPTION
Fixes https://github.com/home-assistant/ui-schema/issues/230

I'm not sure how I feel about my implementation. I took the easy route as I saw this as a low-hanging FR, but it might be better to make secondary_info an object and you can specify type/prefix/suffix/format