### PR TITLE
Added config title to View Configuration Card

### DIFF
--- a/src/panels/lovelace/editor/view-editor/hui-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-edit-view.ts
@@ -87,6 +87,17 @@ export class HuiEditView extends LitElement {
     return this.shadowRoot!.querySelector("ha-paper-dialog")!;
   }
 
+  private get _viewConfigTitle(): string {
+    let title = this.hass!.localize(
+      "ui.panel.lovelace.editor.edit_view.header"
+    );
+    if (!this._config || !this._config.title || this._config.title === "") {
+      return title;
+    }
+
+    return `${this._config.title} ${title}`;
+  }
+
   protected render(): TemplateResult | void {
     let content;
     switch (this._curTab) {
@@ -118,7 +129,7 @@ export class HuiEditView extends LitElement {
     return html`
       <ha-paper-dialog with-backdrop>
         <h2>
-          ${this.hass!.localize("ui.panel.lovelace.editor.edit_view.header")}
+          ${this._viewConfigTitle}
         </h2>
         <paper-tabs
           scrollable


### PR DESCRIPTION
Fixed #4025 issue to make the 'View Configuration' card more usable.

Added data binding to the config title, so that it would display the title properly, concatenated to the current 'View Configuration' title.

<img width="668" alt="Screen Shot 2019-10-17 at 9 51 16 AM" src="https://user-images.githubusercontent.com/15388788/67030156-af30a300-f0c3-11e9-85d4-ec80515aa6f8.png">
