### PR TITLE
Pass credentials (cookies e.g.) for cross origin links

### DIFF
--- a/src/html/authorize.html.template
+++ b/src/html/authorize.html.template
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>Home Assistant</title>
-    <link rel="preload" href="<%= latestPageJS %>" as="script" crossorigin />
+    <link rel="preload" href="<%= latestPageJS %>" as="script" crossorigin="use-credentials" />
     <link
       rel="preload"
       href="/static/fonts/roboto/Roboto-Light.ttf"
@@ -47,7 +47,7 @@
 
     <%= renderTemplate('_js_base') %>
 
-    <script type="module">
+    <script type="module" crossorigin="use-credentials">
       import "<%= latestPageJS %>";
       import "<%= latestHassIconsJS %>";
       window.providersPromise = fetch("/auth/providers", {

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="preload" href="<%= latestCoreJS %>" as="script" crossorigin />
+    <link rel="preload" href="<%= latestCoreJS %>" as="script" crossorigin="use-credentials" />
     <link
       rel="preload"
       href="/static/fonts/roboto/Roboto-Regular.ttf"
@@ -59,7 +59,7 @@
 
     <%= renderTemplate('_js_base') %>
 
-    <script type="module">
+    <script type="module" crossorigin="use-credentials">
       import "<%= latestCoreJS %>";
       import "<%= latestAppJS %>";
       import "<%= latestHassIconsJS %>";

--- a/src/html/onboarding.html.template
+++ b/src/html/onboarding.html.template
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>Home Assistant</title>
-    <link rel="preload" href="<%= latestPageJS %>" as="script" crossorigin />
+    <link rel="preload" href="<%= latestPageJS %>" as="script" crossorigin="use-credentials" />
     <link
       rel="preload"
       href="/static/fonts/roboto/Roboto-Light.ttf"
@@ -49,7 +49,7 @@
 
     <%= renderTemplate('_js_base') %>
 
-    <script type="module">
+    <script type="module" crossorigin="use-credentials">
       import "<%= latestPageJS %>";
       import "<%= latestHassIconsJS %>";
       window.stepsPromise = fetch("/api/onboarding", {


### PR DESCRIPTION
Otherwise we'll fail to load key assets of the frontend when
it's behind e.g. Cloudflare Access that sets the CF_Authorization
cookie.