### PR TITLE
Force rerender on update/save

### DIFF
--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -155,7 +155,9 @@ class LovelaceFullConfigEditor extends LitElement {
     } else if (!this._changed && window.onbeforeunload) {
       window.onbeforeunload = null;
     }
-    if (this._changed) this.requestUpdate();
+    if (this._changed) {
+      this.requestUpdate();
+    }
   }
 
   private _closeEditor() {

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -116,6 +116,11 @@ class LovelaceFullConfigEditor extends LitElement {
           color: var(--dark-text-color);
         }
 
+        mwc-button[disabled] {
+          background-color: var(--mdc-theme-on-primary);
+          border-radius: 4px;
+        }
+
         .comments {
           font-size: 16px;
         }

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -1,4 +1,5 @@
 import {
+  customElement,
   LitElement,
   html,
   TemplateResult,
@@ -34,13 +35,15 @@ const lovelaceStruct = struct.interface({
   resources: struct.optional(["object"]),
 });
 
+@customElement("hui-editor")
 class LovelaceFullConfigEditor extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public lovelace?: Lovelace;
   @property() public closeEditor?: () => void;
   @property() private _saving?: boolean;
   @property() private _changed?: boolean;
-  @property() private _generation = 1;
+
+  private _generation = 1;
 
   public render(): TemplateResult | void {
     return html`
@@ -247,5 +250,3 @@ declare global {
     "hui-editor": LovelaceFullConfigEditor;
   }
 }
-
-customElements.define("hui-editor", LovelaceFullConfigEditor);

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -73,7 +73,10 @@ class LovelaceFullConfigEditor extends LitElement {
                     "ui.panel.lovelace.editor.raw_editor.saved"
                   )}
             </div>
-            <mwc-button raised @click="${this._handleSave}"
+            <mwc-button
+              raised
+              @click="${this._handleSave}"
+              .disabled=${!this._changed}
               >${this.hass!.localize(
                 "ui.panel.lovelace.editor.raw_editor.save"
               )}</mwc-button
@@ -152,6 +155,7 @@ class LovelaceFullConfigEditor extends LitElement {
     } else if (!this._changed && window.onbeforeunload) {
       window.onbeforeunload = null;
     }
+    if (this._changed) this.requestUpdate();
   }
 
   private _closeEditor() {
@@ -230,6 +234,7 @@ class LovelaceFullConfigEditor extends LitElement {
     window.onbeforeunload = null;
     this._saving = false;
     this._changed = false;
+    this.requestUpdate();
   }
 
   private get yamlEditor(): HaCodeEditor {

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -1,4 +1,11 @@
-import { LitElement, html, TemplateResult, CSSResult, css } from "lit-element";
+import {
+  LitElement,
+  html,
+  TemplateResult,
+  CSSResult,
+  css,
+  property,
+} from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 import { safeDump, safeLoad } from "js-yaml";
 
@@ -28,22 +35,12 @@ const lovelaceStruct = struct.interface({
 });
 
 class LovelaceFullConfigEditor extends LitElement {
-  public hass!: HomeAssistant;
-  public lovelace?: Lovelace;
-  public closeEditor?: () => void;
-  private _saving?: boolean;
-  private _changed?: boolean;
-  private _generation = 1;
-
-  static get properties() {
-    return {
-      hass: {},
-      lovelace: {},
-      closeEditor: {},
-      _saving: {},
-      _changed: {},
-    };
-  }
+  @property() public hass!: HomeAssistant;
+  @property() public lovelace?: Lovelace;
+  @property() public closeEditor?: () => void;
+  @property() private _saving?: boolean;
+  @property() private _changed?: boolean;
+  @property() private _generation = 1;
 
   public render(): TemplateResult | void {
     return html`
@@ -155,9 +152,6 @@ class LovelaceFullConfigEditor extends LitElement {
     } else if (!this._changed && window.onbeforeunload) {
       window.onbeforeunload = null;
     }
-    if (this._changed) {
-      this.requestUpdate();
-    }
   }
 
   private _closeEditor() {
@@ -236,7 +230,6 @@ class LovelaceFullConfigEditor extends LitElement {
     window.onbeforeunload = null;
     this._saving = false;
     this._changed = false;
-    this.requestUpdate();
   }
 
   private get yamlEditor(): HaCodeEditor {


### PR DESCRIPTION
# Changes

- Adds a disabled property to the save button if there are no changes.
- Changes to property definitions to use `@property()`.
- Add styles to the disabled save button.

Closes #4391
This also fixes an issue where the "Saved" and "Unsaved changes" were not showing.

![rerender](https://user-images.githubusercontent.com/15093472/71556413-ab60bb80-2a38-11ea-8aa1-743a3dcb1f07.gif)
