### PR TITLE
Move Home Assistant and version on info page into h2

### DIFF
--- a/src/panels/developer-tools/info/developer-tools-info.ts
+++ b/src/panels/developer-tools/info/developer-tools-info.ts
@@ -48,8 +48,7 @@ class HaPanelDevInfo extends LitElement {
               alt="Home Assistant logo"
           /></a>
           <br />
-          Home Assistant<br />
-          ${hass.config.version}
+          <h2>Home Assistant ${hass.config.version}</h2>
         </p>
         <p>
           Path to configuration.yaml: ${hass.config.config_dir}
@@ -92,21 +91,23 @@ class HaPanelDevInfo extends LitElement {
         </p>
         <p>
           Frontend version: ${JS_VERSION} - ${JS_TYPE}
-          ${customUiList.length > 0
-            ? html`
-                <div>
-                  Custom UIs:
-                  ${customUiList.map(
-                    (item) => html`
-                      <div>
-                        <a href="${item.url}" target="_blank"> ${item.name}</a>:
-                        ${item.version}
-                      </div>
-                    `
-                  )}
-                </div>
-              `
-            : ""}
+          ${
+            customUiList.length > 0
+              ? html`
+                  <div>
+                    Custom UIs:
+                    ${customUiList.map(
+                      (item) => html`
+                        <div>
+                          <a href="${item.url}" target="_blank"> ${item.name}</a
+                          >: ${item.version}
+                        </div>
+                      `
+                    )}
+                  </div>
+                `
+              : ""
+          }
         </p>
         <p>
           <a href="${nonDefaultLink}">${nonDefaultLinkText}</a><br />


### PR DESCRIPTION
This resolves #4048

This PR removes the line break between Home Assistant and the version number and wraps them in a `h2`.

Before:
![image](https://user-images.githubusercontent.com/5158502/67138346-a391c900-f1f6-11e9-9ace-48e81d7490e9.png)

After:
![image](https://user-images.githubusercontent.com/5158502/67138348-a8567d00-f1f6-11e9-9c1d-cc6f3d6054d1.png)

Prettier formatted some stuff when I saved.  Assuming this is OK 🤷‍♂ 