### PR TITLE
Rename HVAC mode auto to program

### DIFF
--- a/src/data/climate.ts
+++ b/src/data/climate.ts
@@ -8,7 +8,7 @@ export type HvacMode =
   | "heat"
   | "cool"
   | "heat_cool"
-  | "auto"
+  | "program"
   | "dry"
   | "fan_only";
 

--- a/src/data/climate.ts
+++ b/src/data/climate.ts
@@ -15,8 +15,8 @@ export type HvacMode =
 export type HvacAction = "off" | "Heating" | "cooling" | "drying" | "idle";
 
 export type ClimateEntity = HassEntityBase & {
+  state: HvacMode;
   attributes: HassEntityAttributeBase & {
-    hvac_mode: HvacMode;
     hvac_modes: HvacMode[];
     hvac_action?: HvacAction;
     current_temperature: number;

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -208,6 +208,7 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
 
       this._jQuery("#thermostat", this.shadowRoot).roundSlider({
         value: sliderValue,
+        disabled: stateObj.state === "program",
       });
       this._updateSetTemp(uiValue);
     }

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -37,7 +37,7 @@ const thermostatConfig = {
 };
 
 const modeIcons: { [mode in HvacMode]: string } = {
-  auto: "hass:autorenew",
+  program: "hass:desktop-classic",
   heat_cool: "hass:autorenew",
   heat: "hass:fire",
   cool: "hass:snowflake",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -178,8 +178,8 @@
       "off": "[%key:state::default::off%]",
       "heat": "Heat",
       "cool": "Cool",
-      "heat_cool": "Auto",
-      "auto": "Auto",
+      "heat_cool": "Heat/Cool",
+      "program": "Program",
       "dry": "Dry",
       "fan_only": "Fan only"
     },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -317,7 +317,7 @@
       "fan_mode": {
         "off": "[%key:state::default::off%]",
         "on": "[%key:state::default::on%]",
-        "auto": "[%key:state::climate::auto%]"
+        "auto": "Auto"
       },
       "preset_mode": {
         "none": "None",


### PR DESCRIPTION
Rename HVAC MODE `auto` to `program`.

Arch issue: https://github.com/home-assistant/architecture/issues/260