### PR TITLE
[logbook] configure flex container to display entries correctly on mobile devices

### DIFF
--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -132,6 +132,7 @@ class HaLogbook extends LitElement {
 
       .time {
         width: 65px;
+        flex-shrink: 0;
         font-size: 0.8em;
         color: var(--secondary-text-color);
       }
@@ -142,6 +143,7 @@ class HaLogbook extends LitElement {
 
       ha-icon {
         margin: 0 8px 0 16px;
+        flex-shrink: 0;
         color: var(--primary-text-color);
       }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After adding seconds in logbook I noticed that log entries don't look right from the mobile browser. This happens when entry message doesn't fit one line. Then flex container tries to shrink time and icon which looks bad. This change protects width of these elements so only message itself can be shrank.

Before:
<img width="318" alt="Screen Shot 2020-02-08 at 10 30 39 PM" src="https://user-images.githubusercontent.com/3767331/74092989-dae8f600-4ac3-11ea-9865-6173865030ff.png">
After:
<img width="320" alt="Screen Shot 2020-02-08 at 10 31 35 PM" src="https://user-images.githubusercontent.com/3767331/74092991-e2100400-4ac3-11ea-81e4-8b52f6eb3979.png">


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
