### PR TITLE
Remove automatically including preset None

### DIFF
--- a/src/dialogs/more-info/controls/more-info-climate.ts
+++ b/src/dialogs/more-info/controls/more-info-climate.ts
@@ -206,11 +206,6 @@ class MoreInfoClimate extends LitElement {
                     .selected=${stateObj.attributes.preset_mode}
                     @selected-changed=${this._handlePresetmodeChanged}
                   >
-                    <paper-item item-name="">
-                      ${hass.localize(
-                        `state_attributes.climate.preset_mode.none`
-                      )}
-                    </paper-item>
                     ${stateObj.attributes.preset_modes!.map(
                       (mode) => html`
                         <paper-item item-name=${mode}>


### PR DESCRIPTION
We should not include "none" automatically but let integrations include it if they support it.