### PR TITLE
Improve customize.yaml non-inclusion warning message

### DIFF
--- a/src/panels/config/customize/ha-form-customize.js
+++ b/src/panels/config/customize/ha-form-customize.js
@@ -26,9 +26,10 @@ class HaFormCustomize extends PolymerElement {
         if="[[computeShowWarning(localConfig, globalConfig)]]"
       >
         <div class="warning">
-          It seems that your configuration.yaml doesn't properly include
-          customize.yaml<br />
-          Changes made here won't affect your configuration.
+          It seems that your configuration.yaml doesn't properly
+          <a href="https://www.home-assistant.io/docs/configuration/customizing-devices/#customization-using-the-ui" target="_blank">include customize.yaml</a>.<br />
+          Changes made here are written in it, but will not be applied after a
+          restart unless the include is in place.
         </div>
       </template>
       <template is="dom-if" if="[[hasLocalAttributes]]">

--- a/src/panels/config/customize/ha-form-customize.js
+++ b/src/panels/config/customize/ha-form-customize.js
@@ -29,7 +29,7 @@ class HaFormCustomize extends PolymerElement {
           It seems that your configuration.yaml doesn't properly
           <a href="https://www.home-assistant.io/docs/configuration/customizing-devices/#customization-using-the-ui" target="_blank">include customize.yaml</a>.<br />
           Changes made here are written in it, but will not be applied after a
-          restart unless the include is in place.
+          configuration reload unless the include is in place.
         </div>
       </template>
       <template is="dom-if" if="[[hasLocalAttributes]]">

--- a/src/panels/config/customize/ha-form-customize.js
+++ b/src/panels/config/customize/ha-form-customize.js
@@ -27,7 +27,11 @@ class HaFormCustomize extends PolymerElement {
       >
         <div class="warning">
           It seems that your configuration.yaml doesn't properly
-          <a href="https://www.home-assistant.io/docs/configuration/customizing-devices/#customization-using-the-ui" target="_blank">include customize.yaml</a>.<br />
+          <a
+            href="https://www.home-assistant.io/docs/configuration/customizing-devices/#customization-using-the-ui"
+            target="_blank"
+            >include customize.yaml</a
+          >.<br />
           Changes made here are written in it, but will not be applied after a
           configuration reload unless the include is in place.
         </div>


### PR DESCRIPTION
Link to relevant docs, note that changes won't be applied after a
restart if the include isn't in place (changes _do_ actually affect the
current runtime configuration and are persisted in customize.yaml).