### PR TITLE
Change selected sidebar item background variable

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -535,7 +535,7 @@ class HaSidebar extends LitElement {
         left: 0;
         pointer-events: none;
         content: "";
-        background-color: var(--sidebar-selected-icon-color);
+        background-color: var(--sidebar-selected-background-color);
         opacity: 0.12;
         transition: opacity 15ms linear;
         will-change: opacity;


### PR DESCRIPTION
By changing the background from `var(--sidebar-selected-icon-color)` to `var(--sidebar-selected-background-color)`, users can control the background color of the selected menu items independently from the text/icon color.