### PR TITLE
Force refresh tokens if external app

### DIFF
--- a/src/entrypoints/core.ts
+++ b/src/entrypoints/core.ts
@@ -55,8 +55,12 @@ const connProm = async (auth) => {
       throw err;
     }
     // We can get invalid auth if auth tokens were stored that are no longer valid
-    // Clear stored tokens.
-    if (!isExternal) {
+    if (isExternal) {
+      // Tell the external app to force refresh the access tokens.
+      // This should trigger their unauthorized handling.
+      await auth.refreshAccessToken(true);
+    } else {
+      // Clear stored tokens.
       saveTokens(null);
     }
     auth = await authProm();


### PR DESCRIPTION
In `core.ts`, handle non-expired invalid access tokens when using external auth.

Will implement the frontend part of https://github.com/home-assistant/home-assistant-android/issues/257

~~TODO: PR for dev docs~~ https://github.com/home-assistant/developers.home-assistant/pull/387