### PR TITLE
Add group management to the ZHA config panel

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -91,6 +91,15 @@ export const fetchGroups = (hass: HomeAssistant): Promise<ZHAGroup[]> =>
     type: "zha/groups",
   });
 
+export const removeGroups = (
+  hass: HomeAssistant,
+  groupIdsToRemove: number[]
+): Promise<ZHAGroup[]> =>
+  hass.callWS({
+    type: "zha/group/remove",
+    group_ids: groupIdsToRemove,
+  });
+
 export const fetchGroup = (
   hass: HomeAssistant,
   groupId: number

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -109,6 +109,17 @@ export const fetchGroup = (
     group_id: groupId,
   });
 
+export const addGroup = (
+  hass: HomeAssistant,
+  groupName: string,
+  membersToAdd?: string[]
+): Promise<ZHAGroup> =>
+  hass.callWS({
+    type: "zha/group/add",
+    group_name: groupName,
+    members: membersToAdd,
+  });
+
 export const addMembersToGroup = (
   hass: HomeAssistant,
   groupId: number,

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -91,6 +91,15 @@ export const fetchGroups = (hass: HomeAssistant): Promise<ZHAGroup[]> =>
     type: "zha/groups",
   });
 
+export const fetchGroup = (
+  hass: HomeAssistant,
+  groupId: number
+): Promise<ZHAGroup> =>
+  hass.callWS({
+    type: "zha/group",
+    group_id: groupId,
+  });
+
 export const fetchZHADevice = (
   hass: HomeAssistant,
   ieeeAddress: string

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -24,6 +24,12 @@ export interface ZHADevice {
   area_id?: string;
 }
 
+export interface ZHAGroup {
+  name: string;
+  group_id: number;
+  members: ZHADevice[];
+}
+
 export interface Attribute {
   name: string;
   id: number;
@@ -78,6 +84,11 @@ export const fetchAttributesForCluster = (
 export const fetchDevices = (hass: HomeAssistant): Promise<ZHADevice[]> =>
   hass.callWS({
     type: "zha/devices",
+  });
+
+export const fetchGroups = (hass: HomeAssistant): Promise<ZHAGroup[]> =>
+  hass.callWS({
+    type: "zha/groups",
   });
 
 export const fetchZHADevice = (

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -86,6 +86,13 @@ export const fetchDevices = (hass: HomeAssistant): Promise<ZHADevice[]> =>
     type: "zha/devices",
   });
 
+export const fetchGroupableDevices = (
+  hass: HomeAssistant
+): Promise<ZHADevice[]> =>
+  hass.callWS({
+    type: "zha/devices/groupable",
+  });
+
 export const fetchGroups = (hass: HomeAssistant): Promise<ZHAGroup[]> =>
   hass.callWS({
     type: "zha/groups",

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -100,6 +100,28 @@ export const fetchGroup = (
     group_id: groupId,
   });
 
+export const addMembersToGroup = (
+  hass: HomeAssistant,
+  groupId: number,
+  membersToAdd: string[]
+): Promise<ZHAGroup> =>
+  hass.callWS({
+    type: "zha/group/members/add",
+    group_id: groupId,
+    members: membersToAdd,
+  });
+
+export const removeMembersFromGroup = (
+  hass: HomeAssistant,
+  groupId: number,
+  membersToRemove: string[]
+): Promise<ZHAGroup> =>
+  hass.callWS({
+    type: "zha/group/members/remove",
+    group_id: groupId,
+    members: membersToRemove,
+  });
+
 export const fetchZHADevice = (
   hass: HomeAssistant,
   ieeeAddress: string

--- a/src/panels/config/zha/functions.ts
+++ b/src/panels/config/zha/functions.ts
@@ -1,4 +1,4 @@
-import { ZHADevice } from "../../../data/zha";
+import { ZHADevice, ZHAGroup } from "../../../data/zha";
 
 export const formatAsPaddedHex = (value: string | number): string => {
   let hex = value;
@@ -11,5 +11,11 @@ export const formatAsPaddedHex = (value: string | number): string => {
 export const sortZHADevices = (a: ZHADevice, b: ZHADevice): number => {
   const nameA = a.user_given_name ? a.user_given_name : a.name;
   const nameb = b.user_given_name ? b.user_given_name : b.name;
+  return nameA.localeCompare(nameb);
+};
+
+export const sortZHAGroups = (a: ZHAGroup, b: ZHAGroup): number => {
+  const nameA = a.name;
+  const nameb = b.name;
   return nameA.localeCompare(nameb);
 };

--- a/src/panels/config/zha/ha-config-zha.ts
+++ b/src/panels/config/zha/ha-config-zha.ts
@@ -5,6 +5,7 @@ import "./zha-cluster-attributes";
 import "./zha-cluster-commands";
 import "./zha-network";
 import "./zha-node";
+import "./zha-groups-tile";
 import "@polymer/paper-icon-button/paper-icon-button";
 
 import {
@@ -45,12 +46,18 @@ export class HaConfigZha extends LitElement {
           .hass="${this.hass}"
         ></zha-network>
 
+        <zha-groups-tile
+          .isWide="${this.isWide}"
+          .hass="${this.hass}"
+        ></zha-groups-tile>
+
         <zha-node
           .isWide="${this.isWide}"
           .hass="${this.hass}"
           @zha-cluster-selected="${this._onClusterSelected}"
           @zha-node-selected="${this._onDeviceSelected}"
         ></zha-node>
+
         ${this._selectedCluster
           ? html`
               <zha-cluster-attributes

--- a/src/panels/config/zha/zha-add-group-page.ts
+++ b/src/panels/config/zha/zha-add-group-page.ts
@@ -1,0 +1,172 @@
+import {
+  property,
+  LitElement,
+  html,
+  customElement,
+  css,
+  CSSResult,
+} from "lit-element";
+
+import "../../../layouts/hass-subpage";
+import "../../../layouts/hass-error-screen";
+import "../ha-config-section";
+import { HomeAssistant } from "../../../types";
+import { haStyleDialog } from "../../../resources/styles";
+import { ZHADevice, fetchDevices, addGroup, ZHAGroup } from "../../../data/zha";
+import "./zha-devices-data-table";
+import { SelectionChangedEvent } from "../../../components/data-table/ha-data-table";
+import { navigate } from "../../../common/navigate";
+import { PolymerChangedEvent } from "../../../polymer-types";
+import { PaperInputElement } from "@polymer/paper-input/paper-input";
+
+@customElement("zha-add-group-page")
+export class ZHAAddGroupPage extends LitElement {
+  @property() public hass!: HomeAssistant;
+  @property() public narrow!: boolean;
+  @property() public devices: ZHADevice[] = [];
+  @property() private _canAdd: boolean = false;
+  @property() private _processingAdd: boolean = false;
+  @property() private _groupName: string = "";
+
+  private _selectedDevicesToAdd: string[] = [];
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    this._fetchData();
+  }
+
+  protected render() {
+    return html`
+      <hass-subpage
+        .header=${this.hass.localize("ui.panel.config.zha.common.create_group")}
+      >
+        <ha-config-section .isWide=${!this.narrow}>
+          <span slot="introduction">
+            ${this.hass.localize(
+              "ui.panel.config.zha.common.create_group_details"
+            )}
+          </span>
+          <paper-input
+            type="string"
+            .value="${this._groupName}"
+            @value-changed=${this._handleNameChange}
+            placeholder="${this.hass!.localize(
+              "ui.panel.config.zha.common.group_name_placeholder"
+            )}"
+          ></paper-input>
+
+          <div class="header">
+            ${this.hass.localize("ui.panel.config.zha.common.add_members")}
+          </div>
+
+          <zha-devices-data-table
+            .hass=${this.hass}
+            .devices=${this.devices}
+            .narrow=${this.narrow}
+            .selectable=${true}
+            @selection-changed=${this._handleAddSelectionChanged}
+            class="table"
+          >
+          </zha-devices-data-table>
+
+          <div class="paper-dialog-buttons">
+            <mwc-button
+              ?disabled="${!this._canAdd}"
+              @click="${this._createGroup}"
+              class="button"
+            >
+              <paper-spinner
+                ?active="${this._processingAdd}"
+                alt="Creating Group"
+              ></paper-spinner>
+              ${this.hass!.localize(
+                "ui.panel.config.zha.common.create"
+              )}</mwc-button
+            >
+          </div>
+        </ha-config-section>
+      </hass-subpage>
+    `;
+  }
+
+  private async _fetchData() {
+    this.devices = await fetchDevices(this.hass!);
+  }
+
+  private _handleAddSelectionChanged(ev: CustomEvent): void {
+    const changedSelection = ev.detail as SelectionChangedEvent;
+    const entity = changedSelection.id;
+    if (changedSelection.selected) {
+      this._selectedDevicesToAdd.push(entity);
+    } else {
+      const index = this._selectedDevicesToAdd.indexOf(entity);
+      if (index !== -1) {
+        this._selectedDevicesToAdd.splice(index, 1);
+      }
+    }
+    this._canAdd = this._selectedDevicesToAdd.length > 0;
+  }
+
+  private async _createGroup(ev: CustomEvent): Promise<void> {
+    this._processingAdd = true;
+    const group: ZHAGroup = await addGroup(
+      this.hass,
+      this._groupName,
+      this._selectedDevicesToAdd
+    );
+    this._selectedDevicesToAdd = [];
+    this._canAdd = false;
+    this._processingAdd = false;
+    navigate(this, `/config/zha/group/${group.group_id}`);
+  }
+
+  private _handleNameChange(ev: PolymerChangedEvent<string>) {
+    const target = ev.currentTarget as PaperInputElement;
+    if (target.value) {
+      this._groupName = target.value;
+    }
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        .header {
+          font-family: var(--paper-font-display1_-_font-family);
+          -webkit-font-smoothing: var(
+            --paper-font-display1_-_-webkit-font-smoothing
+          );
+          font-size: var(--paper-font-display1_-_font-size);
+          font-weight: var(--paper-font-display1_-_font-weight);
+          letter-spacing: var(--paper-font-display1_-_letter-spacing);
+          line-height: var(--paper-font-display1_-_line-height);
+          opacity: var(--dark-primary-opacity);
+        }
+
+        .button {
+          float: right;
+        }
+
+        .table {
+          height: 400px;
+          overflow: auto;
+        }
+
+        ha-config-section *:last-child {
+          padding-bottom: 24px;
+        }
+        mwc-button paper-spinner {
+          width: 14px;
+          height: 14px;
+          margin-right: 20px;
+        }
+        paper-spinner {
+          display: none;
+        }
+        paper-spinner[active] {
+          display: block;
+        }
+      `,
+    ];
+  }
+}

--- a/src/panels/config/zha/zha-add-group-page.ts
+++ b/src/panels/config/zha/zha-add-group-page.ts
@@ -12,7 +12,12 @@ import "../../../layouts/hass-error-screen";
 import "../ha-config-section";
 import { HomeAssistant } from "../../../types";
 import { haStyleDialog } from "../../../resources/styles";
-import { ZHADevice, fetchDevices, addGroup, ZHAGroup } from "../../../data/zha";
+import {
+  ZHADevice,
+  fetchGroupableDevices,
+  addGroup,
+  ZHAGroup,
+} from "../../../data/zha";
 import "./zha-devices-data-table";
 import { SelectionChangedEvent } from "../../../components/data-table/ha-data-table";
 import { navigate } from "../../../common/navigate";
@@ -90,7 +95,7 @@ export class ZHAAddGroupPage extends LitElement {
   }
 
   private async _fetchData() {
-    this.devices = await fetchDevices(this.hass!);
+    this.devices = await fetchGroupableDevices(this.hass!);
   }
 
   private _handleAddSelectionChanged(ev: CustomEvent): void {

--- a/src/panels/config/zha/zha-add-group-page.ts
+++ b/src/panels/config/zha/zha-add-group-page.ts
@@ -104,10 +104,9 @@ export class ZHAAddGroupPage extends LitElement {
         this._selectedDevicesToAdd.splice(index, 1);
       }
     }
-    this._canAdd = this._selectedDevicesToAdd.length > 0;
   }
 
-  private async _createGroup(ev: CustomEvent): Promise<void> {
+  private async _createGroup(): Promise<void> {
     this._processingAdd = true;
     const group: ZHAGroup = await addGroup(
       this.hass,
@@ -117,13 +116,17 @@ export class ZHAAddGroupPage extends LitElement {
     this._selectedDevicesToAdd = [];
     this._canAdd = false;
     this._processingAdd = false;
-    navigate(this, `/config/zha/group/${group.group_id}`);
+    this._groupName = "";
+    navigate(this, `/config/zha/group/${group.group_id}`, true);
   }
 
   private _handleNameChange(ev: PolymerChangedEvent<string>) {
     const target = ev.currentTarget as PaperInputElement;
     if (target.value) {
       this._groupName = target.value;
+      if (target.value.length > 0) {
+        this._canAdd = true;
+      }
     }
   }
 

--- a/src/panels/config/zha/zha-config-panel.ts
+++ b/src/panels/config/zha/zha-config-panel.ts
@@ -43,6 +43,11 @@ class ZHAConfigPanel extends HassRouterPage {
         load: () =>
           import(/* webpackChunkName: "zha-group-page" */ "./zha-group-page"),
       },
+      "group-add": {
+        tag: "zha-add-group-page",
+        load: () =>
+          import(/* webpackChunkName: "zha-add-group-page" */ "./zha-add-group-page"),
+      },
     },
   };
 

--- a/src/panels/config/zha/zha-config-panel.ts
+++ b/src/panels/config/zha/zha-config-panel.ts
@@ -32,6 +32,11 @@ class ZHAConfigPanel extends HassRouterPage {
             /* webpackChunkName: "zha-add-devices-page" */ "./zha-add-devices-page"
           ),
       },
+      groups: {
+        tag: "zha-groups-dashboard",
+        load: () =>
+          import(/* webpackChunkName: "zha-groups-dashboard" */ "./zha-groups-dashboard"),
+      },
     },
   };
 

--- a/src/panels/config/zha/zha-config-panel.ts
+++ b/src/panels/config/zha/zha-config-panel.ts
@@ -36,7 +36,9 @@ class ZHAConfigPanel extends HassRouterPage {
       groups: {
         tag: "zha-groups-dashboard",
         load: () =>
-          import(/* webpackChunkName: "zha-groups-dashboard" */ "./zha-groups-dashboard"),
+          import(
+            /* webpackChunkName: "zha-groups-dashboard" */ "./zha-groups-dashboard"
+          ),
       },
       group: {
         tag: "zha-group-page",
@@ -46,7 +48,9 @@ class ZHAConfigPanel extends HassRouterPage {
       "group-add": {
         tag: "zha-add-group-page",
         load: () =>
-          import(/* webpackChunkName: "zha-add-group-page" */ "./zha-add-group-page"),
+          import(
+            /* webpackChunkName: "zha-add-group-page" */ "./zha-add-group-page"
+          ),
       },
     },
   };

--- a/src/panels/config/zha/zha-config-panel.ts
+++ b/src/panels/config/zha/zha-config-panel.ts
@@ -12,6 +12,7 @@ import { HomeAssistant } from "../../../types";
 class ZHAConfigPanel extends HassRouterPage {
   @property() public hass!: HomeAssistant;
   @property() public isWide!: boolean;
+  @property() public narrow!: boolean;
 
   protected routerOptions: RouterOptions = {
     defaultPage: "configuration",
@@ -37,6 +38,11 @@ class ZHAConfigPanel extends HassRouterPage {
         load: () =>
           import(/* webpackChunkName: "zha-groups-dashboard" */ "./zha-groups-dashboard"),
       },
+      group: {
+        tag: "zha-group-page",
+        load: () =>
+          import(/* webpackChunkName: "zha-group-page" */ "./zha-group-page"),
+      },
     },
   };
 
@@ -44,6 +50,10 @@ class ZHAConfigPanel extends HassRouterPage {
     el.route = this.routeTail;
     el.hass = this.hass;
     el.isWide = this.isWide;
+    el.narrow = this.narrow;
+    if (this._currentPage === "group") {
+      el.groupId = this.routeTail.path.substr(1);
+    }
   }
 }
 

--- a/src/panels/config/zha/zha-devices-data-table.ts
+++ b/src/panels/config/zha/zha-devices-data-table.ts
@@ -12,12 +12,10 @@ import {
 } from "lit-element";
 import { HomeAssistant } from "../../../types";
 // tslint:disable-next-line
-import {
-  DataTableColumnContainer,
-  DataTableRowData,
-} from "../../../components/data-table/ha-data-table";
+import { DataTableColumnContainer } from "../../../components/data-table/ha-data-table";
 // tslint:disable-next-line
 import { ZHADevice } from "../../../data/zha";
+import { showZHADeviceInfoDialog } from "../../../dialogs/zha-device-info-dialog/show-dialog-zha-device-info";
 
 export interface DeviceRowData extends ZHADevice {
   device?: DeviceRowData;
@@ -36,7 +34,7 @@ export class ZHADevicesDataTable extends LitElement {
     outputDevices = outputDevices.map((device) => {
       return {
         ...device,
-        name: device.name,
+        name: device.user_given_name ? device.user_given_name : device.name,
         model: device.model,
         manufacturer: device.manufacturer,
         id: device.ieee,
@@ -55,11 +53,11 @@ export class ZHADevicesDataTable extends LitElement {
               sortable: true,
               filterable: true,
               direction: "asc",
-              template: (name: DataTableRowData) => {
-                return html`
-                  ${name}<br />
-                `;
-              },
+              template: (name) => html`
+                <div @click=${this._handleClicked} style="cursor: pointer;">
+                  ${name}
+                </div>
+              `,
             },
           }
         : {
@@ -68,6 +66,11 @@ export class ZHADevicesDataTable extends LitElement {
               sortable: true,
               filterable: true,
               direction: "asc",
+              template: (name) => html`
+                <div @click=${this._handleClicked} style="cursor: pointer;">
+                  ${name}
+                </div>
+              `,
             },
             manufacturer: {
               title: "Manufacturer",
@@ -92,6 +95,13 @@ export class ZHADevicesDataTable extends LitElement {
         .selectable=${this.selectable}
       ></ha-data-table>
     `;
+  }
+
+  private async _handleClicked(ev: CustomEvent) {
+    const ieee = (ev.target as HTMLElement)
+      .closest("tr")!
+      .getAttribute("data-row-id")!;
+    showZHADeviceInfoDialog(this, { ieee });
   }
 }
 

--- a/src/panels/config/zha/zha-devices-data-table.ts
+++ b/src/panels/config/zha/zha-devices-data-table.ts
@@ -28,7 +28,7 @@ export class ZHADevicesDataTable extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public narrow = false;
   @property() public selectable = false;
-  @property() public devices!: ZHADevice[];
+  @property() public devices: ZHADevice[] = [];
 
   private _devices = memoizeOne((devices: ZHADevice[]) => {
     let outputDevices: DeviceRowData[] = devices;

--- a/src/panels/config/zha/zha-devices-data-table.ts
+++ b/src/panels/config/zha/zha-devices-data-table.ts
@@ -1,0 +1,102 @@
+import "../../../components/data-table/ha-data-table";
+import "../../../components/entity/ha-state-icon";
+
+import memoizeOne from "memoize-one";
+
+import {
+  LitElement,
+  html,
+  TemplateResult,
+  property,
+  customElement,
+} from "lit-element";
+import { HomeAssistant } from "../../../types";
+// tslint:disable-next-line
+import {
+  DataTableColumnContainer,
+  DataTableRowData,
+} from "../../../components/data-table/ha-data-table";
+// tslint:disable-next-line
+import { ZHADevice } from "../../../data/zha";
+
+export interface DeviceRowData extends ZHADevice {
+  device?: DeviceRowData;
+}
+
+@customElement("zha-devices-data-table")
+export class ZHADevicesDataTable extends LitElement {
+  @property() public hass!: HomeAssistant;
+  @property() public narrow = false;
+  @property() public selectable = false;
+  @property() public devices!: ZHADevice[];
+
+  private _devices = memoizeOne((devices: ZHADevice[]) => {
+    let outputDevices: DeviceRowData[] = devices;
+
+    outputDevices = outputDevices.map((device) => {
+      return {
+        ...device,
+        name: device.name,
+        model: device.model,
+        manufacturer: device.manufacturer,
+        id: device.ieee,
+      };
+    });
+
+    return outputDevices;
+  });
+
+  private _columns = memoizeOne(
+    (narrow: boolean): DataTableColumnContainer =>
+      narrow
+        ? {
+            name: {
+              title: "Devices",
+              sortable: true,
+              filterable: true,
+              direction: "asc",
+              template: (name: DataTableRowData) => {
+                return html`
+                  ${name}<br />
+                `;
+              },
+            },
+          }
+        : {
+            name: {
+              title: "Name",
+              sortable: true,
+              filterable: true,
+              direction: "asc",
+            },
+            manufacturer: {
+              title: "Manufacturer",
+              sortable: true,
+              filterable: true,
+              direction: "asc",
+            },
+            model: {
+              title: "Model",
+              sortable: true,
+              filterable: true,
+              direction: "asc",
+            },
+          }
+  );
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-data-table
+        .columns=${this._columns(this.narrow)}
+        .data=${this._devices(this.devices)}
+        .selectable=${this.selectable}
+      ></ha-data-table>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "zha-devices-data-table": ZHADevicesDataTable;
+  }
+}

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -21,10 +21,12 @@ import {
   fetchDevices,
   addMembersToGroup,
   removeMembersFromGroup,
+  removeGroups,
 } from "../../../data/zha";
 import { formatAsPaddedHex } from "./functions";
 import "./zha-devices-data-table";
 import { SelectionChangedEvent } from "../../../components/data-table/ha-data-table";
+import { navigate } from "../../../common/navigate";
 
 @customElement("zha-group-page")
 export class ZHAGroupPage extends LitElement {
@@ -67,7 +69,8 @@ export class ZHAGroupPage extends LitElement {
       <hass-subpage .header=${this.group.name}>
         <paper-icon-button
           slot="toolbar-icon"
-          icon="hass:settings"
+          icon="hass:delete"
+          @click=${this._deleteGroup}
         ></paper-icon-button>
         <ha-config-section .isWide=${!this.narrow}>
           <div class="header">
@@ -227,6 +230,11 @@ export class ZHAGroupPage extends LitElement {
     this._selectedDevicesToRemove = [];
     this._canRemove = false;
     this._processingRemove = false;
+  }
+
+  private async _deleteGroup(ev: CustomEvent): Promise<void> {
+    await removeGroups(this.hass, [this.groupId]);
+    navigate(this, `/config/zha/groups`);
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -1,0 +1,151 @@
+import {
+  property,
+  LitElement,
+  html,
+  customElement,
+  css,
+  CSSResult,
+} from "lit-element";
+
+import memoizeOne from "memoize-one";
+
+import "../../../layouts/hass-subpage";
+import "../../../layouts/hass-error-screen";
+import "../ha-config-section";
+import { HomeAssistant } from "../../../types";
+import {
+  ZHADevice,
+  ZHAGroup,
+  fetchGroup,
+  fetchDevices,
+} from "../../../data/zha";
+import { formatAsPaddedHex } from "./functions";
+import "./zha-devices-data-table";
+import { SelectionChangedEvent } from "../../../components/data-table/ha-data-table";
+
+@customElement("zha-group-page")
+export class ZHAGroupPage extends LitElement {
+  @property() public hass!: HomeAssistant;
+  @property() public group!: ZHAGroup;
+  @property() public devices!: ZHADevice[];
+  @property() public groupId!: number;
+  @property() public narrow!: boolean;
+  private _selectedDevices: string[] = [];
+  private _members = memoizeOne(
+    (group: ZHAGroup): ZHADevice[] => group.members
+  );
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    this._fetchData();
+  }
+
+  protected render() {
+    if (!this.group) {
+      return html`
+        <hass-error-screen
+          error="${this.hass.localize(
+            "ui.panel.config.devices.device_not_found"
+          )}"
+        ></hass-error-screen>
+      `;
+    }
+
+    const members = this._members(this.group);
+
+    return html`
+      <hass-subpage .header=${this.group.name}>
+        <paper-icon-button
+          slot="toolbar-icon"
+          icon="hass:settings"
+        ></paper-icon-button>
+        <ha-config-section .isWide=${!this.narrow}>
+          <span slot="header"
+            >${this.hass.localize(
+              "ui.panel.config.zha.common.group_info"
+            )}</span
+          >
+          <span slot="introduction">
+            ${this.hass.localize("ui.panel.config.zha.common.group_details")}
+          </span>
+          <span> <b>Name:</b> ${this.group.name} </span>
+          <span>
+            <b>Group Id:</b> ${formatAsPaddedHex(this.group.group_id)}
+          </span>
+          <div class="header">
+            ${this.hass.localize("ui.panel.config.zha.common.members")}
+          </div>
+
+          ${members.length
+            ? members.map(
+                (member) => html`
+                  <zha-device-card
+                    class="card"
+                    .hass=${this.hass}
+                    .device=${member}
+                    .narrow=${this.narrow}
+                  ></zha-device-card>
+                `
+              )
+            : html`
+                <span>
+                  This group has no members
+                </span>
+              `}
+          <div class="header">
+            ${this.hass.localize("ui.panel.config.zha.common.add_members")}
+          </div>
+
+          <zha-devices-data-table
+            .hass=${this.hass}
+            .devices=${this.devices}
+            .narrow=${this.narrow}
+            .selectable=${true}
+            @selection-changed=${this._handleSelectionChanged}
+          >
+          </zha-devices-data-table>
+        </ha-config-section>
+      </hass-subpage>
+    `;
+  }
+
+  private async _fetchData() {
+    if (this.groupId !== null && this.groupId !== undefined) {
+      this.group = await fetchGroup(this.hass!, this.groupId);
+    }
+    this.devices = await fetchDevices(this.hass!);
+  }
+
+  private _handleSelectionChanged(ev: CustomEvent): void {
+    const changedSelection = ev.detail as SelectionChangedEvent;
+    const entity = changedSelection.id;
+    if (changedSelection.selected) {
+      this._selectedDevices.push(entity);
+    } else {
+      const index = this._selectedDevices.indexOf(entity);
+      if (index !== -1) {
+        this._selectedDevices.splice(index, 1);
+      }
+    }
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      .header {
+        font-family: var(--paper-font-display1_-_font-family);
+        -webkit-font-smoothing: var(
+          --paper-font-display1_-_-webkit-font-smoothing
+        );
+        font-size: var(--paper-font-display1_-_font-size);
+        font-weight: var(--paper-font-display1_-_font-weight);
+        letter-spacing: var(--paper-font-display1_-_letter-spacing);
+        line-height: var(--paper-font-display1_-_line-height);
+        opacity: var(--dark-primary-opacity);
+      }
+
+      ha-config-section *:last-child {
+        padding-bottom: 24px;
+      }
+    `;
+  }
+}

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -13,6 +13,7 @@ import "../../../layouts/hass-subpage";
 import "../../../layouts/hass-error-screen";
 import "../ha-config-section";
 import { HomeAssistant } from "../../../types";
+import { haStyleDialog } from "../../../resources/styles";
 import {
   ZHADevice,
   ZHAGroup,
@@ -30,7 +31,11 @@ export class ZHAGroupPage extends LitElement {
   @property() public devices!: ZHADevice[];
   @property() public groupId!: number;
   @property() public narrow!: boolean;
+  @property() private _canSave: boolean = false;
+  @property() private _processing: boolean = false;
+
   private _selectedDevices: string[] = [];
+
   private _members = memoizeOne(
     (group: ZHAGroup): ZHADevice[] => group.members
   );
@@ -104,6 +109,21 @@ export class ZHAGroupPage extends LitElement {
             @selection-changed=${this._handleSelectionChanged}
           >
           </zha-devices-data-table>
+
+          <div class="paper-dialog-buttons">
+            <mwc-button
+              ?disabled="${!this._canSave}"
+              @click="${this._addMembersToGroup}"
+            >
+              <paper-spinner
+                ?active="${this._processing}"
+                alt="Adding Members"
+              ></paper-spinner>
+              ${this.hass!.localize(
+                "ui.panel.config.zha.common.add_members"
+              )}</mwc-button
+            >
+          </div>
         </ha-config-section>
       </hass-subpage>
     `;
@@ -127,25 +147,42 @@ export class ZHAGroupPage extends LitElement {
         this._selectedDevices.splice(index, 1);
       }
     }
+    this._canSave = this._selectedDevices.length > 0;
   }
 
-  static get styles(): CSSResult {
-    return css`
-      .header {
-        font-family: var(--paper-font-display1_-_font-family);
-        -webkit-font-smoothing: var(
-          --paper-font-display1_-_-webkit-font-smoothing
-        );
-        font-size: var(--paper-font-display1_-_font-size);
-        font-weight: var(--paper-font-display1_-_font-weight);
-        letter-spacing: var(--paper-font-display1_-_letter-spacing);
-        line-height: var(--paper-font-display1_-_line-height);
-        opacity: var(--dark-primary-opacity);
-      }
+  private _addMembersToGroup(ev: CustomEvent): void {}
 
-      ha-config-section *:last-child {
-        padding-bottom: 24px;
-      }
-    `;
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        .header {
+          font-family: var(--paper-font-display1_-_font-family);
+          -webkit-font-smoothing: var(
+            --paper-font-display1_-_-webkit-font-smoothing
+          );
+          font-size: var(--paper-font-display1_-_font-size);
+          font-weight: var(--paper-font-display1_-_font-weight);
+          letter-spacing: var(--paper-font-display1_-_letter-spacing);
+          line-height: var(--paper-font-display1_-_line-height);
+          opacity: var(--dark-primary-opacity);
+        }
+
+        ha-config-section *:last-child {
+          padding-bottom: 24px;
+        }
+        mwc-button paper-spinner {
+          width: 14px;
+          height: 14px;
+          margin-right: 20px;
+        }
+        paper-spinner {
+          display: none;
+        }
+        paper-spinner[active] {
+          display: block;
+        }
+      `,
+    ];
   }
 }

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -18,7 +18,7 @@ import {
   ZHADevice,
   ZHAGroup,
   fetchGroup,
-  fetchDevices,
+  fetchGroupableDevices,
   addMembersToGroup,
   removeMembersFromGroup,
   removeGroups,
@@ -177,7 +177,7 @@ export class ZHAGroupPage extends LitElement {
     if (this.groupId !== null && this.groupId !== undefined) {
       this.group = await fetchGroup(this.hass!, this.groupId);
     }
-    this.devices = await fetchDevices(this.hass!);
+    this.devices = await fetchGroupableDevices(this.hass!);
   }
 
   private _handleAddSelectionChanged(ev: CustomEvent): void {

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -70,11 +70,9 @@ export class ZHAGroupPage extends LitElement {
           icon="hass:settings"
         ></paper-icon-button>
         <ha-config-section .isWide=${!this.narrow}>
-          <span slot="header"
-            >${this.hass.localize(
-              "ui.panel.config.zha.common.group_info"
-            )}</span
-          >
+          <div class="header">
+            ${this.hass.localize("ui.panel.config.zha.common.group_info")}
+          </div>
           <span slot="introduction">
             ${this.hass.localize("ui.panel.config.zha.common.group_details")}
           </span>
@@ -116,6 +114,7 @@ export class ZHAGroupPage extends LitElement {
                   .narrow=${this.narrow}
                   .selectable=${true}
                   @selection-changed=${this._handleRemoveSelectionChanged}
+                  class="table"
                 >
                 </zha-devices-data-table>
 
@@ -123,6 +122,7 @@ export class ZHAGroupPage extends LitElement {
                   <mwc-button
                     ?disabled="${!this._canRemove}"
                     @click="${this._removeMembersFromGroup}"
+                    class="button"
                   >
                     <paper-spinner
                       ?active="${this._processingRemove}"
@@ -146,6 +146,7 @@ export class ZHAGroupPage extends LitElement {
             .narrow=${this.narrow}
             .selectable=${true}
             @selection-changed=${this._handleAddSelectionChanged}
+            class="table"
           >
           </zha-devices-data-table>
 
@@ -153,6 +154,7 @@ export class ZHAGroupPage extends LitElement {
             <mwc-button
               ?disabled="${!this._canAdd}"
               @click="${this._addMembersToGroup}"
+              class="button"
             >
               <paper-spinner
                 ?active="${this._processingAdd}"
@@ -241,6 +243,15 @@ export class ZHAGroupPage extends LitElement {
           letter-spacing: var(--paper-font-display1_-_letter-spacing);
           line-height: var(--paper-font-display1_-_line-height);
           opacity: var(--dark-primary-opacity);
+        }
+
+        .button {
+          float: right;
+        }
+
+        .table {
+          height: 200px;
+          overflow: auto;
         }
 
         ha-config-section *:last-child {

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -19,6 +19,7 @@ import {
   ZHAGroup,
   fetchGroup,
   fetchDevices,
+  addMembersToGroup,
 } from "../../../data/zha";
 import { formatAsPaddedHex } from "./functions";
 import "./zha-devices-data-table";
@@ -150,7 +151,15 @@ export class ZHAGroupPage extends LitElement {
     this._canSave = this._selectedDevices.length > 0;
   }
 
-  private _addMembersToGroup(ev: CustomEvent): void {}
+  private async _addMembersToGroup(ev: CustomEvent): Promise<void> {
+    this._processing = true;
+    this.group = await addMembersToGroup(
+      this.hass,
+      this.groupId,
+      this._selectedDevices
+    );
+    this._processing = false;
+  }
 
   static get styles(): CSSResult[] {
     return [

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -32,7 +32,7 @@ import { navigate } from "../../../common/navigate";
 export class ZHAGroupPage extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public group!: ZHAGroup;
-  @property() public devices!: ZHADevice[];
+  @property() public devices: ZHADevice[] = [];
   @property() public groupId!: number;
   @property() public narrow!: boolean;
   @property() private _canAdd: boolean = false;

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -208,7 +208,7 @@ export class ZHAGroupPage extends LitElement {
     this._canRemove = this._selectedDevicesToRemove.length > 0;
   }
 
-  private async _addMembersToGroup(ev: CustomEvent): Promise<void> {
+  private async _addMembersToGroup(): Promise<void> {
     this._processingAdd = true;
     this.group = await addMembersToGroup(
       this.hass,
@@ -220,7 +220,7 @@ export class ZHAGroupPage extends LitElement {
     this._processingAdd = false;
   }
 
-  private async _removeMembersFromGroup(ev: CustomEvent): Promise<void> {
+  private async _removeMembersFromGroup(): Promise<void> {
     this._processingRemove = true;
     this.group = await removeMembersFromGroup(
       this.hass,
@@ -232,9 +232,9 @@ export class ZHAGroupPage extends LitElement {
     this._processingRemove = false;
   }
 
-  private async _deleteGroup(ev: CustomEvent): Promise<void> {
+  private async _deleteGroup(): Promise<void> {
     await removeGroups(this.hass, [this.groupId]);
-    navigate(this, `/config/zha/groups`);
+    navigate(this, `/config/zha/groups`, true);
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/zha/zha-groups-dashboard.ts
@@ -11,11 +11,19 @@ import {
   css,
 } from "lit-element";
 import { HomeAssistant } from "../../../types";
+import { ZHAGroup, fetchGroups } from "../../../data/zha";
+import { sortZHAGroups } from "./functions";
 
 @customElement("zha-groups-dashboard")
 export class ZHAGroupsDashboard extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public narrow = false;
+  @property() public _groups!: ZHAGroup[];
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    this._fetchGroups();
+  }
 
   protected render(): TemplateResult {
     return html`
@@ -28,10 +36,15 @@ export class ZHAGroupsDashboard extends LitElement {
           <zha-groups-data-table
             .hass=${this.hass}
             .narrow=${this.narrow}
+            .groups=${this._groups}
           ></zha-groups-data-table>
         </div>
       </hass-subpage>
     `;
+  }
+
+  private async _fetchGroups() {
+    this._groups = (await fetchGroups(this.hass!)).sort(sortZHAGroups);
   }
 
   static get styles(): CSSResult {

--- a/src/panels/config/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/zha/zha-groups-dashboard.ts
@@ -93,7 +93,7 @@ export class ZHAGroupsDashboard extends LitElement {
     this._canRemove = this._selectedGroupsToRemove.length > 0;
   }
 
-  private async _removeGroup(ev: CustomEvent): Promise<void> {
+  private async _removeGroup(): Promise<void> {
     this._processingRemove = true;
     this._groups = await removeGroups(this.hass, this._selectedGroupsToRemove);
     this._selectedGroupsToRemove = [];
@@ -101,7 +101,7 @@ export class ZHAGroupsDashboard extends LitElement {
     this._processingRemove = false;
   }
 
-  private async _addGroup(ev: CustomEvent): Promise<void> {
+  private async _addGroup(): Promise<void> {
     navigate(this, `/config/zha/group-add`);
   }
 

--- a/src/panels/config/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/zha/zha-groups-dashboard.ts
@@ -15,6 +15,7 @@ import { haStyleDialog } from "../../../resources/styles";
 import { ZHAGroup, fetchGroups, removeGroups } from "../../../data/zha";
 import { sortZHAGroups } from "./functions";
 import { SelectionChangedEvent } from "../../../components/data-table/ha-data-table";
+import { navigate } from "../../../common/navigate";
 
 @customElement("zha-groups-dashboard")
 export class ZHAGroupsDashboard extends LitElement {
@@ -100,7 +101,9 @@ export class ZHAGroupsDashboard extends LitElement {
     this._processingRemove = false;
   }
 
-  private async _addGroup(ev: CustomEvent): Promise<void> {}
+  private async _addGroup(ev: CustomEvent): Promise<void> {
+    navigate(this, `/config/zha/group-add`);
+  }
 
   static get styles(): CSSResult[] {
     return [

--- a/src/panels/config/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/zha/zha-groups-dashboard.ts
@@ -11,14 +11,20 @@ import {
   css,
 } from "lit-element";
 import { HomeAssistant } from "../../../types";
-import { ZHAGroup, fetchGroups } from "../../../data/zha";
+import { haStyleDialog } from "../../../resources/styles";
+import { ZHAGroup, fetchGroups, removeGroups } from "../../../data/zha";
 import { sortZHAGroups } from "./functions";
+import { SelectionChangedEvent } from "../../../components/data-table/ha-data-table";
 
 @customElement("zha-groups-dashboard")
 export class ZHAGroupsDashboard extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public narrow = false;
   @property() public _groups!: ZHAGroup[];
+  @property() private _canRemove: boolean = false;
+  @property() private _processingRemove: boolean = false;
+
+  private _selectedGroupsToRemove: number[] = [];
 
   public connectedCallback(): void {
     super.connectedCallback();
@@ -32,12 +38,37 @@ export class ZHAGroupsDashboard extends LitElement {
           "ui.panel.config.zha.common.zha_zigbee_groups"
         )}
       >
+        <paper-icon-button
+          slot="toolbar-icon"
+          icon="hass:plus"
+          @click=${this._addGroup}
+        ></paper-icon-button>
+
         <div class="content">
           <zha-groups-data-table
             .hass=${this.hass}
             .narrow=${this.narrow}
             .groups=${this._groups}
+            .selectable=${true}
+            @selection-changed=${this._handleRemoveSelectionChanged}
+            class="table"
           ></zha-groups-data-table>
+        </div>
+
+        <div class="paper-dialog-buttons">
+          <mwc-button
+            ?disabled="${!this._canRemove}"
+            @click="${this._removeGroup}"
+            class="button"
+          >
+            <paper-spinner
+              ?active="${this._processingRemove}"
+              alt="Removing Groups"
+            ></paper-spinner>
+            ${this.hass!.localize(
+              "ui.panel.config.zha.common.remove_groups"
+            )}</mwc-button
+          >
         </div>
       </hass-subpage>
     `;
@@ -47,15 +78,61 @@ export class ZHAGroupsDashboard extends LitElement {
     this._groups = (await fetchGroups(this.hass!)).sort(sortZHAGroups);
   }
 
-  static get styles(): CSSResult {
-    return css`
-      .content {
-        padding: 4px;
+  private _handleRemoveSelectionChanged(ev: CustomEvent): void {
+    const changedSelection = ev.detail as SelectionChangedEvent;
+    const groupId = Number(changedSelection.id);
+    if (changedSelection.selected) {
+      this._selectedGroupsToRemove.push(groupId);
+    } else {
+      const index = this._selectedGroupsToRemove.indexOf(groupId);
+      if (index !== -1) {
+        this._selectedGroupsToRemove.splice(index, 1);
       }
-      zha-groups-data-table {
-        width: 100%;
-      }
-    `;
+    }
+    this._canRemove = this._selectedGroupsToRemove.length > 0;
+  }
+
+  private async _removeGroup(ev: CustomEvent): Promise<void> {
+    this._processingRemove = true;
+    this._groups = await removeGroups(this.hass, this._selectedGroupsToRemove);
+    this._selectedGroupsToRemove = [];
+    this._canRemove = false;
+    this._processingRemove = false;
+  }
+
+  private async _addGroup(ev: CustomEvent): Promise<void> {}
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        .content {
+          padding: 4px;
+        }
+        zha-groups-data-table {
+          width: 100%;
+        }
+        .button {
+          float: right;
+        }
+
+        .table {
+          height: 200px;
+          overflow: auto;
+        }
+        mwc-button paper-spinner {
+          width: 14px;
+          height: 14px;
+          margin-right: 20px;
+        }
+        paper-spinner {
+          display: none;
+        }
+        paper-spinner[active] {
+          display: block;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/config/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/zha/zha-groups-dashboard.ts
@@ -1,0 +1,53 @@
+import "../../../layouts/hass-subpage";
+import "./zha-groups-data-table";
+
+import {
+  LitElement,
+  html,
+  TemplateResult,
+  property,
+  customElement,
+  CSSResult,
+  css,
+} from "lit-element";
+import { HomeAssistant } from "../../../types";
+
+@customElement("zha-groups-dashboard")
+export class ZHAGroupsDashboard extends LitElement {
+  @property() public hass!: HomeAssistant;
+  @property() public narrow = false;
+
+  protected render(): TemplateResult {
+    return html`
+      <hass-subpage
+        header=${this.hass.localize(
+          "ui.panel.config.zha.common.zha_zigbee_groups"
+        )}
+      >
+        <div class="content">
+          <zha-groups-data-table
+            .hass=${this.hass}
+            .narrow=${this.narrow}
+          ></zha-groups-data-table>
+        </div>
+      </hass-subpage>
+    `;
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      .content {
+        padding: 4px;
+      }
+      zha-groups-data-table {
+        width: 100%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "zha-groups-dashboard": ZHAGroupsDashboard;
+  }
+}

--- a/src/panels/config/zha/zha-groups-data-table.ts
+++ b/src/panels/config/zha/zha-groups-data-table.ts
@@ -31,7 +31,7 @@ export class ZHAGroupsDataTable extends LitElement {
   @property() public selectable = false;
 
   private _groups = memoizeOne((groups: ZHAGroup[]) => {
-    let outputGroups: GroupRowData[] = groups;
+    let outputGroups: GroupRowData[] = groups || [];
 
     outputGroups = outputGroups.map((group) => {
       return {

--- a/src/panels/config/zha/zha-groups-data-table.ts
+++ b/src/panels/config/zha/zha-groups-data-table.ts
@@ -12,11 +12,7 @@ import {
 } from "lit-element";
 import { HomeAssistant } from "../../../types";
 // tslint:disable-next-line
-import {
-  DataTableColumnContainer,
-  RowClickedEvent,
-  DataTableRowData,
-} from "../../../components/data-table/ha-data-table";
+import { DataTableColumnContainer } from "../../../components/data-table/ha-data-table";
 // tslint:disable-next-line
 import { navigate } from "../../../common/navigate";
 import { ZHAGroup, ZHADevice } from "../../../data/zha";
@@ -24,7 +20,7 @@ import { formatAsPaddedHex } from "./functions";
 
 export interface GroupRowData extends ZHAGroup {
   group?: GroupRowData;
-  id: number;
+  id?: number;
 }
 
 @customElement("zha-groups-data-table")
@@ -32,6 +28,7 @@ export class ZHAGroupsDataTable extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public narrow = false;
   @property() public groups!: ZHAGroup[];
+  @property() public selectable = false;
 
   private _groups = memoizeOne((groups: ZHAGroup[]) => {
     let outputGroups: GroupRowData[] = groups;
@@ -58,11 +55,11 @@ export class ZHAGroupsDataTable extends LitElement {
               sortable: true,
               filterable: true,
               direction: "asc",
-              template: (name: DataTableRowData) => {
-                return html`
-                  ${name}<br />
-                `;
-              },
+              template: (name) => html`
+                <div @click=${this._handleRowClicked} style="cursor: pointer;">
+                  ${name}
+                </div>
+              `,
             },
           }
         : {
@@ -71,6 +68,11 @@ export class ZHAGroupsDataTable extends LitElement {
               sortable: true,
               filterable: true,
               direction: "asc",
+              template: (name) => html`
+                <div @click=${this._handleRowClicked} style="cursor: pointer;">
+                  ${name}
+                </div>
+              `,
             },
             group_id: {
               title: this.hass.localize("ui.panel.config.zha.common.group_id"),
@@ -102,13 +104,15 @@ export class ZHAGroupsDataTable extends LitElement {
       <ha-data-table
         .columns=${this._columns(this.narrow)}
         .data=${this._groups(this.groups)}
-        @row-click=${this._handleRowClicked}
+        .selectable=${this.selectable}
       ></ha-data-table>
     `;
   }
 
   private _handleRowClicked(ev: CustomEvent) {
-    const groupId = (ev.detail as RowClickedEvent).id;
+    const groupId = (ev.target as HTMLElement)
+      .closest("tr")!
+      .getAttribute("data-row-id")!;
     navigate(this, `/config/zha/group/${groupId}`);
   }
 }

--- a/src/panels/config/zha/zha-groups-data-table.ts
+++ b/src/panels/config/zha/zha-groups-data-table.ts
@@ -27,7 +27,7 @@ export interface GroupRowData extends ZHAGroup {
 export class ZHAGroupsDataTable extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public narrow = false;
-  @property() public groups!: ZHAGroup[];
+  @property() public groups: ZHAGroup[] = [];
   @property() public selectable = false;
 
   private _groups = memoizeOne((groups: ZHAGroup[]) => {

--- a/src/panels/config/zha/zha-groups-data-table.ts
+++ b/src/panels/config/zha/zha-groups-data-table.ts
@@ -24,6 +24,7 @@ import { formatAsPaddedHex } from "./functions";
 
 export interface GroupRowData extends ZHAGroup {
   group?: GroupRowData;
+  id: number;
 }
 
 @customElement("zha-groups-data-table")
@@ -41,6 +42,7 @@ export class ZHAGroupsDataTable extends LitElement {
         name: group.name,
         group_id: group.group_id,
         members: group.members,
+        id: group.group_id,
       };
     });
 
@@ -106,8 +108,8 @@ export class ZHAGroupsDataTable extends LitElement {
   }
 
   private _handleRowClicked(ev: CustomEvent) {
-    const deviceId = (ev.detail as RowClickedEvent).id;
-    navigate(this, `/config/devices/device/${deviceId}`);
+    const groupId = (ev.detail as RowClickedEvent).id;
+    navigate(this, `/config/zha/group/${groupId}`);
   }
 }
 

--- a/src/panels/config/zha/zha-groups-data-table.ts
+++ b/src/panels/config/zha/zha-groups-data-table.ts
@@ -1,0 +1,83 @@
+import "../../../components/data-table/ha-data-table";
+import "../../../components/entity/ha-state-icon";
+
+import memoizeOne from "memoize-one";
+
+import {
+  LitElement,
+  html,
+  TemplateResult,
+  property,
+  customElement,
+} from "lit-element";
+import { HomeAssistant } from "../../../types";
+// tslint:disable-next-line
+import {
+  DataTableColumnContainer,
+  RowClickedEvent,
+  DataTableRowData,
+} from "../../../components/data-table/ha-data-table";
+// tslint:disable-next-line
+import { DeviceRegistryEntry } from "../../../data/device_registry";
+import { navigate } from "../../../common/navigate";
+import { LocalizeFunc } from "../../../common/translations/localize";
+
+export interface GroupRowData extends DeviceRegistryEntry {
+  device?: GroupRowData;
+  area?: string;
+  integration?: string;
+  battery_entity?: string;
+}
+
+@customElement("zha-groups-data-table")
+export class ZHAGroupsDataTable extends LitElement {
+  @property() public hass!: HomeAssistant;
+  @property() public narrow = false;
+
+  private _columns = memoizeOne(
+    (narrow: boolean): DataTableColumnContainer =>
+      narrow
+        ? {
+            name: {
+              title: "Group",
+              sortable: true,
+              filterable: true,
+              direction: "asc",
+              template: (name, group: DataTableRowData) => {
+                return html`
+                  ${name}<br />
+                `;
+              },
+            },
+          }
+        : {
+            name: {
+              title: this.hass.localize("ui.panel.config.zha.common.groups"),
+              sortable: true,
+              filterable: true,
+              direction: "asc",
+            },
+          }
+  );
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-data-table
+        .columns=${this._columns(this.narrow)}
+        .data=${[]}
+        @row-click=${this._handleRowClicked}
+      ></ha-data-table>
+    `;
+  }
+
+  private _handleRowClicked(ev: CustomEvent) {
+    const deviceId = (ev.detail as RowClickedEvent).id;
+    navigate(this, `/config/devices/device/${deviceId}`);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "zha-groups-data-table": ZHAGroupsDataTable;
+  }
+}

--- a/src/panels/config/zha/zha-groups-tile.ts
+++ b/src/panels/config/zha/zha-groups-tile.ts
@@ -1,0 +1,112 @@
+import "../../../components/ha-card";
+import "../ha-config-section";
+import "@material/mwc-button";
+import "@polymer/paper-icon-button/paper-icon-button";
+
+import {
+  css,
+  CSSResult,
+  html,
+  LitElement,
+  TemplateResult,
+  property,
+  customElement,
+} from "lit-element";
+
+import { navigate } from "../../../common/navigate";
+import { haStyle } from "../../../resources/styles";
+import { HomeAssistant } from "../../../types";
+
+@customElement("zha-groups-tile")
+export class ZHAGroupsTile extends LitElement {
+  @property() public hass?: HomeAssistant;
+  @property() public isWide?: boolean;
+  @property() private _showHelp = false;
+
+  protected render(): TemplateResult | void {
+    return html`
+      <ha-config-section .isWide="${this.isWide}">
+        <div style="position: relative" slot="header">
+          <span>
+            ${this.hass!.localize(
+              "ui.panel.config.zha.groups_management.header"
+            )}
+          </span>
+          <paper-icon-button
+            class="toggle-help-icon"
+            @click="${this._onHelpTap}"
+            icon="hass:help-circle"
+          ></paper-icon-button>
+        </div>
+        <span slot="introduction">
+          ${this.hass!.localize(
+            "ui.panel.config.zha.groups_management.introduction"
+          )}
+        </span>
+
+        <ha-card class="content">
+          <div class="card-actions">
+            <mwc-button @click=${this._onAddDevicesClick}>
+              ${this.hass!.localize("ui.panel.config.zha.common.manage_groups")}
+            </mwc-button>
+          </div>
+        </ha-card>
+      </ha-config-section>
+    `;
+  }
+
+  private _onHelpTap(): void {
+    this._showHelp = !this._showHelp;
+  }
+
+  private _onAddDevicesClick() {
+    navigate(this, "groups");
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyle,
+      css`
+        .content {
+          margin-top: 24px;
+        }
+
+        ha-card {
+          margin: 0 auto;
+          max-width: 600px;
+        }
+
+        .card-actions.warning ha-call-service-button {
+          color: var(--google-red-500);
+        }
+
+        .toggle-help-icon {
+          position: absolute;
+          top: -6px;
+          right: 0;
+          color: var(--primary-color);
+        }
+
+        ha-service-description {
+          display: block;
+          color: grey;
+        }
+
+        [hidden] {
+          display: none;
+        }
+
+        .help-text2 {
+          color: grey;
+          padding: 16px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "zha-groups-tile": ZHAGroupsTile;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1384,6 +1384,8 @@
             "zha_zigbee_groups": "ZHA Zigbee Groups",
             "manage_groups": "Manage Zigbee Groups",
             "groups": "Groups",
+            "group_id": "Group ID",
+            "members": "Members",
             "devices": "Devices",
             "manufacturer_code_override": "Manufacturer Code Override",
             "value": "Value"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1381,6 +1381,9 @@
           "common": {
             "add_devices": "Add Devices",
             "clusters": "Clusters",
+            "zha_zigbee_groups": "ZHA Zigbee Groups",
+            "manage_groups": "Manage Zigbee Groups",
+            "groups": "Groups",
             "devices": "Devices",
             "manufacturer_code_override": "Manufacturer Code Override",
             "value": "Value"
@@ -1394,6 +1397,10 @@
           "network_management": {
             "header": "Network Management",
             "introduction": "Commands that affect the entire network"
+          },
+          "groups_management": {
+            "header": "Zigbee Group Management",
+            "introduction": "Create and modify zigbee groups"
           },
           "node_management": {
             "header": "Device Management",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1386,6 +1386,9 @@
             "groups": "Groups",
             "group_id": "Group ID",
             "members": "Members",
+            "add_members": "Add Members",
+            "group_info": "Group Information",
+            "group_details": "Here are all the details for the selected Zigbee group.",
             "devices": "Devices",
             "manufacturer_code_override": "Manufacturer Code Override",
             "value": "Value"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1387,6 +1387,7 @@
             "group_id": "Group ID",
             "members": "Members",
             "add_members": "Add Members",
+            "remove_members": "Remove Members",
             "group_info": "Group Information",
             "group_details": "Here are all the details for the selected Zigbee group.",
             "devices": "Devices",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1389,8 +1389,12 @@
             "add_members": "Add Members",
             "remove_members": "Remove Members",
             "remove_groups": "Remove Groups",
+            "create_group": "Create New ZHA Zigbee Group",
+            "create": "Create Group",
             "group_info": "Group Information",
             "group_details": "Here are all the details for the selected Zigbee group.",
+            "create_group_details": "Enter the required details to create a new zigbee group",
+            "group_name_placeholder": "Group Name",
             "devices": "Devices",
             "manufacturer_code_override": "Manufacturer Code Override",
             "value": "Value"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1388,6 +1388,7 @@
             "members": "Members",
             "add_members": "Add Members",
             "remove_members": "Remove Members",
+            "remove_groups": "Remove Groups",
             "group_info": "Group Information",
             "group_details": "Here are all the details for the selected Zigbee group.",
             "devices": "Devices",


### PR DESCRIPTION
This PR adds a UI for managing ZHA Zigbee groups. It supports the basic CRUD actions. I'll split this into separate PR's if it is preferred. Here are some screen shots that outline the functionality:

Manage groups added to main ZHA config panel:
<img width="1230" alt="Screen Shot 2019-12-16 at 11 12 55 AM" src="https://user-images.githubusercontent.com/1335687/70923485-f240c100-1ff5-11ea-988e-350967211666.png">

Groups View:
<img width="1399" alt="Screen Shot 2019-12-16 at 11 13 09 AM" src="https://user-images.githubusercontent.com/1335687/70923507-f967cf00-1ff5-11ea-9b44-ef46dcab928d.png">

Selected Groups details:
<img width="1398" alt="Screen Shot 2019-12-16 at 11 13 51 AM" src="https://user-images.githubusercontent.com/1335687/70923513-fc62bf80-1ff5-11ea-8e0b-8529d6dc963b.png">
<img width="1391" alt="Screen Shot 2019-12-16 at 11 14 03 AM" src="https://user-images.githubusercontent.com/1335687/70923522-ff5db000-1ff5-11ea-830e-861f559c66c8.png">

Create Group view:
<img width="1388" alt="Screen Shot 2019-12-16 at 11 14 42 AM" src="https://user-images.githubusercontent.com/1335687/70923529-01c00a00-1ff6-11ea-83c2-c909252d0805.png">

Device details dialog in group view:
<img width="1218" alt="Screen Shot 2019-12-16 at 11 15 10 AM" src="https://user-images.githubusercontent.com/1335687/70923542-04bafa80-1ff6-11ea-8c6c-f81680f2c178.png">


I wanted to get this open to gather feedback as I have had this in this state for a few weeks now. I am thinking about how to break this up if that's preferred. I am thinking I could open the following PR's:

- add the manage groups button to the main screen and the groups view
- add the individual groups details view
- add editing of individual group (including delete)
- add group creation

Let me know if that makes sense to do or not.