### PR TITLE
Use correct suffix for elevation

### DIFF
--- a/src/onboarding/onboarding-core-config.ts
+++ b/src/onboarding/onboarding-core-config.ts
@@ -116,9 +116,13 @@ class OnboardingCoreConfig extends LitElement {
           @value-changed=${this._handleChange}
         >
           <span slot="suffix">
-            ${this.hass.localize(
-              "ui.panel.config.core.section.core.core_config.elevation_meters"
-            )}
+            ${this._unitSystem === "metric"
+              ? this.hass.localize(
+                  "ui.panel.config.core.section.core.core_config.elevation_meters"
+                )
+              : this.hass.localize(
+                  "ui.panel.config.core.section.core.core_config.elevation_feet"
+                )}
           </span>
         </paper-input>
       </div>

--- a/src/panels/config/core/ha-config-core-form.ts
+++ b/src/panels/config/core/ha-config-core-form.ts
@@ -102,9 +102,13 @@ class ConfigCoreForm extends LitElement {
               @value-changed=${this._handleChange}
             >
               <span slot="suffix">
-                ${this.hass.localize(
-                  "ui.panel.config.core.section.core.core_config.elevation_meters"
-                )}
+                ${this._unitSystem === "metric"
+                  ? this.hass.localize(
+                      "ui.panel.config.core.section.core.core_config.elevation_meters"
+                    )
+                  : this.hass.localize(
+                      "ui.panel.config.core.section.core.core_config.elevation_feet"
+                    )}
               </span>
             </paper-input>
           </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -705,6 +705,7 @@
                 "longitude": "Longitude",
                 "elevation": "Elevation",
                 "elevation_meters": "meters",
+                "elevation_feet": "feet",
                 "time_zone": "Time Zone",
                 "unit_system": "Unit System",
                 "unit_system_imperial": "Imperial",


### PR DESCRIPTION
Fixes #4452

![feet](https://user-images.githubusercontent.com/15093472/72220777-74b89400-3554-11ea-8a38-5511146d529d.gif)
