### PR TITLE
Align behaviour state badge

### DIFF
--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -104,6 +104,7 @@ class StateBadge extends LitElement {
         text-align: center;
         background-size: cover;
         line-height: 40px;
+        vertical-align: middle;
       }
 
       ha-icon {


### PR DESCRIPTION
State badge would behave different depending of it shows a icon or image. This fixes that.