### PR TITLE
Close script tag

### DIFF
--- a/src/html/_js_base.html.template
+++ b/src/html/_js_base.html.template
@@ -17,7 +17,7 @@
       };
       if (!("customElements" in window &&
             "content" in document.createElement("template"))) {
-        document.write("<script src='/static/polyfills/webcomponents-bundle.js'>");
+        document.write("<script src='/static/polyfills/webcomponents-bundle.js'></script>");
       }
       var isS101 = /\s+Version\/10\.1(?:\.\d+)?\s+Safari\//.test(navigator.userAgent);
     </script>


### PR DESCRIPTION
Properly closing script tag. The open script tag was swalling all content after it, including loading the UI.

Fixes #3383