### PR TITLE
add create helper functions for custom cards

### DIFF
--- a/src/panels/lovelace/custom-card-helpers.ts
+++ b/src/panels/lovelace/custom-card-helpers.ts
@@ -1,0 +1,11 @@
+import { createRowElement as createRowElement_ } from "./create-element/create-row-element";
+import { createCardElement as createCardElement_ } from "./create-element/create-card-element";
+import { createBadgeElement as createBadgeElement_ } from "./create-element/create-badge-element";
+import { createHeaderFooterElement as createHeaderFooterElement_ } from "./create-element/create-header-footer-element";
+import { createHuiElement as createHuiElement_ } from "./create-element/create-hui-element";
+
+export const createRowElement = createRowElement_;
+export const createCardElement = createCardElement_;
+export const createBadgeElement = createBadgeElement_;
+export const createHeaderFooterElement = createHeaderFooterElement_;
+export const createHuiElement = createHuiElement_;

--- a/src/panels/lovelace/custom-card-helpers.ts
+++ b/src/panels/lovelace/custom-card-helpers.ts
@@ -1,11 +1,5 @@
-import { createRowElement as createRowElement_ } from "./create-element/create-row-element";
-import { createCardElement as createCardElement_ } from "./create-element/create-card-element";
-import { createBadgeElement as createBadgeElement_ } from "./create-element/create-badge-element";
-import { createHeaderFooterElement as createHeaderFooterElement_ } from "./create-element/create-header-footer-element";
-import { createHuiElement as createHuiElement_ } from "./create-element/create-hui-element";
-
-export const createRowElement = createRowElement_;
-export const createCardElement = createCardElement_;
-export const createBadgeElement = createBadgeElement_;
-export const createHeaderFooterElement = createHeaderFooterElement_;
-export const createHuiElement = createHuiElement_;
+export { createRowElement } from "./create-element/create-row-element";
+export { createCardElement } from "./create-element/create-card-element";
+export { createBadgeElement } from "./create-element/create-badge-element";
+export { createHeaderFooterElement } from "./create-element/create-header-footer-element";
+export { createHuiElement } from "./create-element/create-hui-element";

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -24,6 +24,8 @@ import { showSaveDialog } from "./editor/show-save-config-dialog";
 import { generateLovelaceConfigFromHass } from "./common/generate-lovelace-config";
 import { showToast } from "../../util/toast";
 
+(window as any).loadCardHelpers = () => import("./custom-card-helpers");
+
 interface LovelacePanelConfig {
   mode: "yaml" | "storage";
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Exposing the create helpers functions so that custom cards can use them. Will add this to the dev docs as they are added.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
Simple custom card implementation to use it
```ts
/* eslint-disable @typescript-eslint/no-explicit-any */
import { LitElement, html, customElement, property, CSSResult, TemplateResult, css, PropertyValues } from 'lit-element';
import { HomeAssistant, hasConfigOrEntityChanged } from 'custom-card-helpers';
import deepClone from 'deep-clone-simple';

import { CustomCardConfig } from './types';
import { CARD_VERSION } from './const';

import { localize } from './localize/localize';

/* eslint no-console: 0 */
console.info(
  `%c  custom-card \n%c  ${localize('common.version')} ${CARD_VERSION}    `,
  'color: orange; font-weight: bold; background: black',
  'color: white; font-weight: bold; background: dimgray',
);

@customElement('custom-card')
export class CustomCard extends LitElement {
  @property() public hass?: HomeAssistant;
  @property() private _config?: CustomCardConfig;
  @property() private _helpers?: any;

  public setConfig(config: CustomCardConfig): void {
    if (!config) {
      throw new Error(localize('common.invalid_configuration'));
    }

    this._config = {
      ...config,
    };

    this.loadCardHelpers();
  }

  protected shouldUpdate(changedProps: PropertyValues): boolean {
    return hasConfigOrEntityChanged(this, changedProps, false);
  }

  protected render(): TemplateResult | void {
    if (!this._config || !this.hass || !this._helpers) {
      return html``;
    }

    const config = deepClone(this._config);
    delete config['type'];
    const element = this._helpers.createRowElement(config);

    if (this.hass) {
      element.hass = this.hass;
    }

    return html`
      <div>${element}</div>
    `;
  }

  private async loadCardHelpers(): Promise<void> {
    this._helpers = await (window as any).loadCardHelpers();
  }

  static get styles(): CSSResult {
    return css``;
  }
}
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
