### PR TITLE
Ignore LL updates for a second in YAML mode

### DIFF
--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -49,7 +49,8 @@ class LovelacePanel extends LitElement {
 
   private mqls?: MediaQueryList[];
 
-  private _saving: boolean = false;
+  private _ignoreNextUpdateEventBecauseOfSave = false;
+  private _ignoreUpdateUntilTime: number | undefined;
 
   constructor() {
     super();
@@ -184,19 +185,25 @@ class LovelacePanel extends LitElement {
   }
 
   private _lovelaceChanged() {
-    if (this._saving) {
-      this._saving = false;
-    } else {
-      showToast(this, {
-        message: this.hass!.localize("ui.panel.lovelace.changed_toast.message"),
-        action: {
-          action: () => this._fetchConfig(false),
-          text: this.hass!.localize("ui.panel.lovelace.changed_toast.refresh"),
-        },
-        duration: 0,
-        dismissable: false,
-      });
+    if (
+      this._ignoreUpdateUntilTime &&
+      new Date().getTime() < this._ignoreUpdateUntilTime
+    ) {
+      return;
     }
+    if (this._ignoreNextUpdateEventBecauseOfSave) {
+      this._ignoreNextUpdateEventBecauseOfSave = false;
+      return;
+    }
+    showToast(this, {
+      message: this.hass!.localize("ui.panel.lovelace.changed_toast.message"),
+      action: {
+        action: () => this._fetchConfig(false),
+        text: this.hass!.localize("ui.panel.lovelace.changed_toast.refresh"),
+      },
+      duration: 0,
+      dismissable: false,
+    });
   }
 
   private _forceFetchConfig() {
@@ -214,6 +221,13 @@ class LovelacePanel extends LitElement {
       confProm = llWindow.llConfProm;
       llWindow.llConfProm = undefined;
     } else {
+      // Refreshing a YAML config can trigger an update event. We will ignore
+      // all update events for a second after we refresh, as we already have
+      // the latest config in that case.
+      if (this.lovelace && this.lovelace.mode === "yaml") {
+        this._ignoreUpdateUntilTime = new Date().getTime() + 1000;
+      }
+
       confProm = fetchConfig(this.hass!.connection, forceDiskRefresh);
     }
 
@@ -265,7 +279,7 @@ class LovelacePanel extends LitElement {
             config: newConfig,
             mode: "storage",
           });
-          this._saving = true;
+          this._ignoreNextUpdateEventBecauseOfSave = true;
           await saveConfig(this.hass!, newConfig);
         } catch (err) {
           // tslint:disable-next-line


### PR DESCRIPTION
In YAML mode, ignore updates for a second after refresh.

Backend PR: https://github.com/home-assistant/home-assistant/pull/25507