### PR TITLE
Exclude persistent_notifications domain when computing unused entities

### DIFF
--- a/src/panels/lovelace/common/compute-unused-entities.ts
+++ b/src/panels/lovelace/common/compute-unused-entities.ts
@@ -1,7 +1,7 @@
 import { LovelaceConfig, ActionConfig } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
 
-const EXCLUDED_DOMAINS = ["zone"];
+const EXCLUDED_DOMAINS = ["zone", "persistent_notification"];
 
 const addFromAction = (entities: Set<string>, actionConfig: ActionConfig) => {
   if (


### PR DESCRIPTION
This resolves #3878

Added the persistent_notification domain to `EXCLUDED_DOMAINS`  in compute unused entities so that they no longer show up in the unused entities table.