### PR TITLE
Add secondary-info: last-triggered

### DIFF
--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -105,7 +105,7 @@ class HuiGenericEntityRow extends LitElement {
                     .datetime=${stateObj.last_changed}
                   ></ha-relative-time>
                 `
-              : this.config.secondary_info === "last-triggered"
+              : this.config.secondary_info === "last-triggered" && stateObj.attributes.last_triggered
               ? html`
                   <ha-relative-time
                     .hass=${this.hass}

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -105,7 +105,8 @@ class HuiGenericEntityRow extends LitElement {
                     .datetime=${stateObj.last_changed}
                   ></ha-relative-time>
                 `
-              : this.config.secondary_info === "last-triggered" && stateObj.attributes.last_triggered
+              : this.config.secondary_info === "last-triggered" &&
+                  stateObj.attributes.last_triggered
               ? html`
                   <ha-relative-time
                     .hass=${this.hass}

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -105,6 +105,13 @@ class HuiGenericEntityRow extends LitElement {
                     .datetime=${stateObj.last_changed}
                   ></ha-relative-time>
                 `
+              : this.config.secondary_info === "last-triggered"
+              ? html`
+                  <ha-relative-time
+                    .hass=${this.hass}
+                    .datetime=${stateObj.last_triggered}
+                  ></ha-relative-time>
+                `
               : ""}
           </div>
         </div>

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -109,7 +109,7 @@ class HuiGenericEntityRow extends LitElement {
               ? html`
                   <ha-relative-time
                     .hass=${this.hass}
-                    .datetime=${stateObj.last_triggered}
+                    .datetime=${stateObj.attributes.last_triggered}
                   ></ha-relative-time>
                 `
               : ""}

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -106,7 +106,7 @@ class HuiGenericEntityRow extends LitElement {
                   ></ha-relative-time>
                 `
               : this.config.secondary_info === "last-triggered" &&
-                  stateObj.attributes.last_triggered
+                stateObj.attributes.last_triggered
               ? html`
                   <ha-relative-time
                     .hass=${this.hass}


### PR DESCRIPTION
add last-triggered to the currently available options 'entity-id' and 'last-changed' see:https://www.home-assistant.io/lovelace/entities/#secondary_info

Docs: https://github.com/home-assistant/home-assistant.io/pull/11221