### PR TITLE
Fix timer stops updating when changing views in LL

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
@@ -40,6 +40,14 @@ class HuiTimerEntityRow extends LitElement {
     this._clearInterval();
   }
 
+  public connectedCallback(): void {
+    super.connectedCallback();
+    if (this._config!.entity) {
+      const stateObj = this.hass!.states[this._config!.entity];
+      this._startInterval(stateObj);
+    }
+  }
+
   protected render(): TemplateResult | void {
     if (!this._config || !this.hass) {
       return html``;

--- a/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
@@ -44,7 +44,9 @@ class HuiTimerEntityRow extends LitElement {
     super.connectedCallback();
     if (this._config && this._config.entity) {
       const stateObj = this.hass!.states[this._config!.entity];
-      this._startInterval(stateObj);
+      if (stateObj) {
+        this._startInterval(stateObj);
+      }
     }
   }
 

--- a/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
@@ -42,7 +42,7 @@ class HuiTimerEntityRow extends LitElement {
 
   public connectedCallback(): void {
     super.connectedCallback();
-    if (this._config!.entity) {
+    if (this._config && this._config.entity) {
       const stateObj = this.hass!.states[this._config!.entity];
       this._startInterval(stateObj);
     }


### PR DESCRIPTION
This PR fixes the fact that when you switch from a LL view with a timer displayed to another view and back to the initial one, the timer stops updating because the element is disconnected from the DOM during the switch and the window interval is cleared.
The display update is restarted when the element is connected again to the DOM through the call to `connectedCallback`