### PR TITLE
Fix demo camera images

### DIFF
--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -48,12 +48,12 @@ class HaCameraStream extends LitElement {
     }
 
     return html`
-      ${this._shouldRenderMJPEG
+      ${__DEMO__ || this._shouldRenderMJPEG
         ? html`
             <img
               @load=${this._elementResized}
               .src=${__DEMO__
-                ? "/demo/webcamp.jpg"
+                ? `/api/camera_proxy_stream/${this.stateObj.entity_id}`
                 : computeMJPEGStreamUrl(this.stateObj)}
               .alt=${computeStateName(this.stateObj)}
             />


### PR DESCRIPTION
With the recent refactors, we broke the demo camera picture. This fixes it and makes it sure we don't break it in the future.