### PR TITLE
Add the "add all device entities to Lovelace" functionality to ZHA device card

### DIFF
--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -42,6 +42,7 @@ import { navigate } from "../../../common/navigate";
 import { UnsubscribeFunc, HassEvent } from "home-assistant-js-websocket";
 import { formatAsPaddedHex } from "./functions";
 import { computeStateName } from "../../../common/entity/compute_state_name";
+import { addEntitiesToLovelaceView } from "../../lovelace/editor/add-entities-to-view";
 
 declare global {
   // for fire event
@@ -109,9 +110,6 @@ class ZHADeviceCard extends LitElement {
     this.addEventListener("hass-service-called", (ev) =>
       this.serviceCalled(ev)
     );
-    this._serviceData = {
-      ieee_address: this.device!.ieee,
-    };
   }
 
   protected updated(changedProperties: PropertyValues): void {
@@ -125,6 +123,9 @@ class ZHADeviceCard extends LitElement {
           ) + 1;
       }
       this._userGivenName = this.device!.user_given_name;
+      this._serviceData = {
+        ieee_address: this.device!.ieee,
+      };
     }
     super.update(changedProperties);
   }
@@ -220,6 +221,13 @@ class ZHADeviceCard extends LitElement {
               </paper-icon-item>
             `
           )}
+        </div>
+        <div class="card-actions">
+          <mwc-button @click=${this._addToLovelaceView}>
+            ${this.hass.localize(
+              "ui.panel.config.devices.entities.add_entities_lovelace"
+            )}
+          </mwc-button>
         </div>
         ${
           this.showEditableInfo
@@ -391,6 +399,14 @@ class ZHADeviceCard extends LitElement {
 
   private _onAddDevicesClick() {
     navigate(this, "/config/zha/add/" + this.device!.ieee);
+  }
+
+  private _addToLovelaceView(): void {
+    addEntitiesToLovelaceView(
+      this,
+      this.hass,
+      this.device!.entities.map((entity) => entity.entity_id)
+    );
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/zha/zha-node.ts
+++ b/src/panels/config/zha/zha-node.ts
@@ -56,17 +56,26 @@ export class ZHANode extends LitElement {
           )}
         </span>
         <div class="content">
-          <zha-device-card
-            class="card"
-            .hass=${this.hass}
-            .device=${this.device}
-            .narrow=${!this.isWide}
-            .showHelp=${this._showHelp}
-            showName
-            showModelInfo
-            .showEntityDetail=${false}
-            @zha-device-removed=${this._onDeviceRemoved}
-          ></zha-device-card>
+          ${this.device
+            ? html`
+                <zha-device-card
+                  class="card"
+                  .hass=${this.hass}
+                  .device=${this.device}
+                  .narrow=${!this.isWide}
+                  .showHelp=${this._showHelp}
+                  showName
+                  showModelInfo
+                  .showEntityDetail=${false}
+                  @zha-device-removed=${this._onDeviceRemoved}
+                ></zha-device-card>
+              `
+            : html`
+                <paper-spinner
+                  active
+                  alt=${this.hass!.localize("ui.common.loading")}
+                ></paper-spinner>
+              `}
         </div>
       </ha-config-section>
     `;


### PR DESCRIPTION
This PR adds the ability to use Lovelace card generation for device entities to the ZHA device card. This will allow users to add the entities to their UI right from the ZHA device pairing UI and other places in the ZHA config panel that leverage the card. It also corrects a race condition that was found during testing. 