### PR TITLE
Added integration name to System Options dialog

### DIFF
--- a/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
@@ -60,7 +60,9 @@ class DialogConfigEntrySystemOptions extends LitElement {
         @opened-changed="${this._openedChanged}"
       >
         <h2>
-          ${this.hass.localize("ui.dialogs.config_entry_system_options.title")}
+          ${this.hass.localize(
+            "ui.dialogs.config_entry_system_options.title"
+          )}${this._params.entry.domain}
         </h2>
         <paper-dialog-scrollable>
           ${this._loading
@@ -89,7 +91,11 @@ class DialogConfigEntrySystemOptions extends LitElement {
                       </p>
                       <p class="secondary">
                         ${this.hass.localize(
-                          "ui.dialogs.config_entry_system_options.enable_new_entities_description"
+                          "ui.dialogs.config_entry_system_options.enable_new_entities_description_start"
+                        )}
+                        ${this._params.entry.domain}
+                        ${this.hass.localize(
+                          "ui.dialogs.config_entry_system_options.enable_new_entities_description_end"
                         )}
                       </p>
                     </div>

--- a/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
@@ -63,7 +63,9 @@ class DialogConfigEntrySystemOptions extends LitElement {
           ${this.hass.localize(
             "ui.dialogs.config_entry_system_options.title",
             "integration",
-            this._params.entry.domain
+            this.hass.localize(
+              `component.${this._params.entry.domain}.config.title`
+            )
           )}
         </h2>
         <paper-dialog-scrollable>
@@ -95,7 +97,11 @@ class DialogConfigEntrySystemOptions extends LitElement {
                         ${this.hass.localize(
                           "ui.dialogs.config_entry_system_options.enable_new_entities_description",
                           "integration",
-                          this._params.entry.domain
+                          this.hass.localize(
+                            `component.${
+                              this._params.entry.domain
+                            }.config.title`
+                          )
                         )}
                       </p>
                     </div>

--- a/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
@@ -65,7 +65,7 @@ class DialogConfigEntrySystemOptions extends LitElement {
             "integration",
             this.hass.localize(
               `component.${this._params.entry.domain}.config.title`
-            )
+            ) || this._params.entry.domain
           )}
         </h2>
         <paper-dialog-scrollable>
@@ -101,7 +101,7 @@ class DialogConfigEntrySystemOptions extends LitElement {
                             `component.${
                               this._params.entry.domain
                             }.config.title`
-                          )
+                          ) || this._params.entry.domain
                         )}
                       </p>
                     </div>

--- a/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
@@ -61,8 +61,10 @@ class DialogConfigEntrySystemOptions extends LitElement {
       >
         <h2>
           ${this.hass.localize(
-            "ui.dialogs.config_entry_system_options.title"
-          )}${this._params.entry.domain}
+            "ui.dialogs.config_entry_system_options.title",
+            "integration",
+            this._params.entry.domain
+          )}
         </h2>
         <paper-dialog-scrollable>
           ${this._loading
@@ -91,11 +93,9 @@ class DialogConfigEntrySystemOptions extends LitElement {
                       </p>
                       <p class="secondary">
                         ${this.hass.localize(
-                          "ui.dialogs.config_entry_system_options.enable_new_entities_description_start"
-                        )}
-                        ${this._params.entry.domain}
-                        ${this.hass.localize(
-                          "ui.dialogs.config_entry_system_options.enable_new_entities_description_end"
+                          "ui.dialogs.config_entry_system_options.enable_new_entities_description",
+                          "integration",
+                          this._params.entry.domain
                         )}
                       </p>
                     </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -559,10 +559,9 @@
         }
       },
       "config_entry_system_options": {
-        "title": "System Options for ",
+        "title": "System Options for {integration}",
         "enable_new_entities_label": "Enable newly added entities.",
-        "enable_new_entities_description_start": "If disabled, newly discovered entities for ",
-        "enable_new_entities_description_end": "will not be automatically added to Home Assistant."
+        "enable_new_entities_description": "If disabled, newly discovered entities for {integration} will not be automatically added to Home Assistant."
       },
       "zha_device_info": {
         "manuf": "by {manufacturer}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -559,9 +559,10 @@
         }
       },
       "config_entry_system_options": {
-        "title": "System Options",
+        "title": "System Options for ",
         "enable_new_entities_label": "Enable newly added entities.",
-        "enable_new_entities_description": "If disabled, newly discovered entities will not be automatically added to Home Assistant."
+        "enable_new_entities_description_start": "If disabled, newly discovered entities for ",
+        "enable_new_entities_description_end": "will not be automatically added to Home Assistant."
       },
       "zha_device_info": {
         "manuf": "by {manufacturer}",


### PR DESCRIPTION
Issues affected: #3948 

Changes:
- added integration name to title of System Options Dialog
- added integration name into the description of System Options Dialog
- updated the title in src/translations/en.json
- split `enable_new_entities_description `into two key-value pairs

Result:
![grafik](https://user-images.githubusercontent.com/46536646/66718211-a26d3000-ede1-11e9-9a9f-9251e58f39a5.png)
