### PR TITLE
Don't proxy external accessible covers

### DIFF
--- a/src/cards/ha-media_player-card.js
+++ b/src/cards/ha-media_player-card.js
@@ -279,6 +279,14 @@ class HaMediaPlayerCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
     }
 
     // We have a new picture url
+    // If entity picture is non-relative, we use that url directly.
+    if (picture.substr(0, 1) !== "/") {
+      this._coverShowing = true;
+      this._coverLoadError = false;
+      this.$.cover.style.backgroundImage = `url(${picture})`;
+      return;
+    }
+
     try {
       const {
         content_type: contentType,


### PR DESCRIPTION
Requires https://github.com/home-assistant/home-assistant/pull/23337

When a media player has an external accessible cover, don't proxy the data through Home Assistant backend.