### PR TITLE
Add Zigbee group removal to the ZHA config panel

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -164,3 +164,12 @@ export const fetchGroups = (hass: HomeAssistant): Promise<ZHAGroup[]> =>
   hass.callWS({
     type: "zha/groups",
   });
+
+export const removeGroups = (
+  hass: HomeAssistant,
+  groupIdsToRemove: number[]
+): Promise<ZHAGroup[]> =>
+  hass.callWS({
+    type: "zha/group/remove",
+    group_ids: groupIdsToRemove,
+  });

--- a/src/panels/config/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/zha/zha-groups-dashboard.ts
@@ -61,7 +61,7 @@ export class ZHAGroupsDashboard extends LitElement {
               alt="Removing Groups"
             ></paper-spinner>
             ${this.hass!.localize(
-              "ui.panel.config.zha.common.remove_groups"
+              "ui.panel.config.zha.groups.remove_groups"
             )}</mwc-button
           >
         </div>

--- a/src/panels/config/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/zha/zha-groups-dashboard.ts
@@ -22,7 +22,7 @@ import "@polymer/paper-spinner/paper-spinner";
 export class ZHAGroupsDashboard extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public narrow = false;
-  @property() public _groups!: ZHAGroup[];
+  @property() public _groups?: ZHAGroup[];
   @property() private _processingRemove: boolean = false;
   @property() private _selectedGroupsToRemove: number[] = [];
   private _firstUpdatedCalled: boolean = false;
@@ -63,7 +63,7 @@ export class ZHAGroupsDashboard extends LitElement {
               `
             : html`
                 <paper-spinner
-                  ?active="${!this._groups}"
+                  active
                   alt=${this.hass!.localize("ui.common.loading")}
                 ></paper-spinner>
               `}

--- a/src/panels/config/zha/zha-groups-data-table.ts
+++ b/src/panels/config/zha/zha-groups-data-table.ts
@@ -27,6 +27,7 @@ export class ZHAGroupsDataTable extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public narrow = false;
   @property() public groups: ZHAGroup[] = [];
+  @property() public selectable = false;
 
   private _columns = memoizeOne(
     (narrow: boolean): DataTableColumnContainer =>
@@ -73,6 +74,7 @@ export class ZHAGroupsDataTable extends LitElement {
         .columns=${this._columns(this.narrow)}
         .data=${this.groups}
         .id=${"group_id"}
+        .selectable=${this.selectable}
       ></ha-data-table>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1446,7 +1446,8 @@
             "members": "Members",
             "header": "Zigbee Group Management",
             "introduction": "Create and modify zigbee groups",
-            "remove_groups": "Remove Groups"
+            "remove_groups": "Remove Groups",
+            "removing_groups": "Removing Groups"
           }
         },
         "zwave": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1445,7 +1445,8 @@
             "group_id": "Group ID",
             "members": "Members",
             "header": "Zigbee Group Management",
-            "introduction": "Create and modify zigbee groups"
+            "introduction": "Create and modify zigbee groups",
+            "remove_groups": "Remove Groups"
           }
         },
         "zwave": {


### PR DESCRIPTION
This PR adds the ability to remove Zigbee groups to the ZHA config panel. This is the second PR in a series to add full group management to the configuration panel. See PR #4352 for the desired end state.