### PR TITLE
Fix zwave-node-values component

### DIFF
--- a/src/data/zwave.ts
+++ b/src/data/zwave.ts
@@ -5,10 +5,13 @@ export interface ZWaveNetworkStatus {
 }
 
 export interface ZWaveValue {
-  index: number;
-  instance: number;
-  label: string;
-  poll_intensity: number;
+  key: number;
+  value: {
+    index: number;
+    instance: number;
+    label: string;
+    poll_intensity: number;
+  };
 }
 
 export interface ZWaveConfigItem {

--- a/src/panels/config/zwave/zwave-values.ts
+++ b/src/panels/config/zwave/zwave-values.ts
@@ -104,12 +104,12 @@ export class ZwaveValues extends LitElement {
   }
 
   private _computeCaption(item) {
-    let html = `${item.value.label}`;
-    html += ` (${this.hass.localize("ui.panel.config.zwave.common.instance")}:`;
-    html += ` ${item.value.instance},`;
-    html += ` ${this.hass.localize("ui.panel.config.zwave.common.index")}:`;
-    html += ` ${item.value.index})`;
-    return html;
+    let out = `${item.value.label}`;
+    out += ` (${this.hass.localize("ui.panel.config.zwave.common.instance")}:`;
+    out += ` ${item.value.instance},`;
+    out += ` ${this.hass.localize("ui.panel.config.zwave.common.index")}:`;
+    out += ` ${item.value.index})`;
+    return out;
   }
 }
 

--- a/src/panels/config/zwave/zwave-values.ts
+++ b/src/panels/config/zwave/zwave-values.ts
@@ -23,7 +23,7 @@ import { ZWaveValue } from "../../../data/zwave";
 @customElement("zwave-values")
 export class ZwaveValues extends LitElement {
   @property() public hass!: HomeAssistant;
-  @property() private _values: ZWaveValue[] = [];
+  @property() public values: ZWaveValue[] = [];
   @property() private _selectedValue: number = -1;
 
   protected render(): TemplateResult | void {
@@ -34,7 +34,7 @@ export class ZwaveValues extends LitElement {
         >
           <div class="device-picker">
             <paper-dropdown-menu
-              label=${this.hass.localize("ui.panel.config.zwave.common.value")}
+              .label=${this.hass.localize("ui.panel.config.zwave.common.value")}
               dynamic-align
               class="flex"
             >
@@ -42,19 +42,11 @@ export class ZwaveValues extends LitElement {
                 slot="dropdown-content"
                 .selected=${this._selectedValue}
               >
-                ${this._values.map(
+                ${this.values.map(
                   (item) => html`
-                    <paper-item
-                      >${item.label}
-                      (${this.hass.localize(
-                        "ui.panel.config.zwave.common.instance"
-                      )}:
-                      ${item.instance},
-                      ${this.hass.localize(
-                        "ui.panel.config.zwave.common.index"
-                      )}:
-                      ${item.index})</paper-item
-                    >
+                    <paper-item>
+                      ${this._computeCaption(item)}
+                    </paper-item>
                   `
                 )}
               </paper-listbox>
@@ -109,6 +101,15 @@ export class ZwaveValues extends LitElement {
         }
       `,
     ];
+  }
+
+  private _computeCaption(item) {
+    let html = `${item.value.label}`;
+    html += ` (${this.hass.localize("ui.panel.config.zwave.common.instance")}:`;
+    html += ` ${item.value.instance},`;
+    html += ` ${this.hass.localize("ui.panel.config.zwave.common.index")}:`;
+    html += ` ${item.value.index})`;
+    return html;
   }
 }
 


### PR DESCRIPTION
The last commit I did in the previous PR for this element broke the list display and I must have been using a a cached copy of the page when I tested it.

This restores the list and works around a bug(?) with paper-listbox that renders all of the spaces used in indentation/code styling like in this picture:
![image](https://user-images.githubusercontent.com/7545841/62376865-a17d6f80-b50f-11e9-940c-ec38a1eea8df.png)

