### PR TITLE
Device automations: Rename name to entity_name, introduce subtype

### DIFF
--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -6,6 +6,7 @@ export interface DeviceAutomation {
   domain: string;
   entity_id: string;
   type?: string;
+  subtype?: string;
   event?: string;
 }
 
@@ -62,8 +63,14 @@ export const localizeDeviceAutomationCondition = (
     `component.${condition.domain}.device_automation.condition_type.${
       condition.type
     }`,
-    "name",
-    state ? compute_state_name(state) : "<unknown>"
+    "entity_name",
+    state ? compute_state_name(state) : "<unknown>",
+    "subtype",
+    hass.localize(
+      `component.${condition.domain}.device_automation.condition_subtype.${
+        condition.subtype
+      }`
+    )
   );
 };
 
@@ -76,7 +83,13 @@ export const localizeDeviceAutomationTrigger = (
     `component.${trigger.domain}.device_automation.trigger_type.${
       trigger.type
     }`,
-    "name",
-    state ? compute_state_name(state) : "<unknown>"
+    "entity_name",
+    state ? compute_state_name(state) : "<unknown>",
+    "subtype",
+    hass.localize(
+      `component.${trigger.domain}.device_automation.trigger_subtype.${
+        trigger.subtype
+      }`
+    )
   );
 };


### PR DESCRIPTION
Add `subtype` as input to `device_automation` `conditition_type` and `trigger_type`translations.
The `subtype` string is generated by first translating a `condition_subtype` or `trigger_subtype`.

This allows a trigger like this:
```json
{
"platform": "device",
"device_id": "3308d8f481a24188addef9ebc8d87e2a",
"domain": "example",
"type": "short_press",
"subtype": "turn_off",
}
```

To be displayed as:
`Key "Turn On" pressed"`

With help of translations strings like these:
```json
{
  "device_automation": {
    "trigger_type": {
      "turn_on": "{entity_name} turned on",
      "short_press": "Key \"{subtype}\" pressed"
    },
    "trigger_subtype": {
      "turn_on": "Turn On",
      "turn_off": "Turn Off"
    }
  }
}
```

Back-end PR home-assistant/home-assistant#26491 to change existing translations for light entities