### PR TITLE
Fixed two-part pin code input in Manual Alarm Control Panel

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -7,6 +7,7 @@ import {
   css,
   property,
   customElement,
+  query,
 } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 
@@ -50,6 +51,8 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
   @property() public hass?: HomeAssistant;
 
   @property() private _config?: AlarmPanelCardConfig;
+
+  @query("#alarmCode") private _input?: PaperInputElement;
 
   public getCardSize(): number {
     if (!this._config || !this.hass) {
@@ -217,26 +220,22 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
   }
 
   private _handlePadClick(e: MouseEvent): void {
-    const input = this.shadowRoot!.querySelector(
-      "#alarmCode"
-    ) as PaperInputElement;
     const val = (e.currentTarget! as any).value;
-    input.value = val === "clear" ? "" : input.value + val;
+    this._input!.value = val === "clear" ? "" : this._input!.value + val;
   }
 
   private _handleActionClick(e: MouseEvent): void {
-    const input = this.shadowRoot!.querySelector(
-      "#alarmCode"
-    ) as PaperInputElement;
     const code =
-      input && input.value && input.value.length > 0 ? input.value : "";
+      this._input && this._input!.value && this._input!.value.length > 0
+        ? this._input!.value
+        : "";
     callAlarmAction(
       this.hass!,
       this._config!.entity,
       (e.currentTarget! as any).action,
       code
     );
-    input.value = "";
+    this._input!.value = "";
   }
 
   static get styles(): CSSResult {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -225,17 +225,16 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
   }
 
   private _handleActionClick(e: MouseEvent): void {
+    const input = this._input!;
     const code =
-      this._input && this._input!.value && this._input!.value.length > 0
-        ? this._input!.value
-        : "";
+      input && input.value && input.value.length > 0 ? input.value : "";
     callAlarmAction(
       this.hass!,
       this._config!.entity,
       (e.currentTarget! as any).action,
       code
     );
-    this._input!.value = "";
+    input.value = "";
   }
 
   static get styles(): CSSResult {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -51,8 +51,6 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
 
   @property() private _config?: AlarmPanelCardConfig;
 
-  @property() private _code?: string;
-
   public getCardSize(): number {
     if (!this._config || !this.hass) {
       return 0;
@@ -79,7 +77,6 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
     };
 
     this._config = { ...defaults, ...config };
-    this._code = "";
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -103,7 +100,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
-    if (changedProps.has("_config") || changedProps.has("_code")) {
+    if (changedProps.has("_config")) {
       return true;
     }
 
@@ -174,7 +171,6 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                 id="alarmCode"
                 label="Alarm Code"
                 type="password"
-                .value="${this._code}"
               ></paper-input>
             `}
         ${stateObj.attributes.code_format !== FORMAT_NUMBER
@@ -221,8 +217,11 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
   }
 
   private _handlePadClick(e: MouseEvent): void {
+    const input = this.shadowRoot!.querySelector(
+      "#alarmCode"
+    ) as PaperInputElement;
     const val = (e.currentTarget! as any).value;
-    this._code = val === "clear" ? "" : this._code + val;
+    input.value = val === "clear" ? "" : input.value + val;
   }
 
   private _handleActionClick(e: MouseEvent): void {
@@ -230,15 +229,14 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       "#alarmCode"
     ) as PaperInputElement;
     const code =
-      this._code ||
-      (input && input.value && input.value.length > 0 ? input.value : "");
+      input && input.value && input.value.length > 0 ? input.value : "";
     callAlarmAction(
       this.hass!,
       this._config!.entity,
       (e.currentTarget! as any).action,
       code
     );
-    this._code = "";
+    input.value = "";
   }
 
   static get styles(): CSSResult {


### PR DESCRIPTION
Fixes home-assistant/home-assistant#28736

Problem:
- input via a physical keyboard is not taken care off
- two-parts (physical keyboard and GUI pad) of input which are not the same
- _code property is not set/updated while using a physical keyboard
-> paper-input is not cleared after dis/arming or clicking the clear pad

Solution:
- remove _code property completely
- get and set the value of the paper-input element manually
-> consolidates both input methods into one since both use the paper-input element

Now it is even possible to switch between the two different input methods while entering the pin code.