### PR TITLE
Fix development instructions

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Resolve all frontend dependencies that the application requires to develop.
+
+# Stop on errors
+set -e
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+


### PR DESCRIPTION
script/setup exists for the main home-assistant repo, but not for the frontend.

The bottom part of this change was generated by the git commit-hook.