### PR TITLE
climate: display humidity if the device does not support temperature

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -12,6 +12,8 @@ const LINE_ATTRIBUTES_TO_KEEP = [
   "target_temp_low",
   "target_temp_high",
   "hvac_action",
+  "humidity",
+  "current_humidity",
 ];
 
 export interface LineChartState {


### PR DESCRIPTION
If a `climate` device only supports humidity control but no temperature, the frontend shows grayed-out slider with disabled controlls and an empty graph on the detailed view. It does allow to control humidity though with the detailed view, but it would be much more informative if we displayed current humidity on the main card when the device does not support temperature.
This pull request adds the described functionality.