### PR TITLE
[logbook] implement shouldUpdate

### DIFF
--- a/src/panels/logbook/ha-logbook-data.js
+++ b/src/panels/logbook/ha-logbook-data.js
@@ -59,7 +59,7 @@ class HaLogbookData extends PolymerElement {
 
     this._setIsLoading(true);
 
-    this.getDate(this.filterDate, this.filterPeriod, this.filterEntity).then(
+    this.getData(this.filterDate, this.filterPeriod, this.filterEntity).then(
       (logbookEntries) => {
         this._setEntries(logbookEntries);
         this._setIsLoading(false);
@@ -67,7 +67,7 @@ class HaLogbookData extends PolymerElement {
     );
   }
 
-  getDate(date, period, entityId) {
+  getData(date, period, entityId) {
     if (!entityId) entityId = ALL_ENTITIES;
 
     if (!DATA_CACHE[period]) DATA_CACHE[period] = [];

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -25,19 +25,14 @@ class HaLogbook extends LitElement {
   // @ts-ignore
   private _rtl = false;
 
-  protected updated(changedProps: PropertyValues) {
-    super.updated(changedProps);
-    if (!changedProps.has("hass")) {
-      return;
-    }
+  protected shouldUpdate(changedProps: PropertyValues) {
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-    if (oldHass && oldHass.language !== this.hass.language) {
-      this._rtl = computeRTL(this.hass);
-    }
+    const languageChanged =
+      oldHass !== undefined && oldHass.language !== this.hass.language;
+    return changedProps.has("entries") || languageChanged;
   }
 
-  protected firstUpdated(changedProps: PropertyValues) {
-    super.firstUpdated(changedProps);
+  protected updated(_changedProps: PropertyValues) {
     this._rtl = computeRTL(this.hass);
   }
 

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -28,7 +28,7 @@ class HaLogbook extends LitElement {
   protected shouldUpdate(changedProps: PropertyValues) {
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
     const languageChanged =
-      oldHass !== undefined && oldHass.language !== this.hass.language;
+      oldHass === undefined || oldHass.language !== this.hass.language;
     return changedProps.has("entries") || languageChanged;
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I noticed many unnecessary calls of loogbook `render`. This is because of updated `hass` property which actually usually contains no changes. This is especially bad when there are many entries loaded and causes UI freezes.

Implement `shouldUpdate` to update logbook only when entries are updated or when rtl is changed.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
