### PR TITLE
⏪ revert fix for card editor overflow menu selection

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -62,7 +62,6 @@ export class HuiCardOptions extends LitElement {
             horizontal-align="right"
             vertical-align="bottom"
             vertical-offset="40"
-            close-on-activate
           >
             <paper-icon-button
               icon="hass:dots-vertical"


### PR DESCRIPTION
revert https://github.com/home-assistant/home-assistant-polymer/pull/4508

as this actually made things worse: https://github.com/home-assistant/home-assistant-polymer/issues/4515

issue is related to click handling in the confirmation. this workaround worked as a reminder: https://github.com/home-assistant/home-assistant-polymer/pull/4497