### PR TITLE
Fix proper script closing tag

### DIFF
--- a/src/html/_js_base.html.template
+++ b/src/html/_js_base.html.template
@@ -17,7 +17,7 @@
       };
       if (!("customElements" in window &&
             "content" in document.createElement("template"))) {
-        document.write("<script src='/static/polyfills/webcomponents-bundle.js'></script>");
+        document.write("<script src='/static/polyfills/webcomponents-bundle.js'><"+"/script>");
       }
       var isS101 = /\s+Version\/10\.1(?:\.\d+)?\s+Safari\//.test(navigator.userAgent);
     </script>


### PR DESCRIPTION
Adding the word `</script>` inside a script tag, even as a string, will be interpolated as the end of the script tag, outputting the rest of the script on the page.