### PR TITLE
Update de.json show_header_toggle

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -1685,7 +1685,7 @@
                         },
                         "entities": {
                             "name": "Elemente",
-                            "show_header_toggle": "Namen anzeigen?",
+                            "show_header_toggle": "Schalter anzeigen?",
                             "toggle": "Entitäten umschalten"
                         },
                         "entity-button": {


### PR DESCRIPTION
Changed the show_header_toggle value from "Namen anzeigern?" to "Schalter anzeigen?". Because it toggles the switch and not the name of the card. For general information Schalter means switch in german.

If this change is not desired, just close/delete the PR :)