### PR TITLE
revert lovelace selectable text

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -73,14 +73,6 @@ class HUIRoot extends LitElement {
     );
   }
 
-  protected firstUpdated(changedProperties: PropertyValues): void {
-    super.firstUpdated(changedProperties);
-    this.classList.toggle(
-      "disable-text-select",
-      /Chrome/.test(navigator.userAgent) && /Android/.test(navigator.userAgent)
-    );
-  }
-
   protected render(): TemplateResult | void {
     return html`
     <app-route .route="${this.route}" pattern="/:view" data="${
@@ -321,9 +313,6 @@ class HUIRoot extends LitElement {
         :host {
           --dark-color: #455a64;
           --text-dark-color: #fff;
-        }
-
-        :host(.disable-text-select) {
           -ms-user-select: none;
           -webkit-user-select: none;
           -moz-user-select: none;


### PR DESCRIPTION
fixes https://github.com/home-assistant/home-assistant-polymer/issues/4092#issuecomment-544698898

As notifications have been moved out of core lovelace, I don't see a value in being to select text, actually. Didn't realize this when I initially did this first PR. Can't think of a good reason to have selectable text outside of notifications for things like IR codes.