### PR TITLE
Added note about more integrations to bottom of Set up new integration dialog

### DIFF
--- a/src/dialogs/config-flow/step-flow-pick-handler.ts
+++ b/src/dialogs/config-flow/step-flow-pick-handler.ts
@@ -59,7 +59,6 @@ class StepFlowPickHandler extends LitElement {
 
   protected render(): TemplateResult | void {
     const handlers = this._getHandlers(this.handlers, this.filter);
-    const websiteLink = "https://www.home-assistant.io/integrations/";
 
     return html`
       <h2>${this.hass.localize("ui.panel.config.integrations.new")}</h2>
@@ -80,21 +79,17 @@ class StepFlowPickHandler extends LitElement {
             `
         )}
       </div>
-      <p style=${styleMap({ textAlign: `center` })}>
-        <span style=${styleMap({ display: `block` })}>
-          ${this.hass.localize(
-            "ui.panel.config.integrations.note_about_integrations"
-          )}
-        </span>
-        <span>
-          ${this.hass.localize(
-            "ui.panel.config.integrations.note_about_website_reference"
-          )}<a href=${websiteLink}
-            >${this.hass.localize(
-              "ui.panel.config.integrations.home_assistant_website"
-            )}.</a
-          >
-        </span>
+      <p>
+        ${this.hass.localize(
+          "ui.panel.config.integrations.note_about_integrations"
+        )}<br />
+        ${this.hass.localize(
+          "ui.panel.config.integrations.note_about_website_reference"
+        )}<a href="https://www.home-assistant.io/integrations/"
+          >${this.hass.localize(
+            "ui.panel.config.integrations.home_assistant_website"
+          )}.</a
+        >
       </p>
     `;
   }
@@ -135,6 +130,9 @@ class StepFlowPickHandler extends LitElement {
       }
       paper-item {
         cursor: pointer;
+      }
+      p {
+        text-align: center;
       }
     `;
   }

--- a/src/dialogs/config-flow/step-flow-pick-handler.ts
+++ b/src/dialogs/config-flow/step-flow-pick-handler.ts
@@ -59,6 +59,7 @@ class StepFlowPickHandler extends LitElement {
 
   protected render(): TemplateResult | void {
     const handlers = this._getHandlers(this.handlers, this.filter);
+    const websiteLink = "https://www.home-assistant.io/integrations/";
 
     return html`
       <h2>${this.hass.localize("ui.panel.config.integrations.new")}</h2>
@@ -79,6 +80,22 @@ class StepFlowPickHandler extends LitElement {
             `
         )}
       </div>
+      <p style=${styleMap({ textAlign: `center` })}>
+        <span style=${styleMap({ display: `block` })}>
+          ${this.hass.localize(
+            "ui.panel.config.integrations.note_about_integrations"
+          )}
+        </span>
+        <span>
+          ${this.hass.localize(
+            "ui.panel.config.integrations.note_about_website_reference"
+          )}<a href=${websiteLink}
+            >${this.hass.localize(
+              "ui.panel.config.integrations.home_assistant_website"
+            )}.</a
+          >
+        </span>
+      </p>
     `;
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1162,6 +1162,9 @@
           "discovered": "Discovered",
           "configured": "Configured",
           "new": "Set up a new integration",
+          "note_about_integrations": "Not all integrations can be configured via the UI yet.",
+          "note_about_website_reference": "More are available on the ",
+          "home_assistant_website": "Home Assistant website",
           "configure": "Configure",
           "none": "Nothing configured yet",
           "config_entry": {


### PR DESCRIPTION
Issues affected: #3951 

Description:
 - added a `<p>` to the bottom of the custom html element step-flow-pick-handler
 - including two `<span>` elements containing the note about more integrations
 - added three key-value pairs to `src/translations/en.json`

Result:
![grafik](https://user-images.githubusercontent.com/46536646/66705703-4abfbd80-ed2a-11e9-9fa0-a670dc05f996.png)
