### PR TITLE
Replace standard browser scrollbar for sidebar

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -412,6 +412,17 @@ class HaSidebar extends LitElement {
         display: initial;
       }
 
+      ::-webkit-scrollbar {
+        width: 0.4rem;
+        height: 0.4rem;
+      }
+
+      ::-webkit-scrollbar-thumb {
+        -webkit-border-radius: 4px;
+        border-radius: 4px;
+        background: var(--secondary-text-color);
+      }
+
       paper-listbox {
         padding: 4px 0;
         display: flex;

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -124,17 +124,6 @@ documentContainer.innerHTML = `<custom-style>
       /* mwc */
       --mdc-theme-primary: var(--primary-color);
     }
-
-    ::-webkit-scrollbar {
-      width: 0.4rem;
-      height: 0.4rem;
-    }
-
-    ::-webkit-scrollbar-thumb {
-      -webkit-border-radius: 4px;
-      border-radius: 4px;
-      background: var(--secondary-text-color);
-    }
   </style>
 
   <style shady-unscoped="">

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -124,6 +124,17 @@ documentContainer.innerHTML = `<custom-style>
       /* mwc */
       --mdc-theme-primary: var(--primary-color);
     }
+
+    ::-webkit-scrollbar {
+      width: 0.4rem;
+      height: 0.4rem;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      -webkit-border-radius: 4px;
+      border-radius: 4px;
+      background: var(--secondary-text-color);
+    }
   </style>
 
   <style shady-unscoped="">


### PR DESCRIPTION
Updated to beta today. Really liked the new sidebar, but the default browser scrollbars were causing all sorts of issues. Primarily, they were taking up 30% of the sidebar when minimised. There is also horizontal scrolling when the scrollbar appears on the sidebar which this change fixes.

This adds css for a scrollbar I have used in other apps which replaces the scrollbar to a much nicer one, similar to the ones mobile devices use by default.

### Before

![image](https://user-images.githubusercontent.com/28114703/61079439-cc960700-a41a-11e9-9909-dde07ff70d24.png)

### After

![image](https://user-images.githubusercontent.com/28114703/61079474-dddf1380-a41a-11e9-94ae-07d178702a4f.png)


I have only been able to replace the scrollbar in the sidebar and overview.

Let me know where I can add this to make the change global, whether I should stick to just the sidebar, what you think etc. :+1: 
