### PR TITLE
Fix for more-info-alarm_control_panel when using code_arm_required

### DIFF
--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
@@ -187,10 +187,8 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(
       },
       _codeValid: {
         type: Boolean,
-        computed: "_validateCode(_enteredCode, \
-                                 _codeFormat, \
-                                 _armVisible, \
-                                 _codeArmRequired)",
+        computed:
+          "_validateCode(_enteredCode,  _codeFormat,  _armVisible, _codeArmRequired)",
       },
       _disarmVisible: {
         type: Boolean,

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.js
@@ -187,7 +187,10 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(
       },
       _codeValid: {
         type: Boolean,
-        computed: "_validateCode(_enteredCode, _codeFormat)",
+        computed: "_validateCode(_enteredCode, \
+                                 _codeFormat, \
+                                 _armVisible, \
+                                 _codeArmRequired)",
       },
       _disarmVisible: {
         type: Boolean,
@@ -220,6 +223,7 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(
       const props = {
         _codeFormat: newVal.attributes.code_format,
         _armVisible: state === "disarmed",
+        _codeArmRequired: newVal.attributes.code_arm_required,
         _disarmVisible:
           this._armedStates.includes(state) ||
           state === "pending" ||
@@ -240,8 +244,8 @@ class MoreInfoAlarmControlPanel extends LocalizeMixin(
     return format === "Number";
   }
 
-  _validateCode(code, format) {
-    return !format || code.length > 0;
+  _validateCode(code, format, armVisible, codeArmRequired) {
+    return !format || code.length > 0 || (armVisible && !codeArmRequired);
   }
 
   _digitClicked(ev) {


### PR DESCRIPTION
This change fixes home-assistant bug [#22263](https://github.com/home-assistant/home-assistant/issues/22263)

manual alarm, manual alarm with mqtt and mqtt alarm all have the option of not requiring the code to arm.  This is via the option `code_arm_required: False`.

The more info dialog disables the arm buttons until at least one character has been entered within the code field.  This change gives the more dialog visibility of the code_arm_required boolean and uses it to enable the arm buttons even when no code is entered when code_arm_required is False.

This change should not be implemented until PR [22641](https://github.com/home-assistant/home-assistant/pull/22641) has been accepted as it sets a default value to True for code_arm_required unless overridden.