### PR TITLE
Display history-graph entries in the order they were specified

### DIFF
--- a/src/panels/lovelace/cards/hui-history-graph-card.js
+++ b/src/panels/lovelace/cards/hui-history-graph-card.js
@@ -75,7 +75,7 @@ class HuiHistoryGraphCard extends PolymerElement {
 
     this.setProperties({
       _cacheConfig: {
-        cacheKey: _entities.sort().join(),
+        cacheKey: _entities.join(),
         hoursToShow: config.hours_to_show || 24,
         refresh: config.refresh_interval || 0,
       },


### PR DESCRIPTION
Fixes home-assistant/ui-schema#213
Full fix also requires home-assistant/home-assistant#25560