### PR TITLE
Add copy entity ID/state/attributes menu button in dev tools/states

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "regenerator-runtime": "^0.13.2",
     "roboto-fontface": "^0.10.0",
     "superstruct": "^0.6.1",
+    "copy-to-clipboard": "^1.0.9",
     "tslib": "^1.10.0",
     "unfetch": "^4.1.0",
     "web-animations-js": "^2.3.1",

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -1,9 +1,6 @@
 import "@material/mwc-button";
 import "@polymer/paper-checkbox/paper-checkbox";
 import "@polymer/paper-input/paper-input";
-import "@polymer/paper-tooltip";
-// import "copy-to-clipboard";
-import "@polymer/paper-toast/paper-toast";
 import copy from "copy-to-clipboard";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
@@ -183,24 +180,11 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               is="dom-if"
               if="[[computeShowAttributes(narrow, _showAttributes)]]"
             >
-              <td>
-                [[attributeString(entity)]]
-                <paper-tooltip
-                  id="tooltip-[[sanitizeId(entity.entity_id)]]"
-                  for$="entity-id-[[sanitizeId(entity.entity_id)]]"
-                  animation-delay="0"
-                  manual-mode="true"
-                  offset="0"
-                  paper-tooltip-duration-in="0"
-                  >Copiédddd</paper-tooltip
-                >
-              </td>
+              <td>[[attributeString(entity)]]</td>
             </template>
           </tr>
         </template>
       </table>
-
-      <paper-toast id="toast0" alwaysOnTop="true" text="Copié"></paper-toast>
     `;
   }
 
@@ -294,21 +278,6 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
   entityCopyId(ev) {
     copy(ev.model.entity.entity_id);
     showToast(this, { message: "Copié" });
-    // this.$.toast0.alwaysOnTop = true;
-    // this.$.toast0.left = 200;
-    // this.$.toast0.open();
-    // var tooltipId = "tooltip-" + this.sanitizeId(ev.model.entity.entity_id);
-    // var btnId = "copyBtn-" + this.sanitizeId(ev.model.entity.entity_id);
-    // var btn = this.shadowRoot.getElementById(btnId);
-    // btn.icon = "hass:information-outline";
-    // var state = this.shadowRoot.getElementById(tooltipId);
-    // state.playAnimation("entry");
-    // setTimeout(function() {
-    //   var btnId = "copyBtn-" + this.sanitizeId(ev.model.entity.entity_id);
-    //   var btn = this.shadowRoot.getElementById(btnId);
-    //   state.playAnimation("exit");
-    //   btn.icon = "hass:content-copy";
-    // }, 2000);
   }
 
   handleSetState() {

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -1,6 +1,7 @@
 import "@material/mwc-button";
 import "@polymer/paper-checkbox/paper-checkbox";
 import "@polymer/paper-input/paper-input";
+import "@polymer/paper-menu-button";
 import copy from "copy-to-clipboard";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
@@ -69,6 +70,9 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
         .entities a {
           color: var(--primary-color);
+        }
+        paper-item {
+          cursor: pointer;
         }
       </style>
 
@@ -159,14 +163,45 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
                 title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
               >
               </paper-icon-button>
-              <paper-icon-button
-                id="copyBtn-[[entity.entity_id]]"
-                on-click="entityCopyId"
-                icon="hass:content-copy"
-                alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
-                title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
-              >
-              </paper-icon-button>
+
+              <paper-menu-button>
+                <paper-icon-button
+                  icon="hass:menu"
+                  slot="dropdown-trigger"
+                  alt="menu"
+                ></paper-icon-button>
+                <paper-listbox slot="dropdown-content" role="listbox">
+                  <paper-item action="copyId" on-click="entityCopyValue">
+                    <paper-icon-button
+                      icon="hass:content-copy"
+                      alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
+                      title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
+                    ></paper-icon-button>
+                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]
+                  </paper-item>
+
+                  <paper-item action="copyState" on-click="entityCopyValue">
+                    <paper-icon-button
+                      icon="hass:content-copy"
+                      alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]"
+                      title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]"
+                    ></paper-icon-button>
+                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]
+                  </paper-item>
+
+                  <paper-item
+                    action="copyAttributes"
+                    on-click="entityCopyValue"
+                  >
+                    <paper-icon-button
+                      icon="hass:content-copy"
+                      alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]"
+                      title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]"
+                    ></paper-icon-button>
+                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]
+                  </paper-item>
+                </paper-listbox>
+              </paper-menu-button>
               <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>
             </td>
             <td>[[entity.state]]</td>
@@ -174,7 +209,9 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               is="dom-if"
               if="[[computeShowAttributes(narrow, _showAttributes)]]"
             >
-              <td>[[attributeString(entity)]]</td>
+              <td id="attributes-[[entity.entity_id]]">
+                [[attributeString(entity)]]
+              </td>
             </template>
           </tr>
         </template>
@@ -265,8 +302,22 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
     this.fire("hass-more-info", { entityId: ev.model.entity.entity_id });
   }
 
-  entityCopyId(ev) {
-    copy(ev.model.entity.entity_id);
+  entityCopyValue(ev) {
+    var action = ev.currentTarget.attributes.action.value;
+    if (action == "copyId") {
+      copy(ev.model.entity.entity_id);
+    } else if (action == "copyState") {
+      copy(ev.model.entity.state);
+    } else if (action == "copyAttributes") {
+      var td = this.shadowRoot.getElementById(
+        "attributes-" + ev.model.entity.entity_id
+      );
+      // copy(td.textContent.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1'+ '<br />' +'$2'));
+      //copy(td.textContent.replace(/(\r\n|\n\r|\r|\n)/g, '<br />'));
+      copy(td.textContent.replace(/\n/g, "<br />"));
+    } else {
+      return;
+    }
     showToast(this, {
       message: this.hass.localize(
         "ui.panel.developer-tools.tabs.states.copied"

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -160,19 +160,14 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               >
               </paper-icon-button>
               <paper-icon-button
-                id="copyBtn-[[sanitizeId(entity.entity_id)]]"
+                id="copyBtn-[[entity.entity_id]]"
                 on-click="entityCopyId"
                 icon="hass:content-copy"
                 alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
                 title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
               >
               </paper-icon-button>
-              <a
-                href="#"
-                on-click="entitySelected"
-                id="entity-id-[[sanitizeId(entity.entity_id)]]"
-                >[[entity.entity_id]]</a
-              >
+              <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>
             </td>
             <td>[[entity.state]]</td>
             <template
@@ -268,10 +263,6 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
   entityMoreInfo(ev) {
     ev.preventDefault();
     this.fire("hass-more-info", { entityId: ev.model.entity.entity_id });
-  }
-
-  sanitizeId(id) {
-    return id.replace(".", "-");
   }
 
   entityCopyId(ev) {

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -163,7 +163,6 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
                 title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
               >
               </paper-icon-button>
-
               <paper-menu-button>
                 <paper-icon-button
                   icon="hass:menu"
@@ -209,9 +208,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               is="dom-if"
               if="[[computeShowAttributes(narrow, _showAttributes)]]"
             >
-              <td id="attributes-[[entity.entity_id]]">
-                [[attributeString(entity)]]
-              </td>
+              <td id="attributes-[[entity.entity_id]]">[[attributeString(entity)]]</td>
             </template>
           </tr>
         </template>

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -75,7 +75,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         .entities a {
           color: var(--primary-color);
         }
-        paper-item {
+        paper-icon-item {
           cursor: pointer;
         }
       </style>
@@ -171,48 +171,43 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
                   role="listbox"
                   selected="{{selectedItem}}"
                 >
-                  <paper-item on-click="entityMoreInfo">
-                    <paper-icon-item>
-                      <ha-icon
-                        icon="hass:information-outline"
-                        slot="item-icon"
-                      ></ha-icon>
-                      [[localize('ui.panel.developer-tools.tabs.states.more_info')]]
-                    </paper-icon-item>
-                  </paper-item>
+                  <paper-icon-item on-click="entityMoreInfo">
+                    <ha-icon
+                      icon="hass:information-outline"
+                      slot="item-icon"
+                    ></ha-icon>
+                    [[localize('ui.panel.developer-tools.tabs.states.more_info')]]
+                  </paper-icon-item>
 
-                  <paper-item action="copyId" on-click="entityCopyValue">
-                    <paper-icon-item>
-                      <ha-icon
-                        icon="hass:content-copy"
-                        slot="item-icon"
-                      ></ha-icon>
-                      [[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]
-                    </paper-icon-item>
-                  </paper-item>
+                  <paper-icon-item action="copyId" on-click="entityCopyValue">
+                    <ha-icon
+                      icon="hass:content-copy"
+                      slot="item-icon"
+                    ></ha-icon>
+                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]
+                  </paper-icon-item>
 
-                  <paper-item action="copyState" on-click="entityCopyValue">
-                    <paper-icon-item>
-                      <ha-icon
-                        icon="hass:content-copy"
-                        slot="item-icon"
-                      ></ha-icon>
-                      [[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]
-                    </paper-icon-item>
-                  </paper-item>
+                  <paper-icon-item
+                    action="copyState"
+                    on-click="entityCopyValue"
+                  >
+                    <ha-icon
+                      icon="hass:content-copy"
+                      slot="item-icon"
+                    ></ha-icon>
+                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]
+                  </paper-icon-item>
 
-                  <paper-item
+                  <paper-icon-item
                     action="copyAttributes"
                     on-click="entityCopyValue"
                   >
-                    <paper-icon-item>
-                      <ha-icon
-                        icon="hass:content-copy"
-                        slot="item-icon"
-                      ></ha-icon>
-                      [[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]
-                    </paper-icon-item>
-                  </paper-item>
+                    <ha-icon
+                      icon="hass:content-copy"
+                      slot="item-icon"
+                    ></ha-icon>
+                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]
+                  </paper-icon-item>
                 </paper-listbox>
               </paper-menu-button>
               <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -3,6 +3,7 @@ import "@polymer/paper-checkbox/paper-checkbox";
 import "@polymer/paper-input/paper-input";
 import "@polymer/paper-tooltip";
 // import "copy-to-clipboard";
+import "@polymer/paper-toast/paper-toast";
 import copy from "copy-to-clipboard";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
@@ -14,6 +15,7 @@ import "../../../components/ha-code-editor";
 import "../../../resources/ha-style";
 import { EventsMixin } from "../../../mixins/events-mixin";
 import LocalizeMixin from "../../../mixins/localize-mixin";
+import { showToast } from "../../../util/toast";
 
 const ERROR_SENTINEL = {};
 /*
@@ -73,6 +75,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         }
       </style>
 
+      <span id="toto_test">pour test</span>
       <div class="inputs">
         <p>
           [[localize('ui.panel.developer-tools.tabs.states.description1')]]<br />
@@ -161,31 +164,43 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               >
               </paper-icon-button>
               <paper-icon-button
-                id="copyBtn[[entity.entity_id]]"
+                id="copyBtn-[[sanitizeId(entity.entity_id)]]"
                 on-click="entityCopyId"
                 icon="hass:content-copy"
                 alt="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
                 title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
               >
               </paper-icon-button>
-              <paper-tooltip
-                id="tooltip[[entity.entity_id]]"
-                for$="copyBtn[[entity.entity_id]]"
-                position="top"
-                >👍</paper-tooltip
+              <a
+                href="#"
+                on-click="entitySelected"
+                id="entity-id-[[sanitizeId(entity.entity_id)]]"
+                >[[entity.entity_id]]</a
               >
-              <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>
             </td>
             <td>[[entity.state]]</td>
             <template
               is="dom-if"
               if="[[computeShowAttributes(narrow, _showAttributes)]]"
             >
-              <td>[[attributeString(entity)]]</td>
+              <td>
+                [[attributeString(entity)]]
+                <paper-tooltip
+                  id="tooltip-[[sanitizeId(entity.entity_id)]]"
+                  for$="entity-id-[[sanitizeId(entity.entity_id)]]"
+                  animation-delay="0"
+                  manual-mode="true"
+                  offset="0"
+                  paper-tooltip-duration-in="0"
+                  >Copiédddd</paper-tooltip
+                >
+              </td>
             </template>
           </tr>
         </template>
       </table>
+
+      <paper-toast id="toast0" alwaysOnTop="true" text="Copié"></paper-toast>
     `;
   }
 
@@ -272,16 +287,28 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
     this.fire("hass-more-info", { entityId: ev.model.entity.entity_id });
   }
 
-  entityCopyId(ev) {
-    copy(ev.model.entity.entity_id, {
-      debug: true,
-    });
+  sanitizeId(id) {
+    return id.replace(".", "-");
+  }
 
-    var state = this.shadowRoot.getElementById(
-      "tooltip" + ev.model.entity.entity_id
-    );
-    state.playAnimation("entry");
-    // alert("Copied to clipboard successfully!"+"tooltip" + ev.model.entity.entity_id);
+  entityCopyId(ev) {
+    copy(ev.model.entity.entity_id);
+    showToast(this, { message: "Copié" });
+    // this.$.toast0.alwaysOnTop = true;
+    // this.$.toast0.left = 200;
+    // this.$.toast0.open();
+    // var tooltipId = "tooltip-" + this.sanitizeId(ev.model.entity.entity_id);
+    // var btnId = "copyBtn-" + this.sanitizeId(ev.model.entity.entity_id);
+    // var btn = this.shadowRoot.getElementById(btnId);
+    // btn.icon = "hass:information-outline";
+    // var state = this.shadowRoot.getElementById(tooltipId);
+    // state.playAnimation("entry");
+    // setTimeout(function() {
+    //   var btnId = "copyBtn-" + this.sanitizeId(ev.model.entity.entity_id);
+    //   var btn = this.shadowRoot.getElementById(btnId);
+    //   state.playAnimation("exit");
+    //   btn.icon = "hass:content-copy";
+    // }, 2000);
   }
 
   handleSetState() {

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -160,7 +160,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         <template is="dom-repeat" items="[[_entities]]" as="entity">
           <tr>
             <td>
-              <paper-menu-button close-on-activate="true">
+              <paper-menu-button close-on-activate>
                 <paper-icon-button
                   icon="hass:dots-vertical"
                   slot="dropdown-trigger"
@@ -172,42 +172,46 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
                   selected="{{selectedItem}}"
                 >
                   <paper-item on-click="entityMoreInfo">
-                    <paper-icon-button
-                      icon="hass:information-outline"
-                      alt="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
-                      title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
-                    ></paper-icon-button>
-                    [[localize('ui.panel.developer-tools.tabs.states.more_info')]]
+                    <paper-icon-item>
+                      <ha-icon
+                        icon="hass:information-outline"
+                        slot="item-icon"
+                      ></ha-icon>
+                      [[localize('ui.panel.developer-tools.tabs.states.more_info')]]
+                    </paper-icon-item>
                   </paper-item>
 
                   <paper-item action="copyId" on-click="entityCopyValue">
-                    <paper-icon-button
-                      icon="hass:content-copy"
-                      alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
-                      title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
-                    ></paper-icon-button>
-                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]
+                    <paper-icon-item>
+                      <ha-icon
+                        icon="hass:content-copy"
+                        slot="item-icon"
+                      ></ha-icon>
+                      [[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]
+                    </paper-icon-item>
                   </paper-item>
 
                   <paper-item action="copyState" on-click="entityCopyValue">
-                    <paper-icon-button
-                      icon="hass:content-copy"
-                      alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]"
-                      title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]"
-                    ></paper-icon-button>
-                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]
+                    <paper-icon-item>
+                      <ha-icon
+                        icon="hass:content-copy"
+                        slot="item-icon"
+                      ></ha-icon>
+                      [[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]
+                    </paper-icon-item>
                   </paper-item>
 
                   <paper-item
                     action="copyAttributes"
                     on-click="entityCopyValue"
                   >
-                    <paper-icon-button
-                      icon="hass:content-copy"
-                      alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]"
-                      title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]"
-                    ></paper-icon-button>
-                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]
+                    <paper-icon-item>
+                      <ha-icon
+                        icon="hass:content-copy"
+                        slot="item-icon"
+                      ></ha-icon>
+                      [[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]
+                    </paper-icon-item>
                   </paper-item>
                 </paper-listbox>
               </paper-menu-button>
@@ -316,7 +320,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
     } else if (action === "copyState") {
       copy(ev.model.entity.state);
     } else if (action === "copyAttributes") {
-      copy(this.attributeString(ev.model.entity).replace(/\n/g, "<br />"));
+      copy(safeDump(ev.model.entity.attributes).replace(/\n/g, "<br />"));
     } else {
       return;
     }

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -1,6 +1,7 @@
 import "@material/mwc-button";
 import "@polymer/paper-checkbox/paper-checkbox";
 import "@polymer/paper-input/paper-input";
+import "@polymer/paper-tooltip";
 // import "copy-to-clipboard";
 import copy from "copy-to-clipboard";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
@@ -160,12 +161,19 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               >
               </paper-icon-button>
               <paper-icon-button
+                id="copyBtn[[entity.entity_id]]"
                 on-click="entityCopyId"
                 icon="hass:content-copy"
                 alt="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
                 title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
               >
               </paper-icon-button>
+              <paper-tooltip
+                id="tooltip[[entity.entity_id]]"
+                for$="copyBtn[[entity.entity_id]]"
+                position="top"
+                >👍</paper-tooltip
+              >
               <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>
             </td>
             <td>[[entity.state]]</td>
@@ -268,7 +276,12 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
     copy(ev.model.entity.entity_id, {
       debug: true,
     });
-    alert("Copied to clipboard successfully!");
+
+    var state = this.shadowRoot.getElementById(
+      "tooltip" + ev.model.entity.entity_id
+    );
+    state.playAnimation("entry");
+    // alert("Copied to clipboard successfully!"+"tooltip" + ev.model.entity.entity_id);
   }
 
   handleSetState() {

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -72,7 +72,6 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         }
       </style>
 
-      <span id="toto_test">pour test</span>
       <div class="inputs">
         <p>
           [[localize('ui.panel.developer-tools.tabs.states.description1')]]<br />
@@ -164,8 +163,8 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
                 id="copyBtn-[[sanitizeId(entity.entity_id)]]"
                 on-click="entityCopyId"
                 icon="hass:content-copy"
-                alt="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
-                title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
+                alt="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
+                title="[[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]"
               >
               </paper-icon-button>
               <a
@@ -277,7 +276,11 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
   entityCopyId(ev) {
     copy(ev.model.entity.entity_id);
-    showToast(this, { message: "Copié" });
+    showToast(this, {
+      message: this.hass.localize(
+        "ui.panel.developer-tools.tabs.states.copied"
+      ),
+    });
   }
 
   handleSetState() {

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -63,6 +63,10 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
           height: 24px;
           padding: 0;
         }
+        .entities paper-menu-button {
+          height: 24px;
+          padding: 0;
+        }
         .entities td:nth-child(3) {
           white-space: pre-wrap;
           word-break: break-word;
@@ -156,20 +160,26 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         <template is="dom-repeat" items="[[_entities]]" as="entity">
           <tr>
             <td>
-              <paper-icon-button
-                on-click="entityMoreInfo"
-                icon="hass:information-outline"
-                alt="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
-                title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
-              >
-              </paper-icon-button>
-              <paper-menu-button>
+              <paper-menu-button close-on-activate="true">
                 <paper-icon-button
-                  icon="hass:menu"
+                  icon="hass:dots-vertical"
                   slot="dropdown-trigger"
                   alt="menu"
                 ></paper-icon-button>
-                <paper-listbox slot="dropdown-content" role="listbox">
+                <paper-listbox
+                  slot="dropdown-content"
+                  role="listbox"
+                  selected="{{selectedItem}}"
+                >
+                  <paper-item on-click="entityMoreInfo">
+                    <paper-icon-button
+                      icon="hass:information-outline"
+                      alt="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
+                      title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
+                    ></paper-icon-button>
+                    [[localize('ui.panel.developer-tools.tabs.states.more_info')]]
+                  </paper-item>
+
                   <paper-item action="copyId" on-click="entityCopyValue">
                     <paper-icon-button
                       icon="hass:content-copy"

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -1,6 +1,8 @@
 import "@material/mwc-button";
 import "@polymer/paper-checkbox/paper-checkbox";
 import "@polymer/paper-input/paper-input";
+// import "copy-to-clipboard";
+import copy from "copy-to-clipboard";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 
@@ -157,6 +159,13 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
                 title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
               >
               </paper-icon-button>
+              <paper-icon-button
+                on-click="entityCopyId"
+                icon="hass:content-copy"
+                alt="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
+                title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
+              >
+              </paper-icon-button>
               <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>
             </td>
             <td>[[entity.state]]</td>
@@ -253,6 +262,13 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
   entityMoreInfo(ev) {
     ev.preventDefault();
     this.fire("hass-more-info", { entityId: ev.model.entity.entity_id });
+  }
+
+  entityCopyId(ev) {
+    copy(ev.model.entity.entity_id, {
+      debug: true,
+    });
+    alert("Copied to clipboard successfully!");
   }
 
   handleSetState() {

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -304,16 +304,14 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
   entityCopyValue(ev) {
     var action = ev.currentTarget.attributes.action.value;
-    if (action == "copyId") {
+    if (action === "copyId") {
       copy(ev.model.entity.entity_id);
-    } else if (action == "copyState") {
+    } else if (action === "copyState") {
       copy(ev.model.entity.state);
-    } else if (action == "copyAttributes") {
+    } else if (action === "copyAttributes") {
       var td = this.shadowRoot.getElementById(
         "attributes-" + ev.model.entity.entity_id
       );
-      // copy(td.textContent.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1'+ '<br />' +'$2'));
-      //copy(td.textContent.replace(/(\r\n|\n\r|\r|\n)/g, '<br />'));
       copy(td.textContent.replace(/\n/g, "<br />"));
     } else {
       return;

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -208,7 +208,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               is="dom-if"
               if="[[computeShowAttributes(narrow, _showAttributes)]]"
             >
-              <td id="attributes-[[entity.entity_id]]">[[attributeString(entity)]]</td>
+              <td>[[attributeString(entity)]]</td>
             </template>
           </tr>
         </template>
@@ -306,10 +306,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
     } else if (action === "copyState") {
       copy(ev.model.entity.state);
     } else if (action === "copyAttributes") {
-      var td = this.shadowRoot.getElementById(
-        "attributes-" + ev.model.entity.entity_id
-      );
-      copy(td.textContent.replace(/\n/g, "<br />"));
+      copy(this.attributeString(ev.model.entity).replace(/\n/g, "<br />"));
     } else {
       return;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2043,10 +2043,10 @@
             "no_entities": "No entities",
             "more_info": "More Info",
             "alert_entity_field": "Entity is a mandatory field",
-            "copy_entity_id": "Copy entity ID",
-            "copy_entity_state": "Copy entity state",
-            "copy_entity_attribute": "Copy entity attributes",
-            "copied": "Copied!"
+            "copy_entity_id": "Copy ID",
+            "copy_entity_state": "Copy state",
+            "copy_entity_attribute": "Copy attributes",
+            "copied": "Copied to clipboard"
           },
           "templates": {
             "title": "Template",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2044,6 +2044,8 @@
             "more_info": "More Info",
             "alert_entity_field": "Entity is a mandatory field",
             "copy_entity_id": "Copy entity ID",
+            "copy_entity_state": "Copy entity state",
+            "copy_entity_attribute": "Copy entity attributes",
             "copied": "Copied!"
           },
           "templates": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2042,7 +2042,9 @@
             "filter_attributes": "Filter attributes",
             "no_entities": "No entities",
             "more_info": "More Info",
-            "alert_entity_field": "Entity is a mandatory field"
+            "alert_entity_field": "Entity is a mandatory field",
+            "copy_entity_id": "Copy entity ID",
+            "copied": "Copied!"
           },
           "templates": {
             "title": "Template",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4635,6 +4635,13 @@ copy-props@^2.0.1:
     each-props "^1.3.0"
     is-plain-object "^2.0.1"
 
+copy-to-clipboard@^1.0.9:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-1.1.1.tgz#5bcddb4e25743f1a9e862554363e23fc78077b78"
+  integrity sha1-W83bTiV0PxqehiVUNj4j/HgHe3g=
+  dependencies:
+    toggle-selection "^1.0.3"
+
 copy-webpack-plugin@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.2.tgz#56186dfddbf9aa1b29c97fa4c796c1be98870da4"
@@ -12607,6 +12614,11 @@ to-through@^2.0.0:
   integrity sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=
   dependencies:
     through2 "^2.0.3"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hi 
I added a functionality I wished I had numerous times : the ability to quickly copy the entity id without having to manually select text, etc...
For this I added a button next to the "More Info" that will store the ID in the clipboard.
I used the "copy-to-clipboard" package.

It look like this: 
![HA-copy](https://user-images.githubusercontent.com/10168765/69338917-7bb5db00-0c64-11ea-86c7-7114ff52dcfc.gif)

That's my first PR for HA so I don't really know the process, please tell me how I proceed now.
I'm not really a front-end developer so any feedback and improvement for a future merge in master are more than welcome.

Also I wasn't really sure how to deal with the new labels I use and their translation in Lokalize , so I only modified the file `en.json`