### PR TITLE
experimental sidebar

### DIFF
--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -7,6 +7,7 @@ import { DEFAULT_DOMAIN_ICON } from "../const";
 
 const fixedIcons = {
   alert: "hass:alert",
+  alexa: "hass:amazon-alexa",
   automation: "hass:playlist-play",
   calendar: "hass:calendar",
   camera: "hass:video",
@@ -15,6 +16,7 @@ const fixedIcons = {
   conversation: "hass:text-to-speech",
   device_tracker: "hass:account",
   fan: "hass:fan",
+  google_assistant: "hass:google-assistant",
   group: "hass:google-circles-communities",
   history_graph: "hass:chart-line",
   homeassistant: "hass:home-assistant",

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -227,7 +227,7 @@ class HaSidebar extends LitElement {
                   ></ha-user-badge>
 
                   <span class="item-text">
-                    ${hass.localize(`panel.profile`)}
+                    ${hass.user.name}
                   </span>
                 </paper-icon-item>
               </a>
@@ -281,17 +281,6 @@ class HaSidebar extends LitElement {
     });
     this.addEventListener("mouseleave", () => {
       this._contract();
-    });
-    this.addEventListener("click", (ev) => {
-      for (const el of ev.composedPath()) {
-        if (el instanceof HTMLAnchorElement) {
-          this._contract();
-          break;
-        }
-        if (el instanceof HaSidebar) {
-          break;
-        }
-      }
     });
   }
 

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -198,6 +198,7 @@ class HaSidebar extends LitElement {
                   ></paper-icon-button>
                 </a>
               </div>
+              <div class="divider" disabled></div>
             `
           : ""}
         ${this._externalConfig && this._externalConfig.hasSettingsScreen
@@ -330,6 +331,8 @@ class HaSidebar extends LitElement {
         );
         width: 64px;
         transition: width 0.2s ease-in;
+        will-change: width;
+        contain: strict;
       }
       :host([expanded]) {
         width: 256px;
@@ -461,6 +464,8 @@ class HaSidebar extends LitElement {
         flex-direction: row;
         justify-content: space-between;
         padding: 0 8px;
+        width: 256px;
+        box-sizing: border-box;
       }
 
       .dev-tools a {

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -74,9 +74,9 @@ const renderPanel = (hass, panel) => html`
   >
     <paper-icon-item>
       <ha-icon slot="item-icon" .icon="${panel.icon}"></ha-icon>
-      <span class="item-text"
-        >${hass.localize(`panel.${panel.title}`) || panel.title}</span
-      >
+      <span class="item-text">
+        ${hass.localize(`panel.${panel.title}`) || panel.title}
+      </span>
     </paper-icon-item>
   </a>
 `;
@@ -111,13 +111,6 @@ class HaSidebar extends LitElement {
         ? html`
             <app-toolbar>
               <div main-title>Home Assistant</div>
-              ${hass.user
-                ? html`
-                    <a href="/profile">
-                      <ha-user-badge .user=${hass.user}></ha-user-badge>
-                    </a>
-                  `
-                : ""}
             </app-toolbar>
           `
         : html`
@@ -224,16 +217,29 @@ class HaSidebar extends LitElement {
             `
           : ""}
         ${configPanel ? renderPanel(hass, configPanel) : ""}
-        ${!hass.user
+        ${hass.user
           ? html`
+              <a href="/profile" data-panel="panel" tabindex="-1">
+                <paper-icon-item class="profile">
+                  <ha-user-badge
+                    slot="item-icon"
+                    .user=${hass.user}
+                  ></ha-user-badge>
+
+                  <span class="item-text">
+                    ${hass.localize(`panel.profile`)}
+                  </span>
+                </paper-icon-item>
+              </a>
+            `
+          : html`
               <paper-icon-item @click=${this._handleLogOut} class="logout">
                 <ha-icon slot="item-icon" icon="hass:exit-to-app"></ha-icon>
                 <span class="item-text"
                   >${hass.localize("ui.sidebar.log_out")}</span
                 >
               </paper-icon-item>
-            `
-          : html``}
+            `}
       </paper-listbox>
     `;
   }
@@ -356,11 +362,6 @@ class HaSidebar extends LitElement {
         color: var(--primary-text-color);
       }
 
-      ha-user-badge {
-        position: relative;
-        top: 3px;
-      }
-
       paper-listbox {
         padding: 4px 0;
         height: calc(100% - 65px);
@@ -434,6 +435,13 @@ class HaSidebar extends LitElement {
 
       paper-icon-item.logout {
         margin-top: 16px;
+      }
+
+      paper-icon-item.profile {
+        padding-left: 4px;
+      }
+      .profile .item-text {
+        margin-left: 8px;
       }
 
       .spacer {

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -324,7 +324,6 @@ class HaSidebar extends LitElement {
         transition: width 0.2s ease-in;
       }
       :host([expanded]) {
-        transition-delay: 0.2s;
         width: 256px;
       }
 

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -277,10 +277,6 @@ class HaSidebar extends LitElement {
       this._contract();
     });
     this.addEventListener("click", (ev) => {
-      // Do not contract sidebar if clicked within the contracted sidebar width
-      if (ev.clientX < 64) {
-        return;
-      }
       for (const el of ev.composedPath()) {
         if (el instanceof HTMLAnchorElement) {
           this._contract();
@@ -339,7 +335,7 @@ class HaSidebar extends LitElement {
       }
 
       .logo {
-        height: 64px;
+        height: 65px;
         box-sizing: border-box;
         padding: 8px;
         border-bottom: 1px solid transparent;

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -276,9 +276,12 @@ class HaSidebar extends LitElement {
         this._externalConfig = conf;
       });
     }
-    this.addEventListener("mouseenter", () => {
-      this.expanded = true;
-    });
+    this.shadowRoot!.querySelector("paper-listbox")!.addEventListener(
+      "mouseenter",
+      () => {
+        this.expanded = true;
+      }
+    );
     this.addEventListener("mouseleave", () => {
       this._contract();
     });

--- a/src/components/user/ha-user-badge.ts
+++ b/src/components/user/ha-user-badge.ts
@@ -7,7 +7,6 @@ import {
   property,
   customElement,
 } from "lit-element";
-import { classMap } from "lit-html/directives/class-map";
 import { User } from "../../data/user";
 import { CurrentUser } from "../../types";
 

--- a/src/components/user/ha-user-badge.ts
+++ b/src/components/user/ha-user-badge.ts
@@ -33,24 +33,23 @@ class StateBadge extends LitElement {
 
   protected render(): TemplateResult | void {
     const user = this.user;
-
     const initials = user ? computeInitials(user.name) : "?";
-
     return html`
-      <div
-        class="${classMap({
-          "profile-badge": true,
-          long: initials.length > 2,
-        })}"
-      >
-        ${initials}
-      </div>
+      ${initials}
     `;
+  }
+
+  protected updated(changedProps) {
+    super.updated(changedProps);
+    this.toggleAttribute(
+      "long",
+      (this.user ? computeInitials(this.user.name) : "?").length > 2
+    );
   }
 
   static get styles(): CSSResult {
     return css`
-      .profile-badge {
+      :host {
         display: inline-block;
         box-sizing: border-box;
         width: 40px;
@@ -63,7 +62,7 @@ class StateBadge extends LitElement {
         overflow: hidden;
       }
 
-      .profile-badge.long {
+      :host([long]) {
         font-size: 80%;
       }
     `;

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -44,7 +44,7 @@ export const connectionMixin = (
         localize: () => "",
 
         translationMetadata,
-        dockedSidebar: false,
+        dockedSidebar: true,
         moreInfoEntityId: null,
         callService: async (domain, service, serviceData = {}) => {
           if (__DEV__) {


### PR DESCRIPTION
@Juanmtech posted [a mockup on Twitter](https://twitter.com/JuanMTech/status/1143757213971943424) showing an idea to have the sidebar be smaller.

This PR implements it.

Features: 
 - When the sidebar is docked, show it with a width of 64px
 - When the sidebar is hovered, expand it to the original 256px
 - Only affects desktop/tablet
 - When clicking an item and you are on the expanded area, contract
 - Hide the dev tools when contracted
 - Move dev tools, configuration, profile to the bottom of the sidebar

[Demo](https://sidebar-experiment--home-assistant-demo.netlify.com/)