### PR TITLE
Make script editor translatable

### DIFF
--- a/src/panels/config/script/ha-script-editor.js
+++ b/src/panels/config/script/ha-script-editor.js
@@ -259,7 +259,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
     if (
       this.dirty &&
       // eslint-disable-next-line
-      !confirm("[[localize('ui.panel.config.script.editor.unsaved_confirm')]]")
+      !confirm("[[localize('ui.panel.config.common.editor.confirm_unsaved')]]")
     ) {
       return;
     }

--- a/src/panels/config/script/ha-script-editor.js
+++ b/src/panels/config/script/ha-script-editor.js
@@ -236,7 +236,9 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
         },
         () => {
           alert(
-            "[[localize('ui.panel.config.script.editor.load_error_not_editable')]]"
+            this.hass.localize(
+              "ui.panel.config.script.editor.load_error_not_editable"
+            )
           );
           history.back();
         }
@@ -249,7 +251,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
     }
     this.dirty = false;
     this.config = {
-      alias: "[[localize('ui.panel.config.script.editor.default_name')]]",
+      alias: this.hass.localize("ui.panel.config.script.editor.default_name"),
       sequence: [{ service: "", data: {} }],
     };
     this._updateComponent();
@@ -259,7 +261,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
     if (
       this.dirty &&
       // eslint-disable-next-line
-      !confirm("[[localize('ui.panel.config.common.editor.confirm_unsaved')]]")
+      !confirm(this.hass.localize("ui.panel.config.common.editor.confirm_unsaved"))
     ) {
       return;
     }
@@ -287,7 +289,9 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
 
   async _delete() {
     if (
-      !confirm("[[localize('ui.panel.config.script.editor.delete_confirm')]]")
+      !confirm(
+        this.hass.localize("ui.panel.config.script.editor.delete_confirm")
+      )
     ) {
       return;
     }

--- a/src/panels/config/script/ha-script-editor.js
+++ b/src/panels/config/script/ha-script-editor.js
@@ -100,7 +100,10 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
             <ha-paper-icon-button-arrow-prev
               on-click="backTapped"
             ></ha-paper-icon-button-arrow-prev>
-            <div main-title>[[localize('ui.panel.config.script.caption')]] [[computeName(script)]]</div>
+            <div main-title>
+              [[localize('ui.panel.config.script.caption')]]
+              [[computeName(script)]]
+            </div>
             <template is="dom-if" if="[[!creatingNew]]">
               <paper-icon-button
                 icon="hass:delete"
@@ -232,7 +235,9 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
           this._updateComponent();
         },
         () => {
-          alert("[[localize('ui.panel.config.script.editor.load_error_not_editable')]]");
+          alert(
+            "[[localize('ui.panel.config.script.editor.load_error_not_editable')]]"
+          );
           history.back();
         }
       );
@@ -281,7 +286,9 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
   }
 
   async _delete() {
-    if (!confirm("[[localize('ui.panel.config.script.editor.delete_confirm')]]")) {
+    if (
+      !confirm("[[localize('ui.panel.config.script.editor.delete_confirm')]]")
+    ) {
       return;
     }
     await deleteScript(this.hass, computeObjectId(this.script.entity_id));

--- a/src/panels/config/script/ha-script-editor.js
+++ b/src/panels/config/script/ha-script-editor.js
@@ -101,8 +101,8 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
               on-click="backTapped"
             ></ha-paper-icon-button-arrow-prev>
             <div main-title>
-              [[localize('ui.panel.config.script.caption')]]
-              [[computeName(script)]]
+              [[localize('ui.panel.config.script.caption'), 'name',
+              computeName(script)]]
             </div>
             <template is="dom-if" if="[[!creatingNew]]">
               <paper-icon-button

--- a/src/panels/config/script/ha-script-editor.js
+++ b/src/panels/config/script/ha-script-editor.js
@@ -100,7 +100,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
             <ha-paper-icon-button-arrow-prev
               on-click="backTapped"
             ></ha-paper-icon-button-arrow-prev>
-            <div main-title>Script [[computeName(script)]]</div>
+            <div main-title>[[localize('ui.panel.config.script.caption')]] [[computeName(script)]]</div>
             <template is="dom-if" if="[[!creatingNew]]">
               <paper-icon-button
                 icon="hass:delete"
@@ -120,7 +120,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
           is-wide$="[[isWide]]"
           dirty$="[[dirty]]"
           icon="hass:content-save"
-          title="Save"
+          title="[[localize('ui.common.save')]]"
           on-click="saveScript"
           rtl$="[[rtl]]"
         ></ha-fab>
@@ -232,7 +232,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
           this._updateComponent();
         },
         () => {
-          alert("Only scripts inside scripts.yaml are editable.");
+          alert("[[localize('ui.panel.config.script.editor.load_error_not_editable')]]");
           history.back();
         }
       );
@@ -244,7 +244,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
     }
     this.dirty = false;
     this.config = {
-      alias: "New Script",
+      alias: "[[localize('ui.panel.config.script.editor.default_name')]]",
       sequence: [{ service: "", data: {} }],
     };
     this._updateComponent();
@@ -254,7 +254,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
     if (
       this.dirty &&
       // eslint-disable-next-line
-      !confirm("You have unsaved changes. Are you sure you want to leave?")
+      !confirm("[[localize('ui.panel.config.script.editor.unsaved_confirm')]]")
     ) {
       return;
     }
@@ -281,7 +281,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
   }
 
   async _delete() {
-    if (!confirm("Are you sure you want to delete this script?")) {
+    if (!confirm("[[localize('ui.panel.config.script.editor.delete_confirm')]]")) {
       return;
     }
     await deleteScript(this.hass, computeObjectId(this.script.entity_id));

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -38,22 +38,32 @@ class HaScriptPicker extends LitElement {
         .header=${this.hass.localize("ui.panel.config.script.caption")}
       >
         <ha-config-section .isWide=${this.isWide}>
-          <div slot="header">Script Editor</div>
+          <div slot="header">${this.hass.localize("ui.panel.config.script.picker.header")}</div>
           <div slot="introduction">
-            The script editor allows you to create and edit scripts. Please read
-            <a
-              href="https://home-assistant.io/docs/scripts/editor/"
-              target="_blank"
-              >the instructions</a
-            >
-            to make sure that you have configured Home Assistant correctly.
+            ${this.hass.localize(
+              "ui.panel.config.script.picker.introduction"
+            )}
+            <p>
+              <a
+                href="https://home-assistant.io/docs/scripts/editor/"
+                target="_blank"
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.script.picker.learn_more"
+                )}
+              </a>
+            </p>
           </div>
 
-          <ha-card header="Pick script to edit">
+          <ha-card
+            header="${this.hass.localize("ui.panel.config.script.picker.pick_script")}"
+          >
             ${this.scripts.length === 0
               ? html`
                   <div class="card-content">
-                    <p>We couldn't find any scripts.</p>
+                    <p>
+                      ${this.hass.localize("ui.panel.config.script.picker.no_scripts")}
+                    </p>
                   </div>
                 `
               : this.scripts.map(
@@ -85,7 +95,7 @@ class HaScriptPicker extends LitElement {
             slot="fab"
             ?is-wide=${this.isWide}
             icon="hass:plus"
-            title="Add Script"
+            title="${this.hass.localize("ui.panel.config.script.picker.add_script")}"
             ?rtl=${computeRTL(this.hass)}
           ></ha-fab>
         </a>
@@ -97,7 +107,7 @@ class HaScriptPicker extends LitElement {
     const script = ev.currentTarget.script as HassEntity;
     await triggerScript(this.hass, script.entity_id);
     showToast(this, {
-      message: `Triggered ${computeStateName(script)}`,
+      message: `${this.hass.localize("ui.dialogs.notification_toast.triggered")} ${computeStateName(script)}`,
     });
   }
 

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -38,11 +38,11 @@ class HaScriptPicker extends LitElement {
         .header=${this.hass.localize("ui.panel.config.script.caption")}
       >
         <ha-config-section .isWide=${this.isWide}>
-          <div slot="header">${this.hass.localize("ui.panel.config.script.picker.header")}</div>
+          <div slot="header">
+            ${this.hass.localize("ui.panel.config.script.picker.header")}
+          </div>
           <div slot="introduction">
-            ${this.hass.localize(
-              "ui.panel.config.script.picker.introduction"
-            )}
+            ${this.hass.localize("ui.panel.config.script.picker.introduction")}
             <p>
               <a
                 href="https://home-assistant.io/docs/scripts/editor/"
@@ -56,13 +56,17 @@ class HaScriptPicker extends LitElement {
           </div>
 
           <ha-card
-            header="${this.hass.localize("ui.panel.config.script.picker.pick_script")}"
+            header="${this.hass.localize(
+              "ui.panel.config.script.picker.pick_script"
+            )}"
           >
             ${this.scripts.length === 0
               ? html`
                   <div class="card-content">
                     <p>
-                      ${this.hass.localize("ui.panel.config.script.picker.no_scripts")}
+                      ${this.hass.localize(
+                        "ui.panel.config.script.picker.no_scripts"
+                      )}
                     </p>
                   </div>
                 `
@@ -95,7 +99,9 @@ class HaScriptPicker extends LitElement {
             slot="fab"
             ?is-wide=${this.isWide}
             icon="hass:plus"
-            title="${this.hass.localize("ui.panel.config.script.picker.add_script")}"
+            title="${this.hass.localize(
+              "ui.panel.config.script.picker.add_script"
+            )}"
             ?rtl=${computeRTL(this.hass)}
           ></ha-fab>
         </a>
@@ -107,7 +113,9 @@ class HaScriptPicker extends LitElement {
     const script = ev.currentTarget.script as HassEntity;
     await triggerScript(this.hass, script.entity_id);
     showToast(this, {
-      message: `${this.hass.localize("ui.dialogs.notification_toast.triggered")} ${computeStateName(script)}`,
+      message: `${this.hass.localize(
+        "ui.dialogs.notification_toast.triggered"
+      )} ${computeStateName(script)}`,
     });
   }
 

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -114,8 +114,10 @@ class HaScriptPicker extends LitElement {
     await triggerScript(this.hass, script.entity_id);
     showToast(this, {
       message: `${this.hass.localize(
-        "ui.dialogs.notification_toast.triggered"
-      )} ${computeStateName(script)}`,
+        "ui.dialogs.notification_toast.triggered",
+        "name",
+        computeStateName(script)
+      )}`,
     });
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -598,7 +598,7 @@
     "notification_toast": {
       "service_call_failed": "Failed to call service {service}.",
       "connection_lost": "Connection lost. Reconnecting…",
-      "triggered": "Triggered"
+      "triggered": "Triggered {name}"
     },
     "sidebar": {
       "external_app_configuration": "App Configuration"
@@ -896,7 +896,7 @@
           }
         },
         "script": {
-          "caption": "Script",
+          "caption": "Script {name}",
           "description": "Create and edit scripts",
           "picker": {
             "header": "Script Editor",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -607,6 +607,11 @@
       "config": {
         "header": "Configure Home Assistant",
         "introduction": "Here it is possible to configure your components and Home Assistant. Not everything is possible to configure from the UI yet, but we're working on it.",
+        "common": {
+          "editor": {
+            "confirm_unsaved": "You have unsaved changes. Are you sure you want to leave?"
+          }
+        },
         "area_registry": {
           "caption": "Area Registry",
           "description": "Overview of all areas in your home.",
@@ -904,7 +909,6 @@
           "editor": {
             "default_name": "New Script",
             "load_error_not_editable": "Only scripts inside scripts.yaml are editable.",
-            "unsaved_confirm": "You have unsaved changes. Are you sure you want to leave?",
             "delete_confirm": "Are you sure you want to delete this script?"
           }
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -597,7 +597,8 @@
     },
     "notification_toast": {
       "service_call_failed": "Failed to call service {service}.",
-      "connection_lost": "Connection lost. Reconnecting…"
+      "connection_lost": "Connection lost. Reconnecting…",
+      "triggered": "Triggered"
     },
     "sidebar": {
       "external_app_configuration": "App Configuration"
@@ -891,7 +892,15 @@
         },
         "script": {
           "caption": "Script",
-          "description": "Create and edit scripts"
+          "description": "Create and edit scripts",
+          "picker": {
+            "header": "Script Editor",
+            "introduction": "The script editor allows you to create and edit scripts. Please follow the link below to read the instructions to make sure that you have configured Home Assistant correctly.",
+            "learn_more": "Learn more about scripts",
+            "pick_script": "Pick script to edit",
+            "no_scripts": "We couldn’t find any editable scripts",
+            "add_script": "Add script"
+          }
         },
         "cloud": {
           "caption": "Home Assistant Cloud",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -900,6 +900,12 @@
             "pick_script": "Pick script to edit",
             "no_scripts": "We couldn’t find any editable scripts",
             "add_script": "Add script"
+          },
+          "editor": {
+            "default_name": "New Script",
+            "load_error_not_editable": "Only scripts inside scripts.yaml are editable.",
+            "unsaved_confirm": "You have unsaved changes. Are you sure you want to leave?",
+            "delete_confirm": "Are you sure you want to delete this script?"
           }
         },
         "cloud": {


### PR DESCRIPTION
Introduces translatable keys for script editor analogous to automation editor's translation.

Resolves #3848.