### PR TITLE
Add Fill and Line Graph Color Config to Sensor Card

### DIFF
--- a/src/panels/lovelace/cards/hui-sensor-card.ts
+++ b/src/panels/lovelace/cards/hui-sensor-card.ts
@@ -257,6 +257,8 @@ class HuiSensorCard extends LitElement implements LovelaceCard {
       `;
     }
 
+    const fillColor = this._config.fill_color || "var(--accent-color)";
+    const lineColor = this._config.line_color || "var(--accent-color)";
     let graph;
 
     if (stateObj && this._config.graph === "line") {
@@ -282,7 +284,7 @@ class HuiSensorCard extends LitElement implements LovelaceCard {
                   d="${this._history} L 500, 100 L 0, 100 z"
                 />
               </mask>
-              <rect height="100%" width="100%" id="fill-rect" fill="var(--accent-color)" mask="url(#fill)"></rect>
+              <rect height="100%" width="100%" id="fill-rect" fill="${fillColor}" mask="url(#fill)"></rect>
               <mask id="line">
                 <path
                   fill="none"
@@ -293,7 +295,7 @@ class HuiSensorCard extends LitElement implements LovelaceCard {
                   d=${this._history}
                 ></path>
               </mask>
-              <rect height="100%" width="100%" id="rect" fill="var(--accent-color)" mask="url(#line)"></rect>
+              <rect height="100%" width="100%" id="rect" fill="${lineColor}" mask="url(#line)"></rect>
             </g>
           </svg>
         `;

--- a/src/panels/lovelace/cards/hui-sensor-card.ts
+++ b/src/panels/lovelace/cards/hui-sensor-card.ts
@@ -257,8 +257,7 @@ class HuiSensorCard extends LitElement implements LovelaceCard {
       `;
     }
 
-    const fillColor = this._config.fill_color || "var(--accent-color)";
-    const lineColor = this._config.line_color || "var(--accent-color)";
+    const graphColor = this._config.graph_color || "var(--accent-color)";
     let graph;
 
     if (stateObj && this._config.graph === "line") {
@@ -284,7 +283,7 @@ class HuiSensorCard extends LitElement implements LovelaceCard {
                   d="${this._history} L 500, 100 L 0, 100 z"
                 />
               </mask>
-              <rect height="100%" width="100%" id="fill-rect" fill="${fillColor}" mask="url(#fill)"></rect>
+              <rect height="100%" width="100%" id="fill-rect" fill="${graphColor}" mask="url(#fill)"></rect>
               <mask id="line">
                 <path
                   fill="none"
@@ -295,7 +294,7 @@ class HuiSensorCard extends LitElement implements LovelaceCard {
                   d=${this._history}
                 ></path>
               </mask>
-              <rect height="100%" width="100%" id="rect" fill="${lineColor}" mask="url(#line)"></rect>
+              <rect height="100%" width="100%" id="rect" fill="${graphColor}" mask="url(#line)"></rect>
             </g>
           </svg>
         `;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -237,6 +237,8 @@ export interface SensorCardConfig extends LovelaceCardConfig {
   detail?: number;
   theme?: string;
   hours_to_show?: number;
+  fill_color?: string;
+  line_color?: string;
 }
 
 export interface ShoppingListCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -237,8 +237,7 @@ export interface SensorCardConfig extends LovelaceCardConfig {
   detail?: number;
   theme?: string;
   hours_to_show?: number;
-  fill_color?: string;
-  line_color?: string;
+  graph_color?: string;
 }
 
 export interface ShoppingListCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
@@ -31,6 +31,8 @@ const cardConfigStruct = struct({
   detail: "number?",
   theme: "string?",
   hours_to_show: "number?",
+  fill_color: "string?",
+  line_color: "string?",
 });
 
 @customElement("hui-sensor-card-editor")
@@ -75,6 +77,14 @@ export class HuiSensorCardEditor extends LitElement
 
   get _hours_to_show(): number | string {
     return this._config!.hours_to_show || "24";
+  }
+
+  get _fill_color(): string {
+    return this._config!.fill_color || "";
+  }
+
+  get _line_color(): string {
+    return this._config!.line_color || "";
   }
 
   protected render(): TemplateResult {
@@ -183,6 +193,30 @@ export class HuiSensorCardEditor extends LitElement
             .configValue="${"hours_to_show"}"
             @value-changed="${this._valueChanged}"
           ></paper-input>
+        </div>
+        <div class="side-by-side">
+          <paper-input
+            .label="${this.hass.localize(
+              "ui.panel.lovelace.editor.card.sensor.fill_color"
+            )} (${this.hass.localize(
+              "ui.panel.lovelace.editor.card.config.optional"
+            )})"
+            .value="${this._fill_color}"
+            .configValue="${"fill_color"}"
+            @value-changed="${this._valueChanged}"
+          >
+          </paper-input>
+          <paper-input
+            .label="${this.hass.localize(
+              "ui.panel.lovelace.editor.card.sensor.line_color"
+            )} (${this.hass.localize(
+              "ui.panel.lovelace.editor.card.config.optional"
+            )})"
+            .value="${this._line_color}"
+            .configValue="${"line_color"}"
+            @value-changed="${this._valueChanged}"
+          >
+          </paper-input>
         </div>
       </div>
     `;

--- a/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
@@ -31,8 +31,7 @@ const cardConfigStruct = struct({
   detail: "number?",
   theme: "string?",
   hours_to_show: "number?",
-  fill_color: "string?",
-  line_color: "string?",
+  graph_color: "string?",
 });
 
 @customElement("hui-sensor-card-editor")
@@ -79,12 +78,8 @@ export class HuiSensorCardEditor extends LitElement
     return this._config!.hours_to_show || "24";
   }
 
-  get _fill_color(): string {
-    return this._config!.fill_color || "";
-  }
-
-  get _line_color(): string {
-    return this._config!.line_color || "";
+  get _graph_color(): string {
+    return this._config!.graph_color || "";
   }
 
   protected render(): TemplateResult {
@@ -194,30 +189,17 @@ export class HuiSensorCardEditor extends LitElement
             @value-changed="${this._valueChanged}"
           ></paper-input>
         </div>
-        <div class="side-by-side">
-          <paper-input
-            .label="${this.hass.localize(
-              "ui.panel.lovelace.editor.card.sensor.fill_color"
-            )} (${this.hass.localize(
-              "ui.panel.lovelace.editor.card.config.optional"
-            )})"
-            .value="${this._fill_color}"
-            .configValue="${"fill_color"}"
-            @value-changed="${this._valueChanged}"
-          >
-          </paper-input>
-          <paper-input
-            .label="${this.hass.localize(
-              "ui.panel.lovelace.editor.card.sensor.line_color"
-            )} (${this.hass.localize(
-              "ui.panel.lovelace.editor.card.config.optional"
-            )})"
-            .value="${this._line_color}"
-            .configValue="${"line_color"}"
-            @value-changed="${this._valueChanged}"
-          >
-          </paper-input>
-        </div>
+        <paper-input
+          .label="${this.hass.localize(
+            "ui.panel.lovelace.editor.card.sensor.graph_color"
+          )} (${this.hass.localize(
+            "ui.panel.lovelace.editor.card.config.optional"
+          )})"
+          .value="${this._graph_color}"
+          .configValue="${"graph_color"}"
+          @value-changed="${this._valueChanged}"
+        >
+        </paper-input>
       </div>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2104,8 +2104,7 @@
               "name": "Sensor",
               "graph_detail": "Graph Detail",
               "graph_type": "Graph Type",
-              "fill_color": "Fill Color",
-              "line_color": "Line Color",
+              "graph_color": "Graph Color",
               "description": "The Sensor card gives you a quick overview of your sensors state with an optional graph to visualize change over time."
             },
             "shopping-list": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2104,6 +2104,8 @@
               "name": "Sensor",
               "graph_detail": "Graph Detail",
               "graph_type": "Graph Type",
+              "fill_color": "Fill Color",
+              "line_color": "Line Color",
               "description": "The Sensor card gives you a quick overview of your sensors state with an optional graph to visualize change over time."
             },
             "shopping-list": {


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds two new options to sensor card config for fill and line color for the graph.

![Screenshot_20200316_182541](https://user-images.githubusercontent.com/28114703/76788856-a0096a80-67b3-11ea-932b-7e1c6cff13e3.png)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (thank you!)

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
entity: sensor.upstairs_temperature
graph: line
type: sensor
graph_color: '#212121'
```

Additional information
- Link to documentation pull request: home-assistant/home-assistant.io/pull/12380

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
