### PR TITLE
Fix text areas not working in Preact

### DIFF
--- a/src/components/ha-textarea.js
+++ b/src/components/ha-textarea.js
@@ -27,6 +27,7 @@ class HaTextarea extends PolymerElement {
 
   static get properties() {
     return {
+      name: String,
       label: String,
       value: {
         type: String,


### PR DESCRIPTION
Textareas now work again in Preact. 

Fixes  #3508
Fixes #1601 