### PR TITLE
Add loading screen when external step is done and fetching next step

### DIFF
--- a/src/dialogs/config-flow/step-flow-external.ts
+++ b/src/dialogs/config-flow/step-flow-external.ts
@@ -75,8 +75,9 @@ class StepFlowExternal extends LitElement {
           return;
         }
 
-        const step = await fetchConfigFlow(this.hass, this.step.flow_id);
-        fireEvent(this, "flow-update", { step });
+        fireEvent(this, "flow-update", {
+          stepPromise: fetchConfigFlow(this.hass, this.step.flow_id),
+        });
       },
       "data_entry_flow_progressed"
     );


### PR DESCRIPTION
When the external step is finished, show a loading screen while we're fetching the next step (which could take a while because it's finishing the setup).

CC @elupus (I think you requested this)