### PR TITLE
add state_color option to glance, button and state-icon

### DIFF
--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -49,6 +49,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
       hold_action: { action: "more-info" },
       show_icon: true,
       show_name: true,
+      state_color: true,
     };
   }
 
@@ -148,7 +149,9 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
           ? html`
               <ha-icon
                 data-domain=${ifDefined(
-                  stateObj ? computeStateDomain(stateObj) : undefined
+                  this._config.state_color && stateObj
+                    ? computeStateDomain(stateObj)
+                    : undefined
                 )}
                 data-state=${ifDefined(
                   stateObj ? computeActiveState(stateObj) : undefined
@@ -226,7 +229,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   private _computeBrightness(stateObj: HassEntity | LightEntity): string {
-    if (!stateObj.attributes.brightness) {
+    if (!stateObj.attributes.brightness || !this._config?.state_color) {
       return "";
     }
     const brightness = stateObj.attributes.brightness;
@@ -234,7 +237,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   private _computeColor(stateObj: HassEntity | LightEntity): string {
-    if (!stateObj.attributes.hs_color) {
+    if (!stateObj.attributes.hs_color || !this._config?.state_color) {
       return "";
     }
     const [hue, sat] = stateObj.attributes.hs_color;

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -237,10 +237,9 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                 .stateObj=${stateObj}
                 .overrideIcon=${entityConf.icon}
                 .overrideImage=${entityConf.image}
-                .stateColor=${entityConf.state_color === false ||
-                entityConf.state_color
-                  ? entityConf.state_color
-                  : this._config!.state_color}
+                .stateColor=${(entityConf.state_color === false ||
+                  entityConf.state_color) ??
+                  this._config!.state_color}
               ></state-badge>
             `
           : ""}

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -59,7 +59,7 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: GlanceCardConfig): void {
-    this._config = { theme: "default", ...config };
+    this._config = { theme: "default", state_color: true, ...config };
     const entities = processConfigEntities<GlanceConfigEntity>(config.entities);
 
     for (const entity of entities) {
@@ -237,7 +237,10 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                 .stateObj=${stateObj}
                 .overrideIcon=${entityConf.icon}
                 .overrideImage=${entityConf.image}
-                stateColor
+                .stateColor=${entityConf.state_color === false ||
+                entityConf.state_color
+                  ? entityConf.state_color
+                  : this._config!.state_color}
               ></state-badge>
             `
           : ""}

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -57,6 +57,7 @@ export interface ButtonCardConfig extends LovelaceCardConfig {
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
+  state_color?: boolean;
 }
 
 export interface EntityFilterCardConfig extends LovelaceCardConfig {
@@ -102,6 +103,7 @@ export interface GlanceConfigEntity extends ConfigEntity {
   show_last_changed?: boolean;
   image?: string;
   show_state?: boolean;
+  state_color?: boolean;
 }
 
 export interface GlanceCardConfig extends LovelaceCardConfig {
@@ -112,6 +114,7 @@ export interface GlanceCardConfig extends LovelaceCardConfig {
   theme?: string;
   entities: ConfigEntity[];
   columns?: number;
+  state_color?: boolean;
 }
 
 export interface IframeCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/elements/hui-state-icon-element.ts
+++ b/src/panels/lovelace/elements/hui-state-icon-element.ts
@@ -32,7 +32,7 @@ export class HuiStateIconElement extends LitElement implements LovelaceElement {
       throw Error("Invalid Configuration: 'entity' required");
     }
 
-    this._config = config;
+    this._config = { state_color: true, ...config };
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
@@ -71,7 +71,7 @@ export class HuiStateIconElement extends LitElement implements LovelaceElement {
           hasAction(this._config.tap_action) ? "0" : undefined
         )}
         .overrideIcon=${this._config.icon}
-        stateColor
+        .stateColor=${this._config.state_color}
       ></state-badge>
     `;
   }

--- a/src/panels/lovelace/elements/types.ts
+++ b/src/panels/lovelace/elements/types.ts
@@ -59,6 +59,7 @@ export interface StateIconElementConfig extends LovelaceElementConfig {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
   icon?: string;
+  state_color?: boolean;
 }
 
 export interface StateLabelElementConfig extends LovelaceElementConfig {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
add state_color option to glance card and its entities, button card and state-icon element

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: glance
state_color: false
entities:
  - entity: light.ceiling_lights
    state_color: true
  - entity: light.ceiling_lights
```

```yaml
type: entity-button
tap_action:
  action: toggle
hold_action:
  action: more-info
show_icon: true
show_name: true
entity: light.ceiling_lights
state_color: false
```
```yaml
type: picture-elements
image: 'https://www.home-assistant.io/images/merchandise/shirt-frontpage.png'
elements:
  - type: state-icon
    entity: light.ceiling_lights
    state_color: false
    style:
      top: 50%
      left: 50%
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4838
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
