### PR TITLE
Include release fragment id in HA update card release notes link

### DIFF
--- a/hassio/src/dashboard/hassio-update.ts
+++ b/hassio/src/dashboard/hassio-update.ts
@@ -70,7 +70,11 @@ export class HassioUpdate extends LitElement {
             "hassio/homeassistant/update",
             `https://${
               this.hassInfo.last_version.includes("b") ? "rc" : "www"
-            }.home-assistant.io/latest-release-notes/`,
+            }.home-assistant.io/latest-release-notes/${
+              this.hassInfo.last_version.endsWith(".0")
+                ? ""
+                : "#release-" + this.hassInfo.last_version
+            }`,
             "hassio:home-assistant"
           )}
           ${this._renderUpdateCard(
@@ -78,7 +82,9 @@ export class HassioUpdate extends LitElement {
             this.supervisorInfo.version,
             this.supervisorInfo.last_version,
             "hassio/supervisor/update",
-            `https://github.com//home-assistant/hassio/releases/tag/${this.supervisorInfo.last_version}`
+            `https://github.com//home-assistant/hassio/releases/tag/${
+              this.supervisorInfo.last_version
+            }`
           )}
           ${this.hassOsInfo
             ? this._renderUpdateCard(
@@ -86,7 +92,9 @@ export class HassioUpdate extends LitElement {
                 this.hassOsInfo.version,
                 this.hassOsInfo.version_latest,
                 "hassio/hassos/update",
-                `https://github.com//home-assistant/hassos/releases/tag/${this.hassOsInfo.version_latest}`
+                `https://github.com//home-assistant/hassos/releases/tag/${
+                  this.hassOsInfo.version_latest
+                }`
               )
             : ""}
         </div>


### PR DESCRIPTION


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the release notes links from the UI just point to the latest release page, I think it would be more interesting to point to the patch release info. This along with https://github.com/home-assistant/home-assistant.io/pull/12130 should "fix" that.

Suppressing the fragment if the release is a `.0` is a bit hacky, done because those versions likely won't have anchors with ids, but on the other hand letting it through (even if the id wouldn't exist in the target doc) wouldn't be an actual problem either, just a nuisance.

I don't know why pre-commit makes the two last, unrelated change hunks in the patch, but I cannot seem to convince it not to do that.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/home-assistant.io/pull/12130
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
