### PR TITLE
Fixes documentation URL for HTML5 push notifications

### DIFF
--- a/src/panels/profile/ha-push-notifications-row.js
+++ b/src/panels/profile/ha-push-notifications-row.js
@@ -28,7 +28,7 @@ class HaPushNotificationsRow extends LocalizeMixin(PolymerElement) {
         <span slot="description">
           [[_description(_platformLoaded, _pushSupported)]]
           <a
-            href="https://www.home-assistant.io/integrations/notify.html5/"
+            href="https://www.home-assistant.io/integrations/html5"
             target="_blank"
             >[[localize('ui.panel.profile.push_notifications.link_promo')]]</a
           >


### PR DESCRIPTION
Fixed a documentation URL in the frontend for the HTML5 push notifications.
Wrongly replaced that URL in #3857, thanks @SeanPM5 for finding this 👀 