### PR TITLE
Increase ZHA add device subscription time

### DIFF
--- a/src/panels/config/zha/zha-add-devices-page.ts
+++ b/src/panels/config/zha/zha-add-devices-page.ts
@@ -159,7 +159,7 @@ class ZHAAddDevicesPage extends LitElement {
     this._active = true;
     this._addDevicesTimeoutHandle = setTimeout(
       () => this._unsubscribe(),
-      60000
+      75000
     );
   }
 


### PR DESCRIPTION
This PR adds time to buffer the length of the subscription for the add device functionality to prevent missing events that happen on the ending edge of the permit time. 