### PR TITLE
Use named slots to have advanced ha-card headers

### DIFF
--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -28,19 +28,21 @@ class HaCard extends LitElement {
         display: block;
         transition: all 0.3s ease-out;
       }
-      .header:not(:empty) {
+      .header:not(:empty),
+      .header::slotted(*) {
         font-size: 24px;
         letter-spacing: -0.012em;
         line-height: 32px;
         opacity: 0.87;
         padding: 24px 16px 16px;
+        display: block;
       }
     `;
   }
 
   protected render(): TemplateResult {
     return html`
-      <div class="header">${this.header}</div>
+      <slot class="header" name="header">${this.header}</slot>
       <slot></slot>
     `;
   }

--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -30,10 +30,11 @@ class HaCard extends LitElement {
       }
       .header:not(:empty),
       .header::slotted(*) {
-        font-size: 24px;
+        color: var(--ha-card-header-color, --primary-text-color);
+        font-family: var(--ha-card-header-font-family, inherit);
+        font-size: var(--ha-card-header-font-size, 24px);
         letter-spacing: -0.012em;
         line-height: 32px;
-        opacity: 0.87;
         padding: 24px 16px 16px;
         display: block;
       }

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -89,7 +89,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
         ${!title && !show_header_toggle
           ? html``
           : html`
-              <div class="header">
+              <div class="header" slot="header">
                 <div class="name">${title}</div>
                 ${show_header_toggle === false
                   ? html``
@@ -114,12 +114,8 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
   static get styles(): CSSResult {
     return css`
-      ha-card {
-        padding: 16px;
-      }
-
       #states {
-        margin: -4px 0;
+        padding: 12px 16px;
       }
 
       #states > * {
@@ -131,28 +127,16 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
       }
 
       .header {
-        /* start paper-font-headline style */
-        font-family: "Roboto", "Noto", sans-serif;
-        -webkit-font-smoothing: antialiased; /* OS X subpixel AA bleed bug */
-        text-rendering: optimizeLegibility;
-        font-size: 24px;
-        font-weight: 400;
-        letter-spacing: -0.012em;
-        /* end paper-font-headline style */
-
-        line-height: 40px;
-        color: var(--primary-text-color);
-        padding: 4px 0 12px;
+        margin-bottom: -8px;
+        padding-bottom: 0px;
         display: flex;
         justify-content: space-between;
       }
 
       .header .name {
-        /* start paper-font-common-nowrap style */
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        /* end paper-font-common-nowrap */
       }
 
       .state-card-dialog {


### PR DESCRIPTION
In the discussions for #2701 I mentioned I tried to use named slots in ha-card for "advanced" headers, like the entities-card one with the toggle.

I finally came up with a way to make it work.

This avoids code duplication w.r.t. things like header font size and stuff.