### PR TITLE
Lovelace: make weblink target attribute based off relative/full url

### DIFF
--- a/src/panels/lovelace/special-rows/hui-weblink-row.ts
+++ b/src/panels/lovelace/special-rows/hui-weblink-row.ts
@@ -37,7 +37,10 @@ class HuiWeblinkRow extends LitElement implements EntityRow {
     }
 
     return html`
-      <a href="${this._config.url}" target="_blank">
+      <a
+        href=${this._config.url}
+        target=${this._config.url.indexOf("://") !== -1 ? "_blank" : ""}
+      >
         <ha-icon .icon="${this._config.icon}"></ha-icon>
         <div>${this._config.name}</div>
       </a>


### PR DESCRIPTION
If a weblink is pointing at a relative url, we no longer set `target=_blank`, causing the link to open in a new window. This way it's possible to link to other Lovelace pages from a weblink row.

Note, if people do not like this change, we can always make target a config option but keep the defaults as this PR sets them (which I think make the most sense).