### PR TITLE
Increase touch target of menu button with notifications

### DIFF
--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -127,6 +127,7 @@ class HaMenuButton extends LitElement {
         position: relative;
       }
       .dot {
+        pointer-events: none;
         position: absolute;
         background-color: var(--accent-color);
         width: 12px;


### PR DESCRIPTION
Disable the notification dot from capturing the touch events, causing the menu not to open.