### PR TITLE
Fix LL menu on Android/iOS 13+

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -116,11 +116,11 @@ class HUIRoot extends LitElement {
                       @iron-select="${this._deselect}"
                       slot="dropdown-content"
                     >
-                      <paper-item @click="${this.lovelace!.enableFullEditMode}"
-                        >${this.hass!.localize(
+                      <paper-item @tap="${this.lovelace!.enableFullEditMode}">
+                        ${this.hass!.localize(
                           "ui.panel.lovelace.editor.menu.raw_editor"
-                        )}</paper-item
-                      >
+                        )}
+                      </paper-item>
                     </paper-listbox>
                   </paper-menu-button>
                 </app-toolbar>
@@ -154,7 +154,7 @@ class HUIRoot extends LitElement {
                               aria-label=${this.hass!.localize(
                                 "ui.panel.lovelace.menu.refresh"
                               )}
-                              @click="${this._handleRefresh}"
+                              @tap="${this._handleRefresh}"
                             >
                               ${this.hass!.localize(
                                 "ui.panel.lovelace.menu.refresh"
@@ -169,7 +169,7 @@ class HUIRoot extends LitElement {
                               aria-label=${this.hass!.localize(
                                 "ui.panel.lovelace.menu.unused_entities"
                               )}
-                              @click="${this._handleUnusedEntities}"
+                              @tap="${this._handleUnusedEntities}"
                             >
                               ${this.hass!.localize(
                                 "ui.panel.lovelace.menu.unused_entities"
@@ -180,20 +180,20 @@ class HUIRoot extends LitElement {
                         aria-label=${this.hass!.localize(
                           "ui.panel.lovelace.menu.configure_ui"
                         )}
-                        @click="${this._editModeEnable}"
-                        >${this.hass!.localize(
-                          "ui.panel.lovelace.menu.configure_ui"
-                        )}</paper-item
+                        @tap="${this._editModeEnable}"
                       >
+                        ${this.hass!.localize(
+                          "ui.panel.lovelace.menu.configure_ui"
+                        )}
+                      </paper-item>
                       <paper-item
                         aria-label=${this.hass!.localize(
                           "ui.panel.lovelace.menu.help"
                         )}
-                        @click="${this._handleHelp}"
-                        >${this.hass!.localize(
-                          "ui.panel.lovelace.menu.help"
-                        )}</paper-item
+                        @tap="${this._handleHelp}"
                       >
+                        ${this.hass!.localize("ui.panel.lovelace.menu.help")}
+                      </paper-item>
                     </paper-listbox>
                   </paper-menu-button>
                 </app-toolbar>


### PR DESCRIPTION
Polymer contains it's own [touch event normalizer](https://github.com/Polymer/polymer/blob/master/lib/utils/gestures.js). The normalized event is called `tap`. We were not using it because it's a non-standard thing, but it looks like it all of a sudden became the solution? 

Tested this on FF on Android.

Please test this on iOS 13 beta by clicking on the netlify preview below and let me know if this works.

CC @SeanPM5 @cyberjacob @RomRider 

Fix #3453 