### PR TITLE
Dont cache requests to auth APIs

### DIFF
--- a/src/entrypoints/service-worker-hass.js
+++ b/src/entrypoints/service-worker-hass.js
@@ -15,7 +15,7 @@ function initRouting() {
 
   // Get api from network.
   workbox.routing.registerRoute(
-    new RegExp(`${location.host}/api/.*`),
+    new RegExp(`${location.host}/(api|auth)/.*`),
     new workbox.strategies.NetworkOnly()
   );
 


### PR DESCRIPTION
Make sure we bypass the service worker when fetching the login page.