### PR TITLE
WIP: Add option to show states to picture glance card

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -141,12 +141,12 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
                 <div class="title">${this._config.title}</div>
               `
             : ""}
-          <div>
+          <div class="row">
             ${this._entitiesDialog!.map((entityConf) =>
               this.renderEntity(entityConf, true)
             )}
           </div>
-          <div>
+          <div class="row">
             ${this._entitiesToggle!.map((entityConf) =>
               this.renderEntity(entityConf, false)
             )}
@@ -175,21 +175,35 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
     }
 
     return html`
-      <ha-icon
-        .entity="${stateObj.entity_id}"
-        @click="${dialog ? this._openDialog : this._callService}"
-        class="${classMap({
-          "state-on": !STATES_OFF.has(stateObj.state),
-        })}"
-        .icon="${entityConf.icon || stateIcon(stateObj)}"
-        title="${`
-            ${computeStateName(stateObj)} : ${computeStateDisplay(
-          this.hass!.localize,
-          stateObj,
-          this.hass!.language
-        )}
+      <div class="wrapper">
+        <ha-icon
+          .entity="${stateObj.entity_id}"
+          @click="${dialog ? this._openDialog : this._callService}"
+          class="${classMap({
+            "state-on": !STATES_OFF.has(stateObj.state),
+            "show-state": entityConf.show_state === true,
+          })}"
+          .icon="${entityConf.icon || stateIcon(stateObj)}"
+          title="${`
+            ${computeStateName(stateObj)}: ${computeStateDisplay(
+            this.hass!.localize,
+            stateObj,
+            this.hass!.language
+          )}
           `}"
-      ></ha-icon>
+        ></ha-icon>
+        ${entityConf.show_state === true
+          ? html`
+              <div class="state">
+                ${computeStateDisplay(
+                  this.hass!.localize,
+                  stateObj,
+                  this.hass!.language
+                )}
+              </div>
+            `
+          : ""}
+      </div>
     `;
   }
 
@@ -239,6 +253,7 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
         color: white;
         display: flex;
         justify-content: space-between;
+        flex-direction: row;
       }
 
       .box .title {
@@ -254,6 +269,26 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
 
       ha-icon.state-on {
         color: white;
+      }
+      ha-icon.show-state {
+        width: 20px;
+        height: 20px;
+        padding-bottom: 4px;
+        padding-top: 4px;
+      }
+      .state {
+        display: block;
+        font-size: 12px;
+        text-align: center;
+        line-height: 12px;
+      }
+      .row {
+        display: flex;
+        flex-direction: row;
+      }
+      .wrapper {
+        display: flex;
+        flex-direction: column;
       }
     `;
   }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -163,6 +163,7 @@ export interface PictureGlanceCardConfig extends LovelaceCardConfig {
   entity?: string;
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
+  show_state?: boolean;
 }
 
 export interface PlantAttributeTarget extends EventTarget {

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -24,6 +24,7 @@ export interface CallServiceConfig extends EntityConfig {
   action_name?: string;
   service: string;
   service_data?: { [key: string]: any };
+  show_state?: boolean;
 }
 export type EntityRowConfig =
   | EntityConfig


### PR DESCRIPTION
A poc for showing states in a picture glance card. Has lots of issues and I don't really know enough frontend to fix them I think. Would be glad if someone would like to help or even take over from here.
How it looks now:
![image](https://user-images.githubusercontent.com/1287159/64549034-77c91c80-d2f5-11e9-8206-67079d77d7f0.png)

Issues I can think of now:
- Needs to hide overflow when state is too long.
- Needs to resolve how to make it look good if you are not showing states on all entities in the card.

Closes https://github.com/home-assistant/home-assistant-polymer/issues/3901