### PR TITLE
Remove obsolete homebridge_* attributes

### DIFF
--- a/src/util/hass-attributes-util.js
+++ b/src/util/hass-attributes-util.js
@@ -80,8 +80,6 @@ hassAttributeUtil.LOGIC_STATE_ATTRIBUTES = hassAttributeUtil.LOGIC_STATE_ATTRIBU
   },
   haaska_hidden: undefined,
   haaska_name: undefined,
-  homebridge_hidden: { type: "boolean" },
-  homebridge_name: { type: "string" },
   supported_features: undefined,
   attribution: undefined,
   restored: undefined,


### PR DESCRIPTION
Remove the custom attributes for HomeBridge.
The thing has been deprecated since 2018: <https://github.com/home-assistant/homebridge-homeassistant>

Nothing in our active backend uses them. It is just the documentation that still has them. This PR removes it. Our HomeKit integration handles it differently.


Also created a PR to remove it from the documentation: <https://github.com/home-assistant/home-assistant.io/pull/11823>