### PR TITLE
Fix variable column widths

### DIFF
--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -133,9 +133,9 @@ export class HUIView extends LitElement {
         }
 
         .column {
-          flex-basis: 0;
-          flex-grow: 1;
+          flex: 1 0 0;
           max-width: 500px;
+          min-width: 0;
         }
 
         .column > * {


### PR DESCRIPTION
Caused by https://github.com/home-assistant/home-assistant-polymer/pull/3971, setting `min-width` to `0` should make sure the columns don't grow and still prevent the scrollbars from showing.
Fixes https://github.com/home-assistant/home-assistant-polymer/issues/4125