### PR TITLE
Allow device triggers to specify extra fields, update ha-form with support for paper-time-input

### DIFF
--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -274,28 +274,30 @@ class HaForm extends EventsMixin(PolymerElement) {
   _durationChanged(ev, unit) {
     let value = parseInt(ev.detail.value);
 
-    if (value === this.data[unit]) {
+    if (this.data && value === this.data[unit]) {
       return;
     }
 
     if (unit === "seconds" && value > 59) {
-      this.set(
-        "data.minutes",
-        (this.data.minutes || 0) + Math.floor(value / 60)
-      );
-      value %= 60;
+      // this.set(
+      //  "data.minutes",
+      //  (this.data.minutes || 0) + Math.floor(value / 60)
+      // );
+      // value %= 60;
+      value = 59;
     }
 
     if (unit === "minutes" && value > 59) {
-      this.set("data.hours", (this.data.hours || 0) + Math.floor(value / 60));
-      value %= 60;
+      // this.set("data.hours", (this.data.hours || 0) + Math.floor(value / 60));
+      // value %= 60;
+      value = 59;
     }
 
-    if (!value) {
+    if (this.data && !value) {
       delete this.data[unit];
-      this.notifyPath(["data", unit]);
+      this.notifyPath(["data"]);
     } else {
-      this.set(["data", unit], value);
+      this.set(["data"], { ...this.data, [unit]: value });
     }
   }
 

--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -160,6 +160,31 @@ class HaForm extends EventsMixin(PolymerElement) {
             </paper-listbox>
           </paper-dropdown-menu>
         </template>
+
+        <template
+          is="dom-if"
+          if='[[_equals(schema.type, "time_period_dict")]]'
+          restamp=""
+        >
+          <paper-time-input
+            label="[[computeLabel(schema)]]"
+            type="number"
+            required="[[schema.required]]"
+            auto-validate="[[schema.required]]"
+            error-message="Required"
+            enable-day
+            enable-second
+            format="24"
+            day$="[[_parseDuration(data, 'days')]]"
+            hour$="[[_parseDuration(data, 'hours')]]"
+            min$="[[_parseDuration(data, 'minutes')]]"
+            sec$="[[_parseDuration(data, 'seconds')]]"
+            on-day-changed="_dayChanged"
+            on-hour-changed="_hourChanged"
+            on-min-changed="_minChanged"
+            on-sec-changed="_secChanged"
+          ></paper-time-input>
+        </template>
       </template>
     `;
   }
@@ -230,6 +255,60 @@ class HaForm extends EventsMixin(PolymerElement) {
       value = Number(ev.detail.value);
     }
     this.set(["data", ev.model.item.name], value);
+  }
+
+  _dayChanged(ev) {
+    this._durationChanged(ev, "days");
+  }
+
+  _hourChanged(ev) {
+    this._durationChanged(ev, "hours");
+  }
+
+  _minChanged(ev) {
+    this._durationChanged(ev, "minutes");
+  }
+
+  _secChanged(ev) {
+    this._durationChanged(ev, "seconds");
+  }
+
+  _durationChanged(ev, unit) {
+    const value = ev.detail.value;
+    this.set(
+      ["data"],
+      Object.assign({}, this.get(["data"]), { [unit]: value })
+    );
+  }
+
+  _parseDuration(duration, unit) {
+    let days = "0";
+    let hours = "00";
+    let minutes = "00";
+    let seconds = "00";
+    if (
+      duration &&
+      (duration.days || duration.hours || duration.minutes || duration.seconds)
+    ) {
+      // If the duration was defined using yaml dict syntax, extract days, hours, minutes and seconds
+      ({ days = "0", hours = "00", minutes = "00", seconds = "00" } = duration);
+    }
+    duration = {
+      days,
+      hours: this._pad(hours),
+      minutes: this._pad(minutes),
+      seconds: this._pad(seconds),
+    };
+    return duration[unit];
+  }
+
+  _pad(value) {
+    // Convert to zero-padded string for display
+    value = parseInt(value, 10).toString();
+    if (value.length === 1) {
+      value = value.padStart(2, "0");
+    }
+    return value;
   }
 
   _passwordFieldType(unmaskedPassword) {

--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -163,7 +163,7 @@ class HaForm extends EventsMixin(PolymerElement) {
 
         <template
           is="dom-if"
-          if='[[_equals(schema.type, "positive_time_delta_dict")]]'
+          if='[[_equals(schema.type, "positive_time_period_dict")]]'
           restamp=""
         >
           <paper-time-input

--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -183,8 +183,8 @@ class HaForm extends EventsMixin(PolymerElement) {
             on-hour-changed="_hourChanged"
             on-min-changed="_minChanged"
             on-sec-changed="_secChanged"
-            float-input-labels="true"
-            always-float-input-labels="true"
+            float-input-labels
+            always-float-input-labels
             day-label="days"
             hour-label="hh"
             min-label="mm"

--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -175,14 +175,20 @@ class HaForm extends EventsMixin(PolymerElement) {
             enable-day
             enable-second
             format="24"
-            day$="[[_parseDuration(data, 'days')]]"
-            hour$="[[_parseDuration(data, 'hours')]]"
-            min$="[[_parseDuration(data, 'minutes')]]"
-            sec$="[[_parseDuration(data, 'seconds')]]"
+            day="[[_parseDuration(data, 'days')]]"
+            hour="[[_parseDuration(data, 'hours')]]"
+            min="[[_parseDuration(data, 'minutes')]]"
+            sec="[[_parseDuration(data, 'seconds')]]"
             on-day-changed="_dayChanged"
             on-hour-changed="_hourChanged"
             on-min-changed="_minChanged"
             on-sec-changed="_secChanged"
+            float-input-labels="true"
+            always-float-input-labels="true"
+            day-label="days"
+            hour-label="hh"
+            min-label="mm"
+            sec-label="ss"
           ></paper-time-input>
         </template>
       </template>
@@ -292,20 +298,11 @@ class HaForm extends EventsMixin(PolymerElement) {
     }
     duration = {
       days,
-      hours: this._pad(hours),
-      minutes: this._pad(minutes),
-      seconds: this._pad(seconds),
+      hours,
+      minutes,
+      seconds,
     };
     return duration[unit];
-  }
-
-  _pad(value) {
-    // Convert to zero-padded string for display
-    value = parseInt(value, 10).toString();
-    if (value.length === 1) {
-      value = value.padStart(2, "0");
-    }
-    return value;
   }
 
   _passwordFieldType(unmaskedPassword) {

--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -163,7 +163,7 @@ class HaForm extends EventsMixin(PolymerElement) {
 
         <template
           is="dom-if"
-          if='[[_equals(schema.type, "time_period_dict")]]'
+          if='[[_equals(schema.type, "positive_time_delta_dict")]]'
           restamp=""
         >
           <paper-time-input
@@ -275,10 +275,7 @@ class HaForm extends EventsMixin(PolymerElement) {
 
   _durationChanged(ev, unit) {
     const value = ev.detail.value;
-    this.set(
-      ["data"],
-      Object.assign({}, this.get(["data"]), { [unit]: value })
-    );
+    this.set(["data"], { ...this.get(["data"]), [unit]: value });
   }
 
   _parseDuration(duration, unit) {

--- a/src/components/ha-form.js
+++ b/src/components/ha-form.js
@@ -175,10 +175,10 @@ class HaForm extends EventsMixin(PolymerElement) {
             enable-day
             enable-second
             format="24"
-            day="[[_parseDuration(data, 'days')]]"
-            hour="[[_parseDuration(data, 'hours')]]"
-            min="[[_parseDuration(data, 'minutes')]]"
-            sec="[[_parseDuration(data, 'seconds')]]"
+            day$="[[_parseDuration(data, 'days')]]"
+            hour$="[[_parseDuration(data, 'hours')]]"
+            min$="[[_parseDuration(data, 'minutes')]]"
+            sec$="[[_parseDuration(data, 'seconds')]]"
             on-day-changed="_dayChanged"
             on-hour-changed="_hourChanged"
             on-min-changed="_minChanged"
@@ -280,21 +280,21 @@ class HaForm extends EventsMixin(PolymerElement) {
   }
 
   _durationChanged(ev, unit) {
-    const value = ev.detail.value;
+    const value = ev.detail.value.toString() | undefined;
     this.set(["data"], { ...this.get(["data"]), [unit]: value });
   }
 
   _parseDuration(duration, unit) {
-    let days = "0";
-    let hours = "00";
-    let minutes = "00";
-    let seconds = "00";
+    let days = 0;
+    let hours = 0;
+    let minutes = 0;
+    let seconds = 0;
     if (
       duration &&
       (duration.days || duration.hours || duration.minutes || duration.seconds)
     ) {
       // If the duration was defined using yaml dict syntax, extract days, hours, minutes and seconds
-      ({ days = "0", hours = "00", minutes = "00", seconds = "00" } = duration);
+      ({ days = 0, hours = 0, minutes = 0, seconds = 0 } = duration);
     }
     duration = {
       days,

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -144,13 +144,13 @@ export class PaperTimeInput extends PolymerElement {
           type="number"
           value="{{sec}}"
           on-change="_formatSec"
-          required
+          required=""
           auto-validate="[[autoValidate]]"
           prevent-invalid-input
           maxlength="2"
           max="59"
           min="0"
-          no-label-float
+          no-label-float=""
           disabled="[[disabled]]"
           hidden$="[[!enableSecond]]"
         >

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -102,6 +102,25 @@ export class PaperTimeInput extends PolymerElement {
 
       <label hidden$="[[hideLabel]]">[[label]]</label>
       <div class="time-input-wrap">
+        <!-- Day Input -->
+        <paper-input
+          id="day"
+          type="number"
+          value="{{day}}"
+          on-change="_formatDay"
+          required=""
+          auto-validate="[[autoValidate]]"
+          prevent-invalid-input=""
+          maxlength="2"
+          max="99"
+          min="0"
+          no-label-float=""
+          disabled="[[disabled]]"
+          hidden$="[[!enableDay]]"
+        >
+          <span hidden$="[[!enableDay]]" suffix slot="suffix"> </span>
+        </paper-input>
+
         <!-- Hour Input -->
         <paper-input
           id="hour"
@@ -215,6 +234,13 @@ export class PaperTimeInput extends PolymerElement {
         value: false,
       },
       /**
+       * day
+       */
+      day: {
+        type: String,
+        notify: true,
+      },
+      /**
        * hour
        */
       hour: {
@@ -234,6 +260,13 @@ export class PaperTimeInput extends PolymerElement {
       sec: {
         type: String,
         notify: true,
+      },
+      /**
+       * show the day field
+       */
+      enableDay: {
+        type: Boolean,
+        value: false,
       },
       /**
        * show the sec field
@@ -268,6 +301,10 @@ export class PaperTimeInput extends PolymerElement {
    */
   validate() {
     var valid = true;
+    // Validate day field
+    if (this.enableDay && !this.$.day.validate()) {
+      valid = false;
+    }
     // Validate hour & min fields
     if (!this.$.hour.validate() | !this.$.min.validate()) {
       valid = false;
@@ -332,6 +369,11 @@ export class PaperTimeInput extends PolymerElement {
       this.hour = this.hour.toString().padStart(2, "0");
     }
   }
+
+  /**
+   * Format day
+   */
+  _formatDay() {}
 
   /**
    * 24 hour format has a max hr of 23

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -49,7 +49,11 @@ export class PaperTimeInput extends PolymerElement {
             display: none;
           }
           --paper-input-container-shared-input-style_-_-webkit-appearance: textfield;
-          --paper-input-container-invalid-color: red;
+        }
+
+        .day-input {
+          width: 40px;
+          text-align: left;
         }
 
         paper-dropdown-menu {
@@ -88,6 +92,10 @@ export class PaperTimeInput extends PolymerElement {
 
         label {
           @apply --paper-font-caption;
+          color: var(
+            --paper-input-container-color,
+            var(--secondary-text-color)
+          );
         }
 
         .time-input-wrap {
@@ -104,9 +112,11 @@ export class PaperTimeInput extends PolymerElement {
       <div class="time-input-wrap">
         <!-- Day Input -->
         <paper-input
+          class="day-input"
           id="day"
           type="number"
           value="{{day}}"
+          label="[[dayLabel]]"
           on-change="_formatDay"
           required=""
           auto-validate="[[autoValidate]]"
@@ -114,11 +124,13 @@ export class PaperTimeInput extends PolymerElement {
           maxlength="2"
           max="99"
           min="0"
-          no-label-float=""
+          ?no-label-float="[[!floatInputLabels]]"
+          ?always-float-label="[[alwaysFloatInputLabels]]"
+          always-float-label=""
           disabled="[[disabled]]"
           hidden$="[[!enableDay]]"
         >
-          <span hidden$="[[!enableDay]]" suffix slot="suffix"> </span>
+          <span hidden$="[[!enableDay]]" suffix slot="suffix"></span>
         </paper-input>
 
         <!-- Hour Input -->
@@ -126,6 +138,7 @@ export class PaperTimeInput extends PolymerElement {
           id="hour"
           type="number"
           value="{{hour}}"
+          label="[[hourLabel]]"
           on-change="_shouldFormatHour"
           required=""
           auto-validate="[[autoValidate]]"
@@ -133,7 +146,9 @@ export class PaperTimeInput extends PolymerElement {
           maxlength="2"
           max="[[_computeHourMax(format)]]"
           min="0"
-          no-label-float=""
+          ?no-label-float="[[!floatInputLabels]]"
+          ?always-float-label="[[alwaysFloatInputLabels]]"
+          always-float-label=""
           disabled="[[disabled]]"
         >
           <span suffix="" slot="suffix">:</span>
@@ -144,6 +159,7 @@ export class PaperTimeInput extends PolymerElement {
           id="min"
           type="number"
           value="{{min}}"
+          label="[[minLabel]]"
           on-change="_formatMin"
           required=""
           auto-validate="[[autoValidate]]"
@@ -151,7 +167,9 @@ export class PaperTimeInput extends PolymerElement {
           maxlength="2"
           max="59"
           min="0"
-          no-label-float=""
+          ?no-label-float="[[!floatInputLabels]]"
+          ?always-float-label="[[alwaysFloatInputLabels]]"
+          always-float-label=""
           disabled="[[disabled]]"
         >
           <span hidden$="[[!enableSecond]]" suffix slot="suffix">:</span>
@@ -162,6 +180,7 @@ export class PaperTimeInput extends PolymerElement {
           id="sec"
           type="number"
           value="{{sec}}"
+          label="[[secLabel]]"
           on-change="_formatSec"
           required=""
           auto-validate="[[autoValidate]]"
@@ -169,7 +188,9 @@ export class PaperTimeInput extends PolymerElement {
           maxlength="2"
           max="59"
           min="0"
-          no-label-float=""
+          ?no-label-float="[[!floatInputLabels]]"
+          ?always-float-label="[[alwaysFloatInputLabels]]"
+          always-float-label=""
           disabled="[[disabled]]"
           hidden$="[[!enableSecond]]"
         >
@@ -220,6 +241,20 @@ export class PaperTimeInput extends PolymerElement {
         value: false,
       },
       /**
+       * float the input labels
+       */
+      floatInputLabels: {
+        type: Boolean,
+        value: false,
+      },
+      /**
+       * always float the input labels
+       */
+      alwaysFloatInputLabels: {
+        type: Boolean,
+        value: true,
+      },
+      /**
        * 12 or 24 hr format
        */
       format: {
@@ -260,6 +295,34 @@ export class PaperTimeInput extends PolymerElement {
       sec: {
         type: String,
         notify: true,
+      },
+      /**
+       * Label for the day input
+       */
+      dayLabel: {
+        type: String,
+        value: "days",
+      },
+      /**
+       * Suffix for the hour input
+       */
+      hourLabel: {
+        type: String,
+        value: "",
+      },
+      /**
+       * Suffix for the min input
+       */
+      minLabel: {
+        type: String,
+        value: ":",
+      },
+      /**
+       * Suffix for the sec input
+       */
+      secLabel: {
+        type: String,
+        value: "",
       },
       /**
        * show the day field
@@ -347,33 +410,35 @@ export class PaperTimeInput extends PolymerElement {
    * Format sec
    */
   _formatSec() {
-    if (this.sec.toString().length === 1) {
-      this.sec = this.sec.toString().padStart(2, "0");
-    }
+    this.sec = this.sec.toString().padStart(2, "0");
+    this.sec = this.sec.substring(0, 2);
   }
 
   /**
    * Format min
    */
   _formatMin() {
-    if (this.min.toString().length === 1) {
-      this.min = this.min.toString().padStart(2, "0");
-    }
+    this.min = this.min.toString().padStart(2, "0");
+    this.min = this.min.substring(0, 2);
   }
 
   /**
    * Hour needs a leading zero in 24hr format
    */
   _shouldFormatHour() {
-    if (this.format === 24 && this.hour.toString().length === 1) {
+    if (this.format === 24) {
       this.hour = this.hour.toString().padStart(2, "0");
     }
+    this.hour = this.hour.substring(0, 2);
   }
 
   /**
    * Format day
    */
-  _formatDay() {}
+  _formatDay() {
+    this.hour = this.hour.toString().padStart(1, "0");
+    this.day = this.day.substring(0, 2);
+  }
 
   /**
    * 24 hour format has a max hr of 23

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -115,7 +115,7 @@ export class PaperTimeInput extends PolymerElement {
           class="day-input"
           id="day"
           type="number"
-          value="{{day}}"
+          value="{{dayString}}"
           label="[[dayLabel]]"
           on-change="_formatDay"
           required=""
@@ -136,7 +136,7 @@ export class PaperTimeInput extends PolymerElement {
         <paper-input
           id="hour"
           type="number"
-          value="{{hour}}"
+          value="{{hourString}}"
           label="[[hourLabel]]"
           on-change="_shouldFormatHour"
           required=""
@@ -156,7 +156,7 @@ export class PaperTimeInput extends PolymerElement {
         <paper-input
           id="min"
           type="number"
-          value="{{min}}"
+          value="{{minString}}"
           label="[[minLabel]]"
           on-change="_formatMin"
           required=""
@@ -176,7 +176,7 @@ export class PaperTimeInput extends PolymerElement {
         <paper-input
           id="sec"
           type="number"
-          value="{{sec}}"
+          value="{{secString}}"
           label="[[secLabel]]"
           on-change="_formatSec"
           required=""
@@ -211,6 +211,15 @@ export class PaperTimeInput extends PolymerElement {
         </paper-dropdown-menu>
       </div>
     `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    console.log("paper-time-input created!");
+    this.secString = this._getSecString();
+    this.minString = this._getMinString();
+    this.hourString = this._getHourString();
+    this.dayString = this._getDayString();
   }
 
   static get properties() {
@@ -289,6 +298,34 @@ export class PaperTimeInput extends PolymerElement {
        * second
        */
       sec: {
+        type: String,
+        notify: true,
+      },
+      /**
+       * day
+       */
+      dayString: {
+        type: String,
+        notify: true,
+      },
+      /**
+       * hour
+       */
+      hourString: {
+        type: String,
+        notify: true,
+      },
+      /**
+       * minute
+       */
+      minString: {
+        type: String,
+        notify: true,
+      },
+      /**
+       * second
+       */
+      secString: {
         type: String,
         notify: true,
       },
@@ -405,35 +442,76 @@ export class PaperTimeInput extends PolymerElement {
   /**
    * Format sec
    */
+  _getSecString() {
+    let val = this.sec;
+    if (val === undefined || val === null) {
+      val = 0; // always display 00
+    }
+    return val.toString().padStart(2, "0");
+  }
   _formatSec() {
-    this.sec = this.sec.toString().padStart(2, "0");
-    this.sec = this.sec.substring(0, 2);
+    const val = parseInt(this.secString) || 0;
+    if (val < 0) val = 0;
+    if (val > 59) val = 59;
+    this.sec = val;
+    this.secString = this._getSecString();
   }
 
   /**
    * Format min
    */
+  _getMinString() {
+    let val = this.min;
+    if (val === undefined || val === null) {
+      val = 0; // always display 00
+    }
+    return val.toString().padStart(2, "0");
+  }
   _formatMin() {
-    this.min = this.min.toString().padStart(2, "0");
-    this.min = this.min.substring(0, 2);
+    const val = parseInt(this.minString) || 0;
+    if (val < 0) val = 0;
+    if (val > 59) val = 59;
+    this.min = val;
+    this.minString = this._getMinString();
   }
 
   /**
    * Hour needs a leading zero in 24hr format
    */
-  _shouldFormatHour() {
-    if (this.format === 24) {
-      this.hour = this.hour.toString().padStart(2, "0");
+  _getHourString() {
+    let val = this.hour;
+    if (val === undefined || val === null) {
+      val = 0; // always display 00
     }
-    this.hour = this.hour.substring(0, 2);
+    if (this.format === 24) {
+      return val.toString().padStart(2, "0");
+    }
+    return val.toString();
+  }
+  _shouldFormatHour() {
+    const val = parseInt(this.hourString) || 0;
+    if (val < 0) val = 0;
+    if (val > 23) val = 23; // Blabla fix 12 or 23
+    this.hour = val;
+    this.hourString = this._getHourString();
   }
 
   /**
    * Format day
    */
+  _getDayString() {
+    let val = this.day;
+    if (val === undefined || val === null) {
+      val = 0; // always display 00
+    }
+    return val.toString().padStart(1, "0");
+  }
   _formatDay() {
-    this.hour = this.hour.toString().padStart(1, "0");
-    this.day = this.day.substring(0, 2);
+    const val = parseInt(this.dayString) || 0;
+    if (val < 0) val = 0;
+    if (val > 99) val = 99;
+    this.day = val;
+    this.dayString = this._getDayString();
   }
 
   /**

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -288,7 +288,10 @@ export class PaperTimeInput extends PolymerElement {
    */
   _computeTime(min, hour, sec, amPm) {
     let str;
-    if (hour && min) {
+    if (hour || min || (sec && this.enableSecond)) {
+      hour = hour || "00";
+      min = min || "00";
+      sec = sec || "00";
       str = hour + ":" + min;
       // add sec field
       if (this.enableSecond && sec) {
@@ -307,21 +310,25 @@ export class PaperTimeInput extends PolymerElement {
    * Format sec
    */
   _formatSec() {
-    this.sec = this.sec.toString().padStart(2, "0");
+    if (this.sec.toString().length === 1) {
+      this.sec = this.sec.toString().padStart(2, "0");
+    }
   }
 
   /**
    * Format min
    */
   _formatMin() {
-    this.min = this.min.toString().padStart(2, "0");
+    if (this.min.toString().length === 1) {
+      this.min = this.min.toString().padStart(2, "0");
+    }
   }
 
   /**
    * Hour needs a leading zero in 24hr format
    */
   _shouldFormatHour() {
-    if (this.format === 24) {
+    if (this.format === 24 && this.hour.toString().length === 1) {
       this.hour = this.hour.toString().padStart(2, "0");
     }
   }

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -124,9 +124,8 @@ export class PaperTimeInput extends PolymerElement {
           maxlength="2"
           max="99"
           min="0"
-          ?no-label-float="[[!floatInputLabels]]"
-          ?always-float-label="[[alwaysFloatInputLabels]]"
-          always-float-label=""
+          no-label-float="[[!floatInputLabels]]"
+          always-float-label="[[alwaysFloatInputLabels]]"
           disabled="[[disabled]]"
           hidden$="[[!enableDay]]"
         >
@@ -146,9 +145,8 @@ export class PaperTimeInput extends PolymerElement {
           maxlength="2"
           max="[[_computeHourMax(format)]]"
           min="0"
-          ?no-label-float="[[!floatInputLabels]]"
-          ?always-float-label="[[alwaysFloatInputLabels]]"
-          always-float-label=""
+          no-label-float$="[[!floatInputLabels]]"
+          always-float-label$="[[alwaysFloatInputLabels]]"
           disabled="[[disabled]]"
         >
           <span suffix="" slot="suffix">:</span>
@@ -167,9 +165,8 @@ export class PaperTimeInput extends PolymerElement {
           maxlength="2"
           max="59"
           min="0"
-          ?no-label-float="[[!floatInputLabels]]"
-          ?always-float-label="[[alwaysFloatInputLabels]]"
-          always-float-label=""
+          no-label-float$="[[!floatInputLabels]]"
+          always-float-label$="[[alwaysFloatInputLabels]]"
           disabled="[[disabled]]"
         >
           <span hidden$="[[!enableSecond]]" suffix slot="suffix">:</span>
@@ -188,9 +185,8 @@ export class PaperTimeInput extends PolymerElement {
           maxlength="2"
           max="59"
           min="0"
-          ?no-label-float="[[!floatInputLabels]]"
-          ?always-float-label="[[alwaysFloatInputLabels]]"
-          always-float-label=""
+          no-label-float$="[[!floatInputLabels]]"
+          always-float-label$="[[alwaysFloatInputLabels]]"
           disabled="[[disabled]]"
           hidden$="[[!enableSecond]]"
         >
@@ -252,7 +248,7 @@ export class PaperTimeInput extends PolymerElement {
        */
       alwaysFloatInputLabels: {
         type: Boolean,
-        value: true,
+        value: false,
       },
       /**
        * 12 or 24 hr format

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -51,11 +51,6 @@ export class PaperTimeInput extends PolymerElement {
           --paper-input-container-shared-input-style_-_-webkit-appearance: textfield;
         }
 
-        .day-input {
-          width: 40px;
-          text-align: left;
-        }
-
         paper-dropdown-menu {
           width: 55px;
           padding: 0;
@@ -110,38 +105,16 @@ export class PaperTimeInput extends PolymerElement {
 
       <label hidden$="[[hideLabel]]">[[label]]</label>
       <div class="time-input-wrap">
-        <!-- Day Input -->
-        <paper-input
-          class="day-input"
-          id="day"
-          type="number"
-          value="{{dayString}}"
-          label="[[dayLabel]]"
-          on-change="_formatDay"
-          required=""
-          auto-validate="[[autoValidate]]"
-          prevent-invalid-input=""
-          maxlength="2"
-          max="99"
-          min="0"
-          no-label-float="[[!floatInputLabels]]"
-          always-float-label="[[alwaysFloatInputLabels]]"
-          disabled="[[disabled]]"
-          hidden$="[[!enableDay]]"
-        >
-          <span hidden$="[[!enableDay]]" suffix slot="suffix"></span>
-        </paper-input>
-
         <!-- Hour Input -->
         <paper-input
           id="hour"
           type="number"
-          value="{{hourString}}"
+          value="{{hour}}"
           label="[[hourLabel]]"
           on-change="_shouldFormatHour"
-          required=""
+          required
+          prevent-invalid-input
           auto-validate="[[autoValidate]]"
-          prevent-invalid-input=""
           maxlength="2"
           max="[[_computeHourMax(format)]]"
           min="0"
@@ -156,12 +129,12 @@ export class PaperTimeInput extends PolymerElement {
         <paper-input
           id="min"
           type="number"
-          value="{{minString}}"
+          value="{{min}}"
           label="[[minLabel]]"
           on-change="_formatMin"
-          required=""
+          required
           auto-validate="[[autoValidate]]"
-          prevent-invalid-input=""
+          prevent-invalid-input
           maxlength="2"
           max="59"
           min="0"
@@ -176,10 +149,10 @@ export class PaperTimeInput extends PolymerElement {
         <paper-input
           id="sec"
           type="number"
-          value="{{secString}}"
+          value="{{sec}}"
           label="[[secLabel]]"
           on-change="_formatSec"
-          required=""
+          required
           auto-validate="[[autoValidate]]"
           prevent-invalid-input
           maxlength="2"
@@ -211,15 +184,6 @@ export class PaperTimeInput extends PolymerElement {
         </paper-dropdown-menu>
       </div>
     `;
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    console.log("paper-time-input created!");
-    this.secString = this._getSecString();
-    this.minString = this._getMinString();
-    this.hourString = this._getHourString();
-    this.dayString = this._getDayString();
   }
 
   static get properties() {
@@ -274,13 +238,6 @@ export class PaperTimeInput extends PolymerElement {
         value: false,
       },
       /**
-       * day
-       */
-      day: {
-        type: String,
-        notify: true,
-      },
-      /**
        * hour
        */
       hour: {
@@ -300,41 +257,6 @@ export class PaperTimeInput extends PolymerElement {
       sec: {
         type: String,
         notify: true,
-      },
-      /**
-       * day
-       */
-      dayString: {
-        type: String,
-        notify: true,
-      },
-      /**
-       * hour
-       */
-      hourString: {
-        type: String,
-        notify: true,
-      },
-      /**
-       * minute
-       */
-      minString: {
-        type: String,
-        notify: true,
-      },
-      /**
-       * second
-       */
-      secString: {
-        type: String,
-        notify: true,
-      },
-      /**
-       * Label for the day input
-       */
-      dayLabel: {
-        type: String,
-        value: "days",
       },
       /**
        * Suffix for the hour input
@@ -358,16 +280,16 @@ export class PaperTimeInput extends PolymerElement {
         value: "",
       },
       /**
-       * show the day field
+       * show the sec field
        */
-      enableDay: {
+      enableSecond: {
         type: Boolean,
         value: false,
       },
       /**
-       * show the sec field
+       * limit hours input
        */
-      enableSecond: {
+      noHoursLimit: {
         type: Boolean,
         value: false,
       },
@@ -397,10 +319,6 @@ export class PaperTimeInput extends PolymerElement {
    */
   validate() {
     var valid = true;
-    // Validate day field
-    if (this.enableDay && !this.$.day.validate()) {
-      valid = false;
-    }
     // Validate hour & min fields
     if (!this.$.hour.validate() | !this.$.min.validate()) {
       valid = false;
@@ -442,82 +360,37 @@ export class PaperTimeInput extends PolymerElement {
   /**
    * Format sec
    */
-  _getSecString() {
-    let val = this.sec;
-    if (val === undefined || val === null) {
-      val = 0; // always display 00
-    }
-    return val.toString().padStart(2, "0");
-  }
   _formatSec() {
-    const val = parseInt(this.secString) || 0;
-    if (val < 0) val = 0;
-    if (val > 59) val = 59;
-    this.sec = val;
-    this.secString = this._getSecString();
+    if (this.sec.toString().length === 1) {
+      this.sec = this.sec.toString().padStart(2, "0");
+    }
   }
 
   /**
    * Format min
    */
-  _getMinString() {
-    let val = this.min;
-    if (val === undefined || val === null) {
-      val = 0; // always display 00
-    }
-    return val.toString().padStart(2, "0");
-  }
   _formatMin() {
-    const val = parseInt(this.minString) || 0;
-    if (val < 0) val = 0;
-    if (val > 59) val = 59;
-    this.min = val;
-    this.minString = this._getMinString();
+    if (this.min.toString().length === 1) {
+      this.min = this.min.toString().padStart(2, "0");
+    }
   }
 
   /**
-   * Hour needs a leading zero in 24hr format
+   * Format hour
    */
-  _getHourString() {
-    let val = this.hour;
-    if (val === undefined || val === null) {
-      val = 0; // always display 00
-    }
-    if (this.format === 24) {
-      return val.toString().padStart(2, "0");
-    }
-    return val.toString();
-  }
   _shouldFormatHour() {
-    const val = parseInt(this.hourString) || 0;
-    if (val < 0) val = 0;
-    if (val > 23) val = 23; // Blabla fix 12 or 23
-    this.hour = val;
-    this.hourString = this._getHourString();
-  }
-
-  /**
-   * Format day
-   */
-  _getDayString() {
-    let val = this.day;
-    if (val === undefined || val === null) {
-      val = 0; // always display 00
+    if (this.format === 24 && this.hour.toString().length === 1) {
+      this.hour = this.hour.toString().padStart(2, "0");
     }
-    return val.toString().padStart(1, "0");
-  }
-  _formatDay() {
-    const val = parseInt(this.dayString) || 0;
-    if (val < 0) val = 0;
-    if (val > 99) val = 99;
-    this.day = val;
-    this.dayString = this._getDayString();
   }
 
   /**
    * 24 hour format has a max hr of 23
    */
   _computeHourMax(format) {
+    if (this.noHoursLimit) {
+      return null;
+    }
     if (format === 12) {
       return format;
     }

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -49,6 +49,7 @@ export class PaperTimeInput extends PolymerElement {
             display: none;
           }
           --paper-input-container-shared-input-style_-_-webkit-appearance: textfield;
+          --paper-input-container-invalid-color: red;
         }
 
         paper-dropdown-menu {
@@ -286,7 +287,7 @@ export class PaperTimeInput extends PolymerElement {
    * Create time string
    */
   _computeTime(min, hour, sec, amPm) {
-    let str = undefined;
+    let str;
     if (hour && min) {
       str = hour + ":" + min;
       // add sec field
@@ -313,17 +314,15 @@ export class PaperTimeInput extends PolymerElement {
    * Format min
    */
   _formatMin() {
-    if (this.min.toString().length === 1) {
-      this.min = this.min < 10 ? "0" + this.min : this.min;
-    }
+    this.min = this.min.toString().padStart(2, "0");
   }
 
   /**
    * Hour needs a leading zero in 24hr format
    */
   _shouldFormatHour() {
-    if (this.format === 24 && this.hour.toString().length === 1) {
-      this.hour = this.hour < 10 ? "0" + this.hour : this.hour;
+    if (this.format === 24) {
+      this.hour = this.hour.toString().padStart(2, "0");
     }
   }
 

--- a/src/components/paper-time-input.js
+++ b/src/components/paper-time-input.js
@@ -134,6 +134,25 @@ export class PaperTimeInput extends PolymerElement {
           no-label-float=""
           disabled="[[disabled]]"
         >
+          <span hidden$="[[!enableSecond]]" suffix slot="suffix">:</span>
+        </paper-input>
+
+        <!-- Sec Input -->
+        <paper-input
+          id="sec"
+          type="number"
+          value="{{sec}}"
+          on-change="_formatSec"
+          required
+          auto-validate="[[autoValidate]]"
+          prevent-invalid-input
+          maxlength="2"
+          max="59"
+          min="0"
+          no-label-float
+          disabled="[[disabled]]"
+          hidden$="[[!enableSecond]]"
+        >
         </paper-input>
 
         <!-- Dropdown Menu -->
@@ -209,6 +228,20 @@ export class PaperTimeInput extends PolymerElement {
         notify: true,
       },
       /**
+       * second
+       */
+      sec: {
+        type: String,
+        notify: true,
+      },
+      /**
+       * show the sec field
+       */
+      enableSecond: {
+        type: Boolean,
+        value: false,
+      },
+      /**
        * AM or PM
        */
       amPm: {
@@ -223,7 +256,7 @@ export class PaperTimeInput extends PolymerElement {
         type: String,
         notify: true,
         readOnly: true,
-        computed: "_computeTime(min, hour, amPm)",
+        computed: "_computeTime(min, hour, sec, amPm)",
       },
     };
   }
@@ -238,6 +271,10 @@ export class PaperTimeInput extends PolymerElement {
     if (!this.$.hour.validate() | !this.$.min.validate()) {
       valid = false;
     }
+    // Validate second field
+    if (this.enableSecond && !this.$.sec.validate()) {
+      valid = false;
+    }
     // Validate AM PM if 12 hour time
     if (this.format === 12 && !this.$.dropdown.validate()) {
       valid = false;
@@ -248,15 +285,28 @@ export class PaperTimeInput extends PolymerElement {
   /**
    * Create time string
    */
-  _computeTime(min, hour, amPm) {
+  _computeTime(min, hour, sec, amPm) {
+    let str = undefined;
     if (hour && min) {
-      // No ampm on 24 hr time
-      if (this.format === 24) {
-        amPm = "";
+      str = hour + ":" + min;
+      // add sec field
+      if (this.enableSecond && sec) {
+        str = str + ":" + sec;
       }
-      return hour + ":" + min + " " + amPm;
+      // No ampm on 24 hr time
+      if (this.format === 12) {
+        str = str + " " + amPm;
+      }
     }
-    return undefined;
+
+    return str;
+  }
+
+  /**
+   * Format sec
+   */
+  _formatSec() {
+    this.sec = this.sec.toString().padStart(2, "0");
   }
 
   /**

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -39,7 +39,14 @@ export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
     device_id: deviceId,
   });
 
-const whitelist = ["for", "supports"];
+export const fetchDeviceTriggerCapabilities = (
+  hass: HomeAssistant,
+  trigger: DeviceTrigger
+) =>
+  hass.callWS<DeviceTrigger[]>({
+    type: "device_automation/trigger/capabilities",
+    trigger: trigger,
+  });
 
 export const deviceAutomationsEqual = (
   a: DeviceAutomation,

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -39,7 +39,7 @@ export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
     device_id: deviceId,
   });
 
-const whitelist = ["for"];
+const whitelist = ["for", "supports"];
 
 export const deviceAutomationsEqual = (
   a: DeviceAutomation,

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -39,6 +39,8 @@ export const fetchDeviceTriggers = (hass: HomeAssistant, deviceId: string) =>
     device_id: deviceId,
   });
 
+const whitelist = ["for"];
+
 export const deviceAutomationsEqual = (
   a: DeviceAutomation,
   b: DeviceAutomation
@@ -48,11 +50,17 @@ export const deviceAutomationsEqual = (
   }
 
   for (const property in a) {
+    if (whitelist.includes(property)) {
+      continue;
+    }
     if (!Object.is(a[property], b[property])) {
       return false;
     }
   }
   for (const property in b) {
+    if (whitelist.includes(property)) {
+      continue;
+    }
     if (!Object.is(a[property], b[property])) {
       return false;
     }

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -45,8 +45,10 @@ export const fetchDeviceTriggerCapabilities = (
 ) =>
   hass.callWS<DeviceTrigger[]>({
     type: "device_automation/trigger/capabilities",
-    trigger: trigger,
+    trigger,
   });
+
+const whitelist = ["for"];
 
 export const deviceAutomationsEqual = (
   a: DeviceAutomation,

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -333,7 +333,7 @@ export class HaAutomationEditor extends LitElement {
           left: 24px;
         }
 
-        paper-input {
+        #device-trigger-days {
           display: inline-block;
           width: 50px;
         }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -332,15 +332,6 @@ export class HaAutomationEditor extends LitElement {
           right: auto;
           left: 24px;
         }
-
-        #device-trigger-days {
-          display: inline-block;
-          width: 50px;
-        }
-
-        paper-time-input {
-          display: inline-block;
-        }
       `,
     ];
   }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -332,6 +332,15 @@ export class HaAutomationEditor extends LitElement {
           right: auto;
           left: 24px;
         }
+
+        paper-input {
+          display: inline-block;
+          width: 50px;
+        }
+
+        paper-time-input {
+          display: inline-block;
+        }
       `,
     ];
   }

--- a/src/panels/config/js/preact-types.ts
+++ b/src/panels/config/js/preact-types.ts
@@ -17,6 +17,7 @@ declare global {
       "paper-menu-button": any;
       "paper-dropdown-menu-light": any;
       "paper-icon-button": any;
+      "paper-time-input": any;
       "ha-device-picker": any;
       "ha-device-condition-picker": any;
       "ha-textarea": any;

--- a/src/panels/config/js/preact-types.ts
+++ b/src/panels/config/js/preact-types.ts
@@ -25,6 +25,7 @@ declare global {
       "mwc-button": any;
       "ha-device-trigger-picker": any;
       "ha-device-action-picker": any;
+      "ha-form": any;
     }
   }
 }

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -4,17 +4,13 @@ import "../../../../components/device/ha-device-picker";
 import "../../../../components/device/ha-device-trigger-picker";
 import "../../../../components/paper-time-input";
 
-import { onChangeEvent } from "../../../../common/preact/event";
-
 import { fetchDeviceTriggerCapabilities } from "../../../../data/device_automation";
 
 export default class DeviceTrigger extends Component<any, any> {
-  private onChange: (obj: any) => void;
   private hass;
   constructor() {
     super();
 
-    this.onChange = onChangeEvent.bind(this, "trigger");
     this.daysChanged = this.daysChanged.bind(this);
     this.hoursChanged = this.hoursChanged.bind(this);
     this.minutesChanged = this.minutesChanged.bind(this);

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -25,10 +25,6 @@ export default class DeviceTrigger extends Component<any, any> {
     const showFor = deviceTrigger.hasOwnProperty("for");
     if (showFor) {
       deviceTrigger = { ...deviceTrigger, for: trgFor };
-      // deviceTrigger = Object.assign(
-      //  {},
-      //  deviceTrigger, { for: trgFor }
-      // );
     }
     this.props.onChange(this.props.index, deviceTrigger);
   }
@@ -40,7 +36,6 @@ export default class DeviceTrigger extends Component<any, any> {
     const duration = ev.detail.value;
     this.props.onChange(
       this.props.index,
-      // Object.assign({}, this.props.trigger, { for: duration })
       { ...this.props.trigger, for: duration }
     );
   }

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -2,15 +2,7 @@ import { h, Component } from "preact";
 
 import "../../../../components/device/ha-device-picker";
 import "../../../../components/device/ha-device-trigger-picker";
-import "../../../../components/paper-time-input.js";
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      "paper-time-input": any;
-    }
-  }
-}
+import "../../../../components/paper-time-input";
 
 export default class DeviceTrigger extends Component<any, any> {
   constructor() {
@@ -76,20 +68,21 @@ export default class DeviceTrigger extends Component<any, any> {
           hass={hass}
           label="Trigger"
         />
-        <paper-time-input
-          label={hass.localize(
-            "ui.panel.config.automation.editor.triggers.type.state.for"
-          )}
-          hour={hours}
-          min={minutes}
-          sec={seconds}
-          enable-second
-          format={24}
-          onhour-changed={this.hourChanged}
-          onmin-changed={this.minuteChanged}
-          onsec-changed={this.secondChanged}
-          hidden={!showFor}
-        />
+        {showFor && (
+          <paper-time-input
+            label={hass.localize(
+              "ui.panel.config.automation.editor.triggers.type.state.for"
+            )}
+            hour={hours}
+            min={minutes}
+            sec={seconds}
+            enable-second
+            format={24}
+            onhour-changed={this.hourChanged}
+            onmin-changed={this.minuteChanged}
+            onsec-changed={this.secondChanged}
+          />
+        )}
       </div>
     );
   }

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -2,12 +2,16 @@ import { h, Component } from "preact";
 
 import "../../../../components/device/ha-device-picker";
 import "../../../../components/device/ha-device-trigger-picker";
+import "../../../../components/paper-time-input.js";
+// tslint:disable-next-line:no-duplicate-imports
+import { PaperTimeInput } from "../../../../components/paper-time-input.js";
 
 export default class DeviceTrigger extends Component<any, any> {
   constructor() {
     super();
     this.devicePicked = this.devicePicked.bind(this);
     this.deviceTriggerPicked = this.deviceTriggerPicked.bind(this);
+    this.durationChanged = this.durationChanged.bind(this);
     this.state = { device_id: undefined };
   }
 
@@ -16,8 +20,29 @@ export default class DeviceTrigger extends Component<any, any> {
   }
 
   public deviceTriggerPicked(ev) {
-    const deviceTrigger = ev.target.value;
+    const trgFor = this.props.trigger.for;
+    let deviceTrigger = ev.target.value;
+    const showFor = deviceTrigger.hasOwnProperty("for");
+    if (showFor) {
+      deviceTrigger = { ...deviceTrigger, for: trgFor };
+      // deviceTrigger = Object.assign(
+      //  {},
+      //  deviceTrigger, { for: trgFor }
+      // );
+    }
     this.props.onChange(this.props.index, deviceTrigger);
+  }
+
+  public durationChanged(ev) {
+    if (!this.props.trigger.hasOwnProperty("for")) {
+      return;
+    }
+    const duration = ev.detail.value;
+    this.props.onChange(
+      this.props.index,
+      // Object.assign({}, this.props.trigger, { for: duration })
+      { ...this.props.trigger, for: duration }
+    );
   }
 
   /* eslint-disable camelcase */
@@ -25,6 +50,30 @@ export default class DeviceTrigger extends Component<any, any> {
     if (device_id === undefined) {
       device_id = trigger.device_id;
     }
+    const showFor = trigger.hasOwnProperty("for");
+    const trgFor = trigger.for;
+    let hours = "00";
+    let minutes = "00";
+    let seconds = "00";
+
+    if (trgFor && (trgFor.hours || trgFor.minutes || trgFor.seconds)) {
+      // If the trigger was defined using the yaml dict syntax, extract hours, minutes and seconds
+      ({ hours = "00", minutes = "00", seconds = "00" } = trgFor);
+    }
+    if (typeof trgFor === "string" && trgFor.includes(":")) {
+      // Parse hours, minutes and seconds from ':'-delimited string
+      [hours = "00", minutes = "00", seconds = "00"] = trgFor.split(":");
+    }
+    // Convert to zero-padded string for display
+    hours = parseInt(hours, 10)
+      .toString()
+      .padStart(2, "0");
+    minutes = parseInt(minutes, 10)
+      .toString()
+      .padStart(2, "0");
+    seconds = parseInt(seconds, 10)
+      .toString()
+      .padStart(2, "0");
 
     return (
       <div>
@@ -40,6 +89,19 @@ export default class DeviceTrigger extends Component<any, any> {
           onChange={this.deviceTriggerPicked}
           hass={hass}
           label="Trigger"
+        />
+        <paper-time-input
+          label={hass.localize(
+            "ui.panel.config.automation.editor.triggers.type.state.for"
+          )}
+          name="for"
+          hour={hours}
+          min={minutes}
+          sec={seconds}
+          enable-second
+          format={24}
+          onvalue-changed={this.durationChanged}
+          hidden={!showFor}
         />
       </div>
     );

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -2,6 +2,7 @@ import { h, Component } from "preact";
 
 import "../../../../components/device/ha-device-picker";
 import "../../../../components/device/ha-device-trigger-picker";
+import "../../../../components/ha-form";
 import "../../../../components/paper-time-input";
 
 import { fetchDeviceTriggerCapabilities } from "../../../../data/device_automation";
@@ -11,12 +12,9 @@ export default class DeviceTrigger extends Component<any, any> {
   constructor() {
     super();
 
-    this.daysChanged = this.daysChanged.bind(this);
-    this.hoursChanged = this.hoursChanged.bind(this);
-    this.minutesChanged = this.minutesChanged.bind(this);
-    this.secondsChanged = this.secondsChanged.bind(this);
     this.devicePicked = this.devicePicked.bind(this);
     this.deviceTriggerPicked = this.deviceTriggerPicked.bind(this);
+    this._extraFieldsChanged = this._extraFieldsChanged.bind(this);
     this.state = { device_id: undefined, capabilities: undefined };
   }
 
@@ -33,22 +31,6 @@ export default class DeviceTrigger extends Component<any, any> {
     this.props.onChange(this.props.index, deviceTrigger);
   }
 
-  public daysChanged(ev) {
-    this._timeChanged(ev, "days");
-  }
-
-  public hoursChanged(ev) {
-    this._timeChanged(ev, "hours");
-  }
-
-  public minutesChanged(ev) {
-    this._timeChanged(ev, "minutes");
-  }
-
-  public secondsChanged(ev) {
-    this._timeChanged(ev, "seconds");
-  }
-
   /* eslint-disable camelcase */
   public render({ trigger, hass }, { device_id }) {
     this.hass = hass;
@@ -62,16 +44,16 @@ export default class DeviceTrigger extends Component<any, any> {
     if (device_id === undefined) {
       device_id = trigger.device_id;
     }
-    const showFor =
-      this.state.capabilities &&
-      this.state.capabilities.supports &&
-      this.state.capabilities.supports.includes("for");
-    const trgFor = trigger.for;
-    let { days, hours, minutes, seconds } = this._parseTime(trgFor);
-    days = days.toString();
-    hours = this._pad(hours.toString());
-    minutes = this._pad(minutes.toString());
-    seconds = this._pad(seconds.toString());
+    let extra_fields_data = {}
+    if (this.state.capabilities && this.state.capabilities.extra_fields) {
+      for (let i in this.state.capabilities.extra_fields) {
+        let item = this.state.capabilities.extra_fields[i]
+        extra_fields_data = {
+          ...extra_fields_data,
+          [item.name]: this.props.trigger[item.name],
+        };
+      }
+    }
 
     return (
       <div>
@@ -88,74 +70,34 @@ export default class DeviceTrigger extends Component<any, any> {
           hass={hass}
           label="Trigger"
         />
-        {showFor && (
-          <div>
-            <paper-input
-              id="device-trigger-days"
-              label="Days"
-              name="days"
-              type="number"
-              value={days}
-              onvalue-changed={this.daysChanged}
-            />
-            <paper-time-input
-              label={hass.localize(
-                "ui.panel.config.automation.editor.triggers.type.state.for"
-              )}
-              hour={hours}
-              min={minutes}
-              sec={seconds}
-              enable-second
-              format={24}
-              onhour-changed={this.hoursChanged}
-              onmin-changed={this.minutesChanged}
-              onsec-changed={this.secondsChanged}
-            />
-          </div>
+        {this.state.capabilities && this.state.capabilities.extra_fields && (
+          <ha-form
+            data={ extra_fields_data }
+            data-changed={this._extraFieldsChanged}
+            ondata-changed={this._extraFieldsChanged}
+            onData-changed={this._extraFieldsChanged}
+            on-data-changed={this._extraFieldsChanged}
+            schema={this.state.capabilities.extra_fields}
+            //.error=${step.errors}
+            //.computeLabel=${this._labelCallback}
+            //.computeError=${this._errorCallback}
+          ></ha-form>
         )}
       </div>
     );
   }
 
-  private _pad(value) {
-    // Convert to zero-padded string for display
-    return parseInt(value, 10)
-      .toString()
-      .padStart(2, "0");
-  }
-
-  private _parseTime(trgFor) {
-    let days = "0";
-    let hours = "00";
-    let minutes = "00";
-    let seconds = "00";
-    if (trgFor && (trgFor.hours || trgFor.minutes || trgFor.seconds)) {
-      // If the trigger was defined using the yaml dict syntax, extract days, hours, minutes and seconds
-      ({ days = "0", hours = "00", minutes = "00", seconds = "00" } = trgFor);
-    }
-    if (typeof trgFor === "string" && trgFor.includes(":")) {
-      // Parse hours, minutes and seconds from ':'-delimited string
-      [hours = "00", minutes = "00", seconds = "00"] = trgFor.split(":");
-    }
-    return { days, hours, minutes, seconds };
-  }
-
-  private _timeChanged(ev, unit) {
-    const showFor =
-      this.state.capabilities &&
-      this.state.capabilities.supports &&
-      this.state.capabilities.supports.includes("for");
-    if (!showFor) {
+  private _extraFieldsChanged(ev) {
+    console.log(ev, ev.detail.value, JSON.stringify(ev.detail));
+    if (!ev.detail.path) {
       return;
     }
-    const value = ev.detail.value || 0;
-    const duration = {
-      ...this._parseTime(this.props.trigger.for),
-      [unit]: value,
-    };
+    const item = ev.detail.path.replace("data.", "");
+    const value = ev.detail.value;
+
     this.props.onChange(this.props.index, {
       ...this.props.trigger,
-      for: duration,
+      [item]: value,
     });
   }
 }

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -8,7 +8,6 @@ import "../../../../components/paper-time-input";
 import { fetchDeviceTriggerCapabilities } from "../../../../data/device_automation";
 
 export default class DeviceTrigger extends Component<any, any> {
-  private hass;
   constructor() {
     super();
 
@@ -25,7 +24,7 @@ export default class DeviceTrigger extends Component<any, any> {
   public async deviceTriggerPicked(ev) {
     const deviceTrigger = ev.target.value;
     const capabilities = deviceTrigger.domain
-      ? await fetchDeviceTriggerCapabilities(this.hass, deviceTrigger)
+      ? await fetchDeviceTriggerCapabilities(this.props.hass, deviceTrigger)
       : null;
     this.setState({ ...this.state, capabilities });
     this.props.onChange(this.props.index, deviceTrigger);
@@ -33,14 +32,6 @@ export default class DeviceTrigger extends Component<any, any> {
 
   /* eslint-disable camelcase */
   public render({ trigger, hass }, { device_id }) {
-    this.hass = hass;
-    if (!this.state.capabilities && trigger.domain) {
-      fetchDeviceTriggerCapabilities(this.hass, trigger).then(
-        (capabilities) => {
-          this.setState({ ...this.state, capabilities });
-        }
-      );
-    }
     if (device_id === undefined) {
       device_id = trigger.device_id;
     }
@@ -82,6 +73,17 @@ export default class DeviceTrigger extends Component<any, any> {
         )}
       </div>
     );
+  }
+
+  public componentDidMount() {
+    const hass = this.props.hass;
+    const trigger = this.props.trigger;
+
+    if (!this.state.capabilities && trigger.domain) {
+      fetchDeviceTriggerCapabilities(hass, trigger).then((capabilities) => {
+        this.setState({ ...this.state, capabilities });
+      });
+    }
   }
 
   private _extraFieldsChanged(ev) {

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -91,7 +91,7 @@ export default class DeviceTrigger extends Component<any, any> {
       return;
     }
     const item = ev.detail.path.replace("data.", "");
-    const value = ev.detail.value;
+    const value = ev.detail.value || undefined;
 
     this.props.onChange(this.props.index, {
       ...this.props.trigger,

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -96,6 +96,7 @@ export default class DeviceTrigger extends Component<any, any> {
         {showFor && (
           <div>
             <paper-input
+              id="device-trigger-days"
               label="Days"
               name="days"
               type="number"
@@ -116,7 +117,6 @@ export default class DeviceTrigger extends Component<any, any> {
               onsec-changed={this.secondsChanged}
             />
           </div>
-        )}
         )}
       </div>
     );

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -23,7 +23,6 @@ export default class DeviceTrigger extends Component<any, any> {
     this.deviceTriggerPicked = this.deviceTriggerPicked.bind(this);
     this.state = { device_id: undefined, capabilities: undefined };
   }
-  }
 
   public devicePicked(ev) {
     this.setState({ ...this.state, device_id: ev.target.value });

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -6,10 +6,7 @@ import "../../../../components/paper-time-input";
 
 import { onChangeEvent } from "../../../../common/preact/event";
 
-import {
-  fetchDeviceTriggerCapabilities,
-} from "../../../../data/device_automation";
-
+import { fetchDeviceTriggerCapabilities } from "../../../../data/device_automation";
 
 export default class DeviceTrigger extends Component<any, any> {
   private onChange: (obj: any) => void;
@@ -33,13 +30,15 @@ export default class DeviceTrigger extends Component<any, any> {
   }
 
   public async deviceTriggerPicked(ev) {
-    let deviceTrigger = ev.target.value;
-    const capabilities = deviceTrigger.domain ? await fetchDeviceTriggerCapabilities(this.hass, deviceTrigger) : null;
-    this.setState({ ...this.state, capabilities: capabilities });
+    const deviceTrigger = ev.target.value;
+    const capabilities = deviceTrigger.domain
+      ? await fetchDeviceTriggerCapabilities(this.hass, deviceTrigger)
+      : null;
+    this.setState({ ...this.state, capabilities });
     this.props.onChange(this.props.index, deviceTrigger);
   }
 
-  private daysChanged(ev) {
+  public daysChanged(ev) {
     this._timeChanged(ev, "days");
   }
 
@@ -59,12 +58,19 @@ export default class DeviceTrigger extends Component<any, any> {
   public render({ trigger, hass }, { device_id }) {
     this.hass = hass;
     if (!this.state.capabilities && trigger.domain) {
-      fetchDeviceTriggerCapabilities(this.hass, trigger).then((capabilities) => {this.setState({ ...this.state, capabilities: capabilities });})
+      fetchDeviceTriggerCapabilities(this.hass, trigger).then(
+        (capabilities) => {
+          this.setState({ ...this.state, capabilities });
+        }
+      );
     }
     if (device_id === undefined) {
       device_id = trigger.device_id;
     }
-    const showFor = this.state.capabilities && this.state.capabilities.supports && this.state.capabilities.supports.includes("for");
+    const showFor =
+      this.state.capabilities &&
+      this.state.capabilities.supports &&
+      this.state.capabilities.supports.includes("for");
     const trgFor = trigger.for;
     let { days, hours, minutes, seconds } = this._parseTime(trgFor);
     days = days.toString();
@@ -88,26 +94,27 @@ export default class DeviceTrigger extends Component<any, any> {
           label="Trigger"
         />
         {showFor && (
-          <paper-input
-            label="days"
-            name="days"
-            type="number"
-            value={days}
-            onvalue-changed={this.daysChanged}
-          />
-          <paper-time-input
-            label={hass.localize(
-              "ui.panel.config.automation.editor.triggers.type.state.for"
-            )}
-            hour={hours}
-            min={minutes}
-            sec={seconds}
-            enable-second
-            format={24}
-            onhour-changed={this.hoursChanged}
-            onmin-changed={this.minutesChanged}
-            onsec-changed={this.secondsChanged}
-          />
+          <div>
+            <paper-input
+              label="Days"
+              name="days"
+              type="number"
+              value={days}
+              onvalue-changed={this.daysChanged}
+            />
+            <paper-time-input
+              label={hass.localize(
+                "ui.panel.config.automation.editor.triggers.type.state.for"
+              )}
+              hour={hours}
+              min={minutes}
+              sec={seconds}
+              enable-second
+              format={24}
+              onhour-changed={this.hoursChanged}
+              onmin-changed={this.minutesChanged}
+              onsec-changed={this.secondsChanged}
+            />
           </div>
         )}
         )}
@@ -123,7 +130,7 @@ export default class DeviceTrigger extends Component<any, any> {
   }
 
   private _parseTime(trgFor) {
-    let days = "0"
+    let days = "0";
     let hours = "00";
     let minutes = "00";
     let seconds = "00";
@@ -139,7 +146,10 @@ export default class DeviceTrigger extends Component<any, any> {
   }
 
   private _timeChanged(ev, unit) {
-    const showFor = this.state.capabilities && this.state.capabilities.supports && this.state.capabilities.supports.includes("for");
+    const showFor =
+      this.state.capabilities &&
+      this.state.capabilities.supports &&
+      this.state.capabilities.supports.includes("for");
     if (!showFor) {
       return;
     }

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -44,15 +44,15 @@ export default class DeviceTrigger extends Component<any, any> {
     if (device_id === undefined) {
       device_id = trigger.device_id;
     }
-    let extra_fields_data = {}
+    let extraFieldsData = {};
     if (this.state.capabilities && this.state.capabilities.extra_fields) {
-      for (let i in this.state.capabilities.extra_fields) {
-        let item = this.state.capabilities.extra_fields[i]
-        extra_fields_data = {
-          ...extra_fields_data,
-          [item.name]: this.props.trigger[item.name],
-        };
-      }
+      this.state.capabilities.extra_fields.forEach(
+        (item) =>
+          (extraFieldsData = {
+            ...extraFieldsData,
+            [item.name]: this.props.trigger[item.name],
+          })
+      );
     }
 
     return (
@@ -72,23 +72,19 @@ export default class DeviceTrigger extends Component<any, any> {
         />
         {this.state.capabilities && this.state.capabilities.extra_fields && (
           <ha-form
-            data={ extra_fields_data }
-            data-changed={this._extraFieldsChanged}
-            ondata-changed={this._extraFieldsChanged}
+            data={extraFieldsData}
             onData-changed={this._extraFieldsChanged}
-            on-data-changed={this._extraFieldsChanged}
             schema={this.state.capabilities.extra_fields}
-            //.error=${step.errors}
-            //.computeLabel=${this._labelCallback}
-            //.computeError=${this._errorCallback}
-          ></ha-form>
+            // .error=${step.errors}
+            computeLabel={this._extraFieldsComputeLabelCallback(hass.localize)}
+            // .computeError=${this._errorCallback}
+          />
         )}
       </div>
     );
   }
 
   private _extraFieldsChanged(ev) {
-    console.log(ev, ev.detail.value, JSON.stringify(ev.detail));
     if (!ev.detail.path) {
       return;
     }
@@ -99,6 +95,16 @@ export default class DeviceTrigger extends Component<any, any> {
       ...this.props.trigger,
       [item]: value,
     });
+  }
+
+  private _extraFieldsComputeLabelCallback(localize) {
+    // Returns a callback for ha-form to calculate labels per schema object
+    return (schema) =>
+      localize(
+        `ui.panel.config.automation.editor.triggers.type.device.extra_fields.${
+          schema.name
+        }`
+      ) || schema.name;
   }
 }
 

--- a/src/panels/config/js/trigger/device.tsx
+++ b/src/panels/config/js/trigger/device.tsx
@@ -3,15 +3,23 @@ import { h, Component } from "preact";
 import "../../../../components/device/ha-device-picker";
 import "../../../../components/device/ha-device-trigger-picker";
 import "../../../../components/paper-time-input.js";
-// tslint:disable-next-line:no-duplicate-imports
-import { PaperTimeInput } from "../../../../components/paper-time-input.js";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "paper-time-input": any;
+    }
+  }
+}
 
 export default class DeviceTrigger extends Component<any, any> {
   constructor() {
     super();
     this.devicePicked = this.devicePicked.bind(this);
     this.deviceTriggerPicked = this.deviceTriggerPicked.bind(this);
-    this.durationChanged = this.durationChanged.bind(this);
+    this.hourChanged = this.hourChanged.bind(this);
+    this.minuteChanged = this.minuteChanged.bind(this);
+    this.secondChanged = this.secondChanged.bind(this);
     this.state = { device_id: undefined };
   }
 
@@ -29,15 +37,16 @@ export default class DeviceTrigger extends Component<any, any> {
     this.props.onChange(this.props.index, deviceTrigger);
   }
 
-  public durationChanged(ev) {
-    if (!this.props.trigger.hasOwnProperty("for")) {
-      return;
-    }
-    const duration = ev.detail.value;
-    this.props.onChange(
-      this.props.index,
-      { ...this.props.trigger, for: duration }
-    );
+  public hourChanged(ev) {
+    this._timeChanged(ev, "hours");
+  }
+
+  public minuteChanged(ev) {
+    this._timeChanged(ev, "minutes");
+  }
+
+  public secondChanged(ev) {
+    this._timeChanged(ev, "seconds");
   }
 
   /* eslint-disable camelcase */
@@ -47,28 +56,10 @@ export default class DeviceTrigger extends Component<any, any> {
     }
     const showFor = trigger.hasOwnProperty("for");
     const trgFor = trigger.for;
-    let hours = "00";
-    let minutes = "00";
-    let seconds = "00";
-
-    if (trgFor && (trgFor.hours || trgFor.minutes || trgFor.seconds)) {
-      // If the trigger was defined using the yaml dict syntax, extract hours, minutes and seconds
-      ({ hours = "00", minutes = "00", seconds = "00" } = trgFor);
-    }
-    if (typeof trgFor === "string" && trgFor.includes(":")) {
-      // Parse hours, minutes and seconds from ':'-delimited string
-      [hours = "00", minutes = "00", seconds = "00"] = trgFor.split(":");
-    }
-    // Convert to zero-padded string for display
-    hours = parseInt(hours, 10)
-      .toString()
-      .padStart(2, "0");
-    minutes = parseInt(minutes, 10)
-      .toString()
-      .padStart(2, "0");
-    seconds = parseInt(seconds, 10)
-      .toString()
-      .padStart(2, "0");
+    let { hours, minutes, seconds } = this._parseTime(trgFor);
+    hours = this._pad(hours);
+    minutes = this._pad(minutes);
+    seconds = this._pad(seconds);
 
     return (
       <div>
@@ -89,17 +80,62 @@ export default class DeviceTrigger extends Component<any, any> {
           label={hass.localize(
             "ui.panel.config.automation.editor.triggers.type.state.for"
           )}
-          name="for"
           hour={hours}
           min={minutes}
           sec={seconds}
           enable-second
           format={24}
-          onvalue-changed={this.durationChanged}
+          onhour-changed={this.hourChanged}
+          onmin-changed={this.minuteChanged}
+          onsec-changed={this.secondChanged}
           hidden={!showFor}
         />
       </div>
     );
+  }
+
+  private _pad(value) {
+    // Convert to zero-padded string for display
+    return parseInt(value, 10)
+      .toString()
+      .padStart(2, "0");
+  }
+
+  private _parseTime(trgFor) {
+    let hours = "00";
+    let minutes = "00";
+    let seconds = "00";
+    if (trgFor && (trgFor.hours || trgFor.minutes || trgFor.seconds)) {
+      // If the trigger was defined using the yaml dict syntax, extract hours, minutes and seconds
+      ({ hours = "00", minutes = "00", seconds = "00" } = trgFor);
+    }
+    if (typeof trgFor === "string" && trgFor.includes(":")) {
+      // Parse hours, minutes and seconds from ':'-delimited string
+      [hours = "00", minutes = "00", seconds = "00"] = trgFor.split(":");
+    }
+    return { hours, minutes, seconds };
+  }
+
+  private _formatTime({ hours, minutes, seconds }) {
+    hours = this._pad(hours);
+    minutes = this._pad(minutes);
+    seconds = this._pad(seconds);
+    return hours + ":" + minutes + ":" + seconds;
+  }
+
+  private _timeChanged(ev, unit) {
+    if (!this.props.trigger.hasOwnProperty("for")) {
+      return;
+    }
+    const value = ev.detail.value || 0;
+    const duration = {
+      ...this._parseTime(this.props.trigger.for),
+      [unit]: value,
+    };
+    this.props.onChange(this.props.index, {
+      ...this.props.trigger,
+      for: this._formatTime(duration),
+    });
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -737,7 +737,10 @@
               "type_select": "Trigger type",
               "type": {
                 "device": {
-                  "label": "Device"
+                  "label": "Device",
+                  "extra_fields": {
+                    "for": "Duration"
+                  }
                 },
                 "event": {
                   "label": "Event",


### PR DESCRIPTION
Allow device triggers to specify extra fields which will then be shown in the UI using ha-form.
Some extra love is given to support `for` (duration) in device automation triggers

Screenshot:
![image](https://user-images.githubusercontent.com/14281572/65974275-f3d60080-e46c-11e9-952a-dc3d61273766.png)

Intended for backend PRs home-assistant/home-assistant#26658, home-assistant/home-assistant#27133 etc.