### PR TITLE
Add relevant device_class icons for Cover entity

### DIFF
--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -11,8 +11,6 @@ export default function coverIcon(state: HassEntity): string {
       return open ? "hass:door-open" : "hass:door-closed";
     case "window":
       return open ? "hass:window-open" : "hass:window-closed";
-    case "awning":
-      return open ? "hass:umbrella-open" : "hass:umbrella-closed";
     default:
       return domainIcon("cover", state.state);
   }

--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -7,6 +7,20 @@ export default function coverIcon(state: HassEntity): string {
   switch (state.attributes.device_class) {
     case "garage":
       return open ? "hass:garage-open" : "hass:garage";
+    case "door":
+      return open ? "hass:door-open" : "hass:door-closed";
+    case "window":
+      return open ? "hass:window-open" : "hass:window-closed";
+
+    case "awning":
+      return open ? "hass:umbrella-open" : "hass:umbrella-closed";
+
+    case "blind":
+    case "curtain":
+    case "shade":
+    case "shutter":
+      return "hass:blinds";
+
     default:
       return domainIcon("cover", state.state);
   }

--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -11,16 +11,8 @@ export default function coverIcon(state: HassEntity): string {
       return open ? "hass:door-open" : "hass:door-closed";
     case "window":
       return open ? "hass:window-open" : "hass:window-closed";
-
     case "awning":
       return open ? "hass:umbrella-open" : "hass:umbrella-closed";
-
-    case "blind":
-    case "curtain":
-    case "shade":
-    case "shutter":
-      return "hass:blinds";
-
     default:
       return domainIcon("cover", state.state);
   }


### PR DESCRIPTION
I added icons for those which have relevant open/close representations. Fixes #3473 