### PR TITLE
Fix gui-editor resizing problem

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -68,6 +68,7 @@ export class HuiCardEditor extends LitElement {
         if (this._yamlEditor) {
           this._yamlEditor.codemirror.refresh();
         }
+        fireEvent(this as HTMLElement, "iron-resize");
       }, 1);
       this._error = undefined;
     } catch (err) {


### PR DESCRIPTION
GUI editor for large cards (e.g. the picture-elements card on the first page of the demo) could cause the editor to be rendered outside of the borders of the window. This fixes that.