### PR TITLE
Fix stale user given name display on ZHA device card

### DIFF
--- a/src/panels/config/zha/zha-device-card.ts
+++ b/src/panels/config/zha/zha-device-card.ts
@@ -244,7 +244,7 @@ class ZHADeviceCard extends LitElement {
                   <paper-input
                     type="string"
                     @change="${this._saveCustomName}"
-                    .value="${this._userGivenName}"
+                    .value="${this._userGivenName || ""}"
                     .placeholder="${this.hass!.localize(
                       "ui.dialogs.zha_device_info.zha_device_card.device_name_placeholder"
                     )}"


### PR DESCRIPTION
## Proposed change
This PR updates the ZHA device card to prevent it from displaying stale info for the `user_given_name` field. If you viewed a device that had a custom user provided name and then you viewed one that didn't the element was showing the previous devices custom name. This PR corrects that.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.