### PR TITLE
Hide protection mode toggle if not usable

### DIFF
--- a/hassio/src/addon-view/hassio-addon-info.js
+++ b/hassio/src/addon-view/hassio-addon-info.js
@@ -373,19 +373,21 @@ class HassioAddonInfo extends EventsMixin(PolymerElement) {
                 </template>
               </div>
             </template>
-            <div class="state">
-              <div>
-                Protection mode
-                <span>
-                  <iron-icon icon="hassio:information"></iron-icon>
-                  <paper-tooltip>Grant the add-on elevated system access.</paper-tooltip>
-                </span>
+            <template is="dom-if" if="[[_computeUsesProtectedOptions(addon)]]">
+              <div class="state">
+                <div>
+                  Protection mode
+                  <span>
+                    <iron-icon icon="hassio:information"></iron-icon>
+                    <paper-tooltip>Grant the add-on elevated system access.</paper-tooltip>
+                  </span>
+                </div>
+                <ha-switch
+                  on-change="protectionToggled"
+                  checked="[[addon.protected]]"
+                ></ha-switch>
               </div>
-              <ha-switch
-                on-change="protectionToggled"
-                checked="[[addon.protected]]"
-              ></ha-switch>
-            </div>
+            </template>
           </template>
         </div>
         <div class="card-actions">
@@ -608,6 +610,10 @@ class HassioAddonInfo extends EventsMixin(PolymerElement) {
 
   _computeCannotIngressSidebar(hass, addon) {
     return !addon.ingress || !this._computeHA92plus(hass);
+  }
+
+  _computeUsesProtectedOptions(addon) {
+    return addon.docker_api || addon.full_access || addon.host_pid;
   }
 
   _computeHA92plus(hass) {


### PR DESCRIPTION
This will hide the "Protection mode" toggle on addons that do not need it.

![image](https://user-images.githubusercontent.com/15093472/71550440-93555180-29d0-11ea-9151-9739123770b3.png)
