### PR TITLE
Add group editing to the ZHA config panel

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -182,3 +182,32 @@ export const fetchGroup = (
     type: "zha/group",
     group_id: groupId,
   });
+
+export const fetchGroupableDevices = (
+  hass: HomeAssistant
+): Promise<ZHADevice[]> =>
+  hass.callWS({
+    type: "zha/devices/groupable",
+  });
+
+export const addMembersToGroup = (
+  hass: HomeAssistant,
+  groupId: number,
+  membersToAdd: string[]
+): Promise<ZHAGroup> =>
+  hass.callWS({
+    type: "zha/group/members/add",
+    group_id: groupId,
+    members: membersToAdd,
+  });
+
+export const removeMembersFromGroup = (
+  hass: HomeAssistant,
+  groupId: number,
+  membersToRemove: string[]
+): Promise<ZHAGroup> =>
+  hass.callWS({
+    type: "zha/group/members/remove",
+    group_id: groupId,
+    members: membersToRemove,
+  });

--- a/src/panels/config/zha/zha-devices-data-table.ts
+++ b/src/panels/config/zha/zha-devices-data-table.ts
@@ -25,7 +25,7 @@ export interface DeviceRowData extends ZHADevice {
 export class ZHADevicesDataTable extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public narrow = false;
-  @property() public selectable = false;
+  @property({ type: Boolean }) public selectable = false;
   @property() public devices: ZHADevice[] = [];
 
   private _devices = memoizeOne((devices: ZHADevice[]) => {

--- a/src/panels/config/zha/zha-devices-data-table.ts
+++ b/src/panels/config/zha/zha-devices-data-table.ts
@@ -34,7 +34,7 @@ export class ZHADevicesDataTable extends LitElement {
     outputDevices = outputDevices.map((device) => {
       return {
         ...device,
-        name: device.user_given_name ? device.user_given_name : device.name,
+        name: device.user_given_name || device.name,
         model: device.model,
         manufacturer: device.manufacturer,
         id: device.ieee,

--- a/src/panels/config/zha/zha-devices-data-table.ts
+++ b/src/panels/config/zha/zha-devices-data-table.ts
@@ -1,0 +1,110 @@
+import "../../../components/data-table/ha-data-table";
+import "../../../components/entity/ha-state-icon";
+
+import memoizeOne from "memoize-one";
+
+import {
+  LitElement,
+  html,
+  TemplateResult,
+  property,
+  customElement,
+} from "lit-element";
+import { HomeAssistant } from "../../../types";
+// tslint:disable-next-line
+import { DataTableColumnContainer } from "../../../components/data-table/ha-data-table";
+// tslint:disable-next-line
+import { ZHADevice } from "../../../data/zha";
+import { showZHADeviceInfoDialog } from "../../../dialogs/zha-device-info-dialog/show-dialog-zha-device-info";
+
+export interface DeviceRowData extends ZHADevice {
+  device?: DeviceRowData;
+}
+
+@customElement("zha-devices-data-table")
+export class ZHADevicesDataTable extends LitElement {
+  @property() public hass!: HomeAssistant;
+  @property() public narrow = false;
+  @property() public selectable = false;
+  @property() public devices: ZHADevice[] = [];
+
+  private _devices = memoizeOne((devices: ZHADevice[]) => {
+    let outputDevices: DeviceRowData[] = devices;
+
+    outputDevices = outputDevices.map((device) => {
+      return {
+        ...device,
+        name: device.user_given_name ? device.user_given_name : device.name,
+        model: device.model,
+        manufacturer: device.manufacturer,
+        id: device.ieee,
+      };
+    });
+
+    return outputDevices;
+  });
+
+  private _columns = memoizeOne(
+    (narrow: boolean): DataTableColumnContainer =>
+      narrow
+        ? {
+            name: {
+              title: "Devices",
+              sortable: true,
+              filterable: true,
+              direction: "asc",
+              template: (name) => html`
+                <div @click=${this._handleClicked} style="cursor: pointer;">
+                  ${name}
+                </div>
+              `,
+            },
+          }
+        : {
+            name: {
+              title: "Name",
+              sortable: true,
+              filterable: true,
+              direction: "asc",
+              template: (name) => html`
+                <div @click=${this._handleClicked} style="cursor: pointer;">
+                  ${name}
+                </div>
+              `,
+            },
+            manufacturer: {
+              title: "Manufacturer",
+              sortable: true,
+              filterable: true,
+            },
+            model: {
+              title: "Model",
+              sortable: true,
+              filterable: true,
+            },
+          }
+  );
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-data-table
+        .columns=${this._columns(this.narrow)}
+        .data=${this._devices(this.devices)}
+        .selectable=${this.selectable}
+      ></ha-data-table>
+    `;
+  }
+
+  private async _handleClicked(ev: CustomEvent) {
+    const ieee = (ev.target as HTMLElement)
+      .closest("tr")!
+      .getAttribute("data-row-id")!;
+    showZHADeviceInfoDialog(this, { ieee });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "zha-devices-data-table": ZHADevicesDataTable;
+  }
+}

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -149,7 +149,7 @@ export class ZHAGroupPage extends LitElement {
 
                 <div class="paper-dialog-buttons">
                   <mwc-button
-                    ?disabled="${!this._selectedDevicesToRemove.length ||
+                    .disabled="${!this._selectedDevicesToRemove.length ||
                       this._processingRemove}"
                     @click="${this._removeMembersFromGroup}"
                     class="button"

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -184,7 +184,7 @@ export class ZHAGroupPage extends LitElement {
 
           <div class="paper-dialog-buttons">
             <mwc-button
-              ?disabled="${!this._selectedDevicesToAdd.length ||
+              .disabled="${!this._selectedDevicesToAdd.length ||
                 this._processingAdd}"
               @click="${this._addMembersToGroup}"
               class="button"

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -176,7 +176,7 @@ export class ZHAGroupPage extends LitElement {
             .hass=${this.hass}
             .devices=${this._filteredDevices}
             .narrow=${this.narrow}
-            .selectable=${true}
+            selectable
             @selection-changed=${this._handleAddSelectionChanged}
             class="table"
           >

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -141,7 +141,7 @@ export class ZHAGroupPage extends LitElement {
                   .hass=${this.hass}
                   .devices=${members}
                   .narrow=${this.narrow}
-                  .selectable=${true}
+                  selectable
                   @selection-changed=${this._handleRemoveSelectionChanged}
                   class="table"
                 >

--- a/src/panels/config/zha/zha-group-page.ts
+++ b/src/panels/config/zha/zha-group-page.ts
@@ -217,10 +217,7 @@ export class ZHAGroupPage extends LitElement {
   private _filterDevices() {
     // filter the groupable devices so we only show devices that aren't already in the group
     this._filteredDevices = this.devices.filter((device) => {
-      return !(
-        this.group!.members.filter((member) => member.ieee === device.ieee)
-          .length > 0
-      );
+      return !this.group!.members.some((member) => member.ieee === device.ieee);
     });
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1450,7 +1450,11 @@
             "removing_groups": "Removing Groups",
             "group_info": "Group Information",
             "group_details": "Here are all the details for the selected Zigbee group.",
-            "group_not_found": "Group not found!"
+            "group_not_found": "Group not found!",
+            "add_members": "Add Members",
+            "remove_members": "Remove Members",
+            "adding_members": "Adding Members",
+            "removing_members": "Removing Members"
           }
         },
         "zwave": {


### PR DESCRIPTION
This PR adds the ability to edit individual Zigbee group details (add and remove members) to the ZHA config panel. This is the fourth PR in a series to add full group management to the configuration panel. See PR #4352 for the desired end state.

![ezgif-6-cb6e2779db6e](https://user-images.githubusercontent.com/1335687/71419722-e92ba180-263e-11ea-968e-9ca8fa99968f.gif)
