### PR TITLE
Enable ha-icons in markdown card

### DIFF
--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -106,7 +106,6 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
             ? html`
                 <ha-markdown
                   .content=${this._computeStepDescription(step)}
-                  allow-svg
                 ></ha-markdown>
               `
             : html``}

--- a/src/components/ha-markdown.js
+++ b/src/components/ha-markdown.js
@@ -3,12 +3,7 @@ import { EventsMixin } from "../mixins/events-mixin";
 
 let loaded = null;
 
-/**
- * White list allowed svg tag.
- * Only put in the tag used in QR code, can be extend in future.
- * Also white list ha-icon.
- */
-const svgWhiteList = ["svg", "path", "ha-icon"];
+const tagWhiteList = ["svg", "path", "ha-icon"];
 
 /*
  * @appliesMixin EventsMixin
@@ -16,10 +11,6 @@ const svgWhiteList = ["svg", "path", "ha-icon"];
 class HaMarkdown extends EventsMixin(PolymerElement) {
   static get properties() {
     return {
-      allowSvg: {
-        type: Boolean,
-        value: false,
-      },
       content: {
         observer: "_render",
         type: String,
@@ -70,9 +61,8 @@ class HaMarkdown extends EventsMixin(PolymerElement) {
             tables: true,
           }),
           {
-            onIgnoreTag: this.allowSvg
-              ? (tag, html) => (svgWhiteList.indexOf(tag) >= 0 ? html : null)
-              : null,
+            onIgnoreTag: (tag, html) =>
+              tagWhiteList.indexOf(tag) >= 0 ? html : null,
           }
         );
         this._resize();

--- a/src/components/ha-markdown.js
+++ b/src/components/ha-markdown.js
@@ -6,8 +6,10 @@ let loaded = null;
 /**
  * White list allowed svg tag.
  * Only put in the tag used in QR code, can be extend in future.
+ * Also white list ha-icon.
+ *
  */
-const svgWhiteList = ["svg", "path"];
+const svgWhiteList = ["svg", "path", "ha-icon"];
 
 /*
  * @appliesMixin EventsMixin

--- a/src/components/ha-markdown.js
+++ b/src/components/ha-markdown.js
@@ -7,7 +7,6 @@ let loaded = null;
  * White list allowed svg tag.
  * Only put in the tag used in QR code, can be extend in future.
  * Also white list ha-icon.
- *
  */
 const svgWhiteList = ["svg", "path", "ha-icon"];
 
@@ -17,13 +16,13 @@ const svgWhiteList = ["svg", "path", "ha-icon"];
 class HaMarkdown extends EventsMixin(PolymerElement) {
   static get properties() {
     return {
-      content: {
-        type: String,
-        observer: "_render",
-      },
       allowSvg: {
         type: Boolean,
         value: false,
+      },
+      content: {
+        observer: "_render",
+        type: String,
       },
     };
   }
@@ -53,7 +52,9 @@ class HaMarkdown extends EventsMixin(PolymerElement) {
   }
 
   _render() {
-    if (this._scriptLoaded === 0 || this._renderScheduled) return;
+    if (this._scriptLoaded === 0 || this._renderScheduled) {
+      return;
+    }
 
     this._renderScheduled = true;
 
@@ -64,9 +65,9 @@ class HaMarkdown extends EventsMixin(PolymerElement) {
       if (this._scriptLoaded === 1) {
         this.innerHTML = this.filterXSS(
           this.marked(this.content, {
+            breaks: true,
             gfm: true,
             tables: true,
-            breaks: true,
           }),
           {
             onIgnoreTag: this.allowSvg

--- a/src/dialogs/config-flow/step-flow-abort.ts
+++ b/src/dialogs/config-flow/step-flow-abort.ts
@@ -37,7 +37,7 @@ class StepFlowAbort extends LitElement {
       <div class="content">
         ${description
           ? html`
-              <ha-markdown .content=${description} allow-svg></ha-markdown>
+              <ha-markdown .content=${description}></ha-markdown>
             `
           : ""}
       </div>

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -56,7 +56,7 @@ class StepFlowCreateEntry extends LitElement {
       <div class="content">
         ${description
           ? html`
-              <ha-markdown .content=${description} allow-svg></ha-markdown>
+              <ha-markdown .content=${description}></ha-markdown>
             `
           : ""}
         <p>Created config for ${step.title}.</p>

--- a/src/dialogs/config-flow/step-flow-external.ts
+++ b/src/dialogs/config-flow/step-flow-external.ts
@@ -51,7 +51,7 @@ class StepFlowExternal extends LitElement {
         </p>
         ${description
           ? html`
-              <ha-markdown .content=${description} allow-svg></ha-markdown>
+              <ha-markdown .content=${description}></ha-markdown>
             `
           : ""}
         <div class="open-button">

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -79,7 +79,7 @@ class StepFlowForm extends LitElement {
           : ""}
         ${description
           ? html`
-              <ha-markdown .content=${description} allow-svg></ha-markdown>
+              <ha-markdown .content=${description}></ha-markdown>
             `
           : ""}
         <ha-form

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -54,7 +54,6 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
             "no-header": !this._config.title,
           })}"
           .content="${this._config.content}"
-          allow-svg
         ></ha-markdown>
       </ha-card>
     `;

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -54,6 +54,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
             "no-header": !this._config.title,
           })}"
           .content="${this._config.content}"
+          allow-svg
         ></ha-markdown>
       </ha-card>
     `;

--- a/src/panels/profile/ha-mfa-module-setup-flow.js
+++ b/src/panels/profile/ha-mfa-module-setup-flow.js
@@ -91,7 +91,6 @@ class HaMfaModuleSetupFlow extends LocalizeMixin(EventsMixin(PolymerElement)) {
               >
                 <ha-markdown
                   content="[[_computeStepDescription(localize, _step)]]"
-                  allow-svg
                 ></ha-markdown>
               </template>
 


### PR DESCRIPTION
```yaml
type: markdown
title: ha-icon
content: |
  This is a markdown card! With mdi icons!
  <ha-icon icon="mdi:home-assistant"></ha-icon>

  Right in the <ha-icon icon="mdi:format-align-middle"></ha-icon> of the <ha-icon icon="mdi:text"></ha-icon> too.
```

![image](https://user-images.githubusercontent.com/1299821/62443864-42606a80-b75c-11e9-9988-1e448dff36a9.png)
