### PR TITLE
Warn that only automations in automations.yaml are editable

### DIFF
--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -147,18 +147,34 @@ class HaAutomationEditor extends LitElement {
           "GET",
           `config/automation/config/${this.automation.attributes.id}`
         )
-        .then((config) => {
-          // Normalize data: ensure trigger, action and condition are lists
-          // Happens when people copy paste their automations into the config
-          for (const key of ["trigger", "condition", "action"]) {
-            const value = config[key];
-            if (value && !Array.isArray(value)) {
-              config[key] = [value];
+        .then(
+          (config) => {
+            // Normalize data: ensure trigger, action and condition are lists
+            // Happens when people copy paste their automations into the config
+            for (const key of ["trigger", "condition", "action"]) {
+              const value = config[key];
+              if (value && !Array.isArray(value)) {
+                config[key] = [value];
+              }
             }
+            this._dirty = false;
+            this._config = config;
+          },
+          (resp) => {
+            alert(
+              resp.status_code === 404
+                ? this.hass.localize(
+                    "ui.panel.config.automation.editor.load_error_not_editable"
+                  )
+                : this.hass.localize(
+                    "ui.panel.config.automation.editor.load_error_unknown",
+                    "err_no",
+                    resp.status_code
+                  )
+            );
+            history.back();
           }
-          this._dirty = false;
-          this._config = config;
-        });
+        );
     }
 
     if (changedProps.has("creatingNew") && this.creatingNew && this.hass) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -627,6 +627,8 @@
           "editor": {
             "introduction": "Use automations to bring your home alive",
             "default_name": "New Automation",
+            "load_error_not_editable": "Only automations in automations.yaml are editable.",
+            "load_error_unknown": "Error loading automation ({err_no}).",
             "save": "Save",
             "unsaved_confirm": "You have unsaved changes. Are you sure you want to leave?",
             "alias": "Name",


### PR DESCRIPTION
When a user adds an ID to their automation but it's not defined in automations.yaml, we will now print a proper error.