### PR TITLE
Adds confirmation dialog to reset add-on configuration

### DIFF
--- a/hassio/src/addon-view/hassio-addon-config.js
+++ b/hassio/src/addon-view/hassio-addon-config.js
@@ -48,6 +48,7 @@ class HassioAddonConfig extends PolymerElement {
             hass="[[hass]]"
             path="hassio/addons/[[addonSlug]]/options"
             data="[[resetData]]"
+            confirmation="Are you sure you want to reset the configuration?"
             >Reset to defaults</ha-call-api-button
           >
           <mwc-button on-click="saveTapped" disabled="[[!configParsed]]"

--- a/src/components/buttons/ha-call-api-button.js
+++ b/src/components/buttons/ha-call-api-button.js
@@ -31,6 +31,7 @@ class HaCallApiButton extends LitElement {
       method: String,
       data: {},
       disabled: Boolean,
+      confirmation: String,
     };
   }
 
@@ -39,6 +40,9 @@ class HaCallApiButton extends LitElement {
   }
 
   async _buttonTapped() {
+    if (this.confirmation && !window.confirm(this.confirmation)) {
+      return;
+    }
     this.progress = true;
     const eventData = {
       method: this.method,


### PR DESCRIPTION
## This adds:

- A confirmation property to the `ha-call-api-button` (same as `ha-call-service-button`)
- A confirmation dialog when resetting add-on configuration to the default as requested in #3854

Closes #3854


_Marked as a draft until I get my env up running so I can actually test it._