### PR TITLE
Show notification indicator in forced mobile mode

### DIFF
--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -44,7 +44,7 @@ class HaMenuButton extends LitElement {
 
   protected render(): TemplateResult | void {
     const hasNotifications =
-      this.narrow &&
+      (this.narrow || this.hass.dockedSidebar === "always_hidden") &&
       (this._hasNotifications ||
         Object.keys(this.hass.states).some(
           (entityId) => computeDomain(entityId) === "configurator"
@@ -131,9 +131,10 @@ class HaMenuButton extends LitElement {
         background-color: var(--accent-color);
         width: 12px;
         height: 12px;
-        top: 8px;
-        right: 5px;
+        top: 5px;
+        right: 2px;
         border-radius: 50%;
+        border: 2px solid var(--primary-color);
       }
     `;
   }


### PR DESCRIPTION
Fixes bug where the menu button would not show there are pending notifications when browsing in desktop mode with forced mobile mode on.

Also adds a small border around the indicator to make it more visible.

<img width="485" alt="image" src="https://user-images.githubusercontent.com/1444314/61831705-7e720200-ae23-11e9-92c4-34e4d78b4ebc.png">
