### PR TITLE
Graceful fallback if translations for device automations are missing

### DIFF
--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -110,7 +110,7 @@ export const localizeDeviceAutomationAction = (
       hass.localize(
         `component.${action.domain}.device_automation.action_subtype.${action.subtype}`
       ) || action.subtype
-    ) || '"' + action.subtype + '" ' + action.type
+    ) || `"${action.subtype}" ${action.type}`
   );
 };
 

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -101,14 +101,16 @@ export const localizeDeviceAutomationAction = (
   action: DeviceAction
 ) => {
   const state = action.entity_id ? hass.states[action.entity_id] : undefined;
-  return hass.localize(
-    `component.${action.domain}.device_automation.action_type.${action.type}`,
-    "entity_name",
-    state ? computeStateName(state) : "<unknown>",
-    "subtype",
+  return (
     hass.localize(
-      `component.${action.domain}.device_automation.action_subtype.${action.subtype}`
-    )
+      `component.${action.domain}.device_automation.action_type.${action.type}`,
+      "entity_name",
+      state ? computeStateName(state) : "<unknown>",
+      "subtype",
+      hass.localize(
+        `component.${action.domain}.device_automation.action_subtype.${action.subtype}`
+      ) || action.subtype
+    ) || '"' + action.subtype + '" ' + action.type
   );
 };
 
@@ -119,14 +121,16 @@ export const localizeDeviceAutomationCondition = (
   const state = condition.entity_id
     ? hass.states[condition.entity_id]
     : undefined;
-  return hass.localize(
-    `component.${condition.domain}.device_automation.condition_type.${condition.type}`,
-    "entity_name",
-    state ? computeStateName(state) : "<unknown>",
-    "subtype",
+  return (
     hass.localize(
-      `component.${condition.domain}.device_automation.condition_subtype.${condition.subtype}`
-    )
+      `component.${condition.domain}.device_automation.condition_type.${condition.type}`,
+      "entity_name",
+      state ? computeStateName(state) : "<unknown>",
+      "subtype",
+      hass.localize(
+        `component.${condition.domain}.device_automation.condition_subtype.${condition.subtype}`
+      ) || condition.subtype
+    ) || '"' + condition.subtype + '" ' + condition.type
   );
 };
 
@@ -135,13 +139,15 @@ export const localizeDeviceAutomationTrigger = (
   trigger: DeviceTrigger
 ) => {
   const state = trigger.entity_id ? hass.states[trigger.entity_id] : undefined;
-  return hass.localize(
-    `component.${trigger.domain}.device_automation.trigger_type.${trigger.type}`,
-    "entity_name",
-    state ? computeStateName(state) : "<unknown>",
-    "subtype",
+  return (
     hass.localize(
-      `component.${trigger.domain}.device_automation.trigger_subtype.${trigger.subtype}`
-    )
+      `component.${trigger.domain}.device_automation.trigger_type.${trigger.type}`,
+      "entity_name",
+      state ? computeStateName(state) : "<unknown>",
+      "subtype",
+      hass.localize(
+        `component.${trigger.domain}.device_automation.trigger_subtype.${trigger.subtype}`
+      ) || trigger.subtype
+    ) || '"' + trigger.subtype + '" ' + trigger.type
   );
 };

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -130,7 +130,7 @@ export const localizeDeviceAutomationCondition = (
       hass.localize(
         `component.${condition.domain}.device_automation.condition_subtype.${condition.subtype}`
       ) || condition.subtype
-    ) || '"' + condition.subtype + '" ' + condition.type
+    ) || `"${condition.subtype}" ${condition.type}`
   );
 };
 

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -105,7 +105,7 @@ export const localizeDeviceAutomationAction = (
     hass.localize(
       `component.${action.domain}.device_automation.action_type.${action.type}`,
       "entity_name",
-      state ? computeStateName(state) : "<unknown>",
+      state ? computeStateName(state) : action.entity_id || "<unknown>",
       "subtype",
       hass.localize(
         `component.${action.domain}.device_automation.action_subtype.${action.subtype}`
@@ -125,7 +125,7 @@ export const localizeDeviceAutomationCondition = (
     hass.localize(
       `component.${condition.domain}.device_automation.condition_type.${condition.type}`,
       "entity_name",
-      state ? computeStateName(state) : "<unknown>",
+      state ? computeStateName(state) : condition.entity_id || "<unknown>",
       "subtype",
       hass.localize(
         `component.${condition.domain}.device_automation.condition_subtype.${condition.subtype}`
@@ -143,7 +143,7 @@ export const localizeDeviceAutomationTrigger = (
     hass.localize(
       `component.${trigger.domain}.device_automation.trigger_type.${trigger.type}`,
       "entity_name",
-      state ? computeStateName(state) : "<unknown>",
+      state ? computeStateName(state) : trigger.entity_id || "<unknown>",
       "subtype",
       hass.localize(
         `component.${trigger.domain}.device_automation.trigger_subtype.${trigger.subtype}`

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -148,6 +148,6 @@ export const localizeDeviceAutomationTrigger = (
       hass.localize(
         `component.${trigger.domain}.device_automation.trigger_subtype.${trigger.subtype}`
       ) || trigger.subtype
-    ) || '"' + trigger.subtype + '" ' + trigger.type
+    ) || `"${trigger.subtype}" ${trigger.type}`
   );
 };


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fall back in case device automation translations are missing.
If translation for `subtype` is missing, use `subtype` as is.
If translation for `type` is missing generate string `"subtype" type`.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
