### PR TITLE
Wrap long attributes in more-info-default

### DIFF
--- a/src/components/ha-attributes.js
+++ b/src/components/ha-attributes.js
@@ -11,6 +11,7 @@ class HaAttributes extends PolymerElement {
       <style>
         .data-entry .value {
           max-width: 200px;
+          overflow-wrap: break-word;
         }
         .attribution {
           color: var(--secondary-text-color);


### PR DESCRIPTION
Can likely be applied in many other places

Closes https://github.com/home-assistant/home-assistant-polymer/issues/2811

![image](https://user-images.githubusercontent.com/1287159/64215241-6dcc9700-ce79-11e9-9811-beb975c6750a.png)
