### PR TITLE
Fix link to translation documentation

### DIFF
--- a/translations/README.md
+++ b/translations/README.md
@@ -1,4 +1,4 @@
 # Translation Resources
-Translations are managed through [Lokalise](https://lokalise.co/). If you'd like to contribute, you can [join the project here](https://lokalise.co/signup/3420425759f6d6d241f598.13594006/all/). For more details, see our [translation guidelines documentation](https://home-assistant.io/developers/frontend_translation/).
+Translations are managed through [Lokalise](https://lokalise.co/). If you'd like to contribute, you can [join the project here](https://lokalise.co/signup/3420425759f6d6d241f598.13594006/all/). For more details, see our [translation guidelines documentation](https://developers.home-assistant.io/docs/en/internationalization_translation.html).
 
 Don't make changes to these files directly. Instead, use `script/translations_download` to fetch the latest translations from Lokalise.


### PR DESCRIPTION
The link pointed to the old developer docs, so I changed it to the new URL.