### PR TITLE
💄 additional active icon states

### DIFF
--- a/src/common/entity/compute_active_state.ts
+++ b/src/common/entity/compute_active_state.ts
@@ -1,0 +1,12 @@
+import { HassEntity } from "home-assistant-js-websocket";
+
+export const computeActiveState = (stateObj: HassEntity): string => {
+  const domain = stateObj.entity_id.split(".")[0];
+  let state = stateObj.state;
+
+  if (domain === "climate") {
+    state = stateObj.attributes.hvac_action;
+  }
+
+  return state;
+};

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -1,0 +1,43 @@
+import { css } from "lit-element";
+
+export const iconColorCSS = css`
+  ha-icon[data-domain="alarm_control_panel"][data-state="disarmed"],
+  ha-icon[data-domain="alert"][data-state="on"],
+  ha-icon[data-domain="automation"][data-state="on"],
+  ha-icon[data-domain="binary_sensor"][data-state="on"],
+  ha-icon[data-domain="calendar"][data-state="on"],
+  ha-icon[data-domain="camera"][data-state="streaming"],
+  ha-icon[data-domain="cover"][data-state="open"],
+  ha-icon[data-domain="fan"][data-state="on"],
+  ha-icon[data-domain="light"][data-state="on"],
+  ha-icon[data-domain="input_boolean"][data-state="on"],
+  ha-icon[data-domain="lock"][data-state="unlocked"],
+  ha-icon[data-domain="media_player"][data-state="paused"],
+  ha-icon[data-domain="media_player"][data-state="playing"],
+  ha-icon[data-domain="script"][data-state="running"],
+  ha-icon[data-domain="sun"][data-state="above_horizon"],
+  ha-icon[data-domain="switch"][data-state="on"],
+  ha-icon[data-domain="timer"][data-state="active"],
+  ha-icon[data-domain="timer"][data-state="paused"],
+  ha-icon[data-domain="vacuum"][data-state="cleaning"] {
+    color: var(--paper-item-icon-active-color, #fdd835);
+  }
+
+  ha-icon[data-domain="climate"][data-state="cooling"] {
+    color: var(--cool-color, #2b9af9);
+  }
+
+  ha-icon[data-domain="climate"][data-state="heating"] {
+    color: var(--heat-color, #ff8100);
+  }
+
+  ha-icon[data-domain="plant"][data-state="problem"],
+  ha-icon[data-domain="zwave"][data-state="dead"] {
+    color: var(--error-state-color, #db4437);
+  }
+
+  /* Color the icon if unavailable */
+  ha-icon[data-state="unavailable"] {
+    color: var(--state-icon-unavailable-color);
+  }
+`;

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -18,7 +18,6 @@ export const iconColorCSS = css`
   ha-icon[data-domain="sun"][data-state="above_horizon"],
   ha-icon[data-domain="switch"][data-state="on"],
   ha-icon[data-domain="timer"][data-state="active"],
-  ha-icon[data-domain="timer"][data-state="paused"],
   ha-icon[data-domain="vacuum"][data-state="cleaning"] {
     color: var(--paper-item-icon-active-color, #fdd835);
   }

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -111,12 +111,21 @@ class StateBadge extends LitElement {
         transition: color 0.3s ease-in-out, filter 0.3s ease-in-out;
       }
 
-      /* Color the icon if light or sun is on */
       ha-icon[data-domain="light"][data-state="on"],
       ha-icon[data-domain="switch"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
       ha-icon[data-domain="fan"][data-state="on"],
-      ha-icon[data-domain="sun"][data-state="above_horizon"] {
+      ha-icon[data-domain="sun"][data-state="above_horizon"],
+      ha-icon[data-domain="input_boolean"][data-state="on"],
+      ha-icon[data-domain="cover"][data-state="open"],
+      ha-icon[data-domain="media_player"][data-state="playing"],
+      ha-icon[data-domain="media_player"][data-state="paused"],
+      ha-icon[data-domain="device_tracker"][data-state="home"],
+      ha-icon[data-domain="person"][data-state="home"],
+      ha-icon[data-domain="plant"][data-state="problem"],
+      ha-icon[data-domain="lock"][data-state="unlocked"],
+      ha-icon[data-domain="climate"][data-state="heating"],
+      ha-icon[data-domain="climate"][data-state="cooling"] {
         color: var(--paper-item-icon-active-color, #fdd835);
       }
 

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -17,13 +17,15 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { HaIcon } from "../ha-icon";
 import { HomeAssistant } from "../../types";
 import { computeActiveState } from "../../common/entity/compute_active_state";
+import { ifDefined } from "lit-html/directives/if-defined";
+import { iconColorCSS } from "../../common/style/icon_color_css";
 
 class StateBadge extends LitElement {
   public hass?: HomeAssistant;
   @property() public stateObj?: HassEntity;
   @property() public overrideIcon?: string;
   @property() public overrideImage?: string;
-  @property() public stateColor?: boolean;
+  @property({ type: Boolean }) public stateColor?: boolean;
   @query("ha-icon") private _icon!: HaIcon;
 
   protected render(): TemplateResult | void {
@@ -36,8 +38,10 @@ class StateBadge extends LitElement {
     return html`
       <ha-icon
         id="icon"
-        data-domain=${this.stateColor ? computeStateDomain(stateObj) : ""}
-        data-state=${this.stateColor ? computeActiveState(stateObj) : ""}
+        data-domain=${ifDefined(
+          this.stateColor ? computeStateDomain(stateObj) : undefined
+        )}
+        data-state=${computeActiveState(stateObj)}
         .icon=${this.overrideIcon || stateIcon(stateObj)}
       ></ha-icon>
     `;
@@ -113,42 +117,7 @@ class StateBadge extends LitElement {
         transition: color 0.3s ease-in-out, filter 0.3s ease-in-out;
       }
 
-      ha-icon[data-domain="alarm_control_panel"][data-state="disarmed"],
-      ha-icon[data-domain="alert"][data-state="on"],
-      ha-icon[data-domain="automation"][data-state="on"],
-      ha-icon[data-domain="binary_sensor"][data-state="on"],
-      ha-icon[data-domain="calendar"][data-state="on"],
-      ha-icon[data-domain="camera"][data-state="streaming"],
-      ha-icon[data-domain="cover"][data-state="open"],
-      ha-icon[data-domain="fan"][data-state="on"],
-      ha-icon[data-domain="light"][data-state="on"],
-      ha-icon[data-domain="input_boolean"][data-state="on"],
-      ha-icon[data-domain="lock"][data-state="unlocked"],
-      ha-icon[data-domain="media_player"][data-state="paused"],
-      ha-icon[data-domain="media_player"][data-state="playing"],
-      ha-icon[data-domain="plant"][data-state="problem"],
-      ha-icon[data-domain="script"][data-state="running"],
-      ha-icon[data-domain="sun"][data-state="above_horizon"],
-      ha-icon[data-domain="switch"][data-state="on"],
-      ha-icon[data-domain="timer"][data-state="active"],
-      ha-icon[data-domain="timer"][data-state="paused"],
-      ha-icon[data-domain="vacuum"][data-state="cleaning"],
-      ha-icon[data-domain="zwave"][data-state="dead"] {
-        color: var(--paper-item-icon-active-color, #fdd835);
-      }
-
-      ha-icon[data-domain="climate"][data-state="cooling"] {
-        color: var(--cool-color, #2b9af9);
-      }
-
-      ha-icon[data-domain="climate"][data-state="heating"] {
-        color: var(--heat-color, #ff8100);
-      }
-
-      /* Color the icon if unavailable */
-      ha-icon[data-state="unavailable"] {
-        color: var(--state-icon-unavailable-color);
-      }
+      ${iconColorCSS}
     `;
   }
 }

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -111,21 +111,21 @@ class StateBadge extends LitElement {
         transition: color 0.3s ease-in-out, filter 0.3s ease-in-out;
       }
 
-      ha-icon[data-domain="light"][data-state="on"],
-      ha-icon[data-domain="switch"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
-      ha-icon[data-domain="fan"][data-state="on"],
-      ha-icon[data-domain="sun"][data-state="above_horizon"],
-      ha-icon[data-domain="input_boolean"][data-state="on"],
       ha-icon[data-domain="cover"][data-state="open"],
-      ha-icon[data-domain="media_player"][data-state="playing"],
-      ha-icon[data-domain="media_player"][data-state="paused"],
+      ha-icon[data-domain="climate"][data-state="cooling"],
+      ha-icon[data-domain="climate"][data-state="heating"],
       ha-icon[data-domain="device_tracker"][data-state="home"],
+      ha-icon[data-domain="fan"][data-state="on"],
+      ha-icon[data-domain="light"][data-state="on"],
+      ha-icon[data-domain="input_boolean"][data-state="on"],
+      ha-icon[data-domain="lock"][data-state="unlocked"],
+      ha-icon[data-domain="media_player"][data-state="paused"],
+      ha-icon[data-domain="media_player"][data-state="playing"],
       ha-icon[data-domain="person"][data-state="home"],
       ha-icon[data-domain="plant"][data-state="problem"],
-      ha-icon[data-domain="lock"][data-state="unlocked"],
-      ha-icon[data-domain="climate"][data-state="heating"],
-      ha-icon[data-domain="climate"][data-state="cooling"] {
+      ha-icon[data-domain="sun"][data-state="above_horizon"],
+      ha-icon[data-domain="switch"][data-state="on"] {
         color: var(--paper-item-icon-active-color, #fdd835);
       }
 

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -16,12 +16,14 @@ import { HassEntity } from "home-assistant-js-websocket";
 // tslint:disable-next-line
 import { HaIcon } from "../ha-icon";
 import { HomeAssistant } from "../../types";
+import { computeActiveState } from "../../common/entity/compute_active_state";
 
 class StateBadge extends LitElement {
   public hass?: HomeAssistant;
   @property() public stateObj?: HassEntity;
   @property() public overrideIcon?: string;
   @property() public overrideImage?: string;
+  @property() public stateColor?: boolean;
   @query("ha-icon") private _icon!: HaIcon;
 
   protected render(): TemplateResult | void {
@@ -34,8 +36,8 @@ class StateBadge extends LitElement {
     return html`
       <ha-icon
         id="icon"
-        data-domain=${computeStateDomain(stateObj)}
-        data-state=${stateObj.state}
+        data-domain=${this.stateColor ? computeStateDomain(stateObj) : ""}
+        data-state=${this.stateColor ? computeActiveState(stateObj) : ""}
         .icon=${this.overrideIcon || stateIcon(stateObj)}
       ></ha-icon>
     `;
@@ -111,22 +113,36 @@ class StateBadge extends LitElement {
         transition: color 0.3s ease-in-out, filter 0.3s ease-in-out;
       }
 
+      ha-icon[data-domain="alarm_control_panel"][data-state="disarmed"],
+      ha-icon[data-domain="alert"][data-state="on"],
+      ha-icon[data-domain="automation"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
+      ha-icon[data-domain="calendar"][data-state="on"],
+      ha-icon[data-domain="camera"][data-state="streaming"],
       ha-icon[data-domain="cover"][data-state="open"],
-      ha-icon[data-domain="climate"][data-state="cooling"],
-      ha-icon[data-domain="climate"][data-state="heating"],
-      ha-icon[data-domain="device_tracker"][data-state="home"],
       ha-icon[data-domain="fan"][data-state="on"],
       ha-icon[data-domain="light"][data-state="on"],
       ha-icon[data-domain="input_boolean"][data-state="on"],
       ha-icon[data-domain="lock"][data-state="unlocked"],
       ha-icon[data-domain="media_player"][data-state="paused"],
       ha-icon[data-domain="media_player"][data-state="playing"],
-      ha-icon[data-domain="person"][data-state="home"],
       ha-icon[data-domain="plant"][data-state="problem"],
+      ha-icon[data-domain="script"][data-state="running"],
       ha-icon[data-domain="sun"][data-state="above_horizon"],
-      ha-icon[data-domain="switch"][data-state="on"] {
+      ha-icon[data-domain="switch"][data-state="on"],
+      ha-icon[data-domain="timer"][data-state="active"],
+      ha-icon[data-domain="timer"][data-state="paused"],
+      ha-icon[data-domain="vacuum"][data-state="cleaning"],
+      ha-icon[data-domain="zwave"][data-state="dead"] {
         color: var(--paper-item-icon-active-color, #fdd835);
+      }
+
+      ha-icon[data-domain="climate"][data-state="cooling"] {
+        color: var(--cool-color, #2b9af9);
+      }
+
+      ha-icon[data-domain="climate"][data-state="heating"] {
+        color: var(--heat-color, #ff8100);
       }
 
       /* Color the icon if unavailable */

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -197,10 +197,14 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   private renderEntity(entityConf: EntitiesCardEntityConfig): TemplateResult {
-    const element = createRowElement({
-      state_color: this._config!.state_color,
-      ...entityConf,
-    });
+    const element = createRowElement(
+      this._config!.state_color
+        ? {
+            state_color: this._config!.state_color,
+            ...entityConf,
+          }
+        : entityConf
+    );
     if (this._hass) {
       element.hass = this._hass;
     }

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -200,7 +200,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     const element = createRowElement(
       this._config!.state_color
         ? {
-            state_color: this._config!.state_color,
+            state_color: true,
             ...entityConf,
           }
         : entityConf

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -197,7 +197,10 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   private renderEntity(entityConf: EntitiesCardEntityConfig): TemplateResult {
-    const element = createRowElement(entityConf);
+    const element = createRowElement({
+      state_color: this._config?.state_color,
+      ...entityConf,
+    });
     if (this._hass) {
       element.hass = this._hass;
     }

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -198,7 +198,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
   private renderEntity(entityConf: EntitiesCardEntityConfig): TemplateResult {
     const element = createRowElement({
-      state_color: this._config?.state_color,
+      state_color: this._config!.state_color,
       ...entityConf,
     });
     if (this._hass) {

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -214,7 +214,17 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
       ha-icon[data-domain="switch"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
       ha-icon[data-domain="fan"][data-state="on"],
-      ha-icon[data-domain="sun"][data-state="above_horizon"] {
+      ha-icon[data-domain="sun"][data-state="above_horizon"],
+      ha-icon[data-domain="input_boolean"][data-state="on"],
+      ha-icon[data-domain="cover"][data-state="open"],
+      ha-icon[data-domain="media_player"][data-state="playing"],
+      ha-icon[data-domain="media_player"][data-state="paused"],
+      ha-icon[data-domain="device_tracker"][data-state="home"],
+      ha-icon[data-domain="person"][data-state="home"],
+      ha-icon[data-domain="plant"][data-state="problem"],
+      ha-icon[data-domain="lock"][data-state="unlocked"],
+      ha-icon[data-domain="climate"][data-state="heating"],
+      ha-icon[data-domain="climate"][data-state="cooling"] {
         color: var(--paper-item-icon-active-color, #fdd835);
       }
 

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -32,6 +32,7 @@ import { hasAction } from "../common/has-action";
 import { handleAction } from "../common/handle-action";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import { computeActiveState } from "../../../common/entity/compute_active_state";
+import { iconColorCSS } from "../../../common/style/icon_color_css";
 
 @customElement("hui-entity-button-card")
 class HuiEntityButtonCard extends LitElement implements LovelaceCard {
@@ -211,41 +212,7 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
         color: var(--paper-item-icon-color, #44739e);
       }
 
-      ha-icon[data-domain="alarm_control_panel"][data-state="disarmed"],
-      ha-icon[data-domain="alert"][data-state="on"],
-      ha-icon[data-domain="automation"][data-state="on"],
-      ha-icon[data-domain="binary_sensor"][data-state="on"],
-      ha-icon[data-domain="calendar"][data-state="on"],
-      ha-icon[data-domain="camera"][data-state="streaming"],
-      ha-icon[data-domain="cover"][data-state="open"],
-      ha-icon[data-domain="fan"][data-state="on"],
-      ha-icon[data-domain="light"][data-state="on"],
-      ha-icon[data-domain="input_boolean"][data-state="on"],
-      ha-icon[data-domain="lock"][data-state="unlocked"],
-      ha-icon[data-domain="media_player"][data-state="paused"],
-      ha-icon[data-domain="media_player"][data-state="playing"],
-      ha-icon[data-domain="plant"][data-state="problem"],
-      ha-icon[data-domain="script"][data-state="running"],
-      ha-icon[data-domain="sun"][data-state="above_horizon"],
-      ha-icon[data-domain="switch"][data-state="on"],
-      ha-icon[data-domain="timer"][data-state="active"],
-      ha-icon[data-domain="timer"][data-state="paused"],
-      ha-icon[data-domain="vacuum"][data-state="cleaning"],
-      ha-icon[data-domain="zwave"][data-state="dead"] {
-        color: var(--paper-item-icon-active-color, #fdd835);
-      }
-
-      ha-icon[data-domain="climate"][data-state="cooling"] {
-        color: var(--cool-color, #2b9af9);
-      }
-
-      ha-icon[data-domain="climate"][data-state="heating"] {
-        color: var(--heat-color, #ff8100);
-      }
-
-      ha-icon[data-state="unavailable"] {
-        color: var(--state-icon-unavailable-color);
-      }
+      ${iconColorCSS}
     `;
   }
 

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -31,6 +31,7 @@ import { actionHandler } from "../common/directives/action-handler-directive";
 import { hasAction } from "../common/has-action";
 import { handleAction } from "../common/handle-action";
 import { ActionHandlerEvent } from "../../../data/lovelace";
+import { computeActiveState } from "../../../common/entity/compute_active_state";
 
 @customElement("hui-entity-button-card")
 class HuiEntityButtonCard extends LitElement implements LovelaceCard {
@@ -142,16 +143,16 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
         ${this._config.show_icon
           ? html`
               <ha-icon
-                data-domain="${computeStateDomain(stateObj)}"
-                data-state="${stateObj.state}"
-                .icon="${this._config.icon || stateIcon(stateObj)}"
-                style="${styleMap({
+                data-domain=${computeStateDomain(stateObj)}
+                data-state=${computeActiveState(stateObj)}
+                .icon=${this._config.icon || stateIcon(stateObj)}
+                style=${styleMap({
                   filter: this._computeBrightness(stateObj),
                   color: this._computeColor(stateObj),
                   height: this._config.icon_height
                     ? this._config.icon_height
                     : "auto",
-                })}"
+                })}
               ></ha-icon>
             `
           : ""}
@@ -210,22 +211,36 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
         color: var(--paper-item-icon-color, #44739e);
       }
 
+      ha-icon[data-domain="alarm_control_panel"][data-state="disarmed"],
+      ha-icon[data-domain="alert"][data-state="on"],
+      ha-icon[data-domain="automation"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
+      ha-icon[data-domain="calendar"][data-state="on"],
+      ha-icon[data-domain="camera"][data-state="streaming"],
       ha-icon[data-domain="cover"][data-state="open"],
-      ha-icon[data-domain="climate"][data-state="cooling"],
-      ha-icon[data-domain="climate"][data-state="heating"],
-      ha-icon[data-domain="device_tracker"][data-state="home"],
       ha-icon[data-domain="fan"][data-state="on"],
       ha-icon[data-domain="light"][data-state="on"],
       ha-icon[data-domain="input_boolean"][data-state="on"],
       ha-icon[data-domain="lock"][data-state="unlocked"],
       ha-icon[data-domain="media_player"][data-state="paused"],
       ha-icon[data-domain="media_player"][data-state="playing"],
-      ha-icon[data-domain="person"][data-state="home"],
       ha-icon[data-domain="plant"][data-state="problem"],
+      ha-icon[data-domain="script"][data-state="running"],
       ha-icon[data-domain="sun"][data-state="above_horizon"],
-      ha-icon[data-domain="switch"][data-state="on"] {
+      ha-icon[data-domain="switch"][data-state="on"],
+      ha-icon[data-domain="timer"][data-state="active"],
+      ha-icon[data-domain="timer"][data-state="paused"],
+      ha-icon[data-domain="vacuum"][data-state="cleaning"],
+      ha-icon[data-domain="zwave"][data-state="dead"] {
         color: var(--paper-item-icon-active-color, #fdd835);
+      }
+
+      ha-icon[data-domain="climate"][data-state="cooling"] {
+        color: var(--cool-color, #2b9af9);
+      }
+
+      ha-icon[data-domain="climate"][data-state="heating"] {
+        color: var(--heat-color, #ff8100);
       }
 
       ha-icon[data-state="unavailable"] {

--- a/src/panels/lovelace/cards/hui-entity-button-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-button-card.ts
@@ -210,21 +210,21 @@ class HuiEntityButtonCard extends LitElement implements LovelaceCard {
         color: var(--paper-item-icon-color, #44739e);
       }
 
-      ha-icon[data-domain="light"][data-state="on"],
-      ha-icon[data-domain="switch"][data-state="on"],
       ha-icon[data-domain="binary_sensor"][data-state="on"],
-      ha-icon[data-domain="fan"][data-state="on"],
-      ha-icon[data-domain="sun"][data-state="above_horizon"],
-      ha-icon[data-domain="input_boolean"][data-state="on"],
       ha-icon[data-domain="cover"][data-state="open"],
-      ha-icon[data-domain="media_player"][data-state="playing"],
-      ha-icon[data-domain="media_player"][data-state="paused"],
+      ha-icon[data-domain="climate"][data-state="cooling"],
+      ha-icon[data-domain="climate"][data-state="heating"],
       ha-icon[data-domain="device_tracker"][data-state="home"],
+      ha-icon[data-domain="fan"][data-state="on"],
+      ha-icon[data-domain="light"][data-state="on"],
+      ha-icon[data-domain="input_boolean"][data-state="on"],
+      ha-icon[data-domain="lock"][data-state="unlocked"],
+      ha-icon[data-domain="media_player"][data-state="paused"],
+      ha-icon[data-domain="media_player"][data-state="playing"],
       ha-icon[data-domain="person"][data-state="home"],
       ha-icon[data-domain="plant"][data-state="problem"],
-      ha-icon[data-domain="lock"][data-state="unlocked"],
-      ha-icon[data-domain="climate"][data-state="heating"],
-      ha-icon[data-domain="climate"][data-state="cooling"] {
+      ha-icon[data-domain="sun"][data-state="above_horizon"],
+      ha-icon[data-domain="switch"][data-state="on"] {
         color: var(--paper-item-icon-active-color, #fdd835);
       }
 

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -235,6 +235,7 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                 .stateObj=${stateObj}
                 .overrideIcon=${entityConf.icon}
                 .overrideImage=${entityConf.image}
+                .stateColor="true"
               ></state-badge>
             `
           : ""}

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -235,7 +235,7 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                 .stateObj=${stateObj}
                 .overrideIcon=${entityConf.icon}
                 .overrideImage=${entityConf.image}
-                .stateColor="true"
+                stateColor
               ></state-badge>
             `
           : ""}

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -32,6 +32,7 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
+  state_color?: boolean;
 }
 
 export interface EntitiesCardConfig extends LovelaceCardConfig {
@@ -43,6 +44,7 @@ export interface EntitiesCardConfig extends LovelaceCardConfig {
   icon?: string;
   header?: LovelaceHeaderFooterConfig;
   footer?: LovelaceHeaderFooterConfig;
+  state_color?: boolean;
 }
 
 export interface EntityButtonCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -68,6 +68,7 @@ class HuiGenericEntityRow extends LitElement {
         .stateObj=${stateObj}
         .overrideIcon=${this.config.icon}
         .overrideImage=${this.config.image}
+        .stateColor=${this.config.state_color}
         @action=${this._handleAction}
         .actionHandler=${actionHandler({
           hasHold: hasAction(this.config!.hold_action),

--- a/src/panels/lovelace/elements/hui-state-icon-element.ts
+++ b/src/panels/lovelace/elements/hui-state-icon-element.ts
@@ -71,7 +71,7 @@ export class HuiStateIconElement extends LitElement implements LovelaceElement {
           hasAction(this._config.tap_action) ? "0" : undefined
         )}
         .overrideIcon=${this._config.icon}
-        .stateColor="true"
+        stateColor
       ></state-badge>
     `;
   }

--- a/src/panels/lovelace/elements/hui-state-icon-element.ts
+++ b/src/panels/lovelace/elements/hui-state-icon-element.ts
@@ -71,6 +71,7 @@ export class HuiStateIconElement extends LitElement implements LovelaceElement {
           hasAction(this._config.tap_action) ? "0" : undefined
         )}
         .overrideIcon=${this._config.icon}
+        .stateColor="true"
       ></state-badge>
     `;
   }

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -80,6 +80,9 @@ class HuiInputSelectEntityRow extends LitElement implements EntityRow {
     return html`
       <state-badge
         .stateObj=${stateObj}
+        .stateColor=${this._config.state_color}
+        .overrideIcon=${this._config.icon}
+        .overrideImage=${this._config.image}
         class=${classMap({
           pointer,
         })}


### PR DESCRIPTION
I think highlighting devices that require potential attention is the main goal and after some thought propose the following changes:

**Domain - Active State**
_Existing_
```
light - on
switch - on
binary_sensor - on
fan - on
sun - above_horizon
```
_Additional_
```
input_boolean - on
cover - open
media_player - playing/paused
device_tracker/person - home
plant - problem
lock - unlocked
climate - heating/cooling
```

fixes https://github.com/home-assistant/home-assistant-polymer/issues/3897