### PR TITLE
Automatically strip area name from entities

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -178,7 +178,7 @@ export interface PictureEntityCardConfig extends LovelaceCardConfig {
   camera_image?: string;
   camera_view?: HuiImage["cameraView"];
   state_image?: {};
-  state_filter: string[];
+  state_filter?: string[];
   aspect_ratio?: string;
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -20,7 +20,13 @@ import { computeDomain } from "../../../common/entity/compute_domain";
 
 import { LovelaceRowConfig, WeblinkConfig } from "../entity-rows/types";
 import { LocalizeFunc } from "../../../common/translations/localize";
-import { EntitiesCardConfig } from "../cards/types";
+import {
+  EntitiesCardConfig,
+  AlarmPanelCardConfig,
+  PictureEntityCardConfig,
+  ThermostatCardConfig,
+  LightCardConfig,
+} from "../cards/types";
 import {
   subscribeAreaRegistry,
   AreaRegistryEntry,
@@ -107,64 +113,86 @@ export const computeCards = (
   // For entity card
   const entities: Array<string | LovelaceRowConfig> = [];
 
+  const titlePrefix = entityCardOptions.title
+    ? `${entityCardOptions.title} `
+    : undefined;
+
   for (const [entityId, stateObj] of states) {
     const domain = computeDomain(entityId);
 
     if (domain === "alarm_control_panel") {
-      cards.push({
+      const cardConfig: AlarmPanelCardConfig = {
         type: "alarm-panel",
         entity: entityId,
-      });
+      };
+      cards.push(cardConfig);
     } else if (domain === "camera") {
-      cards.push({
+      const cardConfig: PictureEntityCardConfig = {
         type: "picture-entity",
         entity: entityId,
-      });
+      };
+      cards.push(cardConfig);
     } else if (domain === "climate") {
-      cards.push({
+      const cardConfig: ThermostatCardConfig = {
         type: "thermostat",
         entity: entityId,
-      });
+      };
+      cards.push(cardConfig);
     } else if (domain === "history_graph" && stateObj) {
-      cards.push({
+      const cardConfig = {
         type: "history-graph",
         entities: stateObj.attributes.entity_id,
         hours_to_show: stateObj.attributes.hours_to_show,
         title: stateObj.attributes.friendly_name,
         refresh_interval: stateObj.attributes.refresh,
-      });
+      };
+      cards.push(cardConfig);
     } else if (domain === "light" && single) {
-      cards.push({
+      const cardConfig: LightCardConfig = {
         type: "light",
         entity: entityId,
-      });
+      };
+      cards.push(cardConfig);
     } else if (domain === "media_player") {
-      cards.push({
+      const cardConfig = {
         type: "media-control",
         entity: entityId,
-      });
+      };
+      cards.push(cardConfig);
     } else if (domain === "plant") {
-      cards.push({
+      const cardConfig = {
         type: "plant-status",
         entity: entityId,
-      });
+      };
+      cards.push(cardConfig);
     } else if (domain === "weather") {
-      cards.push({
+      const cardConfig = {
         type: "weather-forecast",
         entity: entityId,
-      });
+      };
+      cards.push(cardConfig);
     } else if (domain === "weblink" && stateObj) {
       const conf: WeblinkConfig = {
         type: "weblink",
         url: stateObj.state,
-        name: computeStateName(stateObj),
       };
       if ("icon" in stateObj.attributes) {
         conf.icon = stateObj.attributes.icon;
       }
       entities.push(conf);
     } else {
-      entities.push(entityId);
+      let name: string;
+      const entityConf =
+        titlePrefix &&
+        stateObj &&
+        (name = computeStateName(stateObj)).startsWith(titlePrefix)
+          ? {
+              entity: entityId,
+              name: name.substr(titlePrefix.length),
+            }
+          : entityId;
+
+      entities.push(entityConf);
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When generating a Lovelace UI, when generating entity cards for groups and areas, we'll now automatically strip the area/group name of the entity if the entity name starts with it.

Example.

Area: Bedroom
- Entity: Bedroom Light

Will render like this:

![image](https://user-images.githubusercontent.com/1444314/73113511-2fd41c00-3ec9-11ea-95d6-bf07149f7729.png)


Also added some card types to generation for type checking. Found one bug in the types :)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
