### PR TITLE
Fix integration names not wrapping

### DIFF
--- a/src/onboarding/integration-badge.ts
+++ b/src/onboarding/integration-badge.ts
@@ -74,6 +74,7 @@ class IntegrationBadge extends LitElement {
 
       .title {
         min-height: 2.3em;
+        word-break: break-word;
       }
     `;
   }


### PR DESCRIPTION
Fixes https://github.com/home-assistant/home-assistant-polymer/issues/3850

When there would be very long words, they would not wrap. It now breaks the words.
![image](https://user-images.githubusercontent.com/5662298/66757232-05230200-ee9c-11e9-9a3b-cc2b59b6c9dd.png)
