### PR TITLE
Dark Mode for Map Card

### DIFF
--- a/src/common/dom/setup-leaflet-map.ts
+++ b/src/common/dom/setup-leaflet-map.ts
@@ -4,7 +4,8 @@ import { Map } from "leaflet";
 export type LeafletModuleType = typeof import("leaflet");
 
 export const setupLeafletMap = async (
-  mapElement: HTMLElement
+  mapElement: HTMLElement,
+  darkMode = false
 ): Promise<[Map, LeafletModuleType]> => {
   if (!mapElement.parentNode) {
     throw new Error("Cannot setup Leaflet map on disconnected element");
@@ -20,9 +21,9 @@ export const setupLeafletMap = async (
   mapElement.parentNode.appendChild(style);
   map.setView([52.3731339, 4.8903147], 13);
   Leaflet.tileLayer(
-    `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}${
-      Leaflet.Browser.retina ? "@2x.png" : ".png"
-    }`,
+    `https://{s}.basemaps.cartocdn.com/${
+      darkMode ? "dark_all" : "light_all"
+    }/{z}/{x}/{y}${Leaflet.Browser.retina ? "@2x.png" : ".png"}`,
     {
       attribution:
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>',

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -182,7 +182,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
   private async loadMap(): Promise<void> {
     [this._leafletMap, this.Leaflet] = await setupLeafletMap(
       this._mapEl,
-      this._config.dark_mode
+      this._config !== undefined ? this._config.dark_mode !== false : false
     );
     this._drawEntities();
     this._leafletMap.invalidateSize();

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -180,7 +180,10 @@ class HuiMapCard extends LitElement implements LovelaceCard {
   }
 
   private async loadMap(): Promise<void> {
-    [this._leafletMap, this.Leaflet] = await setupLeafletMap(this._mapEl);
+    [this._leafletMap, this.Leaflet] = await setupLeafletMap(
+      this._mapEl,
+      this._config.dark_mode
+    );
     this._drawEntities();
     this._leafletMap.invalidateSize();
     this._fitMap();

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -109,6 +109,7 @@ export interface MapCardConfig extends LovelaceCardConfig {
   default_zoom?: number;
   entities?: Array<EntityConfig | string>;
   geo_location_sources?: string[];
+  dark_mode?: Boolean;
 }
 
 export interface MarkdownCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -109,7 +109,7 @@ export interface MapCardConfig extends LovelaceCardConfig {
   default_zoom?: number;
   entities?: Array<EntityConfig | string>;
   geo_location_sources?: string[];
-  dark_mode?: Boolean;
+  dark_mode?: boolean;
 }
 
 export interface MarkdownCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -37,6 +37,7 @@ const cardConfigStruct = struct({
   title: "string?",
   aspect_ratio: "string?",
   default_zoom: "number?",
+  dark_mode: "boolean?",
   entities: [entitiesConfigStruct],
   geo_location_sources: "array?",
 });
@@ -71,6 +72,10 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     return this._config!.geo_location_sources || [];
   }
 
+  get _dark_mode(): boolean {
+    return this._config!.dark_mode || false;
+  }
+
   protected render(): TemplateResult | void {
     if (!this.hass) {
       return html``;
@@ -100,6 +105,12 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
             @value-changed="${this._valueChanged}"
           ></paper-input>
         </div>
+        <paper-toggle-button
+          ?checked="${this._dark_mode !== false}"
+          .configValue="${"dark_mode"}"
+          @change="${this._valueChanged}"
+          >Dark Mode?</paper-toggle-button
+        >
         <hui-entity-editor
           .hass="${this.hass}"
           .entities="${this._configEntities}"
@@ -155,7 +166,8 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
         }
         this._config = {
           ...this._config,
-          [target.configValue!]: value,
+          [target.configValue]:
+            target.checked !== undefined ? target.checked : target.value,
         };
       }
     }

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -167,7 +167,7 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
         this._config = {
           ...this._config,
           [target.configValue]:
-            target.checked !== undefined ? target.checked : target.value,
+            target.checked !== undefined ? target.checked : value,
         };
       }
     }


### PR DESCRIPTION
The purpose of this PR is to allow the user to select dark mode for the map card.  It just replaces the tile set for the map to the dark_all or light_all depending on config.

Dark Mode -> False:
![image](https://user-images.githubusercontent.com/1051414/59000974-db194f00-87da-11e9-9393-9cb52814a020.png)

Dark Mode -> True:
![image](https://user-images.githubusercontent.com/1051414/59001005-fd12d180-87da-11e9-9e3d-0a6c6236e2da.png)
