### PR TITLE
Allow state-label-element to show attributes

### DIFF
--- a/src/panels/lovelace/elements/hui-state-label-element.ts
+++ b/src/panels/lovelace/elements/hui-state-label-element.ts
@@ -90,9 +90,9 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
           hasAction(this._config.tap_action) ? "0" : undefined
         )}
       >
-        ${this._config.prefix}${attribute
-          ? attributeDisplay
-          : stateDisplay}${this._config.suffix}
+        ${this._config.prefix}${!attribute
+          ? stateDisplay
+          : attributeDisplay}${this._config.suffix}
       </div>
     `;
   }

--- a/src/panels/lovelace/elements/hui-state-label-element.ts
+++ b/src/panels/lovelace/elements/hui-state-label-element.ts
@@ -45,6 +45,7 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
     }
 
     const stateObj = this.hass.states[this._config.entity!];
+    const attribute = this._config.attribute!;
 
     if (!stateObj) {
       return html`
@@ -58,6 +59,25 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
       `;
     }
 
+    if (attribute && !stateObj.attributes[attribute]) {
+      return html`
+        <hui-warning-element
+          label=${this.hass.localize(
+            "ui.panel.lovelace.warning.attribute_not_found",
+            "attribute",
+            this._config.attribute,
+            "entity",
+            this._config.entity
+          )}
+        ></hui-warning-element>
+      `;
+    }
+
+    const stateDisplay = stateObj
+      ? computeStateDisplay(this.hass.localize, stateObj, this.hass.language)
+      : "-";
+    const attributeDisplay = stateObj ? stateObj.attributes[attribute] : "-";
+
     return html`
       <div
         .title="${computeTooltip(this.hass, this._config)}"
@@ -70,13 +90,9 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
           hasAction(this._config.tap_action) ? "0" : undefined
         )}
       >
-        ${this._config.prefix}${stateObj
-          ? computeStateDisplay(
-              this.hass.localize,
-              stateObj,
-              this.hass.language
-            )
-          : "-"}${this._config.suffix}
+        ${this._config.prefix}${attribute
+          ? attributeDisplay
+          : stateDisplay}${this._config.suffix}
       </div>
     `;
   }

--- a/src/panels/lovelace/elements/hui-state-label-element.ts
+++ b/src/panels/lovelace/elements/hui-state-label-element.ts
@@ -45,7 +45,6 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
     }
 
     const stateObj = this.hass.states[this._config.entity!];
-    const attribute = this._config.attribute!;
 
     if (!stateObj) {
       return html`
@@ -59,7 +58,10 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
       `;
     }
 
-    if (attribute && !stateObj.attributes[attribute]) {
+    if (
+      this._config.attribute &&
+      !stateObj.attributes[this._config.attribute]
+    ) {
       return html`
         <hui-warning-element
           label=${this.hass.localize(
@@ -73,11 +75,6 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
       `;
     }
 
-    const stateDisplay = stateObj
-      ? computeStateDisplay(this.hass.localize, stateObj, this.hass.language)
-      : "-";
-    const attributeDisplay = stateObj ? stateObj.attributes[attribute] : "-";
-
     return html`
       <div
         .title="${computeTooltip(this.hass, this._config)}"
@@ -90,9 +87,13 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
           hasAction(this._config.tap_action) ? "0" : undefined
         )}
       >
-        ${this._config.prefix}${!attribute
-          ? stateDisplay
-          : attributeDisplay}${this._config.suffix}
+        ${this._config.prefix}${!this._config.attribute
+          ? computeStateDisplay(
+              this.hass.localize,
+              stateObj,
+              this.hass.language
+            )
+          : stateObj.attributes[this._config.attribute]}${this._config.suffix}
       </div>
     `;
   }

--- a/src/panels/lovelace/elements/types.ts
+++ b/src/panels/lovelace/elements/types.ts
@@ -64,6 +64,7 @@ export interface StateIconElementConfig extends LovelaceElementConfig {
 
 export interface StateLabelElementConfig extends LovelaceElementConfig {
   entity: string;
+  attribute?: string;
   prefix?: string;
   suffix?: string;
   tap_action?: ActionConfig;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1934,6 +1934,7 @@
           }
         },
         "warning": {
+          "attribute_not_found": "Attribute {attribute} not available in: {entity}",
           "entity_not_found": "Entity not available: {entity}",
           "entity_non_numeric": "Entity is non-numeric: {entity}"
         },


### PR DESCRIPTION
Add an additional (optional) parameter to the state-label element,
so that instead of showing the state, an attribute can be shown instead.

Can be used to e.g. add a climate entity to the floorplan,
but show the current temperature instead of the desired one.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the possibility to set "attribute" as a parameter to the picture-elements state-label type,
so that instead of showing the state, a specific attribute can be shown instead, but the actions
still refer to the original entity.

Can be used to e.g. show the current temperature instead of the desired one in a label, but still be able to control it with a simple click.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
title: My Awesome Home
views:
  - title: Example
    cards:
      - type: picture-elements
        image: /local/floorplan.png
        title: My Home
        elements:
          - type: state-label
            entity: sun.sun
            prefix: "Sun elevation:"
            attribute: elevation
            style:
              top: 15%
              left: 70%
              color: white
          - type: state-label
            entity: binary_sensor.updater
            attribute: unexisting_attribute
            style:
              top: 30%
              left: 20%
              color: white
          - type: state-label
            entity: sensor.not_existing
            style:
              top: 30%
              left: 70%
              color: white

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/12151

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
