### PR TITLE
Fix stack size

### DIFF
--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -41,7 +41,9 @@ export abstract class HuiStackCard extends LitElement implements LovelaceCard {
     }
   }
 
-  public abstract getCardSize(): number;
+  public getCardSize(): number {
+    return 1;
+  }
 
   public setConfig(config: StackCardConfig): void {
     if (!config || !config.cards || !Array.isArray(config.cards)) {


### PR DESCRIPTION
Weird shit with abstract methods, not sure why this suddenly stopped working...

The inherited class would not be able to override the function and it would be undefined. What would the use of an abstract method be then? 🤔 