### PR TITLE
Fix Cast race condition

### DIFF
--- a/cast/src/receiver/layout/hc-main.ts
+++ b/cast/src/receiver/layout/hc-main.ts
@@ -57,7 +57,13 @@ export class HcMain extends HassElement {
       `;
     }
 
-    if (!this._lovelaceConfig || this._lovelacePath === null) {
+    if (
+      !this._lovelaceConfig ||
+      this._lovelacePath === null ||
+      // Guard against part of HA not being loaded yet.
+      (this.hass &&
+        (!this.hass.states || !this.hass.config || !this.hass.services))
+    ) {
       return html`
         <hc-launch-screen
           .hass=${this.hass}


### PR DESCRIPTION
When the `hass` object is made available by the `HassBaseElement` in `hc-main`, is is not fully initialized yet. This could cause a race condition if we would send a message to show the Lovelace view before it was fully loaded. The UI would break because it tried to interact with `hass` while `hass.states` was `null`.

This would surface when using the Python backend to cast views, as it's faster. 
