### PR TITLE
Add stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,56 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - feature request
+  - Help wanted
+  - to do
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  There hasn't been any activity on this issue recently. Due to the high number
+  of incoming GitHub notifications, we have to clean some of the old issues,
+  as many of them have already been resolved with the latest updates.
+
+  Please make sure to update to the latest Home Assistant version and check
+  if that solves the issue. Let us know if that works for you by adding a
+  comment 👍
+
+  This issue now has been marked as stale and will be closed if no further
+  activity occurs. Thank you for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
This PR adds stalebot to this repository:

- Only handles issues, PR's are untouched
- Doesn't touch issues in a milestone
- Doesn't touch issues on a project board
- Doesn't touch issues with tag:
  - `feature request`
  - `Help wanted`
  - `to do`
- 90 days until first notification
- 7 days after first notification without response closes the issue