### PR TITLE
add icon option to entities card name

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -153,7 +153,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
       }
 
       .icon {
-        padding: 0px 16px 0px 8px;
+        padding: 0px 18px 0px 8px;
       }
     `;
   }

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -85,7 +85,9 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
     return html`
       <ha-card>
-        ${!this._config.title && !this._config.show_header_toggle
+        ${!this._config.title &&
+        !this._config.show_header_toggle &&
+        !this._config.icon
           ? html``
           : html`
               <div class="card-header">

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -82,16 +82,25 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     if (!this._config || !this._hass) {
       return html``;
     }
-    const { show_header_toggle, title } = this._config;
 
     return html`
       <ha-card>
-        ${!title && !show_header_toggle
+        ${!this._config.title && !this._config.show_header_toggle
           ? html``
           : html`
               <div class="card-header">
-                <div class="name">${title}</div>
-                ${show_header_toggle === false
+                <div class="name">
+                  ${this._config.icon
+                    ? html`
+                        <ha-icon
+                          class="icon"
+                          .icon="${this._config.icon}"
+                        ></ha-icon>
+                      `
+                    : ""}
+                  ${this._config.title}
+                </div>
+                ${this._config.show_header_toggle === false
                   ? html``
                   : html`
                       <hui-entities-toggle
@@ -139,6 +148,10 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
       .state-card-dialog {
         cursor: pointer;
+      }
+
+      .icon {
+        padding: 0px 16px 0px 8px;
       }
     `;
   }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -35,6 +35,7 @@ export interface EntitiesCardConfig extends LovelaceCardConfig {
   title?: string;
   entities: EntitiesCardEntityConfig[];
   theme?: string;
+  icon?: string;
 }
 
 export interface EntityButtonCardConfig extends LovelaceCardConfig {


### PR DESCRIPTION
```yaml
entities:
  - entity: media_player.bedroom
type: entities
title: test
icon: 'mdi:home'
```
![image](https://user-images.githubusercontent.com/1287159/66946120-e5afe480-f015-11e9-800d-bded7242bd5f.png)

Docs: https://github.com/home-assistant/home-assistant.io/pull/10835