### PR TITLE
Hide "Save" on card configuration modal if no card is picked

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -117,16 +117,20 @@ export class HuiDialogEditCard extends LitElement {
           <mwc-button @click="${this._close}">
             ${this.hass!.localize("ui.common.cancel")}
           </mwc-button>
-          <mwc-button
-            ?disabled="${!this._canSave || this._saving}"
-            @click="${this._save}"
-          >
-            ${this._saving
-              ? html`
-                  <paper-spinner active alt="Saving"></paper-spinner>
-                `
-              : this.hass!.localize("ui.common.save")}
-          </mwc-button>
+          ${this._cardConfig !== undefined
+            ? html`
+                <mwc-button
+                  ?disabled="${!this._canSave || this._saving}"
+                  @click="${this._save}"
+                >
+                  ${this._saving
+                    ? html`
+                        <paper-spinner active alt="Saving"></paper-spinner>
+                      `
+                    : this.hass!.localize("ui.common.save")}
+                </mwc-button>
+              `
+            : ``}
         </div>
       </ha-paper-dialog>
     `;


### PR DESCRIPTION
This resolves #4044

This PR hides the save button when the _cardConfig is undefined so if the user has not selected a card to add yet they won't see a disabled save button.

![no-save-save](https://user-images.githubusercontent.com/5158502/67138543-cd98ba80-f1f9-11e9-999b-bb031bb067ca.gif)
