### PR TITLE
Fix translations in production builds

### DIFF
--- a/build-scripts/env.js
+++ b/build-scripts/env.js
@@ -1,6 +1,14 @@
 module.exports = {
-  isProdBuild: process.env.NODE_ENV === "production",
-  isStatsBuild: process.env.STATS === "1",
-  isTravis: process.env.TRAVIS === "true",
-  isNetlify: process.env.NETLIFY === "true",
+  isProdBuild() {
+    return process.env.NODE_ENV === "production";
+  },
+  isStatsBuild() {
+    return process.env.STATS === "1";
+  },
+  isTravis() {
+    return process.env.TRAVIS === "true";
+  },
+  isNetlify() {
+    return process.env.NETLIFY === "true";
+  },
 };

--- a/build-scripts/gulp/app.js
+++ b/build-scripts/gulp/app.js
@@ -42,7 +42,7 @@ gulp.task(
     "copy-static",
     "webpack-prod-app",
     ...// Don't compress running tests
-    (envVars.isTravis ? [] : ["compress-app"]),
+    (envVars.isTravis() ? [] : ["compress-app"]),
     gulp.parallel(
       "gen-pages-prod",
       "gen-index-app-prod",

--- a/build-scripts/gulp/hassio.js
+++ b/build-scripts/gulp/hassio.js
@@ -29,6 +29,6 @@ gulp.task(
     gulp.parallel("gen-icons-hassio", "gen-icons-mdi"),
     "webpack-prod-hassio",
     ...// Don't compress running tests
-    (envVars.isTravis ? [] : ["compress-hassio"])
+    (envVars.isTravis() ? [] : ["compress-hassio"])
   )
 );

--- a/build-scripts/gulp/translations.js
+++ b/build-scripts/gulp/translations.js
@@ -11,6 +11,7 @@ const minify = require("gulp-jsonminify");
 const rename = require("gulp-rename");
 const transform = require("gulp-json-transform");
 const { mapFiles } = require("../util");
+const env = require("../env");
 const paths = require("../paths");
 
 const inDir = "translations";
@@ -291,12 +292,11 @@ gulp.task(
   function fingerprintTranslationFiles() {
     // Fingerprint full file of each language
     const files = fs.readdirSync(fullDir);
-    const isProdBuild = process.env.NODE_ENV === "production";
 
     for (let i = 0; i < files.length; i++) {
       fingerprints[files[i].split(".")[0]] = {
         // In dev we create fake hashes
-        hash: isProdBuild
+        hash: env.isProdBuild()
           ? crypto
               .createHash("md5")
               .update(fs.readFileSync(path.join(fullDir, files[i]), "utf-8"))
@@ -333,9 +333,7 @@ gulp.task(
   gulp.series(
     "clean-translations",
     "ensure-translations-build-dir",
-    process.env.NODE_ENV === "production"
-      ? (done) => done()
-      : "create-test-translation",
+    env.isProdBuild() ? (done) => done() : "create-test-translation",
     "build-master-translation",
     "build-merged-translations",
     gulp.parallel(...splitTasks),

--- a/build-scripts/gulp/translations.js
+++ b/build-scripts/gulp/translations.js
@@ -11,7 +11,6 @@ const minify = require("gulp-jsonminify");
 const rename = require("gulp-rename");
 const transform = require("gulp-json-transform");
 const { mapFiles } = require("../util");
-const env = require("../env");
 const paths = require("../paths");
 
 const inDir = "translations";
@@ -292,10 +291,12 @@ gulp.task(
   function fingerprintTranslationFiles() {
     // Fingerprint full file of each language
     const files = fs.readdirSync(fullDir);
+    const isProdBuild = process.env.NODE_ENV === "production";
+
     for (let i = 0; i < files.length; i++) {
       fingerprints[files[i].split(".")[0]] = {
         // In dev we create fake hashes
-        hash: env.isProdBuild
+        hash: isProdBuild
           ? crypto
               .createHash("md5")
               .update(fs.readFileSync(path.join(fullDir, files[i]), "utf-8"))
@@ -332,7 +333,9 @@ gulp.task(
   gulp.series(
     "clean-translations",
     "ensure-translations-build-dir",
-    env.isProdBuild ? (done) => done() : "create-test-translation",
+    process.env.NODE_ENV === "production"
+      ? (done) => done()
+      : "create-test-translation",
     "build-master-translation",
     "build-merged-translations",
     gulp.parallel(...splitTasks),

--- a/build-scripts/webpack.js
+++ b/build-scripts/webpack.js
@@ -155,7 +155,7 @@ const createAppConfig = ({ isProdBuild, latestBuild, isStatsBuild }) => {
       `/static/translations/${englishFilename}`
     ] = `build-translations/output/${englishFilename}`;
 
-    Object.keys(translationMetadata.fragments).forEach((fragment) => {
+    translationMetadata.fragments.forEach((fragment) => {
       workBoxTranslationsTemplatedURLs[
         `/static/translations/${fragment}/${englishFilename}`
       ] = `build-translations/output/${fragment}/${englishFilename}`;

--- a/cast/webpack.config.js
+++ b/cast/webpack.config.js
@@ -6,6 +6,6 @@ const { isProdBuild } = require("../build-scripts/env.js");
 const latestBuild = true;
 
 module.exports = createCastConfig({
-  isProdBuild,
+  isProdBuild: isProdBuild(),
   latestBuild,
 });

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -6,7 +6,7 @@ const { isProdBuild, isStatsBuild } = require("../build-scripts/env.js");
 const latestBuild = true;
 
 module.exports = createDemoConfig({
-  isProdBuild,
-  isStatsBuild,
+  isProdBuild: isProdBuild(),
+  isStatsBuild: isStatsBuild(),
   latestBuild,
 });

--- a/hassio/webpack.config.js
+++ b/hassio/webpack.config.js
@@ -6,6 +6,6 @@ const { isProdBuild } = require("../build-scripts/env.js");
 const latestBuild = false;
 
 module.exports = createHassioConfig({
-  isProdBuild,
+  isProdBuild: isProdBuild(),
   latestBuild,
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,8 @@ const { isProdBuild, isStatsBuild } = require("./build-scripts/env.js");
 
 const configs = [
   createAppConfig({
-    isProdBuild,
-    isStatsBuild,
+    isProdBuild: isProdBuild(),
+    isStatsBuild: isStatsBuild(),
     latestBuild: true,
   }),
 ];
@@ -14,8 +14,8 @@ const configs = [
 if (isProdBuild && !isStatsBuild) {
   configs.push(
     createAppConfig({
-      isProdBuild,
-      isStatsBuild,
+      isProdBuild: isProdBuild(),
+      isStatsBuild: isStatsBuild(),
       latestBuild: false,
     })
   );


### PR DESCRIPTION
Somehow `require("../env")` is not correct in translation, not sure why actually.
And we used `Object.keys` on the fragments array, in the manifest resulting in numbers instead of the fragment name.