### PR TITLE
Add margin to data table component

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -435,6 +435,7 @@ export class HaDataTable extends BaseElement {
         display: inline-flex;
         flex-direction: column;
         box-sizing: border-box;
+        margin: 8px;
         overflow-x: auto;
       }
 


### PR DESCRIPTION
It looks a bit nicer and the MDC data table isn't pressed against the edges of the HA data table and the edges on the devices page.