### PR TITLE
Card Editor: Add Toggle to Dialog

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -249,6 +249,7 @@ export class HuiCardEditor extends LitElement {
         this._handleUIConfigChanged(ev as UIConfigChangedEvent)
       );
 
+      this.GUImode = true;
       return;
     } catch (err) {
       if (err.message.startsWith("WARNING:")) {

--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -33,7 +33,7 @@ declare global {
       config: LovelaceCardConfig;
       error?: string;
     };
-    "GUImode-changed": {};
+    "GUImode-changed": { guiMode: boolean };
   }
 }
 

--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -33,6 +33,7 @@ declare global {
       config: LovelaceCardConfig;
       error?: string;
     };
+    "GUImode-changed": {};
   }
 }
 
@@ -85,8 +86,23 @@ export class HuiCardEditor extends LitElement {
     }
   }
 
+  public get hasWarning(): boolean {
+    return this._warning !== undefined;
+  }
+
   public get hasError(): boolean {
     return this._error !== undefined;
+  }
+
+  public get GUImode(): boolean {
+    return this._GUImode;
+  }
+
+  public set GUImode(guiMode: boolean) {
+    this._GUImode = guiMode;
+    fireEvent(this as HTMLElement, "GUImode-changed", {
+      guiMode,
+    });
   }
 
   private get _yamlEditor(): HaCodeEditor {
@@ -94,7 +110,7 @@ export class HuiCardEditor extends LitElement {
   }
 
   public toggleMode() {
-    this._GUImode = !this._GUImode;
+    this.GUImode = !this.GUImode;
   }
 
   public connectedCallback() {
@@ -105,7 +121,7 @@ export class HuiCardEditor extends LitElement {
   protected render(): TemplateResult {
     return html`
       <div class="wrapper">
-        ${this._GUImode
+        ${this.GUImode
           ? html`
               <div class="gui-editor">
                 ${this._loading
@@ -145,18 +161,6 @@ export class HuiCardEditor extends LitElement {
               </div>
             `
           : ""}
-        <div class="buttons">
-          <mwc-button
-            @click=${this.toggleMode}
-            ?disabled=${this._warning || this._error}
-          >
-            ${this.hass!.localize(
-              this._GUImode
-                ? "ui.panel.lovelace.editor.edit_card.show_code_editor"
-                : "ui.panel.lovelace.editor.edit_card.show_visual_editor"
-            )}
-          </mwc-button>
-        </div>
       </div>
     `;
   }
@@ -165,7 +169,7 @@ export class HuiCardEditor extends LitElement {
     super.updated(changedProperties);
 
     if (changedProperties.has("_GUImode")) {
-      if (this._GUImode === false) {
+      if (this.GUImode === false) {
         // Refresh code editor when switching to yaml mode
         this._refreshYamlEditor(true);
       }
@@ -252,7 +256,7 @@ export class HuiCardEditor extends LitElement {
       } else {
         this._error = err;
       }
-      this._GUImode = false;
+      this.GUImode = false;
     } finally {
       this._loading = false;
       fireEvent(this, "iron-resize");
@@ -276,10 +280,6 @@ export class HuiCardEditor extends LitElement {
       }
       .warning {
         color: #ffa726;
-      }
-      .buttons {
-        text-align: right;
-        padding: 8px 0px;
       }
       paper-spinner {
         display: block;

--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -23,6 +23,7 @@ import { HaCodeEditor } from "../../../../components/ha-code-editor";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { EntityConfig } from "../../entity-rows/types";
 import { getCardElementClass } from "../../create-element/create-card-element";
+import { GUIModeChangedEvent } from "../types";
 
 declare global {
   interface HASSDomEvents {
@@ -33,7 +34,7 @@ declare global {
       config: LovelaceCardConfig;
       error?: string;
     };
-    "GUImode-changed": { guiMode: boolean };
+    "GUImode-changed": GUIModeChangedEvent;
   }
 }
 
@@ -100,9 +101,7 @@ export class HuiCardEditor extends LitElement {
 
   public set GUImode(guiMode: boolean) {
     this._GUImode = guiMode;
-    fireEvent(this as HTMLElement, "GUImode-changed", {
-      guiMode,
-    });
+    fireEvent(this as HTMLElement, "GUImode-changed", { guiMode });
   }
 
   private get _yamlEditor(): HaCodeEditor {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -112,6 +112,7 @@ export class HuiDialogEditCard extends LitElement {
                       .lovelace="${this._params.lovelaceConfig}"
                       .value="${this._cardConfig}"
                       @config-changed="${this._handleConfigChanged}"
+                      @GUImode-changed=${() => this.requestUpdate()}
                     ></hui-card-editor>
                   </div>
                   <div class="element-preview">
@@ -133,6 +134,22 @@ export class HuiDialogEditCard extends LitElement {
               `}
         </paper-dialog-scrollable>
         <div class="paper-dialog-buttons">
+          ${this._cardConfig !== undefined
+            ? html`
+                <mwc-button
+                  @click=${() => this._cardEditorEl?.toggleMode()}
+                  ?disabled=${this._cardEditorEl?.hasWarning ||
+                    this._cardEditorEl?.hasError}
+                  class="gui-mode-button"
+                >
+                  ${this.hass!.localize(
+                    !this._cardEditorEl || this._cardEditorEl.GUImode
+                      ? "ui.panel.lovelace.editor.edit_card.show_code_editor"
+                      : "ui.panel.lovelace.editor.edit_card.show_visual_editor"
+                  )}
+                </mwc-button>
+              `
+            : ""}
           <mwc-button @click="${this._close}">
             ${this.hass!.localize("ui.common.cancel")}
           </mwc-button>
@@ -249,6 +266,9 @@ export class HuiDialogEditCard extends LitElement {
           margin-bottom: 4px;
           display: block;
           width: 100%;
+        }
+        .gui-mode-button {
+          margin-right: auto;
         }
       `,
     ];

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -299,7 +299,8 @@ export class HuiDialogEditCard extends LitElement {
     }
   }
 
-  private _handleGUIModeChanged(ev: GUIModeChangedEvent): void {
+  private _handleGUIModeChanged(ev: HASSDomEvent<GUIModeChangedEvent>): void {
+    ev.stopPropagation();
     this._GUImode = ev.detail.guiMode;
   }
 

--- a/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
@@ -15,6 +15,7 @@ import { LovelaceCardEditor } from "../../types";
 import { StackCardConfig } from "../../cards/types";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { LovelaceConfig } from "../../../../data/lovelace";
+import { HuiCardEditor } from "../card-editor/hui-card-editor";
 
 const cardConfigStruct = struct({
   type: "string",
@@ -73,6 +74,18 @@ export class HuiStackCardEditor extends LitElement
             selected < numcards
               ? html`
                   <div id="card-options">
+                    <mwc-button
+                      @click=${() => this._cardEditorEl?.toggleMode()}
+                      ?disabled=${this._cardEditorEl?.hasWarning ||
+                        this._cardEditorEl?.hasError}
+                      class="gui-mode-button"
+                    >
+                      ${this.hass!.localize(
+                        !this._cardEditorEl || this._cardEditorEl.GUImode
+                          ? "ui.panel.lovelace.editor.edit_card.show_code_editor"
+                          : "ui.panel.lovelace.editor.edit_card.show_visual_editor"
+                      )}
+                    </mwc-button>
                     <paper-icon-button
                       id="move-before"
                       title="Move card before"
@@ -100,6 +113,7 @@ export class HuiStackCardEditor extends LitElement
                     .value="${this._config.cards[selected]}"
                     .lovelace=${this.lovelace}
                     @config-changed="${this._handleConfigChanged}"
+                    @GUImode-changed=${() => this.requestUpdate()}
                   ></hui-card-editor>
                 `
               : html`
@@ -113,6 +127,10 @@ export class HuiStackCardEditor extends LitElement
         </div>
       </div>
     `;
+  }
+
+  private get _cardEditorEl(): HuiCardEditor | null {
+    return this.shadowRoot!.querySelector("hui-card-editor");
   }
 
   private _handleSelectedCard(ev) {
@@ -193,6 +211,10 @@ export class HuiStackCardEditor extends LitElement
         #editor {
           margin: 0 -12px;
         }
+      }
+
+      .gui-mode-button {
+        margin-right: auto;
       }
     `;
   }

--- a/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
@@ -14,7 +14,7 @@ import { struct } from "../../common/structs/struct";
 import { HomeAssistant } from "../../../../types";
 import { LovelaceCardEditor } from "../../types";
 import { StackCardConfig } from "../../cards/types";
-import { fireEvent } from "../../../../common/dom/fire_event";
+import { fireEvent, HASSDomEvent } from "../../../../common/dom/fire_event";
 import { LovelaceConfig } from "../../../../data/lovelace";
 import { HuiCardEditor } from "../card-editor/hui-card-editor";
 import { GUIModeChangedEvent } from "../types";
@@ -180,7 +180,8 @@ export class HuiStackCardEditor extends LitElement
     fireEvent(this, "config-changed", { config: this._config });
   }
 
-  private _handleGUIModeChanged(ev: GUIModeChangedEvent): void {
+  private _handleGUIModeChanged(ev: HASSDomEvent<GUIModeChangedEvent>): void {
+    ev.stopPropagation();
     this._GUImode = ev.detail.guiMode;
   }
 

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -14,6 +14,12 @@ export interface YamlChangedEvent extends Event {
   };
 }
 
+export interface GUIModeChangedEvent extends Event {
+  detail: {
+    guiMode: boolean;
+  };
+}
+
 export interface ViewEditEvent extends Event {
   detail: {
     config: LovelaceViewConfig;

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -14,10 +14,8 @@ export interface YamlChangedEvent extends Event {
   };
 }
 
-export interface GUIModeChangedEvent extends Event {
-  detail: {
-    guiMode: boolean;
-  };
+export interface GUIModeChangedEvent {
+  guiMode: boolean;
 }
 
 export interface ViewEditEvent extends Event {


### PR DESCRIPTION
## Proposed change

Places the Toggle between Code and Visual Editors on the Dialog

![image](https://user-images.githubusercontent.com/18730868/77017482-04156580-6951-11ea-90c5-6a9e940d9b87.png)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #4086
- This PR is related to the issue: #4112
- Link to documentation pull request: 