### PR TITLE
Fix entity registry dialog translations

### DIFF
--- a/src/panels/config/entities/dialog-entity-registry-detail.ts
+++ b/src/panels/config/entities/dialog-entity-registry-detail.ts
@@ -62,7 +62,7 @@ export class DialogEntityRegistryDetail extends LitElement {
         <app-toolbar>
           <paper-icon-button
             aria-label=${this.hass.localize(
-              "ui.panel.config.entities.dialog.dismiss"
+              "ui.dialogs.entity_registry.dismiss"
             )}
             icon="hass:close"
             dialog-dismiss
@@ -76,7 +76,7 @@ export class DialogEntityRegistryDetail extends LitElement {
             ? html`
                 <paper-icon-button
                   aria-label=${this.hass.localize(
-                    "ui.panel.config.entities.dialog.control"
+                    "ui.dialogs.entity_registry.control"
                   )}
                   icon="hass:tune"
                   @click=${this._openMoreInfo}
@@ -91,10 +91,10 @@ export class DialogEntityRegistryDetail extends LitElement {
           @selected-item-changed=${this._handleTabSelected}
         >
           <paper-tab id="tab-settings">
-            ${this.hass.localize("ui.panel.config.entities.dialog.settings")}
+            ${this.hass.localize("ui.dialogs.entity_registry.settings")}
           </paper-tab>
           <paper-tab id="tab-related">
-            ${this.hass.localize("ui.panel.config.entities.dialog.related")}
+            ${this.hass.localize("ui.dialogs.entity_registry.related")}
           </paper-tab>
         </paper-tabs>
         ${cache(

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -67,7 +67,7 @@ export class EntityRegistrySettings extends LitElement {
           ? html`
               <div>
                 ${this.hass!.localize(
-                  "ui.panel.config.entities.editor.unavailable"
+                  "ui.dialogs.entity_registry.editor.unavailable"
                 )}
               </div>
             `
@@ -81,7 +81,9 @@ export class EntityRegistrySettings extends LitElement {
           <paper-input
             .value=${this._name}
             @value-changed=${this._nameChanged}
-            .label=${this.hass.localize("ui.panel.config.entities.editor.name")}
+            .label=${this.hass.localize(
+              "ui.dialogs.entity_registry.editor.name"
+            )}
             .placeholder=${stateObj ? computeStateName(stateObj) : ""}
             .disabled=${this._submitting}
           ></paper-input>
@@ -89,7 +91,7 @@ export class EntityRegistrySettings extends LitElement {
             .value=${this._entityId}
             @value-changed=${this._entityIdChanged}
             .label=${this.hass.localize(
-              "ui.panel.config.entities.editor.entity_id"
+              "ui.dialogs.entity_registry.editor.entity_id"
             )}
             error-message="Domain needs to stay the same"
             .invalid=${invalidDomainUpdate}
@@ -103,13 +105,13 @@ export class EntityRegistrySettings extends LitElement {
               <div>
                 <div>
                   ${this.hass.localize(
-                    "ui.panel.config.entities.editor.enabled_label"
+                    "ui.dialogs.entity_registry.editor.enabled_label"
                   )}
                 </div>
                 <div class="secondary">
                   ${this._disabledBy && this._disabledBy !== "user"
                     ? this.hass.localize(
-                        "ui.panel.config.entities.editor.enabled_cause",
+                        "ui.dialogs.entity_registry.editor.enabled_cause",
                         "cause",
                         this.hass.localize(
                           `config_entry.disabled_by.${this._disabledBy}`
@@ -117,10 +119,10 @@ export class EntityRegistrySettings extends LitElement {
                       )
                     : ""}
                   ${this.hass.localize(
-                    "ui.panel.config.entities.editor.enabled_description"
+                    "ui.dialogs.entity_registry.editor.enabled_description"
                   )}
                   <br />${this.hass.localize(
-                    "ui.panel.config.entities.editor.note"
+                    "ui.dialogs.entity_registry.editor.note"
                   )}
                 </div>
               </div>
@@ -135,13 +137,13 @@ export class EntityRegistrySettings extends LitElement {
           .disabled=${this._submitting ||
             !(stateObj && stateObj.attributes.restored)}
         >
-          ${this.hass.localize("ui.panel.config.entities.editor.delete")}
+          ${this.hass.localize("ui.dialogs.entity_registry.editor.delete")}
         </mwc-button>
         <mwc-button
           @click="${this._updateEntry}"
           .disabled=${invalidDomainUpdate || this._submitting}
         >
-          ${this.hass.localize("ui.panel.config.entities.editor.update")}
+          ${this.hass.localize("ui.dialogs.entity_registry.editor.update")}
         </mwc-button>
       </div>
     `;
@@ -187,7 +189,7 @@ export class EntityRegistrySettings extends LitElement {
   private _confirmDeleteEntry(): void {
     showConfirmationDialog(this, {
       text: this.hass.localize(
-        "ui.panel.config.entities.editor.confirm_delete"
+        "ui.dialogs.entity_registry.editor.confirm_delete"
       ),
       confirm: () => this._deleteEntry(),
     });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -603,6 +603,24 @@
           "confirm_remove_text": "Are you sure you want to remove this entity?"
         }
       },
+      "entity_registry": {
+        "settings": "Settings",
+        "control": "Control",
+        "related": "Related",
+        "dismiss": "Dismiss",
+        "editor": {
+          "name": "Name Override",
+          "entity_id": "Entity ID",
+          "unavailable": "This entity is not currently available.",
+          "enabled_label": "Enable entity",
+          "enabled_cause": "Disabled by {cause}.",
+          "enabled_description": "Disabled entities will not be added to Home Assistant.",
+          "delete": "DELETE",
+          "confirm_delete": "Are you sure you want to delete this entry?",
+          "update": "UPDATE",
+          "note": "Note: this might not work yet with all integrations."
+        }
+      },
       "options_flow": {
         "form": {
           "header": "Options"
@@ -1303,24 +1321,6 @@
               "confirm_title": "Do you want to remove {number} entities?",
               "confirm_text": "Entities can only be removed when the integration is no longer providing the entities."
             }
-          },
-          "dialog": {
-            "settings": "Settings",
-            "control": "Control",
-            "related": "Related",
-            "dismiss": "Dismiss"
-          },
-          "editor": {
-            "name": "Name Override",
-            "entity_id": "Entity ID",
-            "unavailable": "This entity is not currently available.",
-            "enabled_label": "Enable entity",
-            "enabled_cause": "Disabled by {cause}.",
-            "enabled_description": "Disabled entities will not be added to Home Assistant.",
-            "delete": "DELETE",
-            "confirm_delete": "Are you sure you want to delete this entry?",
-            "update": "UPDATE",
-            "note": "Note: this might not work yet with all integrations."
           }
         },
         "person": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Splits out translations of the entity registry dialog that were only loaded when the config panel was loaded.
Fixes #4567 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4567
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
