### PR TITLE
Normalize longitude to the range between -180 to +180 degrees

### DIFF
--- a/src/components/map/ha-location-editor.ts
+++ b/src/components/map/ha-location-editor.ts
@@ -77,8 +77,11 @@ class LocationEditor extends LitElement {
   }
 
   private _updateLocation(latlng: LatLng) {
-    // Normalize longitude if map provides values beyond -180 to +180 degrees.
-    const longitude = (((latlng.lng % 360.0) + 540.0) % 360.0) - 180.0;
+    let longitude = latlng.lng;
+    if (Math.abs(longitude) > 180.0) {
+      // Normalize longitude if map provides values beyond -180 to +180 degrees.
+      longitude = (((longitude % 360.0) + 540.0) % 360.0) - 180.0;
+    }
     this.location = this._ignoreFitToMap = [latlng.lat, longitude];
     fireEvent(this, "change", undefined, { bubbles: false });
   }

--- a/src/components/map/ha-location-editor.ts
+++ b/src/components/map/ha-location-editor.ts
@@ -77,7 +77,9 @@ class LocationEditor extends LitElement {
   }
 
   private _updateLocation(latlng: LatLng) {
-    this.location = this._ignoreFitToMap = [latlng.lat, latlng.lng];
+    // Normalize longitude if map provides values beyond -180 to +180 degrees.
+    const longitude = (((latlng.lng % 360.0) + 540.0) % 360.0) - 180.0;
+    this.location = this._ignoreFitToMap = [latlng.lat, longitude];
     fireEvent(this, "change", undefined, { bubbles: false });
   }
 


### PR DESCRIPTION
Fixes https://github.com/home-assistant/home-assistant-polymer/issues/3793
Fixes https://github.com/home-assistant/home-assistant/issues/26057

When fully zooming out of the map in the general configuration section, you will see multiple "versions" of the world's surface. When selecting a position outside the central version of the map, the longitude value will be smaller than -180º or greater than +180º which is wrong and won't be accepted by the HA backend's validator.

This change normalizes the longitude value received by the map.

The long form of the normalization would be to keep adding 360 to the value while it is smaller than -180º, or subtract 360 from the value while it is greater than +180º. The proposed code yields the same result in a single line.