### PR TITLE
Use logical Zigbee device type in ZHA config panel

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -22,6 +22,7 @@ export interface ZHADevice {
   user_given_name?: string;
   power_source?: string;
   area_id?: string;
+  device_type: string;
 }
 
 export interface Attribute {

--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -163,6 +163,8 @@ class ZHADeviceCard extends LitElement {
             <dd class="zha-info">${this.device!.ieee}</dd>
             <dt>Nwk:</dt>
             <dd class="zha-info">${formatAsPaddedHex(this.device!.nwk)}</dd>
+            <dt>Device Type:</dt>
+            <dd class="zha-info">${this.device!.device_type}</dd>
             <dt>LQI:</dt>
             <dd class="zha-info">${this.device!.lqi ||
               this.hass!.localize("ui.dialogs.zha_device_info.unknown")}</dd>
@@ -304,7 +306,8 @@ class ZHADeviceCard extends LitElement {
                         </div>
                       `
                     : ""}
-                  ${this.device!.power_source === "Mains"
+                  ${this.device!.power_source === "Mains" &&
+                  this.device!.device_type === "Router"
                     ? html`
                         <mwc-button @click=${this._onAddDevicesClick}>
                           ${this.hass!.localize(


### PR DESCRIPTION
**NEEDS BACKEND PR:** https://github.com/home-assistant/home-assistant/pull/30954

This PR adds the logical Zigbee device type to the ZHA device card and it uses it to determine if a device can be used to open the network for device pairing