### PR TITLE
Green shade in climate history for platforms that don't support `hvac_action`

### DIFF
--- a/src/components/state-history-chart-line.js
+++ b/src/components/state-history-chart-line.js
@@ -155,14 +155,14 @@ class StateHistoryChartLine extends LocalizeMixin(PolymerElement) {
         domain === "climate" ||
         domain === "water_heater"
       ) {
-        const isHeating =
-          domain === "climate"
-            ? (state) => state.attributes.hvac_action === "heating"
-            : (state) => state.state === "heat";
-        const isCooling =
-          domain === "climate"
-            ? (state) => state.attributes.hvac_action === "cooling"
-            : (state) => state.state === "cool";
+        const isHeating = (state) =>
+          domain === "climate" && state.attributes.hvac_action
+            ? state.attributes.hvac_action === "heating"
+            : state.state === "heat";
+        const isCooling = (state) =>
+          domain === "climate" && state.attributes.hvac_action
+            ? state.attributes.hvac_action === "cooling"
+            : state.state === "cool";
 
         // We differentiate between thermostats that have a target temperature
         // range versus ones that have just a target temperature

--- a/src/components/state-history-chart-line.js
+++ b/src/components/state-history-chart-line.js
@@ -155,15 +155,21 @@ class StateHistoryChartLine extends LocalizeMixin(PolymerElement) {
         domain === "climate" ||
         domain === "water_heater"
       ) {
+        const hasHvacAction = states.states.some(
+          (state) => state.attributes && state.attributes.hvac_action
+        );
+
         const isHeating = (state) =>
-          domain === "climate" && state.attributes.hvac_action
+          domain === "climate" && hasHvacAction
             ? state.attributes.hvac_action === "heating"
             : state.state === "heat";
         const isCooling = (state) =>
-          domain === "climate" && state.attributes.hvac_action
+          domain === "climate" && hasHvacAction
             ? state.attributes.hvac_action === "cooling"
             : state.state === "cool";
 
+        const hasHeat = states.states.some(isHeating);
+        const hasCool = states.states.some(isCooling);
         // We differentiate between thermostats that have a target temperature
         // range versus ones that have just a target temperature
 
@@ -174,8 +180,6 @@ class StateHistoryChartLine extends LocalizeMixin(PolymerElement) {
             state.attributes.target_temp_high !==
               state.attributes.target_temp_low
         );
-        const hasHeat = states.states.some(isHeating);
-        const hasCool = states.states.some(isCooling);
 
         addColumn(name + " current temperature", true);
         if (hasHeat) {

--- a/src/components/state-history-chart-line.js
+++ b/src/components/state-history-chart-line.js
@@ -159,14 +159,14 @@ class StateHistoryChartLine extends LocalizeMixin(PolymerElement) {
           (state) => state.attributes && state.attributes.hvac_action
         );
 
-        const isHeating = (state) =>
+        const isHeating =
           domain === "climate" && hasHvacAction
-            ? state.attributes.hvac_action === "heating"
-            : state.state === "heat";
-        const isCooling = (state) =>
+            ? (state) => state.attributes.hvac_action === "heating"
+            : (state) => state.state === "heat";
+        const isCooling =
           domain === "climate" && hasHvacAction
-            ? state.attributes.hvac_action === "cooling"
-            : state.state === "cool";
+            ? (state) => state.attributes.hvac_action === "cooling"
+            : (state) => state.state === "cool";
 
         const hasHeat = states.states.some(isHeating);
         const hasCool = states.states.some(isCooling);


### PR DESCRIPTION
Following the discussion on green shade for platforms that don't implement `hvac_action` and its conclusion [here](https://github.com/home-assistant/home-assistant-polymer/issues/3468#issuecomment-523963447), this PR implements this.

The green shade is picked up by the values in the `name + " heating"` and `name + " cooling"` columns, but I couldn't find where the shade is actually implemented, so not sure on the best way to implement for `HVAC_MODE_HEAT_COOL` and `HVAC_MODE_AUTO`. However, I think the implementation for `HVAC_MODE_HEAT` and `HVAC_MODE_COOL` should cover most cases.