### PR TITLE
Revise hassio update card design

### DIFF
--- a/hassio/src/dashboard/hassio-update.ts
+++ b/hassio/src/dashboard/hassio-update.ts
@@ -115,7 +115,7 @@ export class HassioUpdate extends LitElement {
                 </div>
               `
             : ""}
-          <div class="update-heading">${name} ${lastVersion} is available</div>
+          <div class="update-heading">${name} ${lastVersion}</div>
           <div class="warning">
             You are currently running version ${curVersion}
           </div>
@@ -172,7 +172,7 @@ export class HassioUpdate extends LitElement {
           margin-bottom: 0.5em;
         }
         .warning {
-          color: var(--google-yellow-700);
+          color: var(--secondary-text-color);
         }
         .card-actions {
           text-align: right;

--- a/hassio/src/dashboard/hassio-update.ts
+++ b/hassio/src/dashboard/hassio-update.ts
@@ -168,7 +168,7 @@ export class HassioUpdate extends LitElement {
         }
         .update-heading {
           font-size: var(--paper-font-subhead_-_font-size);
-          font-weight: bold;
+          font-weight: 500;
           margin-bottom: 0.5em;
         }
         .warning {

--- a/hassio/src/dashboard/hassio-update.ts
+++ b/hassio/src/dashboard/hassio-update.ts
@@ -7,6 +7,7 @@ import {
   property,
   customElement,
 } from "lit-element";
+import "@polymer/iron-icon/iron-icon";
 
 import { HomeAssistant } from "../../../src/types";
 import {
@@ -33,12 +34,15 @@ export class HassioUpdate extends LitElement {
   @property() public error?: string;
 
   protected render(): TemplateResult | void {
-    if (
-      this.hassInfo.version === this.hassInfo.last_version &&
-      this.supervisorInfo.version === this.supervisorInfo.last_version &&
-      (!this.hassOsInfo ||
-        this.hassOsInfo.version === this.hassOsInfo.version_latest)
-    ) {
+    const updatesAvailable: number = [
+      this.hassInfo,
+      this.supervisorInfo,
+      this.hassOsInfo,
+    ].filter((value) => {
+      return !!value && value.version !== value.last_version;
+    }).length;
+
+    if (!updatesAvailable) {
       return html``;
     }
 
@@ -50,6 +54,11 @@ export class HassioUpdate extends LitElement {
             `
           : ""}
         <div class="card-group">
+          <div class="title">
+            ${updatesAvailable > 1
+              ? "Updates Available 🎉"
+              : "Update Available 🎉"}
+          </div>
           ${this._renderUpdateCard(
             "Home Assistant",
             this.hassInfo.version,
@@ -57,7 +66,8 @@ export class HassioUpdate extends LitElement {
             "hassio/homeassistant/update",
             `https://${
               this.hassInfo.last_version.includes("b") ? "rc" : "www"
-            }.home-assistant.io/latest-release-notes/`
+            }.home-assistant.io/latest-release-notes/`,
+            "hassio:home-assistant"
           )}
           ${this._renderUpdateCard(
             "Hass.io Supervisor",
@@ -89,18 +99,31 @@ export class HassioUpdate extends LitElement {
     curVersion: string,
     lastVersion: string,
     apiPath: string,
-    releaseNotesUrl: string
+    releaseNotesUrl: string,
+    icon?: string
   ): TemplateResult {
     if (lastVersion === curVersion) {
       return html``;
     }
     return html`
-      <paper-card heading="${name} update available! 🎉">
+      <paper-card>
         <div class="card-content">
-          ${name} ${lastVersion} is available and you are currently running
-          ${name} ${curVersion}.
+          ${icon
+            ? html`
+                <div class="icon">
+                  <iron-icon .icon="${icon}" />
+                </div>
+              `
+            : ""}
+          <div class="update-heading">${name} ${lastVersion} is available</div>
+          <div class="warning">
+            You are currently running version ${curVersion}
+          </div>
         </div>
         <div class="card-actions">
+          <a href="${releaseNotesUrl}" target="_blank">
+            <mwc-button>Release notes</mwc-button>
+          </a>
           <ha-call-api-button
             .hass=${this.hass}
             .path=${apiPath}
@@ -108,9 +131,6 @@ export class HassioUpdate extends LitElement {
           >
             Update
           </ha-call-api-button>
-          <a href="${releaseNotesUrl}" target="_blank">
-            <mwc-button>Release notes</mwc-button>
-          </a>
         </div>
       </paper-card>
     `;
@@ -139,6 +159,23 @@ export class HassioUpdate extends LitElement {
         paper-card {
           display: inline-block;
           margin-bottom: 32px;
+        }
+        .icon {
+          --iron-icon-height: 48px;
+          --iron-icon-width: 48px;
+          float: right;
+          margin: 0 0 2px 10px;
+        }
+        .update-heading {
+          font-size: var(--paper-font-subhead_-_font-size);
+          font-weight: bold;
+          margin-bottom: 0.5em;
+        }
+        .warning {
+          color: var(--google-yellow-700);
+        }
+        .card-actions {
+          text-align: right;
         }
         .errors {
           color: var(--google-red-500);


### PR DESCRIPTION
See https://github.com/home-assistant/home-assistant-polymer/issues/3916 for the original mockup this change is going for. I don't have the short release note text included yet, perhaps that can be a follow-up PR if/when we can get that data included on the `hassInfo`, `hassOsInfo`, and `supervisorInfo` objects. I'm not sure how to go about doing that, especially if it requires a change in the release process. I also removed the word "available" from the cards because it seemed redundant.

A couple other open questions:
* Do we want icons for the supervisor and HassOS update cards, or just for the Home Assistant card?
* Should the Home Assistant release notes be contextual depending on whether the user can update to a new minor version or just a new patch version (e.g. updating from 0.99.0 to 0.100.1 could display release notes for 0.100, but updating from 0.100.0 to 0.100.1 isn't as helpful to show those same release notes because the user is already using the new features in 0.100.0)
* For the supervisor and HassOS cards, do we include release note text?

Here is the result of the current PR:
![Screen Shot 2019-10-17 at 2 16 28 PM](https://user-images.githubusercontent.com/1522068/67048283-cc2b9d00-f0e8-11e9-9be3-1f07e6ecae7a.png)

