### PR TITLE
Allow editing of device name

### DIFF
--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -16,8 +16,8 @@ export interface DeviceRegistryEntry {
 }
 
 export interface DeviceRegistryEntryMutableParams {
-  area_id?: string;
-  name_by_user?: string;
+  area_id?: string | null;
+  name_by_user?: string | null;
 }
 
 export const updateDeviceRegistryEntry = (

--- a/src/panels/config/integrations/dialog-device-registry-detail.ts
+++ b/src/panels/config/integrations/dialog-device-registry-detail.ts
@@ -2,9 +2,10 @@ import {
   LitElement,
   html,
   css,
-  PropertyDeclarations,
   CSSResult,
   TemplateResult,
+  customElement,
+  property,
 } from "lit-element";
 import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
 import "@polymer/paper-input/paper-input";
@@ -24,25 +25,18 @@ import {
   AreaRegistryEntry,
 } from "../../../data/area_registry";
 
+@customElement("dialog-device-registry-detail")
 class DialogDeviceRegistryDetail extends LitElement {
-  public hass!: HomeAssistant;
-  private _nameByUser!: string;
-  private _error?: string;
-  private _params?: DeviceRegistryDetailDialogParams;
-  private _submitting?: boolean;
-  private _areas?: AreaRegistryEntry[];
-  private _areaId?: string;
-  private _unsubAreas?: any;
+  @property() public hass!: HomeAssistant;
 
-  static get properties(): PropertyDeclarations {
-    return {
-      _error: {},
-      _nameByUser: {},
-      _areaId: {},
-      _areas: {},
-      _params: {},
-    };
-  }
+  @property() private _nameByUser!: string;
+  @property() private _error?: string;
+  @property() private _params?: DeviceRegistryDetailDialogParams;
+  @property() private _areas?: AreaRegistryEntry[];
+  @property() private _areaId?: string;
+
+  private _submitting?: boolean;
+  private _unsubAreas?: any;
 
   public async showDialog(
     params: DeviceRegistryDetailDialogParams
@@ -207,8 +201,3 @@ declare global {
     "dialog-device-registry-detail": DialogDeviceRegistryDetail;
   }
 }
-
-customElements.define(
-  "dialog-device-registry-detail",
-  DialogDeviceRegistryDetail
-);

--- a/src/panels/config/integrations/dialog-device-registry-detail.ts
+++ b/src/panels/config/integrations/dialog-device-registry-detail.ts
@@ -1,0 +1,214 @@
+import {
+  LitElement,
+  html,
+  css,
+  PropertyDeclarations,
+  CSSResult,
+  TemplateResult,
+} from "lit-element";
+import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
+import "@polymer/paper-input/paper-input";
+import "@polymer/paper-listbox/paper-listbox";
+import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
+import "@polymer/paper-item/paper-item";
+import "@material/mwc-button/mwc-button";
+
+import "../../../components/dialog/ha-paper-dialog";
+
+import { DeviceRegistryDetailDialogParams } from "./show-dialog-device-registry-detail";
+import { PolymerChangedEvent } from "../../../polymer-types";
+import { haStyleDialog } from "../../../resources/styles";
+import { HomeAssistant } from "../../../types";
+import {
+  subscribeAreaRegistry,
+  AreaRegistryEntry,
+} from "../../../data/area_registry";
+
+class DialogDeviceRegistryDetail extends LitElement {
+  public hass!: HomeAssistant;
+  private _nameByUser!: string;
+  private _error?: string;
+  private _params?: DeviceRegistryDetailDialogParams;
+  private _submitting?: boolean;
+  private _areas?: AreaRegistryEntry[];
+  private _areaId?: string;
+  private _unsubAreas?: any;
+
+  static get properties(): PropertyDeclarations {
+    return {
+      _error: {},
+      _nameByUser: {},
+      _areaId: {},
+      _areas: {},
+      _params: {},
+    };
+  }
+
+  public async showDialog(
+    params: DeviceRegistryDetailDialogParams
+  ): Promise<void> {
+    this._params = params;
+    this._error = undefined;
+    this._nameByUser = this._params.device.name_by_user || "";
+    this._areaId = this._params.device.area_id;
+    await this.updateComplete;
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    this._unsubAreas = subscribeAreaRegistry(this.hass, (areas) => {
+      this._areas = areas;
+    });
+  }
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._unsubAreas) {
+      this._unsubAreas();
+    }
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this._params) {
+      return html``;
+    }
+    const device = this._params.device;
+
+    return html`
+      <ha-paper-dialog
+        with-backdrop
+        opened
+        @opened-changed="${this._openedChanged}"
+      >
+        <h2>${device.name}</h2>
+        <paper-dialog-scrollable>
+          ${this._error
+            ? html`
+                <div class="error">${this._error}</div>
+              `
+            : ""}
+          <div class="form">
+            <paper-input
+              .value=${this._nameByUser}
+              @value-changed=${this._nameChanged}
+              .label=${this.hass.localize("ui.dialogs.more_info_settings.name")}
+              .placeholder=${device.name || ""}
+              .disabled=${this._submitting}
+            ></paper-input>
+            <div class="area">
+              <paper-dropdown-menu label="Area" class="flex">
+                <paper-listbox
+                  slot="dropdown-content"
+                  .selected="${this._computeSelectedArea()}"
+                  @iron-select="${this._areaIndexChanged}"
+                >
+                  <paper-item>
+                    ${this.hass.localize(
+                      "ui.panel.config.integrations.config_entry.no_area"
+                    )}
+                  </paper-item>
+                  ${this._renderAreas()}
+                </paper-listbox>
+              </paper-dropdown-menu>
+            </div>
+          </div>
+        </paper-dialog-scrollable>
+        <div class="paper-dialog-buttons">
+          <mwc-button @click="${this._updateEntry}">
+            ${this.hass.localize(
+              "ui.panel.config.entity_registry.editor.update"
+            )}
+          </mwc-button>
+        </div>
+      </ha-paper-dialog>
+    `;
+  }
+
+  private _nameChanged(ev: PolymerChangedEvent<string>): void {
+    this._error = undefined;
+    this._nameByUser = ev.detail.value;
+  }
+
+  private _renderAreas() {
+    if (!this._areas) {
+      return;
+    }
+    return this._areas!.map(
+      (area) => html`
+        <paper-item>${area.name}</paper-item>
+      `
+    );
+  }
+
+  private _computeSelectedArea() {
+    if (!this._params || !this._areas) {
+      return -1;
+    }
+    const device = this._params!.device;
+    if (!device.area_id) {
+      return 0;
+    }
+    // +1 because of "No Area" entry
+    return this._areas.findIndex((area) => area.area_id === device.area_id) + 1;
+  }
+
+  private _areaIndexChanged(event): void {
+    const selectedAreaIdx = event.target!.selected;
+    this._areaId =
+      selectedAreaIdx < 1
+        ? undefined
+        : this._areas![selectedAreaIdx - 1].area_id;
+  }
+
+  private async _updateEntry(): Promise<void> {
+    this._submitting = true;
+    try {
+      await this._params!.updateEntry({
+        name_by_user: this._nameByUser.trim() || null,
+        area_id: this._areaId || null,
+      });
+      this._params = undefined;
+    } catch (err) {
+      this._error = err.message || "Unknown error";
+    } finally {
+      this._submitting = false;
+    }
+  }
+
+  private _openedChanged(ev: PolymerChangedEvent<boolean>): void {
+    if (!(ev.detail as any).value) {
+      this._params = undefined;
+    }
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        ha-paper-dialog {
+          min-width: 400px;
+        }
+        .form {
+          padding-bottom: 24px;
+        }
+        mwc-button.warning {
+          margin-right: auto;
+        }
+        .error {
+          color: var(--google-red-500);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-device-registry-detail": DialogDeviceRegistryDetail;
+  }
+}
+
+customElements.define(
+  "dialog-device-registry-detail",
+  DialogDeviceRegistryDetail
+);

--- a/src/panels/config/integrations/dialog-device-registry-detail.ts
+++ b/src/panels/config/integrations/dialog-device-registry-detail.ts
@@ -50,7 +50,7 @@ class DialogDeviceRegistryDetail extends LitElement {
 
   public connectedCallback() {
     super.connectedCallback();
-    this._unsubAreas = subscribeAreaRegistry(this.hass, (areas) => {
+    this._unsubAreas = subscribeAreaRegistry(this.hass.connection, (areas) => {
       this._areas = areas;
     });
   }

--- a/src/panels/config/integrations/show-dialog-device-registry-detail.ts
+++ b/src/panels/config/integrations/show-dialog-device-registry-detail.ts
@@ -1,0 +1,26 @@
+import { fireEvent } from "../../../common/dom/fire_event";
+import {
+  DeviceRegistryEntry,
+  DeviceRegistryEntryMutableParams,
+} from "../../../data/device_registry";
+
+export interface DeviceRegistryDetailDialogParams {
+  device: DeviceRegistryEntry;
+  updateEntry: (
+    updates: Partial<DeviceRegistryEntryMutableParams>
+  ) => Promise<unknown>;
+}
+
+export const loadDeviceRegistryDetailDialog = () =>
+  import(/* webpackChunkName: "device-registry-detail-dialog" */ "./dialog-device-registry-detail");
+
+export const showDeviceRegistryDetailDialog = (
+  element: HTMLElement,
+  deviceRegistryDetailParams: DeviceRegistryDetailDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-device-registry-detail",
+    dialogImport: loadDeviceRegistryDetailDialog,
+    dialogParams: deviceRegistryDetailParams,
+  });
+};

--- a/translations/en.json
+++ b/translations/en.json
@@ -626,6 +626,9 @@
                             "description": "This step requires you to visit an external website to be completed.",
                             "open_site": "Open website"
                         }
+                    },
+                    "device_registry": {
+                        "area": "area"
                     }
                 },
                 "zha": {


### PR DESCRIPTION
My first front-end commit!

Adds a new dialog to allow editing the device details, including the device name and area.

![Device Card](https://user-images.githubusercontent.com/6317645/58293861-e5f6db80-7df9-11e9-8427-8226ebee48f0.png)

The device card in the Integrations config page. Note the customised name and the gear icon. 

The area only displays if it's actually set and you can't edit it from here any more. I've added a i18n key for "area" and provided an en translation. I used lower case for area because that's what the "by" uses, but styled the actual device name back in the primary colour (black). 

I wonder if the "by" string from the device should be styled back in primary colour too?

The integration window has also been updated to track the area list, before if you added an area and then went back here the areas would all be messed up.

![Edit Dialog](https://user-images.githubusercontent.com/6317645/58293776-839ddb00-7df9-11e9-8450-c16740c8d6da.png)

The edit dialog displayed when the gear icon is clicked. The title is the device name as set by the integration, and the Name Override will default back to the normal device name as set by the integration if you delete it completely.

Fixes: home-assistant/home-assistant#23995