### PR TITLE
Google banner background to support incorrect themes

### DIFF
--- a/src/panels/config/cloud/ha-config-cloud-google-assistant.ts
+++ b/src/panels/config/cloud/ha-config-cloud-google-assistant.ts
@@ -278,7 +278,10 @@ class CloudGoogleAssistant extends LitElement {
     return css`
       .banner {
         color: var(--primary-text-color);
-        background-color: var(--card-background-color);
+        background-color: var(
+          --ha-card-background,
+          var(--paper-card-background-color, white)
+        );
         padding: 16px 8px;
         text-align: center;
       }


### PR DESCRIPTION
Successor of #3232 with the suggestion of @thomasloven how to specify the card background color and still support themes that are not using the correct variables.