### PR TITLE
🐛 fix picture glance card's camera_view option in editor

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
@@ -79,7 +79,7 @@ export class HuiPictureGlanceCardEditor extends LitElement
   }
 
   get _camera_view(): string {
-    return this._config!.camera_view || this._camera_image ? "auto" : "";
+    return this._config!.camera_view || "auto";
   }
 
   get _state_image(): {} {


### PR DESCRIPTION
fixes https://github.com/home-assistant/home-assistant-polymer/issues/4478