### PR TITLE
Ask users if they want to install iOS app

### DIFF
--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -9,6 +9,7 @@
     <link rel='apple-touch-icon' sizes='180x180'
           href='/static/icons/favicon-apple-180x180.png'>
     <link rel="mask-icon" href="/static/icons/mask-icon.svg" color="#03a9f4">
+    <meta name="apple-itunes-app" content="app-id=1099568401">
     <meta name='apple-mobile-web-app-capable' content='yes'>
     <meta name="msapplication-square70x70logo" content="/static/icons/tile-win-70x70.png"/>
     <meta name="msapplication-square150x150logo" content="/static/icons/tile-win-150x150.png"/>


### PR DESCRIPTION
This PR enables the [Smart App Banner](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/PromotingAppswithAppBanners/PromotingAppswithAppBanners.html) for the official iOS app. When users load frontend in Safari on iOS they will see the banner and can install the app with one click. If the user hides the banner, it will be hidden _forever_. If the user already has the app installed the banner doesn't appear.