### PR TITLE
✨ fire custom action events

### DIFF
--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -86,7 +86,7 @@ export const handleAction = (
       forwardHaptic("light");
       break;
     default:
-      if (actionConfig.action.includes("custom") {
+      if (actionConfig.action.includes("custom")) {
         fireEvent(node, actionConfig.action, actionConfig);
       }
   }

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -86,6 +86,8 @@ export const handleAction = (
       forwardHaptic("light");
       break;
     default:
-      fireEvent(node, actionConfig.action, actionConfig);
+      if (actionConfig.action.includes("custom") {
+        fireEvent(node, actionConfig.action, actionConfig);
+      }
   }
 };

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -86,6 +86,6 @@ export const handleAction = (
       forwardHaptic("light");
       break;
     default:
-      fireEvent(node, actionConfig.action, actionConfig});
+      fireEvent(node, actionConfig.action, actionConfig);
   }
 };

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -76,7 +76,7 @@ export const handleAction = (
         forwardHaptic("light");
       }
       break;
-    case "call-service": {
+    case "call-service":
       if (!actionConfig.service) {
         forwardHaptic("failure");
         return;
@@ -84,6 +84,8 @@ export const handleAction = (
       const [domain, service] = actionConfig.service.split(".", 2);
       hass.callService(domain, service, actionConfig.service_data);
       forwardHaptic("light");
-    }
+      break;
+    default:
+      fireEvent(node, actionConfig.action, actionConfig});
   }
 };

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -5,6 +5,12 @@ import { toggleEntity } from "./entity/toggle-entity";
 import { ActionConfig } from "../../../data/lovelace";
 import { forwardHaptic } from "../../../data/haptics";
 
+declare global {
+  interface HASSDomEvents {
+    custom: ActionConfig;
+  }
+}
+
 export const handleAction = (
   node: HTMLElement,
   hass: HomeAssistant,
@@ -85,9 +91,7 @@ export const handleAction = (
       hass.callService(domain, service, actionConfig.service_data);
       forwardHaptic("light");
       break;
-    default:
-      if (actionConfig.action.includes("custom")) {
-        fireEvent(node, actionConfig.action, actionConfig);
-      }
+    case "custom":
+      fireEvent(node, "custom", actionConfig);
   }
 };


### PR DESCRIPTION
I haven't tested this out yet, but the idea is that if the defined action is not supported, we fire an event so a custom event listener can pick it up and handle it.

This is my idea to implement this: https://github.com/home-assistant/home-assistant-polymer/pull/4124 in a cleaner way in a custom solution and opens up some cool possibilities, I think.