### PR TITLE
WIP: Add support for a app configuration button in the sidebar

### DIFF
--- a/gulp/tasks/gen-icons.js
+++ b/gulp/tasks/gen-icons.js
@@ -22,6 +22,7 @@ const BUILT_IN_PANEL_ICONS = [
   "mailbox", // Mailbox
   "tooltip-account", // Map
   "cart", // Shopping List
+  "cellphone-settings-variant", // External App Configuration
 ];
 
 // Given an icon name, load the SVG file

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -117,6 +117,17 @@ class HaSidebar extends LitElement {
             </a>
           `
         )}
+        <a href="#external-app-configuration" tabindex="-1">
+          <paper-icon-item @click=${this._handleExternalAppConfiguration}>
+            <ha-icon
+              slot="item-icon"
+              icon="hass:cellphone-settings-variant"
+            ></ha-icon>
+            <span class="item-text"
+              >${hass.localize("ui.sidebar.external_app_configuration")}</span
+            >
+          </paper-icon-item>
+        </a>
         ${!hass.user
           ? html`
               <paper-icon-item @click=${this._handleLogOut} class="logout">
@@ -212,6 +223,10 @@ class HaSidebar extends LitElement {
 
   private _handleLogOut() {
     fireEvent(this, "hass-logout");
+  }
+
+  private _handleExternalAppConfiguration() {
+    fireEvent(this, "open-external-app-configuration");
   }
 
   static get styles(): CSSResult {

--- a/src/layouts/app/connection-mixin.js
+++ b/src/layouts/app/connection-mixin.js
@@ -16,6 +16,7 @@ import { getLocalLanguage } from "../../util/hass-translation";
 import { fetchWithAuth } from "../../util/fetch-with-auth";
 import hassCallApi from "../../util/hass-call-api";
 import { subscribePanels } from "../../data/ws-panels";
+import { fireEvent } from "../../common/dom/fire_event";
 
 export default (superClass) =>
   class extends EventsMixin(LocalizeMixin(superClass)) {
@@ -126,10 +127,14 @@ export default (superClass) =>
 
       const conn = this.hass.connection;
 
+      fireEvent(document, "connected");
+
       conn.addEventListener("ready", () => this.hassReconnected());
       conn.addEventListener("disconnected", () => this.hassDisconnected());
       // If we reconnect after losing connection and auth is no longer valid.
       conn.addEventListener("reconnect-error", (_conn, err) => {
+        fireEvent(document, "auth-invalid");
+
         if (err === ERR_INVALID_AUTH) location.reload();
       });
 
@@ -142,10 +147,12 @@ export default (superClass) =>
     hassReconnected() {
       super.hassReconnected();
       this._updateHass({ connected: true });
+      fireEvent(document, "connected");
     }
 
     hassDisconnected() {
       super.hassDisconnected();
       this._updateHass({ connected: false });
+      fireEvent(document, "disconnected");
     }
   };

--- a/src/polymer-types.ts
+++ b/src/polymer-types.ts
@@ -33,5 +33,8 @@ declare global {
       response: unknown;
     };
     "open-external-app-configuration": undefined;
+    "auth-invalid": undefined;
+    connected: undefined;
+    disconnected: undefined;
   }
 }

--- a/src/polymer-types.ts
+++ b/src/polymer-types.ts
@@ -32,5 +32,6 @@ declare global {
       success: boolean;
       response: unknown;
     };
+    "open-external-app-configuration": undefined;
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -924,6 +924,7 @@
             }
         },
         "sidebar": {
+            "external_app_configuration": "App Configuration",
             "log_out": "Log out",
             "developer_tools": "Developer tools"
         },


### PR DESCRIPTION
This PR adds a new button to the sidebar that when tapped will fire a JS event which can be caught by a external application to cause its native settings view to open.

![image](https://user-images.githubusercontent.com/18516/56453760-b4bb5500-62fb-11e9-803d-5050a1058268.png)

[Here's a little video too](https://cdn.discordapp.com/attachments/351047592588869643/569047305936699393/video.mov)