### PR TITLE
Update ZHA device card

### DIFF
--- a/src/data/entity_registry.ts
+++ b/src/data/entity_registry.ts
@@ -66,6 +66,12 @@ const subscribeEntityRegistryUpdates = (conn, store) =>
     "entity_registry_updated"
   );
 
+export const subscribeEntityRegistryEntryUpdated = (conn, callback) =>
+  conn.subscribeEvents(
+    debounce((event) => callback(event), 500, true),
+    "entity_registry_updated"
+  );
+
 export const subscribeEntityRegistry = (
   conn: Connection,
   onChange: (entities: EntityRegistryEntry[]) => void

--- a/src/data/entity_registry.ts
+++ b/src/data/entity_registry.ts
@@ -66,12 +66,6 @@ const subscribeEntityRegistryUpdates = (conn, store) =>
     "entity_registry_updated"
   );
 
-export const subscribeEntityRegistryEntryUpdated = (conn, callback) =>
-  conn.subscribeEvents(
-    debounce((event) => callback(event), 500, true),
-    "entity_registry_updated"
-  );
-
 export const subscribeEntityRegistry = (
   conn: Connection,
   onChange: (entities: EntityRegistryEntry[]) => void

--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -40,7 +40,7 @@ import { haStyle } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
 import { ItemSelectedEvent, NodeServiceData } from "./types";
 import { navigate } from "../../../common/navigate";
-import { UnsubscribeFunc } from "home-assistant-js-websocket";
+import { UnsubscribeFunc, HassEvent } from "home-assistant-js-websocket";
 import { formatAsPaddedHex } from "./functions";
 import computeStateName from "../../../common/entity/compute_state_name";
 
@@ -102,7 +102,7 @@ class ZHADeviceCard extends LitElement {
       }
     );
     this.hass.connection
-      .subscribeEvents((event) => {
+      .subscribeEvents((event: HassEvent) => {
         if (this.device) {
           this.device!.entities.forEach((deviceEntity) => {
             if (event.data.old_entity_id === deviceEntity.entity_id) {

--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -29,7 +29,6 @@ import {
 import {
   DeviceRegistryEntryMutableParams,
   updateDeviceRegistryEntry,
-  subscribeDeviceRegistry,
 } from "../../../data/device_registry";
 import {
   reconfigureNode,
@@ -66,16 +65,12 @@ class ZHADeviceCard extends LitElement {
   @property() private _selectedAreaIndex: number = -1;
   @property() private _userGivenName?: string;
   private _unsubAreas?: UnsubscribeFunc;
-  private _unsubDevices?: UnsubscribeFunc;
   private _unsubEntities?: UnsubscribeFunc;
 
   public disconnectedCallback() {
     super.disconnectedCallback();
     if (this._unsubAreas) {
       this._unsubAreas();
-    }
-    if (this._unsubDevices) {
-      this._unsubDevices();
     }
     if (this._unsubEntities) {
       this._unsubEntities();
@@ -87,20 +82,6 @@ class ZHADeviceCard extends LitElement {
     this._unsubAreas = subscribeAreaRegistry(this.hass.connection, (areas) => {
       this._areas = areas;
     });
-    this._unsubDevices = subscribeDeviceRegistry(
-      this.hass.connection,
-      (devices) => {
-        if (this.device) {
-          const haDevice = devices.find(
-            (device) => device.id === this.device!.device_reg_id
-          );
-          if (haDevice) {
-            this.device.user_given_name = haDevice.name_by_user;
-            this.device.area_id = haDevice.area_id;
-          }
-        }
-      }
-    );
     this.hass.connection
       .subscribeEvents((event: HassEvent) => {
         if (this.device) {

--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -102,9 +102,8 @@ class ZHADeviceCard extends LitElement {
         }
       }
     );
-    this._unsubEntities = subscribeEntityRegistryEntryUpdated(
-      this.hass.connection,
-      (event) => {
+    this.hass.connection
+      .subscribeEvents((event) => {
         if (this.device) {
           this.device!.entities.forEach((deviceEntity) => {
             if (event.data.old_entity_id === deviceEntity.entity_id) {
@@ -112,8 +111,8 @@ class ZHADeviceCard extends LitElement {
             }
           });
         }
-      }
-    );
+      }, "entity_registry_updated")
+      .then((unsub) => (this._unsubEntities = unsub));
   }
 
   protected firstUpdated(changedProperties: PropertyValues): void {

--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -31,7 +31,6 @@ import {
   updateDeviceRegistryEntry,
   subscribeDeviceRegistry,
 } from "../../../data/device_registry";
-import { subscribeEntityRegistryEntryUpdated } from "../../../data/entity_registry";
 import {
   reconfigureNode,
   ZHADevice,


### PR DESCRIPTION
This PR addresses a few issues with the ZHA device card:

- entity id changes from the more info dialog are now reflected correctly on the card
- the entity name is now used instead of the device name for each entity
- entity name changes from the more info dialog are now reflected correctly on the card
- device registry related changes are accurately reflected