### PR TITLE
Add a smarter default value for entity card show header toggle

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -25,6 +25,8 @@ import { EntitiesCardConfig, EntitiesCardEntityConfig } from "./types";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { createHeaderFooterElement } from "../create-element/create-header-footer-element";
 import { LovelaceHeaderFooterConfig } from "../header-footer/types";
+import { DOMAINS_TOGGLE } from "../../../common/const";
+import { computeDomain } from "../../../common/entity/compute_domain";
 
 @customElement("hui-entities-card")
 class HuiEntitiesCard extends LitElement implements LovelaceCard {
@@ -44,6 +46,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   private _hass?: HomeAssistant;
 
   private _configEntities?: EntitiesCardEntityConfig[];
+  private _showHeaderToggle?: boolean;
 
   set hass(hass: HomeAssistant) {
     this._hass = hass;
@@ -78,6 +81,22 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
     this._config = { theme: "default", ...config };
     this._configEntities = entities;
+    if (config.show_header_toggle === undefined) {
+      // Default value is show toggle if we can at least toggle 2 entities.
+      let toggleable = 0;
+      for (const rowConf of entities) {
+        if (!rowConf.entity) {
+          continue;
+        }
+        toggleable += Number(DOMAINS_TOGGLE.has(computeDomain(rowConf.entity)));
+        if (toggleable === 2) {
+          break;
+        }
+      }
+      this._showHeaderToggle = toggleable === 2;
+    } else {
+      this._showHeaderToggle = config.show_header_toggle;
+    }
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -110,9 +129,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
         ${this._config.header
           ? this.renderHeaderFooter(this._config.header, "header")
           : ""}
-        ${!this._config.title &&
-        !this._config.show_header_toggle &&
-        !this._config.icon
+        ${!this._config.title && !this._showHeaderToggle && !this._config.icon
           ? ""
           : html`
               <div class="card-header">
@@ -127,7 +144,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
                     : ""}
                   ${this._config.title}
                 </div>
-                ${this._config.show_header_toggle === false
+                ${!this._showHeaderToggle
                   ? html``
                   : html`
                       <hui-entities-toggle

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -273,7 +273,6 @@ export const generateDefaultViewConfig = (
         areaEntities.map((entity) => [entity.entity_id, entity]),
         {
           title: area.name,
-          show_header_toggle: true,
         }
       )
     );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If no `show_header_toggle` value is given to the entities card, base it off if we can at least toggle 2 entities in that card.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
