### PR TITLE
Filter met during onboarding

### DIFF
--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -216,9 +216,11 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
                       ></ha-icon>
                     </div>
                   </template>
-                  <div class="temp">
-                    [[item.temperature]] [[getUnit('temperature')]]
-                  </div>
+                  <template is="dom-if" if="[[_showValue(item.temperature)]]">
+                    <div class="temp">
+                      [[item.temperature]] [[getUnit('temperature')]]
+                    </div>
+                  </template>
                   <template is="dom-if" if="[[_showValue(item.templow)]]">
                     <div class="templow">
                       [[item.templow]] [[getUnit('temperature')]]

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -42,6 +42,7 @@ const fixedIcons = {
   updater: "hass:cloud-upload",
   vacuum: "hass:robot-vacuum",
   water_heater: "hass:thermometer",
+  weather: "hass:weather-cloudy",
   weblink: "hass:open-in-new",
 };
 

--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -151,7 +151,10 @@ class OnboardingIntegrations extends LitElement {
       getConfigEntries(this.hass!),
     ]);
     this._discovered = discovered;
-    this._entries = entries;
+    // We filter out the config entry for the local weather.
+    // It is one that we create automatically and it will confuse the user
+    // if it starts showing up during onboarding.
+    this._entries = entries.filter((entry) => entry.domain !== "met");
   }
 
   private async _finish() {


### PR DESCRIPTION
Do not show the existing config entry for Met during the integrations onboarding step. Since it is created by the system, it will confuse the user. The user can always later remove it via config -> integrations.