### PR TITLE
Fix refreshing cloud prefs after changing Google prefs

### DIFF
--- a/src/panels/config/cloud/ha-config-cloud-google-assistant.ts
+++ b/src/panels/config/cloud/ha-config-cloud-google-assistant.ts
@@ -249,7 +249,7 @@ class CloudGoogleAssistant extends LitElement {
     // Cache parent because by the time popstate happens,
     // this element is detached
     const parent = this.parentElement!;
-    this.addEventListener(
+    window.addEventListener(
       "popstate",
       () => fireEvent(parent, "ha-refresh-cloud-status"),
       { once: true }

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -6,6 +6,13 @@ import { CloudStatus, fetchCloudStatus } from "../../data/cloud";
 import { listenMediaQuery } from "../../common/dom/media_query";
 import { HassRouterPage, RouterOptions } from "../../layouts/hass-router-page";
 
+declare global {
+  // for fire event
+  interface HASSDomEvents {
+    "ha-refresh-cloud-status": undefined;
+  }
+}
+
 @customElement("ha-panel-config")
 class HaPanelConfig extends HassRouterPage {
   @property() public hass!: HomeAssistant;

--- a/src/polymer-types.ts
+++ b/src/polymer-types.ts
@@ -30,7 +30,6 @@ declare global {
     "hass-logout": undefined;
     "iron-resize": undefined;
     "config-refresh": undefined;
-    "ha-refresh-cloud-status": undefined;
     "hass-api-called": {
       success: boolean;
       response: unknown;


### PR DESCRIPTION
Listen to popstate on `window`, where the event is fired.