### PR TITLE
Fix editing wait actions in script editor

### DIFF
--- a/src/panels/config/js/script/wait.js
+++ b/src/panels/config/js/script/wait.js
@@ -18,8 +18,8 @@ export default class WaitAction extends Component {
   onTemplateChange(ev) {
     this.props.onChange(
       this.props.index,
-      Object.assign({}, this.props.trigger, {
-        [ev.target.name]: ev.target.value,
+      Object.assign({}, this.props.action, {
+        [ev.target.getAttribute("name")]: ev.target.value,
       })
     );
   }


### PR DESCRIPTION
The wait_template in the script editor would not use the correct name and it would throw away the other info. This PR fixes it.

Fixes https://github.com/home-assistant/home-assistant/issues/23768