### PR TITLE
🐛 fix confirmation dialog actions

### DIFF
--- a/src/dialogs/confirmation/dialog-confirmation.ts
+++ b/src/dialogs/confirmation/dialog-confirmation.ts
@@ -17,6 +17,7 @@ import { HomeAssistant } from "../../types";
 import { ConfirmationDialogParams } from "./show-dialog-confirmation";
 import { PolymerChangedEvent } from "../../polymer-types";
 import { haStyleDialog } from "../../resources/styles";
+import { actionHandler } from "../../panels/lovelace/common/directives/action-handler-directive";
 
 @customElement("dialog-confirmation")
 class DialogConfirmation extends LitElement {
@@ -48,12 +49,15 @@ class DialogConfirmation extends LitElement {
           <p>${this._params.text}</p>
         </paper-dialog-scrollable>
         <div class="paper-dialog-buttons">
-          <mwc-button @click="${this._dismiss}">
+          <mwc-button @action=${this._dismiss}>
             ${this._params.cancelBtnText
               ? this._params.cancelBtnText
               : this.hass.localize("ui.dialogs.confirmation.cancel")}
           </mwc-button>
-          <mwc-button @click="${this._confirm}">
+          <mwc-button
+            @action=${this._confirm}
+            .actionHandler=${actionHandler({})}
+          >
             ${this._params.confirmBtnText
               ? this._params.confirmBtnText
               : this.hass.localize("ui.dialogs.confirmation.ok")}


### PR DESCRIPTION
fixes https://github.com/home-assistant/home-assistant-polymer/issues/4468

I was able to replicate the issue but could not figure out why `@click` was not functioning properly. We have plenty of other uses of `@click` that work on iOS, so not sure what makes this different. The action-handler feels like a work-around, I guess, but it has been annoying me quite a bit on mobile as well.