### PR TITLE
ability to filter badges based on state

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -11,13 +11,21 @@ export interface LovelaceConfig {
 export interface LovelaceViewConfig {
   index?: number;
   title?: string;
-  badges?: string[];
+  badges?: Array<LovelaceBadgeConfig | string>;
   cards?: LovelaceCardConfig[];
   path?: string;
   icon?: string;
   theme?: string;
   panel?: boolean;
   background?: string;
+}
+
+export interface LovelaceBadgeConfig {
+  entity: string;
+  name?: string;
+  icon?: string;
+  image?: string;
+  state_filter?: Array<{ key: string } | string>;
 }
 
 export interface LovelaceCardConfig {

--- a/src/panels/lovelace/editor/view-editor/hui-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-edit-view.ts
@@ -26,11 +26,11 @@ import { HomeAssistant } from "../../../../types";
 import {
   LovelaceViewConfig,
   LovelaceCardConfig,
+  LovelaceBadgeConfig,
 } from "../../../../data/lovelace";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { EntitiesEditorEvent, ViewEditEvent } from "../types";
 import { processEditorEntities } from "../process-editor-entities";
-import { EntityConfig } from "../../entity-rows/types";
 import { navigate } from "../../../../common/navigate";
 import { Lovelace } from "../../types";
 import { deleteView, addView, replaceView } from "../config-util";
@@ -45,7 +45,7 @@ export class HuiEditView extends LitElement {
 
   @property() private _config?: LovelaceViewConfig;
 
-  @property() private _badges?: EntityConfig[];
+  @property() private _badges?: LovelaceBadgeConfig[];
 
   @property() private _cards?: LovelaceCardConfig[];
 
@@ -216,7 +216,9 @@ export class HuiEditView extends LitElement {
 
     const viewConf: LovelaceViewConfig = {
       cards: this._cards,
-      badges: this._badges!.map((entityConf) => entityConf.entity),
+      badges: this._badges!.map((entityConf) =>
+        Object.keys(entityConf).length > 1 ? entityConf : entityConf.entity
+      ),
       ...this._config,
     };
 

--- a/src/panels/lovelace/editor/view-editor/hui-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-edit-view.ts
@@ -216,9 +216,7 @@ export class HuiEditView extends LitElement {
 
     const viewConf: LovelaceViewConfig = {
       cards: this._cards,
-      badges: this._badges!.map((entityConf) =>
-        Object.keys(entityConf).length > 1 ? entityConf : entityConf.entity
-      ),
+      badges: this._badges,
       ...this._config,
     };
 


### PR DESCRIPTION
Closes home-assistant/ui-schema#165

```yaml
    badges:
      - sensor.yr_symbol
      - binary_sensor.movement_backyard
      - person.ian
      - entity: sensor.outside_humidity
        state_filter:
          - operator: '>'
            value: 55
      - binary_sensor.basement_floor_wet
      - input_number.slider2
```

Docs: https://github.com/home-assistant/home-assistant.io/pull/10499