### PR TITLE
Card Picker: Firefox Fix

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -192,9 +192,9 @@ export class HuiCardPicker extends LitElement {
         .preview > :first-child {
           zoom: 0.6;
           -moz-transform: scale(0.6); /* Firefox */
-          -moz-transform-origin: 0 0;
+          -moz-transform-origin: center;
           -o-transform: scale(0.6); /* Opera */
-          -o-transform-origin: 0 0;
+          -o-transform-origin: center;
           display: block;
           width: 100%;
         }


### PR DESCRIPTION
## Proposed change

Currently, this first commit fixes the Scale Origin. It now places the cards back in the middle of the container.

Overall, I would like to resolve this issue: #5097 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

- This PR fixes or closes issue: fixes #5097 