### PR TITLE
Remove duplicate word from onboarding error

### DIFF
--- a/src/onboarding/ha-onboarding.ts
+++ b/src/onboarding/ha-onboarding.ts
@@ -123,7 +123,7 @@ class HaOnboarding extends litLocalizeLiteMixin(HassElement) {
 
       this._steps = steps;
     } catch (err) {
-      alert("Something went wrong loading loading onboarding, try refreshing");
+      alert("Something went wrong loading onboarding, try refreshing");
     }
   }
 


### PR DESCRIPTION
Someone shared an error message in Discord and I noticed it mentioned the word "loading" twice in a row. This removes the duplicate word from the alert.