### PR TITLE
Template markdown card

### DIFF
--- a/src/data/ws-templates.ts
+++ b/src/data/ws-templates.ts
@@ -6,18 +6,11 @@ interface RenderTemplateResult {
 
 export const subscribeRenderTemplate = (
   conn: Connection,
-  template: string,
   onChange: (result: string) => void,
-  entityIDs?: string | string[],
-  variables?: object
+  params?: object
 ): Promise<UnsubscribeFunc> => {
   return conn.subscribeMessage(
     (msg: RenderTemplateResult) => onChange(msg.result),
-    {
-      type: "render_template",
-      template,
-      entityIDs,
-      variables,
-    }
+    { type: "render_template", ...params }
   );
 };

--- a/src/data/ws-templates.ts
+++ b/src/data/ws-templates.ts
@@ -7,7 +7,11 @@ interface RenderTemplateResult {
 export const subscribeRenderTemplate = (
   conn: Connection,
   onChange: (result: string) => void,
-  params?: object
+  params: {
+    template: string;
+    entity_ids?: string | string[];
+    variables?: object;
+  }
 ): Promise<UnsubscribeFunc> => {
   return conn.subscribeMessage(
     (msg: RenderTemplateResult) => onChange(msg.result),

--- a/src/data/ws-templates.ts
+++ b/src/data/ws-templates.ts
@@ -1,0 +1,23 @@
+import { Connection, UnsubscribeFunc } from "home-assistant-js-websocket";
+
+interface RenderTemplateResult {
+  result: string;
+}
+
+export const subscribeRenderTemplate = (
+  conn: Connection,
+  template: string,
+  onChange: (result: string) => void,
+  entityIDs?: string | string[],
+  variables?: object
+): Promise<UnsubscribeFunc> => {
+  return conn.subscribeMessage(
+    (msg: RenderTemplateResult) => onChange(msg.result),
+    {
+      type: "render_template",
+      template,
+      entityIDs,
+      variables,
+    }
+  );
+};

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -51,6 +51,9 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
     this._cardSize = config._card_size;
 
     this._disconnect();
+    if (this._hass) {
+      this._connect();
+    }
   }
 
   public disconnectedCallback() {
@@ -83,11 +86,13 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
     if (!this._unsubRenderTemplate && this._hass && this._config) {
       this._unsubRenderTemplate = await subscribeRenderTemplate(
         this._hass.connection,
-        this._config.content,
         (result) => {
           this._content = result;
         },
-        this._config.entity_id
+        {
+          template: this._config.content,
+          entity_ids: this._config.entity_id,
+        }
       );
     }
   }

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -28,6 +28,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
 
   @property() private _config?: MarkdownCardConfig;
   @property() private content?: string = "";
+  @property() private connection: (() => void) | null = null;
 
   public getCardSize(): number {
     return (
@@ -49,17 +50,19 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
   }
 
   public set hass(hass) {
-    if (!this.connection && hass) {
-      hass.connection.subscribeMessage(
-        (msg) => {
-          this.content = msg.result;
-        },
-        {
-          type: "render_template",
-          template: this._config.content,
-          entity_ids: this._config.entity_id,
-        }
-      ).then((con) => this.connection = con);
+    if (!this.connection && this._config && hass) {
+      hass.connection
+        .subscribeMessage(
+          (msg) => {
+            this.content = msg.result;
+          },
+          {
+            type: "render_template",
+            template: this._config.content,
+            entity_ids: this._config.entity_id,
+          }
+        )
+        .then((con) => (this.connection = con));
     }
   }
 

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -103,14 +103,17 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
 
   private async _disconnect() {
     if (this._unsubRenderTemplate) {
-      this._unsubRenderTemplate
-        .then((unsub) => {
-          this._unsubRenderTemplate = undefined;
-          return unsub();
-        })
-        .catch(() => {
+      try {
+        const unsub = await this._unsubRenderTemplate;
+        this._unsubRenderTemplate = undefined;
+        await unsub();
+      } catch (e) {
+        if (e.code === "not_found") {
           // If we get here, the connection was probably already closed. Ignore.
-        });
+        } else {
+          throw e;
+        }
+      }
     }
   }
 

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -42,8 +42,9 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
 
     this._config = config;
 
-    if(this.connection)
+    if (this.connection) {
       this.connection();
+    }
     this.connection = null;
   }
 
@@ -56,6 +57,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
         {
           type: "render_template",
           template: this._config.content,
+          entity_ids: this._config.entity_id,
         }
       ).then((con) => this.connection = con);
     }

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -96,6 +96,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
       );
       this._unsubRenderTemplate.catch(() => {
         this._content = this._config!.content;
+        this._unsubRenderTemplate = undefined;
       });
     }
   }

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -32,14 +32,14 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
   @property() private _config?: MarkdownCardConfig;
   @property() private _content?: string = "";
   @property() private _unsubRenderTemplate?: Promise<UnsubscribeFunc>;
-  @property() private _cardSize?: number;
   @property() private _hass?: HomeAssistant;
 
   public getCardSize(): number {
-    return this._cardSize !== undefined
-      ? this._cardSize
-      : this._config!.content.split("\n").length +
-          (this._config!.title ? 1 : 0);
+    return this._config === undefined
+      ? 3
+      : this._config.card_size === undefined
+      ? this._config.content.split("\n").length + (this._config.title ? 1 : 0)
+      : this._config.card_size;
   }
 
   public setConfig(config: MarkdownCardConfig): void {
@@ -48,7 +48,6 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
     }
 
     this._config = config;
-    this._cardSize = config._card_size;
 
     this._disconnect();
     if (this._hass) {

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -27,6 +27,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
   }
 
   @property() private _config?: MarkdownCardConfig;
+  @property() private content?: string = "";
 
   public getCardSize(): number {
     return (
@@ -40,6 +41,24 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
     }
 
     this._config = config;
+
+    if(this.connection)
+      this.connection();
+    this.connection = null;
+  }
+
+  public set hass(hass) {
+    if (!this.connection && hass) {
+      hass.connection.subscribeMessage(
+        (msg) => {
+          this.content = msg.result;
+        },
+        {
+          type: "render_template",
+          template: this._config.content,
+        }
+      ).then((con) => this.connection = con);
+    }
   }
 
   protected render(): TemplateResult | void {
@@ -53,7 +72,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
           class="markdown ${classMap({
             "no-header": !this._config.title,
           })}"
-          .content="${this._config.content}"
+          .content="${this.content}"
         ></ha-markdown>
       </ha-card>
     `;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -118,6 +118,7 @@ export interface MarkdownCardConfig extends LovelaceCardConfig {
   type: "markdown";
   content: string;
   title?: string;
+  card_size?: number;
   entity_ids?: string | string[];
 }
 

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -118,6 +118,7 @@ export interface MarkdownCardConfig extends LovelaceCardConfig {
   type: "markdown";
   content: string;
   title?: string;
+  entity_ids?: string | string[];
 }
 
 export interface MediaControlCardConfig extends LovelaceCardConfig {


### PR DESCRIPTION
Make markdown-card use the new render_template websocket subscription.

Adds the optional `entity_ids:` parameter for specifying which entities should trigger a rerender on state change.

Requires home-assistant/home-assistant#25614

## Documentation:
home-assistant/home-assistant.io#10051