### PR TITLE
Allow auth provider bypass login form

### DIFF
--- a/src/auth/ha-auth-flow.js
+++ b/src/auth/ha-auth-flow.js
@@ -121,6 +121,12 @@ class HaAuthFlow extends localizeLiteMixin(PolymerElement) {
       const data = await response.json();
 
       if (response.ok) {
+        // allow auth provider bypass the login form
+        if (data.type === "create_entry") {
+          this._redirect(data.result);
+          return;
+        }
+
         this._updateStep(data);
       } else {
         this.setProperties({
@@ -136,6 +142,24 @@ class HaAuthFlow extends localizeLiteMixin(PolymerElement) {
         _errorMsg: this.localize("ui.panel.page-authorize.form.unknown_error"),
       });
     }
+  }
+
+  _redirect(authCode) {
+    // OAuth 2: 3.1.2 we need to retain query component of a redirect URI
+    let url = this.redirectUri;
+    if (!url.includes("?")) {
+      url += "?";
+    } else if (!url.endsWith("&")) {
+      url += "&";
+    }
+
+    url += `code=${encodeURIComponent(authCode)}`;
+
+    if (this.oauth2State) {
+      url += `&state=${encodeURIComponent(this.oauth2State)}`;
+    }
+
+    document.location = url;
   }
 
   _updateStep(step) {
@@ -229,21 +253,7 @@ class HaAuthFlow extends localizeLiteMixin(PolymerElement) {
       const newStep = await response.json();
 
       if (newStep.type === "create_entry") {
-        // OAuth 2: 3.1.2 we need to retain query component of a redirect URI
-        let url = this.redirectUri;
-        if (!url.includes("?")) {
-          url += "?";
-        } else if (!url.endsWith("&")) {
-          url += "&";
-        }
-
-        url += `code=${encodeURIComponent(newStep.result)}`;
-
-        if (this.oauth2State) {
-          url += `&state=${encodeURIComponent(this.oauth2State)}`;
-        }
-
-        document.location = url;
+        this._redirect(newStep.result);
         return;
       }
       this._updateStep(newStep);


### PR DESCRIPTION
This is a front end change to allow auth provider bypass the login form if it returns "create_entry" instead of "form" in the initialize flow call.

It need be merged first before back end PR merged.