### PR TITLE
Expand entity-filter options

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -21,7 +21,18 @@ class EntityFilterCard extends HTMLElement implements LovelaceCard {
   }
 
   public setConfig(config: EntityFilterCardConfig): void {
-    if (!config.state_filter || !Array.isArray(config.state_filter)) {
+    if (
+      (!config.state_filter &&
+        config.entities.filter((entity) => {
+          return Boolean(typeof entity === "object" && entity.state_filter);
+        }).length !== config.entities.length) ||
+      (!Array.isArray(config.state_filter) &&
+        config.entities.filter((entity) => {
+          return Boolean(
+            typeof entity === "object" && !Array.isArray(entity.state_filter)
+          );
+        }).length !== config.entities.length)
+    ) {
       throw new Error("Incorrect filter config.");
     }
 

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -21,6 +21,10 @@ class EntityFilterCard extends HTMLElement implements LovelaceCard {
   }
 
   public setConfig(config: EntityFilterCardConfig): void {
+    if (!config.entities || !Array.isArray(config.entities)) {
+      throw new Error("entities must be specified.");
+    }
+
     if (
       (!config.state_filter || !Array.isArray(config.state_filter)) &&
       config.entities.filter((entity) => {
@@ -32,10 +36,6 @@ class EntityFilterCard extends HTMLElement implements LovelaceCard {
       }).length !== config.entities.length
     ) {
       throw new Error("Incorrect filter config.");
-    }
-
-    if (!config.entities) {
-      throw new Error("entities must be specified.");
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -22,16 +22,14 @@ class EntityFilterCard extends HTMLElement implements LovelaceCard {
 
   public setConfig(config: EntityFilterCardConfig): void {
     if (
-      (!config.state_filter &&
-        config.entities.filter((entity) => {
-          return Boolean(typeof entity === "object" && entity.state_filter);
-        }).length !== config.entities.length) ||
-      (!Array.isArray(config.state_filter) &&
-        config.entities.filter((entity) => {
-          return Boolean(
-            typeof entity === "object" && !Array.isArray(entity.state_filter)
-          );
-        }).length !== config.entities.length)
+      (!config.state_filter || !Array.isArray(config.state_filter)) &&
+      config.entities.filter((entity) => {
+        return Boolean(
+          typeof entity === "object" &&
+            entity.state_filter &&
+            Array.isArray(entity.state_filter)
+        );
+      }).length !== config.entities.length
     ) {
       throw new Error("Incorrect filter config.");
     }

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -36,6 +36,10 @@ class EntityFilterCard extends HTMLElement implements LovelaceCard {
       throw new Error("Incorrect filter config.");
     }
 
+    if (!config.entities) {
+      throw new Error("entities must be specified.");
+    }
+
     this._config = config;
     this._configEntities = undefined;
     this._baseCardConfig = {
@@ -61,10 +65,6 @@ class EntityFilterCard extends HTMLElement implements LovelaceCard {
     }
 
     this._hass = hass;
-
-    if (!this._config.entities) {
-      return;
-    }
 
     if (!this._configEntities) {
       this._configEntities = processConfigEntities(this._config.entities);

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -26,14 +26,13 @@ class EntityFilterCard extends HTMLElement implements LovelaceCard {
     }
 
     if (
-      (!config.state_filter || !Array.isArray(config.state_filter)) &&
-      config.entities.filter((entity) => {
-        return Boolean(
+      !(config.state_filter && Array.isArray(config.state_filter)) &&
+      !config.entities.every(
+        (entity) =>
           typeof entity === "object" &&
-            entity.state_filter &&
-            Array.isArray(entity.state_filter)
-        );
-      }).length !== config.entities.length
+          entity.state_filter &&
+          Array.isArray(entity.state_filter)
+      )
     ) {
       throw new Error("Incorrect filter config.");
     }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -51,7 +51,7 @@ export interface EntityButtonCardConfig extends LovelaceCardConfig {
 export interface EntityFilterCardConfig extends LovelaceCardConfig {
   type: "entity-filter";
   entities: Array<EntityConfig | string>;
-  state_filter: string[];
+  state_filter: Array<{ key: string } | string>;
   card: Partial<LovelaceCardConfig>;
   show_empty?: boolean;
 }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -1,6 +1,6 @@
 import { LovelaceCardConfig, ActionConfig } from "../../../data/lovelace";
 import { Condition } from "../common/validate-condition";
-import { EntityConfig } from "../entity-rows/types";
+import { EntityConfig, EntityFilterEntityConfig } from "../entity-rows/types";
 import { LovelaceElementConfig } from "../elements/types";
 import { HuiImage } from "../components/hui-image";
 
@@ -50,7 +50,7 @@ export interface EntityButtonCardConfig extends LovelaceCardConfig {
 
 export interface EntityFilterCardConfig extends LovelaceCardConfig {
   type: "entity-filter";
-  entities: Array<EntityConfig | string>;
+  entities: Array<EntityFilterEntityConfig | string>;
   state_filter: Array<{ key: string } | string>;
   card: Partial<LovelaceCardConfig>;
   show_empty?: boolean;

--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -21,8 +21,7 @@ export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
     case "!=":
       return state !== value;
     case "regex": {
-      const matches = stateObj.state.match(value) ? true : false;
-      return matches;
+      return state.match(value);
     }
     default:
       return false;

--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -1,0 +1,30 @@
+import { HassEntity } from "home-assistant-js-websocket";
+
+export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
+  const operator = filter.operator ? filter.operator : "==";
+  const value = filter.value ? filter.value : filter;
+  const state = filter.attribute
+    ? stateObj.attributes[filter.attribute]
+    : stateObj.state;
+
+  switch (operator) {
+    case "==":
+      return state === value;
+    case "<=":
+      return state <= value;
+    case "<":
+      return state < value;
+    case ">=":
+      return state >= value;
+    case ">":
+      return state > value;
+    case "!=":
+      return state !== value;
+    case "regex": {
+      const matches = stateObj.state.match(value) ? true : false;
+      return matches;
+    }
+    default:
+      return false;
+  }
+};

--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -1,8 +1,8 @@
 import { HassEntity } from "home-assistant-js-websocket";
 
 export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
-  const operator = filter.operator ? filter.operator : "==";
-  const value = filter.value ? filter.value : filter;
+  const operator = filter.operator || "==";
+  const value = filter.value || filter;
   const state = filter.attribute
     ? stateObj.attributes[filter.attribute]
     : stateObj.state;

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -7,6 +7,9 @@ export interface EntityConfig {
   icon?: string;
   image?: string;
 }
+export interface EntityFilterEntityConfig extends EntityConfig {
+  state_filter?: Array<{ key: string } | string>;
+}
 export interface DividerConfig {
   type: "divider";
   style: string;


### PR DESCRIPTION
Closes https://github.com/home-assistant/home-assistant-polymer/issues/3543

Adds the following to `state_filter`:
- `operator` option. Specify operator to use in comparison. Options are `==, >, >=, <, <=, !=, regex`
- `value` option. Specify value to compare against.
- `attribute` option.  Specify attribute to use instead of state in comparison.

Adds `state_filter` as an option to entities as well

e.g.
```yaml
type: entity-filter
state_filter:
  - "on"
  - operator: ">"
    value: 90
entities:
  - sensor.water_leak
  - sensor.outside_temp
  - entity: sensor.humidity_and_temp
    state_filter:
      - operator: ">"
        value: 50
        attribute: humidity
```