### PR TITLE
Convert Hass.io add-on options to YAML

### DIFF
--- a/hassio/src/addon-view/hassio-addon-config.ts
+++ b/hassio/src/addon-view/hassio-addon-config.ts
@@ -10,6 +10,7 @@ import {
   property,
   PropertyValues,
   TemplateResult,
+  query,
 } from "lit-element";
 
 import { HomeAssistant } from "../../../src/types";
@@ -20,30 +21,41 @@ import {
 } from "../../../src/data/hassio/addon";
 import { hassioStyle } from "../resources/hassio-style";
 import { haStyle } from "../../../src/resources/styles";
-import { PolymerChangedEvent } from "../../../src/polymer-types";
 import { fireEvent } from "../../../src/common/dom/fire_event";
+import "../../../src/components/ha-yaml-editor";
+// tslint:disable-next-line: no-duplicate-imports
+import { HaYamlEditor } from "../../../src/components/ha-yaml-editor";
 
 @customElement("hassio-addon-config")
 class HassioAddonConfig extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public addon!: HassioAddonDetails;
   @property() private _error?: string;
-  @property() private _config!: string;
   @property({ type: Boolean }) private _configHasChanged = false;
 
+  @query("ha-yaml-editor") private _editor!: HaYamlEditor;
+
   protected render(): TemplateResult {
+    const editor = this._editor;
+    // If editor not rendered, don't show the error.
+    const valid = editor ? editor.isValid : true;
+
     return html`
       <paper-card heading="Config">
         <div class="card-content">
+          <ha-yaml-editor
+            @value-changed=${this._configChanged}
+          ></ha-yaml-editor>
           ${this._error
             ? html`
                 <div class="errors">${this._error}</div>
               `
             : ""}
-          <iron-autogrow-textarea
-            @value-changed=${this._configChanged}
-            .value=${this._config}
-          ></iron-autogrow-textarea>
+          ${valid
+            ? ""
+            : html`
+                <div class="errors">Invalid YAML</div>
+              `}
         </div>
         <div class="card-actions">
           <mwc-button class="warning" @click=${this._resetTapped}>
@@ -51,7 +63,7 @@ class HassioAddonConfig extends LitElement {
           </mwc-button>
           <mwc-button
             @click=${this._saveTapped}
-            .disabled=${!this._configHasChanged}
+            .disabled=${!this._configHasChanged || !valid}
           >
             Save
           </mwc-button>
@@ -77,7 +89,7 @@ class HassioAddonConfig extends LitElement {
         }
         .errors {
           color: var(--google-red-500);
-          margin-bottom: 16px;
+          margin-top: 16px;
         }
         iron-autogrow-textarea {
           width: 100%;
@@ -93,15 +105,13 @@ class HassioAddonConfig extends LitElement {
   protected updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
     if (changedProperties.has("addon")) {
-      this._config = JSON.stringify(this.addon.options, null, 2);
+      this._editor.setValue(this.addon.options);
     }
   }
 
-  private _configChanged(ev: PolymerChangedEvent<string>): void {
-    this._config =
-      ev.detail.value || JSON.stringify(this.addon.options, null, 2);
-    this._configHasChanged =
-      this._config !== JSON.stringify(this.addon.options, null, 2);
+  private _configChanged(): void {
+    this._configHasChanged = true;
+    this.requestUpdate();
   }
 
   private async _resetTapped(): Promise<void> {
@@ -129,7 +139,7 @@ class HassioAddonConfig extends LitElement {
     this._error = undefined;
     try {
       data = {
-        options: JSON.parse(this._config),
+        options: this._editor.value,
       };
     } catch (err) {
       this._error = err;

--- a/src/components/ha-yaml-editor.ts
+++ b/src/components/ha-yaml-editor.ts
@@ -21,6 +21,7 @@ const isEmpty = (obj: object) => {
 @customElement("ha-yaml-editor")
 export class HaYamlEditor extends LitElement {
   @property() public value?: any;
+  @property() public defaultValue?: any;
   @property() public isValid = true;
   @property() public label?: string;
   @property() private _yaml: string = "";
@@ -40,8 +41,8 @@ export class HaYamlEditor extends LitElement {
   }
 
   protected firstUpdated() {
-    if (this.value) {
-      this.setValue(this.value);
+    if (this.defaultValue) {
+      this.setValue(this.defaultValue);
     }
   }
 
@@ -73,7 +74,6 @@ export class HaYamlEditor extends LitElement {
     if (value) {
       try {
         parsed = safeLoad(value);
-        isValid = true;
       } catch (err) {
         // Invalid YAML
         isValid = false;

--- a/src/components/ha-yaml-editor.ts
+++ b/src/components/ha-yaml-editor.ts
@@ -23,7 +23,7 @@ export class HaYamlEditor extends LitElement {
   @property() public value?: any;
   @property() public isValid = true;
   @property() public label?: string;
-  @property() private _yaml?: string;
+  @property() private _yaml: string = "";
   @query("ha-code-editor") private _editor?: HaCodeEditor;
 
   public setValue(value) {
@@ -40,7 +40,9 @@ export class HaYamlEditor extends LitElement {
   }
 
   protected firstUpdated() {
-    this.setValue(this.value);
+    if (this.value) {
+      this.setValue(this.value);
+    }
   }
 
   protected render() {
@@ -83,9 +85,7 @@ export class HaYamlEditor extends LitElement {
     this.value = parsed;
     this.isValid = isValid;
 
-    if (isValid) {
-      fireEvent(this, "value-changed", { value: parsed });
-    }
+    fireEvent(this, "value-changed", { value: parsed, isValid } as any);
   }
 }
 

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -157,7 +157,7 @@ export default class HaAutomationActionRow extends LitElement {
                       `
                     : ""}
                   <ha-yaml-editor
-                    .value=${this.action}
+                    .defaultValue=${this.action}
                     @value-changed=${this._onYamlChange}
                   ></ha-yaml-editor>
                 </div>
@@ -238,6 +238,9 @@ export default class HaAutomationActionRow extends LitElement {
 
   private _onYamlChange(ev: CustomEvent) {
     ev.stopPropagation();
+    if (!ev.detail.isValid) {
+      return;
+    }
     fireEvent(this, "value-changed", { value: ev.detail.value });
   }
 

--- a/src/panels/config/automation/action/types/ha-automation-action-event.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-event.ts
@@ -57,13 +57,17 @@ export class HaEventAction extends LitElement implements ActionElement {
           "ui.panel.config.automation.editor.actions.type.event.service_data"
         )}
         .name=${"event_data"}
-        .value=${event_data}
+        .defaultValue=${event_data}
         @value-changed=${this._dataChanged}
       ></ha-yaml-editor>
     `;
   }
 
   private _dataChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    if (!ev.detail.isValid) {
+      return;
+    }
     this._actionData = ev.detail.value;
     handleChangeEvent(this, ev);
   }

--- a/src/panels/config/automation/action/types/ha-automation-action-service.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-service.ts
@@ -54,6 +54,7 @@ export class HaServiceAction extends LitElement implements ActionElement {
   });
 
   protected updated(changedProperties: PropertyValues) {
+    console.log(changedProperties);
     if (!changedProperties.has("action")) {
       return;
     }
@@ -94,13 +95,17 @@ export class HaServiceAction extends LitElement implements ActionElement {
           "ui.panel.config.automation.editor.actions.type.service.service_data"
         )}
         .name=${"data"}
-        .value=${data}
+        .defaultValue=${data}
         @value-changed=${this._dataChanged}
       ></ha-yaml-editor>
     `;
   }
 
   private _dataChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    if (!ev.detail.isValid) {
+      return;
+    }
     this._actionData = ev.detail.value;
     handleChangeEvent(this, ev);
   }

--- a/src/panels/config/automation/action/types/ha-automation-action-service.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-service.ts
@@ -54,7 +54,6 @@ export class HaServiceAction extends LitElement implements ActionElement {
   });
 
   protected updated(changedProperties: PropertyValues) {
-    console.log(changedProperties);
     if (!changedProperties.has("action")) {
       return;
     }

--- a/src/panels/config/automation/condition/ha-automation-condition-editor.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-editor.ts
@@ -54,7 +54,7 @@ export default class HaAutomationConditionEditor extends LitElement {
                   `
                 : ""}
               <ha-yaml-editor
-                .value=${this.condition}
+                .defaultValue=${this.condition}
                 @value-changed=${this._onYamlChange}
               ></ha-yaml-editor>
             </div>
@@ -114,6 +114,9 @@ export default class HaAutomationConditionEditor extends LitElement {
 
   private _onYamlChange(ev: CustomEvent) {
     ev.stopPropagation();
+    if (!ev.detail.isValid) {
+      return;
+    }
     fireEvent(this, "value-changed", { value: ev.detail.value });
   }
 }

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -139,7 +139,7 @@ export default class HaAutomationTriggerRow extends LitElement {
                       `
                     : ""}
                   <ha-yaml-editor
-                    .value=${this.trigger}
+                    .defaultValue=${this.trigger}
                     @value-changed=${this._onYamlChange}
                   ></ha-yaml-editor>
                 </div>
@@ -213,6 +213,9 @@ export default class HaAutomationTriggerRow extends LitElement {
 
   private _onYamlChange(ev: CustomEvent) {
     ev.stopPropagation();
+    if (!ev.detail.isValid) {
+      return;
+    }
     fireEvent(this, "value-changed", { value: ev.detail.value });
   }
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-event.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-event.ts
@@ -35,13 +35,17 @@ export class HaEventTrigger extends LitElement implements TriggerElement {
           "ui.panel.config.automation.editor.triggers.type.event.event_data"
         )}
         .name=${"event_data"}
-        .value=${event_data}
+        .defaultValue=${event_data}
         @value-changed=${this._valueChanged}
       ></ha-yaml-editor>
     `;
   }
 
   private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    if (!ev.detail.isValid) {
+      return;
+    }
     handleChangeEvent(this, ev);
   }
 }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
@@ -84,7 +84,9 @@ export class HuiDialogSuggestCard extends LitElement {
           ${this._yamlMode && this._cardConfig
             ? html`
                 <div class="editor">
-                  <ha-yaml-editor .value=${this._cardConfig}></ha-yaml-editor>
+                  <ha-yaml-editor
+                    .defaultValue=${this._cardConfig}
+                  ></ha-yaml-editor>
                 </div>
               `
             : ""}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Converts hassio add-on options to YAML. Show error if it's invalid.

![Screen Shot 2020-01-31 at 22 43 24](https://user-images.githubusercontent.com/1444314/73588289-0d6b7100-447c-11ea-83ac-bc69c33b1a81.png)

Fixes https://github.com/home-assistant/home-assistant-polymer/issues/4622

@bramkragten I made some changes to ha-yaml-editor that we need to validate in other places:
 - Only call `setValue` on firstUpdated if it's defined. I ended up running into a race condition where `value` from parent was being overridden by `firstUpdated`. We should really rename this property to `defaultValue`, because it's only used on initial initialization. It's not used after that.
 - Always fire `value-changed` if the value changed, even if it's invalid and so the value is actually not the same as the entered value. We read the `isValid` option from the editor on value changed to be able to show an error.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
