### PR TITLE
Translated developer tools logs page

### DIFF
--- a/src/panels/developer-tools/logs/dialog-system-log-detail.ts
+++ b/src/panels/developer-tools/logs/dialog-system-log-detail.ts
@@ -13,8 +13,10 @@ import "../../../components/dialog/ha-paper-dialog";
 import { SystemLogDetailDialogParams } from "./show-dialog-system-log-detail";
 import { PolymerChangedEvent } from "../../../polymer-types";
 import { haStyleDialog } from "../../../resources/styles";
+import { HomeAssistant } from "../../../types";
 
 class DialogSystemLogDetail extends LitElement {
+  public hass!: HomeAssistant;
   private _params?: SystemLogDetailDialogParams;
 
   static get properties(): PropertyDeclarations {
@@ -40,7 +42,13 @@ class DialogSystemLogDetail extends LitElement {
         opened
         @opened-changed="${this._openedChanged}"
       >
-        <h2>Log Details (${item.level})</h2>
+        <h2>
+          ${this.hass.localize(
+            "ui.panel.developer-tools.tabs.logs.details",
+            "level",
+            item.level
+          )}
+        </h2>
         <paper-dialog-scrollable>
           <p>${new Date(item.timestamp * 1000)}</p>
           ${item.message

--- a/src/panels/developer-tools/logs/error-log-card.ts
+++ b/src/panels/developer-tools/logs/error-log-card.ts
@@ -13,7 +13,7 @@ import { HomeAssistant } from "../../../types";
 import { fetchErrorLog } from "../../../data/error_log";
 
 class ErrorLogCard extends LitElement {
-  public hass?: HomeAssistant;
+  public hass!: HomeAssistant;
   private _errorLog?: string;
 
   static get properties(): PropertyDeclarations {
@@ -35,7 +35,9 @@ class ErrorLogCard extends LitElement {
             `
           : html`
               <mwc-button raised @click=${this._refreshErrorLog}>
-                Load Full Home Assistant Log
+                ${this.hass.localize(
+                  "ui.panel.developer-tools.tabs.logs.load_log"
+                )}
               </mwc-button>
             `}
       </p>
@@ -64,9 +66,12 @@ class ErrorLogCard extends LitElement {
   }
 
   private async _refreshErrorLog(): Promise<void> {
-    this._errorLog = "Loading error log…";
+    this._errorLog = this.hass.localize(
+      "ui.panel.developer-tools.tabs.logs.loading_log"
+    );
     const log = await fetchErrorLog(this.hass!);
-    this._errorLog = log || "No errors have been reported.";
+    this._errorLog =
+      log || this.hass.localize("ui.panel.developer-tools.tabs.logs.no_errors");
   }
 }
 

--- a/src/panels/developer-tools/logs/error-log-card.ts
+++ b/src/panels/developer-tools/logs/error-log-card.ts
@@ -36,7 +36,7 @@ class ErrorLogCard extends LitElement {
           : html`
               <mwc-button raised @click=${this._refreshErrorLog}>
                 ${this.hass.localize(
-                  "ui.panel.developer-tools.tabs.logs.load_log"
+                  "ui.panel.developer-tools.tabs.logs.load_full_log"
                 )}
               </mwc-button>
             `}

--- a/src/panels/developer-tools/logs/system-log-card.ts
+++ b/src/panels/developer-tools/logs/system-log-card.ts
@@ -32,7 +32,7 @@ const formatLogTime = (date, language: string) => {
 
 @customElement("system-log-card")
 export class SystemLogCard extends LitElement {
-  public hass?: HomeAssistant;
+  public hass!: HomeAssistant;
   public loaded = false;
   private _items?: LoggedError[];
 
@@ -61,7 +61,11 @@ export class SystemLogCard extends LitElement {
             : html`
                 ${this._items.length === 0
                   ? html`
-                      <div class="card-content">There are no new issues!</div>
+                      <div class="card-content">
+                        ${this.hass.localize(
+                          "ui.panel.developer-tools.tabs.logs.no_issues"
+                        )}
+                      </div>
                     `
                   : this._items.map(
                       (item) => html`
@@ -78,12 +82,17 @@ export class SystemLogCard extends LitElement {
                               ${item.source} (${item.level})
                               ${item.count > 1
                                 ? html`
-                                    - message first occured at
-                                    ${formatLogTime(
-                                      item.first_occured,
-                                      this.hass!.language
+                                    -
+                                    ${this.hass.localize(
+                                      "ui.panel.developer-tools.tabs.logs.multiple_messages",
+                                      "time",
+                                      formatLogTime(
+                                        item.first_occured,
+                                        this.hass!.language
+                                      ),
+                                      "counter",
+                                      item.count
                                     )}
-                                    and shows up ${item.count} times
                                   `
                                 : html``}
                             </div>
@@ -97,10 +106,14 @@ export class SystemLogCard extends LitElement {
                     .hass=${this.hass}
                     domain="system_log"
                     service="clear"
-                    >Clear</ha-call-service-button
+                    >${this.hass.localize(
+                      "ui.panel.developer-tools.tabs.logs.clear"
+                    )}</ha-call-service-button
                   >
                   <ha-progress-button @click=${this.fetchData}
-                    >Refresh</ha-progress-button
+                    >${this.hass.localize(
+                      "ui.panel.developer-tools.tabs.logs.refresh"
+                    )}</ha-progress-button
                   >
                 </div>
               `}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1783,7 +1783,15 @@
             "title": "Info"
           },
           "logs": {
-            "title": "Logs"
+            "title": "Logs",
+            "details": "Log Details ({level})",
+            "load_log": "Load Full Home Assistant Log",
+            "loading_log": "Loading error log…",
+            "no_errors": "No errors have been reported.",
+            "no_issues": "There are no new issues!",
+            "clear": "Clear",
+            "refresh": "Refresh",
+            "multiple_messages": "message first occurred at {time} and shows up {counter} times"
           },
           "events": {
             "title": "Events",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1785,7 +1785,7 @@
           "logs": {
             "title": "Logs",
             "details": "Log Details ({level})",
-            "load_log": "Load Full Home Assistant Log",
+            "load_full_log": "Load Full Home Assistant Log",
             "loading_log": "Loading error log…",
             "no_errors": "No errors have been reported.",
             "no_issues": "There are no new issues!",


### PR DESCRIPTION
Issue affected: #3429

Description:
- added developer tools logs page translations to src/translations/en.json
- updated dialog-system-log-detail.ts, error-log-card.ts and system-log-card.ts accordingly

Result:
![grafik](https://user-images.githubusercontent.com/46536646/67101698-67dd0c00-f1c2-11e9-8e5b-f033facd12e9.png)
