### PR TITLE
Bring back chevrons

### DIFF
--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -19,6 +19,7 @@ import { CloudStatus, CloudStatusLoggedIn } from "../../../data/cloud";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 
 import "../../../components/ha-card";
+import "../../../components/ha-icon-next";
 
 import "../ha-config-section";
 import "./ha-config-navigation";

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -74,6 +74,7 @@ class HaConfigNavigation extends LitElement {
                             </div>
                           `}
                     </paper-item-body>
+                    <ha-icon-next></ha-icon-next>
                   </paper-item>
                 </a>
               `


### PR DESCRIPTION
This brings back the chevrons that got lost on config/dashboard.

![image](https://user-images.githubusercontent.com/15093472/72665068-657a9000-3a05-11ea-9d67-0432f0922cdd.png)
