### PR TITLE
Freeze lovelace configuration on load

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "codemirror": "^5.49.0",
     "cpx": "^1.5.0",
     "deep-clone-simple": "^1.1.1",
+    "deep-freeze": "^0.0.1",
     "es6-object-assign": "^1.1.0",
     "fecha": "^3.0.2",
     "fuse.js": "^3.4.4",

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -1,4 +1,6 @@
 import "@material/mwc-button";
+import * as deepFreeze from "deep-freeze";
+import deepClone from "deep-clone-simple";
 
 import {
   fetchConfig,
@@ -272,6 +274,7 @@ class LovelacePanel extends LitElement {
 
   private _setLovelaceConfig(config: LovelaceConfig, mode: Lovelace["mode"]) {
     this._checkLovelaceConfig(config);
+    deepFreeze(config);
     this.lovelace = {
       config,
       mode,
@@ -294,6 +297,10 @@ class LovelacePanel extends LitElement {
         });
       },
       saveConfig: async (newConfig: LovelaceConfig): Promise<void> => {
+        // deepClone is required here because of the filtering in _checkLovelaceConfig
+        // Once the problem behind that is resolved, it can be removed
+        newConfig = deepClone(newConfig);
+
         const { config: previousConfig, mode: previousMode } = this.lovelace!;
         this._checkLovelaceConfig(newConfig);
         try {

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -275,7 +275,7 @@ class LovelacePanel extends LitElement {
         checkedConfig.views[index].badges = view.badges.filter(Boolean);
       }
     });
-    return deepFreeze(checkedConfig || config);
+    return checkedConfig ? deepFreeze(checkedConfig) : config;
   }
 
   private _setLovelaceConfig(config: LovelaceConfig, mode: Lovelace["mode"]) {

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -267,7 +267,10 @@ class LovelacePanel extends LitElement {
     let checkedConfig;
     config.views.forEach((view, index) => {
       if (view.badges && !view.badges.every(Boolean)) {
-        checkedConfig = checkedConfig || { ...config };
+        checkedConfig = checkedConfig || {
+          ...config,
+          views: [...config.views],
+        };
         checkedConfig.views[index] = { ...view };
         checkedConfig.views[index].badges = view.badges.filter(Boolean);
       }

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -275,12 +275,11 @@ class LovelacePanel extends LitElement {
         checkedConfig.views[index].badges = view.badges.filter(Boolean);
       }
     });
-    return checkedConfig || config;
+    return deepFreeze(checkedConfig || config);
   }
 
   private _setLovelaceConfig(config: LovelaceConfig, mode: Lovelace["mode"]) {
     config = this._checkLovelaceConfig(config);
-    deepFreeze(config);
     this.lovelace = {
       config,
       mode,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5403,6 +5403,11 @@ deep-extend@^0.6.0, deep-extend@~0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deep-freeze@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
+  integrity sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
#4851 but with freezing the entire configuration instead of cloning it for each card.

This will break some custom cards, but there's several simple fixes, e.g.:
```javascript
setConfig(config) {
  config = { ...config };
...
```
```javascript
import { deepClone } from "deep-clone-simple";
// https://github.com/balloob/deep-clone-simple

setConfig(config) {
  config = deepClone(config);
...
```
or
```javascript
setConfig(config) {
  config = JSON.parse(JSON.stringify(config));
  ...
```

depending on need and personal preference (besides rethinking the methodology of the card).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
