### PR TITLE
WIP: Adds confirmation dialog to reset add-on configuration

### DIFF
--- a/hassio/src/addon-view/hassio-addon-config.js
+++ b/hassio/src/addon-view/hassio-addon-config.js
@@ -45,6 +45,7 @@ class HassioAddonConfig extends PolymerElement {
         <div class="card-actions">
           <ha-call-api-button
             class="warning"
+            confirmation="Are you sure you want to reset the configuration?"
             hass="[[hass]]"
             path="hassio/addons/[[addonSlug]]/options"
             data="[[resetData]]"

--- a/src/components/buttons/ha-call-api-button.js
+++ b/src/components/buttons/ha-call-api-button.js
@@ -71,7 +71,7 @@ class HaCallApiButton extends LitElement {
         confirm: async () => await this._callApi(),
       });
     } else {
-      await this.callApi();
+      await this._callApi();
     }
   }
 }

--- a/src/components/buttons/ha-call-api-button.js
+++ b/src/components/buttons/ha-call-api-button.js
@@ -2,6 +2,7 @@ import { LitElement, html } from "lit-element";
 
 import "./ha-progress-button";
 import { fireEvent } from "../../common/dom/fire_event";
+import { showConfirmationDialog } from "../../dialogs/confirmation/show-dialog-confirmation";
 
 class HaCallApiButton extends LitElement {
   render() {
@@ -31,6 +32,7 @@ class HaCallApiButton extends LitElement {
       method: String,
       data: {},
       disabled: Boolean,
+      confirmation: String,
     };
   }
 
@@ -38,7 +40,7 @@ class HaCallApiButton extends LitElement {
     return this.renderRoot.querySelector("ha-progress-button");
   }
 
-  async _buttonTapped() {
+  async callApi() {
     this.progress = true;
     const eventData = {
       method: this.method,
@@ -60,6 +62,17 @@ class HaCallApiButton extends LitElement {
     }
 
     fireEvent(this, "hass-api-called", eventData);
+  }
+
+  async _buttonTapped() {
+    if (this.confirmation) {
+      showConfirmationDialog(this, {
+        text: this.confirmation,
+        confirm: async () => await this.callApi(),
+      });
+    } else {
+      await this.callApi();
+    }
   }
 }
 

--- a/src/components/buttons/ha-call-api-button.js
+++ b/src/components/buttons/ha-call-api-button.js
@@ -40,7 +40,7 @@ class HaCallApiButton extends LitElement {
     return this.renderRoot.querySelector("ha-progress-button");
   }
 
-  async callApi() {
+  async _callApi() {
     this.progress = true;
     const eventData = {
       method: this.method,

--- a/src/components/buttons/ha-call-api-button.js
+++ b/src/components/buttons/ha-call-api-button.js
@@ -68,7 +68,7 @@ class HaCallApiButton extends LitElement {
     if (this.confirmation) {
       showConfirmationDialog(this, {
         text: this.confirmation,
-        confirm: async () => await this.callApi(),
+        confirm: async () => await this._callApi(),
       });
     } else {
       await this.callApi();


### PR DESCRIPTION
## This adds:

- A confirmation property to the `ha-call-api-button` (same as `ha-call-service-button`)
- A confirmation dialog when resetting add-on configuration to the default as requested in #3854

Reboot of #3945 
Closes #3854

This time I have actually tested it 🙈 
![image](https://user-images.githubusercontent.com/15093472/71550637-7b340100-29d5-11ea-80aa-3da042dd68b6.png)
