### PR TITLE
Configuration menu updates

### DIFF
--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -10,13 +10,13 @@ import {
 import "@polymer/app-layout/app-header-layout/app-header-layout";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
+import { classMap } from "lit-html/directives/class-map";
 
 import "../../../components/ha-menu-button";
 
 import { haStyle } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
-import { CloudStatus, CloudStatusLoggedIn } from "../../../data/cloud";
-import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import { CloudStatus } from "../../../data/cloud";
 
 import "../../../components/ha-card";
 
@@ -36,11 +36,22 @@ class HaConfigDashboard extends LitElement {
       <app-header-layout has-scrolling-region>
         <app-header fixed slot="header">
           <app-toolbar>
-            <ha-menu-button
-              .hass=${this.hass}
-              .narrow=${this.narrow}
-            ></ha-menu-button>
-            <div main-title>${this.hass.localize("panel.config")}</div>
+            ${!this.isWide
+              ? html`
+                  <ha-menu-button
+                    .hass=${this.hass}
+                    .narrow=${this.narrow}
+                  ></ha-menu-button>
+                `
+              : ""}
+            <div
+              main-title
+              class="${classMap({
+                wideScreen: this.isWide,
+              })}"
+            >
+              ${this.hass.localize("panel.config")}
+            </div>
           </app-toolbar>
         </app-header>
 
@@ -53,38 +64,13 @@ class HaConfigDashboard extends LitElement {
             ${this.hass.localize("ui.panel.config.introduction")}
           </div>
 
-          ${this.cloudStatus && isComponentLoaded(this.hass, "cloud")
-            ? html`
-                <ha-card>
-                  <a href="/config/cloud" tabindex="-1">
-                    <paper-item>
-                      <paper-item-body two-line="">
-                        ${this.hass.localize("ui.panel.config.cloud.caption")}
-                        ${this.cloudStatus.logged_in
-                          ? html`
-                              <div secondary="">
-                                ${this.hass.localize(
-                                  "ui.panel.config.cloud.description_login",
-                                  "email",
-                                  (this.cloudStatus as CloudStatusLoggedIn)
-                                    .email
-                                )}
-                              </div>
-                            `
-                          : html`
-                              <div secondary="">
-                                ${this.hass.localize(
-                                  "ui.panel.config.cloud.description_features"
-                                )}
-                              </div>
-                            `}
-                      </paper-item-body>
-                      <ha-icon-next></ha-icon-next>
-                    </paper-item>
-                  </a>
-                </ha-card>
-              `
-            : ""}
+          <ha-card>
+            <ha-config-navigation
+              .hass=${this.hass}
+              .showAdvanced=${this.showAdvanced}
+              .pages=${[{ page: "cloud", info: this.cloudStatus }]}
+            ></ha-config-navigation>
+          </ha-card>
 
           <ha-card>
             <ha-config-navigation
@@ -99,6 +85,7 @@ class HaConfigDashboard extends LitElement {
               ]}
             ></ha-config-navigation>
           </ha-card>
+
           <ha-card>
             <ha-config-navigation
               .hass=${this.hass}
@@ -157,6 +144,9 @@ class HaConfigDashboard extends LitElement {
         }
         .promo-advanced a {
           color: var(--secondary-text-color);
+        }
+        .wideScreen {
+          margin-left: 64px;
         }
       `,
     ];

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -11,6 +11,7 @@ import "@polymer/app-layout/app-header-layout/app-header-layout";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import { classMap } from "lit-html/directives/class-map";
+import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 
 import "../../../components/ha-menu-button";
 
@@ -64,13 +65,17 @@ class HaConfigDashboard extends LitElement {
             ${this.hass.localize("ui.panel.config.introduction")}
           </div>
 
-          <ha-card>
-            <ha-config-navigation
-              .hass=${this.hass}
-              .showAdvanced=${this.showAdvanced}
-              .pages=${[{ page: "cloud", info: this.cloudStatus }]}
-            ></ha-config-navigation>
-          </ha-card>
+          ${isComponentLoaded(this.hass, "cloud")
+            ? html`
+                <ha-card>
+                  <ha-config-navigation
+                    .hass=${this.hass}
+                    .showAdvanced=${this.showAdvanced}
+                    .pages=${[{ page: "cloud", info: this.cloudStatus }]}
+                  ></ha-config-navigation>
+                </ha-card>
+              `
+            : ""}
 
           <ha-card>
             <ha-config-navigation

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -65,7 +65,7 @@ class HaConfigDashboard extends LitElement {
             ${this.hass.localize("ui.panel.config.introduction")}
           </div>
 
-          ${isComponentLoaded(this.hass, "cloud")
+          ${this.cloudStatus && isComponentLoaded(this.hass, "cloud")
             ? html`
                 <ha-card>
                   <ha-config-navigation

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -74,7 +74,6 @@ class HaConfigNavigation extends LitElement {
                             </div>
                           `}
                     </paper-item-body>
-                    <ha-icon-next></ha-icon-next>
                   </paper-item>
                 </a>
               `

--- a/src/panels/config/dashboard/ha-config-navigation.ts
+++ b/src/panels/config/dashboard/ha-config-navigation.ts
@@ -74,6 +74,7 @@ class HaConfigNavigation extends LitElement {
                             </div>
                           `}
                     </paper-item-body>
+                    <ha-icon-next></ha-icon-next>
                   </paper-item>
                 </a>
               `

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -203,10 +203,7 @@ class HaPanelConfig extends LitElement {
       }
 
       .navigation {
-        background-color: var(
-          --paper-listbox-background-color,
-          var(--primary-background-color)
-        );
+        background-color: var(--sidebar-background-color);
         height: calc(100vh - 64px);
         overflow: auto;
       }

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -184,17 +184,23 @@ class HaPanelConfig extends LitElement {
         height: 64px;
         padding: 0 16px 0 16px;
         pointer-events: none;
+        font-weight: 400;
+        border-bottom: 1px solid var(--divider-color);
         background-color: var(--primary-background-color);
-        background-color: var(--app-header-background-color);
         font-weight: 400;
         color: var(--app-header-text-color, white);
+      }
+
+      div[main-title],
+      ha-menu-button {
+        color: var(--primary-text-color);
       }
 
       .wide-config {
         float: right;
         width: calc(100% - 320px);
         height: 100%;
-        margin-top: -64px;
+        margin-top: -65px;
       }
 
       .navigation {

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -184,7 +184,6 @@ class HaPanelConfig extends LitElement {
         height: 64px;
         padding: 0 16px 0 16px;
         pointer-events: none;
-        font-weight: 400;
         border-bottom: 1px solid var(--divider-color);
         background-color: var(--primary-background-color);
         font-weight: 400;

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -180,9 +180,9 @@ class HaPanelConfig extends LitElement {
       }
 
       .toolbar {
-        width: 288px;
         height: 64px;
         padding: 0 16px 0 16px;
+        width: 288px;
         pointer-events: none;
         border-bottom: 1px solid var(--divider-color);
         background-color: var(--primary-background-color);

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -9,6 +9,7 @@ import {
 } from "lit-element";
 import "@polymer/paper-item/paper-item-body";
 import "@polymer/paper-item/paper-item";
+import "@polymer/app-layout/app-toolbar/app-toolbar";
 import "../../layouts/hass-loading-screen";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { HomeAssistant, Route } from "../../types";
@@ -18,6 +19,7 @@ import {
   getOptimisticFrontendUserDataCollection,
   CoreFrontendUserData,
 } from "../../data/frontend";
+import "../../components/ha-menu-button";
 import "./ha-config-router";
 import "./dashboard/ha-config-navigation";
 import { classMap } from "lit-html/directives/class-map";
@@ -98,8 +100,14 @@ class HaPanelConfig extends LitElement {
     return html`
       ${isWide
         ? html`
+            <app-toolbar class="toolbar">
+              <ha-menu-button
+                .hass=${this.hass}
+                .narrow=${this.narrow}
+              ></ha-menu-button>
+              <div main-title>${this.hass.localize("panel.config")}</div>
+            </app-toolbar>
             <div class="side-bar">
-              <div class="toolbar">Configuration</div>
               <div class="navigation">
                 <ha-config-navigation
                   .hass=${this.hass}
@@ -172,25 +180,28 @@ class HaPanelConfig extends LitElement {
       }
 
       .toolbar {
-        display: flex;
-        align-items: center;
-        font-size: 20px;
+        width: 288px;
         height: 64px;
         padding: 0 16px 0 16px;
         pointer-events: none;
         background-color: var(--primary-background-color);
+        background-color: var(--app-header-background-color);
         font-weight: 400;
-        color: var(--primary-text-color);
-        border-bottom: 1px solid var(--divider-color);
+        color: var(--app-header-text-color, white);
       }
 
       .wide-config {
         float: right;
         width: calc(100% - 320px);
         height: 100%;
+        margin-top: -64px;
       }
 
       .navigation {
+        background-color: var(
+          --paper-listbox-background-color,
+          var(--primary-background-color)
+        );
         height: calc(100vh - 64px);
         overflow: auto;
       }


### PR DESCRIPTION
_Lack of imagination === boring title...._

When "Always hide the sidebar" was active there is no easy way to show the sidebar from the /config
This handles that, and a few other minor changes.


before:
![image](https://user-images.githubusercontent.com/15093472/72665935-8e068800-3a0d-11ea-9382-1245018c5056.png)


after: 
![image](https://user-images.githubusercontent.com/15093472/72665949-a1195800-3a0d-11ea-9130-ab97c4cfed3b.png)

