### PR TITLE
Add a force mobile mode on desktop

### DIFF
--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -78,14 +78,25 @@ class HaMenuButton extends LitElement {
   protected updated(changedProps) {
     super.updated(changedProps);
 
-    if (!changedProps.has("narrow")) {
+    if (!changedProps.has("narrow") && !changedProps.has("hass")) {
+      return;
+    }
+
+    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+    const oldNarrow =
+      changedProps.get("narrow") ||
+      (oldHass && oldHass.dockedSidebar === "always_hidden");
+    const newNarrow =
+      this.narrow || this.hass.dockedSidebar === "always_hidden";
+
+    if (oldNarrow === newNarrow) {
       return;
     }
 
     this.style.visibility =
-      this.narrow || this._alwaysVisible ? "initial" : "hidden";
+      newNarrow || this._alwaysVisible ? "initial" : "hidden";
 
-    if (!this.narrow) {
+    if (!newNarrow) {
       this._hasNotifications = false;
       if (this._unsubNotifications) {
         this._unsubNotifications();

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -218,7 +218,7 @@ class HaSidebar extends LitElement {
         <span class="item-text">
           ${hass.localize("ui.notification_drawer.title")}
         </span>
-        ${this.expanded
+        ${this.expanded && notificationCount > 0
           ? html`
               <span class="notification-badge">${notificationCount}</span>
             `

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -134,7 +134,9 @@ class HaSidebar extends LitElement {
           ? html`
               <paper-icon-button
                 aria-label="Sidebar Toggle"
-                .icon=${hass.dockedSidebar ? "hass:menu-open" : "hass:menu"}
+                .icon=${hass.dockedSidebar === "docked"
+                  ? "hass:menu-open"
+                  : "hass:menu"}
                 @click=${this._toggleSidebar}
               ></paper-icon-button>
             `

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -159,7 +159,7 @@ export const provideHass = (
     localize: () => "",
 
     translationMetadata: translationMetadata as any,
-    dockedSidebar: false,
+    dockedSidebar: "auto",
     moreInfoEntityId: null as any,
     async callService(domain, service, data) {
       if (data && "entity_id" in data) {

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -146,7 +146,8 @@ class HaPanelConfig extends HassRouterPage {
     const showAdvanced = !!(
       this._coreUserData && this._coreUserData.showAdvanced
     );
-    const isWide = this.hass.dockedSidebar ? this._wideSidebar : this._wide;
+    const isWide =
+      this.hass.dockedSidebar === "docked" ? this._wideSidebar : this._wide;
 
     if ("setProperties" in el) {
       // As long as we have Polymer panels

--- a/src/panels/config/zha/zha-config-panel.ts
+++ b/src/panels/config/zha/zha-config-panel.ts
@@ -2,7 +2,6 @@ import "../../../layouts/hass-loading-screen";
 
 import { customElement, property } from "lit-element";
 
-import { listenMediaQuery } from "../../../common/dom/media_query";
 import {
   HassRouterPage,
   RouterOptions,
@@ -12,8 +11,7 @@ import { HomeAssistant } from "../../../types";
 @customElement("zha-config-panel")
 class ZHAConfigPanel extends HassRouterPage {
   @property() public hass!: HomeAssistant;
-  @property() public _wideSidebar: boolean = false;
-  @property() public _wide: boolean = false;
+  @property() public isWide!: boolean;
 
   protected routerOptions: RouterOptions = {
     defaultPage: "configuration",
@@ -33,33 +31,10 @@ class ZHAConfigPanel extends HassRouterPage {
     },
   };
 
-  private _listeners: Array<() => void> = [];
-
-  public connectedCallback(): void {
-    super.connectedCallback();
-    this._listeners.push(
-      listenMediaQuery("(min-width: 1040px)", (matches) => {
-        this._wide = matches;
-      })
-    );
-    this._listeners.push(
-      listenMediaQuery("(min-width: 1296px)", (matches) => {
-        this._wideSidebar = matches;
-      })
-    );
-  }
-
-  public disconnectedCallback(): void {
-    super.disconnectedCallback();
-    while (this._listeners.length) {
-      this._listeners.pop()!();
-    }
-  }
-
   protected updatePageEl(el): void {
     el.route = this.routeTail;
     el.hass = this.hass;
-    el.isWide = this.hass.dockedSidebar ? this._wideSidebar : this._wide;
+    el.isWide = this.isWide;
   }
 }
 

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -178,7 +178,8 @@ class LovelacePanel extends LitElement {
     // Do -1 column if the menu is docked and open
     this._columns = Math.max(
       1,
-      matchColumns - Number(!this.narrow && this.hass!.dockedSidebar)
+      matchColumns -
+        Number(!this.narrow && this.hass!.dockedSidebar === "docked")
     );
   }
 

--- a/src/panels/profile/ha-force-narrow-row.ts
+++ b/src/panels/profile/ha-force-narrow-row.ts
@@ -1,0 +1,52 @@
+import {
+  LitElement,
+  TemplateResult,
+  html,
+  property,
+  customElement,
+} from "lit-element";
+import "@polymer/paper-toggle-button/paper-toggle-button";
+
+import "./ha-settings-row";
+import { HomeAssistant } from "../../types";
+import { fireEvent } from "../../common/dom/fire_event";
+import { PolymerChangedEvent } from "../../polymer-types";
+
+@customElement("ha-force-narrow-row")
+class HaPushNotificationsRow extends LitElement {
+  @property() public hass!: HomeAssistant;
+  @property() public narrow!: boolean;
+
+  protected render(): TemplateResult | void {
+    return html`
+      <ha-settings-row .narrow=${this.narrow}>
+        <span slot="heading">
+          ${this.hass.localize("ui.panel.profile.force_narrow.header")}
+        </span>
+        <span slot="description">
+          ${this.hass.localize("ui.panel.profile.force_narrow.description")}
+        </span>
+        <paper-toggle-button
+          .checked=${this.hass.dockedSidebar === "always_hidden"}
+          @checked-changed=${this._checkedChanged}
+        ></paper-toggle-button>
+      </ha-settings-row>
+    `;
+  }
+
+  private async _checkedChanged(ev: PolymerChangedEvent<boolean>) {
+    const newValue = ev.detail.value;
+    if (newValue === (this.hass.dockedSidebar === "always_hidden")) {
+      return;
+    }
+    fireEvent(this, "hass-dock-sidebar", {
+      dock: newValue ? "always_hidden" : "auto",
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-force-narrow-row": HaPushNotificationsRow;
+  }
+}

--- a/src/panels/profile/ha-panel-profile.js
+++ b/src/panels/profile/ha-panel-profile.js
@@ -84,10 +84,6 @@ class HaPanelProfile extends EventsMixin(LocalizeMixin(PolymerElement)) {
               narrow="[[narrow]]"
               hass="[[hass]]"
             ></ha-pick-theme-row>
-            <ha-push-notifications-row
-              narrow="[[narrow]]"
-              hass="[[hass]]"
-            ></ha-push-notifications-row>
             <template
               is="dom-if"
               if="[[_showNarrowRow(hass.dockedSidebar, narrow)]]"
@@ -97,6 +93,10 @@ class HaPanelProfile extends EventsMixin(LocalizeMixin(PolymerElement)) {
                 hass="[[hass]]"
               ></ha-force-narrow-row>
             </template>
+            <ha-push-notifications-row
+              narrow="[[narrow]]"
+              hass="[[hass]]"
+            ></ha-push-notifications-row>
 
             <div class="card-actions">
               <mwc-button class="warning" on-click="_handleLogOut"

--- a/src/panels/profile/ha-panel-profile.js
+++ b/src/panels/profile/ha-panel-profile.js
@@ -25,6 +25,7 @@ import "./ha-long-lived-access-tokens-card";
 import "./ha-pick-language-row";
 import "./ha-pick-theme-row";
 import "./ha-push-notifications-row";
+import "./ha-force-narrow-row";
 
 /*
  * @appliesMixin EventsMixin
@@ -87,6 +88,15 @@ class HaPanelProfile extends EventsMixin(LocalizeMixin(PolymerElement)) {
               narrow="[[narrow]]"
               hass="[[hass]]"
             ></ha-push-notifications-row>
+            <template
+              is="dom-if"
+              if="[[_showNarrowRow(hass.dockedSidebar, narrow)]]"
+            >
+              <ha-force-narrow-row
+                narrow="[[narrow]]"
+                hass="[[hass]]"
+              ></ha-force-narrow-row>
+            </template>
 
             <div class="card-actions">
               <mwc-button class="warning" on-click="_handleLogOut"
@@ -173,6 +183,10 @@ class HaPanelProfile extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
   _isAdmin(user) {
     return user.is_admin;
+  }
+
+  _showNarrowRow(dockedSidebar, narrow) {
+    return dockedSidebar === "auto" ? !narrow : true;
   }
 }
 

--- a/src/panels/states/ha-panel-states.js
+++ b/src/panels/states/ha-panel-states.js
@@ -237,7 +237,7 @@ class PartialCards extends EventsMixin(NavigateMixin(PolymerElement)) {
     // Do -1 column if the menu is docked and open
     this._columns = Math.max(
       1,
-      matchColumns - (!this.narrow && this.hass.dockedSidebar)
+      matchColumns - (!this.narrow && this.hass.dockedSidebar === "docked")
     );
   }
 

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -44,7 +44,7 @@ export const connectionMixin = (
         localize: () => "",
 
         translationMetadata,
-        dockedSidebar: true,
+        dockedSidebar: "docked",
         moreInfoEntityId: null,
         callService: async (domain, service, serviceData = {}) => {
           if (__DEV__) {

--- a/src/state/sidebar-mixin.ts
+++ b/src/state/sidebar-mixin.ts
@@ -2,9 +2,10 @@ import { storeState } from "../util/ha-pref-storage";
 import { Constructor, LitElement } from "lit-element";
 import { HassBaseEl } from "./hass-base-mixin";
 import { HASSDomEvent } from "../common/dom/fire_event";
+import { HomeAssistant } from "../types";
 
 interface DockSidebarParams {
-  dock: boolean;
+  dock: HomeAssistant["dockedSidebar"];
 }
 
 declare global {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1053,8 +1053,8 @@
         "is_owner": "You are an owner.",
         "logout": "Log out",
         "force_narrow": {
-          "header": "Force Mobile Mode",
-          "description": "This will always hide the sidebar."
+          "header": "Always hide the sidebar",
+          "description": "This will hide the sidebar by default, similar to the mobile experience."
         },
         "push_notifications": {
           "header": "Push Notifications",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1052,6 +1052,10 @@
         "current_user": "You are currently logged in as {fullName}.",
         "is_owner": "You are an owner.",
         "logout": "Log out",
+        "force_narrow": {
+          "header": "Force Mobile Mode",
+          "description": "This will always hide the sidebar."
+        },
         "push_notifications": {
           "header": "Push Notifications",
           "description": "Send notifications to this device.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,7 +139,7 @@ export interface HomeAssistant {
   localize: LocalizeFunc;
   translationMetadata: TranslationMetadata;
 
-  dockedSidebar: boolean;
+  dockedSidebar: "docked" | "always_hidden" | "auto";
   moreInfoEntityId: string | null;
   user?: CurrentUser;
   callService: (

--- a/src/util/ha-pref-storage.ts
+++ b/src/util/ha-pref-storage.ts
@@ -19,7 +19,12 @@ export function getState() {
 
   for (const key of STORED_STATE) {
     if (key in STORAGE) {
-      state[key] = JSON.parse(STORAGE[key]);
+      let value = JSON.parse(STORAGE[key]);
+      // dockedSidebar went from boolean to enum on 20190720
+      if (key === "dockedSidebar" && typeof value === "boolean") {
+        value = value ? "docked" : "auto";
+      }
+      state[key] = value;
     }
   }
 


### PR DESCRIPTION
On desktop, a new "force mobile mode" option is available on the profile page. This will make the sidebar behave like it does on mobile.

![image](https://user-images.githubusercontent.com/1444314/61581584-19da3e80-aad5-11e9-97e1-cc6453a8dfa4.png)
