### PR TITLE
Fix Cast demo

### DIFF
--- a/demo/src/custom-cards/cast-demo-row.ts
+++ b/demo/src/custom-cards/cast-demo-row.ts
@@ -54,7 +54,12 @@ class CastDemoRow extends LitElement implements EntityRow {
         mgr.castContext.addEventListener(
           cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
           (ev) => {
-            if (ev.sessionState === "SESSION_STARTED") {
+            // On Android, opening a new session always results in SESSION_RESUMED.
+            // So treat both as the same.
+            if (
+              ev.sessionState === "SESSION_STARTED" ||
+              ev.sessionState === "SESSION_RESUMED"
+            ) {
               castSendShowDemo(mgr);
             }
           }

--- a/src/cast/cast_manager.ts
+++ b/src/cast/cast_manager.ts
@@ -122,10 +122,12 @@ export class CastManager {
     if (__DEV__) {
       console.log("Cast session state changed", ev.sessionState);
     }
-    if (ev.sessionState === "SESSION_RESUMED") {
-      this.sendMessage({ type: "get_status" });
-      this._attachMessageListener();
-    } else if (ev.sessionState === "SESSION_STARTED") {
+    // On Android, opening a new session always results in SESSION_RESUMED.
+    // So treat both as the same.
+    if (
+      ev.sessionState === "SESSION_STARTED" ||
+      ev.sessionState === "SESSION_RESUMED"
+    ) {
       if (this.auth) {
         castSendAuth(this, this.auth);
       } else {


### PR DESCRIPTION
On Android, opening a new cast session triggers a SESSION_RESUMED instead of SESSION_STARTED.