### PR TITLE
Hungarian translation placeholder fixed (as in issue #4436)

### DIFF
--- a/translations/hu.json
+++ b/translations/hu.json
@@ -1574,7 +1574,7 @@
                         "description_listen": "Téma figyelése",
                         "description_publish": "Csomag közzététele",
                         "listening_to": "Figyelés:",
-                        "message_received": "Üzenet ({id}) érkezett a(z) {topic} témában {idő}-kor:",
+                        "message_received": "Üzenet ({id}) érkezett a(z) {topic} témában {time}-kor:",
                         "payload": "Payload (sablon megengedett)",
                         "publish": "Közzététel",
                         "start_listening": "Figyelés indítása",


### PR DESCRIPTION
Placeholder is fixed in Hungarian translation.