### PR TITLE
Add exceptional icon to weather

### DIFF
--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -281,6 +281,7 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
     this.weatherIcons = {
       "clear-night": "hass:weather-night",
       cloudy: "hass:weather-cloudy",
+      exceptional: "hass:alert-circle-outline",
       fog: "hass:weather-fog",
       hail: "hass:weather-hail",
       lightning: "hass:weather-lightning",

--- a/src/dialogs/more-info/controls/more-info-weather.js
+++ b/src/dialogs/more-info/controls/more-info-weather.js
@@ -158,6 +158,7 @@ class MoreInfoWeather extends LocalizeMixin(PolymerElement) {
     this.weatherIcons = {
       "clear-night": "hass:weather-night",
       cloudy: "hass:weather-cloudy",
+      exceptional: "hass:alert-circle-outline",
       fog: "hass:weather-fog",
       hail: "hass:weather-hail",
       lightning: "hass:weather-lightning",


### PR DESCRIPTION
`exceptional` is supposedly a supported condition for a weather platform, per https://github.com/home-assistant/architecture/issues/263.  However, there is no icon support for it.  This PR adds a warning circle icon, as exceptional is presumably a nonstandard condition meriting a warning.

The only weather platforms that have exceptional conditions are openweathermap, yweather, and nws.  I can't find the documentation for the yweather codes, but openweathermap exceptional includes conditions like smoke, dust, squall, and a few undocumented ones.  NWS includes conditions like tornado, hurricane, tropical storm, hot, cold, etc.  I think a warning icon is appropriate for these.

Here is what it looks like for West Palm Beach Florida at the moment due to hurricane Dorian:
![Screenshot_20190902-071745](https://user-images.githubusercontent.com/39341281/64116310-fa833200-cd5f-11e9-9114-cc61d47e6f6b.png)





Edit: if this PR is welcome, I will also add `exceptional` to the dev docs.