### PR TITLE
Add localized names to card editor

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -11,8 +11,36 @@ import "@material/mwc-button";
 import { HomeAssistant } from "../../../../types";
 import { LovelaceCardConfig } from "../../../../data/lovelace";
 import { getCardElementTag } from "../../common/get-card-element-tag";
-import { CardPickTarget, CardOption } from "../types";
+import { CardPickTarget } from "../types";
 import { fireEvent } from "../../../../common/dom/fire_event";
+
+const cards: string[] = [
+  "alarm-panel",
+  "conditional",
+  "entities",
+  "entity-button",
+  "entity-filter",
+  "gauge",
+  "glance",
+  "history-graph",
+  "horizontal-stack",
+  "iframe",
+  "light",
+  "map",
+  "markdown",
+  "media-control",
+  "picture",
+  "picture-elements",
+  "picture-entity",
+  "picture-glance",
+  "plant-status",
+  "sensor",
+  "shopping-list",
+  "thermostat",
+  "vertical-stack",
+  "weather-forecast",
+];
+
 @customElement("hui-card-picker")
 export class HuiCardPicker extends LitElement {
   public hass?: HomeAssistant;
@@ -20,148 +48,17 @@ export class HuiCardPicker extends LitElement {
   public cardPicked?: (cardConf: LovelaceCardConfig) => void;
 
   protected render(): TemplateResult | void {
-    const cards: CardOption[] = [
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.alarm-panel.name"
-        ),
-        type: "alarm-panel",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.conditional.name"
-        ),
-        type: "conditional",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.entities.name"
-        ),
-        type: "entities",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.entity-button.name"
-        ),
-        type: "entity-button",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.entity-filter.name"
-        ),
-        type: "entity-filter",
-      },
-      {
-        name: this.hass!.localize("ui.panel.lovelace.editor.card.gauge.name"),
-        type: "gauge",
-      },
-      {
-        name: this.hass!.localize("ui.panel.lovelace.editor.card.glance.name"),
-        type: "glance",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.history-graph.name"
-        ),
-        type: "history-graph",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.horizontal-stack.name"
-        ),
-        type: "horizontal-stack",
-      },
-      {
-        name: this.hass!.localize("ui.panel.lovelace.editor.card.iframe.name"),
-        type: "iframe",
-      },
-      {
-        name: this.hass!.localize("ui.panel.lovelace.editor.card.light.name"),
-        type: "light",
-      },
-      {
-        name: this.hass!.localize("ui.panel.lovelace.editor.card.map.name"),
-        type: "map",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.markdown.name"
-        ),
-        type: "markdown",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.media-control.name"
-        ),
-        type: "media-control",
-      },
-      {
-        name: this.hass!.localize("ui.panel.lovelace.editor.card.picture.name"),
-        type: "picture",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.picture-elements.name"
-        ),
-        type: "picture-elements",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.picture-entity.name"
-        ),
-        type: "picture-entity",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.picture-glance.name"
-        ),
-        type: "picture-glance",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.plant-status.name"
-        ),
-        type: "plant-status",
-      },
-      {
-        name: this.hass!.localize("ui.panel.lovelace.editor.card.sensor.name"),
-        type: "sensor",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.shopping-list.name"
-        ),
-        type: "shopping-list",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.thermostat.name"
-        ),
-        type: "thermostat",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.vertical-stack.name"
-        ),
-        type: "vertical-stack",
-      },
-      {
-        name: this.hass!.localize(
-          "ui.panel.lovelace.editor.card.weather-forecast.name"
-        ),
-        type: "weather-forecast",
-      },
-    ];
-
     return html`
       <h3>
         ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card")}
       </h3>
       <div class="cards-container">
-        ${cards.map((card: CardOption) => {
+        ${cards.map((card: string) => {
           return html`
-            <mwc-button @click="${this._cardPicked}" .type="${card.type}">
-              ${card.name}
+            <mwc-button @click="${this._cardPicked}" .type="${card}">
+              ${this.hass!.localize(
+                `ui.panel.lovelace.editor.card.${card}.name`
+              )}
             </mwc-button>
           `;
         })}

--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -11,36 +11,8 @@ import "@material/mwc-button";
 import { HomeAssistant } from "../../../../types";
 import { LovelaceCardConfig } from "../../../../data/lovelace";
 import { getCardElementTag } from "../../common/get-card-element-tag";
-import { CardPickTarget } from "../types";
+import { CardPickTarget, CardOption } from "../types";
 import { fireEvent } from "../../../../common/dom/fire_event";
-
-const cards = [
-  { name: "Alarm panel", type: "alarm-panel" },
-  { name: "Conditional", type: "conditional" },
-  { name: "Entities", type: "entities" },
-  { name: "Entity Button", type: "entity-button" },
-  { name: "Entity Filter", type: "entity-filter" },
-  { name: "Gauge", type: "gauge" },
-  { name: "Glance", type: "glance" },
-  { name: "History Graph", type: "history-graph" },
-  { name: "Horizontal Stack", type: "horizontal-stack" },
-  { name: "iFrame", type: "iframe" },
-  { name: "Light", type: "light" },
-  { name: "Map", type: "map" },
-  { name: "Markdown", type: "markdown" },
-  { name: "Media Control", type: "media-control" },
-  { name: "Picture", type: "picture" },
-  { name: "Picture Elements", type: "picture-elements" },
-  { name: "Picture Entity", type: "picture-entity" },
-  { name: "Picture Glance", type: "picture-glance" },
-  { name: "Plant Status", type: "plant-status" },
-  { name: "Sensor", type: "sensor" },
-  { name: "Shopping List", type: "shopping-list" },
-  { name: "Thermostat", type: "thermostat" },
-  { name: "Vertical Stack", type: "vertical-stack" },
-  { name: "Weather Forecast", type: "weather-forecast" },
-];
-
 @customElement("hui-card-picker")
 export class HuiCardPicker extends LitElement {
   public hass?: HomeAssistant;
@@ -48,12 +20,145 @@ export class HuiCardPicker extends LitElement {
   public cardPicked?: (cardConf: LovelaceCardConfig) => void;
 
   protected render(): TemplateResult | void {
+    const cards: CardOption[] = [
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.alarm-panel.name"
+        ),
+        type: "alarm-panel",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.conditional.name"
+        ),
+        type: "conditional",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.entities.name"
+        ),
+        type: "entities",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.entity-button.name"
+        ),
+        type: "entity-button",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.entity-filter.name"
+        ),
+        type: "entity-filter",
+      },
+      {
+        name: this.hass!.localize("ui.panel.lovelace.editor.card.gauge.name"),
+        type: "gauge",
+      },
+      {
+        name: this.hass!.localize("ui.panel.lovelace.editor.card.glance.name"),
+        type: "glance",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.history-graph.name"
+        ),
+        type: "history-graph",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.horizontal-stack.name"
+        ),
+        type: "horizontal-stack",
+      },
+      {
+        name: this.hass!.localize("ui.panel.lovelace.editor.card.iframe.name"),
+        type: "iframe",
+      },
+      {
+        name: this.hass!.localize("ui.panel.lovelace.editor.card.light.name"),
+        type: "light",
+      },
+      {
+        name: this.hass!.localize("ui.panel.lovelace.editor.card.map.name"),
+        type: "map",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.markdown.name"
+        ),
+        type: "markdown",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.media-control.name"
+        ),
+        type: "media-control",
+      },
+      {
+        name: this.hass!.localize("ui.panel.lovelace.editor.card.picture.name"),
+        type: "picture",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.picture-elements.name"
+        ),
+        type: "picture-elements",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.picture-entity.name"
+        ),
+        type: "picture-entity",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.picture-glance.name"
+        ),
+        type: "picture-glance",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.plant-status.name"
+        ),
+        type: "plant-status",
+      },
+      {
+        name: this.hass!.localize("ui.panel.lovelace.editor.card.sensor.name"),
+        type: "sensor",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.shopping-list.name"
+        ),
+        type: "shopping-list",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.thermostat.name"
+        ),
+        type: "thermostat",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.vertical-stack.name"
+        ),
+        type: "vertical-stack",
+      },
+      {
+        name: this.hass!.localize(
+          "ui.panel.lovelace.editor.card.weather-forecast.name"
+        ),
+        type: "weather-forecast",
+      },
+    ];
+
     return html`
       <h3>
         ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card")}
       </h3>
       <div class="cards-container">
-        ${cards.map((card) => {
+        ${cards.map((card: CardOption) => {
           return html`
             <mwc-button @click="${this._cardPicked}" .type="${card.type}">
               ${card.name}

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -62,13 +62,15 @@ export class HuiDialogEditCard extends LitElement {
       return html``;
     }
 
-    let heading: string = this.hass!.localize(
-      "ui.panel.lovelace.editor.edit_card.header"
-    );
+    let heading: string;
     if (this._cardConfig && this._cardConfig.type) {
       heading = `${this.hass!.localize(
         `ui.panel.lovelace.editor.card.${this._cardConfig.type}.name`
-      )} ${heading}`;
+      )} ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.header")}`;
+    } else {
+      heading = this.hass!.localize(
+        "ui.panel.lovelace.editor.edit_card.header"
+      );
     }
 
     return html`

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -62,10 +62,19 @@ export class HuiDialogEditCard extends LitElement {
       return html``;
     }
 
+    let heading: string = this.hass!.localize(
+      "ui.panel.lovelace.editor.edit_card.header"
+    );
+    if (this._cardConfig && this._cardConfig.type) {
+      heading = `${this.hass!.localize(
+        `ui.panel.lovelace.editor.card.${this._cardConfig.type}.name`
+      )} ${heading}`;
+    }
+
     return html`
       <ha-paper-dialog with-backdrop opened modal>
         <h2>
-          ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.header")}
+          ${heading}
         </h2>
         <paper-dialog-scrollable>
           ${this._cardConfig === undefined

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -101,7 +101,7 @@ export class HuiAlarmPanelCardEditor extends LitElement
         })}
         <paper-dropdown-menu
           .label="${this.hass.localize(
-            "ui.panel.lovelace.editor.card.alarm_panel.available_states"
+            "ui.panel.lovelace.editor.card.alarm-panel.available_states"
           )}"
           @value-changed="${this._stateAdded}"
         >

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -49,6 +49,11 @@ export interface CardPickTarget extends EventTarget {
   type: string;
 }
 
+export interface CardOption {
+  type: string;
+  name: string;
+}
+
 export const actionConfigStruct = struct({
   action: "string",
   navigation_path: "string?",

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -49,11 +49,6 @@ export interface CardPickTarget extends EventTarget {
   type: string;
 }
 
-export interface CardOption {
-  type: string;
-  name: string;
-}
-
 export const actionConfigStruct = struct({
   action: "string",
   navigation_path: "string?",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1376,9 +1376,7 @@
           },
           "card": {
             "alarm-panel": {
-              "name": "Alarm panel"
-            },
-            "alarm_panel": {
+              "name": "Alarm panel",
               "available_states": "Available States"
             },
             "conditional": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1375,17 +1375,31 @@
             "migrate": "Migrate config"
           },
           "card": {
+            "alarm-panel": {
+              "name": "Alarm panel"
+            },
             "alarm_panel": {
               "available_states": "Available States"
+            },
+            "conditional": {
+              "name": "Conditional"
             },
             "config": {
               "required": "Required",
               "optional": "Optional"
             },
             "entities": {
+              "name": "Entities",
               "show_header_toggle": "Show Header Toggle?"
             },
+            "entity-button": {
+              "name": "Entity Button"
+            },
+            "entity-filter": {
+              "name": "Entity Filter"
+            },
             "gauge": {
+              "name": "Gauge",
               "severity": {
                 "define": "Define Severity?",
                 "green": "Green",
@@ -1394,7 +1408,20 @@
               }
             },
             "glance": {
+              "name": "Glance",
               "columns": "Columns"
+            },
+            "history-graph": {
+              "name": "History Graph"
+            },
+            "horizontal-stack": {
+              "name": "Horizontal Stack"
+            },
+            "iframe": {
+              "name": "iFrame"
+            },
+            "light": {
+              "name": "Light"
             },
             "generic": {
               "aspect_ratio": "Aspect Ratio",
@@ -1421,17 +1448,50 @@
               "url": "Url"
             },
             "map": {
+              "name": "Map",
               "geo_location_sources": "Geolocation Sources",
               "dark_mode": "Dark Mode?",
               "default_zoom": "Default Zoom",
               "source": "Source"
             },
             "markdown": {
+              "name": "Markdown",
               "content": "Content"
             },
+            "media-control": {
+              "name": "Media Control"
+            },
+            "picture": {
+              "name": "Picture"
+            },
+            "picture-elements": {
+              "name": "Picture Elements"
+            },
+            "picture-entity": {
+              "name": "Picture Entity"
+            },
+            "picture-glance": {
+              "name": "Picture Glance"
+            },
+            "plant-status": {
+              "name": "Plant Status"
+            },
             "sensor": {
+              "name": "Sensor",
               "graph_detail": "Graph Detail",
               "graph_type": "Graph Type"
+            },
+            "shopping-list": {
+              "name": "Shopping List"
+            },
+            "thermostat": {
+              "name": "Thermostat"
+            },
+            "vertical-stack": {
+              "name": "Vertical Stack"
+            },
+            "weather-forecast": {
+              "name": "Weather Forecast"
             }
           }
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1376,7 +1376,7 @@
           },
           "card": {
             "alarm-panel": {
-              "name": "Alarm panel",
+              "name": "Alarm Panel",
               "available_states": "Available States"
             },
             "conditional": {


### PR DESCRIPTION
### Description

This adds localized names to the card configuration, helping the user to see what card type they are editing.

I have also replaced the hardcoded names in the card picker to localized names. 

### Related Issue

Closes #3658

### Screenshots

![image](https://user-images.githubusercontent.com/28114703/66260149-96b2b580-e7b2-11e9-8fe5-a35cd2965031.png)

![image](https://user-images.githubusercontent.com/28114703/66260153-a205e100-e7b2-11e9-8f18-c292045b4a2d.png)

![image](https://user-images.githubusercontent.com/28114703/66260155-a7fbc200-e7b2-11e9-88b6-fcb3e8889286.png)

---

This populates the heading as soon as it is typed/recognized in the json editor also:

![image](https://user-images.githubusercontent.com/28114703/66260158-afbb6680-e7b2-11e9-87dd-bddfe2ad6191.png)

![image](https://user-images.githubusercontent.com/28114703/66260160-b813a180-e7b2-11e9-9ae4-d936e4ce3900.png)

