### PR TITLE
Add cache headers to demo and cast

### DIFF
--- a/build-scripts/gulp/gather-static.js
+++ b/build-scripts/gulp/gather-static.js
@@ -104,7 +104,10 @@ gulp.task("compress-static", () => compressStatic(paths.static));
 
 gulp.task("copy-static-demo", (done) => {
   // Copy app static files
-  fs.copySync(polyPath("public"), paths.demo_root);
+  fs.copySync(
+    polyPath("public/static"),
+    path.resolve(paths.demo_root, "static")
+  );
   // Copy demo static files
   fs.copySync(path.resolve(paths.demo_dir, "public"), paths.demo_root);
 

--- a/cast/public/_headers
+++ b/cast/public/_headers
@@ -1,0 +1,20 @@
+/*
+  Cache-Control: public, max-age: 0, s-maxage=3600, must-revalidate
+  Content-Security-Policy: form-action https:
+  Feature-Policy: vibrate 'none'; geolocation 'none'; midi 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; payment 'none'
+  Referrer-Policy: no-referrer-when-downgrade
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+
+/images/*
+  Cache-Control: public, max-age: 3600
+
+/manifest.json
+  Cache-Control: public, max-age: 3600
+
+/frontend_es5/*
+  Cache-Control: public, max-age: 604800, s-maxage=604800
+
+/frontend_latest/*
+  Cache-Control: public, max-age: 604800, s-maxage=604800

--- a/cast/public/_headers
+++ b/cast/public/_headers
@@ -8,10 +8,10 @@
   X-XSS-Protection: 1; mode=block
 
 /images/*
-  Cache-Control: public, max-age: 3600
+  Cache-Control: public, max-age: 3600, s-maxage=3600
 
 /manifest.json
-  Cache-Control: public, max-age: 3600
+  Cache-Control: public, max-age: 3600, s-maxage=3600
 
 /frontend_es5/*
   Cache-Control: public, max-age: 604800, s-maxage=604800

--- a/cast/public/_headers
+++ b/cast/public/_headers
@@ -8,7 +8,7 @@
   X-XSS-Protection: 1; mode=block
 
 /images/*
-  Cache-Control: public, max-age: 3600, s-maxage=3600
+  Cache-Control: public, max-age: 86400, s-maxage=86400
 
 /manifest.json
   Cache-Control: public, max-age: 3600, s-maxage=3600

--- a/cast/public/_headers
+++ b/cast/public/_headers
@@ -8,7 +8,7 @@
   X-XSS-Protection: 1; mode=block
 
 /images/*
-  Cache-Control: public, max-age: 86400, s-maxage=86400
+  Cache-Control: public, max-age: 604800, s-maxage=604800
 
 /manifest.json
   Cache-Control: public, max-age: 3600, s-maxage=3600

--- a/demo/public/_headers
+++ b/demo/public/_headers
@@ -1,0 +1,12 @@
+/*
+  Cache-Control: public, max-age: 0, s-maxage=3600, must-revalidate
+  Content-Security-Policy: form-action https:
+  Feature-Policy: vibrate 'none'; geolocation 'none'; midi 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; payment 'none'
+  Referrer-Policy: no-referrer-when-downgrade
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+/*.css
+  Cache-Control: public, max-age: 604800, s-maxage=604800
+/*.js
+  Cache-Control: public, max-age: 604800, s-maxage=604800

--- a/demo/public/_headers
+++ b/demo/public/_headers
@@ -1,10 +1,8 @@
 /*
   Cache-Control: public, max-age: 0, s-maxage=3600, must-revalidate
   Content-Security-Policy: form-action https:
-  Feature-Policy: vibrate 'none'; geolocation 'none'; midi 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; payment 'none'
   Referrer-Policy: no-referrer-when-downgrade
   X-Content-Type-Options: nosniff
-  X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
 /*.css
   Cache-Control: public, max-age: 604800, s-maxage=604800

--- a/demo/public/_headers
+++ b/demo/public/_headers
@@ -6,10 +6,10 @@
   X-XSS-Protection: 1; mode=block
 
 /api/*
-  Cache-Control: public, max-age: 86400, s-maxage=86400
+  Cache-Control: public, max-age: 604800, s-maxage=604800
 
 /assets/*
-  Cache-Control: public, max-age: 86400, s-maxage=86400
+  Cache-Control: public, max-age: 604800, s-maxage=604800
 
 /frontend_es5/*
   Cache-Control: public, max-age: 604800, s-maxage=604800

--- a/demo/public/_headers
+++ b/demo/public/_headers
@@ -4,7 +4,15 @@
   Referrer-Policy: no-referrer-when-downgrade
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 1; mode=block
-/*.css
+
+/api/*
+  Cache-Control: public, max-age: 86400, s-maxage=86400
+
+/assets/*
+  Cache-Control: public, max-age: 86400, s-maxage=86400
+
+/frontend_es5/*
   Cache-Control: public, max-age: 604800, s-maxage=604800
-/*.js
+
+/frontend_latest/*
   Cache-Control: public, max-age: 604800, s-maxage=604800


### PR DESCRIPTION
Add caching headers to demo and cast on Netlify.

## Demo build files
- `api/`: Static assets that mock out API calls
- `assets/`: Assets for the demo configs
- `frontend_es5/`: ES5 build of the demo (hashed files)
- `frontend_latest/`: Latest build of the demo (hashed files)
- `index.html`: Entrypoint for the demo
- `manifest.json`: PWA manifest
- `service_worker.js`: Service worker
- `static/`: Static files from the frontend

## Cast build files
- `faq.html`: Entrypoint for the FAQ
- `frontend_es5/`: ES5 build of Cast (hashed files)
- `frontend_latest/`: Latest build of Cast (hashed files)
- `images/`: Images used in UI
- `index.html`: Entrypoint for Cast Launcher
- `manifest.json`: PWA manifest
- `receiver.html`: Entrypoint for Cast Receiver (runs on Chromecast)
- `service_worker.js`: 
- `static/`: Static files for Cast