### PR TITLE
change to partly-cloudy

### DIFF
--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -40,7 +40,7 @@ const weatherIcons = {
   hail: "hass:weather-hail",
   lightning: "hass:weather-lightning",
   "lightning-rainy": "hass:weather-lightning-rainy",
-  partlycloudy: "hass:weather-partly-cloudy",
+  "partly-cloudy": "hass:weather-partly-cloudy",
   pouring: "hass:weather-pouring",
   rainy: "hass:weather-rainy",
   snowy: "hass:weather-snowy",


### PR DESCRIPTION
following discussion on https://github.com/home-assistant/home-assistant/pull/29569 this aims use partly-cloudy all through HA's weather integrations and backend. Will Pr all integrations and documentation accordingly