### PR TITLE
Fix for Zone icon visibility on Map panel and Lovelace Map card

### DIFF
--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -327,17 +327,13 @@ class HuiMapCard extends LitElement implements LovelaceCard {
 
         // create icon
         let iconHTML = "";
-        const iconColor =
-          this._config!.dark_mode === true ? "#FFFFFF" : "#000000";
         if (icon) {
           const el = document.createElement("ha-icon");
           el.setAttribute("icon", icon);
-          el.style.color = iconColor;
           iconHTML = el.outerHTML;
         } else {
           const el = document.createElement("span");
           el.innerHTML = title;
-          el.style.color = iconColor;
           iconHTML = el.outerHTML;
         }
 
@@ -347,7 +343,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
             icon: Leaflet.divIcon({
               html: iconHTML,
               iconSize: [24, 24],
-              className: "",
+              className: this._config!.dark_mode === true ? "dark" : "light",
             }),
             interactive: false,
             title,
@@ -470,6 +466,14 @@ class HuiMapCard extends LitElement implements LovelaceCard {
 
       :host([ispanel]) #root {
         height: 100%;
+      }
+
+      .dark {
+        color: #ffffff;
+      }
+
+      .light {
+        color: #000000;
       }
     `;
   }

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -325,11 +325,27 @@ class HuiMapCard extends LitElement implements LovelaceCard {
           continue;
         }
 
+        // create icon
+        var iconHTML = "";
+        var iconColor =
+          this._config!.dark_mode === true ? "#FFFFFF" : "#000000";
+        if (icon) {
+          const el = document.createElement("ha-icon");
+          el.setAttribute("icon", icon);
+          el.style.color = iconColor;
+          iconHTML = el.outerHTML;
+        } else {
+          const el = document.createElement("span");
+          el.innerHTML = title;
+          el.style.color = iconColor;
+          iconHTML = el.outerHTML;
+        }
+
         // create marker with the icon
         mapItems.push(
           Leaflet.marker([latitude, longitude], {
             icon: Leaflet.divIcon({
-              html: icon ? `<ha-icon icon="${icon}"></ha-icon>` : title,
+              html: iconHTML,
               iconSize: [24, 24],
               className: "",
             }),

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -326,8 +326,8 @@ class HuiMapCard extends LitElement implements LovelaceCard {
         }
 
         // create icon
-        var iconHTML = "";
-        var iconColor =
+        let iconHTML = "";
+        const iconColor =
           this._config!.dark_mode === true ? "#FFFFFF" : "#000000";
         if (icon) {
           const el = document.createElement("ha-icon");

--- a/src/panels/map/ha-panel-map.js
+++ b/src/panels/map/ha-panel-map.js
@@ -24,6 +24,10 @@ class HaPanelMap extends LocalizeMixin(PolymerElement) {
           width: 100%;
           z-index: 0;
         }
+
+        .light {
+          color: #000000;
+        }
       </style>
 
       <app-toolbar>
@@ -118,19 +122,17 @@ class HaPanelMap extends LocalizeMixin(PolymerElement) {
         if (entity.attributes.icon) {
           const el = document.createElement("ha-icon");
           el.setAttribute("icon", entity.attributes.icon);
-          el.style.color = "#000000";
           iconHTML = el.outerHTML;
         } else {
           const el = document.createElement("span");
           el.innerHTML = title;
-          el.style.color = "#000000";
           iconHTML = el.outerHTML;
         }
 
         icon = this.Leaflet.divIcon({
           html: iconHTML,
           iconSize: [24, 24],
-          className: "",
+          className: "light",
         });
 
         // create marker with the icon

--- a/src/panels/map/ha-panel-map.js
+++ b/src/panels/map/ha-panel-map.js
@@ -121,7 +121,10 @@ class HaPanelMap extends LocalizeMixin(PolymerElement) {
           el.style.color = "#000000";
           iconHTML = el.outerHTML;
         } else {
-          iconHTML = title;
+          const el = document.createElement("span");
+          el.innerHTML = title;
+          el.style.color = "#000000";
+          iconHTML = el.outerHTML;
         }
 
         icon = this.Leaflet.divIcon({
@@ -130,7 +133,7 @@ class HaPanelMap extends LocalizeMixin(PolymerElement) {
           className: "",
         });
 
-        // create market with the icon
+        // create marker with the icon
         mapItems.push(
           this.Leaflet.marker(
             [entity.attributes.latitude, entity.attributes.longitude],

--- a/src/panels/map/ha-panel-map.js
+++ b/src/panels/map/ha-panel-map.js
@@ -118,6 +118,7 @@ class HaPanelMap extends LocalizeMixin(PolymerElement) {
         if (entity.attributes.icon) {
           const el = document.createElement("ha-icon");
           el.setAttribute("icon", entity.attributes.icon);
+          el.style.color = "#000000";
           iconHTML = el.outerHTML;
         } else {
           iconHTML = title;


### PR DESCRIPTION
Fixes #3409

Description:
- Default map panel: icon color hardcoded to black e.g `#000000`
- Lovelace Map card: icon color depends on darkMode setting:
  - darkMode is set - icon color is `#FFFFFF` 
  - darkMode is not set - icon color is `#000000`

Results with default and [slate](https://github.com/seangreen2/slate_theme) theme:
- Default map panel:
![map](https://user-images.githubusercontent.com/46536646/67165964-627eed80-f38b-11e9-9fef-a361092a7841.PNG)

- Lovelace Map Card:
![default_white](https://user-images.githubusercontent.com/46536646/67165933-18960780-f38b-11e9-8f68-4bb284e3eda1.PNG)
![default_black](https://user-images.githubusercontent.com/46536646/67165950-3c594d80-f38b-11e9-8781-425761e772ab.PNG)