### PR TITLE
Change TRIGGER to EXECUTE

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -393,7 +393,7 @@
       },
       "automation": {
         "last_triggered": "Last triggered",
-        "trigger": "Trigger"
+        "trigger": "Execute"
       },
       "camera": {
         "not_available": "Image not available"


### PR DESCRIPTION
There's been some confusion among new users about what the `TRIGGER` button does in the automation info popup. `EXECUTE` better represents what pressing that button does since it bypasses conditions and simply runs the action like a script. The automation docs at <https://www.home-assistant.io/docs/automation/action/> also say "The action of an automation rule is what is being executed when a rule fires."