### PR TITLE
Added title attributes and translated them in Configure UI Mode

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -87,6 +87,9 @@ class HUIRoot extends LitElement {
             ? html`
                 <app-toolbar class="edit-mode">
                   <paper-icon-button
+                    title="${this.hass!.localize(
+                      "ui.panel.lovelace.menu.close"
+                    )}"
                     icon="hass:close"
                     @click="${this._editModeDisable}"
                   ></paper-icon-button>
@@ -94,6 +97,9 @@ class HUIRoot extends LitElement {
                     ${this.config.title ||
                       this.hass!.localize("ui.panel.lovelace.editor.header")}
                     <paper-icon-button
+                      title="${this.hass!.localize(
+                        "ui.panel.lovelace.editor.edit_lovelace.edit_title"
+                      )}"
                       icon="hass:pencil"
                       class="edit-icon"
                       @click="${this._editLovelace}"
@@ -113,6 +119,9 @@ class HUIRoot extends LitElement {
                       aria-label=${this.hass!.localize(
                         "ui.panel.lovelace.editor.menu.open"
                       )}
+                      title="${this.hass!.localize(
+                        "ui.panel.lovelace.editor.menu.open"
+                      )}"
                       icon="hass:dots-vertical"
                       slot="dropdown-trigger"
                     ></paper-icon-button>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1398,7 +1398,8 @@
           "configure_ui": "Configure UI",
           "unused_entities": "Unused entities",
           "help": "Help",
-          "refresh": "Refresh"
+          "refresh": "Refresh",
+          "close": "Close"
         },
         "editor": {
           "header": "Edit UI",
@@ -1414,7 +1415,8 @@
           },
           "edit_lovelace": {
             "header": "Title of your Lovelace UI",
-            "explanation": "This title is shown above all your views in Lovelace."
+            "explanation": "This title is shown above all your views in Lovelace.",
+            "edit_title": "Edit title"
           },
           "edit_view": {
             "header": "View Configuration",


### PR DESCRIPTION
Fixes #4066

Description:
- added title attribute to close, edit title and open menu button
- translated title attribute value

Results:
![close](https://user-images.githubusercontent.com/46536646/67710225-da6a9a80-f9bf-11e9-9a82-140ef002b7a4.PNG)
![edit_title](https://user-images.githubusercontent.com/46536646/67710226-db9bc780-f9bf-11e9-8d9d-b35f218946ad.PNG)
![menu](https://user-images.githubusercontent.com/46536646/67710231-dc345e00-f9bf-11e9-83b0-8d36c81144d0.PNG)
