### PR TITLE
Reset camera prefs

### DIFF
--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -183,6 +183,7 @@ class MoreInfoCamera extends LitElement {
       root.removeChild(root.lastChild);
     }
     this.stateObj = undefined;
+    this._cameraPrefs = undefined;
   }
 
   private async _fetchCameraPrefs() {


### PR DESCRIPTION
When we tear down playback, also reset the camera preferences.