### PR TITLE
Fix paper-icon-button fail

### DIFF
--- a/hassio/src/hassio-main.ts
+++ b/hassio/src/hassio-main.ts
@@ -1,5 +1,6 @@
 import { customElement, PropertyValues, property } from "lit-element";
 import { PolymerElement } from "@polymer/polymer";
+import "@polymer/paper-icon-button";
 
 import "../../src/resources/ha-style";
 import applyThemesOnElement from "../../src/common/dom/apply_themes_on_element";
@@ -18,6 +19,12 @@ import { makeDialogManager } from "../../src/dialogs/make-dialog-manager";
 import { ProvideHassLitMixin } from "../../src/mixins/provide-hass-lit-mixin";
 // Don't codesplit it, that way the dashboard always loads fast.
 import "./hassio-pages-with-tabs";
+
+// The register callback of the IronA11yKeysBehavior inside paper-icon-button
+// is not called, causing _keyBindings to be uninitiliazed for paper-icon-button,
+// causing an exception when added to DOM. When transpiled to ES5, this will
+// break the build.
+customElements.get("paper-icon-button").prototype._keyBindings = {};
 
 @customElement("hassio-main")
 class HassioMain extends ProvideHassLitMixin(HassRouterPage) {

--- a/hassio/src/ingress-view/hassio-ingress-view.ts
+++ b/hassio/src/ingress-view/hassio-ingress-view.ts
@@ -27,7 +27,7 @@ class HassioIngressView extends LitElement {
   protected render(): TemplateResult | void {
     if (!this._hasSession || !this._addon) {
       return html`
-        <hass-loading-screen></hass-loading-screen>
+        <hass-loading-screen rootnav></hass-loading-screen>
       `;
     }
     return html`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,7 +2189,7 @@
     "@vaadin/vaadin-material-styles" "^1.1.0"
     "@vaadin/vaadin-themable-mixin" "^1.2.1"
 
-"@vaadin/vaadin-lumo-styles@^1.1.0", "@vaadin/vaadin-lumo-styles@^1.1.1", "@vaadin/vaadin-lumo-styles@^1.2.0", "@vaadin/vaadin-lumo-styles@^1.3.0", "@vaadin/vaadin-lumo-styles@^1.3.3", "@vaadin/vaadin-lumo-styles@^1.4.1":
+"@vaadin/vaadin-lumo-styles@^1.1.0", "@vaadin/vaadin-lumo-styles@^1.1.1", "@vaadin/vaadin-lumo-styles@^1.2.0", "@vaadin/vaadin-lumo-styles@^1.3.0", "@vaadin/vaadin-lumo-styles@^1.3.3", "@vaadin/vaadin-lumo-styles@^1.4.1", "@vaadin/vaadin-lumo-styles@^1.4.2":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.4.2.tgz#c0f8c6bfeccace2db3601b6f043912da65bdc6ee"
   integrity sha512-6JrmxxQRkDfght5JiViVtd9xoIEwFAHIZjgEwW5ygQw2Zbr++vz6+9oBe6l93nM5JjOMHjR/TXW/+md0FrAZ+w==


### PR DESCRIPTION
So I don't fully understand why it doesn't work, I just know that this will make it work 🤔 

`<paper-icon-button>` uses `iron-a11y-keys-behavior` (we currently use 3.0.1) to support keyboard shortcuts. Something has happened with `<paper-icon-button>`, which prevents [the `iron-a11y-keys-behavior` `registered` callback](https://github.com/PolymerElements/iron-a11y-keys-behavior/blob/26910e31ec4057150dd6f97e3818385638212a43/iron-a11y-keys-behavior.js#L314-L316) from being called. When the paper-icon-button is attached to the DOM and the key event listeners are attached, it [misses](https://github.com/PolymerElements/iron-a11y-keys-behavior/blob/26910e31ec4057150dd6f97e3818385638212a43/iron-a11y-keys-behavior.js#L423) the variable `_keyBindings` which is being initialized in the `registered` callback.

I tried rolling back versions of dependencies but was unable to get it working again. I think that this has been caused by the migration to Lit, but we haven't experienced it yet in the main frontend.

So to unblock things, just adding a placeholder variable 🤷‍♂️ 