### PR TITLE
Support email and url form input types

### DIFF
--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -56,6 +56,7 @@ export class HaFormString extends LitElement implements HaFormElement {
         `
       : html`
           <paper-input
+            .type=${this._stringType}
             .label=${this.label}
             .value=${this.data}
             .required=${this.schema.required}
@@ -83,6 +84,12 @@ export class HaFormString extends LitElement implements HaFormElement {
       },
       { bubbles: false }
     );
+  }
+
+  private _stringType() {
+    if (["email", "url"].includes(this.schema.format)) return this.schema.format;
+    if (this.schema.format === "fqdnurl") return "url";
+    return "text";
   }
 }
 

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -87,11 +87,13 @@ export class HaFormString extends LitElement implements HaFormElement {
   }
 
   private _stringType() {
-    if (["email", "url"].includes(this.schema.format)) {
-      return this.schema.format;
-    }
-    if (this.schema.format === "fqdnurl") {
-      return "url";
+    if (this.schema.format) {
+      if (["email", "url"].includes(this.schema.format)) {
+        return this.schema.format;
+      }
+      if (this.schema.format === "fqdnurl") {
+        return "url";
+      }
     }
     return "text";
   }

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -88,10 +88,10 @@ export class HaFormString extends LitElement implements HaFormElement {
 
   private _stringType() {
     if (["email", "url"].includes(this.schema.format)) {
-      return this.schema.format
+      return this.schema.format;
     }
     if (this.schema.format === "fqdnurl") {
-      return "url"
+      return "url";
     }
     return "text";
   }

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -87,8 +87,12 @@ export class HaFormString extends LitElement implements HaFormElement {
   }
 
   private _stringType() {
-    if (["email", "url"].includes(this.schema.format)) return this.schema.format;
-    if (this.schema.format === "fqdnurl") return "url";
+    if (["email", "url"].includes(this.schema.format)) {
+      return this.schema.format
+    }
+    if (this.schema.format === "fqdnurl") {
+      return "url"
+    }
     return "text";
   }
 }

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -51,6 +51,7 @@ export interface HaFormFloatSchema extends HaFormBaseSchema {
 
 export interface HaFormStringSchema extends HaFormBaseSchema {
   type: "string";
+  format?: string;
 }
 
 export interface HaFormBooleanSchema extends HaFormBaseSchema {


### PR DESCRIPTION
Since https://github.com/balloob/voluptuous-serialize/pull/8, voluptuous-serialize can include format info for strings: url, email, and fqdnurl. Would be useful to support these in HA forms. I would probably have used the url one in Huawei LTE's config UI had it been possible.

This change is completely untested, I have no idea if it works, and I'm really fairly clueless wrt this stuff, but maybe it helps someone to beat it into shape unless it by some scary luck actually works as is :)

In case it doesn't, feel free to take and finalize it, I'm not sure if I have time to get to know this stuff, I rather work on something non-UI in HA.