### PR TITLE
Alarm Panel card: number buttons outline and adjusted padding and font-size fixing #2812

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -164,7 +164,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                         <mwc-button
                           .value="${value}"
                           @click="${this._handlePadClick}"
-                          dense
+                          outlined
                         >
                           ${value === "clear"
                             ? this._label("clear_code")
@@ -289,13 +289,14 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
         justify-content: center;
         flex-wrap: wrap;
         margin: auto;
-        width: 300px;
+        width: 100%;
+        max-width: 300px;
       }
 
       #keypad mwc-button {
         margin-bottom: 5%;
         width: 30%;
-        padding: calc(var(--base-unit));
+        padding: calc(var(--base-unit) / 3);
         font-size: calc(var(--base-unit) * 1.1);
         box-sizing: border-box;
       }

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -136,7 +136,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                 @click="${this._handleActionClick}"
                 outlined
               >
-                ${this._label(state)}
+                <h1 style="font-size:16px;">${this._label(state)}</h1>
               </mwc-button>
             `;
           })}
@@ -165,10 +165,13 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                           .value="${value}"
                           @click="${this._handlePadClick}"
                           outlined
+                          raised
                         >
-                          ${value === "clear"
-                            ? this._label("clear_code")
-                            : value}
+                          <h1 style="font-size:16px;">
+                            ${value === "clear"
+                              ? this._label("clear_code")
+                              : value}
+                          </h1>
                         </mwc-button>
                       `;
                 })}

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -226,8 +226,6 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
         --alarm-color-armed: var(--label-badge-red);
         --alarm-color-autoarm: rgba(0, 153, 255, 0.1);
         --alarm-state-color: var(--alarm-color-armed);
-        --base-unit: 15px;
-        font-size: calc(var(--base-unit));
       }
 
       ha-label-badge {
@@ -271,13 +269,11 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       paper-input {
         margin: 0 auto 8px;
         max-width: 150px;
-        font-size: calc(var(--base-unit));
         text-align: center;
       }
 
       .state {
         margin-left: 16px;
-        font-size: calc(var(--base-unit) * 0.9);
         position: relative;
         bottom: 16px;
         color: var(--alarm-state-color);
@@ -294,10 +290,9 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       }
 
       #keypad mwc-button {
-        margin-bottom: 5%;
+        text-size: 20px;
+        padding: 8px;
         width: 30%;
-        padding: calc(var(--base-unit) / 3);
-        font-size: calc(var(--base-unit) * 1.1);
         box-sizing: border-box;
       }
 
@@ -307,11 +302,9 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
-        font-size: calc(var(--base-unit) * 1);
       }
 
       .actions mwc-button {
-        min-width: calc(var(--base-unit) * 9);
         margin: 0 4px 4px;
       }
 

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -136,7 +136,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                 @click="${this._handleActionClick}"
                 outlined
               >
-                <h1 style="font-size:16px;">${this._label(state)}</h1>
+                ${this._label(state)}
               </mwc-button>
             `;
           })}
@@ -167,11 +167,9 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                           outlined
                           raised
                         >
-                          <h1 style="font-size:16px;">
-                            ${value === "clear"
-                              ? this._label("clear_code")
-                              : value}
-                          </h1>
+                          ${value === "clear"
+                            ? this._label("clear_code")
+                            : value}
                         </mwc-button>
                       `;
                 })}

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -165,7 +165,6 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                           .value="${value}"
                           @click="${this._handlePadClick}"
                           outlined
-                          raised
                         >
                           ${value === "clear"
                             ? this._label("clear_code")


### PR DESCRIPTION
Thanks to @bramkragten for helping out.

Outline on buttons and less padding.
Found a solution for the font-size issue before mwc-button height bug is fixed.

fixes #2812 