### PR TITLE
Simplify list selection

### DIFF
--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -200,8 +200,9 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <paper-listbox
                   slot="dropdown-content"
-                  selected="{{operationMode}}"
+                  selected="[[stateObj.attributes.operation_mode]]"
                   attr-for-selected="item-name"
+                  on-selected-changed="handleOperationmodeChanged"
                 >
                   <template
                     is="dom-repeat"
@@ -226,8 +227,9 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
             >
               <paper-listbox
                 slot="dropdown-content"
-                selected="{{fanMode}}"
+                selected="[[stateObj.attributes.fan_mode]]"
                 attr-for-selected="item-name"
+                on-selected-changed="handleFanmodeChanged"
               >
                 <template
                   is="dom-repeat"
@@ -251,8 +253,9 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
             >
               <paper-listbox
                 slot="dropdown-content"
-                selected="{{swingMode}}"
+                selected="[[stateObj.attributes.swing_mode]]"
                 attr-for-selected="item-name"
+                on-selected-changed="handleSwingmodeChanged"
               >
                 <template
                   is="dom-repeat"
@@ -305,23 +308,6 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: "stateObjChanged",
       },
 
-      operationMode: {
-        type: String,
-        value: "",
-        observer: "handleOperationmodeChanged",
-      },
-
-      fanMode: {
-        type: String,
-        value: "",
-        observer: "handleFanmodeChanged",
-      },
-
-      swingMode: {
-        type: String,
-        value: "",
-        observer: "handleSwingmodeChanged",
-      },
       awayToggleChecked: Boolean,
       auxToggleChecked: Boolean,
       onToggleChecked: Boolean,
@@ -340,9 +326,6 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
         awayToggleChecked: newVal.attributes.away_mode === "on",
         auxToggleChecked: newVal.attributes.aux_heat === "on",
         onToggleChecked: newVal.state !== "off",
-        operationMode: newVal.attributes.operation_mode,
-        fanMode: newVal.attributes.fan_mode,
-        swingMode: newVal.attributes.swing_mode,
       });
     }
 
@@ -498,30 +481,27 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this.callServiceHelper(newVal ? "turn_on" : "turn_off", {});
   }
 
-  handleFanmodeChanged(fanMode) {
-    // Selected Option will transition to '' before transitioning to new value
-    if (fanMode && fanMode !== this.stateObj.attributes.fan_mode) {
-      this.callServiceHelper("set_fan_mode", { fan_mode: fanMode });
-    }
+  handleFanmodeChanged(ev) {
+    const oldVal = this.stateObj.attributes.fan_mode;
+    const newVal = ev.detail.value;
+    if (!newVal || oldVal === newVal) return;
+    this.callServiceHelper("set_fan_mode", { fan_mode: newVal });
   }
 
-  handleOperationmodeChanged(operationMode) {
-    // Selected Option will transition to '' before transitioning to new value
-    if (
-      operationMode &&
-      operationMode !== this.stateObj.attributes.operation_mode
-    ) {
-      this.callServiceHelper("set_operation_mode", {
-        operation_mode: operationMode,
-      });
-    }
+  handleOperationmodeChanged(ev) {
+    const oldVal = this.stateObj.attributes.operation_mode;
+    const newVal = ev.detail.value;
+    if (!newVal || oldVal === newVal) return;
+    this.callServiceHelper("set_operation_mode", {
+      operation_mode: newVal,
+    });
   }
 
-  handleSwingmodeChanged(swingMode) {
-    // Selected Option will transition to '' before transitioning to new value
-    if (swingMode && swingMode !== this.stateObj.attributes.swing_mode) {
-      this.callServiceHelper("set_swing_mode", { swing_mode: swingMode });
-    }
+  handleSwingmodeChanged(ev) {
+    const oldVal = this.stateObj.attributes.swing_mode;
+    const newVal = ev.detail.value;
+    if (!newVal || oldVal === newVal) return;
+    this.callServiceHelper("set_swing_mode", { swing_mode: newVal });
   }
 
   callServiceHelper(service, data) {

--- a/src/dialogs/more-info/controls/more-info-climate.js
+++ b/src/dialogs/more-info/controls/more-info-climate.js
@@ -200,14 +200,14 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <paper-listbox
                   slot="dropdown-content"
-                  selected="{{operationIndex}}"
+                  selected="{{operationMode}}"
+                  attr-for-selected="item-name"
                 >
                   <template
                     is="dom-repeat"
                     items="[[stateObj.attributes.operation_list]]"
-                    on-dom-change="handleOperationListUpdate"
                   >
-                    <paper-item
+                    <paper-item item-name$="[[item]]"
                       >[[_localizeOperationMode(localize, item)]]</paper-item
                     >
                   </template>
@@ -224,13 +224,18 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
               dynamic-align=""
               label="[[localize('ui.card.climate.fan_mode')]]"
             >
-              <paper-listbox slot="dropdown-content" selected="{{fanIndex}}">
+              <paper-listbox
+                slot="dropdown-content"
+                selected="{{fanMode}}"
+                attr-for-selected="item-name"
+              >
                 <template
                   is="dom-repeat"
                   items="[[stateObj.attributes.fan_list]]"
-                  on-dom-change="handleFanListUpdate"
                 >
-                  <paper-item>[[_localizeFanMode(localize, item)]]</paper-item>
+                  <paper-item item-name$="[[item]]"
+                    >[[_localizeFanMode(localize, item)]]
+                  </paper-item>
                 </template>
               </paper-listbox>
             </ha-paper-dropdown-menu>
@@ -244,13 +249,16 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
               dynamic-align=""
               label="[[localize('ui.card.climate.swing_mode')]]"
             >
-              <paper-listbox slot="dropdown-content" selected="{{swingIndex}}">
+              <paper-listbox
+                slot="dropdown-content"
+                selected="{{swingMode}}"
+                attr-for-selected="item-name"
+              >
                 <template
                   is="dom-repeat"
                   items="[[stateObj.attributes.swing_list]]"
-                  on-dom-change="handleSwingListUpdate"
                 >
-                  <paper-item>[[item]]</paper-item>
+                  <paper-item item-name$="[[item]]">[[item]]</paper-item>
                 </template>
               </paper-listbox>
             </ha-paper-dropdown-menu>
@@ -297,21 +305,21 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: "stateObjChanged",
       },
 
-      operationIndex: {
-        type: Number,
-        value: -1,
+      operationMode: {
+        type: String,
+        value: "",
         observer: "handleOperationmodeChanged",
       },
 
-      fanIndex: {
-        type: Number,
-        value: -1,
+      fanMode: {
+        type: String,
+        value: "",
         observer: "handleFanmodeChanged",
       },
 
-      swingIndex: {
-        type: Number,
-        value: -1,
+      swingMode: {
+        type: String,
+        value: "",
         observer: "handleSwingmodeChanged",
       },
       awayToggleChecked: Boolean,
@@ -332,6 +340,9 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
         awayToggleChecked: newVal.attributes.away_mode === "on",
         auxToggleChecked: newVal.attributes.aux_heat === "on",
         onToggleChecked: newVal.state !== "off",
+        operationMode: newVal.attributes.operation_mode,
+        fanMode: newVal.attributes.fan_mode,
+        swingMode: newVal.attributes.swing_mode,
       });
     }
 
@@ -342,36 +353,6 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
         () => {
           this.fire("iron-resize");
         }
-      );
-    }
-  }
-
-  handleOperationListUpdate() {
-    // force polymer to recognize selected item change (to update actual label)
-    this.operationIndex = -1;
-    if (this.stateObj.attributes.operation_list) {
-      this.operationIndex = this.stateObj.attributes.operation_list.indexOf(
-        this.stateObj.attributes.operation_mode
-      );
-    }
-  }
-
-  handleSwingListUpdate() {
-    // force polymer to recognize selected item change (to update actual label)
-    this.swingIndex = -1;
-    if (this.stateObj.attributes.swing_list) {
-      this.swingIndex = this.stateObj.attributes.swing_list.indexOf(
-        this.stateObj.attributes.swing_mode
-      );
-    }
-  }
-
-  handleFanListUpdate() {
-    // force polymer to recognize selected item change (to update actual label)
-    this.fanIndex = -1;
-    if (this.stateObj.attributes.fan_list) {
-      this.fanIndex = this.stateObj.attributes.fan_list.indexOf(
-        this.stateObj.attributes.fan_mode
       );
     }
   }
@@ -517,33 +498,30 @@ class MoreInfoClimate extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this.callServiceHelper(newVal ? "turn_on" : "turn_off", {});
   }
 
-  handleFanmodeChanged(fanIndex) {
+  handleFanmodeChanged(fanMode) {
     // Selected Option will transition to '' before transitioning to new value
-    if (fanIndex === "" || fanIndex === -1) return;
-    const fanInput = this.stateObj.attributes.fan_list[fanIndex];
-    if (fanInput === this.stateObj.attributes.fan_mode) return;
-    this.callServiceHelper("set_fan_mode", { fan_mode: fanInput });
+    if (fanMode && fanMode !== this.stateObj.attributes.fan_mode) {
+      this.callServiceHelper("set_fan_mode", { fan_mode: fanMode });
+    }
   }
 
-  handleOperationmodeChanged(operationIndex) {
+  handleOperationmodeChanged(operationMode) {
     // Selected Option will transition to '' before transitioning to new value
-    if (operationIndex === "" || operationIndex === -1) return;
-    const operationInput = this.stateObj.attributes.operation_list[
-      operationIndex
-    ];
-    if (operationInput === this.stateObj.attributes.operation_mode) return;
-
-    this.callServiceHelper("set_operation_mode", {
-      operation_mode: operationInput,
-    });
+    if (
+      operationMode &&
+      operationMode !== this.stateObj.attributes.operation_mode
+    ) {
+      this.callServiceHelper("set_operation_mode", {
+        operation_mode: operationMode,
+      });
+    }
   }
 
-  handleSwingmodeChanged(swingIndex) {
+  handleSwingmodeChanged(swingMode) {
     // Selected Option will transition to '' before transitioning to new value
-    if (swingIndex === "" || swingIndex === -1) return;
-    const swingInput = this.stateObj.attributes.swing_list[swingIndex];
-    if (swingInput === this.stateObj.attributes.swing_mode) return;
-    this.callServiceHelper("set_swing_mode", { swing_mode: swingInput });
+    if (swingMode && swingMode !== this.stateObj.attributes.swing_mode) {
+      this.callServiceHelper("set_swing_mode", { swing_mode: swingMode });
+    }
   }
 
   callServiceHelper(service, data) {

--- a/src/dialogs/more-info/controls/more-info-fan.js
+++ b/src/dialogs/more-info/controls/more-info-fan.js
@@ -51,7 +51,8 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
           >
             <paper-listbox
               slot="dropdown-content"
-              selected="{{speed}}"
+              selected="[[stateObj.attributes.speed]]"
+              on-selected-changed="speedChanged"
               attr-for-selected="item-name"
             >
               <template
@@ -112,12 +113,6 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: "stateObjChanged",
       },
 
-      speed: {
-        type: String,
-        value: "",
-        observer: "speedChanged",
-      },
-
       oscillationToggleChecked: {
         type: Boolean,
       },
@@ -128,7 +123,6 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
     if (newVal) {
       this.setProperties({
         oscillationToggleChecked: newVal.attributes.oscillating,
-        speed: newVal.attributes.speed,
       });
     }
 
@@ -146,13 +140,16 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
     );
   }
 
-  speedChanged(speed) {
-    if (speed && speed !== this.stateObj.attributes.speed) {
-      this.hass.callService("fan", "turn_on", {
-        entity_id: this.stateObj.entity_id,
-        speed: speed,
-      });
-    }
+  speedChanged(ev) {
+    var oldVal = this.stateObj.attributes.speed;
+    var newVal = ev.detail.value;
+
+    if (!newVal || oldVal === newVal) return;
+
+    this.hass.callService("fan", "turn_on", {
+      entity_id: this.stateObj.entity_id,
+      speed: newVal,
+    });
   }
 
   oscillationToggleChanged(ev) {

--- a/src/dialogs/more-info/controls/more-info-fan.js
+++ b/src/dialogs/more-info/controls/more-info-fan.js
@@ -49,12 +49,16 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
             dynamic-align=""
             label="[[localize('ui.card.fan.speed')]]"
           >
-            <paper-listbox slot="dropdown-content" selected="{{speedIndex}}">
+            <paper-listbox
+              slot="dropdown-content"
+              selected="{{speed}}"
+              attr-for-selected="item-name"
+            >
               <template
                 is="dom-repeat"
                 items="[[stateObj.attributes.speed_list]]"
               >
-                <paper-item>[[item]]</paper-item>
+                <paper-item item-name$="[[item]]">[[item]]</paper-item>
               </template>
             </paper-listbox>
           </ha-paper-dropdown-menu>
@@ -108,9 +112,9 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: "stateObjChanged",
       },
 
-      speedIndex: {
-        type: Number,
-        value: -1,
+      speed: {
+        type: String,
+        value: "",
         observer: "speedChanged",
       },
 
@@ -124,9 +128,7 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
     if (newVal) {
       this.setProperties({
         oscillationToggleChecked: newVal.attributes.oscillating,
-        speedIndex: newVal.attributes.speed_list
-          ? newVal.attributes.speed_list.indexOf(newVal.attributes.speed)
-          : -1,
+        speed: newVal.attributes.speed,
       });
     }
 
@@ -144,18 +146,13 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
     );
   }
 
-  speedChanged(speedIndex) {
-    var speedInput;
-    // Selected Option will transition to '' before transitioning to new value
-    if (speedIndex === "" || speedIndex === -1) return;
-
-    speedInput = this.stateObj.attributes.speed_list[speedIndex];
-    if (speedInput === this.stateObj.attributes.speed) return;
-
-    this.hass.callService("fan", "turn_on", {
-      entity_id: this.stateObj.entity_id,
-      speed: speedInput,
-    });
+  speedChanged(speed) {
+    if (speed && speed !== this.stateObj.attributes.speed) {
+      this.hass.callService("fan", "turn_on", {
+        entity_id: this.stateObj.entity_id,
+        speed: speed,
+      });
+    }
   }
 
   oscillationToggleChanged(ev) {

--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -157,7 +157,8 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
             <paper-listbox
               slot="dropdown-content"
               attr-for-selected="item-name"
-              selected="{{SourceInput}}"
+              selected="[[playerObj.source]]"
+              on-selected-changed="handleSourceChanged"
             >
               <template is="dom-repeat" items="[[playerObj.sourceList]]">
                 <paper-item item-name$="[[item]]">[[item]]</paper-item>
@@ -178,7 +179,8 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
               <paper-listbox
                 slot="dropdown-content"
                 attr-for-selected="item-name"
-                selected="{{SoundModeInput}}"
+                selected="[[playerObj.soundMode]]"
+                on-selected-changed="handleSoundModeChanged"
               >
                 <template is="dom-repeat" items="[[playerObj.soundModeList]]">
                   <paper-item item-name$="[[item]]">[[item]]</paper-item>
@@ -218,18 +220,6 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: "playerObjChanged",
       },
 
-      SourceInput: {
-        type: String,
-        value: "",
-        observer: "handleSourceChanged",
-      },
-
-      SoundModeInput: {
-        type: String,
-        value: "",
-        observer: "handleSoundModeChanged",
-      },
-
       ttsLoaded: {
         type: Boolean,
         computed: "computeTTSLoaded(hass)",
@@ -252,14 +242,6 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
   }
 
   playerObjChanged(newVal, oldVal) {
-    if (newVal && newVal.sourceList !== undefined) {
-      this.SourceInput = newVal.source;
-    }
-
-    if (newVal && newVal.soundModeList !== undefined) {
-      this.SoundModeInput = newVal.soundMode;
-    }
-
     if (oldVal) {
       setTimeout(() => {
         this.fire("iron-resize");
@@ -346,26 +328,26 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this.playerObj.nextTrack();
   }
 
-  handleSourceChanged(newVal, oldVal) {
-    // Selected Option will transition to '' before transitioning to new value
-    if (
-      oldVal &&
-      newVal &&
-      newVal !== this.playerObj.source &&
-      this.playerObj.supportsSelectSource
-    ) {
-      this.playerObj.selectSource(newVal);
-    }
+  handleSourceChanged(ev) {
+    if (!this.playerObj) return;
+
+    var oldVal = this.playerObj.source;
+    var newVal = ev.detail.value;
+
+    if (!newVal || oldVal === newVal) return;
+
+    this.playerObj.selectSource(newVal);
   }
 
-  handleSoundModeChanged(newVal, oldVal) {
-    if (
-      oldVal &&
-      newVal !== this.playerObj.soundMode &&
-      this.playerObj.supportsSelectSoundMode
-    ) {
-      this.playerObj.selectSoundMode(newVal);
-    }
+  handleSoundModeChanged(ev) {
+    if (!this.playerObj) return;
+
+    var oldVal = this.playerObj.soundMode;
+    var newVal = ev.detail.value;
+
+    if (!newVal || oldVal === newVal) return;
+
+    this.playerObj.selectSoundMode(newVal);
   }
 
   handleVolumeTap() {

--- a/src/dialogs/more-info/controls/more-info-water_heater.js
+++ b/src/dialogs/more-info/controls/more-info-water_heater.js
@@ -102,6 +102,7 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
                   slot="dropdown-content"
                   selected="{{operationMode}}"
                   attr-for-selected="item-name"
+                  on-selected-changed="handleOperationmodeChanged"
                 >
                   <template
                     is="dom-repeat"
@@ -146,11 +147,6 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: "stateObjChanged",
       },
 
-      operationMode: {
-        type: String,
-        value: "",
-        observer: "handleOperationmodeChanged",
-      },
       awayToggleChecked: Boolean,
     };
   }
@@ -230,16 +226,13 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this.callServiceHelper("set_away_mode", { away_mode: newVal });
   }
 
-  handleOperationmodeChanged(operationMode) {
-    // Selected Option will transition to '' before transitioning to new value
-    if (
-      operationMode &&
-      operationMode !== this.stateObj.attributes.operation_mode
-    ) {
-      this.callServiceHelper("set_operation_mode", {
-        operation_mode: operationMode,
-      });
-    }
+  handleOperationmodeChanged(ev) {
+    const oldVal = this.stateObj.attributes.operation_mode;
+    const newVal = ev.detail.value;
+    if (!newVal || oldVal === newVal) return;
+    this.callServiceHelper("set_operation_mode", {
+      operation_mode: newVal,
+    });
   }
 
   callServiceHelper(service, data) {

--- a/src/dialogs/more-info/controls/more-info-water_heater.js
+++ b/src/dialogs/more-info/controls/more-info-water_heater.js
@@ -100,14 +100,14 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <paper-listbox
                   slot="dropdown-content"
-                  selected="{{operationIndex}}"
+                  selected="{{operationMode}}"
+                  attr-for-selected="item-name"
                 >
                   <template
                     is="dom-repeat"
                     items="[[stateObj.attributes.operation_list]]"
-                    on-dom-change="handleOperationListUpdate"
                   >
-                    <paper-item
+                    <paper-item item-name$="[[item]]"
                       >[[_localizeOperationMode(localize, item)]]</paper-item
                     >
                   </template>
@@ -146,9 +146,9 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
         observer: "stateObjChanged",
       },
 
-      operationIndex: {
-        type: Number,
-        value: -1,
+      operationMode: {
+        type: String,
+        value: "",
         observer: "handleOperationmodeChanged",
       },
       awayToggleChecked: Boolean,
@@ -159,6 +159,7 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
     if (newVal) {
       this.setProperties({
         awayToggleChecked: newVal.attributes.away_mode === "on",
+        operationMode: newVal.attributes.operation_mode,
       });
     }
 
@@ -169,16 +170,6 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
         () => {
           this.fire("iron-resize");
         }
-      );
-    }
-  }
-
-  handleOperationListUpdate() {
-    // force polymer to recognize selected item change (to update actual label)
-    this.operationIndex = -1;
-    if (this.stateObj.attributes.operation_list) {
-      this.operationIndex = this.stateObj.attributes.operation_list.indexOf(
-        this.stateObj.attributes.operation_mode
       );
     }
   }
@@ -239,17 +230,16 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this.callServiceHelper("set_away_mode", { away_mode: newVal });
   }
 
-  handleOperationmodeChanged(operationIndex) {
+  handleOperationmodeChanged(operationMode) {
     // Selected Option will transition to '' before transitioning to new value
-    if (operationIndex === "" || operationIndex === -1) return;
-    const operationInput = this.stateObj.attributes.operation_list[
-      operationIndex
-    ];
-    if (operationInput === this.stateObj.attributes.operation_mode) return;
-
-    this.callServiceHelper("set_operation_mode", {
-      operation_mode: operationInput,
-    });
+    if (
+      operationMode &&
+      operationMode !== this.stateObj.attributes.operation_mode
+    ) {
+      this.callServiceHelper("set_operation_mode", {
+        operation_mode: operationMode,
+      });
+    }
   }
 
   callServiceHelper(service, data) {

--- a/src/dialogs/more-info/controls/more-info-water_heater.js
+++ b/src/dialogs/more-info/controls/more-info-water_heater.js
@@ -100,7 +100,7 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <paper-listbox
                   slot="dropdown-content"
-                  selected="{{operationMode}}"
+                  selected="[[stateObj.attributes.operation_mode]]"
                   attr-for-selected="item-name"
                   on-selected-changed="handleOperationmodeChanged"
                 >
@@ -155,7 +155,6 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
     if (newVal) {
       this.setProperties({
         awayToggleChecked: newVal.attributes.away_mode === "on",
-        operationMode: newVal.attributes.operation_mode,
       });
     }
 


### PR DESCRIPTION
This is a simplification of listbox selected usage.

By using attr-for-selected and listening for the on-selected-changed property, the extra
property used for selected item can fully be dropped.

The first stage commits in this pull contain the same approach previously added by just avoiding the index usage. But i think the full change make more sense.