### PR TITLE
Add width property to light card to fix #3964

### DIFF
--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -212,7 +212,6 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
 
         .name {
           position: absolute;
-          top: 160px;
           font-size: var(--name-font-size);
           bottom: 16px;
           box-sizing: border-box;

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -216,6 +216,7 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
           left: 50%;
           transform: translate(-50%);
           font-size: var(--name-font-size);
+          width: 90%;
         }
 
         .brightness {

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -213,10 +213,12 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
         .name {
           position: absolute;
           top: 160px;
-          left: 50%;
-          transform: translate(-50%);
           font-size: var(--name-font-size);
-          width: 90%;
+          bottom: 16px;
+          box-sizing: border-box;
+          text-align: center;
+          width: 100%;
+          padding: 0 16px;
         }
 
         .brightness {


### PR DESCRIPTION
Add a width property to the CSS for a light card's name/title box.  Without a width set, it is wrapping the text on long names too soon with plenty of room to spare in the card.

This is to fix issue #3964.