### PR TITLE
Use accent color for notification badge again

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -597,7 +597,7 @@ class HaSidebar extends LitElement {
         box-sizing: border-box;
         border-radius: 50%;
         font-weight: 400;
-        background-color: var(--primary-color);
+        background-color: var(--accent-color);
         line-height: 20px;
         text-align: center;
         padding: 0px 6px;


### PR DESCRIPTION
This fixes https://github.com/home-assistant/home-assistant-polymer/issues/3414 by changing the notification badge to use `accent-color` variable (same behavior as it was prior to 0.96 overhaul). I make extensive use of persistent_notifications and agree with that issue - the color change has made it a little harder to notice now. 

Before and after of how it looks on the default theme:
![badge](https://i.imgur.com/VHnyzQb.png)

The other reason I feel this makes sense, is that `accent-color` is already used in "mobile mode" dot (pic below), so this brings some consistency.

![mobile-badge](https://i.imgur.com/EOvtZGJ.jpg)

If this was an intentional change, feel free to reject/close this.