### PR TITLE
✨ ability to show attribute instead of state in picture-glance ✨

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -256,11 +256,17 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
             `
           : html`
               <div class="state">
-                ${computeStateDisplay(
-                  this.hass!.localize,
-                  stateObj,
-                  this.hass!.language
-                )}
+                ${entityConf.attribute
+                  ? html`
+                      ${entityConf.prefix}${stateObj.attributes[
+                        entityConf.attribute
+                      ]}${entityConf.suffix}
+                    `
+                  : computeStateDisplay(
+                      this.hass!.localize,
+                      stateObj,
+                      this.hass!.language
+                    )}
               </div>
             `}
       </div>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -97,6 +97,9 @@ export interface ConfigEntity extends EntityConfig {
 
 export interface PictureGlanceEntityConfig extends ConfigEntity {
   show_state?: boolean;
+  attribute?: string;
+  prefix?: string;
+  suffix?: string;
 }
 
 export interface GlanceConfigEntity extends ConfigEntity {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ability to show an attribute value instead of the entity state in picture-glance. Prime example is the climate entity which has a pretty useless state; heat/cool, while the current temperature is usually what people want to see

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
![image](https://user-images.githubusercontent.com/1287159/75085988-b98cfe80-54f4-11ea-94a4-72da1bb6491d.png)
```yaml
image: 'https://www.home-assistant.io/images/merchandise/shirt-frontpage.png'
type: picture-glance
entities:
  - entity: climate.ecobee
    show_state: true
    attribute: current_temperature
    suffix: °
aspect_ratio: 0%
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
