### PR TITLE
Lovelace markdown card - fix race condition, add variables to template

### DIFF
--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -91,7 +91,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
         {
           template: this._config.content,
           entity_ids: this._config.entity_id,
-          variables: this._config,
+          variables: {config: this._config},
         }
       );
       this._unsubRenderTemplate.catch(() => {

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -48,11 +48,11 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
     }
 
     this._config = config;
-
-    this._disconnect();
-    if (this._hass) {
-      this._connect();
-    }
+    this._disconnect().then(() => {
+      if (this._hass) {
+        this._connect();
+      }
+    });
   }
 
   public disconnectedCallback() {
@@ -91,6 +91,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
         {
           template: this._config.content,
           entity_ids: this._config.entity_id,
+          variables: this._config,
         }
       );
       this._unsubRenderTemplate.catch(() => {

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -91,7 +91,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
         {
           template: this._config.content,
           entity_ids: this._config.entity_id,
-          variables: {config: this._config},
+          variables: { config: this._config },
         }
       );
       this._unsubRenderTemplate.catch(() => {


### PR DESCRIPTION
There was a race condition for the connection/disconnection to the websocket for the templates in markdown card. This should make sure things happen in the right order when redrawing the card.

I also added the card config as variables to the template. This allows for:

```yaml
type: entity-filter
entities:
  - light.bed_light
  - light.ceiling_lights
  - light.kitchen_lights
card:
  type: markdown
  content: |
    The lights that are on are:
    {% for l in entities %}
      - {{ l.entity }}
    {%- endfor %}
```
