### PR TITLE
Add lovelace template extension points

### DIFF
--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -53,7 +53,7 @@ class HuiGenericEntityRow extends LitElement {
       ></state-badge>
       <div class="flex">
         <div class="info">
-          ${this.config.name || computeStateName(stateObj)}
+          ${this._computeName(stateObj)}
           <div class="secondary">
             ${!this.showSecondary
               ? html`
@@ -131,6 +131,10 @@ class HuiGenericEntityRow extends LitElement {
         margin-right: 8px;
       }
     `;
+  }
+
+  private _computeName(stateObj): string {
+    return !this.config ? "" : this.config.name || computeStateName(stateObj);
   }
 }
 customElements.define("hui-generic-entity-row", HuiGenericEntityRow);

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -45,14 +45,38 @@ class HuiGenericEntityRow extends LitElement {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
-      <state-badge
-        .hass=${this.hass}
-        .stateObj=${stateObj}
-        .overrideIcon=${this.config.icon}
-      ></state-badge>
+      ${this.stateBadgeTemplate(stateObj)}
       <div class="flex">
         <div class="info">
+          ${this.infoTemplate(stateObj)}
+        </div>
+
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  protected stateBadgeTemplate(stateObj): TemplateResult {
+    return !this.config
+      ? html``
+      : html`
+          <state-badge
+            .hass=${this.hass}
+            .stateObj=${stateObj}
+            .overrideIcon=${this.config.icon}
+          ></state-badge>
+        `;
+  }
+
+  protected infoTemplate(stateObj): TemplateResult {
+    return !this.config
+      ? html``
+      : html`
           ${this._computeName(stateObj)}
           <div class="secondary">
             ${!this.showSecondary
@@ -70,11 +94,7 @@ class HuiGenericEntityRow extends LitElement {
                 `
               : ""}
           </div>
-        </div>
-
-        <slot></slot>
-      </div>
-    `;
+        `;
   }
 
   protected updated(changedProps: PropertyValues): void {

--- a/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
@@ -54,6 +54,10 @@ class HuiClimateEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         <ha-climate-state

--- a/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
@@ -55,22 +55,32 @@ class HuiCoverEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
-        ${isTiltOnly(stateObj)
-          ? html`
-              <ha-cover-tilt-controls
-                .hass="${this.hass}"
-                .stateObj="${stateObj}"
-              ></ha-cover-tilt-controls>
-            `
-          : html`
-              <ha-cover-controls
-                .hass="${this.hass}"
-                .stateObj="${stateObj}"
-              ></ha-cover-controls>
-            `}
+        ${this.coverControlTemplate(stateObj)}
       </hui-generic-entity-row>
+    `;
+  }
+
+  protected coverControlTemplate(stateObj): TemplateResult {
+    return html`
+      ${isTiltOnly(stateObj)
+        ? html`
+            <ha-cover-tilt-controls
+              .hass="${this.hass}"
+              .stateObj="${stateObj}"
+            ></ha-cover-tilt-controls>
+          `
+        : html`
+            <ha-cover-controls
+              .hass="${this.hass}"
+              .stateObj="${stateObj}"
+            ></ha-cover-controls>
+          `}
     `;
   }
 

--- a/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
@@ -65,11 +65,7 @@ class HuiGroupEntityRow extends LitElement implements EntityRow {
             `
           : html`
               <div>
-                ${computeStateDisplay(
-                  this.hass!.localize,
-                  stateObj,
-                  this.hass.language
-                )}
+                ${this._computeState(stateObj)}
               </div>
             `}
       </hui-generic-entity-row>
@@ -80,6 +76,12 @@ class HuiGroupEntityRow extends LitElement implements EntityRow {
     return entityIds.some((entityId) =>
       DOMAINS_TOGGLE.has(entityId.split(".", 1)[0])
     );
+  }
+
+  private _computeState(stateObj): string {
+    return !this.hass
+      ? ""
+      : computeStateDisplay(this.hass!.localize, stateObj, this.hass.language);
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
@@ -54,6 +54,10 @@ class HuiGroupEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         ${this._computeCanToggle(stateObj.attributes.entity_id)

--- a/src/panels/lovelace/entity-rows/hui-input-datetime-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-datetime-entity-row.ts
@@ -55,6 +55,10 @@ class HuiInputDatetimeEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         ${stateObj.attributes.has_date

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -80,7 +80,7 @@ class HuiInputNumberEntityRow extends LitElement implements EntityRow {
             ? html`
                 <div class="flex">
                   <ha-slider
-                    .dir="${computeRTLDirection(this.hass!)}"
+                    .dir="${this._computeRTLDirection()}"
                     .step="${Number(stateObj.attributes.step)}"
                     .min="${Number(stateObj.attributes.min)}"
                     .max="${Number(stateObj.attributes.max)}"
@@ -157,6 +157,10 @@ class HuiInputNumberEntityRow extends LitElement implements EntityRow {
     if (element.value !== stateObj.state) {
       setValue(this.hass!, stateObj.entity_id, element.value!);
     }
+  }
+
+  private _computeRTLDirection(): string {
+    return computeRTLDirection(this.hass!);
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -73,6 +73,10 @@ class HuiInputNumberEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         <div>

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -63,6 +63,10 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <state-badge .stateObj="${stateObj}"></state-badge>
       <ha-paper-dropdown-menu

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -66,7 +66,7 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
     return html`
       <state-badge .stateObj="${stateObj}"></state-badge>
       <ha-paper-dropdown-menu
-        .label=${this._config.name || computeStateName(stateObj)}
+        .label=${this._computeName(stateObj)}
         .value=${stateObj.state}
         @iron-select=${this._selectedChanged}
         @click=${stopPropagation}
@@ -131,6 +131,10 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
     forwardHaptic("light");
 
     setInputSelectOption(this.hass!, stateObj.entity_id, option);
+  }
+
+  private _computeName(stateObj): string {
+    return !this._config ? "" : this._config.name || computeStateName(stateObj);
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-input-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-text-entity-row.ts
@@ -52,6 +52,10 @@ class HuiInputTextEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         <paper-input

--- a/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
@@ -52,6 +52,10 @@ class HuiLockEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         <mwc-button @click="${this._callService}">

--- a/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
@@ -53,6 +53,10 @@ class HuiSceneEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         ${stateObj.attributes.can_cancel

--- a/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
@@ -53,6 +53,10 @@ class HuiScriptEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         ${stateObj.attributes.can_cancel

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -59,25 +59,34 @@ class HuiSensorEntityRow extends LitElement implements EntityRow {
       `;
     }
 
-    return html`
-      <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
-        <div>
-          ${stateObj.attributes.device_class === "timestamp"
-            ? html`
-                <hui-timestamp-display
-                  .hass="${this.hass}"
-                  .ts="${new Date(stateObj.state)}"
-                  .format="${this._config.format}"
-                ></hui-timestamp-display>
-              `
-            : computeStateDisplay(
-                this.hass!.localize,
-                stateObj,
-                this.hass.language
-              )}
-        </div>
-      </hui-generic-entity-row>
-    `;
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
+    return !this._config || !this.hass
+      ? html``
+      : html`
+          <hui-generic-entity-row
+            .hass="${this.hass}"
+            .config="${this._config}"
+          >
+            <div>
+              ${stateObj.attributes.device_class === "timestamp"
+                ? html`
+                    <hui-timestamp-display
+                      .hass="${this.hass}"
+                      .ts="${new Date(stateObj.state)}"
+                      .format="${this._config.format}"
+                    ></hui-timestamp-display>
+                  `
+                : computeStateDisplay(
+                    this.hass!.localize,
+                    stateObj,
+                    this.hass.language
+                  )}
+            </div>
+          </hui-generic-entity-row>
+        `;
   }
 
   static get styles(): CSSResult {

--- a/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
@@ -54,6 +54,10 @@ class HuiTextEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         <div>

--- a/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
@@ -57,11 +57,7 @@ class HuiTextEntityRow extends LitElement implements EntityRow {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         <div>
-          ${computeStateDisplay(
-            this.hass!.localize,
-            stateObj,
-            this.hass.language
-          )}
+          ${this._computeState(stateObj)}
         </div>
       </hui-generic-entity-row>
     `;
@@ -73,6 +69,12 @@ class HuiTextEntityRow extends LitElement implements EntityRow {
         text-align: right;
       }
     `;
+  }
+
+  private _computeState(stateObj): string {
+    return !this.hass
+      ? ""
+      : computeStateDisplay(this.hass!.localize, stateObj, this.hass.language);
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
@@ -69,6 +69,10 @@ class HuiTimerEntityRow extends LitElement {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         <div>${this._computeDisplay(stateObj)}</div>

--- a/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
@@ -64,15 +64,17 @@ class HuiToggleEntityRow extends LitElement implements EntityRow {
             `
           : html`
               <div>
-                ${computeStateDisplay(
-                  this.hass!.localize,
-                  stateObj,
-                  this.hass!.language
-                )}
+                ${this._computeState(stateObj)}
               </div>
             `}
       </hui-generic-entity-row>
     `;
+  }
+
+  private _computeState(stateObj): string {
+    return !this.hass
+      ? ""
+      : computeStateDisplay(this.hass!.localize, stateObj, this.hass.language);
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
@@ -53,6 +53,10 @@ class HuiToggleEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    return this.template(stateObj);
+  }
+
+  protected template(stateObj): TemplateResult {
     return html`
       <hui-generic-entity-row .hass="${this.hass}" .config="${this._config}">
         ${stateObj.state === "on" || stateObj.state === "off"


### PR DESCRIPTION
Reintroduce/Extend `Template Extension points` first added with #1230, after the move to `lit-elements`. Additionally I created some functions for dependencies, so custom ui authors could use them within their templates as well (e.g. for `computeStateName`).

As with the original PR, this could remain unofficial or I could add the example below together with a small explanation in the dev documentation.

## Example

Add a `position` value for covers.

<img width="505" alt="Screen Shot 2019-08-04 at 20 04 24" src="https://user-images.githubusercontent.com/30130371/62427446-3c826f00-b6f3-11e9-8066-79ea6a9bfe60.png">

```js
const HuiGenericEntityRow = customElements.get('hui-generic-entity-row');
const HuiCoverEntityRow = customElements.get('hui-cover-entity-row');
const html = HuiGenericEntityRow.prototype.html;


class MyHuiGenericEntityRow extends HuiGenericEntityRow {

  infoTemplate(stateObj) {
    return html`
      ${this._computeName(stateObj)}
      <div class="secondary">
        Position: ${this.position}
      </div>
    `;
  }
}
customElements.define('my-hui-generic-entity-row', MyHuiGenericEntityRow)


class MyHuiCoverEntityRow extends HuiCoverEntityRow {

  template(stateObj) {
    return html`
      <my-hui-generic-entity-row
        .hass="${this.hass}"
        .config="${this._config}"
        .position="${this._computeStatePosition(stateObj)}"
      >
        ${this.coverControlTemplate(stateObj)}
      </my-hui-generic-entity-row>
    `;
  }

  _computeStatePosition(stateObj) {
    return stateObj.attributes.current_position;
  }
}
customElements.define('my-hui-cover', MyHuiCoverEntityRow);
```