### PR TITLE
Fix issue where long states do not wrap

### DIFF
--- a/src/state-summary/state-card-display.js
+++ b/src/state-summary/state-card-display.js
@@ -39,6 +39,7 @@ class StateCardDisplay extends LocalizeMixin(PolymerElement) {
           text-align: right;
           max-width: 40%;
           flex: 0 0 auto;
+          overflow-wrap: break-word;
         }
         :host([rtl]) .state {
           margin-right: 16px;


### PR DESCRIPTION
This resolves #4099 

Note:  In instances where there is a measurement it looks like we are preventing wrapping from happening

```
        .state.has-unit_of_measurement {
          white-space: nowrap;
        }
```

This doesn't seem like a big deal in most instances but worth noting.  This seemed pretty intentional so I didn't change it.  

This PR fixes the instance where state text w/ no unit of measurement is long breaking out of the more info modal.

![image](https://user-images.githubusercontent.com/5158502/67259545-42166800-f44b-11e9-8f67-b61bbc8c0f53.png)
