### PR TITLE
[WIP] Allow separate entity_id for more-info dialog

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -63,6 +63,9 @@ export interface UrlActionConfig extends BaseActionConfig {
 
 export interface MoreInfoActionConfig extends BaseActionConfig {
   action: "more-info";
+  service_data?: {
+    entity_id?: string | [string];
+  };
 }
 
 export interface NoActionConfig extends BaseActionConfig {

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -67,10 +67,8 @@ export const handleAction = (
       ) {
         fireEvent(node, "hass-more-info", {
           entityId: actionConfig.service_data.entity_id
-          ? actionConfig.service_data.entity_id
-          : (config.entity 
-            ? config.entity 
-            : config.camera_image
+            ? actionConfig.service_data.entity_id
+            : (config.entity ? config.entity : config.camera_image
             )!,
         });
       }

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -68,8 +68,7 @@ export const handleAction = (
         fireEvent(node, "hass-more-info", {
           entityId: actionConfig.service_data.entity_id
             ? actionConfig.service_data.entity_id
-            : (config.entity ? config.entity : config.camera_image
-            )!,
+            : (config.entity ? config.entity : config.camera_image)!,
         });
       }
       break;

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -60,9 +60,9 @@ export const handleAction = (
 
   switch (actionConfig.action) {
     case "more-info":
-      if (config.entity || config.camera_image) {
+      if (config.entity || config.camera_image || actionConfig.service_data.entity_id) {
         fireEvent(node, "hass-more-info", {
-          entityId: config.entity ? config.entity : config.camera_image!,
+          entityId: actionConfig.service_data.entity_id ? actionConfig.service_data.entity_id : (config.entity ? config.entity : config.camera_image)!,
         });
       }
       break;

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -60,9 +60,17 @@ export const handleAction = (
 
   switch (actionConfig.action) {
     case "more-info":
-      if (config.entity || config.camera_image || actionConfig.service_data.entity_id) {
+      if (
+        config.entity || 
+        config.camera_image || 
+        actionConfig.service_data.entity_id
+      ) {
         fireEvent(node, "hass-more-info", {
-          entityId: actionConfig.service_data.entity_id ? actionConfig.service_data.entity_id : (config.entity ? config.entity : config.camera_image)!,
+          entityId: actionConfig.service_data.entity_id ? 
+            actionConfig.service_data.entity_id : 
+            (config.entity ? 
+              config.entity : 
+              config.camera_image)!,
         });
       }
       break;

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -61,16 +61,17 @@ export const handleAction = (
   switch (actionConfig.action) {
     case "more-info":
       if (
-        config.entity || 
-        config.camera_image || 
+        config.entity ||
+        config.camera_image ||
         actionConfig.service_data.entity_id
       ) {
         fireEvent(node, "hass-more-info", {
-          entityId: actionConfig.service_data.entity_id ? 
-            actionConfig.service_data.entity_id : 
-            (config.entity ? 
-              config.entity : 
-              config.camera_image)!,
+          entityId: actionConfig.service_data.entity_id
+          ? actionConfig.service_data.entity_id
+          : (config.entity 
+            ? config.entity 
+            : config.camera_image
+            )!,
         });
       }
       break;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

## Proposed change
This PR proposes to allow defining a specific entity_id for the more-info action in Lovelace.

Example use case: 
- The picture-elements card shows the state of a template sensor (e.g., alarm clock time), but the popup should show a group of entitities (e.g., input fields which allow the modification of this alarm clock).
- Have an icon/ element for a light group, but control the lights individually in the more-info dialog by using an entity group

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
```yaml
type: picture-elements
image: /local/images/floorplan.png
elements:
  - type: state-label
    tap_action:
      action: more-info
      service_data:
        entity_id: group.alarm
    entity: sensor.alarm_clock_summary
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
