### PR TITLE
Translated config flow form and steps

### DIFF
--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -122,7 +122,13 @@ export const showConfigFlowDialog = (
               <ha-markdown allowsvg .content=${description}></ha-markdown>
             `
           : ""}
-        <p>Created config for ${step.title}.</p>
+        <p>
+          ${hass.localize(
+            "ui.panel.config.integrations.config_flow.external_step.created_config",
+            "name",
+            step.title
+          )}
+        </p>
       `;
     },
   });

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -124,7 +124,7 @@ export const showConfigFlowDialog = (
           : ""}
         <p>
           ${hass.localize(
-            "ui.panel.config.integrations.config_flow.external_step.created_config",
+            "ui.panel.config.integrations.config_flow.created_config",
             "name",
             step.title
           )}

--- a/src/dialogs/config-flow/step-flow-abort.ts
+++ b/src/dialogs/config-flow/step-flow-abort.ts
@@ -26,12 +26,20 @@ class StepFlowAbort extends LitElement {
 
   protected render(): TemplateResult | void {
     return html`
-      <h2>Aborted</h2>
+      <h2>
+        ${this.hass.localize(
+          "ui.panel.config.integrations.config_entry.aborted"
+        )}
+      </h2>
       <div class="content">
         ${this.flowConfig.renderAbortDescription(this.hass, this.step)}
       </div>
       <div class="buttons">
-        <mwc-button @click="${this._flowDone}">Close</mwc-button>
+        <mwc-button @click="${this._flowDone}"
+          >${this.hass.localize(
+            "ui.panel.config.integrations.config_entry.close"
+          )}</mwc-button
+        >
       </div>
     `;
   }

--- a/src/dialogs/config-flow/step-flow-abort.ts
+++ b/src/dialogs/config-flow/step-flow-abort.ts
@@ -28,7 +28,7 @@ class StepFlowAbort extends LitElement {
     return html`
       <h2>
         ${this.hass.localize(
-          "ui.panel.config.integrations.config_entry.aborted"
+          "ui.panel.config.integrations.config_flow.aborted"
         )}
       </h2>
       <div class="content">
@@ -37,7 +37,7 @@ class StepFlowAbort extends LitElement {
       <div class="buttons">
         <mwc-button @click="${this._flowDone}"
           >${this.hass.localize(
-            "ui.panel.config.integrations.config_entry.close"
+            "ui.panel.config.integrations.config_flow.close"
           )}</mwc-button
         >
       </div>

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -64,7 +64,7 @@ class StepFlowCreateEntry extends LitElement {
                         </div>
                         <paper-dropdown-menu-light
                           label="${localize(
-                            "ui.panel.config.integrations.config_entry.area_picker_label"
+                            "ui.panel.config.integrations.config_flow.area_picker_label"
                           )}"
                           .device=${device.id}
                           @selected-item-changed=${this._handleAreaChanged}
@@ -95,7 +95,7 @@ class StepFlowCreateEntry extends LitElement {
           ? html`
               <mwc-button @click="${this._addArea}"
                 >${localize(
-                  "ui.panel.config.integrations.config_entry.add_area"
+                  "ui.panel.config.integrations.config_flow.add_area"
                 )}</mwc-button
               >
             `
@@ -103,7 +103,7 @@ class StepFlowCreateEntry extends LitElement {
 
         <mwc-button @click="${this._flowDone}"
           >${localize(
-            "ui.panel.config.integrations.config_entry.finish"
+            "ui.panel.config.integrations.config_flow.finish"
           )}</mwc-button
         >
       </div>
@@ -117,7 +117,7 @@ class StepFlowCreateEntry extends LitElement {
   private async _addArea() {
     const name = prompt(
       this.hass.localize(
-        "ui.panel.config.integrations.config_entry.name_new_area"
+        "ui.panel.config.integrations.config_flow.name_new_area"
       )
     );
     if (!name) {
@@ -131,7 +131,7 @@ class StepFlowCreateEntry extends LitElement {
     } catch (err) {
       alert(
         this.hass.localize(
-          "ui.panel.config.integrations.config_entry.failed_create_area"
+          "ui.panel.config.integrations.config_flow.failed_create_area"
         )
       );
     }
@@ -154,8 +154,8 @@ class StepFlowCreateEntry extends LitElement {
     } catch (err) {
       alert(
         this.hass.localize(
-          "ui.panel.config.integrations.config_entry.error_saving_area",
-          "name",
+          "ui.panel.config.integrations.config_flow.error_saving_area",
+          "error",
           "err.message"
         )
       );

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -63,7 +63,9 @@ class StepFlowCreateEntry extends LitElement {
                           ${device.model} (${device.manufacturer})
                         </div>
                         <paper-dropdown-menu-light
-                          label="Area"
+                          label="${localize(
+                            "ui.panel.config.integrations.config_entry.area_picker_label"
+                          )}"
                           .device=${device.id}
                           @selected-item-changed=${this._handleAreaChanged}
                         >
@@ -91,11 +93,19 @@ class StepFlowCreateEntry extends LitElement {
       <div class="buttons">
         ${this.devices.length > 0
           ? html`
-              <mwc-button @click="${this._addArea}">Add Area</mwc-button>
+              <mwc-button @click="${this._addArea}"
+                >${localize(
+                  "ui.panel.config.integrations.config_entry.add_area"
+                )}</mwc-button
+              >
             `
           : ""}
 
-        <mwc-button @click="${this._flowDone}">Finish</mwc-button>
+        <mwc-button @click="${this._flowDone}"
+          >${localize(
+            "ui.panel.config.integrations.config_entry.finish"
+          )}</mwc-button
+        >
       </div>
     `;
   }
@@ -105,7 +115,11 @@ class StepFlowCreateEntry extends LitElement {
   }
 
   private async _addArea() {
-    const name = prompt("Name of the new area?");
+    const name = prompt(
+      this.hass.localize(
+        "ui.panel.config.integrations.config_entry.name_new_area"
+      )
+    );
     if (!name) {
       return;
     }
@@ -115,7 +129,11 @@ class StepFlowCreateEntry extends LitElement {
       });
       this.areas = [...this.areas, area];
     } catch (err) {
-      alert("Failed to create area.");
+      alert(
+        this.hass.localize(
+          "ui.panel.config.integrations.config_entry.failed_create_area"
+        )
+      );
     }
   }
 
@@ -134,7 +152,13 @@ class StepFlowCreateEntry extends LitElement {
         area_id: area,
       });
     } catch (err) {
-      alert(`Error saving area: ${err.message}`);
+      alert(
+        this.hass.localize(
+          "ui.panel.config.integrations.config_entry.error_saving_area",
+          "name",
+          "err.message"
+        )
+      );
       dropdown.value = null;
     }
   }

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -88,7 +88,7 @@ class StepFlowForm extends LitElement {
                   @click=${this._submitStep}
                   .disabled=${!allRequiredInfoFilledIn}
                   >${this.hass.localize(
-                    "ui.panel.config.integrations.config_entry.submit"
+                    "ui.panel.config.integrations.config_flow.submit"
                   )}
                 </mwc-button>
 
@@ -96,7 +96,7 @@ class StepFlowForm extends LitElement {
                   ? html`
                       <paper-tooltip position="left"
                         >${this.hass.localize(
-                          "ui.panel.config.integrations.config_entry.not_all_fields_required"
+                          "ui.panel.config.integrations.config_flow.not_all_fields_required"
                         )}
                       </paper-tooltip>
                     `

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -87,14 +87,17 @@ class StepFlowForm extends LitElement {
                 <mwc-button
                   @click=${this._submitStep}
                   .disabled=${!allRequiredInfoFilledIn}
-                >
-                  Submit
+                  >${this.hass.localize(
+                    "ui.panel.config.integrations.config_entry.submit"
+                  )}
                 </mwc-button>
 
                 ${!allRequiredInfoFilledIn
                   ? html`
-                      <paper-tooltip position="left">
-                        Not all required fields are filled in.
+                      <paper-tooltip position="left"
+                        >${this.hass.localize(
+                          "ui.panel.config.integrations.config_entry.not_all_fields_required"
+                        )}
                       </paper-tooltip>
                     `
                   : html``}

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -96,7 +96,7 @@ class StepFlowForm extends LitElement {
                   ? html`
                       <paper-tooltip position="left"
                         >${this.hass.localize(
-                          "ui.panel.config.integrations.config_flow.not_all_fields_required"
+                          "ui.panel.config.integrations.config_flow.not_all_required_fields"
                         )}
                       </paper-tooltip>
                     `

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1219,7 +1219,7 @@
             "close": "Close",
             "finish": "Finish",
             "submit": "Submit",
-            "not_all_fields_required": "Not all required fields are filled in.",
+            "not_all_required_fields": "Not all required fields are filled in.",
             "add_area": "Add Area",
             "area_picker_label": "Area",
             "failed_create_area": "Failed to create area.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1212,23 +1212,23 @@
             "device_unavailable": "device unavailable",
             "entity_unavailable": "entity unavailable",
             "area": "In {area}",
-            "no_area": "No Area",
-            "area_picker_label": "Area",
-            "add_area": "Add Area",
-            "finish": "Finish",
-            "name_new_area": "Name of the new area?",
-            "failed_create_area": "Failed to create area.",
-            "error_saving_area": "Error saving area: {name}",
-            "aborted": "Aborted",
-            "close": "Close",
-            "submit": "Submit",
-            "not_all_fields_required": "Not all required fields are filled in."
+            "no_area": "No Area"
           },
           "config_flow": {
+            "aborted": "Aborted",
+            "close": "Close",
+            "finish": "Finish",
+            "submit": "Submit",
+            "not_all_fields_required": "Not all required fields are filled in.",
+            "add_area": "Add Area",
+            "area_picker_label": "Area",
+            "failed_create_area": "Failed to create area.",
+            "error_saving_area": "Error saving area: {error}",
+            "name_new_area": "Name of the new area?",
+            "created_config": "Created config for {name}.",
             "external_step": {
               "description": "This step requires you to visit an external website to be completed.",
-              "open_site": "Open website",
-              "created_config": "Created config for {name}."
+              "open_site": "Open website"
             }
           }
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1212,12 +1212,23 @@
             "device_unavailable": "device unavailable",
             "entity_unavailable": "entity unavailable",
             "area": "In {area}",
-            "no_area": "No Area"
+            "no_area": "No Area",
+            "area_picker_label": "Area",
+            "add_area": "Add Area",
+            "finish": "Finish",
+            "name_new_area": "Name of the new area?",
+            "failed_create_area": "Failed to create area.",
+            "error_saving_area": "Error saving area: {name}",
+            "aborted": "Aborted",
+            "close": "Close",
+            "submit": "Submit",
+            "not_all_fields_required": "Not all required fields are filled in."
           },
           "config_flow": {
             "external_step": {
               "description": "This step requires you to visit an external website to be completed.",
-              "open_site": "Open website"
+              "open_site": "Open website",
+              "created_config": "Created config for {name}."
             }
           }
         },


### PR DESCRIPTION
Issue affected: #3429

Description:
- added config flow form and steps translations to src/translations/en.json
- updated the config-flow files and show-dialog-config-flow.ts accordingly

Results:
![add_new_area_prompt](https://user-images.githubusercontent.com/46536646/67623203-013f9a00-f823-11e9-839a-c70caffd1ad9.PNG)
![alert_fail_adding_area](https://user-images.githubusercontent.com/46536646/67623204-03095d80-f823-11e9-9cb4-9e0df379a02d.PNG)
![flow](https://user-images.githubusercontent.com/46536646/67623206-04d32100-f823-11e9-87c5-45b58c332135.PNG)
![submit](https://user-images.githubusercontent.com/46536646/67623207-069ce480-f823-11e9-8211-fde101e0556a.PNG)
![success](https://user-images.githubusercontent.com/46536646/67623208-07ce1180-f823-11e9-8b3d-e36143939c2b.png)
