### PR TITLE
Z-Wave Config Panel Updates

### DIFF
--- a/src/data/zwave.ts
+++ b/src/data/zwave.ts
@@ -5,6 +5,12 @@ export interface ZWaveNetworkStatus {
   state_str: string;
 }
 
+export const ZWAVE_NETWORK_STATE_STOPPED = 0;
+export const ZWAVE_NETWORK_STATE_FAILED = 1;
+export const ZWAVE_NETWORK_STATE_STARTED = 5;
+export const ZWAVE_NETWORK_STATE_AWAKED = 7;
+export const ZWAVE_NETWORK_STATE_READY = 10;
+
 export const fetchNetworkStatus = (
   hass: HomeAssistant
 ): Promise<ZWaveNetworkStatus> =>

--- a/src/data/zwave.ts
+++ b/src/data/zwave.ts
@@ -2,7 +2,6 @@ import { HomeAssistant } from "../types";
 
 export interface ZWaveNetworkStatus {
   state: number;
-  state_str: string;
 }
 
 export const ZWAVE_NETWORK_STATE_STOPPED = 0;

--- a/src/data/zwave.ts
+++ b/src/data/zwave.ts
@@ -1,0 +1,13 @@
+import { HomeAssistant } from "../types";
+
+export interface ZWaveNetworkStatus {
+  state: number;
+  state_str: string;
+}
+
+export const fetchNetworkStatus = (
+  hass: HomeAssistant
+): Promise<ZWaveNetworkStatus> =>
+  hass.callWS({
+    type: "zwave/network_status",
+  });

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -151,7 +151,9 @@ export class ZwaveNetwork extends LitElement {
                           .hass=${this.hass}
                           path="zwave/saveconfig"
                         >
-                          Save Config
+                          ${this.hass!.localize(
+                            "ui.panel.config.zwave.services.save_config"
+                          )}
                         </ha-call-api-button>
                       </div>
                     `

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -194,7 +194,9 @@ export class ZwaveNetwork extends LitElement {
       // Optimistically set the state, wait 1s and poll the backend
       // The backend will still report a state of 0 when the 'network_start'
       // event is first fired.
-      this._networkStatus!["state"] = 5;
+      if (this._networkStatus) {
+        this._networkStatus = { ...this._networkStatus, state: 5 };
+      }
       setTimeout(() => this._getNetworkStatus, 1000);
     } else {
       this._getNetworkStatus();

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -10,6 +10,7 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
+import { UnsubscribeFunc } from "home-assistant-js-websocket";
 
 import { haStyle } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
@@ -36,7 +37,7 @@ export class ZwaveNetwork extends LitElement {
   @property() private _showHelp = false;
   @property() private _networkStatus?: ZWaveNetworkStatus;
   @property() private _networkStarting = false;
-  @property() private _unsubs: UnsubscribeFunc[] = [];
+  @property() private _unsubs: Promise<UnsubscribeFunc>[] = [];
 
   public disconnectedCallback(): void {
     this._unsubscribe();
@@ -186,6 +187,7 @@ export class ZwaveNetwork extends LitElement {
   private async _getNetworkStatus(): Promise<void> {
     this._networkStatus = await fetchNetworkStatus(this.hass!);
   }
+
   private _subscribe(): void {
     this._unsubs = [
       "zwave.network_start",
@@ -203,7 +205,7 @@ export class ZwaveNetwork extends LitElement {
 
   private _unsubscribe(): void {
     while (this._unsubs.length) {
-      this._unsubs.pop()();
+      this._unsubs.pop()!.then((unsub) => unsub());
     }
   }
 

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -51,7 +51,11 @@ export class ZwaveNetwork extends LitElement {
     return html`
       <ha-config-section .isWide="${this.isWide}">
         <div style="position: relative" slot="header">
-          <span>Z-Wave Network Management</span>
+          <span>
+            ${this.hass!.localize(
+              "ui.panel.config.zwave.network_management.header"
+            )}
+          </span>
           <paper-icon-button
             class="toggle-help-icon"
             @click="${this._onHelpTap}"
@@ -59,9 +63,9 @@ export class ZwaveNetwork extends LitElement {
           ></paper-icon-button>
         </div>
         <span slot="introduction">
-          Run commands that affect the Z-Wave network. You won't get feedback on
-          whether the command succeeded, but you can look in the OZW Log to try
-          to figure out.
+          ${this.hass!.localize(
+            "ui.panel.config.zwave.network_management.introduction"
+          )}
         </span>
 
         ${this._networkStatus
@@ -70,14 +74,14 @@ export class ZwaveNetwork extends LitElement {
                 <div class="details">
                   ${this._networkStarting
                     ? html`
-                        <paper-spinner
-                          active
-                          alt="Starting Network..."
-                        ></paper-spinner>
-                        Starting Z-Wave Network...<br />
+                        <paper-spinner active></paper-spinner>
+                        ${this.hass!.localize(
+                          "ui.panel.config.zwave.network_status.network_starting"
+                        )}<br />
                         <small>
-                          This may take a while depending on the size of your
-                          network.
+                          ${this.hass!.localize(
+                            "ui.panel.config.zwave.network_status.network_starting_note"
+                          )}
                         </small>
                       `
                     : html`
@@ -85,32 +89,48 @@ export class ZwaveNetwork extends LitElement {
                         ZWAVE_NETWORK_STATE_STOPPED
                           ? html`
                               <ha-icon icon="hass:close"></ha-icon>
-                              Z-Wave Network Stopped
+                              ${this.hass!.localize(
+                                "ui.panel.config.zwave.network_status.network_stopped"
+                              )}
                             `
                           : this._networkStatus.state ===
                             ZWAVE_NETWORK_STATE_STARTED
                           ? html`
-                              <paper-spinner
-                                alt="Starting Network..."
-                              ></paper-spinner>
-                              Z-Wave Network Starting
+                              <paper-spinner></paper-spinner>
+                              ${this.hass!.localize(
+                                "ui.panel.config.zwave.network_status.network_starting"
+                              )}<br />
+                              <small>
+                                ${this.hass!.localize(
+                                  "ui.panel.config.zwave.network_status.network_starting_note"
+                                )}
+                              </small>
                             `
                           : this._networkStatus.state ===
                             ZWAVE_NETWORK_STATE_AWAKED
                           ? html`
                               <ha-icon icon="hass:checkbox-marked-circle">
                               </ha-icon>
-                              Z-Wave Network Started<br />
+                              ${this.hass!.localize(
+                                "ui.panel.config.zwave.network_status.network_started"
+                              )}<br />
                               <small>
-                                Awake nodes have been queried. Sleeping nodes
-                                will be queried when they wake.
+                                ${this.hass!.localize(
+                                  "ui.panel.config.zwave.network_status.network_started_note_some_queried"
+                                )}
                               </small>
                             `
                           : this._networkStatus.state ===
                             ZWAVE_NETWORK_STATE_READY
                           ? html`
-                              Z-Wave Network Started<br />
-                              <small>All nodes have been queried.</small>
+                              ${this.hass!.localize(
+                                "ui.panel.config.zwave.network_status.network_started"
+                              )}<br />
+                              <small>
+                                ${this.hass!.localize(
+                                  "ui.panel.config.zwave.network_status.network_started_note_all_queried"
+                                )}
+                              </small>
                             `
                           : ""}
                       `}
@@ -118,33 +138,18 @@ export class ZwaveNetwork extends LitElement {
                 <div class="card-actions">
                   ${this._networkStatus.state >= ZWAVE_NETWORK_STATE_AWAKED
                     ? html`
-                        ${this._generateServiceButton(
-                          "stop_network",
-                          "Stop Network"
-                        )}
-                        ${this._generateServiceButton(
-                          "heal_network",
-                          "Heal Network"
-                        )}
-                        ${this._generateServiceButton(
-                          "test_network",
-                          "Test Network"
-                        )}
+                        ${this._generateServiceButton("stop_network")}
+                        ${this._generateServiceButton("heal_network")}
+                        ${this._generateServiceButton("test_network")}
                       `
                     : html`
-                        ${this._generateServiceButton(
-                          "start_network",
-                          "Start Network"
-                        )}
+                        ${this._generateServiceButton("start_network")}
                       `}
                 </div>
                 ${this._networkStatus.state >= ZWAVE_NETWORK_STATE_AWAKED
                   ? html`
                       <div class="card-actions">
-                        ${this._generateServiceButton(
-                          "soft_reset",
-                          "Soft Reset"
-                        )}
+                        ${this._generateServiceButton("soft_reset")}
                         <ha-call-api-button
                           .hass=${this.hass}
                           path="zwave/saveconfig"
@@ -159,21 +164,12 @@ export class ZwaveNetwork extends LitElement {
                 ? html`
                     <ha-card class="content">
                       <div class="card-actions">
-                        ${this._generateServiceButton(
-                          "add_node_secure",
-                          "Add Node Secure"
-                        )}
-                        ${this._generateServiceButton("add_node", "Add Node")}
-                        ${this._generateServiceButton(
-                          "remove_node",
-                          "Remove Node"
-                        )}
+                        ${this._generateServiceButton("add_node_secure")}
+                        ${this._generateServiceButton("add_node")}
+                        ${this._generateServiceButton("remove_node")}
                       </div>
                       <div class="card-actions">
-                        ${this._generateServiceButton(
-                          "cancel_command",
-                          "Cancel Command"
-                        )}
+                        ${this._generateServiceButton("cancel_command")}
                       </div>
                     </ha-card>
                   `
@@ -217,14 +213,14 @@ export class ZwaveNetwork extends LitElement {
     this._showHelp = !this._showHelp;
   }
 
-  private _generateServiceButton(service: string, title: string) {
+  private _generateServiceButton(service: string) {
     return html`
       <ha-call-service-button
         .hass=${this.hass}
         domain="zwave"
         service="${service}"
       >
-        ${title}
+        ${this.hass!.localize("ui.panel.config.zwave.services." + service)}
       </ha-call-service-button>
       <ha-service-description
         .hass=${this.hass}

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -38,6 +38,10 @@ export class ZwaveNetwork extends LitElement {
   @property() private _networkStarting = false;
   @property() private _unsubs: UnsubscribeFunc[] = [];
 
+  public disconnectedCallback(): void {
+    this._unsubscribe();
+  }
+
   protected firstUpdated(changedProps): void {
     super.firstUpdated(changedProps);
     this._getNetworkStatus();
@@ -205,7 +209,7 @@ export class ZwaveNetwork extends LitElement {
 
   private _handleEvent(event) {
     this._getNetworkStatus();
-    this._networkStarting = event["event_type"] === "zwave.network_start";
+    this._networkStarting = event.event_type === "zwave.network_start";
   }
 
   private _onHelpTap(): void {
@@ -229,10 +233,6 @@ export class ZwaveNetwork extends LitElement {
       >
       </ha-service-description>
     `;
-  }
-
-  public disconnectedCallback(): void {
-    this._unsubscribe();
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -39,56 +39,6 @@ export class ZwaveNetwork extends LitElement {
   public disconnectedCallback(): void {
     this._unsubscribe();
   }
-  private async _getNetworkStatus(): Promise<void> {
-    this._networkStatus = await fetchNetworkStatus(this.hass!);
-  }
-  private _subscribe(): void {
-    this._unsubs.push(
-      this.hass!.connection.subscribeEvents(
-        (event) => this._handleEvent(event),
-        "zwave.network_start"
-      )
-    );
-    this._unsubs.push(
-      this.hass!.connection.subscribeEvents(
-        (event) => this._handleEvent(event),
-        "zwave.network_stop"
-      )
-    );
-    this._unsubs.push(
-      this.hass!.connection.subscribeEvents(
-        (event) => this._handleEvent(event),
-        "zwave.network_ready"
-      )
-    );
-    this._unsubs.push(
-      this.hass!.connection.subscribeEvents(
-        (event) => this._handleEvent(event),
-        "zwave.network_complete"
-      )
-    );
-    this._unsubs.push(
-      this.hass!.connection.subscribeEvents(
-        (event) => this._handleEvent(event),
-        "zwave.network_complete_some_dead"
-      )
-    );
-  }
-
-  private _unsubscribe(): void {
-    while (this._unsubs.length) {
-      this._unsubs.pop()();
-    }
-  }
-
-  private _handleEvent(event) {
-    this._getNetworkStatus();
-    if (event["event_type"] == "zwave.network_start") {
-      this._networkStarting = true;
-    } else {
-      this._networkStarting = false;
-    }
-  }
 
   protected render(): TemplateResult | void {
     return html`
@@ -120,17 +70,17 @@ export class ZwaveNetwork extends LitElement {
                         Starting Z-Wave Network...<br />
                         <small
                           >This may take a while depending on the size of your
-                          network</small
+                          network.</small
                         >
                       `
                     : html`
-                        ${this._networkStatus.state == 0
+                        ${this._networkStatus.state === 0
                           ? html`
                               <ha-icon icon="hass:close"> </ha-icon>
                               Z-Wave Network Stopped
                             `
                           : ""}
-                        ${this._networkStatus.state == 5
+                        ${this._networkStatus.state === 5
                           ? html`
                               <paper-spinner
                                 alt="Starting Network..."
@@ -138,7 +88,7 @@ export class ZwaveNetwork extends LitElement {
                               Z-Wave Network Starting
                             `
                           : ""}
-                        ${this._networkStatus.state == 7
+                        ${this._networkStatus.state === 7
                           ? html`
                               <ha-icon icon="hass:checkbox-marked-circle">
                               </ha-icon>
@@ -149,7 +99,7 @@ export class ZwaveNetwork extends LitElement {
                               >
                             `
                           : ""}
-                        ${this._networkStatus.state == 10
+                        ${this._networkStatus.state === 10
                           ? html`
                               Z-Wave Network Started<br />
                               <small>All nodes have been queried.</small>
@@ -224,6 +174,55 @@ export class ZwaveNetwork extends LitElement {
           : ""}
       </ha-config-section>
     `;
+  }
+
+  private async _getNetworkStatus(): Promise<void> {
+    this._networkStatus = await fetchNetworkStatus(this.hass!);
+  }
+  private _subscribe(): void {
+    this._unsubs.push(
+      this.hass!.connection.subscribeEvents(
+        (event) => this._handleEvent(event),
+        "zwave.network_start"
+      )
+    );
+    this._unsubs.push(
+      this.hass!.connection.subscribeEvents(
+        (event) => this._handleEvent(event),
+        "zwave.network_stop"
+      )
+    );
+    this._unsubs.push(
+      this.hass!.connection.subscribeEvents(
+        (event) => this._handleEvent(event),
+        "zwave.network_ready"
+      )
+    );
+    this._unsubs.push(
+      this.hass!.connection.subscribeEvents(
+        (event) => this._handleEvent(event),
+        "zwave.network_complete"
+      )
+    );
+    this._unsubs.push(
+      this.hass!.connection.subscribeEvents(
+        (event) => this._handleEvent(event),
+        "zwave.network_complete_some_dead"
+      )
+    );
+  }
+
+  private _unsubscribe(): void {
+    while (this._unsubs.length) {
+      this._unsubs.pop()();
+    }
+  }
+
+  private _handleEvent(event) {
+    this._getNetworkStatus();
+    event["event_type"] === "zwave.network_start"
+      ? (this._networkStarting = true)
+      : (this._networkStarting = false);
   }
 
   private _onHelpTap(): void {

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -43,9 +43,6 @@ export class ZwaveNetwork extends LitElement {
     this._getNetworkStatus();
     this._subscribe();
   }
-  public disconnectedCallback(): void {
-    this._unsubscribe();
-  }
 
   protected render(): TemplateResult | void {
     return html`
@@ -230,6 +227,10 @@ export class ZwaveNetwork extends LitElement {
       >
       </ha-service-description>
     `;
+  }
+
+  public disconnectedCallback(): void {
+    this._unsubscribe();
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -37,7 +37,7 @@ export class ZwaveNetwork extends LitElement {
   @property() private _showHelp = false;
   @property() private _networkStatus?: ZWaveNetworkStatus;
   @property() private _networkStarting = false;
-  @property() private _unsubs: Promise<UnsubscribeFunc>[] = [];
+  @property() private _unsubs: Array<Promise<UnsubscribeFunc>> = [];
 
   public disconnectedCallback(): void {
     this._unsubscribe();

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -921,7 +921,31 @@
         },
         "zwave": {
           "caption": "Z-Wave",
-          "description": "Manage your Z-Wave network"
+          "description": "Manage your Z-Wave network",
+          "network_management": {
+            "header": "Z-Wave Network Management",
+            "introduction": "Run commands that affect the Z-Wave network. You won't get feedback on whether most commands succeeded, but you can check the OZW Log to try to find out."
+          },
+          "network_status": {
+            "network_stopped": "Z-Wave Network Stopped",
+            "network_starting": "Starting Z-Wave Network...",
+            "network_starting_note": "This may take a while depending on the size of your network.",
+            "network_started": "Z-Wave Network Started",
+            "network_started_note_some_queried": "Awake nodes have been queried. Sleeping nodes will be queried when they wake.",
+            "network_started_note_all_queried": "All nodes have been queried."
+          },
+          "services": {
+            "start_network": "Start Network",
+            "stop_network": "Stop Network",
+            "heal_network": "Heal Network",
+            "test_network": "Test Network",
+            "soft_reset": "Soft Reset",
+            "save_config": "Save Config",
+            "add_node_secure": "Add Node Secure",
+            "add_node": "Add Node",
+            "remove_node": "Remove Node",
+            "cancel_command": "Cancel Command"
+          }
         }
       },
       "history": {


### PR DESCRIPTION
Show the status of the Z-Wave network and hides buttons that control the network if the network is stopped, as these buttons won't do anything.

Also adds translation keys to everything in the "Network Management" portion.

![Z-Wave Panel Updates](https://user-images.githubusercontent.com/7545841/61015621-53cf7600-a35a-11e9-8548-ba379808ec4a.gif)

- [x] Depends on backend PR https://github.com/home-assistant/home-assistant/pull/25066
- [x] Add translations
