### PR TITLE
Add ability to remove Lovelace config

### DIFF
--- a/cast/src/receiver/layout/hc-lovelace.ts
+++ b/cast/src/receiver/layout/hc-lovelace.ts
@@ -39,6 +39,7 @@ class HcLovelace extends LitElement {
       mode: "storage",
       language: "en",
       saveConfig: async () => undefined,
+      deleteConfig: async () => undefined,
       setEditMode: () => undefined,
     };
     return this.lovelaceConfig.views[index].panel

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -113,6 +113,11 @@ export const saveConfig = (
     config,
   });
 
+export const deleteConfig = (hass: HomeAssistant): Promise<void> =>
+  hass.callWS({
+    type: "lovelace/config/delete",
+  });
+
 export const subscribeLovelaceUpdates = (
   conn: Connection,
   onChange: () => void

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -21,6 +21,7 @@ export interface Lovelace {
   enableFullEditMode: () => void;
   setEditMode: (editMode: boolean) => void;
   saveConfig: (newConfig: LovelaceConfig) => Promise<void>;
+  deleteConfig: () => Promise<void>;
 }
 
 export interface LovelaceBadge extends HTMLElement {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1614,11 +1614,14 @@
             "save": "Save",
             "unsaved_changes": "Unsaved changes",
             "saved": "Saved",
+            "confirm_remove_config_title": "Are you sure you want to remove your Lovelace configuration? We will automatically generate your Lovelace views with your areas and devices.",
+            "confirm_remove_config_text": "We will automatically generate your Lovelace views with your areas and devices if you remove your Lovelace configuration.",
             "confirm_unsaved_changes": "You have unsaved changes, are you sure you want to exit?",
             "confirm_unsaved_comments": "Your config contains comment(s), these will not be saved. Do you want to continue?",
             "error_parse_yaml": "Unable to parse YAML: {error}",
             "error_invalid_config": "Your config is not valid: {error}",
-            "error_save_yaml": "Unable to save YAML: {error}"
+            "error_save_yaml": "Unable to save YAML: {error}",
+            "error_remove": "Unable to remove config: {error}"
           },
           "edit_lovelace": {
             "header": "Title of your Lovelace UI",


### PR DESCRIPTION
Needs backend PR https://github.com/home-assistant/home-assistant/pull/30558

Removes the Lovelace config and returns to generated mode if the raw config editor is empty and the config is saved.