### PR TITLE
Adds a white background to the QR code for MFA

### DIFF
--- a/src/panels/profile/ha-mfa-module-setup-flow.js
+++ b/src/panels/profile/ha-mfa-module-setup-flow.js
@@ -30,6 +30,7 @@ class HaMfaModuleSetupFlow extends LocalizeMixin(EventsMixin(PolymerElement)) {
         }
         ha-markdown img:first-child:last-child,
         ha-markdown svg:first-child:last-child {
+          background-color: white;
           display: block;
           margin: 0 auto;
         }


### PR DESCRIPTION
Fixes #4104 so dark themes do not make the QR code difficult/impossible to scan