### PR TITLE
Correctly warn if Google entities defined in YAML

### DIFF
--- a/src/panels/config/cloud/ha-config-cloud-google-assistant.ts
+++ b/src/panels/config/cloud/ha-config-cloud-google-assistant.ts
@@ -60,7 +60,7 @@ class CloudGoogleAssistant extends LitElement {
         <hass-loading-screen></hass-loading-screen>
       `;
     }
-    const emptyFilter = true || isEmptyFilter(this.cloudStatus.google_entities);
+    const emptyFilter = isEmptyFilter(this.cloudStatus.google_entities);
     const filterFunc = this._getEntityFilterFunc(
       this.cloudStatus.google_entities
     );


### PR DESCRIPTION
Correctly show a banner and disable editing exposed entities if filter configured in YAML.