### PR TITLE
Add a class to identify elements used as entities card rows

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -145,6 +145,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
   private renderEntity(entityConf: EntitiesCardEntityConfig): TemplateResult {
     const element = createRowElement(entityConf);
+    element.classList.add("row");
     if (this._hass) {
       element.hass = this._hass;
     }


### PR DESCRIPTION
This allows custom elements to work both as cards, picture-element elements and/or enties rows and know where they have been added to the interface.

Ex:
```js

class MyElement extends LitElement {
...
render() {
  if (this.classList.contains('element')) // Already "supported"
    return html`<my-thing></my-thing>`;
  else if (this.classList.contains('row')) // Support added by this PR
    return html`<hui-generic-entity-row><my-thing></my-thing></hui-generic-entity-row>`;
  else
    return html`<ha-card><my-thing></my-thin></ha-card>`;
}
...
}
```

