### PR TITLE
add never_triggered

### DIFF
--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -114,7 +114,7 @@ class HuiGenericEntityRow extends LitElement {
                     ></ha-relative-time>
                   `
                 : this.hass.localize(
-                    "ui.panel.lovelace.entities.never_triggered"
+                    "ui.panel.lovelace.cards.entities.never_triggered"
                   )
               : ""}
           </div>

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -106,14 +106,14 @@ class HuiGenericEntityRow extends LitElement {
                   ></ha-relative-time>
                 `
               : this.config.secondary_info === "last-triggered"
-               ? stateObj.attributes.last_triggered
-               ? html`
-                   <ha-relative-time
-                     .hass=${this.hass}
-                     .datetime=${stateObj.attributes.last_triggered}
-                   ></ha-relative-time>
-                 `
-               : this.hass.localize("ui.panel.lovelace.entities.never_triggered")
+              ? stateObj.attributes.last_triggered
+              ? html`
+                  <ha-relative-time
+                    .hass=${this.hass}
+                    .datetime=${stateObj.attributes.last_triggered}
+                  ></ha-relative-time>
+                `
+              : this.hass.localize("ui.panel.lovelace.entities.never_triggered")
               : ""}
           </div>
         </div>

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -113,7 +113,9 @@ class HuiGenericEntityRow extends LitElement {
                       .datetime=${stateObj.attributes.last_triggered}
                     ></ha-relative-time>
                   `
-                : this.hass.localize("ui.panel.lovelace.entities.never_triggered")
+                : this.hass.localize(
+                    "ui.panel.lovelace.entities.never_triggered"
+                  )
               : ""}
           </div>
         </div>

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -107,13 +107,13 @@ class HuiGenericEntityRow extends LitElement {
                 `
               : this.config.secondary_info === "last-triggered"
               ? stateObj.attributes.last_triggered
-              ? html`
-                  <ha-relative-time
-                    .hass=${this.hass}
-                    .datetime=${stateObj.attributes.last_triggered}
-                  ></ha-relative-time>
-                `
-              : this.hass.localize("ui.panel.lovelace.entities.never_triggered")
+                ? html`
+                    <ha-relative-time
+                      .hass=${this.hass}
+                      .datetime=${stateObj.attributes.last_triggered}
+                    ></ha-relative-time>
+                  `
+                : this.hass.localize("ui.panel.lovelace.entities.never_triggered")
               : ""}
           </div>
         </div>

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -105,14 +105,15 @@ class HuiGenericEntityRow extends LitElement {
                     .datetime=${stateObj.last_changed}
                   ></ha-relative-time>
                 `
-              : this.config.secondary_info === "last-triggered" &&
-                stateObj.attributes.last_triggered
-              ? html`
-                  <ha-relative-time
-                    .hass=${this.hass}
-                    .datetime=${stateObj.attributes.last_triggered}
-                  ></ha-relative-time>
-                `
+              : this.config.secondary_info === "last-triggered"
+               ? stateObj.attributes.last_triggered
+               ? html`
+                   <ha-relative-time
+                     .hass=${this.hass}
+                     .datetime=${stateObj.attributes.last_triggered}
+                   ></ha-relative-time>
+                 `
+               : this.hass.localize("ui.panel.lovelace.entities.never_triggered")
               : ""}
           </div>
         </div>

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -114,7 +114,7 @@ class HuiGenericEntityRow extends LitElement {
                     ></ha-relative-time>
                   `
                 : this.hass.localize(
-                    "ui.panel.lovelace.cards.entities.never_triggered"
+                    "ui.panel.lovelace.card.entities.never_triggered"
                   )
               : ""}
           </div>

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -114,7 +114,7 @@ class HuiGenericEntityRow extends LitElement {
                     ></ha-relative-time>
                   `
                 : this.hass.localize(
-                    "ui.panel.lovelace.card.entities.never_triggered"
+                    "ui.panel.lovelace.cards.entities.never_triggered"
                   )
               : ""}
           </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -393,6 +393,7 @@
       },
       "automation": {
         "last_triggered": "Last triggered",
+        "never_triggered":"Never triggered",
         "trigger": "Execute"
       },
       "camera": {
@@ -458,6 +459,8 @@
         "activate": "Activate"
       },
       "script": {
+        "last_triggered": "Last triggered",
+        "never_triggered":"Never triggered",
         "execute": "Execute"
       },
       "timer": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -393,7 +393,6 @@
       },
       "automation": {
         "last_triggered": "Last triggered",
-        "never_triggered":"Never triggered",
         "trigger": "Execute"
       },
       "camera": {
@@ -459,8 +458,6 @@
         "activate": "Activate"
       },
       "script": {
-        "last_triggered": "Last triggered",
-        "never_triggered":"Never triggered",
         "execute": "Execute"
       },
       "timer": {
@@ -1701,6 +1698,7 @@
               "optional": "Optional"
             },
             "entities": {
+              "never_triggered":"Never triggered",
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
               "toggle": "Toggle entities."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1580,6 +1580,9 @@
             "no_devices": "This page allows you to control your devices, however it looks like you have no devices set up yet. Head to the integrations page to get started.",
             "go_to_integrations_page": "Go to the integrations page."
           },
+          "entities": {
+            "never_triggered": "Never triggered"
+          },
           "shopping-list": {
             "checked_items": "Checked items",
             "clear_items": "Clear checked items",
@@ -1698,7 +1701,6 @@
               "optional": "Optional"
             },
             "entities": {
-              "never_triggered": "Never triggered",
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
               "toggle": "Toggle entities."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1698,7 +1698,7 @@
               "optional": "Optional"
             },
             "entities": {
-              "never_triggered":"Never triggered",
+              "never_triggered": "Never triggered",
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
               "toggle": "Toggle entities."


### PR DESCRIPTION
Add never_triggered to the last-triggered secondary_info.
as it stands, the secondary_info line is empty when used on an automation or script that hasn't been triggered yet, while the user expects info on that line.

my suggestion would be to add:
```
"automation": {
        "last_triggered": "Last triggered",
        "never_triggered":"Never triggered",
        "trigger": "Execute"
      }
```
and
```
"script": {
        "last_triggered": "Last triggered",
        "never_triggered":"Never triggered",
        "execute": "Execute"
      }
```
to the [translation file](https://github.com/home-assistant/home-assistant-polymer/blob/dev/src/translations/en.json).