### PR TITLE
Replace expanded docked sidebar option with force mobile mode

### DIFF
--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -78,16 +78,23 @@ class HaMenuButton extends LitElement {
   protected updated(changedProps) {
     super.updated(changedProps);
 
-    if (!changedProps.has("narrow")) {
+    if (!changedProps.has("narrow") && !changedProps.has("hass")) {
+      return;
+    }
+
+    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+    const oldVisible =
+      changedProps.get("narrow") || (oldHass && !oldHass.dockedSidebar);
+    const newVisible = this.narrow || !this.hass.dockedSidebar;
+
+    if (oldVisible === newVisible) {
       return;
     }
 
     this.style.visibility =
-      this.narrow || !this.hass.dockedSidebar || this._alwaysVisible
-        ? "initial"
-        : "hidden";
+      newVisible || this._alwaysVisible ? "initial" : "hidden";
 
-    if (!this.narrow) {
+    if (!newVisible) {
       this._hasNotifications = false;
       if (this._unsubNotifications) {
         this._unsubNotifications();

--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -83,7 +83,9 @@ class HaMenuButton extends LitElement {
     }
 
     this.style.visibility =
-      this.narrow || this._alwaysVisible ? "initial" : "hidden";
+      this.narrow || !this.hass.dockedSidebar || this._alwaysVisible
+        ? "initial"
+        : "hidden";
 
     if (!this.narrow) {
       this._hasNotifications = false;

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -134,8 +134,10 @@ class HaSidebar extends LitElement {
           ? html`
               <paper-icon-button
                 aria-label="Sidebar Toggle"
-                .icon=${hass.dockedSidebar ? "hass:menu-open" : "hass:menu"}
-                @click=${this._toggleSidebar}
+                .icon=${hass.dockedSidebar
+                  ? "hass:backburger"
+                  : "hass:menu-open"}
+                @click=${this._clickSidebar}
               ></paper-icon-button>
             `
           : ""}
@@ -270,6 +272,7 @@ class HaSidebar extends LitElement {
     }
     const hass = this.hass;
     return (
+      hass.dockedSidebar !== oldHass.dockedSidebar ||
       hass.panels !== oldHass.panels ||
       hass.panelUrl !== oldHass.panelUrl ||
       hass.user !== oldHass.user ||
@@ -405,8 +408,10 @@ class HaSidebar extends LitElement {
     });
   }
 
-  private _toggleSidebar() {
-    fireEvent(this, "hass-toggle-menu");
+  private _clickSidebar() {
+    fireEvent(this, "hass-dock-sidebar", {
+      dock: !this.hass.dockedSidebar,
+    });
   }
 
   private _renderPanel(urlPath, icon, title) {

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -159,7 +159,7 @@ export const provideHass = (
     localize: () => "",
 
     translationMetadata: translationMetadata as any,
-    dockedSidebar: false,
+    dockedSidebar: true,
     moreInfoEntityId: null as any,
     async callService(domain, service, data) {
       if (data && "entity_id" in data) {

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -96,7 +96,6 @@ class HaPanelConfig extends HassRouterPage {
     },
   };
 
-  @property() private _wideSidebar: boolean = false;
   @property() private _wide: boolean = false;
   @property() private _coreUserData?: CoreFrontendUserData;
   @property() private _cloudStatus?: CloudStatus;
@@ -108,11 +107,6 @@ class HaPanelConfig extends HassRouterPage {
     this._listeners.push(
       listenMediaQuery("(min-width: 1040px)", (matches) => {
         this._wide = matches;
-      })
-    );
-    this._listeners.push(
-      listenMediaQuery("(min-width: 1296px)", (matches) => {
-        this._wideSidebar = matches;
       })
     );
     this._listeners.push(
@@ -146,7 +140,6 @@ class HaPanelConfig extends HassRouterPage {
     const showAdvanced = !!(
       this._coreUserData && this._coreUserData.showAdvanced
     );
-    const isWide = this.hass.dockedSidebar ? this._wideSidebar : this._wide;
 
     if ("setProperties" in el) {
       // As long as we have Polymer panels
@@ -154,7 +147,7 @@ class HaPanelConfig extends HassRouterPage {
         route: this.routeTail,
         hass: this.hass,
         showAdvanced,
-        isWide,
+        isWide: this._wide,
         narrow: this.narrow,
         cloudStatus: this._cloudStatus,
       });
@@ -162,7 +155,7 @@ class HaPanelConfig extends HassRouterPage {
       el.route = this.routeTail;
       el.hass = this.hass;
       el.showAdvanced = showAdvanced;
-      el.isWide = isWide;
+      el.isWide = this._wide;
       el.narrow = this.narrow;
       el.cloudStatus = this._cloudStatus;
     }

--- a/src/panels/config/zha/zha-config-panel.ts
+++ b/src/panels/config/zha/zha-config-panel.ts
@@ -2,7 +2,6 @@ import "../../../layouts/hass-loading-screen";
 
 import { customElement, property } from "lit-element";
 
-import { listenMediaQuery } from "../../../common/dom/media_query";
 import {
   HassRouterPage,
   RouterOptions,
@@ -12,8 +11,7 @@ import { HomeAssistant } from "../../../types";
 @customElement("zha-config-panel")
 class ZHAConfigPanel extends HassRouterPage {
   @property() public hass!: HomeAssistant;
-  @property() public _wideSidebar: boolean = false;
-  @property() public _wide: boolean = false;
+  @property() public isWide!: boolean;
 
   protected routerOptions: RouterOptions = {
     defaultPage: "configuration",
@@ -33,33 +31,10 @@ class ZHAConfigPanel extends HassRouterPage {
     },
   };
 
-  private _listeners: Array<() => void> = [];
-
-  public connectedCallback(): void {
-    super.connectedCallback();
-    this._listeners.push(
-      listenMediaQuery("(min-width: 1040px)", (matches) => {
-        this._wide = matches;
-      })
-    );
-    this._listeners.push(
-      listenMediaQuery("(min-width: 1296px)", (matches) => {
-        this._wideSidebar = matches;
-      })
-    );
-  }
-
-  public disconnectedCallback(): void {
-    super.disconnectedCallback();
-    while (this._listeners.length) {
-      this._listeners.pop()!();
-    }
-  }
-
   protected updatePageEl(el): void {
     el.route = this.routeTail;
     el.hass = this.hass;
-    el.isWide = this.hass.dockedSidebar ? this._wideSidebar : this._wide;
+    el.isWide = this.isWide;
   }
 }
 

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -114,12 +114,6 @@ class LovelacePanel extends LitElement {
     if (!changedProps.has("hass")) {
       return;
     }
-
-    const oldHass = changedProps.get("hass") as this["hass"];
-
-    if (oldHass && this.hass!.dockedSidebar !== oldHass.dockedSidebar) {
-      this._updateColumns();
-    }
   }
 
   public firstUpdated() {
@@ -171,14 +165,9 @@ class LovelacePanel extends LitElement {
   }
 
   private _updateColumns() {
-    const matchColumns = this.mqls!.reduce(
+    this._columns = this.mqls!.reduce(
       (cols, mql) => cols + Number(mql.matches),
       0
-    );
-    // Do -1 column if the menu is docked and open
-    this._columns = Math.max(
-      1,
-      matchColumns - Number(!this.narrow && this.hass!.dockedSidebar)
     );
   }
 

--- a/src/panels/states/ha-panel-states.js
+++ b/src/panels/states/ha-panel-states.js
@@ -210,10 +210,6 @@ class PartialCards extends EventsMixin(NavigateMixin(PolymerElement)) {
     };
   }
 
-  static get observers() {
-    return ["_updateColumns(narrow, hass.dockedSidebar)"];
-  }
-
   ready() {
     this._updateColumns = this._updateColumns.bind(this);
     this.mqls = [300, 600, 900, 1200].map((width) =>
@@ -233,12 +229,7 @@ class PartialCards extends EventsMixin(NavigateMixin(PolymerElement)) {
   }
 
   _updateColumns() {
-    const matchColumns = this.mqls.reduce((cols, mql) => cols + mql.matches, 0);
-    // Do -1 column if the menu is docked and open
-    this._columns = Math.max(
-      1,
-      matchColumns - (!this.narrow && this.hass.dockedSidebar)
-    );
+    this._columns = this.mqls.reduce((cols, mql) => cols + mql.matches, 0);
   }
 
   areTabsHidden(views, showTabs) {


### PR DESCRIPTION
Now that we have tooltips, it might not be necessary to offer a docked full-width sidebar. So we can re-use the menu button to offer a force mobile mode.

Alternative to https://github.com/home-assistant/home-assistant-polymer/pull/3394