### PR TITLE
Remove conversation because it's not part of default config

### DIFF
--- a/src/fake_data/demo_config.ts
+++ b/src/fake_data/demo_config.ts
@@ -11,7 +11,7 @@ export const demoConfig: HassConfig = {
     temperature: "°C",
     volume: "L",
   },
-  components: ["conversation", "notify.html5", "history"],
+  components: ["notify.html5", "history"],
   time_zone: "America/Los_Angeles",
   config_dir: "/config",
   version: "DEMO",


### PR DESCRIPTION
Conversation integration is no longer part of the default config, so let's remove it from demo too.