### PR TITLE
Update Edit Footer for Cards

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -100,9 +100,9 @@ export class HuiCardOptions extends LitElement {
           rgba(0, 0, 0, 0.2) 0px 3px 1px -2px;
         display: flex;
         position: relative;
-        border-radius: var(--ha-card-border-radius, 2px);
         margin-top: -1px;
-        border-radius: 0px 0px 2px 2px;
+        border-radius: 0px 0px var(--ha-card-border-radius, 2px)
+          var(--ha-card-border-radius, 2px);
       }
 
       div.options .primary-actions {

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -33,76 +33,79 @@ export class HuiCardOptions extends LitElement {
   protected render(): TemplateResult {
     return html`
       <slot></slot>
-      <div class="options">
-        <div class="primary-actions">
-          <mwc-button @click="${this._editCard}"
-            >${this.hass!.localize(
-              "ui.panel.lovelace.editor.edit_card.edit"
-            )}</mwc-button
-          >
-        </div>
-        <div class="secondary-actions">
-          <paper-icon-button
-            title="Move card down"
-            class="move-arrow"
-            icon="hass:arrow-down"
-            @click="${this._cardDown}"
-            ?disabled="${this.lovelace!.config.views[this.path![0]].cards!
-              .length ===
-              this.path![1] + 1}"
-          ></paper-icon-button>
-          <paper-icon-button
-            title="Move card up"
-            class="move-arrow"
-            icon="hass:arrow-up"
-            @click="${this._cardUp}"
-            ?disabled="${this.path![1] === 0}"
-          ></paper-icon-button>
-          <paper-menu-button
-            horizontal-align="right"
-            vertical-align="bottom"
-            vertical-offset="40"
-            close-on-activate
-          >
+      <ha-card>
+        <div class="options">
+          <div class="primary-actions">
+            <mwc-button @click="${this._editCard}"
+              >${this.hass!.localize(
+                "ui.panel.lovelace.editor.edit_card.edit"
+              )}</mwc-button
+            >
+          </div>
+          <div class="secondary-actions">
             <paper-icon-button
-              icon="hass:dots-vertical"
-              slot="dropdown-trigger"
-              aria-label=${this.hass!.localize(
-                "ui.panel.lovelace.editor.edit_card.options"
-              )}
+              title="Move card down"
+              class="move-arrow"
+              icon="hass:arrow-down"
+              @click="${this._cardDown}"
+              ?disabled="${this.lovelace!.config.views[this.path![0]].cards!
+                .length ===
+                this.path![1] + 1}"
             ></paper-icon-button>
-            <paper-listbox slot="dropdown-content">
-              <paper-item @tap="${this._moveCard}">
-                ${this.hass!.localize(
-                  "ui.panel.lovelace.editor.edit_card.move"
-                )}</paper-item
-              >
-              <paper-item .class="delete-item" @tap="${this._deleteCard}">
-                ${this.hass!.localize(
-                  "ui.panel.lovelace.editor.edit_card.delete"
-                )}</paper-item
-              >
-            </paper-listbox>
-          </paper-menu-button>
+            <paper-icon-button
+              title="Move card up"
+              class="move-arrow"
+              icon="hass:arrow-up"
+              @click="${this._cardUp}"
+              ?disabled="${this.path![1] === 0}"
+            ></paper-icon-button>
+            <paper-menu-button
+              horizontal-align="right"
+              vertical-align="bottom"
+              vertical-offset="40"
+              close-on-activate
+            >
+              <paper-icon-button
+                icon="hass:dots-vertical"
+                slot="dropdown-trigger"
+                aria-label=${this.hass!.localize(
+                  "ui.panel.lovelace.editor.edit_card.options"
+                )}
+              ></paper-icon-button>
+              <paper-listbox slot="dropdown-content">
+                <paper-item @tap="${this._moveCard}">
+                  ${this.hass!.localize(
+                    "ui.panel.lovelace.editor.edit_card.move"
+                  )}</paper-item
+                >
+                <paper-item .class="delete-item" @tap="${this._deleteCard}">
+                  ${this.hass!.localize(
+                    "ui.panel.lovelace.editor.edit_card.delete"
+                  )}</paper-item
+                >
+              </paper-listbox>
+            </paper-menu-button>
+          </div>
         </div>
-      </div>
+      </ha-card>
     `;
   }
 
   static get styles(): CSSResult {
     return css`
-      div.options {
-        border-top: 1px solid #e8e8e8;
-        padding: 5px 8px;
-        background: var(--paper-card-background-color, white);
+      ha-card {
+        border-top-right-radius: 0;
+        border-top-left-radius: 0;
         box-shadow: rgba(0, 0, 0, 0.14) 0px 2px 2px 0px,
           rgba(0, 0, 0, 0.12) 0px 1px 5px -4px,
           rgba(0, 0, 0, 0.2) 0px 3px 1px -2px;
+      }
+
+      div.options {
+        border-top: 1px solid #e8e8e8;
+        padding: 5px 8px;
         display: flex;
-        position: relative;
         margin-top: -1px;
-        border-radius: 0px 0px var(--ha-card-border-radius, 2px)
-          var(--ha-card-border-radius, 2px);
       }
 
       div.options .primary-actions {

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -99,6 +99,10 @@ export class HuiCardOptions extends LitElement {
           rgba(0, 0, 0, 0.12) 0px 1px 5px -4px,
           rgba(0, 0, 0, 0.2) 0px 3px 1px -2px;
         display: flex;
+        position: relative;
+        border-radius: var(--ha-card-border-radius, 2px);
+        margin-top: -1px;
+        border-radius: 0px 0px 2px 2px;
       }
 
       div.options .primary-actions {


### PR DESCRIPTION
## Proposed change
Updates the Style of the Edit Options to better flow with the current Card. This fixes the Material Design issues as there is not Shadow footer

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

![image](https://user-images.githubusercontent.com/18730868/73771630-b64fef80-474c-11ea-89de-dc1363db2229.png)

:arrow_down:

(old image with out HA-CARD) ❗️ 
![image](https://user-images.githubusercontent.com/18730868/73771644-b94ae000-474c-11ea-87a6-ad7bf85a3e44.png)

(New Image with HA-CARD) ❗️ 
![image](https://user-images.githubusercontent.com/18730868/73876018-385f1780-4824-11ea-8e82-fbce0b667731.png)


## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.