### PR TITLE
Fix ha-sidebar for RTL

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -108,8 +108,8 @@ class HaSidebar extends LitElement {
   @property() private _externalConfig?: ExternalConfig;
   @property() private _notifications?: PersistentNotification[];
   // property used only in css
-  // tslint:disable-next-line
-  @property({ type: Boolean, reflect: true }) private _rtl;
+  // @ts-ignore
+  @property({ type: Boolean, reflect: true }) private _rtl = false;
 
   private _mouseLeaveTimeout?: number;
   private _tooltipHideTimeout?: number;
@@ -132,8 +132,6 @@ class HaSidebar extends LitElement {
         notificationCount++;
       }
     }
-
-    this._rtl = computeRTL(hass);
 
     return html`
       <div class="menu">
@@ -316,6 +314,8 @@ class HaSidebar extends LitElement {
         selectedEl.scrollIntoViewIfNeeded();
       }
     }
+
+    this._rtl = computeRTL(this.hass);
   }
 
   private get _tooltip() {

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -102,6 +102,7 @@ class HaSidebar extends LitElement {
 
   @property({ type: Boolean }) public alwaysExpand = false;
   @property({ type: Boolean, reflect: true }) public expanded = false;
+  @property({ type: Boolean, reflect: true }) public rtl = false;
   @property() public _defaultPage?: string =
     localStorage.defaultPage || DEFAULT_PANEL;
   @property() private _externalConfig?: ExternalConfig;
@@ -139,6 +140,9 @@ class HaSidebar extends LitElement {
                   ? "hass:menu-open"
                   : "hass:menu"}
                 @click=${this._toggleSidebar}
+                class=${classMap({
+                  flipVertical: this.rtl,
+                })}
               ></paper-icon-button>
             `
           : ""}
@@ -472,6 +476,10 @@ class HaSidebar extends LitElement {
       :host([expanded]) .menu paper-icon-button {
         margin-right: 23px;
       }
+      :host([expanded][rtl]) .menu paper-icon-button {
+        margin-right: 0px;
+        margin-left: 23px;
+      }
 
       .title {
         display: none;
@@ -520,6 +528,10 @@ class HaSidebar extends LitElement {
       }
       :host([expanded]) paper-icon-item {
         width: 240px;
+      }
+      :host([rtl]) paper-icon-item {
+        padding-left: auto;
+        padding-right: 12px;
       }
 
       ha-icon[slot="item-icon"] {
@@ -588,8 +600,15 @@ class HaSidebar extends LitElement {
       .profile paper-icon-item {
         padding-left: 4px;
       }
+      :host([rtl]) .profile paper-icon-item {
+        padding-left: auto;
+        padding-right: 4px;
+      }
       .profile .item-text {
         margin-left: 8px;
+      }
+      :host([rtl]) .profile .item-text {
+        margin-right: 8px;
       }
 
       .notification-badge {
@@ -646,6 +665,11 @@ class HaSidebar extends LitElement {
         background-color: var(--sidebar-text-color);
         padding: 4px;
         font-weight: 500;
+      }
+
+      .flipVertical {
+        -webkit-transform: scaleX(-1);
+        transform: scaleX(-1);
       }
     `;
   }

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -303,10 +303,13 @@ class HaSidebar extends LitElement {
     if (changedProps.has("alwaysExpand")) {
       this.expanded = this.alwaysExpand;
     }
+    if (!changedProps.has("hass")) {
+      return;
+    }
 
     this._rtl = computeRTL(this.hass);
 
-    if (!SUPPORT_SCROLL_IF_NEEDED || !changedProps.has("hass")) {
+    if (!SUPPORT_SCROLL_IF_NEEDED) {
       return;
     }
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -107,7 +107,9 @@ class HaSidebar extends LitElement {
     localStorage.defaultPage || DEFAULT_PANEL;
   @property() private _externalConfig?: ExternalConfig;
   @property() private _notifications?: PersistentNotification[];
-  @property({ type: Boolean, reflect: true }) private _rtl = false;
+  // property used only in css
+  // tslint:disable-next-line
+  @property({ type: Boolean, reflect: true }) private _rtl;
 
   private _mouseLeaveTimeout?: number;
   private _tooltipHideTimeout?: number;

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -31,6 +31,7 @@ import computeDomain from "../common/entity/compute_domain";
 import { classMap } from "lit-html/directives/class-map";
 // tslint:disable-next-line: no-duplicate-imports
 import { PaperIconItemElement } from "@polymer/paper-item/paper-icon-item";
+import { computeRTL } from "../common/util/compute_rtl";
 
 const SHOW_AFTER_SPACER = ["config", "developer-tools", "hassio"];
 
@@ -102,11 +103,11 @@ class HaSidebar extends LitElement {
 
   @property({ type: Boolean }) public alwaysExpand = false;
   @property({ type: Boolean, reflect: true }) public expanded = false;
-  @property({ type: Boolean, reflect: true }) public rtl = false;
   @property() public _defaultPage?: string =
     localStorage.defaultPage || DEFAULT_PANEL;
   @property() private _externalConfig?: ExternalConfig;
   @property() private _notifications?: PersistentNotification[];
+  @property({ type: Boolean, reflect: true }) private _rtl = false;
 
   private _mouseLeaveTimeout?: number;
   private _tooltipHideTimeout?: number;
@@ -130,6 +131,8 @@ class HaSidebar extends LitElement {
       }
     }
 
+    this._rtl = computeRTL(hass);
+
     return html`
       <div class="menu">
         ${!this.narrow
@@ -140,9 +143,6 @@ class HaSidebar extends LitElement {
                   ? "hass:menu-open"
                   : "hass:menu"}
                 @click=${this._toggleSidebar}
-                class=${classMap({
-                  flipVertical: this.rtl,
-                })}
               ></paper-icon-button>
             `
           : ""}
@@ -476,7 +476,7 @@ class HaSidebar extends LitElement {
       :host([expanded]) .menu paper-icon-button {
         margin-right: 23px;
       }
-      :host([expanded][rtl]) .menu paper-icon-button {
+      :host([expanded][_rtl]) .menu paper-icon-button {
         margin-right: 0px;
         margin-left: 23px;
       }
@@ -529,7 +529,7 @@ class HaSidebar extends LitElement {
       :host([expanded]) paper-icon-item {
         width: 240px;
       }
-      :host([rtl]) paper-icon-item {
+      :host([_rtl]) paper-icon-item {
         padding-left: auto;
         padding-right: 12px;
       }
@@ -600,14 +600,14 @@ class HaSidebar extends LitElement {
       .profile paper-icon-item {
         padding-left: 4px;
       }
-      :host([rtl]) .profile paper-icon-item {
+      :host([_rtl]) .profile paper-icon-item {
         padding-left: auto;
         padding-right: 4px;
       }
       .profile .item-text {
         margin-left: 8px;
       }
-      :host([rtl]) .profile .item-text {
+      :host([_rtl]) .profile .item-text {
         margin-right: 8px;
       }
 
@@ -667,7 +667,7 @@ class HaSidebar extends LitElement {
         font-weight: 500;
       }
 
-      .flipVertical {
+      :host([_rtl]) .menu paper-icon-button {
         -webkit-transform: scaleX(-1);
         transform: scaleX(-1);
       }

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -303,6 +303,9 @@ class HaSidebar extends LitElement {
     if (changedProps.has("alwaysExpand")) {
       this.expanded = this.alwaysExpand;
     }
+
+    this._rtl = computeRTL(this.hass);
+
     if (!SUPPORT_SCROLL_IF_NEEDED || !changedProps.has("hass")) {
       return;
     }
@@ -314,8 +317,6 @@ class HaSidebar extends LitElement {
         selectedEl.scrollIntoViewIfNeeded();
       }
     }
-
-    this._rtl = computeRTL(this.hass);
   }
 
   private get _tooltip() {

--- a/src/layouts/home-assistant-main.ts
+++ b/src/layouts/home-assistant-main.ts
@@ -21,7 +21,6 @@ import { PolymerChangedEvent } from "../polymer-types";
 // tslint:disable-next-line: no-duplicate-imports
 import { AppDrawerLayoutElement } from "@polymer/app-layout/app-drawer-layout/app-drawer-layout";
 import { showNotificationDrawer } from "../dialogs/notifications/show-notification-drawer";
-import { computeRTL } from "../common/util/compute_rtl";
 
 const NON_SWIPABLE_PANELS = ["kiosk", "map"];
 
@@ -44,8 +43,6 @@ class HomeAssistantMain extends LitElement {
     if (!hass) {
       return;
     }
-
-    const isRTL = computeRTL(hass);
 
     const sidebarNarrow = this._sidebarNarrow;
 
@@ -77,7 +74,6 @@ class HomeAssistantMain extends LitElement {
             .narrow=${sidebarNarrow}
             .alwaysExpand=${sidebarNarrow ||
               this.hass.dockedSidebar === "docked"}
-            .rtl=${isRTL}
           ></ha-sidebar>
         </app-drawer>
 

--- a/src/layouts/home-assistant-main.ts
+++ b/src/layouts/home-assistant-main.ts
@@ -21,6 +21,7 @@ import { PolymerChangedEvent } from "../polymer-types";
 // tslint:disable-next-line: no-duplicate-imports
 import { AppDrawerLayoutElement } from "@polymer/app-layout/app-drawer-layout/app-drawer-layout";
 import { showNotificationDrawer } from "../dialogs/notifications/show-notification-drawer";
+import { computeRTL } from "../common/util/compute_rtl";
 
 const NON_SWIPABLE_PANELS = ["kiosk", "map"];
 
@@ -43,6 +44,8 @@ class HomeAssistantMain extends LitElement {
     if (!hass) {
       return;
     }
+
+    const isRTL = computeRTL(hass);
 
     const sidebarNarrow = this._sidebarNarrow;
 
@@ -74,6 +77,7 @@ class HomeAssistantMain extends LitElement {
             .narrow=${sidebarNarrow}
             .alwaysExpand=${sidebarNarrow ||
               this.hass.dockedSidebar === "docked"}
+            .rtl=${isRTL}
           ></ha-sidebar>
         </app-drawer>
 


### PR DESCRIPTION
Fix menu alignments, icon, profile alignment in collapsed and expanded modes

Everything used to be misaligned.
<img width="55" alt="Capture" src="https://user-images.githubusercontent.com/37745463/62793932-7977a880-badb-11e9-9761-792e2b363018.PNG">
<img width="199" alt="Capture2" src="https://user-images.githubusercontent.com/37745463/62793933-7977a880-badb-11e9-905a-ced7b0333097.PNG">

Now it looks good and tested in both LTR and RTL