### PR TITLE
Add device_class_signal_strength to sensor

### DIFF
--- a/src/common/entity/sensor_icon.ts
+++ b/src/common/entity/sensor_icon.ts
@@ -9,6 +9,7 @@ const fixedDeviceClassIcons = {
   temperature: "hass:thermometer",
   pressure: "hass:gauge",
   power: "hass:flash",
+  signal_strength: "hass:wifi",
 };
 
 export default function sensorIcon(state: HassEntity) {

--- a/src/util/hass-attributes-util.js
+++ b/src/util/hass-attributes-util.js
@@ -34,6 +34,7 @@ hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
     "temperature",
     "pressure",
     "power",
+    "signal_strength",
   ],
 };
 


### PR DESCRIPTION
See home-assistant/architecture#165
Wifi icon is shown for normal operations.
**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#22738