### PR TITLE
Fix background color on Google Assistant UI banner

### DIFF
--- a/src/panels/config/cloud/ha-config-cloud-google-assistant.ts
+++ b/src/panels/config/cloud/ha-config-cloud-google-assistant.ts
@@ -240,7 +240,7 @@ class CloudGoogleAssistant extends LitElement {
     return css`
       .banner {
         color: var(--primary-text-color);
-        background-color: var(--card-background-color);
+        background-color: var(--paper-card-background-color);
         padding: 16px 8px;
         text-align: center;
       }


### PR DESCRIPTION
The background color for new Google Assistant entity UI was using `--card-background-color` which I think is not used among any themes and so displays as white always. Which resulted in issues like this on dark themes:

![image](https://i.imgur.com/LBhPbF6.png)

I am pretty sure (but not 100%) it should be `--paper-card-background-color` instead, this PR updates it.