### PR TITLE
Fix advanced mode not representing state correctly

### DIFF
--- a/src/panels/profile/ha-panel-profile.ts
+++ b/src/panels/profile/ha-panel-profile.ts
@@ -136,7 +136,7 @@ class HaPanelProfile extends LitElement {
             ? html`
                 <ha-advanced-mode-card
                   .hass=${this.hass}
-                  coreUserData=${this._coreUserData}
+                  .coreUserData=${this._coreUserData}
                 ></ha-advanced-mode-card>
               `
             : ""}


### PR DESCRIPTION
Missed a `.`