### PR TITLE
✨ Add card option to more-info action to show a dialog with specified card in it

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -63,15 +63,11 @@ export interface UrlActionConfig extends BaseActionConfig {
 
 export interface MoreInfoActionConfig extends BaseActionConfig {
   action: "more-info";
+  card?: LovelaceCardConfig;
 }
 
 export interface NoActionConfig extends BaseActionConfig {
   action: "none";
-}
-
-export interface CardActionConfig extends BaseActionConfig {
-  action: "card";
-  card: LovelaceCardConfig;
 }
 
 export interface BaseActionConfig {
@@ -93,8 +89,7 @@ export type ActionConfig =
   | NavigateActionConfig
   | UrlActionConfig
   | MoreInfoActionConfig
-  | NoActionConfig
-  | CardActionConfig;
+  | NoActionConfig;
 
 export const fetchConfig = (
   conn: Connection,

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -69,6 +69,11 @@ export interface NoActionConfig extends BaseActionConfig {
   action: "none";
 }
 
+export interface CardActionConfig extends BaseActionConfig {
+  action: "card";
+  card: LovelaceCardConfig;
+}
+
 export interface BaseActionConfig {
   confirmation?: ConfirmationRestrictionConfig;
 }
@@ -88,7 +93,8 @@ export type ActionConfig =
   | NavigateActionConfig
   | UrlActionConfig
   | MoreInfoActionConfig
-  | NoActionConfig;
+  | NoActionConfig
+  | CardActionConfig;
 
 export const fetchConfig = (
   conn: Connection,

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -83,13 +83,19 @@ export interface RestrictionConfig {
   user: string;
 }
 
+export interface CardActionConfig extends BaseActionConfig {
+  action: "card";
+  card: LovelaceCardConfig;
+}
+
 export type ActionConfig =
   | ToggleActionConfig
   | CallServiceActionConfig
   | NavigateActionConfig
   | UrlActionConfig
   | MoreInfoActionConfig
-  | NoActionConfig;
+  | NoActionConfig
+  | CardActionConfig;
 
 export const fetchConfig = (
   conn: Connection,

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -55,9 +55,7 @@ export const handleAction = (
 
   switch (actionConfig.action) {
     case "more-info":
-      if (actionConfig.card) {
-        showCardDialog(node, { card: actionConfig.card });
-      } else if (config.entity || config.camera_image) {
+      if (config.entity || config.camera_image) {
         fireEvent(node, "hass-more-info", {
           entityId: config.entity ? config.entity : config.camera_image!,
         });
@@ -87,6 +85,11 @@ export const handleAction = (
       const [domain, service] = actionConfig.service.split(".", 2);
       hass.callService(domain, service, actionConfig.service_data);
       forwardHaptic("light");
+      break;
+    case "card":
+      if (actionConfig.card) {
+        showCardDialog(node, { card: actionConfig.card });
+      }
       break;
   }
 };

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -55,7 +55,9 @@ export const handleAction = (
 
   switch (actionConfig.action) {
     case "more-info":
-      if (config.entity || config.camera_image) {
+      if (actionConfig.card) {
+        showCardDialog(node, { card: actionConfig.card });
+      } else if (config.entity || config.camera_image) {
         fireEvent(node, "hass-more-info", {
           entityId: config.entity ? config.entity : config.camera_image!,
         });
@@ -85,11 +87,6 @@ export const handleAction = (
       const [domain, service] = actionConfig.service.split(".", 2);
       hass.callService(domain, service, actionConfig.service_data);
       forwardHaptic("light");
-      break;
-    case "card":
-      if (actionConfig.card) {
-        showCardDialog(node, { card: actionConfig.card });
-      }
       break;
   }
 };

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -4,6 +4,7 @@ import { navigate } from "../../../common/navigate";
 import { toggleEntity } from "./entity/toggle-entity";
 import { ActionConfig } from "../../../data/lovelace";
 import { forwardHaptic } from "../../../data/haptics";
+import { showCardDialog } from "../dialogs/card/show-dialog-card";
 
 export const handleAction = (
   node: HTMLElement,
@@ -76,7 +77,7 @@ export const handleAction = (
         forwardHaptic("light");
       }
       break;
-    case "call-service": {
+    case "call-service":
       if (!actionConfig.service) {
         forwardHaptic("failure");
         return;
@@ -84,6 +85,11 @@ export const handleAction = (
       const [domain, service] = actionConfig.service.split(".", 2);
       hass.callService(domain, service, actionConfig.service_data);
       forwardHaptic("light");
-    }
+      break;
+    case "card":
+      if (actionConfig.card) {
+        showCardDialog(node, { card: actionConfig.card });
+      }
+      break;
   }
 };

--- a/src/panels/lovelace/dialogs/card/dialog-card.ts
+++ b/src/panels/lovelace/dialogs/card/dialog-card.ts
@@ -1,0 +1,85 @@
+import {
+  LitElement,
+  html,
+  css,
+  CSSResult,
+  TemplateResult,
+  customElement,
+  property,
+} from "lit-element";
+import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
+
+import "../../../../components/dialog/ha-paper-dialog";
+
+import { HomeAssistant } from "../../../../types";
+import { PolymerChangedEvent } from "../../../../polymer-types";
+import { haStyleDialog } from "../../../../resources/styles";
+import { CardDialogParams } from "./show-dialog-card";
+import { LovelaceCardConfig } from "../../../../data/lovelace";
+import { createCardElement } from "../../common/create-card-element";
+
+@customElement("dialog-card")
+class DialogCard extends LitElement {
+  @property() public hass!: HomeAssistant;
+  @property() private _params?: CardDialogParams;
+
+  public async showDialog(params: CardDialogParams): Promise<void> {
+    this._params = params;
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this._params) {
+      return html``;
+    }
+
+    return html`
+      <ha-paper-dialog
+        with-backdrop
+        opened
+        @opened-changed="${this._openedChanged}"
+      >
+        ${this._renderCard(this._params.card)}
+      </ha-paper-dialog>
+    `;
+  }
+
+  private _renderCard(config: LovelaceCardConfig): TemplateResult {
+    const element = createCardElement(config);
+    if (this.hass) {
+      element.hass = this.hass;
+    }
+
+    return html`
+      ${element}
+    `;
+  }
+
+  private _openedChanged(ev: PolymerChangedEvent<boolean>): void {
+    if (!(ev.detail as any).value) {
+      this._params = undefined;
+    }
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        ha-paper-dialog {
+          min-width: 400px;
+          max-width: 500px;
+        }
+        @media (max-width: 400px) {
+          ha-paper-dialog {
+            min-width: initial;
+          }
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-card": DialogCard;
+  }
+}

--- a/src/panels/lovelace/dialogs/card/dialog-card.ts
+++ b/src/panels/lovelace/dialogs/card/dialog-card.ts
@@ -17,14 +17,24 @@ import { haStyleDialog } from "../../../../resources/styles";
 import { CardDialogParams } from "./show-dialog-card";
 import { LovelaceCardConfig } from "../../../../data/lovelace";
 import { createCardElement } from "../../common/create-card-element";
+import { LovelaceCard } from "../../types";
 
 @customElement("dialog-card")
 class DialogCard extends LitElement {
-  @property() public hass!: HomeAssistant;
+  @property() private _hass!: HomeAssistant;
   @property() private _params?: CardDialogParams;
 
   public async showDialog(params: CardDialogParams): Promise<void> {
     this._params = params;
+  }
+
+  set hass(hass: HomeAssistant) {
+    this._hass = hass;
+
+    const element = this.shadowRoot!.querySelector("#card > *") as LovelaceCard;
+    if (element) {
+      element.hass = hass;
+    }
   }
 
   protected render(): TemplateResult | void {
@@ -34,7 +44,7 @@ class DialogCard extends LitElement {
 
     return html`
       <ha-paper-dialog
-        with-backdrop
+        id="card"
         opened
         @opened-changed="${this._openedChanged}"
       >
@@ -45,8 +55,8 @@ class DialogCard extends LitElement {
 
   private _renderCard(config: LovelaceCardConfig): TemplateResult {
     const element = createCardElement(config);
-    if (this.hass) {
-      element.hass = this.hass;
+    if (this._hass) {
+      element.hass = this._hass;
     }
 
     return html`

--- a/src/panels/lovelace/dialogs/card/show-dialog-card.ts
+++ b/src/panels/lovelace/dialogs/card/show-dialog-card.ts
@@ -1,0 +1,20 @@
+import { LovelaceCardConfig } from "../../../../data/lovelace";
+import { fireEvent } from "../../../../common/dom/fire_event";
+
+export interface CardDialogParams {
+  card: LovelaceCardConfig;
+}
+
+export const loadCardDialog = () =>
+  import(/* webpackChunkName: "confirmation" */ "./dialog-card");
+
+export const showCardDialog = (
+  element: HTMLElement,
+  dialogParams: CardDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-card",
+    dialogImport: loadCardDialog,
+    dialogParams,
+  });
+};


### PR DESCRIPTION
Allows you to create a dialog with a card in it.

```yaml
type: entity-button
tap_action:
  action: toggle
hold_action:
  action: card
  card:
    type: entity-button
    entity: light.kitchen
double_tap_action:
  action: more-info
show_icon: true
show_name: true
entity: light.kitchen
```
![image](https://user-images.githubusercontent.com/1287159/67454844-4c726680-f5f1-11e9-9f46-a647a3bb07c3.png)
Should probably remove that bottom padding

Closes https://github.com/home-assistant/home-assistant-polymer/issues/3998
Docs: TODO