### PR TITLE
Fix area index selection on ZHA device card

### DIFF
--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -81,6 +81,12 @@ class ZHADeviceCard extends LitElement {
     super.connectedCallback();
     this._unsubAreas = subscribeAreaRegistry(this.hass.connection, (areas) => {
       this._areas = areas;
+      if (this.device) {
+        this._selectedAreaIndex =
+          this._areas.findIndex(
+            (area) => area.area_id === this.device!.area_id
+          ) + 1; // account for the no area selected index
+      }
     });
     this.hass.connection
       .subscribeEvents((event: HassEvent) => {


### PR DESCRIPTION
Ensure that the selectedAreaIndex is set properly on the ZHA device card.