### PR TITLE
Add seconds to some UI elements

### DIFF
--- a/src/common/datetime/check_options_support.ts
+++ b/src/common/datetime/check_options_support.ts
@@ -1,0 +1,31 @@
+// Check for support of native locale string options
+function checkToLocaleDateStringSupportsOptions() {
+  try {
+    new Date().toLocaleDateString("i");
+  } catch (e) {
+    return e.name === "RangeError";
+  }
+  return false;
+}
+
+function checkToLocaleTimeStringSupportsOptions() {
+  try {
+    new Date().toLocaleTimeString("i");
+  } catch (e) {
+    return e.name === "RangeError";
+  }
+  return false;
+}
+
+function checkToLocaleStringSupportsOptions() {
+  try {
+    new Date().toLocaleString("i");
+  } catch (e) {
+    return e.name === "RangeError";
+  }
+  return false;
+}
+
+export const toLocaleDateStringSupportsOptions = checkToLocaleDateStringSupportsOptions();
+export const toLocaleTimeStringSupportsOptions = checkToLocaleTimeStringSupportsOptions();
+export const toLocaleStringSupportsOptions = checkToLocaleStringSupportsOptions();

--- a/src/common/datetime/format_date.ts
+++ b/src/common/datetime/format_date.ts
@@ -1,20 +1,11 @@
 import fecha from "fecha";
+import { toLocaleDateStringSupportsOptions } from "./check_options_support";
 
-// Check for support of native locale string options
-function toLocaleDateStringSupportsOptions() {
-  try {
-    new Date().toLocaleDateString("i");
-  } catch (e) {
-    return e.name === "RangeError";
-  }
-  return false;
-}
-
-export default toLocaleDateStringSupportsOptions()
+export const formatDate = toLocaleDateStringSupportsOptions
   ? (dateObj: Date, locales: string) =>
       dateObj.toLocaleDateString(locales, {
         year: "numeric",
         month: "long",
         day: "numeric",
       })
-  : (dateObj: Date) => fecha.format(dateObj, "mediumDate");
+  : (dateObj: Date) => fecha.format(dateObj, "longDate");

--- a/src/common/datetime/format_date_time.ts
+++ b/src/common/datetime/format_date_time.ts
@@ -1,16 +1,7 @@
 import fecha from "fecha";
+import { toLocaleStringSupportsOptions } from "./check_options_support";
 
-// Check for support of native locale string options
-function toLocaleStringSupportsOptions() {
-  try {
-    new Date().toLocaleString("i");
-  } catch (e) {
-    return e.name === "RangeError";
-  }
-  return false;
-}
-
-export default toLocaleStringSupportsOptions()
+export const formatDateTime = toLocaleStringSupportsOptions
   ? (dateObj: Date, locales: string) =>
       dateObj.toLocaleString(locales, {
         year: "numeric",
@@ -19,4 +10,24 @@ export default toLocaleStringSupportsOptions()
         hour: "numeric",
         minute: "2-digit",
       })
-  : (dateObj: Date) => fecha.format(dateObj, "haDateTime");
+  : (dateObj: Date) =>
+      fecha.format(
+        dateObj,
+        `${fecha.masks.longDate}, ${fecha.masks.shortTime}`
+      );
+
+export const formatDateTimeWithSeconds = toLocaleStringSupportsOptions
+  ? (dateObj: Date, locales: string) =>
+      dateObj.toLocaleString(locales, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+      })
+  : (dateObj: Date) =>
+      fecha.format(
+        dateObj,
+        `${fecha.masks.longDate}, ${fecha.masks.mediumTime}`
+      );

--- a/src/common/datetime/format_time.ts
+++ b/src/common/datetime/format_time.ts
@@ -1,19 +1,19 @@
 import fecha from "fecha";
+import { toLocaleTimeStringSupportsOptions } from "./check_options_support";
 
-// Check for support of native locale string options
-function toLocaleTimeStringSupportsOptions() {
-  try {
-    new Date().toLocaleTimeString("i");
-  } catch (e) {
-    return e.name === "RangeError";
-  }
-  return false;
-}
-
-export default toLocaleTimeStringSupportsOptions()
+export const formatTime = toLocaleTimeStringSupportsOptions
   ? (dateObj: Date, locales: string) =>
       dateObj.toLocaleTimeString(locales, {
         hour: "numeric",
         minute: "2-digit",
       })
   : (dateObj: Date) => fecha.format(dateObj, "shortTime");
+
+export const formatTimeWithSeconds = toLocaleTimeStringSupportsOptions
+  ? (dateObj: Date, locales: string) =>
+      dateObj.toLocaleTimeString(locales, {
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+      })
+  : (dateObj: Date) => fecha.format(dateObj, "mediumTime");

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -1,8 +1,8 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { computeStateDomain } from "./compute_state_domain";
-import formatDateTime from "../datetime/format_date_time";
-import formatDate from "../datetime/format_date";
-import formatTime from "../datetime/format_time";
+import { formatDateTime } from "../datetime/format_date_time";
+import { formatDate } from "../datetime/format_date";
+import { formatTime } from "../datetime/format_time";
 import { LocalizeFunc } from "../translations/localize";
 
 export const computeStateDisplay = (

--- a/src/components/entity/ha-chart-base.js
+++ b/src/components/entity/ha-chart-base.js
@@ -6,7 +6,7 @@ import { Debouncer } from "@polymer/polymer/lib/utils/debounce";
 import { timeOut } from "@polymer/polymer/lib/utils/async";
 import { mixinBehaviors } from "@polymer/polymer/lib/legacy/class";
 
-import formatTime from "../../common/datetime/format_time";
+import { formatTime } from "../../common/datetime/format_time";
 // eslint-disable-next-line no-unused-vars
 /* global Chart moment Color */
 

--- a/src/components/state-history-chart-line.js
+++ b/src/components/state-history-chart-line.js
@@ -5,7 +5,7 @@ import { PolymerElement } from "@polymer/polymer/polymer-element";
 import "./entity/ha-chart-base";
 
 import LocalizeMixin from "../mixins/localize-mixin";
-import formatDateTime from "../common/datetime/format_date_time";
+import { formatDateTimeWithSeconds } from "../common/datetime/format_date_time";
 
 class StateHistoryChartLine extends LocalizeMixin(PolymerElement) {
   static get template() {
@@ -317,7 +317,7 @@ class StateHistoryChartLine extends LocalizeMixin(PolymerElement) {
       const item = items[0];
       const date = data.datasets[item.datasetIndex].data[item.index].x;
 
-      return formatDateTime(date, this.hass.language);
+      return formatDateTimeWithSeconds(date, this.hass.language);
     };
 
     const chartOptions = {

--- a/src/components/state-history-chart-timeline.js
+++ b/src/components/state-history-chart-timeline.js
@@ -6,7 +6,7 @@ import LocalizeMixin from "../mixins/localize-mixin";
 
 import "./entity/ha-chart-base";
 
-import formatDateTime from "../common/datetime/format_date_time";
+import { formatDateTimeWithSeconds } from "../common/datetime/format_date_time";
 import { computeRTL } from "../common/util/compute_rtl";
 
 class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
@@ -165,8 +165,8 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
     const formatTooltipLabel = (item, data) => {
       const values = data.datasets[item.datasetIndex].data[item.index];
 
-      const start = formatDateTime(values[0], this.hass.language);
-      const end = formatDateTime(values[1], this.hass.language);
+      const start = formatDateTimeWithSeconds(values[0], this.hass.language);
+      const end = formatDateTimeWithSeconds(values[1], this.hass.language);
       const state = values[2];
 
       return [state, start, end];

--- a/src/dialogs/more-info/controls/more-info-sun.ts
+++ b/src/dialogs/more-info/controls/more-info-sun.ts
@@ -11,7 +11,7 @@ import { HassEntity } from "home-assistant-js-websocket";
 
 import "../../../components/ha-relative-time";
 
-import formatTime from "../../../common/datetime/format_time";
+import { formatTime } from "../../../common/datetime/format_time";
 import { HomeAssistant } from "../../../types";
 
 @customElement("more-info-sun")

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -28,7 +28,7 @@ import {
   showAutomationEditor,
   AutomationConfig,
 } from "../../../data/automation";
-import format_date_time from "../../../common/datetime/format_date_time";
+import { formatDateTime } from "../../../common/datetime/format_date_time";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { showThingtalkDialog } from "./show-dialog-thingtalk";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
@@ -102,7 +102,7 @@ class HaAutomationPicker extends LitElement {
                               "ui.card.automation.last_triggered"
                             )}: ${
                     automation.attributes.last_triggered
-                      ? format_date_time(
+                      ? formatDateTime(
                           new Date(automation.attributes.last_triggered),
                           this.hass.language
                         )

--- a/src/panels/config/cloud/account/cloud-account.js
+++ b/src/panels/config/cloud/account/cloud-account.js
@@ -16,7 +16,7 @@ import "./cloud-remote-pref";
 import { EventsMixin } from "../../../../mixins/events-mixin";
 import { fetchCloudSubscriptionInfo } from "../../../../data/cloud";
 
-import formatDateTime from "../../../../common/datetime/format_date_time";
+import { formatDateTime } from "../../../../common/datetime/format_date_time";
 import LocalizeMixin from "../../../../mixins/localize-mixin";
 
 /*

--- a/src/panels/config/cloud/dialog-cloud-certificate/dialog-cloud-certificate.ts
+++ b/src/panels/config/cloud/dialog-cloud-certificate/dialog-cloud-certificate.ts
@@ -16,7 +16,7 @@ import { HaPaperDialog } from "../../../../components/dialog/ha-paper-dialog";
 import { HomeAssistant } from "../../../../types";
 import { haStyle } from "../../../../resources/styles";
 import { CloudCertificateParams as CloudCertificateDialogParams } from "./show-dialog-cloud-certificate";
-import format_date_time from "../../../../common/datetime/format_date_time";
+import { formatDateTime } from "../../../../common/datetime/format_date_time";
 
 @customElement("dialog-cloud-certificate")
 class DialogCloudCertificate extends LitElement {
@@ -50,7 +50,7 @@ class DialogCloudCertificate extends LitElement {
             ${this.hass!.localize(
               "ui.panel.config.cloud.dialog_certificate.certificate_expiration_date"
             )}
-            ${format_date_time(
+            ${formatDateTime(
               new Date(certificateInfo.expire_date),
               this.hass!.language
             )}<br />

--- a/src/panels/developer-tools/event/event-subscribe-card.ts
+++ b/src/panels/developer-tools/event/event-subscribe-card.ts
@@ -13,7 +13,7 @@ import { HassEvent } from "home-assistant-js-websocket";
 import { HomeAssistant } from "../../../types";
 import { PolymerChangedEvent } from "../../../polymer-types";
 import "../../../components/ha-card";
-import format_time from "../../../common/datetime/format_time";
+import { formatTime } from "../../../common/datetime/format_time";
 
 @customElement("event-subscribe-card")
 class EventSubscribeCard extends LitElement {
@@ -78,7 +78,7 @@ class EventSubscribeCard extends LitElement {
                   "name",
                   ev.id
                 )}
-                ${format_time(
+                ${formatTime(
                   new Date(ev.event.time_fired),
                   this.hass!.language
                 )}:

--- a/src/panels/developer-tools/logs/system-log-card.ts
+++ b/src/panels/developer-tools/logs/system-log-card.ts
@@ -16,8 +16,8 @@ import "../../../components/buttons/ha-call-service-button";
 import "../../../components/buttons/ha-progress-button";
 import { HomeAssistant } from "../../../types";
 import { LoggedError, fetchSystemLog } from "../../../data/system_log";
-import formatDateTime from "../../../common/datetime/format_date_time";
-import formatTime from "../../../common/datetime/format_time";
+import { formatDateTimeWithSeconds } from "../../../common/datetime/format_date_time";
+import { formatTimeWithSeconds } from "../../../common/datetime/format_time";
 import { showSystemLogDetailDialog } from "./show-dialog-system-log-detail";
 
 const formatLogTime = (date, language: string) => {
@@ -26,8 +26,8 @@ const formatLogTime = (date, language: string) => {
   const dateTimeDay = new Date(date * 1000).setHours(0, 0, 0, 0);
 
   return dateTimeDay < today
-    ? formatDateTime(dateTime, language)
-    : formatTime(dateTime, language);
+    ? formatDateTimeWithSeconds(dateTime, language)
+    : formatTimeWithSeconds(dateTime, language);
 };
 
 @customElement("system-log-card")

--- a/src/panels/developer-tools/mqtt/mqtt-subscribe-card.ts
+++ b/src/panels/developer-tools/mqtt/mqtt-subscribe-card.ts
@@ -11,7 +11,7 @@ import "@material/mwc-button";
 import "@polymer/paper-input/paper-input";
 import { HomeAssistant } from "../../../types";
 import "../../../components/ha-card";
-import format_time from "../../../common/datetime/format_time";
+import { formatTime } from "../../../common/datetime/format_time";
 
 import { subscribeMQTTTopic, MQTTMessage } from "../../../data/mqtt";
 
@@ -85,7 +85,7 @@ class MqttSubscribeCard extends LitElement {
                   "topic",
                   msg.message.topic,
                   "time",
-                  format_time(msg.time, this.hass!.language)
+                  formatTime(msg.time, this.hass!.language)
                 )}
                 <pre>${msg.payload}</pre>
                 <div class="bottom">

--- a/src/panels/history/ha-panel-history.js
+++ b/src/panels/history/ha-panel-history.js
@@ -16,7 +16,7 @@ import "../../data/ha-state-history-data";
 import "../../resources/ha-date-picker-style";
 import "../../resources/ha-style";
 
-import formatDate from "../../common/datetime/format_date";
+import { formatDate } from "../../common/datetime/format_date";
 import LocalizeMixin from "../../mixins/localize-mixin";
 import { computeRTL } from "../../common/util/compute_rtl";
 

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -1,6 +1,6 @@
 import "../../components/ha-icon";
-import formatTime from "../../common/datetime/format_time";
-import formatDate from "../../common/datetime/format_date";
+import { formatTimeWithSeconds } from "../../common/datetime/format_time";
+import { formatDate } from "../../common/datetime/format_date";
 import { domainIcon } from "../../common/entity/domain_icon";
 import { stateIcon } from "../../common/entity/state_icon";
 import { computeRTL } from "../../common/util/compute_rtl";
@@ -80,7 +80,7 @@ class HaLogbook extends LitElement {
 
         <div class="entry">
           <div class="time">
-            ${formatTime(new Date(item.when), this.hass.language)}
+            ${formatTimeWithSeconds(new Date(item.when), this.hass.language)}
           </div>
           <ha-icon
             .icon=${state ? stateIcon(state) : domainIcon(item.domain)}
@@ -131,7 +131,7 @@ class HaLogbook extends LitElement {
       }
 
       .time {
-        width: 55px;
+        width: 65px;
         font-size: 0.8em;
         color: var(--secondary-text-color);
       }

--- a/src/panels/logbook/ha-panel-logbook.js
+++ b/src/panels/logbook/ha-panel-logbook.js
@@ -16,7 +16,7 @@ import "../../resources/ha-style";
 import "./ha-logbook-data";
 import "./ha-logbook";
 
-import formatDate from "../../common/datetime/format_date";
+import { formatDate } from "../../common/datetime/format_date";
 import LocalizeMixin from "../../mixins/localize-mixin";
 import { computeRTL } from "../../common/util/compute_rtl";
 

--- a/src/panels/lovelace/components/hui-timestamp-display.ts
+++ b/src/panels/lovelace/components/hui-timestamp-display.ts
@@ -8,15 +8,15 @@ import {
 } from "lit-element";
 
 import { HomeAssistant } from "../../../types";
-import format_date from "../../../common/datetime/format_date";
-import format_date_time from "../../../common/datetime/format_date_time";
-import format_time from "../../../common/datetime/format_time";
+import { formatDate } from "../../../common/datetime/format_date";
+import { formatDateTime } from "../../../common/datetime/format_date_time";
+import { formatTime } from "../../../common/datetime/format_time";
 import relativeTime from "../../../common/datetime/relative_time";
 
 const FORMATS: { [key: string]: (ts: Date, lang: string) => string } = {
-  date: format_date,
-  datetime: format_date_time,
-  time: format_time,
+  date: formatDate,
+  datetime: formatDateTime,
+  time: formatTime,
 };
 const INTERVAL_FORMAT = ["relative", "total"];
 

--- a/src/panels/mailbox/ha-panel-mailbox.js
+++ b/src/panels/mailbox/ha-panel-mailbox.js
@@ -14,7 +14,7 @@ import "../../components/ha-menu-button";
 import "../../components/ha-card";
 import "../../resources/ha-style";
 
-import formatDateTime from "../../common/datetime/format_date_time";
+import { formatDateTime } from "../../common/datetime/format_date_time";
 import LocalizeMixin from "../../mixins/localize-mixin";
 import { EventsMixin } from "../../mixins/events-mixin";
 

--- a/src/panels/profile/ha-long-lived-access-tokens-card.js
+++ b/src/panels/profile/ha-long-lived-access-tokens-card.js
@@ -4,7 +4,7 @@ import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 import { EventsMixin } from "../../mixins/events-mixin";
 import LocalizeMixin from "../../mixins/localize-mixin";
-import formatDateTime from "../../common/datetime/format_date_time";
+import { formatDateTime } from "../../common/datetime/format_date_time";
 import "../../components/ha-card";
 
 import "../../resources/ha-style";

--- a/src/panels/profile/ha-refresh-tokens-card.js
+++ b/src/panels/profile/ha-refresh-tokens-card.js
@@ -7,7 +7,7 @@ import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 import { EventsMixin } from "../../mixins/events-mixin";
 import LocalizeMixin from "../../mixins/localize-mixin";
-import formatDateTime from "../../common/datetime/format_date_time";
+import { formatDateTime } from "../../common/datetime/format_date_time";
 
 import "./ha-settings-row";
 

--- a/test-mocha/common/datetime/format_date.ts
+++ b/test-mocha/common/datetime/format_date.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import formatDate from "../../../src/common/datetime/format_date";
+import { formatDate } from "../../../src/common/datetime/format_date";
 
 describe("formatDate", () => {
   const dateObj = new Date(2017, 10, 18, 11, 12, 13, 1400);

--- a/test-mocha/common/datetime/format_date_time.ts
+++ b/test-mocha/common/datetime/format_date_time.ts
@@ -1,14 +1,28 @@
 import { assert } from "chai";
 
-import formatDateTime from "../../../src/common/datetime/format_date_time";
+import {
+  formatDateTime,
+  formatDateTimeWithSeconds,
+} from "../../../src/common/datetime/format_date_time";
 
 describe("formatDateTime", () => {
-  const dateObj = new Date(2017, 10, 18, 11, 12, 13, 1400);
+  const dateObj = new Date(2017, 10, 18, 11, 12, 13, 400);
 
   it("Formats English date times", () => {
     assert.strictEqual(
       formatDateTime(dateObj, "en"),
       "November 18, 2017, 11:12 AM"
+    );
+  });
+});
+
+describe("formatDateTimeWithSeconds", () => {
+  const dateObj = new Date(2017, 10, 18, 11, 12, 13, 400);
+
+  it("Formats English date times with seconds", () => {
+    assert.strictEqual(
+      formatDateTimeWithSeconds(dateObj, "en"),
+      "November 18, 2017, 11:12:13 AM"
     );
   });
 });

--- a/test-mocha/common/datetime/format_time.ts
+++ b/test-mocha/common/datetime/format_time.ts
@@ -1,11 +1,22 @@
 import { assert } from "chai";
 
-import formatTime from "../../../src/common/datetime/format_time";
+import {
+  formatTime,
+  formatTimeWithSeconds,
+} from "../../../src/common/datetime/format_time";
 
 describe("formatTime", () => {
   const dateObj = new Date(2017, 10, 18, 11, 12, 13, 1400);
 
   it("Formats English times", () => {
     assert.strictEqual(formatTime(dateObj, "en"), "11:12 AM");
+  });
+});
+
+describe("formatTimeWithSeconds", () => {
+  const dateObj = new Date(2017, 10, 18, 11, 12, 13, 400);
+
+  it("Formats English times with seconds", () => {
+    assert.strictEqual(formatTimeWithSeconds(dateObj, "en"), "11:12:13 AM");
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
UI will look slightly differently to users but it shouldn't affect anything.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modern smart home should be fast and responsive. This means it should operate seconds or milliseconds but not minutes. Add new time formats with seconds to display time more precisely in the UI.

And use these new time formats to add seconds to 4 UI elements:

|   | Before | After |
| ------------- | ------------- |  ------------- | 
| **Logbook**  | <img width="723" alt="logbook before" src="https://user-images.githubusercontent.com/3767331/73894115-5f910580-4873-11ea-9d1d-b9143fdc150e.png"> | <img width="724" alt="logbook after" src="https://user-images.githubusercontent.com/3767331/73894147-72a3d580-4873-11ea-8a67-c1382eb7ab65.png"> |
| **System logs**  |  <img width="850" alt="system logs before" src="https://user-images.githubusercontent.com/3767331/73894210-aa128200-4873-11ea-9703-107097a5f048.png"> | <img width="847" alt="system logs after" src="https://user-images.githubusercontent.com/3767331/73894222-b4cd1700-4873-11ea-8279-14593302492b.png">  |
| **History timeline** | <img width="220" alt="history timeline before" src="https://user-images.githubusercontent.com/3767331/73894360-273df700-4874-11ea-9cb3-b4fa0d999990.png"> | <img width="220" alt="history timeline after" src="https://user-images.githubusercontent.com/3767331/73894367-2c02ab00-4874-11ea-9d0a-d58626913063.png"> |
| **History chart** | <img width="224" alt="history chart before" src="https://user-images.githubusercontent.com/3767331/73894429-594f5900-4874-11ea-9f2b-58cf81b15c5f.png"> | <img width="221" alt="history chart after" src="https://user-images.githubusercontent.com/3767331/73894435-5c4a4980-4874-11ea-98e6-0396ac226c08.png"> |

This was requested by some other users as well: https://community.home-assistant.io/t/show-seconds-in-logbook/108019

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

No configuration needed.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
