### PR TITLE
Translated lovelace raw config editor and lovelace editing UI mode

### DIFF
--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -74,7 +74,10 @@ class LovelacePanel extends LitElement {
 
     if (state === "error") {
       return html`
-        <hass-error-screen title="Lovelace" .error="${this._errorMsg}">
+        <hass-error-screen
+          title="${this.hass!.localize("domain.lovelace")}"
+          .error="${this._errorMsg}"
+        >
           <mwc-button on-click="_forceFetchConfig"
             >${this.hass!.localize(
               "ui.panel.lovelace.reload_lovelace"

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -157,7 +157,11 @@ class LovelaceFullConfigEditor extends LitElement {
   private _closeEditor() {
     if (this._changed) {
       if (
-        !confirm("You have unsaved changes, are you sure you want to exit?")
+        !confirm(
+          this.hass.localize(
+            "ui.panel.lovelace.editor.raw_editor.confirm_unsaved_changes"
+          )
+        )
       ) {
         return;
       }
@@ -174,7 +178,9 @@ class LovelaceFullConfigEditor extends LitElement {
     if (this.yamlEditor.hasComments) {
       if (
         !confirm(
-          "Your config contains comment(s), these will not be saved. Do you want to continue?"
+          this.hass.localize(
+            "ui.panel.lovelace.editor.raw_editor.confirm_unsaved_comments"
+          )
         )
       ) {
         return;
@@ -185,20 +191,38 @@ class LovelaceFullConfigEditor extends LitElement {
     try {
       value = safeLoad(this.yamlEditor.value);
     } catch (err) {
-      alert(`Unable to parse YAML: ${err}`);
+      alert(
+        this.hass.localize(
+          "ui.panel.lovelace.editor.raw_editor.error_parse_yaml",
+          "error",
+          err
+        )
+      );
       this._saving = false;
       return;
     }
     try {
       value = lovelaceStruct(value);
     } catch (err) {
-      alert(`Your config is not valid: ${err}`);
+      alert(
+        this.hass.localize(
+          "ui.panel.lovelace.editor.raw_editor.error_invalid_config",
+          "error",
+          err
+        )
+      );
       return;
     }
     try {
       await this.lovelace!.saveConfig(value);
     } catch (err) {
-      alert(`Unable to save YAML: ${err}`);
+      alert(
+        this.hass.localize(
+          "ui.panel.lovelace.editor.raw_editor.error_save_yaml",
+          "error",
+          err
+        )
+      );
     }
     this._generation = this.yamlEditor
       .codemirror!.getDoc()

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -101,7 +101,9 @@ class HUIRoot extends LitElement {
                   </div>
                   <paper-icon-button
                     icon="hass:help-circle"
-                    title="Help"
+                    title="${this.hass!.localize(
+                      "ui.panel.lovelace.menu.help"
+                    )}"
                     @click="${this._handleHelp}"
                   ></paper-icon-button>
                   <paper-menu-button
@@ -247,7 +249,9 @@ class HUIRoot extends LitElement {
                           ${this._editMode
                             ? html`
                                 <ha-paper-icon-button-arrow-prev
-                                  title="Move view left"
+                                  title="${this.hass!.localize(
+                                    "ui.panel.lovelace.editor.edit_view.move_left"
+                                  )}"
                                   class="edit-icon view"
                                   @click="${this._moveViewLeft}"
                                   ?disabled="${this._curView === 0}"
@@ -265,13 +269,17 @@ class HUIRoot extends LitElement {
                           ${this._editMode
                             ? html`
                                 <ha-icon
-                                  title="Edit view"
+                                  title="${this.hass!.localize(
+                                    "ui.panel.lovelace.editor.edit_view.edit"
+                                  )}"
                                   class="edit-icon view"
                                   icon="hass:pencil"
                                   @click="${this._editView}"
                                 ></ha-icon>
                                 <ha-paper-icon-button-arrow-next
-                                  title="Move view right"
+                                  title="${this.hass!.localize(
+                                    "ui.panel.lovelace.editor.edit_view.move_right"
+                                  )}"
                                   class="edit-icon view"
                                   @click="${this._moveViewRight}"
                                   ?disabled="${(this._curView! as number) +

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1408,7 +1408,12 @@
             "header": "Edit Config",
             "save": "Save",
             "unsaved_changes": "Unsaved changes",
-            "saved": "Saved"
+            "saved": "Saved",
+            "confirm_unsaved_changes": "You have unsaved changes, are you sure you want to exit?",
+            "confirm_unsaved_comments": "Your config contains comment(s), these will not be saved. Do you want to continue?",
+            "error_parse_yaml": "Unable to parse YAML: {error}",
+            "error_invalid_config": "Your config is not valid: {error}",
+            "error_save_yaml": "Unable to save YAML: {error}"
           },
           "edit_lovelace": {
             "header": "Title of your Lovelace UI",
@@ -1419,7 +1424,9 @@
             "header_name": "{name} View Configuration",
             "add": "Add view",
             "edit": "Edit view",
-            "delete": "Delete view"
+            "delete": "Delete view",
+            "move_left": "Move view left",
+            "move_right": "Move view right"
           },
           "edit_card": {
             "header": "Card Configuration",


### PR DESCRIPTION
Issue affected: #3429

Translated:
- ha-panel-lovelace.ts - just the title of an element
- hui-editor.ts - confirm and alert messages
- hui-root.ts - labels and titles of elements

Results:
![titles](https://user-images.githubusercontent.com/46536646/67626399-4ecffd00-f84b-11e9-9723-02fe4f1a0cee.PNG)
![titles2](https://user-images.githubusercontent.com/46536646/67626400-5099c080-f84b-11e9-8262-5d12b3d3a6fb.PNG)
![unsaved_comments](https://user-images.githubusercontent.com/46536646/67626401-52638400-f84b-11e9-82a6-21edb4046b04.PNG)
![alert](https://user-images.githubusercontent.com/46536646/67626402-542d4780-f84b-11e9-8d21-6e9f11b9ba71.PNG)
