### PR TITLE
add target="_blank" to match all other links on page

### DIFF
--- a/src/panels/config/automation/ha-automation-picker.js
+++ b/src/panels/config/automation/ha-automation-picker.js
@@ -85,7 +85,7 @@ class HaAutomationPicker extends LocalizeMixin(NavigateMixin(PolymerElement)) {
               <a
                 href="https://home-assistant.io/docs/automation/editor/"
                 target="_blank"
-          >
+              >
                 [[localize('ui.panel.config.automation.picker.learn_more')]]
               </a>
             </p>

--- a/src/panels/config/automation/ha-automation-picker.js
+++ b/src/panels/config/automation/ha-automation-picker.js
@@ -82,10 +82,10 @@ class HaAutomationPicker extends LocalizeMixin(NavigateMixin(PolymerElement)) {
           <div slot="introduction">
             [[localize('ui.panel.config.automation.picker.introduction')]]
             <p>
-              <a 
+              <a
                 href="https://home-assistant.io/docs/automation/editor/"
                 target="_blank"
-                >
+          >
                 [[localize('ui.panel.config.automation.picker.learn_more')]]
               </a>
             </p>

--- a/src/panels/config/automation/ha-automation-picker.js
+++ b/src/panels/config/automation/ha-automation-picker.js
@@ -82,7 +82,7 @@ class HaAutomationPicker extends LocalizeMixin(NavigateMixin(PolymerElement)) {
           <div slot="introduction">
             [[localize('ui.panel.config.automation.picker.introduction')]]
             <p>
-              <a href="https://home-assistant.io/docs/automation/editor/">
+              <a href="https://home-assistant.io/docs/automation/editor/" target="_blank">
                 [[localize('ui.panel.config.automation.picker.learn_more')]]
               </a>
             </p>

--- a/src/panels/config/automation/ha-automation-picker.js
+++ b/src/panels/config/automation/ha-automation-picker.js
@@ -82,7 +82,10 @@ class HaAutomationPicker extends LocalizeMixin(NavigateMixin(PolymerElement)) {
           <div slot="introduction">
             [[localize('ui.panel.config.automation.picker.introduction')]]
             <p>
-              <a href="https://home-assistant.io/docs/automation/editor/" target="_blank">
+              <a 
+                href="https://home-assistant.io/docs/automation/editor/"
+                target="_blank"
+                >
                 [[localize('ui.panel.config.automation.picker.learn_more')]]
               </a>
             </p>

--- a/src/panels/config/js/automation.js
+++ b/src/panels/config/js/automation.js
@@ -74,7 +74,8 @@ export default class Automation extends Component {
             </p>
             <a href="https://home-assistant.io/docs/automation/trigger/"
               target="_blank"
-              >{localize(
+              >
+                {localize(
                 "ui.panel.config.automation.editor.triggers.learn_more"
               )}
             </a>
@@ -99,7 +100,8 @@ export default class Automation extends Component {
             </p>
             <a href="https://home-assistant.io/docs/scripts/conditions/"
               target="_blank"
-              >{localize(
+              >
+                {localize(
                 "ui.panel.config.automation.editor.conditions.learn_more"
               )}
             </a>
@@ -124,7 +126,8 @@ export default class Automation extends Component {
             </p>
             <a href="https://home-assistant.io/docs/automation/action/"
               target="_blank"
-              >{localize("ui.panel.config.automation.editor.actions.learn_more")}
+              >
+                {localize("ui.panel.config.automation.editor.actions.learn_more")}
             </a>
           </span>
           <Script

--- a/src/panels/config/js/automation.js
+++ b/src/panels/config/js/automation.js
@@ -72,10 +72,11 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.triggers.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/automation/trigger/"
+            <a
+              href="https://home-assistant.io/docs/automation/trigger/"
               target="_blank"
-              >
-                {localize(
+            >
+              {localize(
                 "ui.panel.config.automation.editor.triggers.learn_more"
               )}
             </a>
@@ -98,10 +99,11 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.conditions.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/scripts/conditions/"
+            <a
+              href="https://home-assistant.io/docs/scripts/conditions/"
               target="_blank"
-              >
-                {localize(
+            >
+              {localize(
                 "ui.panel.config.automation.editor.conditions.learn_more"
               )}
             </a>
@@ -124,10 +126,11 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.actions.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/automation/action/"
+            <a
+              href="https://home-assistant.io/docs/automation/action/"
               target="_blank"
-              >
-                {localize("ui.panel.config.automation.editor.actions.learn_more")}
+            >
+              {localize("ui.panel.config.automation.editor.actions.learn_more")}
             </a>
           </span>
           <Script

--- a/src/panels/config/js/automation.js
+++ b/src/panels/config/js/automation.js
@@ -72,8 +72,9 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.triggers.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/automation/trigger/" target="_blank">
-              {localize(
+            <a href="https://home-assistant.io/docs/automation/trigger/"
+              target="_blank"
+              >{localize(
                 "ui.panel.config.automation.editor.triggers.learn_more"
               )}
             </a>
@@ -96,8 +97,9 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.conditions.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/scripts/conditions/" target="_blank">
-              {localize(
+            <a href="https://home-assistant.io/docs/scripts/conditions/"
+              target="_blank"
+              >{localize(
                 "ui.panel.config.automation.editor.conditions.learn_more"
               )}
             </a>
@@ -120,8 +122,9 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.actions.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/automation/action/" target="_blank">
-              {localize("ui.panel.config.automation.editor.actions.learn_more")}
+            <a href="https://home-assistant.io/docs/automation/action/"
+              target="_blank"
+              >{localize("ui.panel.config.automation.editor.actions.learn_more")}
             </a>
           </span>
           <Script

--- a/src/panels/config/js/automation.js
+++ b/src/panels/config/js/automation.js
@@ -72,7 +72,7 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.triggers.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/automation/trigger/">
+            <a href="https://home-assistant.io/docs/automation/trigger/" target="_blank">
               {localize(
                 "ui.panel.config.automation.editor.triggers.learn_more"
               )}
@@ -96,7 +96,7 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.conditions.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/scripts/conditions/">
+            <a href="https://home-assistant.io/docs/scripts/conditions/" target="_blank">
               {localize(
                 "ui.panel.config.automation.editor.conditions.learn_more"
               )}
@@ -120,7 +120,7 @@ export default class Automation extends Component {
                 "ui.panel.config.automation.editor.actions.introduction"
               )}
             </p>
-            <a href="https://home-assistant.io/docs/automation/action/">
+            <a href="https://home-assistant.io/docs/automation/action/" target="_blank">
               {localize("ui.panel.config.automation.editor.actions.learn_more")}
             </a>
           </span>

--- a/src/panels/dev-info/ha-panel-dev-info.ts
+++ b/src/panels/dev-info/ha-panel-dev-info.ts
@@ -64,7 +64,7 @@ class HaPanelDevInfo extends LitElement {
         <div class="content">
           <div class="about">
             <p class="version">
-              <a href="https://www.home-assistant.io"
+              <a href="https://www.home-assistant.io" target="_blank"
                 ><img src="/static/icons/favicon-192x192.png" height="192"/></a
               ><br />
               Home Assistant<br />


### PR DESCRIPTION
This ensures that link opens in a new window rather than taking over the current one. All other links on this page have this attribute. See https://github.com/home-assistant/home-assistant-polymer/issues/3153 for more info.

This is my first ever PR here and I am inexperienced at Github so apologies in advance if I didn't do this correctly.