### PR TITLE
Make sure we block emulated mouse events when touch is used

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.js
+++ b/src/dialogs/more-info/controls/more-info-media_player.js
@@ -111,6 +111,7 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
             disabled$="[[playerObj.isMuted]]"
             on-mousedown="handleVolumeDown"
             on-touchstart="handleVolumeDown"
+            on-touchend="handleVolumeTouchEnd"
             icon="hass:volume-medium"
           ></paper-icon-button>
           <paper-icon-button
@@ -118,6 +119,7 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
             disabled$="[[playerObj.isMuted]]"
             on-mousedown="handleVolumeUp"
             on-touchstart="handleVolumeUp"
+            on-touchend="handleVolumeTouchEnd"
             icon="hass:volume-high"
           ></paper-icon-button>
         </div>
@@ -355,6 +357,12 @@ class MoreInfoMediaPlayer extends LocalizeMixin(EventsMixin(PolymerElement)) {
       return;
     }
     this.playerObj.volumeMute(!this.playerObj.isMuted);
+  }
+
+  handleVolumeTouchEnd(ev) {
+    /* when touch ends, we must prevent this from
+     * becoming a mousedown, up, click by emulation */
+    ev.preventDefault();
   }
 
   handleVolumeUp() {


### PR DESCRIPTION
Fixes #3162 

It would have been better to use PointerEvents but seem to not be supported on many older android devices and other stuff:
https://caniuse.com/#search=pointerdown