### PR TITLE
Add frontend version to info

### DIFF
--- a/src/panels/developer-tools/info/developer-tools-info.ts
+++ b/src/panels/developer-tools/info/developer-tools-info.ts
@@ -14,7 +14,8 @@ import "./system-log-card";
 import "./error-log-card";
 import "./system-health-card";
 
-const JS_VERSION = __BUILD__;
+const JS_TYPE = __BUILD__;
+const JS_VERSION = __VERSION__;
 const OPT_IN_PANEL = "states";
 
 class HaPanelDevInfo extends LitElement {
@@ -92,7 +93,7 @@ class HaPanelDevInfo extends LitElement {
           >.
         </p>
         <p>
-          Frontend JavaScript version: ${JS_VERSION}
+          Frontend version: ${JS_VERSION} - ${JS_TYPE}
           ${customUiList.length > 0
             ? html`
                 <div>


### PR DESCRIPTION
On dev info page, now also include the frontend version. Should help verify that people are running a specific version.

> Frontend version: 20190710.0 - latest