### PR TITLE
Allow card editors to use card picker again

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -12,7 +12,7 @@ import { safeDump, safeLoad } from "js-yaml";
 
 import "@material/mwc-button";
 import { HomeAssistant } from "../../../../types";
-import { LovelaceCardConfig } from "../../../../data/lovelace";
+import { LovelaceCardConfig, LovelaceConfig } from "../../../../data/lovelace";
 import { LovelaceCardEditor } from "../../types";
 import { computeRTL } from "../../../../common/util/compute_rtl";
 
@@ -45,6 +45,7 @@ export interface UIConfigChangedEvent extends Event {
 @customElement("hui-card-editor")
 export class HuiCardEditor extends LitElement {
   @property() public hass!: HomeAssistant;
+  @property() public lovelace?: LovelaceConfig;
 
   @property() private _yaml?: string;
   @property() private _config?: LovelaceCardConfig;
@@ -239,6 +240,7 @@ export class HuiCardEditor extends LitElement {
 
       // Perform final setup
       this._configElement!.hass = this.hass;
+      this._configElement!.lovelace = this.lovelace;
       this._configElement!.addEventListener("config-changed", (ev) =>
         this._handleUIConfigChanged(ev as UIConfigChangedEvent)
       );

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -109,6 +109,7 @@ export class HuiDialogEditCard extends LitElement {
                   <div class="element-editor">
                     <hui-card-editor
                       .hass=${this.hass}
+                      .lovelace="${this._params.lovelaceConfig}"
                       .value="${this._cardConfig}"
                       @config-changed="${this._handleConfigChanged}"
                     ></hui-card-editor>

--- a/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
@@ -14,6 +14,7 @@ import { HomeAssistant } from "../../../../types";
 import { LovelaceCardEditor } from "../../types";
 import { StackCardConfig } from "../../cards/types";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { LovelaceConfig } from "../../../../data/lovelace";
 
 const cardConfigStruct = struct({
   type: "string",
@@ -25,6 +26,7 @@ const cardConfigStruct = struct({
 export class HuiStackCardEditor extends LitElement
   implements LovelaceCardEditor {
   @property() public hass?: HomeAssistant;
+  @property() public lovelace?: LovelaceConfig;
   @property() private _config?: StackCardConfig;
   @property() private _selectedCard: number = 0;
 
@@ -102,6 +104,7 @@ export class HuiStackCardEditor extends LitElement
               : html`
                   <hui-card-picker
                     .hass=${this.hass}
+                    .lovelace=${this.lovelace}
                     @config-changed="${this._handleCardPicked}"
                   ></hui-card-picker>
                 `

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -54,5 +54,6 @@ export interface LovelaceHeaderFooter extends HTMLElement {
 
 export interface LovelaceCardEditor extends HTMLElement {
   hass?: HomeAssistant;
+  lovelace?: LovelaceConfig;
   setConfig(config: LovelaceCardConfig): void;
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
