### PR TITLE
Differentiate Heat/Cool

### DIFF
--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -37,7 +37,7 @@ const thermostatConfig = {
 };
 
 const modeIcons: { [mode in HvacMode]: string } = {
-  auto: "hass:autorenew",
+  auto: "hass:calendar-repeat",
   heat_cool: "hass:autorenew",
   heat: "hass:fire",
   cool: "hass:snowflake",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -173,7 +173,7 @@
       "off": "[%key:state::default::off%]",
       "heat": "Heat",
       "cool": "Cool",
-      "heat_cool": "Auto",
+      "heat_cool": "Heat/Cool",
       "auto": "Auto",
       "dry": "Dry",
       "fan_only": "Fan only"


### PR DESCRIPTION
This differentiates heat/cool from auto in the frontend.

Needs to delete the key in Lokalise before we merge this, to remove old and incorrect translation.