### PR TITLE
Allow options flow to define form title/description

### DIFF
--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -52,8 +52,17 @@ export const showOptionsFlowDialog = (
         );
       },
 
-      renderShowFormStepDescription(_hass, _step) {
-        return "";
+      renderShowFormStepDescription(hass, step) {
+        const description = localizeKey(
+          hass.localize,
+          `component.${step.handler}.config.step.${step.step_id}.description`,
+          step.description_placeholders
+        );
+        return description
+          ? html`
+              <ha-markdown allowsvg .content=${description}></ha-markdown>
+            `
+          : "";
       },
 
       renderShowFormStepFieldLabel(hass, step, field) {

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -44,8 +44,12 @@ export const showOptionsFlowDialog = (
           : "";
       },
 
-      renderShowFormStepHeader(hass, _step) {
-        return hass.localize(`ui.dialogs.options_flow.form.header`);
+      renderShowFormStepHeader(hass, step) {
+        return (
+          hass.localize(
+            `component.${step.handler}.options.step.${step.step_id}.title`
+          ) || hass.localize(`ui.dialogs.options_flow.form.header`)
+        );
       },
 
       renderShowFormStepDescription(_hass, _step) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow option flows to optionally define a title for the page that is being shown.

Issue https://github.com/home-assistant/home-assistant/pull/30894#issuecomment-578355761

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
