### PR TITLE
Add link to Alexa skill on Cloud page

### DIFF
--- a/src/panels/config/cloud/account/cloud-alexa-pref.ts
+++ b/src/panels/config/cloud/account/cloud-alexa-pref.ts
@@ -41,8 +41,12 @@ export class CloudAlexaPref extends LitElement {
           control all your Home Assistant devices via any Alexa-enabled device.
           <ul>
             <li>
-              To activate, search in the Alexa app for the Home Assistant Smart
-              Home skill.
+              <a
+                href="https://skills-store.amazon.com/deeplink/dp/B0772J1QKB?deviceType=app"
+                target="_blank"
+              >
+                Enable the Home Assistant skill for Alexa
+              </a>
             </li>
             <li>
               <a


### PR DESCRIPTION
This adds a direct link to the Home Assistant Alexa skill, which is more convenient and less error-prone than telling the user to search for it themselves. On mobile devices it can open the skill directly in the Alexa app which is nice.

Also tweaked the wording from "activate" to "enable" since that is what Amazon uses.