### PR TITLE
Allow 'Discovered' flows to have title placeholders

### DIFF
--- a/src/panels/config/integrations/ha-config-entries-dashboard.js
+++ b/src/panels/config/integrations/ha-config-entries-dashboard.js
@@ -64,7 +64,7 @@ class HaConfigManagerDashboard extends LocalizeMixin(
               <template is="dom-repeat" items="[[progress]]">
                 <div class="config-entry-row">
                   <paper-item-body>
-                    [[_computeIntegrationTitle(localize, item.handler)]]
+                    [[_computeActiveFlowTitle(localize, item)]]
                   </paper-item-body>
                   <mwc-button on-click="_continueFlow"
                     >[[localize('ui.panel.config.integrations.configure')]]</mwc-button
@@ -188,6 +188,23 @@ class HaConfigManagerDashboard extends LocalizeMixin(
 
   _computeIntegrationTitle(localize, integration) {
     return localize(`component.${integration}.config.title`);
+  }
+
+  _computeActiveFlowTitle(localize, integration) {
+    const placeholders = integration.context.placeholders || {};
+    const placeholderKeys = Object.keys(placeholders);
+    if (placeholderKeys.length === 0) {
+      return localize(`component.${integration.handler}.config.title`);
+    }
+    const args = [];
+    placeholderKeys.forEach((key) => {
+      args.push(key);
+      args.push(placeholders[key]);
+    });
+    return localize(
+      `component.${integration.handler}.config.flow_title`,
+      ...args
+    );
   }
 
   _computeConfigEntryEntities(hass, configEntry, entities) {

--- a/src/panels/config/integrations/ha-config-entries-dashboard.js
+++ b/src/panels/config/integrations/ha-config-entries-dashboard.js
@@ -191,7 +191,7 @@ class HaConfigManagerDashboard extends LocalizeMixin(
   }
 
   _computeActiveFlowTitle(localize, integration) {
-    const placeholders = integration.context.placeholders || {};
+    const placeholders = integration.context.title_placeholders || {};
     const placeholderKeys = Object.keys(placeholders);
     if (placeholderKeys.length === 0) {
       return localize(`component.${integration.handler}.config.title`);


### PR DESCRIPTION
This PR is a bit of a proof of concept and more about starting a conversation than anything else.

When I switch homekit_controller over to Config Entries (hopefully in 0.94) even though i know the name and model of the device there doesn't seem to be a mechanism to surface that in the 'Discovered' part of the Integrations panel. Instead I just see the localisation for `component.homekit_controller.config.title`.

This PR allows me to push a `placeholders` dict via a flows context which I can then fill into a new `flow_title` localisation. If there are no placeholders it continues to use the existing `title` localisation so existing integrations are not impacted.

![Screenshot 2019-04-20 at 15 30 21](https://user-images.githubusercontent.com/11544/56458793-0529c580-6383-11e9-9640-8a9ff06fd598.png)

This works, and doesn't require any changes on the server side for existing integrations. For integrations that want to do it, they can just poke a `placeholders` dict into self.context from their `async_step_discovery` and add a `flow_title` to their strings.json.

However it does feel like i'm breaking an abstraction or violating some layering by doing it this way so I thought it best to start a conversation about the "right way". Should I added a new key at the `context` level? Should there (is there?) a nicer way to set context during `async_step_discovery`? Should a flow have an optional title that can be concatenated together with the integration name (I think thats what happens with a config entry's title, for example).

@balloob what do you think? should i be doing this a different way?