### PR TITLE
Don't remove `hvac_action` from history attributes

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -11,6 +11,7 @@ const LINE_ATTRIBUTES_TO_KEEP = [
   "current_temperature",
   "target_temp_low",
   "target_temp_high",
+  "hvac_action",
 ];
 
 export interface LineChartState {


### PR DESCRIPTION
So it can be used to plot a fill when active in the graph.

Fixes https://github.com/home-assistant/home-assistant-polymer/issues/3468