### PR TITLE
Revert "Add copy entity ID/state/attributes menu button in dev tools/states"

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "chart.js": "~2.8.0",
     "chartjs-chart-timeline": "^0.3.0",
     "codemirror": "^5.49.0",
-    "copy-to-clipboard": "^1.0.9",
     "cpx": "^1.5.0",
     "deep-clone-simple": "^1.1.1",
     "es6-object-assign": "^1.1.0",

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -1,8 +1,6 @@
 import "@material/mwc-button";
 import "@polymer/paper-checkbox/paper-checkbox";
 import "@polymer/paper-input/paper-input";
-import "@polymer/paper-menu-button";
-import copy from "copy-to-clipboard";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 
@@ -13,7 +11,6 @@ import "../../../components/ha-code-editor";
 import "../../../resources/ha-style";
 import { EventsMixin } from "../../../mixins/events-mixin";
 import LocalizeMixin from "../../../mixins/localize-mixin";
-import { showToast } from "../../../util/toast";
 
 const ERROR_SENTINEL = {};
 /*
@@ -63,10 +60,6 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
           height: 24px;
           padding: 0;
         }
-        .entities paper-menu-button {
-          height: 24px;
-          padding: 0;
-        }
         .entities td:nth-child(3) {
           white-space: pre-wrap;
           word-break: break-word;
@@ -74,9 +67,6 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
         .entities a {
           color: var(--primary-color);
-        }
-        paper-icon-item {
-          cursor: pointer;
         }
       </style>
 
@@ -160,56 +150,13 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         <template is="dom-repeat" items="[[_entities]]" as="entity">
           <tr>
             <td>
-              <paper-menu-button close-on-activate>
-                <paper-icon-button
-                  icon="hass:dots-vertical"
-                  slot="dropdown-trigger"
-                  alt="menu"
-                ></paper-icon-button>
-                <paper-listbox
-                  slot="dropdown-content"
-                  role="listbox"
-                  selected="{{selectedItem}}"
-                >
-                  <paper-icon-item on-click="entityMoreInfo">
-                    <ha-icon
-                      icon="hass:information-outline"
-                      slot="item-icon"
-                    ></ha-icon>
-                    [[localize('ui.panel.developer-tools.tabs.states.more_info')]]
-                  </paper-icon-item>
-
-                  <paper-icon-item action="copyId" on-click="entityCopyValue">
-                    <ha-icon
-                      icon="hass:content-copy"
-                      slot="item-icon"
-                    ></ha-icon>
-                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_id')]]
-                  </paper-icon-item>
-
-                  <paper-icon-item
-                    action="copyState"
-                    on-click="entityCopyValue"
-                  >
-                    <ha-icon
-                      icon="hass:content-copy"
-                      slot="item-icon"
-                    ></ha-icon>
-                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_state')]]
-                  </paper-icon-item>
-
-                  <paper-icon-item
-                    action="copyAttributes"
-                    on-click="entityCopyValue"
-                  >
-                    <ha-icon
-                      icon="hass:content-copy"
-                      slot="item-icon"
-                    ></ha-icon>
-                    [[localize('ui.panel.developer-tools.tabs.states.copy_entity_attribute')]]
-                  </paper-icon-item>
-                </paper-listbox>
-              </paper-menu-button>
+              <paper-icon-button
+                on-click="entityMoreInfo"
+                icon="hass:information-outline"
+                alt="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
+                title="[[localize('ui.panel.developer-tools.tabs.states.more_info')]]"
+              >
+              </paper-icon-button>
               <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>
             </td>
             <td>[[entity.state]]</td>
@@ -306,24 +253,6 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
   entityMoreInfo(ev) {
     ev.preventDefault();
     this.fire("hass-more-info", { entityId: ev.model.entity.entity_id });
-  }
-
-  entityCopyValue(ev) {
-    var action = ev.currentTarget.attributes.action.value;
-    if (action === "copyId") {
-      copy(ev.model.entity.entity_id);
-    } else if (action === "copyState") {
-      copy(ev.model.entity.state);
-    } else if (action === "copyAttributes") {
-      copy(safeDump(ev.model.entity.attributes).replace(/\n/g, "<br />"));
-    } else {
-      return;
-    }
-    showToast(this, {
-      message: this.hass.localize(
-        "ui.panel.developer-tools.tabs.states.copied"
-      ),
-    });
   }
 
   handleSetState() {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2051,11 +2051,7 @@
             "filter_attributes": "Filter attributes",
             "no_entities": "No entities",
             "more_info": "More Info",
-            "alert_entity_field": "Entity is a mandatory field",
-            "copy_entity_id": "Copy ID",
-            "copy_entity_state": "Copy state",
-            "copy_entity_attribute": "Copy attributes",
-            "copied": "Copied to clipboard"
+            "alert_entity_field": "Entity is a mandatory field"
           },
           "templates": {
             "title": "Template",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5069,13 +5069,6 @@ copy-props@^2.0.1:
     each-props "^1.3.0"
     is-plain-object "^2.0.1"
 
-copy-to-clipboard@^1.0.9:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-1.1.1.tgz#5bcddb4e25743f1a9e862554363e23fc78077b78"
-  integrity sha1-W83bTiV0PxqehiVUNj4j/HgHe3g=
-  dependencies:
-    toggle-selection "^1.0.3"
-
 copy-webpack-plugin@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.2.tgz#56186dfddbf9aa1b29c97fa4c796c1be98870da4"
@@ -13053,11 +13046,6 @@ to-through@^2.0.0:
   integrity sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=
   dependencies:
     through2 "^2.0.3"
-
-toggle-selection@^1.0.3:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
-  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Reverts home-assistant/home-assistant-polymer#4259

This should be revised, this is has a big performance impact. We should look into having the states table as a virtual table.