### PR TITLE
Remove overflow attribute from view column

### DIFF
--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -138,7 +138,6 @@ export class HUIView extends LitElement {
           flex-basis: 0;
           flex-grow: 1;
           max-width: 500px;
-          overflow-x: hidden;
         }
 
         .column > * {


### PR DESCRIPTION
Fixes #3253

I´m not exactly sure, why the `overflow-x` attribute was on the `.column` in the first place. I´ve tested the card with different contents but could not find any issue by removing this style.