### PR TITLE
Use icon image where available

### DIFF
--- a/hassio/src/addon-store/hassio-addon-repository.ts
+++ b/hassio/src/addon-store/hassio-addon-repository.ts
@@ -73,7 +73,7 @@ class HassioAddonRepositoryEl extends LitElement {
                     .title=${addon.name}
                     .description=${addon.description}
                     .available=${addon.available}
-                    icon=${addon.installed !== addon.version
+                    .icon=${addon.installed && addon.installed !== addon.version
                       ? "hassio:arrow-up-bold-circle"
                       : "hassio:puzzle"}
                     .iconTitle=${addon.installed
@@ -93,7 +93,14 @@ class HassioAddonRepositoryEl extends LitElement {
                     .iconImage=${ha105pluss && addon.icon
                       ? `/api/hassio/addons/${addon.slug}/icon`
                       : undefined}
-                    ?showBlueTopbar=${addon.installed}
+                    .showTopbar=${addon.installed || !addon.available}
+                    .topbarClass=${addon.installed
+                      ? addon.installed !== addon.version
+                        ? "update"
+                        : "installed"
+                      : !addon.available
+                      ? "unavailable"
+                      : ""}
                   ></hassio-card-content>
                 </div>
               </paper-card>

--- a/hassio/src/addon-store/hassio-addon-repository.ts
+++ b/hassio/src/addon-store/hassio-addon-repository.ts
@@ -64,7 +64,7 @@ class HassioAddonRepositoryEl extends LitElement {
               <paper-card
                 .addon=${addon}
                 class=${addon.available ? "" : "not_available"}
-                @click=${this.addonTapped}
+                @click=${this._addonTapped}
               >
                 <div class="card-content">
                   <hassio-card-content
@@ -72,10 +72,26 @@ class HassioAddonRepositoryEl extends LitElement {
                     .title=${addon.name}
                     .description=${addon.description}
                     .available=${addon.available}
-                    .icon=${this.computeIcon(addon)}
-                    .iconTitle=${this.computeIconTitle(addon)}
-                    .iconClass=${this.computeIconClass(addon)}
-                    .iconImage=${this._computeIconImageURL(addon)}
+                    icon=${addon.installed !== addon.version
+                      ? "hassio:arrow-up-bold-circle"
+                      : "hassio:puzzle"}
+                    .iconTitle=${addon.installed
+                      ? addon.installed !== addon.version
+                        ? "New version available"
+                        : "Add-on is installed"
+                      : addon.available
+                      ? "Add-on is not installed"
+                      : "Add-on is not available on your system"}
+                    .iconClass=${addon.installed
+                      ? addon.installed !== addon.version
+                        ? "update"
+                        : "installed"
+                      : !addon.available
+                      ? "not_available"
+                      : ""}
+                    .iconImage=${this._computeHA105plus && addon.icon
+                      ? `/api/hassio/addons/${addon.slug}/icon`
+                      : undefined}
                     ?showBlueTopbar=${addon.installed}
                   ></hassio-card-content>
                 </div>
@@ -87,44 +103,13 @@ class HassioAddonRepositoryEl extends LitElement {
     `;
   }
 
-  private computeIcon(addon) {
-    return addon.installed && addon.installed !== addon.version
-      ? "hassio:arrow-up-bold-circle"
-      : "hassio:puzzle";
-  }
-
-  private computeIconTitle(addon) {
-    if (addon.installed) {
-      return addon.installed !== addon.version
-        ? "New version available"
-        : "Add-on is installed";
-    }
-    return addon.available
-      ? "Add-on is not installed"
-      : "Add-on is not available on your system";
-  }
-
-  private computeIconClass(addon) {
-    if (addon.installed) {
-      return addon.installed !== addon.version ? "update" : "installed";
-    }
-    return !addon.available ? "not_available" : "";
-  }
-
-  private addonTapped(ev) {
+  private _addonTapped(ev) {
     navigate(this, `/hassio/addon/${ev.currentTarget.addon.slug}`);
   }
 
   private get _computeHA105plus(): boolean {
     const [major, minor] = this.hass.config.version.split(".", 2);
     return Number(major) > 0 || (major === "0" && Number(minor) >= 105);
-  }
-
-  private _computeIconImageURL(addon: HassioAddonInfo): string | undefined {
-    if (this._computeHA105plus && addon.icon) {
-      return `/api/hassio/addons/${addon.slug}/icon`;
-    }
-    return undefined;
   }
 
   static get styles(): CSSResultArray {

--- a/hassio/src/addon-store/hassio-addon-repository.ts
+++ b/hassio/src/addon-store/hassio-addon-repository.ts
@@ -39,7 +39,7 @@ class HassioAddonRepositoryEl extends LitElement {
   protected render(): TemplateResult {
     const repo = this.repo;
     const addons = this._getAddons(this.addons, this.filter);
-    const Ha105Pluss = this._computeHA105plus;
+    const ha105pluss = this._computeHA105plus;
 
     if (this.filter && addons.length < 1) {
       return html`
@@ -90,7 +90,7 @@ class HassioAddonRepositoryEl extends LitElement {
                       : !addon.available
                       ? "not_available"
                       : ""}
-                    .iconImage=${Ha105Pluss && addon.icon
+                    .iconImage=${ha105pluss && addon.icon
                       ? `/api/hassio/addons/${addon.slug}/icon`
                       : undefined}
                     ?showBlueTopbar=${addon.installed}

--- a/hassio/src/addon-store/hassio-addon-repository.ts
+++ b/hassio/src/addon-store/hassio-addon-repository.ts
@@ -39,7 +39,7 @@ class HassioAddonRepositoryEl extends LitElement {
   protected render(): TemplateResult {
     const repo = this.repo;
     const addons = this._getAddons(this.addons, this.filter);
-    const HA105plus = this._computeHA105plus;
+    const Ha105Pluss = this._computeHA105plus;
 
     if (this.filter && addons.length < 1) {
       return html`
@@ -90,7 +90,7 @@ class HassioAddonRepositoryEl extends LitElement {
                       : !addon.available
                       ? "not_available"
                       : ""}
-                    .iconImage=${HA105plus && addon.icon
+                    .iconImage=${Ha105Pluss && addon.icon
                       ? `/api/hassio/addons/${addon.slug}/icon`
                       : undefined}
                     ?showBlueTopbar=${addon.installed}

--- a/hassio/src/addon-store/hassio-addon-repository.ts
+++ b/hassio/src/addon-store/hassio-addon-repository.ts
@@ -75,6 +75,7 @@ class HassioAddonRepositoryEl extends LitElement {
                     .icon=${this.computeIcon(addon)}
                     .iconTitle=${this.computeIconTitle(addon)}
                     .iconClass=${this.computeIconClass(addon)}
+                    .iconImage=${this._computeIconImageURL(addon)}
                   ></hassio-card-content>
                 </div>
               </paper-card>
@@ -111,6 +112,18 @@ class HassioAddonRepositoryEl extends LitElement {
 
   private addonTapped(ev) {
     navigate(this, `/hassio/addon/${ev.currentTarget.addon.slug}`);
+  }
+
+  private get _computeHA105plus(): boolean {
+    const [major, minor] = this.hass.config.version.split(".", 2);
+    return Number(major) > 0 || (major === "0" && Number(minor) >= 105);
+  }
+
+  private _computeIconImageURL(addon: HassioAddonInfo): string | undefined {
+    if (this._computeHA105plus && addon.icon) {
+      return `/api/hassio/addons/${addon.slug}/icon`;
+    }
+    return undefined;
   }
 
   static get styles(): CSSResultArray {

--- a/hassio/src/addon-store/hassio-addon-repository.ts
+++ b/hassio/src/addon-store/hassio-addon-repository.ts
@@ -76,6 +76,7 @@ class HassioAddonRepositoryEl extends LitElement {
                     .iconTitle=${this.computeIconTitle(addon)}
                     .iconClass=${this.computeIconClass(addon)}
                     .iconImage=${this._computeIconImageURL(addon)}
+                    ?showBlueTopbar=${addon.installed}
                   ></hassio-card-content>
                 </div>
               </paper-card>

--- a/hassio/src/addon-store/hassio-addon-repository.ts
+++ b/hassio/src/addon-store/hassio-addon-repository.ts
@@ -39,6 +39,7 @@ class HassioAddonRepositoryEl extends LitElement {
   protected render(): TemplateResult {
     const repo = this.repo;
     const addons = this._getAddons(this.addons, this.filter);
+    const HA105plus = this._computeHA105plus;
 
     if (this.filter && addons.length < 1) {
       return html`
@@ -89,7 +90,7 @@ class HassioAddonRepositoryEl extends LitElement {
                       : !addon.available
                       ? "not_available"
                       : ""}
-                    .iconImage=${this._computeHA105plus && addon.icon
+                    .iconImage=${HA105plus && addon.icon
                       ? `/api/hassio/addons/${addon.slug}/icon`
                       : undefined}
                     ?showBlueTopbar=${addon.installed}

--- a/hassio/src/addon-view/hassio-addon-info.ts
+++ b/hassio/src/addon-view/hassio-addon-info.ts
@@ -454,7 +454,6 @@ class HassioAddonInfo extends LitElement {
                 <ha-progress-button
                   .disabled=${!this.addon.available}
                   .progress=${this._installing}
-                  class="right"
                   @click=${this._installClicked}
                 >
                   Install

--- a/hassio/src/components/hassio-card-content.ts
+++ b/hassio/src/components/hassio-card-content.ts
@@ -7,6 +7,7 @@ import {
   property,
   customElement,
 } from "lit-element";
+import { classMap } from "lit-html/directives/class-map";
 import "@polymer/iron-icon/iron-icon";
 
 import "../../../src/components/ha-relative-time";
@@ -17,21 +18,45 @@ class HassioCardContent extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public title!: string;
   @property() public description?: string;
-  @property({ type: Boolean }) public available?: boolean;
+  @property({ type: Boolean }) public available: boolean = true;
+  @property({ type: Boolean }) public updateAvailable: boolean = false;
   @property() public datetime?: string;
   @property() public iconTitle?: string;
   @property() public iconClass?: string;
   @property() public icon = "hass:help-circle";
+  @property() public iconImage?: string;
 
   protected render(): TemplateResult {
+    console.log(this.available);
     return html`
-      <iron-icon
-        class=${this.iconClass}
-        .icon=${this.icon}
-        .title=${this.iconTitle}
-      ></iron-icon>
+      ${this.iconImage
+        ? html`
+            <div
+              class=${classMap({
+                icon_image: true,
+                grayscale: this.iconClass === "stopped" || !this.available,
+              })}
+            >
+              <img src="${this.iconImage}" title="${this.iconTitle}" />
+              <div></div>
+            </div>
+          `
+        : html`
+            <iron-icon
+              class=${this.iconClass}
+              .icon=${this.icon}
+              .title=${this.iconTitle}
+            ></iron-icon>
+          `}
       <div>
-        <div class="title">${this.title}</div>
+        <div class="title">
+          ${this.title}
+          ${this.updateAvailable
+            ? html`
+                <div class="update-available" title="Update available"></div>
+              `
+            : ""}
+        </div>
         <div class="addition">
           ${this.description}
           ${/* treat as available when undefined */
@@ -53,7 +78,8 @@ class HassioCardContent extends LitElement {
   static get styles(): CSSResult {
     return css`
       iron-icon {
-        margin-right: 16px;
+        margin-right: 24px;
+        margin-left: 8px;
         margin-top: 16px;
         float: left;
         color: var(--secondary-text-color);
@@ -87,6 +113,25 @@ class HassioCardContent extends LitElement {
       }
       ha-relative-time {
         display: block;
+      }
+      .icon_image img {
+        max-height: 40px;
+        max-width: 40px;
+        margin-top: 4px;
+        margin-right: 16px;
+        float: left;
+      }
+      .grayscale {
+        filter: grayscale(1);
+      }
+      .update-available {
+        position: absolute;
+        background-color: var(--paper-orange-400);
+        width: 12px;
+        height: 12px;
+        top: 8px;
+        right: 8px;
+        border-radius: 50%;
       }
     `;
   }

--- a/hassio/src/components/hassio-card-content.ts
+++ b/hassio/src/components/hassio-card-content.ts
@@ -27,7 +27,6 @@ class HassioCardContent extends LitElement {
   @property() public iconImage?: string;
 
   protected render(): TemplateResult {
-    console.log(this.available);
     return html`
       ${this.iconImage
         ? html`

--- a/hassio/src/components/hassio-card-content.ts
+++ b/hassio/src/components/hassio-card-content.ts
@@ -19,8 +19,8 @@ class HassioCardContent extends LitElement {
   @property() public title!: string;
   @property() public description?: string;
   @property({ type: Boolean }) public available: boolean = true;
-  @property({ type: Boolean }) public showDot: boolean = false;
-  @property({ type: Boolean }) public showBlueTopbar: boolean = false;
+  @property({ type: Boolean }) public showTopbar: boolean = false;
+  @property() public topbarClass?: string;
   @property() public datetime?: string;
   @property() public iconTitle?: string;
   @property() public iconClass?: string;
@@ -29,9 +29,9 @@ class HassioCardContent extends LitElement {
 
   protected render(): TemplateResult {
     return html`
-      ${this.showBlueTopbar
+      ${this.showTopbar
         ? html`
-            <div class="blue-topbar"></div>
+            <div class="topbar ${this.topbarClass}"></div>
           `
         : ""}
       ${this.iconImage
@@ -56,11 +56,6 @@ class HassioCardContent extends LitElement {
       <div>
         <div class="title">
           ${this.title}
-          ${this.showDot
-            ? html`
-                <div class="dot" title="Update available"></div>
-              `
-            : ""}
         </div>
         <div class="addition">
           ${this.description}
@@ -138,14 +133,23 @@ class HassioCardContent extends LitElement {
         right: 8px;
         border-radius: 50%;
       }
-      .blue-topbar {
+      .topbar {
         position: absolute;
         width: 100%;
-        border: 0px;
         height: 2px;
         top: 0;
         left: 0;
-        background-color: var(--google-blue-500);
+        border-top-left-radius: 2px;
+        border-top-right-radius: 2px;
+      }
+      .topbar.installed {
+        background-color: var(--primary-color);
+      }
+      .topbar.update {
+        background-color: var(--accent-color);
+      }
+      .topbar.unavailable {
+        background-color: var(--error-color);
       }
     `;
   }

--- a/hassio/src/components/hassio-card-content.ts
+++ b/hassio/src/components/hassio-card-content.ts
@@ -80,7 +80,7 @@ class HassioCardContent extends LitElement {
       iron-icon {
         margin-right: 24px;
         margin-left: 8px;
-        margin-top: 16px;
+        margin-top: 12px;
         float: left;
         color: var(--secondary-text-color);
       }

--- a/hassio/src/components/hassio-card-content.ts
+++ b/hassio/src/components/hassio-card-content.ts
@@ -19,7 +19,8 @@ class HassioCardContent extends LitElement {
   @property() public title!: string;
   @property() public description?: string;
   @property({ type: Boolean }) public available: boolean = true;
-  @property({ type: Boolean }) public updateAvailable: boolean = false;
+  @property({ type: Boolean }) public showDot: boolean = false;
+  @property({ type: Boolean }) public showBlueTopbar: boolean = false;
   @property() public datetime?: string;
   @property() public iconTitle?: string;
   @property() public iconClass?: string;
@@ -28,6 +29,11 @@ class HassioCardContent extends LitElement {
 
   protected render(): TemplateResult {
     return html`
+      ${this.showBlueTopbar
+        ? html`
+            <div class="blue-topbar"></div>
+          `
+        : ""}
       ${this.iconImage
         ? html`
             <div
@@ -50,9 +56,9 @@ class HassioCardContent extends LitElement {
       <div>
         <div class="title">
           ${this.title}
-          ${this.updateAvailable
+          ${this.showDot
             ? html`
-                <div class="update-available" title="Update available"></div>
+                <div class="dot" title="Update available"></div>
               `
             : ""}
         </div>
@@ -123,7 +129,7 @@ class HassioCardContent extends LitElement {
       .grayscale {
         filter: grayscale(1);
       }
-      .update-available {
+      .dot {
         position: absolute;
         background-color: var(--paper-orange-400);
         width: 12px;
@@ -131,6 +137,15 @@ class HassioCardContent extends LitElement {
         top: 8px;
         right: 8px;
         border-radius: 50%;
+      }
+      .blue-topbar {
+        position: absolute;
+        width: 100%;
+        border: 0px;
+        height: 2px;
+        top: 0;
+        left: 0;
+        background-color: var(--google-blue-500);
       }
     `;
   }

--- a/hassio/src/components/hassio-card-content.ts
+++ b/hassio/src/components/hassio-card-content.ts
@@ -36,12 +36,7 @@ class HassioCardContent extends LitElement {
         : ""}
       ${this.iconImage
         ? html`
-            <div
-              class=${classMap({
-                icon_image: true,
-                grayscale: this.iconClass === "stopped" || !this.available,
-              })}
-            >
+            <div class="icon_image ${this.iconClass}">
               <img src="${this.iconImage}" title="${this.iconTitle}" />
               <div></div>
             </div>
@@ -121,7 +116,8 @@ class HassioCardContent extends LitElement {
         margin-right: 16px;
         float: left;
       }
-      .grayscale {
+      .icon_image.stopped,
+      .icon_image.not_available {
         filter: grayscale(1);
       }
       .dot {

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -62,7 +62,9 @@ class HassioAddons extends LitElement {
                             : "Add-on is running"}
                           .iconClass=${addon.installed &&
                           addon.installed !== addon.version
-                            ? "update"
+                            ? addon.state === "started"
+                              ? "update"
+                              : "update stopped"
                             : addon.installed && addon.state === "started"
                             ? "running"
                             : "stopped"}

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -22,7 +22,9 @@ class HassioAddons extends LitElement {
   @property() public addons?: HassioAddonInfo[];
 
   protected render(): TemplateResult {
-    const ha105pluss = this._computeHA105plus;
+    const [major, minor] = this.hass.config.version.split(".", 2);
+    const ha105pluss =
+      Number(major) > 0 || (major === "0" && Number(minor) >= 105);
     return html`
       <div class="content">
         <h1>Add-ons</h1>
@@ -45,11 +47,12 @@ class HassioAddons extends LitElement {
                       <div class="card-content">
                         <hassio-card-content
                           .hass=${this.hass}
-                          title=${addon.name}
-                          description=${addon.description}
-                          ?available=${addon.available}
-                          ?showDot=${addon.installed !== addon.version}
-                          icon=${addon.installed !== addon.version
+                          .title=${addon.name}
+                          .description=${addon.description}
+                          available
+                          .showTopbar=${addon.installed !== addon.version}
+                          topbarClass="update"
+                          .icon=${addon.installed !== addon.version
                             ? "hassio:arrow-up-bold-circle"
                             : "hassio:puzzle"}
                           .iconTitle=${addon.state !== "started"
@@ -94,11 +97,6 @@ class HassioAddons extends LitElement {
 
   private _openStore(): void {
     navigate(this, "/hassio/store");
-  }
-
-  private get _computeHA105plus(): boolean {
-    const [major, minor] = this.hass.config.version.split(".", 2);
-    return Number(major) > 0 || (major === "0" && Number(minor) >= 105);
   }
 }
 

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -56,7 +56,12 @@ class HassioAddons extends LitElement {
                             : addon.installed !== addon.version
                             ? "New version available"
                             : "Add-on is running"}
-                          .iconClass=${this._computeIconClass(addon)}
+                          .iconClass=${addon.installed &&
+                          addon.installed !== addon.version
+                            ? "update"
+                            : addon.installed && addon.state === "started"
+                            ? "running"
+                            : "stopped"}
                           .iconImage=${this._computeHA105plus && addon.icon
                             ? `/api/hassio/addons/${addon.slug}/icon`
                             : undefined}
@@ -80,16 +85,6 @@ class HassioAddons extends LitElement {
         }
       `,
     ];
-  }
-
-  private _computeIconClass(addon: HassioAddonInfo): string {
-    if (addon.installed) {
-      return addon.state === "started" ? "running" : "stopped";
-    }
-    if (addon.installed !== addon.version) {
-      return "update";
-    }
-    return "";
   }
 
   private _addonTapped(ev: any): void {

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -22,7 +22,7 @@ class HassioAddons extends LitElement {
   @property() public addons?: HassioAddonInfo[];
 
   protected render(): TemplateResult {
-    const HA105plus = this._computeHA105plus;
+    const Ha105Pluss = this._computeHA105plus;
     return html`
       <div class="content">
         <h1>Add-ons</h1>
@@ -63,7 +63,7 @@ class HassioAddons extends LitElement {
                             : addon.installed && addon.state === "started"
                             ? "running"
                             : "stopped"}
-                          .iconImage=${HA105plus && addon.icon
+                          .iconImage=${Ha105Pluss && addon.icon
                             ? `/api/hassio/addons/${addon.slug}/icon`
                             : undefined}
                         ></hassio-card-content>

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -47,11 +47,19 @@ class HassioAddons extends LitElement {
                           title=${addon.name}
                           description=${addon.description}
                           ?available=${addon.available}
-                          ?updateAvailable=${addon.installed !== addon.version}
-                          icon=${this._computeIcon(addon)}
-                          .iconTitle=${this._computeIconTitle(addon)}
+                          ?showDot=${addon.installed !== addon.version}
+                          icon=${addon.installed !== addon.version
+                            ? "hassio:arrow-up-bold-circle"
+                            : "hassio:puzzle"}
+                          .iconTitle=${addon.state !== "started"
+                            ? "Add-on is stopped"
+                            : addon.installed !== addon.version
+                            ? "New version available"
+                            : "Add-on is running"}
                           .iconClass=${this._computeIconClass(addon)}
-                          .iconImage=${this._computeIconImageURL(addon)}
+                          .iconImage=${this._computeHA105plus && addon.icon
+                            ? `/api/hassio/addons/${addon.slug}/icon`
+                            : undefined}
                         ></hassio-card-content>
                       </div>
                     </paper-card>
@@ -72,22 +80,6 @@ class HassioAddons extends LitElement {
         }
       `,
     ];
-  }
-
-  private _computeIcon(addon: HassioAddonInfo): string {
-    return addon.installed !== addon.version
-      ? "hassio:arrow-up-bold-circle"
-      : "hassio:puzzle";
-  }
-
-  private _computeIconTitle(addon: HassioAddonInfo): string {
-    if (addon.state !== "started") {
-      return "Add-on is stopped";
-    }
-    if (addon.installed !== addon.version) {
-      return "New version available";
-    }
-    return "Add-on is running";
   }
 
   private _computeIconClass(addon: HassioAddonInfo): string {
@@ -111,13 +103,6 @@ class HassioAddons extends LitElement {
   private get _computeHA105plus(): boolean {
     const [major, minor] = this.hass.config.version.split(".", 2);
     return Number(major) > 0 || (major === "0" && Number(minor) >= 105);
-  }
-
-  private _computeIconImageURL(addon: HassioAddonInfo): string | undefined {
-    if (this._computeHA105plus && addon.icon) {
-      return `/api/hassio/addons/${addon.slug}/icon`;
-    }
-    return undefined;
   }
 }
 

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -47,9 +47,11 @@ class HassioAddons extends LitElement {
                           title=${addon.name}
                           description=${addon.description}
                           ?available=${addon.available}
+                          ?UpdateAvailable=${addon.installed !== addon.version}
                           icon=${this._computeIcon(addon)}
                           .iconTitle=${this._computeIconTitle(addon)}
                           .iconClass=${this._computeIconClass(addon)}
+                          .iconImage=${this._computeIconImageURL(addon)}
                         ></hassio-card-content>
                       </div>
                     </paper-card>
@@ -79,19 +81,23 @@ class HassioAddons extends LitElement {
   }
 
   private _computeIconTitle(addon: HassioAddonInfo): string {
+    if (addon.state !== "started") {
+      return "Add-on is stopped";
+    }
     if (addon.installed !== addon.version) {
       return "New version available";
     }
-    return addon.state === "started"
-      ? "Add-on is running"
-      : "Add-on is stopped";
+    return "Add-on is running";
   }
 
   private _computeIconClass(addon: HassioAddonInfo): string {
+    if (addon.installed) {
+      return addon.state === "started" ? "running" : "stopped";
+    }
     if (addon.installed !== addon.version) {
       return "update";
     }
-    return addon.state === "started" ? "running" : "";
+    return "";
   }
 
   private _addonTapped(ev: any): void {
@@ -100,6 +106,18 @@ class HassioAddons extends LitElement {
 
   private _openStore(): void {
     navigate(this, "/hassio/store");
+  }
+
+  private get _computeHA105plus(): boolean {
+    const [major, minor] = this.hass.config.version.split(".", 2);
+    return Number(major) > 0 || (major === "0" && Number(minor) >= 105);
+  }
+
+  private _computeIconImageURL(addon: HassioAddonInfo): string | undefined {
+    if (this._computeHA105plus && addon.icon) {
+      return `/api/hassio/addons/${addon.slug}/icon`;
+    }
+    return undefined;
   }
 }
 

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -47,7 +47,7 @@ class HassioAddons extends LitElement {
                           title=${addon.name}
                           description=${addon.description}
                           ?available=${addon.available}
-                          ?UpdateAvailable=${addon.installed !== addon.version}
+                          ?updateAvailable=${addon.installed !== addon.version}
                           icon=${this._computeIcon(addon)}
                           .iconTitle=${this._computeIconTitle(addon)}
                           .iconClass=${this._computeIconClass(addon)}

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -22,7 +22,7 @@ class HassioAddons extends LitElement {
   @property() public addons?: HassioAddonInfo[];
 
   protected render(): TemplateResult {
-    const Ha105Pluss = this._computeHA105plus;
+    const ha105pluss = this._computeHA105plus;
     return html`
       <div class="content">
         <h1>Add-ons</h1>
@@ -63,7 +63,7 @@ class HassioAddons extends LitElement {
                             : addon.installed && addon.state === "started"
                             ? "running"
                             : "stopped"}
-                          .iconImage=${Ha105Pluss && addon.icon
+                          .iconImage=${ha105pluss && addon.icon
                             ? `/api/hassio/addons/${addon.slug}/icon`
                             : undefined}
                         ></hassio-card-content>

--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -22,6 +22,7 @@ class HassioAddons extends LitElement {
   @property() public addons?: HassioAddonInfo[];
 
   protected render(): TemplateResult {
+    const HA105plus = this._computeHA105plus;
     return html`
       <div class="content">
         <h1>Add-ons</h1>
@@ -62,7 +63,7 @@ class HassioAddons extends LitElement {
                             : addon.installed && addon.state === "started"
                             ? "running"
                             : "stopped"}
-                          .iconImage=${this._computeHA105plus && addon.icon
+                          .iconImage=${HA105plus && addon.icon
                             ? `/api/hassio/addons/${addon.slug}/icon`
                             : undefined}
                         ></hassio-card-content>

--- a/hassio/src/entrypoint.ts
+++ b/hassio/src/entrypoint.ts
@@ -1,9 +1,12 @@
 window.loadES5Adapter().then(() => {
   // eslint-disable-next-line
+  import(/* webpackChunkName: "roboto" */ "../../src/resources/roboto");
+  // eslint-disable-next-line
   import(/* webpackChunkName: "hassio-icons" */ "./resources/hassio-icons");
   // eslint-disable-next-line
   import(/* webpackChunkName: "hassio-main" */ "./hassio-main");
 });
+
 const styleEl = document.createElement("style");
 styleEl.innerHTML = `
 body {

--- a/hassio/src/resources/hassio-style.ts
+++ b/hassio/src/resources/hassio-style.ts
@@ -17,11 +17,11 @@ export const hassioStyle = css`
     font-weight: var(--paper-font-headline_-_font-weight);
     letter-spacing: var(--paper-font-headline_-_letter-spacing);
     line-height: var(--paper-font-headline_-_line-height);
-    padding-left: 16px;
+    padding-left: 8px;
   }
   .description {
     margin-top: 4px;
-    padding-left: 16px;
+    padding-left: 8px;
   }
   .card-group {
     display: grid;


### PR DESCRIPTION
## Proposed change

From: <https://twitter.com/andreadonno/status/1218074534936563712?s=20>

- Use icon image where available in both the dashboard and store
- If add-on is installed and stopped or not available on the system, use grayscale on the image.
- If add-on is installed and there is an update pending, show a dot in the corner.

I tried to add a dot in the bottom corner of the icon to indicate the started/stopped statuses, but the images come in every shape possible and it did not look that great, using grayscale always works.

Baloob mentioned and "Update pening" bage on twitter, but that had some issues with jumping text, and when the title was long it should drop the title/go over multiple lines, I think a little dot in the corner is sufficient.

## Screenshots 📷 

### Overview 
![image](https://user-images.githubusercontent.com/15093472/73590592-830b2780-44e4-11ea-9617-820418cebe6d.png)

### Add-on store
![image](https://user-images.githubusercontent.com/15093472/73605306-04be8c00-459d-11ea-89ad-393f6f8d2f31.png)

### Add-on not startet/not available 
![image](https://user-images.githubusercontent.com/15093472/73590610-b1890280-44e4-11ea-8271-f3a0ef51a2b8.png)

### Add-on has an update pending
![image](https://user-images.githubusercontent.com/15093472/73590614-c796c300-44e4-11ea-89bc-bcefbf962f2f.png)

### "old" overview (for refrence)
![image](https://user-images.githubusercontent.com/15093472/73591037-f6636800-44e9-11ea-9735-11c043843e72.png)

### "old" add-on store (for refrence)
![image](https://user-images.githubusercontent.com/15093472/73591040-0418ed80-44ea-11ea-88bc-49e9ea6c1c60.png)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!) _maybe?_
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io