### PR TITLE
Support device triggers in automation editor

### DIFF
--- a/src/components/device/ha-device-picker.ts
+++ b/src/components/device/ha-device-picker.ts
@@ -10,6 +10,7 @@ import {
   html,
   css,
   CSSResult,
+  customElement,
   property,
 } from "lit-element";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
@@ -21,6 +22,7 @@ import {
 } from "../../data/device_registry";
 import { compare } from "../../common/string/compare";
 
+@customElement("ha-device-picker")
 class HaDevicePicker extends LitElement {
   public hass?: HomeAssistant;
   @property() public label?: string;
@@ -36,6 +38,16 @@ class HaDevicePicker extends LitElement {
     sorted.sort((a, b) => compare(a.name || "", b.name || ""));
     return sorted;
   });
+
+  public connectedCallback() {
+    super.connectedCallback();
+    this._unsubDevices = subscribeDeviceRegistry(
+      this.hass!.connection!,
+      (devices) => {
+        this.devices = devices;
+      }
+    );
+  }
 
   public disconnectedCallback() {
     super.disconnectedCallback();
@@ -73,18 +85,6 @@ class HaDevicePicker extends LitElement {
     return this.value || "";
   }
 
-  protected firstUpdated(changedProps) {
-    super.firstUpdated(changedProps);
-    if (this.devices === undefined) {
-      this._unsubDevices = subscribeDeviceRegistry(
-        this.hass!.connection!,
-        (devices) => {
-          this.devices = devices;
-        }
-      );
-    }
-  }
-
   private _deviceChanged(ev) {
     const newValue = ev.detail.item.dataset.deviceId;
 
@@ -99,11 +99,8 @@ class HaDevicePicker extends LitElement {
 
   static get styles(): CSSResult {
     return css`
-      :host {
-        display: inline-block;
-      }
       paper-dropdown-menu-light {
-        display: block;
+        width: 100%;
       }
       paper-listbox {
         min-width: 200px;
@@ -115,4 +112,8 @@ class HaDevicePicker extends LitElement {
   }
 }
 
-customElements.define("ha-device-picker", HaDevicePicker);
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-device-picker": HaDevicePicker;
+  }
+}

--- a/src/components/device/ha-device-picker.ts
+++ b/src/components/device/ha-device-picker.ts
@@ -1,0 +1,108 @@
+import "@polymer/paper-icon-button/paper-icon-button";
+import "@polymer/paper-input/paper-input";
+import "@polymer/paper-item/paper-icon-item";
+import "@polymer/paper-item/paper-item-body";
+import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
+import "@polymer/paper-listbox/paper-listbox";
+import memoizeOne from "memoize-one";
+import {
+  LitElement,
+  TemplateResult,
+  html,
+  css,
+  CSSResult,
+  property,
+} from "lit-element";
+import { HomeAssistant } from "../../types";
+import { fireEvent } from "../../common/dom/fire_event";
+import {
+  DeviceRegistryEntry,
+  fetchDeviceRegistry,
+} from "../../data/device_registry";
+import { compare } from "../../common/string/compare";
+
+class HaEntityPicker extends LitElement {
+  public hass?: HomeAssistant;
+  @property() public label?: string;
+  @property() public value?: string;
+  @property() public devices?: DeviceRegistryEntry[];
+
+  private _sortedDevices = memoizeOne((devices?: DeviceRegistryEntry[]) => {
+    console.log(devices);
+    if (!devices || devices.length === 1) {
+      return devices || [];
+    }
+    const sorted = [...devices];
+    sorted.sort((a, b) => compare(a.name, b.name));
+    return sorted;
+  });
+
+  protected render(): TemplateResult | void {
+    return html`
+      <paper-dropdown-menu-light .label=${this.label}>
+        <paper-listbox
+          slot="dropdown-content"
+          .selected=${this._value}
+          attr-for-selected="data-device-id"
+          @iron-select=${this._deviceChanged}
+        >
+          <paper-icon-item data-device-id="">
+            No device
+          </paper-icon-item>
+          ${this._sortedDevices(this.devices).map(
+            (device) => html`
+              <paper-icon-item data-device-id=${device.id}>
+                ${device.name_by_user || device.name}
+              </paper-icon-item>
+            `
+          )}
+        </paper-listbox>
+      </paper-dropdown-menu-light>
+    `;
+  }
+
+  private get _value() {
+    return this.value || "";
+  }
+
+  protected firstUpdated(changedProps) {
+    super.firstUpdated(changedProps);
+    if (this.devices === undefined) {
+      // TODO: Subscribe to device registry updates?
+      fetchDeviceRegistry(this.hass.connection!).then((devices) => {
+        this.devices = devices;
+      });
+    }
+  }
+
+  private _deviceChanged(ev) {
+    const newValue = ev.detail.item.dataset.deviceId;
+
+    if (newValue !== this._value) {
+      this.value = newValue;
+      setTimeout(() => {
+        fireEvent(this, "value-changed", { value: newValue });
+        fireEvent(this, "change");
+      }, 0);
+    }
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      :host {
+        display: inline-block;
+      }
+      paper-dropdown-menu-light {
+        display: block;
+      }
+      paper-listbox {
+        min-width: 200px;
+      }
+      paper-icon-item {
+        cursor: pointer;
+      }
+    `;
+  }
+}
+
+customElements.define("ha-device-picker", HaEntityPicker);

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -26,13 +26,20 @@ class HaDeviceTriggerPicker extends LitElement {
   public hass?: HomeAssistant;
   @property() public label?: string;
   @property() public deviceId?: string;
-  @property() public triggers: any = {};
+  @property() public triggers: { [key: string]: DeviceTrigger } = {};
   public presetTrigger?: DeviceTrigger;
 
-  private noTrigger: DeviceTrigger = { device_id: "", platform: "device" };
+  private noTrigger: DeviceTrigger = {
+    device_id: "",
+    platform: "device",
+    domain: "",
+    entity_id: "",
+  };
   private unknownTrigger?: DeviceTrigger = {
     device_id: "",
     platform: "device",
+    domain: "",
+    entity_id: "",
   };
   private key?: string;
   private setTrigger?: DeviceTrigger;
@@ -98,7 +105,12 @@ class HaDeviceTriggerPicker extends LitElement {
 
     if (changedProps.has("deviceId")) {
       // Reset trigger if device-id has changed
-      this.noTrigger = { device_id: this.deviceId || "", platform: "device" };
+      this.noTrigger = {
+        device_id: this.deviceId || "",
+        platform: "device",
+        domain: "",
+        entity_id: "",
+      };
 
       if (this.deviceId) {
         const response = await this._loadDeviceTriggers();

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -29,8 +29,11 @@ class HaDeviceTriggerPicker extends LitElement {
   @property() public triggers: any = {};
   public presetTrigger?: DeviceTrigger;
 
-  private noTrigger: DeviceTrigger = { device_id: "", platform: "" };
-  private unknownTrigger?: DeviceTrigger = { device_id: "", platform: "" };
+  private noTrigger: DeviceTrigger = { device_id: "", platform: "device" };
+  private unknownTrigger?: DeviceTrigger = {
+    device_id: "",
+    platform: "device",
+  };
   private key?: string;
   private setTrigger?: DeviceTrigger;
 

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -1,0 +1,155 @@
+import "@polymer/paper-icon-button/paper-icon-button";
+import "@polymer/paper-input/paper-input";
+import "@polymer/paper-item/paper-icon-item";
+import "@polymer/paper-item/paper-item-body";
+import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
+import "@polymer/paper-listbox/paper-listbox";
+import memoizeOne from "memoize-one";
+import {
+  LitElement,
+  TemplateResult,
+  html,
+  css,
+  CSSResult,
+  property,
+} from "lit-element";
+import { HomeAssistant } from "../../types";
+import { fireEvent } from "../../common/dom/fire_event";
+import { compare } from "../../common/string/compare";
+import { LocalizeFunc } from "../../common/translations/localize";
+import computeStateName from "../../common/entity/compute_state_name";
+
+export interface DeviceTrigger {
+  platform: string;
+  domain: string;
+  device_id: string;
+  entity_id?: string;
+  type: string;
+}
+
+const fetchDeviceTriggers = (hass, deviceId) =>
+  hass.callWS<DeviceTrigger[]>({
+    type: "device_automation/list_triggers",
+    device_id: deviceId,
+  });
+
+function isObject(v) {
+  return "[object Object]" === Object.prototype.toString.call(v);
+}
+
+JSON.sort = function(o) {
+  if (Array.isArray(o)) {
+    return o.sort().map(JSON.sort);
+  } else if (isObject(o)) {
+    return Object.keys(o)
+      .sort()
+      .reduce(function(a, k) {
+        a[k] = JSON.sort(o[k]);
+
+        return a;
+      }, {});
+  }
+
+  return o;
+};
+
+class HaEntityPicker extends LitElement {
+  public hass?: HomeAssistant;
+  public localize?: LocalizeFunc;
+  @property() public label?: string;
+  @property() public value?: string;
+  @property() public deviceId?: string;
+  @property() public triggers?: DeviceTrigger[];
+
+  private _sortedTriggers = memoizeOne((triggers?: DeviceTrigger[]) => {
+    return triggers || [];
+  });
+
+  protected render(): TemplateResult | void {
+    return html`
+      <paper-dropdown-menu-light .label=${this.label}>
+        <paper-listbox
+          slot="dropdown-content"
+          .selected=${this._value}
+          attr-for-selected="data-trigger"
+          @iron-select=${this._triggerChanged}
+        >
+          <paper-item
+            data-trigger=${JSON.stringify({
+              device_id: this.deviceId,
+              platform: "device",
+            })}
+          >
+            No trigger
+          </paper-item>
+          ${this._sortedTriggers(this.triggers).map(
+            (trigger) => html`
+              <paper-item data-trigger=${JSON.stringify(JSON.sort(trigger))}>
+                ${this.localize(
+                  `ui.panel.config.automation.editor.triggers.type.device.trigger_type.${
+                    trigger.type
+                  }`,
+                  "entity_id",
+                  trigger.entity_id
+                    ? computeStateName(this.hass.states[trigger.entity_id])
+                    : "",
+                  "event",
+                  trigger.event
+                )}
+              </paper-item>
+            `
+          )}
+        </paper-listbox>
+      </paper-dropdown-menu-light>
+    `;
+  }
+
+  private get _value() {
+    return this.value || "";
+  }
+
+  protected updated(oldProps) {
+    console.log("_triggerChanged");
+    if (oldProps.has("deviceId") && oldProps.get("deviceId") != this.deviceId) {
+      if (this.deviceId) {
+        fetchDeviceTriggers(this.hass!, this.deviceId).then((trigger) => {
+          this.triggers = trigger.triggers;
+        });
+      } else {
+        this.triggers = [];
+      }
+    }
+  }
+
+  private _triggerChanged(ev) {
+    console.log("_triggerChanged");
+    const tmp = JSON.parse(ev.detail.item.dataset.trigger);
+    const newValue = ev.detail.item.dataset.trigger;
+    if (newValue !== this._value) {
+      this.value = newValue;
+      setTimeout(() => {
+        fireEvent(this, "value-changed", { value: newValue });
+        fireEvent(this, "change");
+      }, 0);
+    }
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      :host {
+        display: inline-block;
+      }
+      paper-dropdown-menu-light {
+        display: block;
+      }
+      paper-listbox {
+        min-width: 200px;
+      }
+      paper-icon-item {
+        cursor: pointer;
+      }
+    `;
+  }
+}
+
+customElements.define("ha-device-trigger-picker", HaEntityPicker);

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -24,16 +24,16 @@ import {
 
 @customElement("ha-device-trigger-picker")
 class HaDeviceTriggerPicker extends LitElement {
-  private noTrigger: DeviceTrigger = {};
-  private unknownTrigger: DeviceTrigger = {};
-  private trigger?: DeviceTrigger;
-  private setTrigger?: DeviceTrigger;
-
   public hass?: HomeAssistant;
   @property() public label?: string;
   @property() public deviceId?: string;
   @property() public triggers: DeviceTrigger[] = [];
   public presetTrigger?: DeviceTrigger;
+
+  private noTrigger: DeviceTrigger = {};
+  private unknownTrigger: DeviceTrigger = {};
+  private trigger?: DeviceTrigger;
+  private setTrigger?: DeviceTrigger;
 
   private _sortedTriggers = memoizeOne((triggers?: DeviceTrigger[]) => {
     return triggers || [];

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -30,8 +30,8 @@ class HaDeviceTriggerPicker extends LitElement {
   @property() public triggers: DeviceTrigger[] = [];
   public presetTrigger?: DeviceTrigger;
 
-  private noTrigger: DeviceTrigger = {};
-  private unknownTrigger: DeviceTrigger = {};
+  private noTrigger: DeviceTrigger = { device_id: "", platform: "" };
+  private unknownTrigger?: DeviceTrigger = { device_id: "", platform: "" };
   private trigger?: DeviceTrigger;
   private setTrigger?: DeviceTrigger;
 
@@ -82,7 +82,7 @@ class HaDeviceTriggerPicker extends LitElement {
     return this.trigger;
   }
 
-  protected async firstUpdated(changedProps) {
+  protected async firstUpdated() {
     this.setTrigger = this.presetTrigger;
   }
 
@@ -96,13 +96,12 @@ class HaDeviceTriggerPicker extends LitElement {
       if (this.deviceId) {
         const response = await this._loadDeviceTriggers();
         this.triggers = response.triggers;
-        if (this.triggers.length > 0) {
-          // Set first trigger as default
-          this.trigger = this.triggers[0];
-        } else {
-          this.trigger = this.noTrigger;
-        }
-        if (this.setTrigger.device_id === this.deviceId) {
+        // Set first trigger as default, or no trigger if the device has none
+        this.trigger =
+          this.triggers.length > 0
+            ? (this.trigger = this.triggers[0])
+            : (this.trigger = this.noTrigger);
+        if (this.setTrigger && this.setTrigger.device_id === this.deviceId) {
           // Handles the case when the stored automation does not match any trigger reported by the device
           this.trigger = this.unknownTrigger = this.setTrigger;
         }

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -72,9 +72,9 @@ class HaDeviceTriggerPicker extends LitElement {
             (key) => html`
               <paper-item .key=${key} .trigger=${this.triggers[key]}>
                 ${this.hass!.localize(
-                  `ui.panel.config.automation.editor.triggers.type.device.trigger_type.${
-                    this.triggers[key].type
-                  }`,
+                  `component.${
+                    this.triggers[key].domain
+                  }.device_automation.trigger_type.${this.triggers[key].type}`,
                   "entity_id",
                   this.triggers[key].entity_id
                     ? computeStateName(

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -116,8 +116,8 @@ class HaDeviceTriggerPicker extends LitElement {
     }
 
     // The triggers property has changed, force the listbox to update
-    if (changedProps.has("triggers" && this.shadowRoot)) {
-      const listbox = this.shadowRoot!.querySelector("paper-listbox") as any;
+    if (changedProps.has("triggers") && this.shadowRoot) {
+      const listbox = this.shadowRoot.querySelector("paper-listbox") as any;
       listbox._selectSelected();
     }
   }

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -75,14 +75,12 @@ class HaDeviceTriggerPicker extends LitElement {
                   `component.${
                     this.triggers[key].domain
                   }.device_automation.trigger_type.${this.triggers[key].type}`,
-                  "entity_id",
+                  "name",
                   this.triggers[key].entity_id
                     ? computeStateName(
                         this.hass!.states[this.triggers[key].entity_id]
                       )
-                    : "",
-                  "event",
-                  this.triggers[key].event
+                    : ""
                 )}
               </paper-item>
             `

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -19,7 +19,7 @@ export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
     device_id: deviceId,
   });
 
-export const triggersEqual = (a: any, b: any) => {
+export const triggersEqual = (a: DeviceTrigger, b: DeviceTrigger) => {
   if (typeof a !== typeof b) {
     return false;
   }

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -3,8 +3,8 @@ import { HomeAssistant } from "../types";
 export interface DeviceTrigger {
   platform: string;
   device_id: string;
-  domain?: string;
-  entity_id?: string;
+  domain: string;
+  entity_id: string;
   type?: string;
   event?: string;
 }

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -1,0 +1,32 @@
+import { HomeAssistant } from "../../types";
+import { fireEvent } from "../../common/dom/fire_event";
+import { compare } from "../../common/string/compare";
+import { LocalizeFunc } from "../../common/translations/localize";
+import computeStateName from "../../common/entity/compute_state_name";
+
+export interface DeviceTrigger {
+  platform: string;
+  domain: string;
+  device_id: string;
+  entity_id?: string;
+  type: string;
+}
+
+export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
+  hass.callWS<DeviceTrigger[]>({
+    type: "device_automation/list_triggers",
+    device_id: deviceId,
+  });
+
+export const triggersEqual = (a: any, b: any) => {
+  if (typeof a != typeof b) return false;
+
+  for (var property in a) {
+    if (!Object.is(a[property], b[property])) return false;
+  }
+  for (var property in b) {
+    if (!Object.is(a[property], b[property])) return false;
+  }
+
+  return true;
+};

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -1,31 +1,38 @@
-import { HomeAssistant } from "../../types";
-import { fireEvent } from "../../common/dom/fire_event";
-import { compare } from "../../common/string/compare";
-import { LocalizeFunc } from "../../common/translations/localize";
-import computeStateName from "../../common/entity/compute_state_name";
+import { HomeAssistant } from "../types";
 
 export interface DeviceTrigger {
   platform: string;
-  domain: string;
   device_id: string;
+  domain?: string;
   entity_id?: string;
-  type: string;
+  type?: string;
+  event?: string;
+}
+
+export interface DeviceTriggerList {
+  triggers: DeviceTrigger[];
 }
 
 export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
-  hass.callWS<DeviceTrigger[]>({
+  hass.callWS<DeviceTriggerList>({
     type: "device_automation/list_triggers",
     device_id: deviceId,
   });
 
 export const triggersEqual = (a: any, b: any) => {
-  if (typeof a != typeof b) return false;
-
-  for (var property in a) {
-    if (!Object.is(a[property], b[property])) return false;
+  if (typeof a !== typeof b) {
+    return false;
   }
-  for (var property in b) {
-    if (!Object.is(a[property], b[property])) return false;
+
+  for (const property in a) {
+    if (!Object.is(a[property], b[property])) {
+      return false;
+    }
+  }
+  for (const property in b) {
+    if (!Object.is(a[property], b[property])) {
+      return false;
+    }
   }
 
   return true;

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -14,10 +14,12 @@ export interface DeviceTriggerList {
 }
 
 export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
-  hass.callWS<DeviceTriggerList>({
-    type: "device_automation/trigger/list",
-    device_id: deviceId,
-  });
+  hass
+    .callWS<DeviceTriggerList>({
+      type: "device_automation/trigger/list",
+      device_id: deviceId,
+    })
+    .then((response) => response.triggers);
 
 export const triggersEqual = (a: DeviceTrigger, b: DeviceTrigger) => {
   if (typeof a !== typeof b) {

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -1,4 +1,5 @@
 import { HomeAssistant } from "../types";
+import compute_state_name from "../common/entity/compute_state_name";
 
 export interface DeviceTrigger {
   platform: string;
@@ -21,7 +22,10 @@ export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
     })
     .then((response) => response.triggers);
 
-export const triggersEqual = (a: DeviceTrigger, b: DeviceTrigger) => {
+export const deviceAutomationTriggersEqual = (
+  a: DeviceTrigger,
+  b: DeviceTrigger
+) => {
   if (typeof a !== typeof b) {
     return false;
   }
@@ -39,3 +43,15 @@ export const triggersEqual = (a: DeviceTrigger, b: DeviceTrigger) => {
 
   return true;
 };
+
+export const localizeDeviceAutomationTrigger = (
+  hass: HomeAssistant,
+  trigger: DeviceTrigger
+) =>
+  hass.localize(
+    `component.${trigger.domain}.device_automation.trigger_type.${
+      trigger.type
+    }`,
+    "name",
+    trigger.entity_id ? compute_state_name(hass!.states[trigger.entity_id]) : ""
+  );

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -15,7 +15,7 @@ export interface DeviceTriggerList {
 
 export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
   hass.callWS<DeviceTriggerList>({
-    type: "device_automation/list_triggers",
+    type: "device_automation/trigger/list",
     device_id: deviceId,
   });
 

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -31,7 +31,7 @@ export const updateDeviceRegistryEntry = (
     ...updates,
   });
 
-const fetchDeviceRegistry = (conn) =>
+export const fetchDeviceRegistry = (conn) =>
   conn.sendMessagePromise({
     type: "config/device_registry/list",
   });

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -31,7 +31,7 @@ export const updateDeviceRegistryEntry = (
     ...updates,
   });
 
-export const fetchDeviceRegistry = (conn) =>
+const fetchDeviceRegistry = (conn) =>
   conn.sendMessagePromise({
     type: "config/device_registry/list",
   });

--- a/src/panels/config/js/trigger/device.js
+++ b/src/panels/config/js/trigger/device.js
@@ -5,8 +5,6 @@ import "../../../../components/device/ha-device-trigger-picker";
 
 import { onChangeEvent } from "../../../../common/preact/event";
 
-import { triggersEqual } from "../../../../data/device_automation";
-
 export default class DeviceTrigger extends Component {
   constructor() {
     super();
@@ -17,21 +15,19 @@ export default class DeviceTrigger extends Component {
 
   devicePicked(ev) {
     this.deviceId = ev.target.value;
-    let deviceTrigger = {};
-
     // Reset the trigger if device is changed
-    deviceTrigger.platform = "device";
-    deviceTrigger.device_id = this.deviceId;
+    const deviceTrigger = { platform: "device", device_id: this.deviceId };
+
     this.props.onChange(this.props.index, (this.props.trigger = deviceTrigger));
   }
 
   deviceTriggerPicked(ev) {
-    let deviceTrigger = ev.target.trigger;
+    const deviceTrigger = ev.target.trigger;
     this.props.onChange(this.props.index, (this.props.trigger = deviceTrigger));
   }
 
   /* eslint-disable camelcase */
-  render({ trigger, hass, localize }) {
+  render({ trigger, hass }) {
     const { device_id } = trigger;
     const jsontrigger = trigger;
 

--- a/src/panels/config/js/trigger/device.js
+++ b/src/panels/config/js/trigger/device.js
@@ -1,0 +1,78 @@
+import { h, Component } from "preact";
+
+import "../../../../components/device/ha-device-picker";
+import "../../../../components/device/ha-device-trigger-picker";
+
+import { onChangeEvent } from "../../../../common/preact/event";
+
+function isObject(v) {
+  return "[object Object]" === Object.prototype.toString.call(v);
+}
+
+JSON.sort = function(o) {
+  if (Array.isArray(o)) {
+    return o.sort().map(JSON.sort);
+  } else if (isObject(o)) {
+    return Object.keys(o)
+      .sort()
+      .reduce(function(a, k) {
+        a[k] = JSON.sort(o[k]);
+
+        return a;
+      }, {});
+  }
+
+  return o;
+};
+
+export default class DeviceTrigger extends Component {
+  constructor() {
+    super();
+    this.onChange = onChangeEvent.bind(this, "trigger");
+    this.devicePicked = this.devicePicked.bind(this);
+    this.deviceTriggerPicked = this.deviceTriggerPicked.bind(this);
+  }
+
+  devicePicked(ev) {
+    this.deviceId = ev.target.value;
+    let deviceTrigger = {};
+    // Reset the trigger if device is changed
+    deviceTrigger.platform = "device";
+    deviceTrigger.device_id = this.deviceId;
+    this.props.onChange(this.props.index, (this.props.trigger = deviceTrigger));
+  }
+
+  deviceTriggerPicked(ev) {
+    let deviceTrigger = JSON.parse(ev.target.value);
+    this.props.onChange(this.props.index, (this.props.trigger = deviceTrigger));
+  }
+
+  /* eslint-disable camelcase */
+  render({ trigger, hass, localize }) {
+    const { device_id } = trigger;
+    const jsontrigger = JSON.stringify(JSON.sort(trigger));
+
+    return (
+      <div>
+        <ha-device-picker
+          value={device_id}
+          onChange={this.devicePicked}
+          hass={hass}
+          label="Device"
+        />
+        <ha-device-trigger-picker
+          value={jsontrigger}
+          deviceId={device_id}
+          onChange={this.deviceTriggerPicked}
+          hass={hass}
+          localize={localize}
+          label="Trigger"
+        />
+      </div>
+    );
+  }
+}
+
+DeviceTrigger.defaultConfig = {
+  device_id: "",
+};

--- a/src/panels/config/js/trigger/device.js
+++ b/src/panels/config/js/trigger/device.js
@@ -19,7 +19,7 @@ export default class DeviceTrigger extends Component {
   }
 
   deviceTriggerPicked(ev) {
-    const deviceTrigger = ev.target.setTrigger;
+    const deviceTrigger = ev.target.value;
     this.props.onChange(this.props.index, (this.props.trigger = deviceTrigger));
   }
 
@@ -36,7 +36,7 @@ export default class DeviceTrigger extends Component {
           label="Device"
         />
         <ha-device-trigger-picker
-          presetTrigger={trigger}
+          value={trigger}
           deviceId={device_id}
           onChange={this.deviceTriggerPicked}
           hass={hass}

--- a/src/panels/config/js/trigger/device.js
+++ b/src/panels/config/js/trigger/device.js
@@ -19,7 +19,7 @@ export default class DeviceTrigger extends Component {
   }
 
   deviceTriggerPicked(ev) {
-    const deviceTrigger = ev.target.trigger;
+    const deviceTrigger = ev.target.setTrigger;
     this.props.onChange(this.props.index, (this.props.trigger = deviceTrigger));
   }
 

--- a/src/panels/config/js/trigger/device.js
+++ b/src/panels/config/js/trigger/device.js
@@ -5,25 +5,7 @@ import "../../../../components/device/ha-device-trigger-picker";
 
 import { onChangeEvent } from "../../../../common/preact/event";
 
-function isObject(v) {
-  return "[object Object]" === Object.prototype.toString.call(v);
-}
-
-JSON.sort = function(o) {
-  if (Array.isArray(o)) {
-    return o.sort().map(JSON.sort);
-  } else if (isObject(o)) {
-    return Object.keys(o)
-      .sort()
-      .reduce(function(a, k) {
-        a[k] = JSON.sort(o[k]);
-
-        return a;
-      }, {});
-  }
-
-  return o;
-};
+import { triggersEqual } from "../../../../data/device_automation";
 
 export default class DeviceTrigger extends Component {
   constructor() {
@@ -36,6 +18,7 @@ export default class DeviceTrigger extends Component {
   devicePicked(ev) {
     this.deviceId = ev.target.value;
     let deviceTrigger = {};
+
     // Reset the trigger if device is changed
     deviceTrigger.platform = "device";
     deviceTrigger.device_id = this.deviceId;
@@ -43,14 +26,14 @@ export default class DeviceTrigger extends Component {
   }
 
   deviceTriggerPicked(ev) {
-    let deviceTrigger = JSON.parse(ev.target.value);
+    let deviceTrigger = ev.target.trigger;
     this.props.onChange(this.props.index, (this.props.trigger = deviceTrigger));
   }
 
   /* eslint-disable camelcase */
   render({ trigger, hass, localize }) {
     const { device_id } = trigger;
-    const jsontrigger = JSON.stringify(JSON.sort(trigger));
+    const jsontrigger = trigger;
 
     return (
       <div>
@@ -61,11 +44,10 @@ export default class DeviceTrigger extends Component {
           label="Device"
         />
         <ha-device-trigger-picker
-          value={jsontrigger}
+          presetTrigger={jsontrigger}
           deviceId={device_id}
           onChange={this.deviceTriggerPicked}
           hass={hass}
-          localize={localize}
           label="Trigger"
         />
       </div>

--- a/src/panels/config/js/trigger/device.js
+++ b/src/panels/config/js/trigger/device.js
@@ -29,7 +29,6 @@ export default class DeviceTrigger extends Component {
   /* eslint-disable camelcase */
   render({ trigger, hass }) {
     const { device_id } = trigger;
-    const jsontrigger = trigger;
 
     return (
       <div>
@@ -40,7 +39,7 @@ export default class DeviceTrigger extends Component {
           label="Device"
         />
         <ha-device-trigger-picker
-          presetTrigger={jsontrigger}
+          presetTrigger={trigger}
           deviceId={device_id}
           onChange={this.deviceTriggerPicked}
           hass={hass}

--- a/src/panels/config/js/trigger/device.js
+++ b/src/panels/config/js/trigger/device.js
@@ -11,14 +11,11 @@ export default class DeviceTrigger extends Component {
     this.onChange = onChangeEvent.bind(this, "trigger");
     this.devicePicked = this.devicePicked.bind(this);
     this.deviceTriggerPicked = this.deviceTriggerPicked.bind(this);
+    this.state.device_id = undefined;
   }
 
   devicePicked(ev) {
-    this.deviceId = ev.target.value;
-    // Reset the trigger if device is changed
-    const deviceTrigger = { platform: "device", device_id: this.deviceId };
-
-    this.props.onChange(this.props.index, (this.props.trigger = deviceTrigger));
+    this.setState({ device_id: ev.target.value });
   }
 
   deviceTriggerPicked(ev) {
@@ -27,8 +24,8 @@ export default class DeviceTrigger extends Component {
   }
 
   /* eslint-disable camelcase */
-  render({ trigger, hass }) {
-    const { device_id } = trigger;
+  render({ trigger, hass }, { device_id }) {
+    if (device_id === undefined) device_id = trigger.device_id;
 
     return (
       <div>

--- a/src/panels/config/js/trigger/trigger_edit.js
+++ b/src/panels/config/js/trigger/trigger_edit.js
@@ -4,6 +4,7 @@ import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 
+import DeviceTrigger from "./device";
 import EventTrigger from "./event";
 import GeolocationTrigger from "./geo_location";
 import HassTrigger from "./homeassistant";
@@ -18,6 +19,7 @@ import WebhookTrigger from "./webhook";
 import ZoneTrigger from "./zone";
 
 const TYPES = {
+  device: DeviceTrigger,
   event: EventTrigger,
   state: StateTrigger,
   geo_location: GeolocationTrigger,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -677,6 +677,14 @@
               "unsupported_platform": "Unsupported platform: {platform}",
               "type_select": "Trigger type",
               "type": {
+                "device": {
+                  "label": "Device",
+                  "trigger_type": {
+                    "turn_on": "{entity_id} turned on",
+                    "turn_off": "{entity_id} turned off",
+                    "pressed": "{event} pressed"
+                  }
+                },
                 "event": {
                   "label": "Event",
                   "event_type": "Event type",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -678,12 +678,7 @@
               "type_select": "Trigger type",
               "type": {
                 "device": {
-                  "label": "Device",
-                  "trigger_type": {
-                    "turn_on": "{entity_id} turned on",
-                    "turn_off": "{entity_id} turned off",
-                    "pressed": "{event} pressed"
-                  }
+                  "label": "Device"
                 },
                 "event": {
                   "label": "Event",


### PR DESCRIPTION
Add experimental support for device trigger to automation editor.
This is intended as another step towards home-assistant/architecture#178

This is my first front-end commit, and I really don't know polymer/js so it most likely needs some rewrite.

Screenshot:
![image](https://user-images.githubusercontent.com/14281572/63649796-8c78b280-c742-11e9-9f79-4ddcc10120d5.png)

Issues:
- It should ideally not be possible to try saving an automation with device trigger if device + trigger are not chosen since the resulting error message is not very user friendly. This is possible for other triggers though, so maybe OK.