### PR TITLE
Translated unused entities, device registry page and domain toggler dialog

### DIFF
--- a/src/dialogs/device-registry-detail/dialog-device-registry-detail.ts
+++ b/src/dialogs/device-registry-detail/dialog-device-registry-detail.ts
@@ -74,7 +74,10 @@ class DialogDeviceRegistryDetail extends LitElement {
         opened
         @opened-changed="${this._openedChanged}"
       >
-        <h2>${device.name || "Unnamed device"}</h2>
+        <h2>
+          ${device.name ||
+            this.hass.localize("ui.panel.config.devices.unnamed_device")}
+        </h2>
         <paper-dialog-scrollable>
           ${this._error
             ? html`
@@ -90,7 +93,12 @@ class DialogDeviceRegistryDetail extends LitElement {
               .disabled=${this._submitting}
             ></paper-input>
             <div class="area">
-              <paper-dropdown-menu label="Area" class="flex">
+              <paper-dropdown-menu
+                label="${this.hass.localize(
+                  "ui.panel.config.integrations.config_entry.area_picker_label"
+                )}"
+                class="flex"
+              >
                 <paper-listbox
                   slot="dropdown-content"
                   .selected="${this._computeSelectedArea()}"
@@ -163,7 +171,11 @@ class DialogDeviceRegistryDetail extends LitElement {
       });
       this._params = undefined;
     } catch (err) {
-      this._error = err.message || "Unknown error";
+      this._error =
+        err.message ||
+        this.hass.localize(
+          "ui.panel.config.entity_registry.editor.unknown_error"
+        );
     } finally {
       this._submitting = false;
     }

--- a/src/dialogs/device-registry-detail/dialog-device-registry-detail.ts
+++ b/src/dialogs/device-registry-detail/dialog-device-registry-detail.ts
@@ -95,7 +95,7 @@ class DialogDeviceRegistryDetail extends LitElement {
             <div class="area">
               <paper-dropdown-menu
                 label="${this.hass.localize(
-                  "ui.panel.config.integrations.config_entry.area_picker_label"
+                  "ui.panel.config.devices.area_picker_label"
                 )}"
                 class="flex"
               >
@@ -173,9 +173,7 @@ class DialogDeviceRegistryDetail extends LitElement {
     } catch (err) {
       this._error =
         err.message ||
-        this.hass.localize(
-          "ui.panel.config.entity_registry.editor.unknown_error"
-        );
+        this.hass.localize("ui.panel.config.devices.unknown_error");
     } finally {
       this._submitting = false;
     }

--- a/src/dialogs/domain-toggler/dialog-domain-toggler.ts
+++ b/src/dialogs/domain-toggler/dialog-domain-toggler.ts
@@ -37,7 +37,11 @@ class DomainTogglerDialog extends LitElement {
         opened
         @opened-changed=${this._openedChanged}
       >
-        <h2>Toggle Domains</h2>
+        <h2>
+          ${this.hass.localize(
+            "ui.panel.config.entity_registry.toggle_domains"
+          )}
+        </h2>
         <div>
           ${domains.map(
             (domain) =>

--- a/src/dialogs/domain-toggler/dialog-domain-toggler.ts
+++ b/src/dialogs/domain-toggler/dialog-domain-toggler.ts
@@ -38,9 +38,7 @@ class DomainTogglerDialog extends LitElement {
         @opened-changed=${this._openedChanged}
       >
         <h2>
-          ${this.hass.localize(
-            "ui.panel.config.entity_registry.toggle_domains"
-          )}
+          ${this.hass.localize("ui.dialogs.domain_toggler.title")}
         </h2>
         <div>
           ${domains.map(

--- a/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
+++ b/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
@@ -57,7 +57,9 @@ export class HuiUnusedEntities extends LitElement {
   private _columns = memoizeOne((narrow: boolean) => {
     const columns: DataTableColumnContainer = {
       entity: {
-        title: "Entity",
+        title: this.hass!.localize(
+          "ui.panel.lovelace.menu.unused_entities.entity"
+        ),
         sortable: true,
         filterable: true,
         filterKey: "friendly_name",
@@ -79,17 +81,23 @@ export class HuiUnusedEntities extends LitElement {
     }
 
     columns.entity_id = {
-      title: "Entity id",
+      title: this.hass!.localize(
+        "ui.panel.lovelace.menu.unused_entities.entity_id"
+      ),
       sortable: true,
       filterable: true,
     };
     columns.domain = {
-      title: "Domain",
+      title: this.hass!.localize(
+        "ui.panel.lovelace.menu.unused_entities.domain"
+      ),
       sortable: true,
       filterable: true,
     };
     columns.last_changed = {
-      title: "Last Changed",
+      title: this.hass!.localize(
+        "ui.panel.lovelace.menu.unused_entities.last_changed"
+      ),
       type: "numeric",
       sortable: true,
       template: (lastChanged: string) => html`
@@ -121,14 +129,20 @@ export class HuiUnusedEntities extends LitElement {
     }
 
     return html`
-      <ha-card header="Unused entities">
+      <ha-card
+        header="${this.hass.localize(
+          "ui.panel.lovelace.menu.unused_entities.title"
+        )}"
+      >
         <div class="card-content">
-          These are the entities that you have available, but are not in your
-          Lovelace UI yet.
+          ${this.hass.localize(
+            "ui.panel.lovelace.menu.unused_entities.available_entities"
+          )}
           ${this.lovelace.mode === "storage"
             ? html`
-                <br />Select the entities you want to add to a card and then
-                click the add card button.
+                <br />${this.hass.localize(
+                  "ui.panel.lovelace.menu.unused_entities.select_to_add"
+                )}
               `
             : ""}
         </div>

--- a/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
+++ b/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
@@ -57,9 +57,7 @@ export class HuiUnusedEntities extends LitElement {
   private _columns = memoizeOne((narrow: boolean) => {
     const columns: DataTableColumnContainer = {
       entity: {
-        title: this.hass!.localize(
-          "ui.panel.lovelace.menu.unused_entities.entity"
-        ),
+        title: this.hass!.localize("ui.panel.lovelace.unused_entities.entity"),
         sortable: true,
         filterable: true,
         filterKey: "friendly_name",
@@ -81,22 +79,18 @@ export class HuiUnusedEntities extends LitElement {
     }
 
     columns.entity_id = {
-      title: this.hass!.localize(
-        "ui.panel.lovelace.menu.unused_entities.entity_id"
-      ),
+      title: this.hass!.localize("ui.panel.lovelace.unused_entities.entity_id"),
       sortable: true,
       filterable: true,
     };
     columns.domain = {
-      title: this.hass!.localize(
-        "ui.panel.lovelace.menu.unused_entities.domain"
-      ),
+      title: this.hass!.localize("ui.panel.lovelace.unused_entities.domain"),
       sortable: true,
       filterable: true,
     };
     columns.last_changed = {
       title: this.hass!.localize(
-        "ui.panel.lovelace.menu.unused_entities.last_changed"
+        "ui.panel.lovelace.unused_entities.last_changed"
       ),
       type: "numeric",
       sortable: true,
@@ -131,17 +125,17 @@ export class HuiUnusedEntities extends LitElement {
     return html`
       <ha-card
         header="${this.hass.localize(
-          "ui.panel.lovelace.menu.unused_entities.title"
+          "ui.panel.lovelace.unused_entities.title"
         )}"
       >
         <div class="card-content">
           ${this.hass.localize(
-            "ui.panel.lovelace.menu.unused_entities.available_entities"
+            "ui.panel.lovelace.unused_entities.available_entities"
           )}
           ${this.lovelace.mode === "storage"
             ? html`
                 <br />${this.hass.localize(
-                  "ui.panel.lovelace.menu.unused_entities.select_to_add"
+                  "ui.panel.lovelace.unused_entities.select_to_add"
                 )}
               `
             : ""}

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -125,12 +125,12 @@ class HUIRoot extends LitElement {
                         : html`
                             <paper-item
                               aria-label=${this.hass!.localize(
-                                "ui.panel.lovelace.menu.unused_entities"
+                                "ui.panel.lovelace.menu.unused_entities.title"
                               )}
                               @tap="${this._handleUnusedEntities}"
                             >
                               ${this.hass!.localize(
-                                "ui.panel.lovelace.menu.unused_entities"
+                                "ui.panel.lovelace.menu.unused_entities.title"
                               )}
                             </paper-item>
                           `}
@@ -180,12 +180,12 @@ class HUIRoot extends LitElement {
                             </paper-item>
                             <paper-item
                               aria-label=${this.hass!.localize(
-                                "ui.panel.lovelace.menu.unused_entities"
+                                "ui.panel.lovelace.menu.unused_entities.title"
                               )}
                               @tap="${this._handleUnusedEntities}"
                             >
                               ${this.hass!.localize(
-                                "ui.panel.lovelace.menu.unused_entities"
+                                "ui.panel.lovelace.menu.unused_entities.title"
                               )}
                             </paper-item>
                           `

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -125,12 +125,12 @@ class HUIRoot extends LitElement {
                         : html`
                             <paper-item
                               aria-label=${this.hass!.localize(
-                                "ui.panel.lovelace.menu.unused_entities.title"
+                                "ui.panel.lovelace.unused_entities.title"
                               )}
                               @tap="${this._handleUnusedEntities}"
                             >
                               ${this.hass!.localize(
-                                "ui.panel.lovelace.menu.unused_entities.title"
+                                "ui.panel.lovelace.unused_entities.title"
                               )}
                             </paper-item>
                           `}
@@ -180,12 +180,12 @@ class HUIRoot extends LitElement {
                             </paper-item>
                             <paper-item
                               aria-label=${this.hass!.localize(
-                                "ui.panel.lovelace.menu.unused_entities.title"
+                                "ui.panel.lovelace.unused_entities.title"
                               )}
                               @tap="${this._handleUnusedEntities}"
                             >
                               ${this.hass!.localize(
-                                "ui.panel.lovelace.menu.unused_entities.title"
+                                "ui.panel.lovelace.unused_entities.title"
                               )}
                             </paper-item>
                           `

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -610,6 +610,9 @@
           "area_picker_label": "Area",
           "update_name_button": "Update Name"
         }
+      },
+      "domain_toggler": {
+        "title": "Toggle Domains"
       }
     },
     "duration": {
@@ -1137,7 +1140,6 @@
         "entity_registry": {
           "caption": "Entity Registry",
           "description": "Overview of all known entities.",
-          "toggle_domains": "Toggle Domains",
           "picker": {
             "header": "Entity Registry",
             "introduction": "Home Assistant keeps a registry of every entity it has ever seen that can be uniquely identified. Each of these entities will have an entity ID assigned which will be reserved for just this entity.",
@@ -1392,21 +1394,21 @@
             "more_info": "Show more-info: {name}"
           }
         },
+        "unused_entities": {
+          "title": "Unused entities",
+          "available_entities": "These are the entities that you have available, but are not in your Lovelace UI yet.",
+          "select_to_add": "Select the entities you want to add to a card and then click the add card button.",
+          "entity": "Entity",
+          "entity_id": "Entity ID",
+          "domain": "Domain",
+          "last_changed": "Last Changed"
+        },
         "views": {
           "confirm_delete": "Are you sure you want to delete this view?",
           "existing_cards": "You can't delete a view that has cards in it. Remove the cards first."
         },
         "menu": {
           "configure_ui": "Configure UI",
-          "unused_entities": {
-            "title": "Unused entities",
-            "available_entities": "These are the entities that you have available, but are not in your Lovelace UI yet.",
-            "select_to_add": "Select the entities you want to add to a card and then click the add card button.",
-            "entity": "Entity",
-            "entity_id": "Entity ID",
-            "domain": "Domain",
-            "last_changed": "Last Changed"
-          },
           "help": "Help",
           "refresh": "Refresh"
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1398,7 +1398,15 @@
         },
         "menu": {
           "configure_ui": "Configure UI",
-          "unused_entities": "Unused entities",
+          "unused_entities": {
+            "title": "Unused entities",
+            "available_entities": "These are the entities that you have available, but are not in your Lovelace UI yet.",
+            "select_to_add": "Select the entities you want to add to a card and then click the add card button.",
+            "entity": "Entity",
+            "entity_id": "Entity ID",
+            "domain": "Domain",
+            "last_changed": "Last Changed"
+          },
           "help": "Help",
           "refresh": "Refresh"
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1121,6 +1121,7 @@
         "devices": {
           "caption": "Devices",
           "description": "Manage connected devices",
+          "unnamed_device": "Unnamed device",
           "automation": {
             "triggers": {
               "caption": "Do something when..."
@@ -1136,6 +1137,7 @@
         "entity_registry": {
           "caption": "Entity Registry",
           "description": "Overview of all known entities.",
+          "toggle_domains": "Toggle Domains",
           "picker": {
             "header": "Entity Registry",
             "introduction": "Home Assistant keeps a registry of every entity it has ever seen that can be uniquely identified. Each of these entities will have an entity ID assigned which will be reserved for just this entity.",
@@ -1158,7 +1160,8 @@
             "delete": "DELETE",
             "confirm_delete": "Are you sure you want to delete this entry?",
             "confirm_delete2": "Deleting an entry will not remove the entity from Home Assistant. To do this, you will need to remove the integration '{platform}' from Home Assistant.",
-            "update": "UPDATE"
+            "update": "UPDATE",
+            "unknown_error": "Unknown error"
           }
         },
         "person": {
@@ -1212,7 +1215,8 @@
             "device_unavailable": "device unavailable",
             "entity_unavailable": "entity unavailable",
             "area": "In {area}",
-            "no_area": "No Area"
+            "no_area": "No Area",
+            "area_picker_label": "Area"
           },
           "config_flow": {
             "external_step": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1139,6 +1139,8 @@
           "caption": "Devices",
           "description": "Manage connected devices",
           "unnamed_device": "Unnamed device",
+          "unknown_error": "Unknown error",
+          "area_picker_label": "Area",
           "automation": {
             "triggers": {
               "caption": "Do something when..."
@@ -1176,8 +1178,7 @@
             "delete": "DELETE",
             "confirm_delete": "Are you sure you want to delete this entry?",
             "confirm_delete2": "Deleting an entry will not remove the entity from Home Assistant. To do this, you will need to remove the integration '{platform}' from Home Assistant.",
-            "update": "UPDATE",
-            "unknown_error": "Unknown error"
+            "update": "UPDATE"
           }
         },
         "person": {
@@ -1231,8 +1232,7 @@
             "device_unavailable": "device unavailable",
             "entity_unavailable": "entity unavailable",
             "area": "In {area}",
-            "no_area": "No Area",
-            "area_picker_label": "Area"
+            "no_area": "No Area"
           },
           "config_flow": {
             "external_step": {


### PR DESCRIPTION
Issue affected: #3429

Translated:
- device registry page
- unused entities page
- domain toggler dialog

Results:
![device_areas](https://user-images.githubusercontent.com/46536646/67625713-d3b61900-f841-11e9-9597-cbcac26d78c5.png)
![unused_entities](https://user-images.githubusercontent.com/46536646/67625714-d57fdc80-f841-11e9-8e8c-832139a24075.png)
