### PR TITLE
Do not cache onboarding page

### DIFF
--- a/src/entrypoints/service-worker-hass.js
+++ b/src/entrypoints/service-worker-hass.js
@@ -19,9 +19,11 @@ function initRouting() {
     new workbox.strategies.NetworkOnly()
   );
 
-  // Get manifest and service worker from network.
+  // Get manifest, service worker, onboarding from network.
   workbox.routing.registerRoute(
-    new RegExp(`${location.host}/(service_worker.js|manifest.json)`),
+    new RegExp(
+      `${location.host}/(service_worker.js|manifest.json|onboarding.html)`
+    ),
     new workbox.strategies.NetworkOnly()
   );
 


### PR DESCRIPTION
Make sure we don't cache the onboarding page. This could cause issues if a user is onboarding multiple times for different versions from a url on which it had loaded a previous HA version and so had a service worker active.

Fixes #3336