### PR TITLE
auto area/domain views

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -19,6 +19,8 @@ export interface LovelaceViewConfig {
   panel?: boolean;
   background?: string;
   visible?: boolean | ShowViewConfig[];
+  area?: string;
+  domain?: string;
 }
 
 export interface ShowViewConfig {

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -243,7 +243,7 @@ export const generateDefaultViewConfig = (
   return config;
 };
 
-const generateViewConfig = (
+export const generateViewConfig = (
   localize: LocalizeFunc,
   path: string,
   title: string | undefined,

--- a/src/panels/lovelace/common/get-entities-by-area.ts
+++ b/src/panels/lovelace/common/get-entities-by-area.ts
@@ -11,6 +11,7 @@ export const getEntitiesByArea = (
 ): HassEntities => {
   const allEntities = { ...entities };
   const areaEntities: HassEntities = {};
+  // TODO Actually need to bring in the area registry as well to get the area_id after matching on area name
   const areaDevices = new Set(
     deviceEntries
       .filter((device) => device.area_id === area)

--- a/src/panels/lovelace/common/get-entities-by-area.ts
+++ b/src/panels/lovelace/common/get-entities-by-area.ts
@@ -1,0 +1,27 @@
+import { HassEntities } from "home-assistant-js-websocket";
+
+import { DeviceRegistryEntry } from "../../../data/device_registry";
+import { EntityRegistryEntry } from "../../../data/entity_registry";
+
+export const getEntitiesByArea = (
+  deviceEntries: DeviceRegistryEntry[],
+  entityEntries: EntityRegistryEntry[],
+  entities: HassEntities,
+  area: string
+): HassEntities => {
+  const allEntities = { ...entities };
+  const areaEntities: HassEntities = {};
+  const areaDevices = new Set(
+    deviceEntries
+      .filter((device) => device.area_id === area)
+      .map((device) => device.id)
+  );
+  for (const entity of entityEntries) {
+    if (areaDevices.has(entity.device_id!) && entity.entity_id in allEntities) {
+      areaEntities[entity.entity_id] = allEntities[entity.entity_id];
+      delete allEntities[entity.entity_id];
+    }
+  }
+
+  return areaEntities;
+};

--- a/src/panels/lovelace/common/get-entities-by-domain.ts
+++ b/src/panels/lovelace/common/get-entities-by-domain.ts
@@ -1,0 +1,16 @@
+import { HassEntities } from "home-assistant-js-websocket";
+
+export const getEntitiesByDomain = (
+  entities: HassEntities,
+  domain: string
+): HassEntities => {
+  const domainEntities: HassEntities = {};
+
+  for (const entity of Object.values(entities)) {
+    if (entity.entity_id.split[0] === domain) {
+      domainEntities[entity.entity_id] = entities[entity.entity_id];
+    }
+  }
+
+  return domainEntities;
+};


### PR DESCRIPTION
Having trouble getting the entity and device registries. Not sure how to properly await their retrieval in the `updated` function so that I can use them to auto generate a configuration. Would appreciate some help on this.

closes https://github.com/home-assistant/home-assistant-polymer/issues/4021

Docs: TODO