### PR TITLE
Add intro to OZW log z-wave config section

### DIFF
--- a/src/panels/config/zwave/zwave-log.js
+++ b/src/panels/config/zwave/zwave-log.js
@@ -3,6 +3,7 @@ import "@polymer/paper-checkbox/paper-checkbox";
 import "@polymer/paper-input/paper-input";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
+import LocalizeMixin from "../../../mixins/localize-mixin";
 import { EventsMixin } from "../../../mixins/events-mixin";
 import isPwa from "../../../common/config/is_pwa";
 
@@ -11,7 +12,7 @@ import "../../../components/ha-card";
 
 let registeredDialog = false;
 
-class OzwLog extends EventsMixin(PolymerElement) {
+class OzwLog extends LocalizeMixin(EventsMixin(PolymerElement)) {
   static get template() {
     return html`
     <style include="iron-flex ha-style">
@@ -32,8 +33,13 @@ class OzwLog extends EventsMixin(PolymerElement) {
 
     </style>
     <ha-config-section is-wide="[[isWide]]">
-      <span slot="header">OZW Log</span>
-      <ha-card>
+      <span slot="header">
+        [[localize('ui.panel.config.zwave.ozw_log.header')]]
+      </span>
+      <span slot="introduction">
+        [[localize('ui.panel.config.zwave.ozw_log.introduction')]]
+      </span>
+      <ha-card class="content">
         <div class="device-picker">
           <paper-input label="Number of last log lines." type="number" min="0" max="1000" step="10" value="{{numLogLines}}">
           </paper-input>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1260,6 +1260,10 @@
             "header": "Z-Wave Network Management",
             "introduction": "Run commands that affect the Z-Wave network. You won't get feedback on whether most commands succeeded, but you can check the OZW Log to try to find out."
           },
+          "ozw_log": {
+            "header": "OZW Log",
+            "introduction": "View the log. 0 is the minimum (loads entire log) and 1000 is the maximum. Load will show a static log and tail will auto update with the last specified number of lines of the log."
+          },
           "network_status": {
             "network_stopped": "Z-Wave Network Stopped",
             "network_starting": "Starting Z-Wave Network...",


### PR DESCRIPTION
Resolves #3882


* Added some intro text to the OZW log section (paraphrased the docs to try to keep it a bit more concise)
* Added content class to keep spacing consistent with other sections on this page (text was touching the panel)
* Moved the header and added intro to en.json file and brought in localize.

![image](https://user-images.githubusercontent.com/5158502/66249814-0612a180-e6ee-11e9-970c-97d54ab3e487.png)
