### PR TITLE
Confirm when resetting hassio optoins

### DIFF
--- a/hassio/src/addon-view/hassio-addon-config.ts
+++ b/hassio/src/addon-view/hassio-addon-config.ts
@@ -25,6 +25,7 @@ import { fireEvent } from "../../../src/common/dom/fire_event";
 import "../../../src/components/ha-yaml-editor";
 // tslint:disable-next-line: no-duplicate-imports
 import { HaYamlEditor } from "../../../src/components/ha-yaml-editor";
+import { showConfirmationDialog } from "../../../src/dialogs/generic/show-dialog-box";
 
 @customElement("hassio-addon-config")
 class HassioAddonConfig extends LitElement {
@@ -115,6 +116,16 @@ class HassioAddonConfig extends LitElement {
   }
 
   private async _resetTapped(): Promise<void> {
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.addon.name,
+      text: "Are you sure you want to reset all your options?",
+      confirmText: "reset options",
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
     this._error = undefined;
     const data: HassioAddonSetOptionParams = {
       options: null,

--- a/src/dialogs/generic/show-dialog-box.ts
+++ b/src/dialogs/generic/show-dialog-box.ts
@@ -1,26 +1,32 @@
 import { fireEvent } from "../../common/dom/fire_event";
 
-export interface AlertDialogParams {
+interface BaseDialogParams {
   confirmText?: string;
   text?: string;
   title?: string;
-  confirm?: (out?: string) => void;
 }
 
-interface ConfirmationDialogParams extends AlertDialogParams {
+export interface AlertDialogParams extends BaseDialogParams {
+  confirm?: () => void;
+}
+
+export interface ConfirmationDialogParams extends BaseDialogParams {
   dismissText?: string;
+  confirm?: () => void;
   cancel?: () => void;
 }
 
-interface PromptDialogParams extends AlertDialogParams {
+export interface PromptDialogParams extends BaseDialogParams {
   inputLabel?: string;
   inputType?: string;
   defaultValue?: string;
+  confirm?: (out?: string) => void;
 }
 
 export interface DialogParams
   extends ConfirmationDialogParams,
     PromptDialogParams {
+  confirm?: (out?: string) => void;
   confirmation?: boolean;
   prompt?: boolean;
 }
@@ -28,35 +34,57 @@ export interface DialogParams
 export const loadGenericDialog = () =>
   import(/* webpackChunkName: "confirmation" */ "./dialog-box");
 
+const showDialogHelper = (
+  element: HTMLElement,
+  dialogParams: DialogParams,
+  extra?: {
+    confirmation?: DialogParams["confirmation"];
+    prompt?: DialogParams["prompt"];
+  }
+) =>
+  new Promise((resolve) => {
+    const origCancel = dialogParams.cancel;
+    const origConfirm = dialogParams.confirm;
+
+    fireEvent(element, "show-dialog", {
+      dialogTag: "dialog-box",
+      dialogImport: loadGenericDialog,
+      dialogParams: {
+        ...dialogParams,
+        ...extra,
+        cancel: () => {
+          resolve(extra?.prompt ? null : false);
+          if (origCancel) {
+            origCancel();
+          }
+        },
+        confirm: (out) => {
+          resolve(extra?.prompt ? out : true);
+          if (origConfirm) {
+            origConfirm(out);
+          }
+        },
+      },
+    });
+  });
+
 export const showAlertDialog = (
   element: HTMLElement,
   dialogParams: AlertDialogParams
-): void => {
-  fireEvent(element, "show-dialog", {
-    dialogTag: "dialog-box",
-    dialogImport: loadGenericDialog,
-    dialogParams,
-  });
-};
+) => showDialogHelper(element, dialogParams);
 
 export const showConfirmationDialog = (
   element: HTMLElement,
   dialogParams: ConfirmationDialogParams
-): void => {
-  fireEvent(element, "show-dialog", {
-    dialogTag: "dialog-box",
-    dialogImport: loadGenericDialog,
-    dialogParams: { ...dialogParams, confirmation: true },
-  });
-};
+) =>
+  showDialogHelper(element, dialogParams, { confirmation: true }) as Promise<
+    boolean
+  >;
 
 export const showPromptDialog = (
   element: HTMLElement,
   dialogParams: PromptDialogParams
-): void => {
-  fireEvent(element, "show-dialog", {
-    dialogTag: "dialog-box",
-    dialogImport: loadGenericDialog,
-    dialogParams: { ...dialogParams, prompt: true },
-  });
-};
+) =>
+  showDialogHelper(element, dialogParams, { prompt: true }) as Promise<
+    null | string
+  >;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Confirm when resetting hass.io add-on options to default.

I've updated the confirm dialog API to return a promise that resolves into `true`/`false`. That way it's a lot easier to use than passing `cancel`/`confirm`. The `confirm` API also felt weird, it has an optional `out` parameter? That seems like we merged a little too many types. Better keep them separate. I've simplified it a bit now, I think that we should aim to get rid of all `cancel` and `confirm` options in the codebase and then just pass a `resolve` (from Promise) to the dialog box to collect the result with `null` indicating a cancel.

Fixes #3854
Fixes #4393

![Screen Shot 2020-01-31 at 23 04 54](https://user-images.githubusercontent.com/1444314/73588454-207f4080-447e-11ea-834a-71526b0508c4.png)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
