### PR TITLE
Import extra_html_url using js instead of deprecated link tags

### DIFF
--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -59,17 +59,16 @@
 
     <%= renderTemplate('_js_base') %>
 
-    <script type="module">
-      window.customPanelJS = "<%= latestCustomPanelJS %>";
-    </script>
     <script type="module" crossorigin="use-credentials">
       import "<%= latestCoreJS %>";
       import "<%= latestAppJS %>";
       import "<%= latestHassIconsJS %>";
-      {% for extra_module in extra_modules -%}
-      import "{{ extra_module }}";
-      {% endfor -%}
+      window.customPanelJS = "<%= latestCustomPanelJS %>";
     </script>
+    {% for extra_module in extra_modules -%}
+    <script type="module" crossorigin="use-credentials" src="{{ extra_module }}"></script>
+    {% endfor -%}
+    
 
     <script nomodule>
       (function() {

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -81,7 +81,16 @@
     </script>
 
     {% for extra_url in extra_urls -%}
-    <link rel="import" href="{{ extra_url }}" async />
+    <script type="module" async>
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', "{{ extra_url}}", true);
+      xhr.onreadystatechange = function() {
+        if(this.readyState !== 4) return;
+        if(this.status !== 200) return;
+        document.body.innerHTML += this.responseText;
+      }
+      xhr.send();
+    </script>
     {% endfor -%}
   </body>
 </html>

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -81,8 +81,8 @@
           _ls("<%= es5CoreJS %>");
           _ls("<%= es5AppJS %>");
           _ls("<%= es5HassIconsJS %>");
-          {% for extra_module in extra_modules_es5 -%}
-          _ls("{{ extra_module }}");
+          {% for extra_script in extra_js_es5 -%}
+          _ls("{{ extra_script }}");
           {% endfor -%}
         }
       })();

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -59,6 +59,9 @@
 
     <%= renderTemplate('_js_base') %>
 
+    <script type="module">
+      window.customPanelJS = "<%= latestCustomPanelJS %>";
+    </script>
     <script type="module" crossorigin="use-credentials">
       import "<%= latestCoreJS %>";
       import "<%= latestAppJS %>";
@@ -66,7 +69,6 @@
       {% for extra_module in extra_modules -%}
       import "{{ extra_module }}";
       {% endfor -%}
-      window.customPanelJS = "<%= latestCustomPanelJS %>";
     </script>
 
     <script nomodule>

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -63,6 +63,9 @@
       import "<%= latestCoreJS %>";
       import "<%= latestAppJS %>";
       import "<%= latestHassIconsJS %>";
+      {% for extra_module in extra_modules -%}
+      import "{{ extra_module }}";
+      {% endfor -%}
       window.customPanelJS = "<%= latestCustomPanelJS %>";
     </script>
 
@@ -76,21 +79,15 @@
           _ls("<%= es5CoreJS %>");
           _ls("<%= es5AppJS %>");
           _ls("<%= es5HassIconsJS %>");
+          {% for extra_module in extra_modules_es5 -%}
+          _ls("{{ extra_module }}");
+          {% endfor -%}
         }
       })();
     </script>
 
     {% for extra_url in extra_urls -%}
-    <script type="module" async>
-      const xhr = new XMLHttpRequest();
-      xhr.open('GET', "{{ extra_url}}", true);
-      xhr.onreadystatechange = function() {
-        if(this.readyState !== 4) return;
-        if(this.status !== 200) return;
-        document.body.innerHTML += this.responseText;
-      }
-      xhr.send();
-    </script>
+    <link rel="import" href="{{ extra_url }}" async />
     {% endfor -%}
   </body>
 </html>


### PR DESCRIPTION
**Edit:** Backend PR: home-assistant/home-assistant#24675

`<link rel="import"` are deprecated. Here's *one* different way to do it. I can't imagine this is the *best* way.. but it's a starting point...