### PR TITLE
Renamed Toggle Editor button #3617

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -145,9 +145,12 @@ export class HuiCardEditor extends LitElement {
           <mwc-button
             @click=${this.toggleMode}
             ?disabled=${this._warning || this._error}
-            ?unelevated=${this._GUImode === false}
           >
-            <ha-icon icon="mdi:code-braces"></ha-icon>
+            ${this.hass!.localize(
+              this._GUImode
+                ? "ui.panel.lovelace.editor.edit_card.show_code_editor"
+                : "ui.panel.lovelace.editor.edit_card.show_visual_editor"
+            )}
           </mwc-button>
         </div>
       </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1363,6 +1363,8 @@
             "header": "Card Configuration",
             "pick_card": "Pick the card you want to add.",
             "toggle_editor": "Toggle Editor",
+            "show_visual_editor": "Show Visual Editor",
+            "show_code_editor": "Show Code Editor",
             "add": "Add Card",
             "edit": "Edit",
             "delete": "Delete",


### PR DESCRIPTION
This fixes #3617 by changing the {} button to show "Show Visual Editor / Show Code Editor"

![image](https://user-images.githubusercontent.com/19542826/66447095-265a9d00-ea1b-11e9-8c99-9bf1e3430baf.png)

![image](https://user-images.githubusercontent.com/19542826/66447116-34a8b900-ea1b-11e9-8b4e-3023aa44c74e.png)

