### PR TITLE
Don't render hidden menu button

### DIFF
--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -49,11 +49,7 @@ class HaMenuButton extends LitElement {
         Object.keys(this.hass.states).some(
           (entityId) => computeDomain(entityId) === "configurator"
         ));
-    if (
-      this.narrow ||
-      this.hass.dockedSidebar === "always_hidden" ||
-      !this._alwaysVisible
-    ) {
+    if (this.narrow || this.hass.dockedSidebar !== "always_hidden") {
       return;
     }
     return html`

--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -49,6 +49,13 @@ class HaMenuButton extends LitElement {
         Object.keys(this.hass.states).some(
           (entityId) => computeDomain(entityId) === "configurator"
         ));
+    if (
+      this.narrow ||
+      this.hass.dockedSidebar === "always_hidden" ||
+      !this._alwaysVisible
+    ) {
+      return;
+    }
     return html`
       <paper-icon-button
         aria-label="Sidebar Toggle"


### PR DESCRIPTION
## Description

Stops rendering of menu button when it is hidden

### Before

![image](https://user-images.githubusercontent.com/28114703/67129308-32521600-f1f6-11e9-9025-21fe388efca5.png)

### After

![image](https://user-images.githubusercontent.com/28114703/67129326-43028c00-f1f6-11e9-92b1-a3fb36f0ecf6.png)
![image](https://user-images.githubusercontent.com/28114703/67129336-4c8bf400-f1f6-11e9-8171-30a66e281b4d.png)
![image](https://user-images.githubusercontent.com/28114703/67129344-5150a800-f1f6-11e9-8918-fb78372612ae.png)
![image](https://user-images.githubusercontent.com/28114703/67129349-57df1f80-f1f6-11e9-95c6-b6bd013b0eb0.png)

Button still works with mobile and 'always hide' checked:

![image](https://user-images.githubusercontent.com/28114703/67129650-231f9800-f1f7-11e9-9524-2f3d54c0e75e.png)
![image](https://user-images.githubusercontent.com/28114703/67129669-316db400-f1f7-11e9-84e5-4f6fbafce8fd.png)
