### PR TITLE
Add condition to call the toggle service for media_players

### DIFF
--- a/src/util/hass-media-player-model.js
+++ b/src/util/hass-media-player-model.js
@@ -180,12 +180,10 @@ export default class MediaPlayerEntity {
   togglePower() {
     if (this.supportsTurnOn && this.supportsTurnOff) {
       this.toggle();
+    } else if (this.isOff) {
+      this.turnOn();
     } else {
-      if (this.isOff) {
-        this.turnOn();
-      } else {
-        this.turnOff();
-      }
+      this.turnOff();
     }
   }
 

--- a/src/util/hass-media-player-model.js
+++ b/src/util/hass-media-player-model.js
@@ -178,11 +178,19 @@ export default class MediaPlayerEntity {
   }
 
   togglePower() {
-    if (this.isOff) {
-      this.turnOn();
+    if (this.supportsTurnOn && this.supportsTurnOff) {
+      this.toggle();
     } else {
-      this.turnOff();
+      if (this.isOff) {
+        this.turnOn();
+      } else {
+        this.turnOff();
+      }
     }
+  }
+
+  toggle() {
+    this.callService("toggle");
   }
 
   turnOff() {


### PR DESCRIPTION
Partial fix for Issue: home-assistant/home-assistant#28891.
Don't close issue.

Add condition to call the media_player entity's toggle service if turn on and turn off are both supported. This allows for the turn off/turn on logic to be handled in the backend via the toggle service.