### PR TITLE
Put the actual validation error message into the alert dialog

### DIFF
--- a/src/panels/config/core/ha-config-core-form.ts
+++ b/src/panels/config/core/ha-config-core-form.ts
@@ -215,7 +215,7 @@ class ConfigCoreForm extends LitElement {
         time_zone: this._timeZoneValue,
       });
     } catch (err) {
-      alert("FAIL");
+      alert(err.message);
     } finally {
       this._working = false;
     }


### PR DESCRIPTION
Currently it just alerts with "FAIL!", but we do have the actual vaildation message(s) to display.

Fixes https://github.com/home-assistant/home-assistant/issues/27529 (still in the wrong repo)