### PR TITLE
Add hovers (title attrs) to buttons on integrations config entry

### DIFF
--- a/src/panels/config/integrations/config-entry/ha-config-entry-page.ts
+++ b/src/panels/config/integrations/config-entry/ha-config-entry-page.ts
@@ -66,22 +66,6 @@ class HaConfigEntryPage extends LitElement {
       `;
     }
 
-    const settingsButtonLabel = this.hass.localize(
-      "ui.panel.config.integrations.config_entry.settings_button",
-      "integrationTitle",
-      configEntry.title
-    );
-    const systemOptionsButtonLabel = this.hass.localize(
-      "ui.panel.config.integrations.config_entry.system_options_button",
-      "integrationTitle",
-      configEntry.title
-    );
-    const deleteButtonLabel = this.hass.localize(
-      "ui.panel.config.integrations.config_entry.delete_button",
-      "integrationTitle",
-      configEntry.title
-    );
-
     const configEntryDevices = this._computeConfigEntryDevices(
       configEntry,
       this.deviceRegistryEntries
@@ -100,20 +84,32 @@ class HaConfigEntryPage extends LitElement {
                 slot="toolbar-icon"
                 icon="hass:settings"
                 @click=${this._showSettings}
-                title=${settingsButtonLabel}
+                title=${this.hass.localize(
+                  "ui.panel.config.integrations.config_entry.settings_button",
+                  "integration",
+                  configEntry.title
+                )}
               ></paper-icon-button>
             `
           : ""}
         <paper-icon-button
           slot="toolbar-icon"
           icon="hass:message-settings-variant"
-          title=${systemOptionsButtonLabel}
+          title=${this.hass.localize(
+            "ui.panel.config.integrations.config_entry.system_options_button",
+            "integration",
+            configEntry.title
+          )}
           @click=${this._showSystemOptions}
         ></paper-icon-button>
         <paper-icon-button
           slot="toolbar-icon"
           icon="hass:delete"
-          title=${deleteButtonLabel}
+          title=${this.hass.localize(
+            "ui.panel.config.integrations.config_entry.delete_button",
+            "integration",
+            configEntry.title
+          )}
           @click=${this._removeEntry}
         ></paper-icon-button>
 

--- a/src/panels/config/integrations/config-entry/ha-config-entry-page.ts
+++ b/src/panels/config/integrations/config-entry/ha-config-entry-page.ts
@@ -66,6 +66,22 @@ class HaConfigEntryPage extends LitElement {
       `;
     }
 
+    const settingsButtonLabel = this.hass.localize(
+      "ui.panel.config.integrations.config_entry.settings_button",
+      "integrationTitle",
+      configEntry.title
+    );
+    const systemOptionsButtonLabel = this.hass.localize(
+      "ui.panel.config.integrations.config_entry.system_options_button",
+      "integrationTitle",
+      configEntry.title
+    );
+    const deleteButtonLabel = this.hass.localize(
+      "ui.panel.config.integrations.config_entry.delete_button",
+      "integrationTitle",
+      configEntry.title
+    );
+
     const configEntryDevices = this._computeConfigEntryDevices(
       configEntry,
       this.deviceRegistryEntries
@@ -84,17 +100,20 @@ class HaConfigEntryPage extends LitElement {
                 slot="toolbar-icon"
                 icon="hass:settings"
                 @click=${this._showSettings}
+                title=${settingsButtonLabel}
               ></paper-icon-button>
             `
           : ""}
         <paper-icon-button
           slot="toolbar-icon"
           icon="hass:message-settings-variant"
+          title=${systemOptionsButtonLabel}
           @click=${this._showSystemOptions}
         ></paper-icon-button>
         <paper-icon-button
           slot="toolbar-icon"
           icon="hass:delete"
+          title=${deleteButtonLabel}
           @click=${this._removeEntry}
         ></paper-icon-button>
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1187,9 +1187,9 @@
           "configure": "Configure",
           "none": "Nothing configured yet",
           "config_entry": {
-            "settings_button": "Edit settings for {integrationTitle}",
-            "system_options_button": "System options for {integrationTitle}",
-            "delete_button": "Delete {integrationTitle}",
+            "settings_button": "Edit settings for {integration}",
+            "system_options_button": "System options for {integration}",
+            "delete_button": "Delete {integration}",
             "no_devices": "This integration has no devices.",
             "no_device": "Entities without devices",
             "delete_confirm": "Are you sure you want to delete this integration?",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1187,6 +1187,9 @@
           "configure": "Configure",
           "none": "Nothing configured yet",
           "config_entry": {
+            "settings_button": "Edit settings for {integrationTitle}",
+            "system_options_button": "System options for {integrationTitle}",
+            "delete_button": "Delete {integrationTitle}",
             "no_devices": "This integration has no devices.",
             "no_device": "Entities without devices",
             "delete_confirm": "Are you sure you want to delete this integration?",


### PR DESCRIPTION
Resolves #4047

Hovering over buttons:
![image](https://user-images.githubusercontent.com/5158502/67138245-43e6ee00-f1f5-11e9-9501-5aab083af353.png)

Voiceover now reads what the button is instead of just button:
![image](https://user-images.githubusercontent.com/5158502/67138258-5fea8f80-f1f5-11e9-9070-4ddeeab95825.png)

I'm assuming `configEntry.title` is safe to use as it is set as the panel header on L80 (`.header=${configEntry.title}`).