### PR TITLE
Generate rgb theme vars

### DIFF
--- a/src/common/dom/apply_themes_on_element.ts
+++ b/src/common/dom/apply_themes_on_element.ts
@@ -38,18 +38,20 @@ export default function applyThemesOnElement(
   if (themeName !== "default") {
     const theme = themes.themes[themeName];
     Object.keys(theme).forEach((key) => {
-      const prefixedKey = "--" + key;
+      const prefixedKey = `--${key}`;
       element._themes[prefixedKey] = "";
       styles[prefixedKey] = theme[key];
-      if (!key.startsWith("rgb")) {
-        const rgbKey = "--rgb-" + key;
-        if (theme[rgbKey] === undefined) {
-          element._themes[rgbKey] = "";
-          const rgbValue = hexToRgb(theme[key]);
-          if (rgbValue !== null) {
-            styles[rgbKey] = rgbValue;
-          }
-        }
+      if (key.startsWith("rgb")) {
+        return;
+      }
+      const rgbKey = `--rgb-${key}`;
+      if (theme[rgbKey] === undefined) {
+        return;
+      }
+      element._themes[rgbKey] = "";
+      const rgbValue = hexToRgb(theme[key]);
+      if (rgbValue !== null) {
+        styles[rgbKey] = rgbValue;
       }
     });
   }

--- a/src/common/dom/apply_themes_on_element.ts
+++ b/src/common/dom/apply_themes_on_element.ts
@@ -1,3 +1,18 @@
+const hexToRgb = (hex: string): string | null => {
+  const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+  const checkHex = hex.replace(shorthandRegex, (_m, r, g, b) => {
+    return r + r + g + g + b + b;
+  });
+
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(checkHex);
+  return result
+    ? `${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(
+        result[3],
+        16
+      )}`
+    : null;
+};
+
 /**
  * Apply a theme to an element by setting the CSS variables on it.
  *
@@ -24,14 +39,22 @@ export default function applyThemesOnElement(
     const theme = themes.themes[themeName];
     Object.keys(theme).forEach((key) => {
       const prefixedKey = "--" + key;
+      const rgbKey = "--rgb-" + key;
       element._themes[prefixedKey] = "";
       styles[prefixedKey] = theme[key];
+      if (theme[rgbKey] === undefined) {
+        element._themes[rgbKey] = "";
+        const rgbValue = hexToRgb(theme[key]);
+        if (rgbValue !== null) {
+          styles[rgbKey] = rgbValue;
+        }
+      }
     });
   }
   if (element.updateStyles) {
     element.updateStyles(styles);
   } else if (window.ShadyCSS) {
-    // implement updateStyles() method of Polemer elements
+    // implement updateStyles() method of Polymer elements
     window.ShadyCSS.styleSubtree(/** @type {!HTMLElement} */ (element), styles);
   }
 

--- a/src/common/dom/apply_themes_on_element.ts
+++ b/src/common/dom/apply_themes_on_element.ts
@@ -39,14 +39,16 @@ export default function applyThemesOnElement(
     const theme = themes.themes[themeName];
     Object.keys(theme).forEach((key) => {
       const prefixedKey = "--" + key;
-      const rgbKey = "--rgb-" + key;
       element._themes[prefixedKey] = "";
       styles[prefixedKey] = theme[key];
-      if (theme[rgbKey] === undefined) {
-        element._themes[rgbKey] = "";
-        const rgbValue = hexToRgb(theme[key]);
-        if (rgbValue !== null) {
-          styles[rgbKey] = rgbValue;
+      if (!key.startsWith("rgb")) {
+        const rgbKey = "--rgb-" + key;
+        if (theme[rgbKey] === undefined) {
+          element._themes[rgbKey] = "";
+          const rgbValue = hexToRgb(theme[key]);
+          if (rgbValue !== null) {
+            styles[rgbKey] = rgbValue;
+          }
         }
       }
     });

--- a/src/components/ha-data-table.ts
+++ b/src/components/ha-data-table.ts
@@ -427,7 +427,7 @@ export class HaDataTable extends BaseElement {
       }
 
       .mdc-data-table {
-        background-color: var(--card-background-color);
+        background-color: var(--paper-card-background-color);
         border-radius: 4px;
         border-width: 1px;
         border-style: solid;

--- a/src/components/ha-data-table.ts
+++ b/src/components/ha-data-table.ts
@@ -427,7 +427,7 @@ export class HaDataTable extends BaseElement {
       }
 
       .mdc-data-table {
-        background-color: var(--paper-card-background-color);
+        background-color: var(--card-background-color, white);
         border-radius: 4px;
         border-width: 1px;
         border-style: solid;

--- a/src/components/ha-data-table.ts
+++ b/src/components/ha-data-table.ts
@@ -427,7 +427,7 @@ export class HaDataTable extends BaseElement {
       }
 
       .mdc-data-table {
-        background-color: var(--card-background-color, white);
+        background-color: var(--card-background-color);
         border-radius: 4px;
         border-width: 1px;
         border-style: solid;

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -134,7 +134,7 @@ documentContainer.innerHTML = `<custom-style>
       --mdc-theme-primary: var(--primary-color);
       --mdc-theme-secondary: var(--accent-color);
       --mdc-theme-background: var(--primary-background-color);
-      --mdc-theme-surface: var(--paper-card-background-color);
+      --mdc-theme-surface: var(--paper-card-background-color, var(--card-background-color));
 
       /* mwc text styles */
       --mdc-theme-on-primary: var(--primary-text-color);

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -134,7 +134,7 @@ documentContainer.innerHTML = `<custom-style>
       --mdc-theme-primary: var(--primary-color);
       --mdc-theme-secondary: var(--accent-color);
       --mdc-theme-background: var(--primary-background-color);
-      --mdc-theme-surface: var(--card-background-color);
+      --mdc-theme-surface: var(--paper-card-background-color);
 
       /* mwc text styles */
       --mdc-theme-on-primary: var(--primary-text-color);


### PR DESCRIPTION
Instead of asking a user to add 2 types of vars to their themes, we can calculate the rgb values from the hex values. Will only work if the user entered colors as hex and not as `rgba()` or other format...

If the user does define rgb vars we will leave them alone.

Follow up of https://github.com/home-assistant/home-assistant-polymer/pull/3712