### PR TITLE
Add default text to Markdown card editor

### DIFF
--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -26,7 +26,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
   }
 
   public static getStubConfig(): object {
-    return { content: " " };
+    return { content: "The **Markdown** card allows you to write any text. You can style it **bold**, *italicized*, ~strikethrough~ etc. You can do images, links, and more.\n\nFor more information see the [Markdown Cheatsheet](https://commonmark.org/help)." };
   }
 
   @property() private _config?: MarkdownCardConfig;


### PR DESCRIPTION
Fixes Issue #3943 