### PR TITLE
support actions on rows

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -170,9 +170,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     }
 
     return html`
-      <div>
-        ${element}
-      </div>
+      <div>${element}</div>
     `;
   }
 }

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -178,8 +178,9 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
       element.hass = this._hass;
     }
     if (
-      entityConf.entity &&
-      !DOMAINS_HIDE_MORE_INFO.includes(computeDomain(entityConf.entity))
+      (entityConf.tap_action && entityConf.tap_action.action !== "none") ||
+      (entityConf.entity &&
+        !DOMAINS_HIDE_MORE_INFO.includes(computeDomain(entityConf.entity)))
     ) {
       element.classList.add("state-card-dialog");
     }

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -12,18 +12,13 @@ import {
 import "../../../components/ha-card";
 import "../components/hui-entities-toggle";
 
-import { DOMAINS_HIDE_MORE_INFO } from "../../../common/const";
 import { HomeAssistant } from "../../../types";
 import { EntityRow } from "../entity-rows/types";
 import { LovelaceCard, LovelaceCardEditor } from "../types";
 import { processConfigEntities } from "../common/process-config-entities";
 import { createRowElement } from "../common/create-row-element";
 import { EntitiesCardConfig, EntitiesCardEntityConfig } from "./types";
-import { computeDomain } from "../../../common/entity/compute_domain";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
-import { longPress } from "../common/directives/long-press-directive";
-import { hasDoubleClick } from "../common/has-double-click";
-import { handleClick } from "../common/handle-click";
 
 @customElement("hui-entities-card")
 class HuiEntitiesCard extends LitElement implements LovelaceCard {
@@ -162,10 +157,6 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
         overflow: hidden;
       }
 
-      .state-card-dialog {
-        cursor: pointer;
-      }
-
       .icon {
         padding: 0px 18px 0px 8px;
       }
@@ -177,42 +168,12 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     if (this._hass) {
       element.hass = this._hass;
     }
-    if (
-      (entityConf.tap_action && entityConf.tap_action.action !== "none") ||
-      (entityConf.entity &&
-        !DOMAINS_HIDE_MORE_INFO.includes(computeDomain(entityConf.entity)))
-    ) {
-      element.classList.add("state-card-dialog");
-    }
 
     return html`
-      <div
-        @ha-click=${this._handleClick}
-        @ha-hold=${this._handleHold}
-        @ha-dblclick=${this._handleDblClick}
-        .longPress=${longPress({
-          hasDoubleClick: hasDoubleClick(entityConf.double_tap_action),
-        })}
-        .config=${entityConf}
-      >
+      <div>
         ${element}
       </div>
     `;
-  }
-
-  private _handleClick(ev: MouseEvent): void {
-    const config = (ev.currentTarget as any).config as EntitiesCardEntityConfig;
-    handleClick(this, this.hass!, config, false, false);
-  }
-
-  private _handleHold(ev: MouseEvent): void {
-    const config = (ev.currentTarget as any).config as EntitiesCardEntityConfig;
-    handleClick(this, this.hass!, config, true, false);
-  }
-
-  private _handleDblClick(ev: MouseEvent): void {
-    const config = (ev.currentTarget as any).config as EntitiesCardEntityConfig;
-    handleClick(this, this.hass!, config, false, true);
   }
 }
 

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -200,17 +200,17 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   private _handleClick(ev: MouseEvent): void {
-    const config = (ev.currentTarget as any).config as any;
+    const config = (ev.currentTarget as any).config as EntitiesCardEntityConfig;
     handleClick(this, this.hass!, config, false, false);
   }
 
   private _handleHold(ev: MouseEvent): void {
-    const config = (ev.currentTarget as any).config as any;
+    const config = (ev.currentTarget as any).config as EntitiesCardEntityConfig;
     handleClick(this, this.hass!, config, true, false);
   }
 
   private _handleDblClick(ev: MouseEvent): void {
-    const config = (ev.currentTarget as any).config as any;
+    const config = (ev.currentTarget as any).config as EntitiesCardEntityConfig;
     handleClick(this, this.hass!, config, false, true);
   }
 }

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -210,7 +210,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   private _handleDblClick(ev: MouseEvent): void {
-    const config = (ev.currentTarget as any).entityConf as any;
+    const config = (ev.currentTarget as any).config as any;
     handleClick(this, this.hass!, config, false, true);
   }
 }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -28,6 +28,9 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
   service?: string;
   service_data?: object;
   url?: string;
+  tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
 }
 
 export interface EntitiesCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/common/directives/long-press-directive.ts
+++ b/src/panels/lovelace/common/directives/long-press-directive.ts
@@ -138,9 +138,16 @@ class LongPress extends HTMLElement implements LongPress {
       window.setTimeout(() => (this.cooldownEnd = false), 100);
     };
 
+    const handleEnter = (ev: Event) => {
+      if ((ev as KeyboardEvent).keyCode === 13) {
+        return clickEnd(ev);
+      }
+    };
+
     element.addEventListener("touchstart", clickStart, { passive: true });
     element.addEventListener("touchend", clickEnd);
     element.addEventListener("touchcancel", clickEnd);
+    element.addEventListener("keyup", handleEnter);
 
     // iOS 13 sends a complete normal touchstart-touchend series of events followed by a mousedown-click series.
     // That might be a bug, but until it's fixed, this should make long-press work.

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -72,6 +72,7 @@ class HuiGenericEntityRow extends LitElement {
         .longPress=${longPress({
           hasDoubleClick: hasDoubleClick(this.config.double_tap_action),
         })}
+        tabindex="0"
       ></state-badge>
       <div class="flex">
         <div

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -16,8 +16,14 @@ import "../components/hui-warning";
 
 import { HomeAssistant } from "../../../types";
 import { computeRTL } from "../../../common/util/compute_rtl";
-import { EntitiesCardEntityConfig } from "../cards/types";
 import { toggleAttribute } from "../../../common/dom/toggle_attribute";
+import { longPress } from "../common/directives/long-press-directive";
+import { hasDoubleClick } from "../common/has-double-click";
+import { handleClick } from "../common/handle-click";
+import { DOMAINS_HIDE_MORE_INFO } from "../../../common/const";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import { classMap } from "lit-html/directives/class-map";
+import { EntitiesCardEntityConfig } from "../cards/types";
 
 class HuiGenericEntityRow extends LitElement {
   @property() public hass?: HomeAssistant;
@@ -54,7 +60,25 @@ class HuiGenericEntityRow extends LitElement {
         .overrideImage=${this.config.image}
       ></state-badge>
       <div class="flex">
-        <div class="info">
+        <div
+          class="info"
+          class=${classMap({
+            info: true,
+            pointer:
+              (this.config.tap_action &&
+                this.config.tap_action.action !== "none") ||
+              (this.config.entity &&
+                !DOMAINS_HIDE_MORE_INFO.includes(
+                  computeDomain(this.config.entity)
+                )),
+          })}
+          @ha-click=${this._handleClick}
+          @ha-hold=${this._handleHold}
+          @ha-dblclick=${this._handleDblClick}
+          .longPress=${longPress({
+            hasDoubleClick: hasDoubleClick(this.config.double_tap_action),
+          })}
+        >
           ${this.config.name || computeStateName(stateObj)}
           <div class="secondary">
             ${!this.showSecondary
@@ -84,6 +108,18 @@ class HuiGenericEntityRow extends LitElement {
     if (changedProps.has("hass")) {
       toggleAttribute(this, "rtl", computeRTL(this.hass!));
     }
+  }
+
+  private _handleClick(): void {
+    handleClick(this, this.hass!, this.config!, false, false);
+  }
+
+  private _handleHold(): void {
+    handleClick(this, this.hass!, this.config!, true, false);
+  }
+
+  private _handleDblClick(): void {
+    handleClick(this, this.hass!, this.config!, false, true);
   }
 
   static get styles(): CSSResult {
@@ -131,6 +167,9 @@ class HuiGenericEntityRow extends LitElement {
       :host([rtl]) .flex ::slotted(*) {
         margin-left: 0;
         margin-right: 8px;
+      }
+      .pointer {
+        cursor: pointer;
       }
     `;
   }

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -78,6 +78,10 @@ class HuiGenericEntityRow extends LitElement {
           class=${classMap({
             info: true,
             pointer,
+            padName: this.showSecondary && !this.config.secondary_info,
+            padSecondary: Boolean(
+              !this.showSecondary || this.config.secondary_info
+            ),
           })}
           @ha-click=${this._handleClick}
           @ha-hold=${this._handleHold}
@@ -177,6 +181,12 @@ class HuiGenericEntityRow extends LitElement {
       }
       .pointer {
         cursor: pointer;
+      }
+      .padName {
+        padding: 12px 0px;
+      }
+      .padSecondary {
+        padding: 4px 0px;
       }
     `;
   }

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -52,25 +52,32 @@ class HuiGenericEntityRow extends LitElement {
       `;
     }
 
+    const pointer =
+      (this.config.tap_action && this.config.tap_action.action !== "none") ||
+      (this.config.entity &&
+        !DOMAINS_HIDE_MORE_INFO.includes(computeDomain(this.config.entity)));
+
     return html`
       <state-badge
+        class=${classMap({
+          pointer,
+        })}
         .hass=${this.hass}
         .stateObj=${stateObj}
         .overrideIcon=${this.config.icon}
         .overrideImage=${this.config.image}
+        @ha-click=${this._handleClick}
+        @ha-hold=${this._handleHold}
+        @ha-dblclick=${this._handleDblClick}
+        .longPress=${longPress({
+          hasDoubleClick: hasDoubleClick(this.config.double_tap_action),
+        })}
       ></state-badge>
       <div class="flex">
         <div
-          class="info"
           class=${classMap({
             info: true,
-            pointer:
-              (this.config.tap_action &&
-                this.config.tap_action.action !== "none") ||
-              (this.config.entity &&
-                !DOMAINS_HIDE_MORE_INFO.includes(
-                  computeDomain(this.config.entity)
-                )),
+            pointer,
           })}
           @ha-click=${this._handleClick}
           @ha-hold=${this._handleHold}

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -23,6 +23,12 @@ import { setInputSelectOption } from "../../../data/input-select";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import { forwardHaptic } from "../../../data/haptics";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
+import { longPress } from "../common/directives/long-press-directive";
+import { hasDoubleClick } from "../common/has-double-click";
+import { handleClick } from "../common/handle-click";
+import { classMap } from "lit-html/directives/class-map";
+import { DOMAINS_HIDE_MORE_INFO } from "../../../common/const";
+import { computeDomain } from "../../../common/entity/compute_domain";
 
 @customElement("hui-input-select-entity-row")
 class HuiInputSelectEntityRow extends LitElement implements EntityRow {
@@ -63,8 +69,24 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
       `;
     }
 
+    const pointer =
+      (this._config.tap_action && this._config.tap_action.action !== "none") ||
+      (this._config.entity &&
+        !DOMAINS_HIDE_MORE_INFO.includes(computeDomain(this._config.entity)));
+
     return html`
-      <state-badge .stateObj="${stateObj}"></state-badge>
+      <state-badge
+        .stateObj=${stateObj}
+        class=${classMap({
+          pointer,
+        })}
+        @ha-click=${this._handleClick}
+        @ha-hold=${this._handleHold}
+        @ha-dblclick=${this._handleDblClick}
+        .longPress=${longPress({
+          hasDoubleClick: hasDoubleClick(this._config.double_tap_action),
+        })}
+      ></state-badge>
       <ha-paper-dropdown-menu
         .label=${this._config.name || computeStateName(stateObj)}
         .value=${stateObj.state}
@@ -103,6 +125,18 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
     )!.selected = stateObj.attributes.options.indexOf(stateObj.state);
   }
 
+  private _handleClick(): void {
+    handleClick(this, this.hass!, this._config!, false, false);
+  }
+
+  private _handleHold(): void {
+    handleClick(this, this.hass!, this._config!, true, false);
+  }
+
+  private _handleDblClick(): void {
+    handleClick(this, this.hass!, this._config!, false, true);
+  }
+
   static get styles(): CSSResult {
     return css`
       :host {
@@ -117,6 +151,9 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
       paper-item {
         cursor: pointer;
         min-width: 200px;
+      }
+      .pointer {
+        cursor: pointer;
       }
     `;
   }

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -87,6 +87,7 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
         .longPress=${longPress({
           hasDoubleClick: hasDoubleClick(this._config.double_tap_action),
         })}
+        tabindex="0"
       ></state-badge>
       <ha-paper-dropdown-menu
         .label=${this._config.name || computeStateName(stateObj)}

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -18,7 +18,7 @@ import "../components/hui-warning";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 
 import { HomeAssistant, InputSelectEntity } from "../../../types";
-import { EntityRow, EntityConfig } from "./types";
+import { EntityRow } from "./types";
 import { setInputSelectOption } from "../../../data/input-select";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import { forwardHaptic } from "../../../data/haptics";
@@ -29,14 +29,15 @@ import { handleClick } from "../common/handle-click";
 import { classMap } from "lit-html/directives/class-map";
 import { DOMAINS_HIDE_MORE_INFO } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import { EntitiesCardEntityConfig } from "../cards/types";
 
 @customElement("hui-input-select-entity-row")
 class HuiInputSelectEntityRow extends LitElement implements EntityRow {
   @property() public hass?: HomeAssistant;
 
-  @property() private _config?: EntityConfig;
+  @property() private _config?: EntitiesCardEntityConfig;
 
-  public setConfig(config: EntityConfig): void {
+  public setConfig(config: EntitiesCardEntityConfig): void {
     if (!config || !config.entity) {
       throw new Error("Invalid Configuration: 'entity' required");
     }


### PR DESCRIPTION
Continuation of https://github.com/home-assistant/home-assistant-polymer/pull/3837 (Didn't want to deal with rebase when I'm changing the approach as well)

Docs: https://github.com/home-assistant/home-assistant.io/pull/10826

```yaml
type: entities
entities:
  - entity: sensor.breaking_changes
    hold_action:
      action: url
      url_path: https://www.home-assistant.io
```