### PR TITLE
Fix more info weather card - errant semi colon and zero degrees not displaying

### DIFF
--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -87,7 +87,7 @@ class MoreInfoWeather extends LitElement {
           ${this.stateObj.attributes.temperature} ${this.getUnit("temperature")}
         </div>
       </div>
-      ${this.stateObj.attributes.pressure
+      ${this._showValue(this.stateObj.attributes.pressure)
         ? html`
             <div class="flex">
               <iron-icon icon="hass:gauge"></iron-icon>
@@ -101,7 +101,7 @@ class MoreInfoWeather extends LitElement {
             </div>
           `
         : ""}
-      ${this.stateObj.attributes.humidity
+      ${this._showValue(this.stateObj.attributes.humidity)
         ? html`
             <div class="flex">
               <iron-icon icon="hass:water-percent"></iron-icon>
@@ -112,7 +112,7 @@ class MoreInfoWeather extends LitElement {
             </div>
           `
         : ""}
-      ${this.stateObj.attributes.wind_speed
+      ${this._showValue(this.stateObj.attributes.wind_speed)
         ? html`
             <div class="flex">
               <iron-icon icon="hass:weather-windy"></iron-icon>
@@ -128,7 +128,7 @@ class MoreInfoWeather extends LitElement {
             </div>
           `
         : ""}
-      ${this.stateObj.attributes.visibility
+      ${this._showValue(this.stateObj.attributes.visibility)
         ? html`
             <div class="flex">
               <iron-icon icon="hass:eye"></iron-icon>
@@ -156,14 +156,14 @@ class MoreInfoWeather extends LitElement {
                         ></iron-icon>
                       `
                     : ""}
-                  ${!item.templow
+                  ${!this._showValue(item.templow)
                     ? html`
                         <div class="main">
                           ${this.computeDateTime(item.datetime)}
                         </div>
                       `
                     : ""}
-                  ${item.templow
+                  ${this._showValue(item.templow)
                     ? html`
                         <div class="main">
                           ${this.computeDate(item.datetime)}
@@ -172,7 +172,7 @@ class MoreInfoWeather extends LitElement {
                           ${item.templow} ${this.getUnit("temperature")}
                         </div>
                       `
-                    : ""};
+                    : ""}
                   <div class="temp">
                     ${item.temperature} ${this.getUnit("temperature")}
                   </div>
@@ -278,6 +278,10 @@ class MoreInfoWeather extends LitElement {
       ) || cardinalDirection})`;
     }
     return `${speed} ${this.getUnit("length")}/h`;
+  }
+
+  private _showValue(item: string): boolean {
+    return typeof item !== "undefined" && item !== null;
   }
 }
 


### PR DESCRIPTION
Noted here: https://community.home-assistant.io/t/support-for-environment-canada-platforms/126241/88

In more-info when using daily, there was an errant semi colon in between the low temperature and high temperature.  Also, the conditional statements for each display value could evaluate to false when numerically equal to zero. Therefore showing nothing.

With these changes, it looks like this

![Screenshot_20191116-061139](https://user-images.githubusercontent.com/39341281/68992422-53c81100-0839-11ea-8d35-fc5ff17697e7.png)

As a question, temperature (in current observation and the high temperature) is not checked, but always shown.  Is it a problem if the temperature is None?  I assume it is okay as is, but will show a blank temperature. I'm not a frontend native developer, so I'm not sure.
