### PR TITLE
Fix issue where help icon overlapped with header text on mobile devices

### DIFF
--- a/src/panels/config/zwave/ha-config-zwave.js
+++ b/src/panels/config/zwave/ha-config-zwave.js
@@ -44,6 +44,11 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
           margin-top: 24px;
         }
 
+        .sectionHeader {
+          position: relative;
+          padding-right: 40px;
+        }
+
         .node-info {
           margin-left: 16px;
         }
@@ -77,7 +82,7 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
         .toggle-help-icon {
           position: absolute;
-          top: 6px;
+          top: -6px;
           right: 0;
           color: var(--primary-color);
         }
@@ -102,7 +107,7 @@ class HaConfigZwave extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
         <!-- Node card -->
         <ha-config-section is-wide="[[isWide]]">
-          <div style="position: relative" slot="header">
+          <div class="sectionHeader" slot="header">
             <span>Z-Wave Node Management</span>
             <paper-icon-button
               class="toggle-help-icon"

--- a/src/panels/config/zwave/zwave-network.ts
+++ b/src/panels/config/zwave/zwave-network.ts
@@ -51,7 +51,7 @@ export class ZwaveNetwork extends LitElement {
   protected render(): TemplateResult | void {
     return html`
       <ha-config-section .isWide="${this.isWide}">
-        <div style="position: relative" slot="header">
+        <div class="sectionHeader" slot="header">
           <span>
             ${this.hass!.localize(
               "ui.panel.config.zwave.network_management.header"
@@ -232,6 +232,11 @@ export class ZwaveNetwork extends LitElement {
       css`
         .content {
           margin-top: 24px;
+        }
+
+        .sectionHeader {
+          position: relative;
+          padding-right: 40px;
         }
 
         .network-status {


### PR DESCRIPTION
This fixes #3834

The headers are position relative and the help icons are position absolute to the top right.  

This PR:
* Adds a `sectionHeader` class to the headers on the zwave config panel (this seems consistent with other section headers that have class names)
* Moves inline style to `.sectionHeader`
* adds right padding to the sectionHeader so that the text will wrap before it runs into the icon (padding is same width as the help icon).  This should work regardless of what the translation string is.
* Adjusts the absolute positioning of the Zwave Node Management header's help icon to match the main header's positioning (it was sagging a bit).  I'm guessing the text for this header should be moved to the the translation file 

on iPhone X:
Before
![image](https://user-images.githubusercontent.com/5158502/66103997-29154800-e56c-11e9-8007-13ca1ac12c36.png)

After
![image](https://user-images.githubusercontent.com/5158502/66103938-097e1f80-e56c-11e9-93fd-a731d26bb1af.png)

Desktop after:
![image](https://user-images.githubusercontent.com/5158502/66104216-b6f13300-e56c-11e9-8c96-8d6e7cbaecb0.png)

It was a struggle getting home assistant local dev setup and pointed to the front end.  I wasn't able to fully get it pointed at my remote hass.io setup so sorry the screenshots are missing some of the node UI but that shouldn't affect the fixes (I did test the styles in-browser on my hass.io setup and it looks the same with addition of the extra cards.