### PR TITLE
Consider "on" as valid media state

### DIFF
--- a/src/util/hass-media-player-model.js
+++ b/src/util/hass-media-player-model.js
@@ -37,7 +37,9 @@ export default class MediaPlayerEntity {
   }
 
   get hasMediaControl() {
-    return ["playing", "paused", "unknown"].indexOf(this.stateObj.state) !== -1;
+    return (
+      ["playing", "paused", "unknown", "on"].indexOf(this.stateObj.state) !== -1
+    );
   }
 
   get volumeSliderValue() {


### PR DESCRIPTION
Fixes https://github.com/home-assistant/home-assistant-polymer/issues/2410

![image](https://user-images.githubusercontent.com/1287159/55052793-20c1da80-5028-11e9-9d2a-1bdf3ab46363.png)

![image](https://user-images.githubusercontent.com/1287159/55052824-39ca8b80-5028-11e9-81bd-5b46ace76a44.png)

Tested using same `supported_features` and a state of `on`