### PR TITLE
Allow edit default config

### DIFF
--- a/src/panels/config/core/ha-config-core-form.ts
+++ b/src/panels/config/core/ha-config-core-form.ts
@@ -33,8 +33,10 @@ class ConfigCoreForm extends LitElement {
   @property() private _timeZone!: string;
 
   protected render(): TemplateResult | void {
-    const isStorage = this.hass.config.config_source === "storage";
-    const disabled = this._working || !isStorage;
+    const canEdit = ["storage", "default"].includes(
+      this.hass.config.config_source
+    );
+    const disabled = this._working || !canEdit;
 
     return html`
       <ha-card
@@ -43,7 +45,7 @@ class ConfigCoreForm extends LitElement {
         )}
       >
         <div class="card-content">
-          ${!isStorage
+          ${!canEdit
             ? html`
                 <p>
                   ${this.hass.localize(

--- a/src/panels/config/core/ha-config-name-form.ts
+++ b/src/panels/config/core/ha-config-name-form.ts
@@ -25,13 +25,15 @@ class ConfigNameForm extends LitElement {
   @property() private _name!: ConfigUpdateValues["location_name"];
 
   protected render(): TemplateResult | void {
-    const isStorage = this.hass.config.config_source === "storage";
-    const disabled = this._working || !isStorage;
+    const canEdit = ["storage", "default"].includes(
+      this.hass.config.config_source
+    );
+    const disabled = this._working || !canEdit;
 
     return html`
       <ha-card>
         <div class="card-content">
-          ${!isStorage
+          ${!canEdit
             ? html`
                 <p>
                   ${this.hass.localize(


### PR DESCRIPTION
If a user has no config stored in storage, allow the user to edit the config. This can happen with existing users who have already been onboarded removing their core config from configuration.yaml.