### PR TITLE
Add support for automation description

### DIFF
--- a/src/components/ha-textarea.js
+++ b/src/components/ha-textarea.js
@@ -21,7 +21,11 @@ class HaTextarea extends PolymerElement {
           display: block;
         }
       </style>
-      <paper-textarea label="[[label]]" value="{{value}}"></paper-textarea>
+      <paper-textarea
+        label="[[label]]"
+        placeholder="[[placeholder]]"
+        value="{{value}}"
+      ></paper-textarea>
     `;
   }
 
@@ -29,6 +33,7 @@ class HaTextarea extends PolymerElement {
     return {
       name: String,
       label: String,
+      placeholder: String,
       value: {
         type: String,
         notify: true,

--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -13,7 +13,7 @@ export interface AutomationEntity extends HassEntityBase {
 
 export interface AutomationConfig {
   alias: string;
-  annotation: string;
+  description: string;
   trigger: any[];
   condition?: any[];
   action: any[];

--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -13,6 +13,7 @@ export interface AutomationEntity extends HassEntityBase {
 
 export interface AutomationConfig {
   alias: string;
+  annotation: string;
   trigger: any[];
   condition?: any[];
   action: any[];

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -183,7 +183,7 @@ class HaAutomationEditor extends LitElement {
         alias: this.hass.localize(
           "ui.panel.config.automation.editor.default_name"
         ),
-        annotation: "",
+        description: "",
         trigger: [{ platform: "state" }],
         condition: [],
         action: [{ service: "" }],

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -183,6 +183,7 @@ class HaAutomationEditor extends LitElement {
         alias: this.hass.localize(
           "ui.panel.config.automation.editor.default_name"
         ),
+        annotation: "",
         trigger: [{ platform: "state" }],
         condition: [],
         action: [{ service: "" }],

--- a/src/panels/config/js/automation.tsx
+++ b/src/panels/config/js/automation.tsx
@@ -39,7 +39,7 @@ export default class Automation extends Component<any> {
   }
 
   public render({ automation, isWide, hass, localize }) {
-    const { alias, annotation, trigger, condition, action } = automation;
+    const { alias, description, trigger, condition, action } = automation;
 
     return (
       <div>
@@ -57,10 +57,10 @@ export default class Automation extends Component<any> {
                 onvalue-changed={this.onChange}
               />
               <ha-textarea
-                label={localize("ui.panel.config.automation.editor.comment.label")}
-                placeholder={localize("ui.panel.config.automation.editor.comment.placeholder")}
-                name="annotation"
-                value={annotation}
+                label={localize("ui.panel.config.automation.editor.description.label")}
+                placeholder={localize("ui.panel.config.automation.editor.description.placeholder")}
+                name="description"
+                value={description}
                 onvalue-changed={this.onChange}
               />
             </div>

--- a/src/panels/config/js/automation.tsx
+++ b/src/panels/config/js/automation.tsx
@@ -57,8 +57,12 @@ export default class Automation extends Component<any> {
                 onvalue-changed={this.onChange}
               />
               <ha-textarea
-                label={localize("ui.panel.config.automation.editor.description.label")}
-                placeholder={localize("ui.panel.config.automation.editor.description.placeholder")}
+                label={localize(
+                  "ui.panel.config.automation.editor.description.label"
+                )}
+                placeholder={localize(
+                  "ui.panel.config.automation.editor.description.placeholder"
+                )}
                 name="description"
                 value={description}
                 onvalue-changed={this.onChange}

--- a/src/panels/config/js/automation.tsx
+++ b/src/panels/config/js/automation.tsx
@@ -3,6 +3,7 @@ import { h, Component } from "preact";
 import "@polymer/paper-input/paper-input";
 import "../ha-config-section";
 import "../../../components/ha-card";
+import "../../../components/ha-textarea";
 
 import Trigger from "./trigger/index";
 import Condition from "./condition/index";
@@ -38,7 +39,7 @@ export default class Automation extends Component<any> {
   }
 
   public render({ automation, isWide, hass, localize }) {
-    const { alias, trigger, condition, action } = automation;
+    const { alias, annotation, trigger, condition, action } = automation;
 
     return (
       <div>
@@ -53,6 +54,12 @@ export default class Automation extends Component<any> {
                 label={localize("ui.panel.config.automation.editor.alias")}
                 name="alias"
                 value={alias}
+                onvalue-changed={this.onChange}
+              />
+              <ha-textarea
+                label={localize("ui.panel.config.automation.editor.annotation")}
+                name="annotation"
+                value={annotation}
                 onvalue-changed={this.onChange}
               />
             </div>

--- a/src/panels/config/js/automation.tsx
+++ b/src/panels/config/js/automation.tsx
@@ -57,7 +57,8 @@ export default class Automation extends Component<any> {
                 onvalue-changed={this.onChange}
               />
               <ha-textarea
-                label={localize("ui.panel.config.automation.editor.annotation")}
+                label={localize("ui.panel.config.automation.editor.comment.label")}
+                placeholder={localize("ui.panel.config.automation.editor.comment.placeholder")}
                 name="annotation"
                 value={annotation}
                 onvalue-changed={this.onChange}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -699,7 +699,7 @@
             "add_automation": "Add automation"
           },
           "editor": {
-            "introduction": "Use automations to bring your home alive. Automations rules can be complicated, optionally add a description to document what it does and how.",
+            "introduction": "Use automations to bring your home alive.",
             "default_name": "New Automation",
             "load_error_not_editable": "Only automations in automations.yaml are editable.",
             "load_error_unknown": "Error loading automation ({err_no}).",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -699,14 +699,17 @@
             "add_automation": "Add automation"
           },
           "editor": {
-            "introduction": "Use automations to bring your home alive. Automations rules can be complicated, optionally add an annotation to document what it does and how.",
+            "introduction": "Use automations to bring your home alive. Automations rules can be complicated, optionally add a comment to document what it does and how.",
             "default_name": "New Automation",
             "load_error_not_editable": "Only automations in automations.yaml are editable.",
             "load_error_unknown": "Error loading automation ({err_no}).",
             "save": "Save",
             "unsaved_confirm": "You have unsaved changes. Are you sure you want to leave?",
             "alias": "Name",
-            "annotation": "Annotation",
+            "comment": {
+              "label": "Comment",
+              "placeholder": "Optional comment"
+            },
             "triggers": {
               "header": "Triggers",
               "introduction": "Triggers are what starts the processing of an automation rule. It is possible to specify multiple triggers for the same rule. Once a trigger starts, Home Assistant will validate the conditions, if any, and call the action.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -699,13 +699,14 @@
             "add_automation": "Add automation"
           },
           "editor": {
-            "introduction": "Use automations to bring your home alive",
+            "introduction": "Use automations to bring your home alive. Automations rules can be complicated, optionally add an annotation to document what it does and how.",
             "default_name": "New Automation",
             "load_error_not_editable": "Only automations in automations.yaml are editable.",
             "load_error_unknown": "Error loading automation ({err_no}).",
             "save": "Save",
             "unsaved_confirm": "You have unsaved changes. Are you sure you want to leave?",
             "alias": "Name",
+            "annotation": "Annotation",
             "triggers": {
               "header": "Triggers",
               "introduction": "Triggers are what starts the processing of an automation rule. It is possible to specify multiple triggers for the same rule. Once a trigger starts, Home Assistant will validate the conditions, if any, and call the action.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -699,16 +699,16 @@
             "add_automation": "Add automation"
           },
           "editor": {
-            "introduction": "Use automations to bring your home alive. Automations rules can be complicated, optionally add a comment to document what it does and how.",
+            "introduction": "Use automations to bring your home alive. Automations rules can be complicated, optionally add a description to document what it does and how.",
             "default_name": "New Automation",
             "load_error_not_editable": "Only automations in automations.yaml are editable.",
             "load_error_unknown": "Error loading automation ({err_no}).",
             "save": "Save",
             "unsaved_confirm": "You have unsaved changes. Are you sure you want to leave?",
             "alias": "Name",
-            "comment": {
-              "label": "Comment",
-              "placeholder": "Optional comment"
+            "description": {
+              "label": "Description",
+              "placeholder": "Optional description"
             },
             "triggers": {
               "header": "Triggers",


### PR DESCRIPTION
When using the automation editor, any manually added comments are wiped.
Allow adding `description` string to the automation instead, with the same purpose as a comment.

Depends on backend PR: https://github.com/home-assistant/home-assistant/pull/26662

Screenshots:
![image](https://user-images.githubusercontent.com/14281572/65068353-c9724680-d988-11e9-8cea-bb5897a920bf.png)

![image](https://user-images.githubusercontent.com/14281572/65068383-da22bc80-d988-11e9-8d24-ddf9bd36ba6f.png)
