### PR TITLE
light input_boolean component icon if activated

### DIFF
--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -115,6 +115,7 @@ class StateBadge extends LitElement {
       ha-icon[data-domain="light"][data-state="on"],
       ha-icon[data-domain="switch"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
+      ha-icon[data-domain="input_boolean"][data-state="on"],
       ha-icon[data-domain="fan"][data-state="on"],
       ha-icon[data-domain="sun"][data-state="above_horizon"] {
         color: var(--paper-item-icon-active-color, #fdd835);

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -204,6 +204,7 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
       ha-icon[data-domain="light"][data-state="on"],
       ha-icon[data-domain="switch"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
+      ha-icon[data-domain="input_boolean"][data-state="on"],
       ha-icon[data-domain="fan"][data-state="on"],
       ha-icon[data-domain="sun"][data-state="above_horizon"] {
         color: var(--paper-item-icon-active-color, #fdd835);


### PR DESCRIPTION
For various reasons I use input_boolean components for setting some kind of dummy component to on and off to use them in Node-Red or for other automations.
What I was missing was that the icons of input_boolean components didn't change like they do for lights or switches for example.
This fixes that behaviour.
before:
![before](https://user-images.githubusercontent.com/6394581/70569087-84316f80-1b99-11ea-81a6-0aed9b6b4ada.gif)

after:
![after](https://user-images.githubusercontent.com/6394581/70569100-8bf11400-1b99-11ea-9588-e06d582f6081.gif)
