### PR TITLE
support for themes to define hyperlinks color

### DIFF
--- a/src/panels/dev-state/ha-panel-dev-state.js
+++ b/src/panels/dev-state/ha-panel-dev-state.js
@@ -66,7 +66,7 @@ class HaPanelDevState extends EventsMixin(PolymerElement) {
         }
 
         .entities a {
-          color: var(--primary-color);
+          color: var(--hyperlink-color);
         }
       </style>
 

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -30,6 +30,7 @@ documentContainer.innerHTML = `<custom-style>
       --light-primary-color: #b3e5fC;
       --accent-color: #ff9800;
       --divider-color: rgba(0, 0, 0, .12);
+      --hyperlink-color: var(--primary-color);
 
       /* states and badges */
       --state-icon-color: #44739e;

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -27,6 +27,10 @@ export const haStyle = css`
     @apply --paper-font-title;
   }
 
+  a {
+    color: var(--hyperlink-color);
+  }
+
   button.link {
     background: none;
     color: inherit;


### PR DESCRIPTION
Currently the links on ha take the header color (aka primary) which doesn't make sense if you want your theme to be all solid color (ie. white header and white body). 
The mwc-button elements can be customized via --mdc-theme-primary variable but the links can't be changed.
Please let me know if i missed anything in my pull request, this is my first and I would love to help out more.