### PR TITLE
Fix for vertical button spacing on alarm card

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -305,7 +305,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
 
       .actions mwc-button {
         min-width: calc(var(--base-unit) * 9);
-        margin: 0 4px;
+        margin: 0 4px 4px;
       }
 
       mwc-button#disarm {


### PR DESCRIPTION
Vertical spacing on button card doesn't have padding when 3 or more buttons are present and the card size is small.  Small PR.
![alarm_spacing](https://user-images.githubusercontent.com/35082313/54964733-f1d23880-4f43-11e9-864d-9755752f3201.PNG)
