### PR TITLE
Localize tabs names in view editor

### DIFF
--- a/src/panels/lovelace/editor/view-editor/hui-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-edit-view.ts
@@ -142,8 +142,16 @@ export class HuiEditView extends LitElement {
           .selected="${this._curTabIndex}"
           @selected-item-changed="${this._handleTabSelected}"
         >
-          <paper-tab id="tab-settings">Settings</paper-tab>
-          <paper-tab id="tab-badges">Badges</paper-tab>
+          <paper-tab id="tab-settings"
+            >${this.hass!.localize(
+              "ui.panel.lovelace.editor.edit_view.tab_settings"
+            )}</paper-tab
+          >
+          <paper-tab id="tab-badges"
+            >${this.hass!.localize(
+              "ui.panel.lovelace.editor.edit_view.tab_badges"
+            )}</paper-tab
+          >
         </paper-tabs>
         <paper-dialog-scrollable> ${content} </paper-dialog-scrollable>
         <div class="paper-dialog-buttons">

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1773,7 +1773,9 @@
             "edit": "Edit view",
             "delete": "Delete view",
             "move_left": "Move view left",
-            "move_right": "Move view right"
+            "move_right": "Move view right",
+            "tab_settings": "Settings",
+            "tab_badges": "Badges"
           },
           "edit_card": {
             "header": "Card Configuration",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -2084,9 +2084,7 @@
                         "header": "Konfiguracja widoku",
                         "header_name": "Konfiguracja widoku {name}",
                         "move_left": "Przesuń widok w lewo",
-                        "move_right": "Przesuń widok w prawo",
-                        "tab_settings": "Ustawienia",
-                        "tab_badges": "Odznaki"
+                        "move_right": "Przesuń widok w prawo"
                     },
                     "header": "Edycja interfejsu użytkownika",
                     "menu": {

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -2084,7 +2084,9 @@
                         "header": "Konfiguracja widoku",
                         "header_name": "Konfiguracja widoku {name}",
                         "move_left": "Przesuń widok w lewo",
-                        "move_right": "Przesuń widok w prawo"
+                        "move_right": "Przesuń widok w prawo",
+                        "tab_settings": "Ustawienia",
+                        "tab_badges": "Odznaki"
                     },
                     "header": "Edycja interfejsu użytkownika",
                     "menu": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
