### PR TITLE
History Graph Card - Get Size Calculation

### DIFF
--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -43,7 +43,11 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
   private _interval?: number;
 
   public getCardSize(): number {
-    return 4;
+    if (!this._config) {
+      return 0;
+    }
+    // +1 for the header
+    return (this._config.title ? 1 : 0) + this._config.entities.length * 2;
   }
 
   public setConfig(config: HistoryGraphCardConfig): void {


### PR DESCRIPTION
## Breaking change

Potentially will change the layout of users dashboard


## Proposed change

Update the sensor card size calculation to align with the entities' card. Sensor Cards can grow very large

Though if the new layout gets merged this won't really matter :)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests