### PR TITLE
implemented custom labels for dynamic config entries in a config flow

### DIFF
--- a/src/data/data_entry_flow.ts
+++ b/src/data/data_entry_flow.ts
@@ -30,6 +30,7 @@ export interface DataEntryFlowStepForm {
   data_schema: FieldSchema[];
   errors: { [key: string]: string };
   description_placeholders: { [key: string]: string };
+  labels: { [key: string]: string };
 }
 
 export interface DataEntryFlowStepExternal {
@@ -39,6 +40,7 @@ export interface DataEntryFlowStepExternal {
   step_id: string;
   url: string;
   description_placeholders: { [key: string]: string };
+  labels: { [key: string]: string };
 }
 
 export interface DataEntryFlowStepCreateEntry {
@@ -51,6 +53,7 @@ export interface DataEntryFlowStepCreateEntry {
   result: string;
   description: string;
   description_placeholders: { [key: string]: string };
+  labels: { [key: string]: string };
 }
 
 export interface DataEntryFlowStepAbort {

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -71,7 +71,7 @@ export const showConfigFlowDialog = (
 
     renderShowFormStepFieldLabel(hass, step, field) {
       if (step.labels != null) {
-        if (step.labels[field.name] != null) {     
+        if (step.labels[field.name] != null) {
 	  return step.labels[field.name];
         }
       }

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -72,7 +72,7 @@ export const showConfigFlowDialog = (
     renderShowFormStepFieldLabel(hass, step, field) {
       if (step.labels != null) {
         if (step.labels[field.name] != null) {
-	  return step.labels[field.name];
+          return step.labels[field.name];
         }
       }
       return hass.localize(

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -70,8 +70,8 @@ export const showConfigFlowDialog = (
     },
 
     renderShowFormStepFieldLabel(hass, step, field) {
-      if( step.labels != null ) {
-        if( step.labels[field.name] != null ) {     
+      if (step.labels != null) {
+        if (step.labels[field.name] != null) {     
 	  return step.labels[field.name];
         }
       }

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -70,6 +70,11 @@ export const showConfigFlowDialog = (
     },
 
     renderShowFormStepFieldLabel(hass, step, field) {
+      if( step.labels != null ) {
+        if( step.labels[field.name] != null ) {     
+	  return step.labels[field.name];
+        }
+      }
       return hass.localize(
         `component.${step.handler}.config.step.${step.step_id}.data.${
           field.name

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -54,7 +54,7 @@ export const showOptionsFlowDialog = (
 
       renderShowFormStepFieldLabel(hass, step, field) {
         if (step.labels != null) {
-          if (step.labels[field.name] != null) {     
+          if (step.labels[field.name] != null) {
             return step.labels[field.name];
           }
         }

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -53,18 +53,18 @@ export const showOptionsFlowDialog = (
       },
 
       renderShowFormStepFieldLabel(hass, step, field) {
-        if( step.labels != null ) {
-          if( step.labels[field.name] != null ) {     
+        if (step.labels != null) {
+          if (step.labels[field.name] != null) {     
             return step.labels[field.name];
           }
         }
         return hass.localize(
-          `component.${step.handler}.config.step.${step.step_id}.data.${
+          `component.${configEntry.domain}.options.step.${step.step_id}.data.${
             field.name
           }`
         );
-      },	      
-         
+      },
+
       renderShowFormStepFieldError(hass, _step, error) {
         return hass.localize(
           `component.${configEntry.domain}.options.error.${error}`

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -53,13 +53,18 @@ export const showOptionsFlowDialog = (
       },
 
       renderShowFormStepFieldLabel(hass, step, field) {
+        if( step.labels != null ) {
+          if( step.labels[field.name] != null ) {     
+            return step.labels[field.name];
+          }
+        }
         return hass.localize(
-          `component.${configEntry.domain}.options.step.${step.step_id}.data.${
+          `component.${step.handler}.config.step.${step.step_id}.data.${
             field.name
           }`
         );
-      },
-
+      },	      
+         
       renderShowFormStepFieldError(hass, _step, error) {
         return hass.localize(
           `component.${configEntry.domain}.options.error.${error}`


### PR DESCRIPTION
## Description:
added the possibility to force a custom label in a config flow

**Requires home-assistant PR: https://github.com/home-assistant/home-assistant/pull/28649