### PR TITLE
Upgrade MDI icons to 4.5.95

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@material/mwc-fab": "^0.8.0",
     "@material/mwc-ripple": "^0.8.0",
     "@material/mwc-switch": "^0.8.0",
-    "@mdi/svg": "4.4.95",
+    "@mdi/svg": "4.5.95",
     "@polymer/app-layout": "^3.0.2",
     "@polymer/app-localize-behavior": "^3.0.1",
     "@polymer/app-route": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,10 +978,10 @@
   dependencies:
     "@material/feature-targeting" "^3.1.0"
 
-"@mdi/svg@4.4.95":
-  version "4.4.95"
-  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-4.4.95.tgz#0af47ecd777deb75bd2e1514afa52cfbd81ac262"
-  integrity sha512-ttQWCXZE8tAvqzFh4vijuuBJNbF2VsGB61rny5MAytWorqf0LKd3XyCrFxODi3uo/BH3Skb+7iXYav3E/9+sIw==
+"@mdi/svg@4.5.95":
+  version "4.5.95"
+  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-4.5.95.tgz#b02ea5ac4e118abdf64fee7af59c7807617f32bd"
+  integrity sha512-CwIV4cc6GB4qcNI8Z/5KSf51rONTQnB6dgF6Uji0Ns9eANzQQ14/cPvCFgJ42xNm+ivw+VXaQ5Ed9y/zcK/iXQ==
 
 "@polymer/app-layout@^3.0.2":
   version "3.0.2"


### PR DESCRIPTION
Changelog: https://dev.materialdesignicons.com/changelog#version-4.5.95

<img width="340" alt="Screenshot 2019-10-09 19 41 50" src="https://user-images.githubusercontent.com/29807944/66528167-f10e8780-eacc-11e9-92c5-118abeb52e12.png">