### PR TITLE
Move picking new integration into dialog

### DIFF
--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -6,6 +6,12 @@ export interface FieldSchema {
   optional: boolean;
 }
 
+export interface ConfigFlowProgress {
+  flow_id: string;
+  handler: string;
+  context: { [key: string]: any };
+}
+
 export interface ConfigFlowStepForm {
   type: "form";
   flow_id: string;
@@ -62,3 +68,9 @@ export const handleConfigFlowStep = (
 
 export const deleteConfigFlow = (hass: HomeAssistant, flowId: string) =>
   hass.callApi("DELETE", `config/config_entries/flow/${flowId}`);
+
+export const getConfigFlowsInProgress = (hass: HomeAssistant) =>
+  hass.callApi<ConfigFlowProgress[]>("GET", "config/config_entries/flow");
+
+export const getConfigFlowHandlers = (hass: HomeAssistant) =>
+  hass.callApi<string[]>("GET", "config/config_entries/flow_handlers");

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -1,10 +1,7 @@
-import { HomeAssistant } from "../../types";
 import { fireEvent } from "../../common/dom/fire_event";
 
 export interface HaConfigFlowParams {
-  hass: HomeAssistant;
   continueFlowId?: string;
-  newFlowForHandler?: string;
   dialogClosedCallback: (params: { flowFinished: boolean }) => void;
 }
 

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -167,6 +167,8 @@ class StepFlowForm extends LitElement {
         toSendData
       );
 
+      // make sure we're still showing the same step as when we
+      // fired off request.
       if (!this.step || flowId !== this.step.flow_id) {
         return;
       }

--- a/src/dialogs/config-flow/step-flow-pick-handler.ts
+++ b/src/dialogs/config-flow/step-flow-pick-handler.ts
@@ -1,0 +1,67 @@
+import {
+  LitElement,
+  TemplateResult,
+  html,
+  css,
+  customElement,
+  CSSResult,
+} from "lit-element";
+import "@polymer/paper-spinner/paper-spinner-lite";
+import "@polymer/paper-item/paper-item";
+import "@polymer/paper-item/paper-item-body";
+import { HomeAssistant } from "../../types";
+import { createConfigFlow } from "../../data/config_entries";
+import { fireEvent } from "../../common/dom/fire_event";
+import "../../components/ha-icon-next";
+
+@customElement("step-flow-pick-handler")
+class StepFlowPickHandler extends LitElement {
+  public hass!: HomeAssistant;
+  public handlers!: string[];
+
+  protected render(): TemplateResult | void {
+    return html`
+      <h2>${this.hass.localize("ui.panel.config.integrations.new")}</h2>
+      <div>
+        ${this.handlers.map(
+          (handler) =>
+            html`
+              <paper-item @click=${this._handlerPicked} .handler=${handler}>
+                <paper-item-body>
+                  ${this.hass.localize(`component.${handler}.config.title`)}
+                </paper-item-body>
+                <ha-icon-next></ha-icon-next>
+              </paper-item>
+            `
+        )}
+      </div>
+    `;
+  }
+
+  private async _handlerPicked(ev) {
+    fireEvent(this, "flow-update", {
+      stepPromise: createConfigFlow(this.hass, ev.currentTarget.handler),
+    });
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      h2 {
+        padding-left: 16px;
+      }
+      div {
+        overflow: auto;
+        max-height: 600px;
+      }
+      paper-item {
+        cursor: pointer;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "step-flow-pick-handler": StepFlowPickHandler;
+  }
+}

--- a/src/panels/config/integrations/ha-config-entries-dashboard.js
+++ b/src/panels/config/integrations/ha-config-entries-dashboard.js
@@ -1,6 +1,7 @@
 import "@polymer/iron-flex-layout/iron-flex-layout-classes";
 import "@polymer/paper-tooltip/paper-tooltip";
 import "@material/mwc-button";
+import "@polymer/paper-fab/paper-fab";
 import "@polymer/paper-card/paper-card";
 import "@polymer/iron-icon/iron-icon";
 import "@polymer/paper-item/paper-item";
@@ -13,6 +14,7 @@ import "../../../layouts/hass-subpage";
 import "../../../resources/ha-style";
 import "../../../components/ha-icon-next";
 
+import { computeRTL } from "../../../common/util/compute_rtl";
 import "../ha-config-section";
 import EventsMixin from "../../../mixins/events-mixin";
 import LocalizeMixin from "../../../mixins/localize-mixin";
@@ -49,6 +51,28 @@ class HaConfigManagerDashboard extends LocalizeMixin(
         .configured a {
           color: var(--primary-text-color);
           text-decoration: none;
+        }
+        paper-fab {
+          position: fixed;
+          bottom: 16px;
+          right: 16px;
+          z-index: 1;
+        }
+
+        paper-fab[is-wide] {
+          bottom: 24px;
+          right: 24px;
+        }
+
+        paper-fab[rtl] {
+          right: auto;
+          left: 16px;
+        }
+
+        paper-fab[rtl][is-wide] {
+          bottom: 24px;
+          right: auto;
+          left: 24px;
         }
       </style>
 
@@ -119,23 +143,13 @@ class HaConfigManagerDashboard extends LocalizeMixin(
           </paper-card>
         </ha-config-section>
 
-        <ha-config-section>
-          <span slot="header"
-            >[[localize('ui.panel.config.integrations.new')]]</span
-          >
-          <paper-card>
-            <template is="dom-repeat" items="[[handlers]]">
-              <div class="config-entry-row">
-                <paper-item-body>
-                  [[_computeIntegrationTitle(localize, item)]]
-                </paper-item-body>
-                <mwc-button on-click="_createFlow"
-                  >[[localize('ui.panel.config.integrations.configure')]]</mwc-button
-                >
-              </div>
-            </template>
-          </paper-card>
-        </ha-config-section>
+        <paper-fab
+          icon="hass:plus"
+          title="[[localize('ui.panel.config.integrations.new')]]"
+          on-click="_createFlow"
+          is-wide$="[[isWide]]"
+          rtl$="[[rtl]]"
+        ></paper-fab>
       </hass-subpage>
     `;
   }
@@ -162,6 +176,12 @@ class HaConfigManagerDashboard extends LocalizeMixin(
       progress: Array,
 
       handlers: Array,
+
+      rtl: {
+        type: Boolean,
+        reflectToAttribute: true,
+        computed: "_computeRTL(hass)",
+      },
     };
   }
 
@@ -170,17 +190,14 @@ class HaConfigManagerDashboard extends LocalizeMixin(
     loadConfigFlowDialog();
   }
 
-  _createFlow(ev) {
+  _createFlow() {
     showConfigFlowDialog(this, {
-      hass: this.hass,
-      newFlowForHandler: ev.model.item,
       dialogClosedCallback: () => this.fire("hass-reload-entries"),
     });
   }
 
   _continueFlow(ev) {
     showConfigFlowDialog(this, {
-      hass: this.hass,
       continueFlowId: ev.model.item.flow_id,
       dialogClosedCallback: () => this.fire("hass-reload-entries"),
     });
@@ -212,6 +229,10 @@ class HaConfigManagerDashboard extends LocalizeMixin(
 
   _handleMoreInfo(ev) {
     this.fire("hass-more-info", { entityId: ev.model.item.entity_id });
+  }
+
+  _computeRTL(hass) {
+    return computeRTL(hass);
   }
 }
 


### PR DESCRIPTION
The final step before we can add setting up integrations into onboarding:

This moves the "pick new integration card" into the dialog as the first step.

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/1444314/56484112-c9762500-6482-11e9-9f37-ca417188d0f1.png">

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/1444314/56484121-d266f680-6482-11e9-9065-8bce324bbf5c.png">
