### PR TITLE
change to partly-cloudy

### DIFF
--- a/src/cards/ha-weather-card.js
+++ b/src/cards/ha-weather-card.js
@@ -286,7 +286,7 @@ class HaWeatherCard extends LocalizeMixin(EventsMixin(PolymerElement)) {
       hail: "hass:weather-hail",
       lightning: "hass:weather-lightning",
       "lightning-rainy": "hass:weather-lightning-rainy",
-      partlycloudy: "hass:weather-partly-cloudy",
+      "partly-cloudy": "hass:weather-partly-cloudy",
       pouring: "hass:weather-pouring",
       rainy: "hass:weather-rainy",
       snowy: "hass:weather-snowy",


### PR DESCRIPTION
following discussion on home-assistant/home-assistant#29569 this aims use partly-cloudy all through HA's weather integrations and backend. Will Pr all integrations and documentation accordingly