### PR TITLE
Added view title to heading of Lovelace Add Card picker

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -49,9 +49,6 @@ export class HuiCardPicker extends LitElement {
 
   protected render(): TemplateResult | void {
     return html`
-      <h3>
-        ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card")}
-      </h3>
       <div class="cards-container">
         ${cards.map((card: string) => {
           return html`

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -68,9 +68,16 @@ export class HuiDialogEditCard extends LitElement {
         `ui.panel.lovelace.editor.card.${this._cardConfig.type}.name`
       )} ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.header")}`;
     } else {
-      heading = this.hass!.localize(
-        "ui.panel.lovelace.editor.edit_card.header"
-      );
+      let viewTitle = this._params.lovelace.config.views[this._params.path[0]]
+        .title;
+      heading =
+        viewTitle !== undefined && viewTitle !== ""
+          ? this.hass!.localize(
+              "ui.panel.lovelace.editor.edit_card.pick_card_view_title",
+              "name",
+              '"' + viewTitle + '"'
+            )
+          : this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card");
     }
 
     return html`

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -70,15 +70,18 @@ export class HuiDialogEditCard extends LitElement {
       heading = `${this.hass!.localize(
         `ui.panel.lovelace.editor.card.${this._cardConfig.type}.name`
       )} ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.header")}`;
+    } else if (!this._cardConfig) {
+      heading = this._viewConfig.title
+        ? this.hass!.localize(
+            "ui.panel.lovelace.editor.edit_card.pick_card_view_title",
+            "name",
+            '"' + this._viewConfig.title + '"'
+          )
+        : this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card");
     } else {
-      heading =
-        !this._cardConfig && this._viewConfig.title
-          ? this.hass!.localize(
-              "ui.panel.lovelace.editor.edit_card.pick_card_view_title",
-              "name",
-              '"' + this._viewConfig.title + '"'
-            )
-          : this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card");
+      heading = this.hass!.localize(
+        "ui.panel.lovelace.editor.edit_card.header"
+      );
     }
 
     return html`

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -10,7 +10,10 @@ import {
 
 import { HomeAssistant } from "../../../../types";
 import { HASSDomEvent } from "../../../../common/dom/fire_event";
-import { LovelaceCardConfig } from "../../../../data/lovelace";
+import {
+  LovelaceCardConfig,
+  LovelaceViewConfig,
+} from "../../../../data/lovelace";
 import "./hui-card-editor";
 // tslint:disable-next-line
 import { HuiCardEditor } from "./hui-card-editor";
@@ -40,6 +43,7 @@ export class HuiDialogEditCard extends LitElement {
   @property() private _params?: EditCardDialogParams;
 
   @property() private _cardConfig?: LovelaceCardConfig;
+  @property() private _view!: LovelaceViewConfig;
 
   @property() private _saving: boolean = false;
   @property() private _error?: string;
@@ -47,10 +51,8 @@ export class HuiDialogEditCard extends LitElement {
   public async showDialog(params: EditCardDialogParams): Promise<void> {
     this._params = params;
     const [view, card] = params.path;
-    this._cardConfig =
-      card !== undefined
-        ? params.lovelace.config.views[view].cards![card]
-        : undefined;
+    this._view = params.lovelace.config.views[view];
+    this._cardConfig = card !== undefined ? this._view.cards![card] : undefined;
   }
 
   private get _cardEditorEl(): HuiCardEditor | null {
@@ -68,14 +70,12 @@ export class HuiDialogEditCard extends LitElement {
         `ui.panel.lovelace.editor.card.${this._cardConfig.type}.name`
       )} ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.header")}`;
     } else {
-      let viewTitle = this._params.lovelace.config.views[this._params.path[0]]
-        .title;
       heading =
-        viewTitle !== undefined && viewTitle !== ""
+        this._view.title !== undefined && this._view.title !== ""
           ? this.hass!.localize(
               "ui.panel.lovelace.editor.edit_card.pick_card_view_title",
               "name",
-              '"' + viewTitle + '"'
+              '"' + this._view.title + '"'
             )
           : this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card");
     }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -43,7 +43,7 @@ export class HuiDialogEditCard extends LitElement {
   @property() private _params?: EditCardDialogParams;
 
   @property() private _cardConfig?: LovelaceCardConfig;
-  @property() private _view!: LovelaceViewConfig;
+  @property() private _viewConfig!: LovelaceViewConfig;
 
   @property() private _saving: boolean = false;
   @property() private _error?: string;
@@ -51,8 +51,9 @@ export class HuiDialogEditCard extends LitElement {
   public async showDialog(params: EditCardDialogParams): Promise<void> {
     this._params = params;
     const [view, card] = params.path;
-    this._view = params.lovelace.config.views[view];
-    this._cardConfig = card !== undefined ? this._view.cards![card] : undefined;
+    this._viewConfig = params.lovelace.config.views[view];
+    this._cardConfig =
+      card !== undefined ? this._viewConfig.cards![card] : undefined;
   }
 
   private get _cardEditorEl(): HuiCardEditor | null {
@@ -71,11 +72,11 @@ export class HuiDialogEditCard extends LitElement {
       )} ${this.hass!.localize("ui.panel.lovelace.editor.edit_card.header")}`;
     } else {
       heading =
-        this._view.title !== undefined && this._view.title !== ""
+        !this._cardConfig && this._viewConfig.title
           ? this.hass!.localize(
               "ui.panel.lovelace.editor.edit_card.pick_card_view_title",
               "name",
-              '"' + this._view.title + '"'
+              '"' + this._viewConfig.title + '"'
             )
           : this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card");
     }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -75,7 +75,7 @@ export class HuiDialogEditCard extends LitElement {
         ? this.hass!.localize(
             "ui.panel.lovelace.editor.edit_card.pick_card_view_title",
             "name",
-            '"' + this._viewConfig.title + '"'
+            `"${this._viewConfig.title}"`
           )
         : this.hass!.localize("ui.panel.lovelace.editor.edit_card.pick_card");
     } else {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1403,7 +1403,8 @@
           },
           "edit_card": {
             "header": "Card Configuration",
-            "pick_card": "Pick the card you want to add.",
+            "pick_card": "Which card would you like to add?",
+            "pick_card_view_title": "Which card would you like to add to your {name} view?",
             "toggle_editor": "Toggle Editor",
             "show_visual_editor": "Show Visual Editor",
             "show_code_editor": "Show Code Editor",


### PR DESCRIPTION
Fixes #4029

Description:
- removed heading from hui-card-picker.ts
- added and updated translations key-value pairs for the Add Card picker heading in src/translations/en.json
- updated the H3 heading in hui-dialog-edit-card.ts accordingly

Results:
![withtitle](https://user-images.githubusercontent.com/46536646/67163666-ec21c180-f371-11e9-8528-124eef64c8cd.PNG)
![withouttitle](https://user-images.githubusercontent.com/46536646/67163668-ee841b80-f371-11e9-844e-f7145a411257.PNG)
