### PR TITLE
Add ha-subppage toolbar css styles

### DIFF
--- a/src/layouts/hass-subpage.ts
+++ b/src/layouts/hass-subpage.ts
@@ -53,9 +53,9 @@ class HassSubpage extends LitElement {
         height: 64px;
         padding: 0 16px;
         pointer-events: none;
-        background-color: var(--primary-color);
+        background-color: var(--app-header-background-color);
         font-weight: 400;
-        color: var(--text-primary-color, white);
+        color: var(--app-header-text-color, white);
       }
 
       ha-menu-button,

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -149,6 +149,7 @@ documentContainer.innerHTML = `<custom-style>
       /* app header background color */
       --app-header-text-color: var(--text-primary-color);
       --app-header-background-color: var(--primary-color);
+
     }
   </style>
 


### PR DESCRIPTION
This addresses an issue with styling the toolbar in the same way that the app-header had been previously addressed.

This specific case can be reproduced by doing the following:

- Set primary-color to a dark color (e.g. you want a dark header)
- Open the notifications box, the links are dark (because they use primary-color for the anchor tags)
- Switch primary-color to a light color, requiring you to redefine the app-header background color, and you'll find that most pages render as expected (other than HACS [already fixed upstream] and the integrations page, afaict)