### PR TITLE
Use deep instead of strict equality for Lovelace config

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -417,7 +417,7 @@ class HUIRoot extends LitElement {
         | Lovelace
         | undefined;
 
-      if (!oldLovelace || oldLovelace.config !== this.lovelace!.config) {
+      if (!oldLovelace || this._isLovelaceConfigChanged(oldLovelace)) {
         this._loadResources(this.lovelace!.config.resources || []);
         // On config change, recreate the current view from scratch.
         force = true;
@@ -474,6 +474,13 @@ class HUIRoot extends LitElement {
 
   private _handleNotificationsOpenChanged(ev): void {
     this._notificationsOpen = ev.detail.value;
+  }
+
+  private _isLovelaceConfigChanged(oldLovelace: Lovelace): boolean {
+    return (
+      JSON.stringify(oldLovelace.config) !==
+      JSON.stringify(this.lovelace!.config)
+    );
   }
 
   private _updateNotifications(


### PR DESCRIPTION
The Lovelace configuration was checked for changes using a strict equality check. This resulted in the configuration being marked as changed when there were 2 different instances of the same configuration.

This wouldn't be a problem, except when `this._curView` still contains an old (cached) value, because the failed check will set `force` to `true` and therefore render the wrong tab (see issues below).

I fixed this earlier by resetting `this._curView` to `0` or `undefined` before navigating to the default view (at line 398, see 2dcc02b), but this feels like a better fix to me.

Fixes #3204, #3123