### PR TITLE
Fix test translations

### DIFF
--- a/build-scripts/gulp/clean.js
+++ b/build-scripts/gulp/clean.js
@@ -1,6 +1,17 @@
 const del = require("del");
 const gulp = require("gulp");
 const config = require("../paths");
+require("./translations");
 
-gulp.task("clean", () => del([config.root, config.build_dir]));
-gulp.task("clean-demo", () => del([config.demo_root, config.build_dir]));
+gulp.task(
+  "clean",
+  gulp.parallel("clean-translations", function cleanOutputAndBuildDir() {
+    return del([config.root, config.build_dir]);
+  })
+);
+gulp.task(
+  "clean-demo",
+  gulp.parallel("clean-translations", function cleanOutputAndBuildDir() {
+    return del([config.demo_root, config.build_dir]);
+  })
+);

--- a/build-scripts/gulp/translations.js
+++ b/build-scripts/gulp/translations.js
@@ -124,18 +124,28 @@ gulp.task(taskName, function() {
 });
 tasks.push(taskName);
 
-taskName = "create-test-metadata";
-gulp.task(taskName, function(cb) {
-  fs.writeFile(
-    workDir + "/testMetadata.json",
-    JSON.stringify({
-      test: {
-        nativeName: "Test",
-      },
-    }),
-    cb
-  );
+gulp.task("ensure-translations-build-dir", (done) => {
+  if (!fs.existsSync(workDir)) {
+    fs.mkdirSync(workDir);
+  }
+  done();
 });
+
+taskName = "create-test-metadata";
+gulp.task(
+  taskName,
+  gulp.series("ensure-translations-build-dir", function writeTestMetaData(cb) {
+    fs.writeFile(
+      workDir + "/testMetadata.json",
+      JSON.stringify({
+        test: {
+          nativeName: "Test",
+        },
+      }),
+      cb
+    );
+  })
+);
 tasks.push(taskName);
 
 taskName = "create-test-translation";


### PR DESCRIPTION
- Fix being able to run gulp on a clean checkout. It failed because `build-translations` didn't exist when running the `create-test-metadata` task.
- Make sure we clean the translations dir so that the test translations no longer are getting shipped with prod builds

CC @bramkragten 