### PR TITLE
Fix ZHA add device path.

### DIFF
--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -376,7 +376,7 @@ class ZHADeviceCard extends LitElement {
   }
 
   private _onAddDevicesClick() {
-    navigate(this, "add/" + this.device!.ieee);
+    navigate(this, "/config/zha/add/" + this.device!.ieee);
   }
 
   static get styles(): CSSResult[] {


### PR DESCRIPTION
Adding new ZHA devices through a specific Zigbee router (Config panel -> ZHA -> Pick Zigbee router device -> Add device) is broken and logs the following error in ha log
```
2020-01-15 13:09:20 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection.140702442630840] Error handling message: not a valid value for dictionary value @ data['ieee']. Got 'config/zha/add/00:22:a3:00:00:1b:94:bb'
```

This PR fixes it
