### PR TITLE
Fix incorrect tooltip on Add Person button

### DIFF
--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -112,7 +112,7 @@ class HaConfigPerson extends LitElement {
       <paper-fab
         ?is-wide=${this.isWide}
         icon="hass:plus"
-        title="Create Area"
+        title="Add Person"
         @click=${this._createPerson}
       ></paper-fab>
     `;


### PR DESCRIPTION
The tooltip for the add person button incorrectly says "Create Area" when hovered. This should fix it.

(Also I went with "Add Person" because I think it sounds more natural than "Create Person").