### PR TITLE
Standardize Forgot Password Button

### DIFF
--- a/src/panels/config/cloud/login/cloud-login.js
+++ b/src/panels/config/cloud/login/cloud-login.js
@@ -145,7 +145,7 @@ class CloudLogin extends LocalizeMixin(
                   progress="[[_requestInProgress]]"
                   >[[localize('ui.panel.config.cloud.login.sign_in')]]</ha-progress-button
                 >
-                <button
+                <mwc-button
                   class="link"
                   hidden="[[_requestInProgress]]"
                   on-click="_handleForgotPassword"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1295,7 +1295,7 @@
             "email_error_msg": "Invalid email",
             "password": "Password",
             "password_error_msg": "Passwords are at least 8 characters",
-            "forgot_password": "forgot password?",
+            "forgot_password": "Forgot password?",
             "start_trial": "Start your free 1 month trial",
             "trial_info": "No payment information necessary",
             "alert_password_change_required": "You need to change your password before logging in.",


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Before

![Screenshot_20200315_145216](https://user-images.githubusercontent.com/28114703/76703845-a1139c80-66cc-11ea-9464-3ef6c01d6251.png)
_was lowercase `forgot password?` I just took the screenshot afterwards_

### After

![Screenshot_20200315_145140](https://user-images.githubusercontent.com/28114703/76703833-7e818380-66cc-11ea-9b2b-70819e9a8c40.png)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (thank you!)
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
