### PR TITLE
Upgrade MDI icons to 4.7.95

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@material/mwc-fab": "^0.10.0",
     "@material/mwc-ripple": "^0.10.0",
     "@material/mwc-switch": "^0.10.0",
-    "@mdi/svg": "4.6.95",
+    "@mdi/svg": "4.7.95",
     "@polymer/app-layout": "^3.0.2",
     "@polymer/app-localize-behavior": "^3.0.1",
     "@polymer/app-route": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,10 +1662,10 @@
   dependencies:
     "@material/feature-targeting" "^4.0.0"
 
-"@mdi/svg@4.6.95":
-  version "4.6.95"
-  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-4.6.95.tgz#019672627717db33a3857bf1d90e57063895d3c5"
-  integrity sha512-sY2oKLvVEEsXTmJR2YyckdvoK4390tiZJ/q/bPAN1luq8jgcoukazzTHSPL7NMVcwBVGcOIAb3m1dG8BbjZxcA==
+"@mdi/svg@4.7.95":
+  version "4.7.95"
+  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-4.6.95.tgz#52eb856be80a6fd7021674d4193c6ff21b5d066c"
+  integrity sha512-zvOaCRMmK9lYJ+k6QCiREoyR/pqytWgQD+/ZjtbzxTHkKkriJN1oUWjL1BqSNOGJWB5nzS1Kkq8gFr9SXpVfQA==
 
 "@polymer/app-layout@^3.0.2":
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1664,7 +1664,7 @@
 
 "@mdi/svg@4.7.95":
   version "4.7.95"
-  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-4.6.95.tgz#52eb856be80a6fd7021674d4193c6ff21b5d066c"
+  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-4.7.95.tgz#52eb856be80a6fd7021674d4193c6ff21b5d066c"
   integrity sha512-zvOaCRMmK9lYJ+k6QCiREoyR/pqytWgQD+/ZjtbzxTHkKkriJN1oUWjL1BqSNOGJWB5nzS1Kkq8gFr9SXpVfQA==
 
 "@polymer/app-layout@^3.0.2":


### PR DESCRIPTION
Changelog: https://dev.materialdesignicons.com/changelog#version-4.7.95

<img width="330" alt="Screen Shot 2019-12-09 at 12 34 10 PM" src="https://user-images.githubusercontent.com/29807944/70458555-47258a00-1a80-11ea-84ad-3fe296c01bd5.png">
