### PR TITLE
Reload buttons

### DIFF
--- a/src/panels/config/server_control/ha-config-section-server-control.js
+++ b/src/panels/config/server_control/ha-config-section-server-control.js
@@ -107,35 +107,47 @@ class HaConfigSectionServerControl extends LocalizeMixin(PolymerElement) {
                 service="reload_core_config"
                 >[[localize('ui.panel.config.server_control.section.reloading.core')]]
               </ha-call-service-button>
-              <ha-call-service-button
-                hass="[[hass]]"
-                domain="group"
-                service="reload"
-                hidden$="[[!groupLoaded(hass)]]"
-                >[[localize('ui.panel.config.server_control.section.reloading.group')]]
-              </ha-call-service-button>
-              <ha-call-service-button
-                hass="[[hass]]"
-                domain="automation"
-                service="reload"
-                hidden$="[[!automationLoaded(hass)]]"
-                >[[localize('ui.panel.config.server_control.section.reloading.automation')]]
-              </ha-call-service-button>
-              <ha-call-service-button
-                hass="[[hass]]"
-                domain="script"
-                service="reload"
-                hidden$="[[!scriptLoaded(hass)]]"
-                >[[localize('ui.panel.config.server_control.section.reloading.script')]]
-              </ha-call-service-button>
-              <ha-call-service-button
-                hass="[[hass]]"
-                domain="scene"
-                service="reload"
-                hidden$="[[!sceneLoaded(hass)]]"
-                >[[localize('ui.panel.config.server_control.section.reloading.scene')]]
-              </ha-call-service-button>
             </div>
+            <template is="dom-if" if="[[groupLoaded(hass)]]">
+              <div class="card-actions">
+                <ha-call-service-button
+                  hass="[[hass]]"
+                  domain="group"
+                  service="reload"
+                  >[[localize('ui.panel.config.server_control.section.reloading.group')]]
+                </ha-call-service-button>
+              </div>
+            </template>
+            <template is="dom-if" if="[[automationLoaded(hass)]]">
+              <div class="card-actions">
+                <ha-call-service-button
+                  hass="[[hass]]"
+                  domain="automation"
+                  service="reload"
+                  >[[localize('ui.panel.config.server_control.section.reloading.automation')]]
+                </ha-call-service-button>
+              </div>
+            </template>
+            <template is="dom-if" if="[[scriptLoaded(hass)]]">
+              <div class="card-actions">
+                <ha-call-service-button
+                  hass="[[hass]]"
+                  domain="script"
+                  service="reload"
+                  >[[localize('ui.panel.config.server_control.section.reloading.script')]]
+                </ha-call-service-button>
+              </div>
+            </template>
+            <template is="dom-if" if="[[sceneLoaded(hass)]]">
+              <div class="card-actions">
+                <ha-call-service-button
+                  hass="[[hass]]"
+                  domain="scene"
+                  service="reload"
+                  >[[localize('ui.panel.config.server_control.section.reloading.scene')]]
+                </ha-call-service-button>
+              </div>
+            </template>
           </ha-card>
         </template>
         <ha-card

--- a/translations/en.json
+++ b/translations/en.json
@@ -465,7 +465,7 @@
                             "reloading": {
                                 "heading": "Configuration reloading",
                                 "introduction": "Some parts of Home Assistant can reload without requiring a restart. Hitting reload will unload their current configuration and load the new one.",
-                                "core": "Reload core",
+                                "core": "Reload location & customize",
                                 "group": "Reload groups",
                                 "automation": "Reload automations",
                                 "script": "Reload scripts"


### PR DESCRIPTION
## Motivation:

"Reload core" was confusing for most users, so this changes the base translation of it to "Reload location & customize"

That by itself looked weird https://i.ibb.co/gvr6w5m/image.png

So in addition to that, this PR gives each button a card-action div.
The test to check if the button should be hidden was moved where applicable  from the button to a template statement, so it would not create empty card-action div's

## Result:
![image](https://user-images.githubusercontent.com/15093472/68508861-d405d980-026f-11ea-8efe-d177d54fb84d.png)
