### PR TITLE
Add automation icon active color

### DIFF
--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -116,6 +116,7 @@ class StateBadge extends LitElement {
       ha-icon[data-domain="switch"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
       ha-icon[data-domain="fan"][data-state="on"],
+      ha-icon[data-domain="automation"][data-state="on"],
       ha-icon[data-domain="sun"][data-state="above_horizon"] {
         color: var(--paper-item-icon-active-color, #fdd835);
       }

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -211,6 +211,7 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
       ha-icon[data-domain="switch"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
       ha-icon[data-domain="fan"][data-state="on"],
+      ha-icon[data-domain="automation"][data-state="on"],
       ha-icon[data-domain="sun"][data-state="above_horizon"] {
         color: var(--paper-item-icon-active-color, #fdd835);
       }


### PR DESCRIPTION
Icon for automation entities are not colored #fdd835 when toggled on. This PR fixes it.
![1](https://user-images.githubusercontent.com/20846761/72636327-ca989c00-3999-11ea-880c-0bc40b8389aa.PNG)![2](https://user-images.githubusercontent.com/20846761/72636334-cf5d5000-3999-11ea-8571-81f29e0e4e4b.PNG)