### PR TITLE
Changed outdated "GUI editor" reference to "visual editor"

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -229,7 +229,7 @@ export class HuiCardEditor extends LitElement {
           configElement = await elClass.getConfigElement();
         } else {
           configElement = undefined;
-          throw Error(`WARNING: No GUI editor available for: ${cardType}`);
+          throw Error(`WARNING: No visual editor available for: ${cardType}`);
         }
 
         this._configElement = configElement;


### PR DESCRIPTION
Changed warning text from "GUI editor" to "visual editor" to match the updated naming being used in card editors.
