### PR TITLE
new restriction card

### DIFF
--- a/src/panels/lovelace/cards/hui-restriction-card.ts
+++ b/src/panels/lovelace/cards/hui-restriction-card.ts
@@ -1,0 +1,191 @@
+import { createCardElement } from "../common/create-card-element";
+import { computeCardSize } from "../common/compute-card-size";
+import { HomeAssistant } from "../../../types";
+import { LovelaceCard } from "../types";
+import { RestrictionCardConfig } from "./types";
+import {
+  TemplateResult,
+  customElement,
+  LitElement,
+  property,
+  html,
+  CSSResult,
+  css,
+} from "lit-element";
+import { LovelaceCardConfig } from "../../../data/lovelace";
+
+@customElement("hui-restriction-card")
+class HuiRestrictionCard extends LitElement implements LovelaceCard {
+  @property() protected _config?: RestrictionCardConfig;
+  protected _hass?: HomeAssistant;
+
+  set hass(hass: HomeAssistant) {
+    this._hass = hass;
+
+    const element = this.shadowRoot!.querySelector("#card > *") as any;
+    if (element) {
+      element.hass = hass;
+    }
+  }
+
+  public getCardSize(): number {
+    return computeCardSize(this._config!.card);
+  }
+
+  public setConfig(config: RestrictionCardConfig): void {
+    if (!config.card || !config.restrictions) {
+      throw new Error("Error in card configuration.");
+    }
+
+    if (config.restrictions.pin && !config.restrictions.pin.code) {
+      throw new Error("A pin code is required for pin restrictions");
+    }
+
+    this._config = config;
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this._config || !this._hass) {
+      return html``;
+    }
+
+    return html`
+      <div>
+        ${this._config.exceptions &&
+        this._config.exceptions.some((e) => e.user === this._hass!.user!.id)
+          ? ""
+          : html`
+              <div @click=${this._handleClick} id="overlay">
+                <ha-icon icon="hass:lock-outline" id="lock"></ha-icon>
+              </div>
+            `}
+        ${this.renderCard(this._config.card)}
+      </div>
+    `;
+  }
+
+  private renderCard(config: LovelaceCardConfig): TemplateResult {
+    const element = createCardElement(config);
+    if (this._hass) {
+      element.hass = this._hass;
+    }
+
+    return html`
+      <div id="card">
+        ${element}
+      </div>
+    `;
+  }
+
+  private _handleClick(): void {
+    if (this._config!.restrictions) {
+      if (
+        this._config!.restrictions.block &&
+        (!this._config!.restrictions.block.exceptions ||
+          !this._config!.restrictions.block.exceptions.some(
+            (e) => e.user === this._hass!.user!.id
+          ))
+      ) {
+        alert("This card is blocked");
+        return;
+      }
+
+      if (
+        this._config!.restrictions.pin &&
+        this._config!.restrictions.pin.code &&
+        (!this._config!.restrictions.pin.exceptions ||
+          !this._config!.restrictions.pin.exceptions.some(
+            (e) => e.user === this._hass!.user!.id
+          ))
+      ) {
+        const pin = prompt("Input pin code");
+
+        // tslint:disable-next-line: triple-equals
+        if (pin != this._config!.restrictions.pin.code) {
+          alert("Invalid pin entered");
+          return;
+        }
+      }
+
+      if (
+        this._config!.restrictions.confirm &&
+        (!this._config!.restrictions.confirm.exceptions ||
+          !this._config!.restrictions.confirm.exceptions.some(
+            (e) => e.user === this._hass!.user!.id
+          ))
+      ) {
+        if (!confirm("Are you sure you want to unlock?")) {
+          return;
+        }
+      }
+    }
+
+    const overlay = this.shadowRoot!.getElementById("overlay") as LitElement;
+    overlay.style.setProperty("pointer-events", "none");
+    const lock = this.shadowRoot!.getElementById("lock") as LitElement;
+
+    lock.classList.add("fadeOut");
+
+    window.setTimeout(() => {
+      overlay.style.setProperty("pointer-events", "");
+      if (lock) {
+        lock.classList.remove("fadeOut");
+      }
+    }, 5000);
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      :host {
+        position: relative;
+      }
+
+      #overlay {
+        align-items: flex-start;
+        padding: 8px 7px;
+        opacity: 0.5;
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        z-index: 50;
+        display: flex;
+      }
+
+      #lock {
+        -webkit-animation-duration: 5s;
+        animation-duration: 5s;
+        -webkit-animation-fill-mode: both;
+        animation-fill-mode: both;
+        margin: unset;
+      }
+
+      @keyframes fadeOut {
+        0% {
+          opacity: 0.5;
+        }
+        20% {
+          opacity: 0;
+        }
+        80% {
+          opacity: 0;
+        }
+        100% {
+          opacity: 0.5;
+        }
+      }
+
+      .fadeOut {
+        -webkit-animation-name: fadeOut;
+        animation-name: fadeOut;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-restriction-card": HuiRestrictionCard;
+  }
+}

--- a/src/panels/lovelace/cards/hui-restriction-card.ts
+++ b/src/panels/lovelace/cards/hui-restriction-card.ts
@@ -82,6 +82,8 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
   }
 
   private _handleClick(): void {
+    const lock = this.shadowRoot!.getElementById("lock") as LitElement;
+
     if (this._config!.restrictions) {
       if (
         this._config!.restrictions.block &&
@@ -90,7 +92,12 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
             (e) => e.user === this._hass!.user!.id
           ))
       ) {
-        alert("This card is blocked");
+        lock.classList.add("invalid");
+        window.setTimeout(() => {
+          if (lock) {
+            lock.classList.remove("invalid");
+          }
+        }, 3000);
         return;
       }
 
@@ -106,7 +113,12 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
 
         // tslint:disable-next-line: triple-equals
         if (pin != this._config!.restrictions.pin.code) {
-          alert("Invalid pin entered");
+          lock.classList.add("invalid");
+          window.setTimeout(() => {
+            if (lock) {
+              lock.classList.remove("invalid");
+            }
+          }, 3000);
           return;
         }
       }
@@ -126,10 +138,7 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
 
     const overlay = this.shadowRoot!.getElementById("overlay") as LitElement;
     overlay.style.setProperty("pointer-events", "none");
-    const lock = this.shadowRoot!.getElementById("lock") as LitElement;
-
     lock.classList.add("fadeOut");
-
     window.setTimeout(() => {
       overlay.style.setProperty("pointer-events", "");
       if (lock) {
@@ -158,31 +167,32 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
       }
 
       #lock {
-        -webkit-animation-duration: 5s;
-        animation-duration: 5s;
-        -webkit-animation-fill-mode: both;
-        animation-fill-mode: both;
         margin: unset;
       }
 
       @keyframes fadeOut {
-        0% {
-          opacity: 0.5;
-        }
         20% {
           opacity: 0;
         }
         80% {
           opacity: 0;
         }
-        100% {
-          opacity: 0.5;
-        }
       }
 
       .fadeOut {
-        -webkit-animation-name: fadeOut;
-        animation-name: fadeOut;
+        animation: fadeOut 5s linear;
+        color: green;
+      }
+
+      @keyframes blinker {
+        50% {
+          opacity: 0;
+        }
+      }
+
+      .invalid {
+        animation: blinker 1s linear infinite;
+        color: red;
       }
     `;
   }

--- a/src/panels/lovelace/cards/hui-restriction-card.ts
+++ b/src/panels/lovelace/cards/hui-restriction-card.ts
@@ -33,11 +33,15 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: RestrictionCardConfig): void {
-    if (!config.card || !config.restrictions) {
+    if (!config.card) {
       throw new Error("Error in card configuration.");
     }
 
-    if (config.restrictions.pin && !config.restrictions.pin.code) {
+    if (
+      config.restrictions &&
+      config.restrictions.pin &&
+      !config.restrictions.pin.code
+    ) {
       throw new Error("A pin code is required for pin restrictions");
     }
 

--- a/src/panels/lovelace/cards/hui-restriction-card.ts
+++ b/src/panels/lovelace/cards/hui-restriction-card.ts
@@ -55,8 +55,8 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
 
     return html`
       <div>
-        ${this._config.exceptions &&
-        this._config.exceptions.some((e) => e.user === this._hass!.user!.id)
+        ${this._config.exemptions &&
+        this._config.exemptions.some((e) => e.user === this._hass!.user!.id)
           ? ""
           : html`
               <div @click=${this._handleClick} id="overlay">
@@ -85,8 +85,8 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
     if (this._config!.restrictions) {
       if (
         this._config!.restrictions.block &&
-        (!this._config!.restrictions.block.exceptions ||
-          !this._config!.restrictions.block.exceptions.some(
+        (!this._config!.restrictions.block.exemptions ||
+          !this._config!.restrictions.block.exemptions.some(
             (e) => e.user === this._hass!.user!.id
           ))
       ) {
@@ -97,8 +97,8 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
       if (
         this._config!.restrictions.pin &&
         this._config!.restrictions.pin.code &&
-        (!this._config!.restrictions.pin.exceptions ||
-          !this._config!.restrictions.pin.exceptions.some(
+        (!this._config!.restrictions.pin.exemptions ||
+          !this._config!.restrictions.pin.exemptions.some(
             (e) => e.user === this._hass!.user!.id
           ))
       ) {
@@ -113,8 +113,8 @@ class HuiRestrictionCard extends LitElement implements LovelaceCard {
 
       if (
         this._config!.restrictions.confirm &&
-        (!this._config!.restrictions.confirm.exceptions ||
-          !this._config!.restrictions.confirm.exceptions.some(
+        (!this._config!.restrictions.confirm.exemptions ||
+          !this._config!.restrictions.confirm.exemptions.some(
             (e) => e.user === this._hass!.user!.id
           ))
       ) {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -220,7 +220,7 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
 
 export interface RestrictionCardConfig extends LovelaceCardConfig {
   restrictions?: RestrictionsConfig;
-  exceptions?: RestrictionTypeConfig[];
+  exemptions?: RestrictionTypeConfig[];
 }
 
 export interface RestrictionsConfig {
@@ -230,16 +230,16 @@ export interface RestrictionsConfig {
 }
 
 export interface ConfirmRestrictionTypeConfig {
-  exceptions?: RestrictionTypeConfig[];
+  exemptions?: RestrictionTypeConfig[];
 }
 
 export interface BlockTypeConfig {
-  exceptions?: RestrictionTypeConfig[];
+  exemptions?: RestrictionTypeConfig[];
 }
 
 export interface PinRestrictionConfig {
   code: string;
-  exceptions?: RestrictionTypeConfig[];
+  exemptions?: RestrictionTypeConfig[];
 }
 
 export interface RestrictionTypeConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -217,3 +217,31 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
 }
+
+export interface RestrictionCardConfig extends LovelaceCardConfig {
+  restrictions?: RestrictionsConfig;
+  exceptions?: RestrictionTypeConfig[];
+}
+
+export interface RestrictionsConfig {
+  confirm?: ConfirmRestrictionTypeConfig;
+  pin?: PinRestrictionConfig;
+  block?: BlockTypeConfig;
+}
+
+export interface ConfirmRestrictionTypeConfig {
+  exceptions?: RestrictionTypeConfig[];
+}
+
+export interface BlockTypeConfig {
+  exceptions?: RestrictionTypeConfig[];
+}
+
+export interface PinRestrictionConfig {
+  code: string;
+  exceptions?: RestrictionTypeConfig[];
+}
+
+export interface RestrictionTypeConfig {
+  user: string;
+}

--- a/src/panels/lovelace/common/create-card-element.ts
+++ b/src/panels/lovelace/common/create-card-element.ts
@@ -25,6 +25,7 @@ import "../cards/hui-picture-elements-card";
 import "../cards/hui-picture-entity-card";
 import "../cards/hui-picture-glance-card";
 import "../cards/hui-plant-status-card";
+import "../cards/hui-restriction-card";
 import "../cards/hui-sensor-card";
 import "../cards/hui-vertical-stack-card";
 import "../cards/hui-shopping-list-card";
@@ -55,6 +56,7 @@ const CARD_TYPES = new Set([
   "picture-entity",
   "picture-glance",
   "plant-status",
+  "restriction",
   "sensor",
   "shopping-list",
   "thermostat",

--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -34,6 +34,7 @@ const cards: string[] = [
   "picture-entity",
   "picture-glance",
   "plant-status",
+  "restriction",
   "sensor",
   "shopping-list",
   "thermostat",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1391,7 +1391,8 @@
             },
             "config": {
               "required": "Required",
-              "optional": "Optional"
+              "optional": "Optional",
+              "invalid": "Error in card configuration."
             },
             "entities": {
               "name": "Entities",
@@ -1480,6 +1481,9 @@
             },
             "plant-status": {
               "name": "Plant Status"
+            },
+            "restriction": {
+              "name": "Restriction"
             },
             "sensor": {
               "name": "Sensor",


### PR DESCRIPTION
New card type `restriction` that allows you to add some security to cards. Thoughts on a `visible` restriction? 

```yaml
type: restriction
restrictions:
  confirm:
    exemptions:
      - user: adminid
  pin:
    code: 1234
    exemptions:
      - user: wifeid
      - user: adminid
  block:
    exemptions:
      - user: guestid
      - user: wifeid
      - user: adminid
exemptions:
  - user: ianid
card:
  type: thermostat
  entity: climate.house
```

Explanation of above configuration (as I feel like I need to explain it, there is probably a better way to define this configuration, but you would likely not have a complex one like this in most cases):

- ianid: has no restrictions and a lock is not displayed
- adminid: has a lock but no confirmation or pin
- wifeid: has to confirm prompt to unlock
- guestid: has to enter a pin in prompt to unlock
- anyone else is blocked from unlocking

Docs: TODO
Localization: TODO

Feedback on terminology for prompts/alerts before I add translations? How do we handle localization in `setConfig` since `hass` might not be available yet?

Crappy example recording
![Screen record from 2019-10-12 17 09 55@2x](https://user-images.githubusercontent.com/1287159/66708303-fc9fbf80-ed13-11e9-8a46-b02f9f7dad55.gif)

Simplest example
```yaml
type: restriction
card:
  type: thermostat
  entity: climate.house
```
Just presents a toggle lock
![Screen record from 2019-10-12 17 25 14@2x](https://user-images.githubusercontent.com/1287159/66708398-91ef8380-ed15-11e9-9676-53789e327049.gif)

Once kinks are worked out here, plan to extract core functionality and create row and element types as well.