### PR TITLE
Allow developer-tools service panel to use services.yaml limit_entity_domain to filter entity list

### DIFF
--- a/src/components/entity/ha-entities-picker.ts
+++ b/src/components/entity/ha-entities-picker.ts
@@ -24,7 +24,7 @@ class HaEntitiesPickerLight extends LitElement {
   @property() public value?: string[];
   /**
    * Show entities from specific domains.
-   * @type {string}
+   * @type {Array}
    * @attr include-domains
    */
   @property({ type: Array, attribute: "include-domains" })

--- a/src/panels/developer-tools/service/developer-tools-service.js
+++ b/src/panels/developer-tools/service/developer-tools-service.js
@@ -291,7 +291,9 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
       field.limit_entity_domain &&
       field.limit_entity_domain.length
     ) {
-      return field.limit_entity_domain;
+      return Array.isArray(field.limit_entity_domain)
+        ? field.limit_entity_domain
+        : [field.limit_entity_domain];
     }
     return ENTITY_COMPONENT_DOMAINS.includes(domain) ? [domain] : null;
   }

--- a/src/panels/developer-tools/service/developer-tools-service.js
+++ b/src/panels/developer-tools/service/developer-tools-service.js
@@ -286,11 +286,7 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
 
   _computeEntityDomainFilter(domain, attributes) {
     const field = attributes.find((attribute) => attribute.key === "entity_id");
-    if (
-      field &&
-      "limit_entity_domain" in field &&
-      field.limit_entity_domain.length > 0
-    ) {
+    if (field?.limit_entity_domain) {
       return field.limit_entity_domain;
     }
     return ENTITY_COMPONENT_DOMAINS.includes(domain) ? [domain] : null;

--- a/src/panels/developer-tools/service/developer-tools-service.js
+++ b/src/panels/developer-tools/service/developer-tools-service.js
@@ -112,7 +112,7 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
               value="[[_computeEntityValue(parsedJSON)]]"
               on-change="_entityPicked"
               disabled="[[!validJSON]]"
-              include-domains="[[_computeEntityDomainFilter(hass, _domain, _service)]]"
+              include-domains="[[_computeEntityDomainFilter(_domain, _attributes)]]"
               allow-custom-entity
             ></ha-entity-picker>
           </template>
@@ -284,12 +284,14 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
     return parsedJSON === ERROR_SENTINEL ? "" : parsedJSON.entity_id;
   }
 
-  _computeEntityDomainFilter(hass, domain, service) {
-    const serviceDomains = hass.services;
-    if (domain in serviceDomains &&
-        service in serviceDomains[domain] && 
-        serviceDomains[domain][service].limit_entity_domain.length > 0) {
-      return serviceDomains[domain][service].limit_entity_domain;
+  _computeEntityDomainFilter(domain, attributes) {
+    const field = attributes.find((attribute) => attribute.key === "entity_id");
+    if (
+      field &&
+      "limit_entity_domain" in field &&
+      field.limit_entity_domain.length > 0
+    ) {
+      return field.limit_entity_domain;
     }
     return ENTITY_COMPONENT_DOMAINS.includes(domain) ? [domain] : null;
   }

--- a/src/panels/developer-tools/service/developer-tools-service.js
+++ b/src/panels/developer-tools/service/developer-tools-service.js
@@ -286,7 +286,11 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
 
   _computeEntityDomainFilter(domain, attributes) {
     const field = attributes.find((attribute) => attribute.key === "entity_id");
-    if (field?.limit_entity_domain) {
+    if (
+      field &&
+      field.limit_entity_domain &&
+      field.limit_entity_domain.length
+    ) {
       return field.limit_entity_domain;
     }
     return ENTITY_COMPONENT_DOMAINS.includes(domain) ? [domain] : null;

--- a/src/panels/developer-tools/service/developer-tools-service.js
+++ b/src/panels/developer-tools/service/developer-tools-service.js
@@ -112,7 +112,7 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
               value="[[_computeEntityValue(parsedJSON)]]"
               on-change="_entityPicked"
               disabled="[[!validJSON]]"
-              include-domains="[[_computeEntityDomainFilter(_domain)]]"
+              include-domains="[[_computeEntityDomainFilter(hass, _domain, _service)]]"
               allow-custom-entity
             ></ha-entity-picker>
           </template>
@@ -284,7 +284,11 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
     return parsedJSON === ERROR_SENTINEL ? "" : parsedJSON.entity_id;
   }
 
-  _computeEntityDomainFilter(domain) {
+  _computeEntityDomainFilter(hass, domain, service) {
+    const serviceDomains = hass.services;
+    if (serviceDomains[domain][service].limit_entity_domain.length > 0) {
+      return serviceDomains[domain][service].limit_entity_domain;
+    }
     return ENTITY_COMPONENT_DOMAINS.includes(domain) ? [domain] : null;
   }
 

--- a/src/panels/developer-tools/service/developer-tools-service.js
+++ b/src/panels/developer-tools/service/developer-tools-service.js
@@ -286,7 +286,9 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
 
   _computeEntityDomainFilter(hass, domain, service) {
     const serviceDomains = hass.services;
-    if (serviceDomains[domain][service].limit_entity_domain.length > 0) {
+    if (domain in serviceDomains &&
+        service in serviceDomains[domain] && 
+        serviceDomains[domain][service].limit_entity_domain.length > 0) {
       return serviceDomains[domain][service].limit_entity_domain;
     }
     return ENTITY_COMPONENT_DOMAINS.includes(domain) ? [domain] : null;


### PR DESCRIPTION
This follows home-assistant/home-assistant#29833 to help implement home-assistant/architecture#313. Two things of note:

1. I did not include any changes to support the new `limit_entity_integration` parameter because I can't see how to figure out what integration an entity came from. As far as I can tell,  this is currently not stored by HA, so that would need to be added before support for the other new parameter can be added.
2. I assumed in this PR that if `limit_entity_domain` is not empty, I should not include the service `domain` in the list of domains to filter on. That behavior can easily be modified depending on what makes the most sense.