### PR TITLE
Hass.io panel localization - dashboard

### DIFF
--- a/hassio/src/dashboard/hassio-addons.ts
+++ b/hassio/src/dashboard/hassio-addons.ts
@@ -1,3 +1,4 @@
+import "@material/mwc-button";
 import "@polymer/paper-card/paper-card";
 import {
   css,
@@ -33,9 +34,16 @@ class HassioAddons extends LitElement {
             ? html`
                 <paper-card>
                   <div class="card-content">
-                    You don't have any add-ons installed yet. Head over to
-                    <a href="#" @click=${this._openStore}>the add-on store</a>
-                    to get started!
+                    ${this.hass.localize(
+                      "ui.panel.hassio.dashboard.no_installed_addons"
+                    )}
+                  </div>
+                  <div class="card-actions">
+                    <mwc-button @click=${this._openStore}>
+                      ${this.hass.localize(
+                        "ui.panel.hassio.dashboard.open_addon_store"
+                      )}
+                    </mwc-button>
                   </div>
                 </paper-card>
               `
@@ -56,10 +64,16 @@ class HassioAddons extends LitElement {
                             ? "hassio:arrow-up-bold-circle"
                             : "hassio:puzzle"}
                           .iconTitle=${addon.state !== "started"
-                            ? "Add-on is stopped"
+                            ? this.hass.localize(
+                                "ui.panel.hassio.addon.is_stopped"
+                              )
                             : addon.installed !== addon.version
-                            ? "New version available"
-                            : "Add-on is running"}
+                            ? this.hass.localize(
+                                "ui.panel.hassio.addon.has_new_version"
+                              )
+                            : this.hass.localize(
+                                "ui.panel.hassio.addon.is_runing"
+                              )}
                           .iconClass=${addon.installed &&
                           addon.installed !== addon.version
                             ? addon.state === "started"

--- a/hassio/src/dashboard/hassio-update.ts
+++ b/hassio/src/dashboard/hassio-update.ts
@@ -54,13 +54,20 @@ export class HassioUpdate extends LitElement {
       <div class="content">
         ${this._error
           ? html`
-              <div class="error">Error: ${this._error}</div>
+              <div class="error">
+                ${this.hass.localize("ui.panel.hassio.common.error")}:
+                ${this._error}
+              </div>
             `
           : ""}
         <h1>
           ${updatesAvailable > 1
-            ? "Updates Available 🎉"
-            : "Update Available 🎉"}
+            ? `${this.hass.localize(
+                "ui.panel.hassio.dashboard.updates_available"
+              )} 🎉`
+            : `${this.hass.localize(
+                "ui.panel.hassio.dashboard.update_available"
+              )} 🎉`}
         </h1>
         <div class="card-group">
           ${this._renderUpdateCard(
@@ -82,7 +89,9 @@ export class HassioUpdate extends LitElement {
           )}
           ${this.hassOsInfo
             ? this._renderUpdateCard(
-                "Operating System",
+                this.hass.localize(
+                  "ui.panel.hassio.dashboard.operating_system"
+                ),
                 this.hassOsInfo.version,
                 this.hassOsInfo.version_latest,
                 "hassio/hassos/update",
@@ -117,19 +126,27 @@ export class HassioUpdate extends LitElement {
             : ""}
           <div class="update-heading">${name} ${lastVersion}</div>
           <div class="warning">
-            You are currently running version ${curVersion}
+            ${this.hass.localize(
+              "ui.panel.hassio.dashboard.current_version_running",
+              "version",
+              curVersion
+            )}
           </div>
         </div>
         <div class="card-actions">
           <a href="${releaseNotesUrl}" target="_blank">
-            <mwc-button>Release notes</mwc-button>
+            <mwc-button
+              >${this.hass.localize(
+                "ui.panel.hassio.dashboard.release_notes"
+              )}</mwc-button
+            >
           </a>
           <ha-call-api-button
             .hass=${this.hass}
             .path=${apiPath}
             @hass-api-called=${this._apiCalled}
           >
-            Update
+            ${this.hass.localize("ui.panel.hassio.common.update")}
           </ha-call-api-button>
         </div>
       </paper-card>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1652,6 +1652,20 @@
           }
         }
       },
+      "hassio": {
+        "common": {
+          "error": "Error",
+          "update": "Update"
+        },
+        "dashboard": {
+          "update_available": "Update available",
+          "updates_available": "Updates available",
+          "release_notes": "Release notes",
+          "operating_system": "Operating System",
+          "current_version_running": "You are currently running version {version}"
+        }
+      },
+
       "history": {
         "showing_entries": "Showing entries for",
         "period": "Period"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1653,6 +1653,11 @@
         }
       },
       "hassio": {
+        "addon": {
+          "is_stopped": "Add-on is stopped",
+          "is_runing": "Add-on is running",
+          "has_new_version": "New version available"
+        },
         "common": {
           "error": "Error",
           "update": "Update"
@@ -1662,10 +1667,11 @@
           "updates_available": "Updates available",
           "release_notes": "Release notes",
           "operating_system": "Operating System",
-          "current_version_running": "You are currently running version {version}"
+          "current_version_running": "You are currently running version {version}",
+          "no_installed_addons": "You don't have any add-ons installed yet. Head over to the add-on store to get started!",
+          "open_addon_store": "Open the add-on store"
         }
       },
-
       "history": {
         "showing_entries": "Showing entries for",
         "period": "Period"


### PR DESCRIPTION
## Proposed change

- Adds localization to the "dashboard" section of the Hass.io panel.
- For the part where there were no installed addons, I changed the inline href to an action button instead (was not sure how that would have been handled with localizations).

![image](https://user-images.githubusercontent.com/15093472/73776803-b372f000-4788-11ea-95f1-3d5e22107df7.png)




### Not translated:

- "Add-ons" (Title over the installed addons)
- Home Assistant Core (Title in update card)
- Supervisor(Title in update card)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
_more to come_
