### PR TITLE
Media Card: Caching Values

### DIFF
--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -1,4 +1,6 @@
 import { HassEntity } from "home-assistant-js-websocket";
+import { MediaEntity } from "../types";
+import { computeStateName } from "../common/entity/compute_state_name";
 
 export const SUPPORT_PAUSE = 1;
 export const SUPPORT_SEEK = 2;
@@ -60,3 +62,43 @@ export const computeMediaDescription = (stateObj: HassEntity): string => {
 
   return secondaryTitle;
 };
+
+interface MediaState extends MediaEntity {
+  timestamp: number;
+}
+
+export class MediaStateController {
+  private _stateObjectArray: MediaState[] = [];
+  private _updateCallback?: () => void;
+
+  constructor() {}
+
+  public addState(stateObj: MediaEntity): void {
+    if (!this._stateObjectArray.length) {
+      this._stateObjectArray.push({ ...stateObj, timestamp: Date.now() });
+    }
+  }
+
+  public set updateCallback(callback: () => void) {
+    this._updateCallback = callback;
+  }
+
+  public get entityName() {
+    return computeStateName(this._mostRecentState);
+  }
+
+  public get mediaTitle() {
+    return (
+      this._mostRecentState.attributes.media_title ||
+      computeMediaDescription(this._mostRecentState)
+    );
+  }
+
+  private get _mostRecentState(): MediaEntity {
+    return this._stateObjectArray[this._stateObjectArray.length - 1];
+  }
+
+  private get _oldestState(): MediaEntity {
+    return this._stateObjectArray[this._stateObjectArray.length - 1];
+  }
+}

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -142,11 +142,15 @@ export class MediaStateController {
     );
   }
 
+  public get hasStates(): boolean {
+    return this._stateObjectArray.length !== 0;
+  }
+
   private get _mostRecentState(): MediaEntity {
     return this._stateObjectArray[this._stateObjectArray.length - 1];
   }
 
   private get _oldestState(): MediaEntity {
-    return this._stateObjectArray[this._stateObjectArray.length - 1];
+    return this._stateObjectArray[0];
   }
 }

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -73,14 +73,31 @@ interface MediaState extends MediaEntity {
 export class MediaStateController {
   private _stateObjectArray: MediaState[] = [];
   private _updateCallback?: () => void;
+  private _stateTimeout?: number;
 
   constructor() {}
 
   public addState(stateObj: MediaEntity): void {
-    this._stateObjectArray.push({ ...stateObj, timestamp: Date.now() });
+    const timestamp = Date.now();
+    this._stateObjectArray.push({ ...stateObj, timestamp });
     if (this._updateCallback) {
       this._updateCallback();
     }
+
+    // if (this._stateObjectArray.length > 1 && !this._stateTimeout) {
+    //   this._stateTimeout = window.setTimeout(() => {
+    //     this._stateTimeout = undefined;
+    //     this._stateObjectArray.slice(
+    //       0,
+    //       this._stateObjectArray.findIndex(
+    //         (state) => state.timestamp === timestamp
+    //       )
+    //     );
+    //     if (this._updateCallback) {
+    //       this._updateCallback();
+    //     }
+    //   }, 3000);
+    // }
   }
 
   public set updateCallback(callback: () => void) {
@@ -100,7 +117,7 @@ export class MediaStateController {
   }
 
   public get isOff(): boolean {
-    return this._mostRecentState.state === "off";
+    return this._mostRecentState === "off";
   }
 
   public get isUnavailable(): boolean {
@@ -144,6 +161,10 @@ export class MediaStateController {
 
   public get hasStates(): boolean {
     return this._stateObjectArray.length !== 0;
+  }
+
+  public get currentProgress(): number {
+    return getCurrentProgress(this._mostRecentState);
   }
 
   private get _mostRecentState(): MediaEntity {

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -43,6 +43,7 @@ import {
   getCurrentProgress,
   computeMediaDescription,
   SUPPORT_TURN_OFF,
+  MediaStateController,
 } from "../../../data/media-player";
 
 import "../../../components/ha-card";
@@ -202,6 +203,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
   @property() private _marqueeActive: boolean = false;
   private _progressInterval?: number;
   private _resizeObserver?: ResizeObserver;
+  private _mediaStateController?: MediaStateController;
 
   public getCardSize(): number {
     return 3;
@@ -249,7 +251,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
   }
 
   protected render(): TemplateResult {
-    if (!this.hass || !this._config) {
+    if (!this.hass || !this._config || !this._mediaStateController) {
       return html``;
     }
     const stateObj = this._stateObj;
@@ -341,8 +343,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
             <div class="icon-name">
               <ha-icon class="icon" .icon=${stateIcon(stateObj)}></ha-icon>
               <div>
-                ${this._config!.name ||
-                  computeStateName(this.hass!.states[this._config!.entity])}
+                ${this._config!.name || this._mediaStateController.entityName}
               </div>
             </div>
             <div>
@@ -423,6 +424,8 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
 
   protected firstUpdated(): void {
     this._attachObserver();
+
+    this._mediaStateController = new MediaStateController();
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -443,6 +446,8 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
       this._backgroundColor = undefined;
       return;
     }
+
+    this._mediaStateController!.addState(stateObj);
 
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
     const oldConfig = changedProps.get("_config") as


### PR DESCRIPTION
## Proposed change

Cache Image, Showing of Progress Bar, and State. This allows the media card to wait until the states have settled and then make the changes on the final state change

Only issue I am having is when the Player is turned off. It still doesn't have the best animation because the title no longer exists.

I don't know if this is the best implementation for caching these (probably not). Open to better ways of doing this.

https://imgur.com/xsMq4rl

## Type of change

- Dependency upgrade
- Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- Breaking change (fix/feature causing existing functionality to break)
- Code quality improvements to existing code or addition of tests


## Additional information

Style Map doesn't like undefined values. So I set them all to be the default instead of undefined. May just remove style map?
