### PR TITLE
Make panel-view it's own component

### DIFF
--- a/src/panels/lovelace/hui-panel-view.ts
+++ b/src/panels/lovelace/hui-panel-view.ts
@@ -1,16 +1,9 @@
 import {
-  html,
-  css,
-  CSSResult,
-  LitElement,
   property,
-  query,
   PropertyValues,
-  TemplateResult,
   customElement,
+  UpdatingElement,
 } from "lit-element";
-
-import { classMap } from "lit-html/directives/class-map";
 
 import applyThemesOnElement from "../../common/dom/apply_themes_on_element";
 
@@ -20,21 +13,13 @@ import { createCardElement } from "./common/create-card-element";
 import { LovelaceViewConfig } from "../../data/lovelace";
 
 @customElement("hui-panel-view")
-export class HUIPanelView extends LitElement {
+export class HUIPanelView extends UpdatingElement {
   @property() public hass?: HomeAssistant;
   @property() public config?: LovelaceViewConfig;
-  @property() public tabsHidden = false;
-  @query("#panel") private _panel;
 
-  protected render(): TemplateResult | void {
-    return html`
-      <div
-        id="panel"
-        class="${classMap({
-          "tabs-hidden": this.tabsHidden,
-        })}"
-      ></div>
-    `;
+  protected firstUpdated(changedProperties: PropertyValues): void {
+    super.firstUpdated(changedProperties);
+    this.style.setProperty("background", "var(--lovelace-background)");
   }
 
   protected updated(changedProperties: PropertyValues): void {
@@ -47,7 +32,7 @@ export class HUIPanelView extends LitElement {
     if (changedProperties.has("config")) {
       this._createCard();
     } else if (hassChanged) {
-      this._panel.lastChild.hass = this.hass;
+      (this.lastChild! as LovelaceCard).hass = this.hass;
     }
 
     if (
@@ -61,33 +46,14 @@ export class HUIPanelView extends LitElement {
   }
 
   private _createCard(): void {
-    const panel = this._panel;
-
-    if (panel.lastChild) {
-      panel.removeChild(panel.lastChild);
+    if (this.lastChild) {
+      this.removeChild(this.lastChild);
     }
 
     const card: LovelaceCard = createCardElement(this.config!.cards![0]);
     card.hass = this.hass;
     card.isPanel = true;
-    panel.append(card);
-  }
-
-  static get styles(): CSSResult {
-    return css`
-      #panel {
-        background: var(--lovelace-background);
-        min-height: calc(100vh - 112px);
-        display: flex;
-      }
-      #panel.tabs-hidden {
-        min-height: calc(100vh - 64px);
-      }
-      #panel > * {
-        flex: 1;
-        width: 100%;
-      }
-    `;
+    this.append(card);
   }
 }
 

--- a/src/panels/lovelace/hui-panel-view.ts
+++ b/src/panels/lovelace/hui-panel-view.ts
@@ -1,0 +1,98 @@
+import {
+  html,
+  css,
+  CSSResult,
+  LitElement,
+  property,
+  query,
+  PropertyValues,
+  TemplateResult,
+  customElement,
+} from "lit-element";
+
+import { classMap } from "lit-html/directives/class-map";
+
+import applyThemesOnElement from "../../common/dom/apply_themes_on_element";
+
+import { HomeAssistant } from "../../types";
+import { LovelaceCard } from "./types";
+import { createCardElement } from "./common/create-card-element";
+import { LovelaceViewConfig } from "../../data/lovelace";
+
+@customElement("hui-panel-view")
+export class HUIPanelView extends LitElement {
+  @property() public hass?: HomeAssistant;
+  @property() public config?: LovelaceViewConfig;
+  @property() public tabsHidden = false;
+  @query("#panel") private _panel;
+
+  protected render(): TemplateResult | void {
+    return html`
+      <div
+        id="panel"
+        class="${classMap({
+          "tabs-hidden": this.tabsHidden,
+        })}"
+      ></div>
+    `;
+  }
+
+  protected updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+
+    const hass = this.hass!;
+    const hassChanged = changedProperties.has("hass");
+    const oldHass = changedProperties.get("hass") as this["hass"] | undefined;
+
+    if (changedProperties.has("config")) {
+      this._createCard();
+    } else if (hassChanged) {
+      this._panel.lastChild.hass = this.hass;
+    }
+
+    if (
+      hassChanged &&
+      oldHass &&
+      (hass.themes !== oldHass.themes ||
+        hass.selectedTheme !== oldHass.selectedTheme)
+    ) {
+      applyThemesOnElement(this, hass.themes, this.config!.theme);
+    }
+  }
+
+  private _createCard(): void {
+    const panel = this._panel;
+
+    if (panel.lastChild) {
+      panel.removeChild(panel.lastChild);
+    }
+
+    const card: LovelaceCard = createCardElement(this.config!.cards![0]);
+    card.hass = this.hass;
+    card.isPanel = true;
+    panel.append(card);
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      #panel {
+        background: var(--lovelace-background);
+        min-height: calc(100vh - 112px);
+        display: flex;
+      }
+      #panel.tabs-hidden {
+        min-height: calc(100vh - 64px);
+      }
+      #panel > * {
+        flex: 1;
+        width: 100%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-panel-view": HUIPanelView;
+  }
+}

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -39,12 +39,13 @@ import "./hui-view";
 // Not a duplicate import, this one is for type
 // tslint:disable-next-line
 import { HUIView } from "./hui-view";
-import { createCardElement } from "./common/create-card-element";
+import "./hui-panel-view";
+// tslint:disable-next-line
+import { HUIPanelView } from "./hui-panel-view";
 import { showEditViewDialog } from "./editor/view-editor/show-edit-view-dialog";
 import { showEditLovelaceDialog } from "./editor/lovelace-editor/show-edit-lovelace-dialog";
-import { Lovelace, LovelaceCard } from "./types";
+import { Lovelace } from "./types";
 import { afterNextRender } from "../../common/util/render-status";
-import applyThemesOnElement from "../../common/dom/apply_themes_on_element";
 import { haStyle } from "../../resources/styles";
 import { computeRTLDirection } from "../../common/util/compute_rtl";
 import { loadLovelaceResources } from "./common/load-resources";
@@ -369,18 +370,6 @@ class HUIRoot extends LitElement {
         #view.tabs-hidden {
           min-height: calc(100vh - 64px);
         }
-        #panel {
-          background: var(--lovelace-background);
-          min-height: calc(100vh - 112px);
-          display: flex;
-        }
-        #panel.tabs-hidden {
-          min-height: calc(100vh - 64px);
-        }
-        #panel > * {
-          flex: 1;
-          width: 100%;
-        }
         paper-item {
           cursor: pointer;
         }
@@ -392,9 +381,13 @@ class HUIRoot extends LitElement {
     super.updated(changedProperties);
 
     const view = this._viewRoot;
-    const huiView = view.lastChild as HUIView;
+    const huiView = view.lastChild as HUIView | HUIPanelView;
 
-    if (changedProperties.has("columns") && huiView) {
+    if (
+      changedProperties.has("columns") &&
+      huiView &&
+      huiView instanceof HUIView
+    ) {
       huiView.columns = this.columns;
     }
 
@@ -627,15 +620,9 @@ class HUIRoot extends LitElement {
       view = this._viewCache![viewIndex];
     } else {
       if (viewConfig.panel && viewConfig.cards && viewConfig.cards.length > 0) {
-        view = document.createElement("div");
-        view.id = "panel";
-        if (viewConfig.theme) {
-          applyThemesOnElement(view, this.hass!.themes, viewConfig.theme);
-        }
-        const card = createCardElement(viewConfig.cards[0]);
-        card.hass = this.hass;
-        (card as LovelaceCard).isPanel = true;
-        view.append(card);
+        view = document.createElement("hui-panel-view");
+        view.tabsHidden = this.lovelace!.config.views.length < 2;
+        view.config = viewConfig;
       } else {
         view = document.createElement("hui-view");
         view.lovelace = this.lovelace;

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -621,7 +621,6 @@ class HUIRoot extends LitElement {
     } else {
       if (viewConfig.panel && viewConfig.cards && viewConfig.cards.length > 0) {
         view = document.createElement("hui-panel-view");
-        view.tabsHidden = this.lovelace!.config.views.length < 2;
         view.config = viewConfig;
       } else {
         view = document.createElement("hui-view");


### PR DESCRIPTION
Got a little complicated with panels, bringing it all to its own components keeps the logic clean and allows to add editor capabilities etc. in the future.

Fixes https://github.com/home-assistant/home-assistant-polymer/issues/3744