### PR TITLE
Fix duplicate tab when regen LL

### DIFF
--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -128,6 +128,7 @@ class LovelacePanel extends LitElement {
     } else if (this.lovelace && this.lovelace.mode === "generated") {
       // When lovelace is generated, we re-generate each time a user goes
       // to the states panel to make sure new entities are shown.
+      this._state = "loading";
       this._regenerateConfig();
     }
   }
@@ -135,6 +136,7 @@ class LovelacePanel extends LitElement {
   private async _regenerateConfig() {
     const conf = await generateLovelaceConfig(this.hass!, this.hass!.localize);
     this._setLovelaceConfig(conf, "generated");
+    this._state = "loaded";
   }
 
   private _closeEditor() {

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -399,6 +399,7 @@ class HUIRoot extends LitElement {
         views
       ) {
         navigate(this, `/lovelace/${views[0].path || 0}`, true);
+        newSelectView = 0;
       } else if (this._routeData!.view === "hass-unused-entities") {
         newSelectView = "hass-unused-entities";
       } else if (this._routeData!.view) {


### PR DESCRIPTION
When Lovelace is in generate mode, don't show Lovelace right away, and then update it right away, but instead show a loading spinner.

Fixes #3123
Fixes #3204
Fixes #3205
