### PR TITLE
Translated automation and script editor

### DIFF
--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -82,6 +82,9 @@ export class HaAutomationEditor extends LitElement {
               ? ""
               : html`
                   <paper-icon-button
+                    title="${this.hass.localize(
+                      "ui.panel.config.automation.picker.delete_automation"
+                    )}"
                     icon="hass:delete"
                     @click=${this._delete}
                   ></paper-icon-button>
@@ -218,7 +221,11 @@ export class HaAutomationEditor extends LitElement {
   }
 
   private async _delete() {
-    if (!confirm("Are you sure you want to delete this automation?")) {
+    if (
+      !confirm(
+        this.hass.localize("ui.panel.config.automation.picker.delete_confirm")
+      )
+    ) {
       return;
     }
     await deleteAutomation(this.hass, this.automation.attributes.id!);

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -85,16 +85,16 @@ class HaAutomationPicker extends LitElement {
                         <paper-item-body two-line>
                           <div>${computeStateName(automation)}</div>
                           <div secondary>
-                            Last triggered: ${
-                              automation.attributes.last_triggered
-                                ? format_date_time(
-                                    new Date(
-                                      automation.attributes.last_triggered
-                                    ),
-                                    this.hass.language
-                                  )
-                                : "never"
-                            }
+                            ${this.hass.localize(
+                              "ui.card.automation.last_triggered"
+                            )}: ${
+                    automation.attributes.last_triggered
+                      ? format_date_time(
+                          new Date(automation.attributes.last_triggered),
+                          this.hass.language
+                        )
+                      : this.hass.localize("ui.components.relative_time.never")
+                  }
                           </div>
                         </paper-item-body>
                         <div class='actions'>
@@ -102,6 +102,9 @@ class HaAutomationPicker extends LitElement {
                             .automation=${automation}
                             @click=${this._showInfo}
                             icon="hass:information-outline"
+                            title="${this.hass.localize(
+                              "ui.panel.config.automation.picker.show_info_automation"
+                            )}"
                           ></paper-icon-button>
                           <a
                             href=${ifDefined(
@@ -113,6 +116,9 @@ class HaAutomationPicker extends LitElement {
                             )}
                           >
                             <paper-icon-button
+                              title="${this.hass.localize(
+                                "ui.panel.config.automation.picker.edit_automation"
+                              )}"
                               icon="hass:pencil"
                               .disabled=${!automation.attributes.id}
                             ></paper-icon-button>
@@ -120,8 +126,9 @@ class HaAutomationPicker extends LitElement {
                               !automation.attributes.id
                                 ? html`
                                     <paper-tooltip position="left">
-                                      Only automations defined in
-                                      automations.yaml are editable.
+                                      ${this.hass.localize(
+                                        "ui.panel.config.automation.picker.only_editable"
+                                      )}
                                     </paper-tooltip>
                                   `
                                 : ""

--- a/src/panels/config/js/script.tsx
+++ b/src/panels/config/js/script.tsx
@@ -40,7 +40,7 @@ export default class ScriptEditor extends Component<{
         <ha-config-section is-wide={isWide}>
           <span slot="header">{alias}</span>
           <span slot="introduction">
-            Use scripts to execute a sequence of actions.
+            {localize("ui.panel.config.script.editor.introduction")}
           </span>
           <ha-card>
             <div class="card-content">
@@ -55,12 +55,16 @@ export default class ScriptEditor extends Component<{
         </ha-config-section>
 
         <ha-config-section is-wide={isWide}>
-          <span slot="header">Sequence</span>
+          <span slot="header">
+            {localize("ui.panel.config.script.editor.sequence")}
+          </span>
           <span slot="introduction">
-            The sequence of actions of this script.
+            {localize("ui.panel.config.script.editor.sequence_sentence")}
             <p>
               <a href="https://home-assistant.io/docs/scripts/" target="_blank">
-                Learn more about available actions.
+                {localize(
+                  "ui.panel.config.script.editor.link_available_actions"
+                )}
               </a>
             </p>
           </span>

--- a/src/panels/config/script/ha-script-editor.js
+++ b/src/panels/config/script/ha-script-editor.js
@@ -104,6 +104,7 @@ class HaScriptEditor extends LocalizeMixin(NavigateMixin(PolymerElement)) {
             <template is="dom-if" if="[[!creatingNew]]">
               <paper-icon-button
                 icon="hass:delete"
+                title="[[localize('ui.panel.config.script.editor.delete_script')]]"
                 on-click="_delete"
               ></paper-icon-button>
             </template>

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -72,6 +72,9 @@ class HaScriptPicker extends LitElement {
                       <paper-icon-button
                         .script=${script}
                         icon="hass:play"
+                        title="${this.hass.localize(
+                          "ui.panel.config.script.picker.trigger_script"
+                        )}"
                         @click=${this._runScript}
                       ></paper-icon-button>
                       <paper-item-body>
@@ -81,6 +84,9 @@ class HaScriptPicker extends LitElement {
                         <a href=${`/config/script/edit/${script.entity_id}`}>
                           <paper-icon-button
                             icon="hass:pencil"
+                            title="${this.hass.localize(
+                              "ui.panel.config.script.picker.edit_script"
+                            )}"
                           ></paper-icon-button>
                         </a>
                       </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -737,7 +737,12 @@
             "learn_more": "Learn more about automations",
             "pick_automation": "Pick automation to edit",
             "no_automations": "We couldn’t find any editable automations",
-            "add_automation": "Add automation"
+            "add_automation": "Add automation",
+            "only_editable": "Only automations defined in automations.yaml are editable.",
+            "edit_automation": "Edit automation",
+            "show_info_automation": "Show info about automation",
+            "delete_automation": "Delete automation",
+            "delete_confirm": "Are you sure you want to delete this automation?"
           },
           "editor": {
             "introduction": "Use automations to bring your home alive.",
@@ -954,13 +959,20 @@
             "introduction": "The script editor allows you to create and edit scripts. Please follow the link below to read the instructions to make sure that you have configured Home Assistant correctly.",
             "learn_more": "Learn more about scripts",
             "no_scripts": "We couldn’t find any editable scripts",
-            "add_script": "Add script"
+            "add_script": "Add script",
+            "trigger_script": "Trigger script",
+            "edit_script": "Edit script"
           },
           "editor": {
+            "introduction": "Use scripts to execute a sequence of actions.",
             "header": "Script: {name}",
             "default_name": "New Script",
             "load_error_not_editable": "Only scripts inside scripts.yaml are editable.",
-            "delete_confirm": "Are you sure you want to delete this script?"
+            "delete_confirm": "Are you sure you want to delete this script?",
+            "delete_script": "Delete script",
+            "sequence": "Sequence",
+            "sequence_sentence": "The sequence of actions of this script.",
+            "link_available_actions": "Learn more about available actions."
           }
         },
         "cloud": {


### PR DESCRIPTION
Issue affected: #3429

Description:
- translated automation and script editor
- added title attributes to icons e.g. edit, delete, info and trigger

Results:
- automation editor:
![automation_trigger](https://user-images.githubusercontent.com/46536646/67639880-a6c33e00-f8f5-11e9-9328-f7e3889f0a1b.PNG)
![info_automation_title](https://user-images.githubusercontent.com/46536646/67639884-b2166980-f8f5-11e9-86bd-b67f7fc06773.PNG)

- script editor:
![script_editor](https://user-images.githubusercontent.com/46536646/67639874-96ab5e80-f8f5-11e9-9d00-c120601fd93b.PNG)
![trigger_script_title](https://user-images.githubusercontent.com/46536646/67639876-9ad77c00-f8f5-11e9-9516-1237707d794d.PNG)
![edit_script_title](https://user-images.githubusercontent.com/46536646/67639878-9e6b0300-f8f5-11e9-8323-7bad38c4d3ad.PNG)
![delete_script_title](https://user-images.githubusercontent.com/46536646/67639879-a0cd5d00-f8f5-11e9-874e-671bebae23a0.PNG)

