### PR TITLE
bring custom text-divider row to core

### DIFF
--- a/src/panels/lovelace/common/create-row-element.ts
+++ b/src/panels/lovelace/common/create-row-element.ts
@@ -25,6 +25,7 @@ import "../entity-rows/hui-toggle-entity-row";
 import "../special-rows/hui-call-service-row";
 import "../special-rows/hui-divider-row";
 import "../special-rows/hui-section-row";
+import "../special-rows/hui-text-divider-row";
 import "../special-rows/hui-weblink-row";
 import "../special-rows/hui-cast-row";
 import { EntityConfig, EntityRow } from "../entity-rows/types";
@@ -37,6 +38,7 @@ const SPECIAL_TYPES = new Set([
   "weblink",
   "cast",
   "select",
+  "text-divider",
 ]);
 const DOMAIN_TO_ELEMENT_TYPE = {
   alert: "toggle",

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -14,6 +14,10 @@ export interface DividerConfig {
   type: "divider";
   style: string;
 }
+export interface TextDividerConfig {
+  type: "divider";
+  label: string;
+}
 export interface SectionConfig {
   type: "section";
   label: string;

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -13,6 +13,7 @@ export interface EntityFilterEntityConfig extends EntityConfig {
 export interface DividerConfig {
   type: "divider";
   style: string;
+  label?: string;
 }
 export interface TextDividerConfig {
   type: "divider";

--- a/src/panels/lovelace/special-rows/hui-divider-row.ts
+++ b/src/panels/lovelace/special-rows/hui-divider-row.ts
@@ -4,10 +4,13 @@ import {
   TemplateResult,
   customElement,
   property,
+  CSSResult,
+  css,
 } from "lit-element";
 
 import { EntityRow, DividerConfig } from "../entity-rows/types";
 import { HomeAssistant } from "../../../types";
+import { styleMap } from "lit-html/directives/style-map";
 
 @customElement("hui-divider-row")
 class HuiDividerRow extends LitElement implements EntityRow {
@@ -21,10 +24,6 @@ class HuiDividerRow extends LitElement implements EntityRow {
     }
 
     this._config = {
-      style: {
-        height: "1px",
-        "background-color": "var(--secondary-text-color)",
-      },
       ...config,
     };
   }
@@ -34,14 +33,47 @@ class HuiDividerRow extends LitElement implements EntityRow {
       return html``;
     }
 
-    const el = document.createElement("div");
+    const style = {};
 
-    Object.keys(this._config.style).forEach((prop) => {
-      el.style.setProperty(prop, this._config!.style[prop]);
-    });
+    if (this._config.style) {
+      Object.keys(this._config.style).forEach((prop) => {
+        style[prop] = this._config!.style[prop];
+      });
+    }
 
     return html`
-      ${el}
+      <h2 class="text-divider" style=${styleMap(style)}>
+        ${this._config.label
+          ? html`
+              <span>${this._config.label}</span>
+            `
+          : ""}
+      </h2>
+    `;
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      .text-divider {
+        margin: 1em 0;
+        line-height: 0;
+        text-align: center;
+        white-space: nowrap;
+        display: flex;
+        align-items: center;
+      }
+      .text-divider span {
+        padding: 1em;
+        color: var(--secondary-text-color);
+      }
+      .text-divider:before,
+      .text-divider:after {
+        content: "";
+        background: var(--secondary-text-color);
+        display: block;
+        height: 1px;
+        width: 100%;
+      }
     `;
   }
 }

--- a/src/panels/lovelace/special-rows/hui-text-divider-row.ts
+++ b/src/panels/lovelace/special-rows/hui-text-divider-row.ts
@@ -1,0 +1,68 @@
+import {
+  html,
+  LitElement,
+  TemplateResult,
+  customElement,
+  property,
+  CSSResult,
+  css,
+} from "lit-element";
+
+import { EntityRow, TextDividerConfig } from "../entity-rows/types";
+import { HomeAssistant } from "../../../types";
+
+@customElement("hui-text-divider-row")
+class HuiTextDividerRow extends LitElement implements EntityRow {
+  public hass?: HomeAssistant;
+
+  @property() private _config?: TextDividerConfig;
+
+  public setConfig(config): void {
+    if (!config || !config.label) {
+      throw new Error("Error in card configuration.");
+    }
+
+    this._config = config;
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this._config) {
+      return html``;
+    }
+
+    return html`
+      <h2 class="text-divider"><span>${this._config.label}</span></h2>
+    `;
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      .text-divider {
+        margin: 1em 0;
+        line-height: 0;
+        text-align: center;
+        white-space: nowrap;
+        display: flex;
+        align-items: center;
+      }
+      .text-divider span {
+        padding: 1em;
+        color: var(--secondary-text-color);
+      }
+      .text-divider:before,
+      .text-divider:after {
+        content: "";
+        background: var(--secondary-text-color);
+        display: block;
+        height: 1px;
+        width: 100%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-text-divider-row": HuiTextDividerRow;
+  }
+}


### PR DESCRIPTION
looking to retire my custom row and is a simple/clear addition to core: https://github.com/custom-cards/text-divider-row
![image](https://user-images.githubusercontent.com/1287159/67544588-af303480-f6bb-11e9-9056-659fee355d10.png)
```yaml
entities:
  - type: text-divider
    label: TEST
  - type: divider
  - type: section
    label: section
type: entities
```

Docs: TODO