### PR TITLE
Link to beta release notes for beta release in hassio

### DIFF
--- a/hassio/src/dashboard/hassio-hass-update.js
+++ b/hassio/src/dashboard/hassio-hass-update.js
@@ -41,10 +41,11 @@ class HassioHassUpdate extends PolymerElement {
                   >Update</ha-call-api-button
                 >
                 <a
-                  href="https://www.home-assistant.io/latest-release-notes/"
+                  href="[[computeReleaseNotesUrl(hassInfo.version)]]"
                   target="_blank"
-                  ><mwc-button>Release notes</mwc-button></a
                 >
+                  <mwc-button>Release notes</mwc-button>
+                </a>
               </div>
             </paper-card>
           </div>
@@ -83,6 +84,12 @@ class HassioHassUpdate extends PolymerElement {
 
   computeUpdateAvailable(hassInfo) {
     return hassInfo.version !== hassInfo.last_version;
+  }
+
+  computeReleaseNotesUrl(version) {
+    return `https://${
+      version.includes("b") ? "rc" : "www"
+    }.home-assistant.io/latest-release-notes/`;
   }
 }
 


### PR DESCRIPTION
On Hass.io, if the available update is a beta version, link to the RC website that contains the RC notes.