### PR TITLE
Add Stream Element

### DIFF
--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -19,6 +19,10 @@ class HaCameraStream extends LitElement {
   @property() public stateObj?: CameraEntity;
   private _hlsPolyfillInstance?: Hls;
 
+  public disconnectedCallback() {
+    this._teardownPlayback();
+  }
+
   protected render(): TemplateResult | void {
     return html`
       <video autoplay controls muted playsinline></video>

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -66,8 +66,7 @@ class HaCameraStream extends UpdatingElement {
     videoEl.autoplay = true;
     videoEl.controls = this.showControls;
     videoEl.muted = true;
-    // @ts-ignore
-    videoEl.playsinline = true;
+    videoEl.setAttribute("playsinline", "playsinline");
 
     // tslint:disable-next-line
     const Hls = ((await import(/* webpackChunkName: "hls.js" */ "hls.js")) as any)

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -6,6 +6,7 @@ import {
   html,
   CSSResult,
   css,
+  customElement,
 } from "lit-element";
 
 import computeStateName from "../common/entity/compute_state_name";
@@ -20,6 +21,7 @@ import { supportsFeature } from "../common/entity/supports-feature";
 
 type HLSModule = typeof import("hls.js");
 
+@customElement("ha-camera-stream")
 class HaCameraStream extends LitElement {
   @property() public hass?: HomeAssistant;
   @property() public stateObj?: CameraEntity;
@@ -202,4 +204,8 @@ class HaCameraStream extends LitElement {
   }
 }
 
-customElements.define("ha-camera-stream", HaCameraStream);
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-camera-stream": HaCameraStream;
+  }
+}

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -73,7 +73,7 @@ class HaCameraStream extends LitElement {
   protected updated(changedProps: PropertyValues) {
     super.updated(changedProps);
 
-    const stateObjChanged = changedProps.has("_attached");
+    const stateObjChanged = changedProps.has("stateObj");
     const attachedChanged = changedProps.has("_attached");
 
     const oldState = changedProps.get("stateObj") as this["stateObj"];

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -10,15 +10,25 @@ type HLSModule = typeof import("hls.js");
 class HaCameraStream extends UpdatingElement {
   @property() public hass?: HomeAssistant;
   @property() public stateObj?: CameraEntity;
+  @property() public showControls: boolean = false;
   private _hlsPolyfillInstance?: Hls;
+
+  public connectedCallback() {
+    super.connectedCallback();
+    // @ts-ignore
+    if (!this._hasRequestedUpdate) {
+      this.requestUpdate();
+    }
+  }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     this._teardownPlayback();
   }
 
-  protected updated(changedProps: PropertyValues) {
-    if (!changedProps.has("stateObj")) {
+  protected update(changedProps: PropertyValues) {
+    super.update(changedProps);
+    if (this.lastChild) {
       return;
     }
 
@@ -54,7 +64,7 @@ class HaCameraStream extends UpdatingElement {
     const videoEl = document.createElement("video");
     videoEl.style.width = "100%";
     videoEl.autoplay = true;
-    videoEl.controls = true;
+    videoEl.controls = this.showControls;
     videoEl.muted = true;
     // @ts-ignore
     videoEl.playsinline = true;
@@ -138,7 +148,6 @@ class HaCameraStream extends UpdatingElement {
     while (this.lastChild) {
       this.removeChild(this.lastChild);
     }
-    this.stateObj = undefined;
   }
 }
 

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -93,6 +93,7 @@ class HaCameraStream extends UpdatingElement {
 
   private async _renderHLSNative(videoEl: HTMLVideoElement, url: string) {
     videoEl.src = url;
+    this.appendChild(videoEl);
     await new Promise((resolve) =>
       videoEl.addEventListener("loadedmetadata", resolve)
     );

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -1,0 +1,137 @@
+import {
+  css,
+  CSSResult,
+  html,
+  LitElement,
+  property,
+  PropertyValues,
+  TemplateResult,
+} from "lit-element";
+
+import { HomeAssistant, CameraEntity } from "../types";
+import { fireEvent } from "../common/dom/fire_event";
+import { fetchStreamUrl } from "../data/camera";
+
+type HLSModule = typeof import("hls.js");
+
+class HaCameraStream extends LitElement {
+  @property() public hass?: HomeAssistant;
+  @property() public stateObj?: CameraEntity;
+  private _hlsPolyfillInstance?: Hls;
+
+  protected render(): TemplateResult | void {
+    return html`
+      <video autoplay controls muted playsinline></video>
+    `;
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    if (!changedProps.has("stateObj")) {
+      return;
+    }
+
+    const oldState = changedProps.get("stateObj") as this["stateObj"];
+    const oldEntityId = oldState ? oldState.entity_id : undefined;
+    const curEntityId = this.stateObj ? this.stateObj.entity_id : undefined;
+
+    // Same entity, ignore.
+    if (curEntityId === oldEntityId) {
+      return;
+    }
+
+    // Tear down if we have something and we need to build it up
+    if (oldEntityId) {
+      this._teardownPlayback();
+    }
+
+    if (curEntityId) {
+      this._startPlayback();
+    }
+  }
+
+  private async _startPlayback(): Promise<void> {
+    if (!this.stateObj) {
+      return;
+    }
+
+    // tslint:disable-next-line
+    const Hls = ((await import(/* webpackChunkName: "hls.js" */ "hls.js")) as any)
+      .default as HLSModule;
+    let hlsSupported = Hls.isSupported();
+
+    if (!hlsSupported) {
+      hlsSupported =
+        this._videoEl.canPlayType("application/vnd.apple.mpegurl") !== "";
+    }
+
+    if (hlsSupported) {
+      try {
+        const { url } = await fetchStreamUrl(
+          this.hass!,
+          this.stateObj.entity_id
+        );
+
+        if (Hls.isSupported()) {
+          this._renderHLSPolyfill(Hls, url);
+        } else {
+          this._renderHLSNative(url);
+        }
+        return;
+      } catch (err) {
+        // When an error happens, we will do nothing so we render mjpeg.
+        // TODO: Actually do something
+      }
+    }
+  }
+
+  private get _videoEl(): HTMLVideoElement {
+    return this.shadowRoot!.querySelector("video")! as HTMLVideoElement;
+  }
+
+  private async _renderHLSNative(url: string) {
+    const videoEl = this._videoEl;
+    videoEl.src = url;
+    await new Promise((resolve) =>
+      videoEl.addEventListener("loadedmetadata", resolve)
+    );
+    videoEl.play();
+  }
+
+  private async _renderHLSPolyfill(
+    // tslint:disable-next-line
+    Hls: HLSModule,
+    url: string
+  ) {
+    const hls = new Hls();
+    const videoEl = this._videoEl;
+    this._hlsPolyfillInstance = hls;
+    await new Promise((resolve) => {
+      hls.on(Hls.Events.MEDIA_ATTACHED, resolve);
+      hls.attachMedia(videoEl);
+    });
+    hls.loadSource(url);
+    videoEl.addEventListener("loadeddata", () =>
+      fireEvent(this, "iron-resize")
+    );
+  }
+
+  private _teardownPlayback(): any {
+    if (this._hlsPolyfillInstance) {
+      this._hlsPolyfillInstance.destroy();
+      this._hlsPolyfillInstance = undefined;
+    } else {
+      this._videoEl.src = "";
+    }
+    this.stateObj = undefined;
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      video {
+        width: 100%;
+      }
+    `;
+  }
+}
+
+customElements.define("ha-camera-stream", HaCameraStream);

--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -27,11 +27,6 @@ class MoreInfoCamera extends LitElement {
   @property() public stateObj?: CameraEntity;
   @property() private _cameraPrefs?: CameraPreferences;
 
-  public disconnectedCallback() {
-    super.disconnectedCallback();
-    this.stateObj = undefined;
-  }
-
   protected render(): TemplateResult | void {
     if (!this.hass || !this.stateObj) {
       return html``;

--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -27,6 +27,11 @@ class MoreInfoCamera extends LitElement {
   @property() public stateObj?: CameraEntity;
   @property() private _cameraPrefs?: CameraPreferences;
 
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this.stateObj = undefined;
+  }
+
   protected render(): TemplateResult | void {
     if (!this.hass || !this.stateObj) {
       return html``;
@@ -36,6 +41,7 @@ class MoreInfoCamera extends LitElement {
       <ha-camera-stream
         .hass="${this.hass}"
         .stateObj="${this.stateObj}"
+        showControls="true"
       ></ha-camera-stream>
       ${this._cameraPrefs
         ? html`

--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -68,7 +68,7 @@ class MoreInfoCamera extends LitElement {
             <ha-camera-stream
               .hass="${this.hass}"
               .stateObj="${this.stateObj}"
-            />
+            ></ha-camera-stream>
             ${this._cameraPrefs
               ? html`
                   <paper-checkbox

--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -41,7 +41,7 @@ class MoreInfoCamera extends LitElement {
       <ha-camera-stream
         .hass="${this.hass}"
         .stateObj="${this.stateObj}"
-        showControls="true"
+        showcontrols
       ></ha-camera-stream>
       ${this._cameraPrefs
         ? html`
@@ -72,9 +72,8 @@ class MoreInfoCamera extends LitElement {
 
     if (
       curEntityId &&
-      this.stateObj &&
       this.hass!.config.components.includes("stream") &&
-      supportsFeature(this.stateObj, CAMERA_SUPPORT_STREAM)
+      supportsFeature(this.stateObj!, CAMERA_SUPPORT_STREAM)
     ) {
       // Fetch in background while we set up the video.
       this._fetchCameraPrefs();

--- a/src/panels/lovelace/cards/hui-picture-elements-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.ts
@@ -60,6 +60,7 @@ class HuiPictureElementsCard extends LitElement implements LovelaceCard {
             .image="${this._config.image}"
             .stateImage="${this._config.state_image}"
             .cameraImage="${this._config.camera_image}"
+            .cameraView="${this._config.camera_view}"
             .entity="${this._config.entity}"
             .aspectRatio="${this._config.aspect_ratio}"
           ></hui-image>

--- a/src/panels/lovelace/cards/hui-picture-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.ts
@@ -108,6 +108,7 @@ class HuiPictureEntityCard extends LitElement implements LovelaceCard {
           .cameraImage="${computeDomain(this._config.entity) === "camera"
             ? this._config.entity
             : this._config.camera_image}"
+          .cameraView="${this._config.camera_view}"
           .entity="${this._config.entity}"
           .aspectRatio="${this._config.aspect_ratio}"
           @ha-click="${this._handleTap}"

--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -131,6 +131,7 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
           .image="${this._config.image}"
           .stateImage="${this._config.state_image}"
           .cameraImage="${this._config.camera_image}"
+          .cameraView="${this._config.camera_view}"
           .entity="${this._config.entity}"
           .aspectRatio="${this._config.aspect_ratio}"
         ></hui-image>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -2,6 +2,7 @@ import { LovelaceCardConfig, ActionConfig } from "../../../data/lovelace";
 import { Condition } from "../common/validate-condition";
 import { EntityConfig } from "../entity-rows/types";
 import { LovelaceElementConfig } from "../elements/types";
+import { HuiImage } from "../components/hui-image";
 
 export interface AlarmPanelCardConfig extends LovelaceCardConfig {
   entity: string;
@@ -129,7 +130,7 @@ export interface PictureElementsCardConfig extends LovelaceCardConfig {
   title?: string;
   image?: string;
   camera_image?: string;
-  camera_view?: string;
+  camera_view?: HuiImage["cameraView"];
   state_image?: {};
   aspect_ratio?: string;
   entity?: string;
@@ -141,7 +142,7 @@ export interface PictureEntityCardConfig extends LovelaceCardConfig {
   name?: string;
   image?: string;
   camera_image?: string;
-  camera_view?: string;
+  camera_view?: HuiImage["cameraView"];
   state_image?: {};
   aspect_ratio?: string;
   tap_action?: ActionConfig;
@@ -155,7 +156,7 @@ export interface PictureGlanceCardConfig extends LovelaceCardConfig {
   title?: string;
   image?: string;
   camera_image?: string;
-  camera_view?: string;
+  camera_view?: HuiImage["cameraView"];
   state_image?: {};
   aspect_ratio?: string;
   entity?: string;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -129,6 +129,7 @@ export interface PictureElementsCardConfig extends LovelaceCardConfig {
   title?: string;
   image?: string;
   camera_image?: string;
+  camera_view?: string;
   state_image?: {};
   aspect_ratio?: string;
   entity?: string;
@@ -140,6 +141,7 @@ export interface PictureEntityCardConfig extends LovelaceCardConfig {
   name?: string;
   image?: string;
   camera_image?: string;
+  camera_view?: string;
   state_image?: {};
   aspect_ratio?: string;
   tap_action?: ActionConfig;
@@ -153,6 +155,7 @@ export interface PictureGlanceCardConfig extends LovelaceCardConfig {
   title?: string;
   image?: string;
   camera_image?: string;
+  camera_view?: string;
   state_image?: {};
   aspect_ratio?: string;
   entity?: string;

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -14,7 +14,7 @@ import {
   query,
   customElement,
 } from "lit-element";
-import { HomeAssistant } from "../../../types";
+import { HomeAssistant, CameraEntity } from "../../../types";
 import { styleMap } from "lit-html/directives/style-map";
 import { classMap } from "lit-html/directives/class-map";
 import { b64toBlob } from "../../../common/file/b64-to-blob";
@@ -39,6 +39,8 @@ class HuiImage extends LitElement {
 
   @property() public cameraImage?: string;
 
+  @property() public cameraView?: string;
+
   @property() public aspectRatio?: string;
 
   @property() public filter?: string;
@@ -60,7 +62,9 @@ class HuiImage extends LitElement {
   public connectedCallback(): void {
     super.connectedCallback();
     this._attached = true;
-    this._startUpdateCameraInterval();
+    if (this.cameraImage && this.cameraView !== "live") {
+      this._startUpdateCameraInterval();
+    }
   }
 
   public disconnectedCallback(): void {
@@ -77,11 +81,17 @@ class HuiImage extends LitElement {
 
     // Figure out image source to use
     let imageSrc: string | undefined;
+    let cameraObj: CameraEntity | undefined;
     // Track if we are we using a fallback image, used for filter.
     let imageFallback = !this.stateImage;
 
     if (this.cameraImage) {
-      imageSrc = this._cameraImageSrc;
+      if (this.cameraView === "live") {
+        cameraObj =
+          this.hass && (this.hass.states[this.cameraImage] as CameraEntity);
+      } else {
+        imageSrc = this._cameraImageSrc;
+      }
     } else if (this.stateImage) {
       const stateImage = this.stateImage[state];
 
@@ -119,16 +129,25 @@ class HuiImage extends LitElement {
           ratio: Boolean(ratio && ratio.w > 0 && ratio.h > 0),
         })}
       >
-        <img
-          id="image"
-          src=${imageSrc}
-          @error=${this._onImageError}
-          @load=${this._onImageLoad}
-          style=${styleMap({
-            filter,
-            display: this._loadError ? "none" : "block",
-          })}
-        />
+        ${this.cameraImage && this.cameraView === "live"
+          ? html`
+              <ha-camera-stream
+                .hass="${this.hass}"
+                .stateObj="${cameraObj}"
+              ></ha-camera-stream>
+            `
+          : html`
+              <img
+                id="image"
+                src=${imageSrc}
+                @error=${this._onImageError}
+                @load=${this._onImageLoad}
+                style=${styleMap({
+                  filter,
+                  display: this._loadError ? "none" : "block",
+                })}
+              />
+            `}
         <div
           id="brokenImage"
           style=${styleMap({
@@ -141,7 +160,7 @@ class HuiImage extends LitElement {
   }
 
   protected updated(changedProps: PropertyValues): void {
-    if (changedProps.has("cameraImage")) {
+    if (changedProps.has("cameraImage") && this.cameraView !== "live") {
       this._updateCameraImageSrc();
       this._startUpdateCameraInterval();
       return;
@@ -197,7 +216,8 @@ class HuiImage extends LitElement {
 
   static get styles(): CSSResult {
     return css`
-      img {
+      img,
+      video {
         display: block;
         height: auto;
         transition: filter 0.2s linear;

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -28,7 +28,7 @@ export interface StateSpecificConfig {
 }
 
 @customElement("hui-image")
-class HuiImage extends LitElement {
+export class HuiImage extends LitElement {
   @property() public hass?: HomeAssistant;
 
   @property() public entity?: string;
@@ -39,7 +39,7 @@ class HuiImage extends LitElement {
 
   @property() public cameraImage?: string;
 
-  @property() public cameraView?: string;
+  @property() public cameraView?: "live" | "auto";
 
   @property() public aspectRatio?: string;
 
@@ -216,8 +216,7 @@ class HuiImage extends LitElement {
 
   static get styles(): CSSResult {
     return css`
-      img,
-      video {
+      img {
         display: block;
         height: auto;
         transition: filter 0.2s linear;


### PR DESCRIPTION
This PR abstracts the camera stream logic out to a new LitElement and uses it in `camera-more-info`, `hui-image`, and the `picture-*` lovelace cards.

It exposes `camera_view: live` to the lovelace config to enable the new stream element.  I will update docs and link that PR once this has been reviewed further.

![inline_video](https://user-images.githubusercontent.com/747670/56074338-5c75d780-5d7e-11e9-812c-6446c320d574.gif)

![fullscreen_video](https://user-images.githubusercontent.com/747670/56074354-aeb6f880-5d7e-11e9-8a13-4a04c2f61651.gif)
