### PR TITLE
Add device_class for switches

### DIFF
--- a/src/util/hass-attributes-util.js
+++ b/src/util/hass-attributes-util.js
@@ -36,6 +36,7 @@ hassAttributeUtil.DOMAIN_DEVICE_CLASS = {
     "power",
     "signal_strength",
   ],
+  switch: ["switch", "outlet"],
 };
 
 hassAttributeUtil.UNKNOWN_TYPE = "json";
@@ -78,7 +79,7 @@ hassAttributeUtil.LOGIC_STATE_ATTRIBUTES = hassAttributeUtil.LOGIC_STATE_ATTRIBU
     type: "array",
     options: hassAttributeUtil.DOMAIN_DEVICE_CLASS,
     description: "Device class",
-    domains: ["binary_sensor", "cover", "sensor"],
+    domains: ["binary_sensor", "cover", "sensor", "switch"],
   },
   hidden: { type: "boolean", description: "Hide from UI" },
   assumed_state: {


### PR DESCRIPTION
This allow selection of outlet as device_class in customization for use with:
https://github.com/home-assistant/home-assistant/pull/23149
