### PR TITLE
Add 'unignore' to DISCOVERY_SOURCES that can be ignored.

### DIFF
--- a/src/data/config_flow.ts
+++ b/src/data/config_flow.ts
@@ -4,7 +4,7 @@ import { debounce } from "../common/util/debounce";
 import { getCollection, Connection } from "home-assistant-js-websocket";
 import { LocalizeFunc } from "../common/translations/localize";
 
-export const DISCOVERY_SOURCES = ["homekit", "ssdp", "zeroconf"];
+export const DISCOVERY_SOURCES = ["unignore", "homekit", "ssdp", "zeroconf"];
 
 export const createConfigFlow = (hass: HomeAssistant, handler: string) =>
   hass.callApi<DataEntryFlowStep>("POST", "config/config_entries/flow", {


### PR DESCRIPTION
As discussed in https://github.com/home-assistant/home-assistant/pull/30099. This adds "unignore" to the list of config flows that can be ignored.