### PR TITLE
Set rel noopener and noreferrer on external links in markdown

### DIFF
--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -49,7 +49,7 @@ class HaMarkdown extends UpdatingElement {
 
       // Open external links in a new window
       if (
-        node.nodeName === "A" &&
+        node instanceof HTMLAnchorElement &&
         node.host !== document.location.host
       ) {
         node.target = "_blank";
@@ -59,7 +59,7 @@ class HaMarkdown extends UpdatingElement {
         node.rel = "noreferrer noopener";
 
         // Fire a resize event when images loaded to notify content resized
-      } else if (node.nodeName === "IMG") {
+      } else if (node) {
         node.addEventListener("load", this._resize);
       }
     }

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -50,7 +50,6 @@ class HaMarkdown extends UpdatingElement {
       // Open external links in a new window
       if (
         node.nodeName === "A" &&
-        node instanceof HTMLAnchorElement &&
         node.host !== document.location.host
       ) {
         node.target = "_blank";

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -50,9 +50,14 @@ class HaMarkdown extends UpdatingElement {
       // Open external links in a new window
       if (
         node.nodeName === "A" &&
-        (node as HTMLAnchorElement).host !== document.location.host
+        node instanceof HTMLAnchorElement &&
+        node.host !== document.location.host
       ) {
-        (node as HTMLAnchorElement).target = "_blank";
+        node.target = "_blank";
+
+        // protect referrer on external links and deny window.opener access for security reasons
+        // (see https://mathiasbynens.github.io/rel-noopener/)
+        node.rel = "noreferrer noopener";
 
         // Fire a resize event when images loaded to notify content resized
       } else if (node.nodeName === "IMG") {


### PR DESCRIPTION
For security reasons the rel="noopener" attribute should be set on external links to prevent accessing the window object of the home assistant page. (see https://mathiasbynens.github.io/rel-noopener/) There should be no well meaning reason to need this, so this should be a non breaking change.

Additionally as a small privacy improvement i also set the noreferrer attribute to prevent leaking the homeassistant url to the linked site. 

