### PR TITLE
Fixed body missing background colour when rubberbanding

### DIFF
--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -6,7 +6,8 @@ export const haStyle = css`
   }
 
   app-header-layout,
-  ha-app-layout {
+  ha-app-layout,
+  body {
     background-color: var(--primary-background-color);
   }
 


### PR DESCRIPTION
I've made a very simple fix to make sure that the body has the correct background colour. In iOS and macOS, when the user scrolls to the top or bottom of the page, there is a rubber band effect where the user can scroll past the content. 

If the body doesn't have a background colour, a default (typically white) colour will be used, which becomes especially apparent when using a dark theme. 

This fix simply applies `--primary-background-color` to the body element.

Here's an example of how this currently looks like without the fix:
<img width="911" alt="rubber band" src="https://user-images.githubusercontent.com/5121830/68821355-5f2b0900-068e-11ea-89d8-a63990d701a4.png">
