### PR TITLE
Update slider's min/max when thermostat gets updated

### DIFF
--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -223,7 +223,7 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
         value: sliderValue,
         disabled: sliderValue === null,
         min: stateObj.attributes.min_temp,
-        max: stateObj.attributes.max_temp
+        max: stateObj.attributes.max_temp,
       });
       this._updateSetTemp(uiValue);
     }

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -222,6 +222,8 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
         sliderType,
         value: sliderValue,
         disabled: sliderValue === null,
+        min: stateObj.attributes.min_temp,
+        max: stateObj.attributes.max_temp
       });
       this._updateSetTemp(uiValue);
     }


### PR DESCRIPTION
Hi, 

I'm working on a thermostat integration with different min/max depending on the hvac mode (which is a very common practice).

I found out that these parameters (min/max) weren't updated when the thermostat gets updated, and I cannot find any good reason why it's that way. 

I tested this modification locally and I didn't encountered any problem since the min/max are always passed to the `stateObj.attributes` object.

Thanks for reviewing this PR and please tell me if something seems odd with it.