### PR TITLE
use --text-primary-color for href instead of --primary-color

### DIFF
--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -60,7 +60,7 @@ class HaPanelDevState extends EventsMixin(PolymerElement) {
         }
 
         .entities a {
-          color: var(--primary-color);
+          color: var(--text-primary-color);
         }
       </style>
 


### PR DESCRIPTION
the entity name on the dev-states page should not be the same color as the background

screenshot for reference: https://user-images.githubusercontent.com/47465166/52512392-6847f080-2bb9-11e9-98eb-7b936f37799a.JPG