### PR TITLE
Card Editor: Copy Card

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -78,6 +78,11 @@ export class HuiCardOptions extends LitElement {
                     "ui.panel.lovelace.editor.edit_card.move"
                   )}</paper-item
                 >
+                <paper-item @tap="${this._copyCard}"
+                  >${this.hass!.localize(
+                    "ui.panel.lovelace.editor.edit_card.copy"
+                  )}</paper-item
+                >
                 <paper-item .class="delete-item" @tap="${this._deleteCard}">
                   ${this.hass!.localize(
                     "ui.panel.lovelace.editor.edit_card.delete"
@@ -150,6 +155,17 @@ export class HuiCardOptions extends LitElement {
         color: var(--google-red-500);
       }
     `;
+  }
+
+  private _copyCard(): void {
+    const path = this.path!;
+    const cardConfig = this.lovelace!.config.views[path[0]].cards![path[1]];
+    showEditCardDialog(this, {
+      lovelaceConfig: this.lovelace!.config,
+      cardConfig,
+      saveConfig: this.lovelace!.saveConfig,
+      path: [path[0]],
+    });
   }
 
   private _editCard(): void {

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -78,9 +78,9 @@ export class HuiCardOptions extends LitElement {
                     "ui.panel.lovelace.editor.edit_card.move"
                   )}</paper-item
                 >
-                <paper-item @tap="${this._copyCard}"
+                <paper-item @tap=${this._duplicateCard}
                   >${this.hass!.localize(
-                    "ui.panel.lovelace.editor.edit_card.copy"
+                    "ui.panel.lovelace.editor.edit_card.duplicate"
                   )}</paper-item
                 >
                 <paper-item .class="delete-item" @tap="${this._deleteCard}">
@@ -157,7 +157,7 @@ export class HuiCardOptions extends LitElement {
     `;
   }
 
-  private _copyCard(): void {
+  private _duplicateCard(): void {
     const path = this.path!;
     const cardConfig = this.lovelace!.config.views[path[0]].cards![path[1]];
     showEditCardDialog(this, {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -56,7 +56,7 @@ export class HuiDialogEditCard extends LitElement {
     const [view, card] = params.path;
     this._viewConfig = params.lovelaceConfig.views[view];
     this._cardConfig =
-      card !== undefined ? this._viewConfig.cards![card] : undefined;
+      card !== undefined ? this._viewConfig.cards![card] : params.cardConfig;
     if (this._cardConfig && !Object.isFrozen(this._cardConfig)) {
       this._cardConfig = deepFreeze(this._cardConfig);
     }

--- a/src/panels/lovelace/editor/card-editor/show-edit-card-dialog.ts
+++ b/src/panels/lovelace/editor/card-editor/show-edit-card-dialog.ts
@@ -1,11 +1,12 @@
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { LovelaceConfig } from "../../../../data/lovelace";
+import { LovelaceConfig, LovelaceCardConfig } from "../../../../data/lovelace";
 
 export interface EditCardDialogParams {
   lovelaceConfig: LovelaceConfig;
   saveConfig: (config: LovelaceConfig) => void;
   path: [number] | [number, number];
   entities?: string[]; // We can pass entity id's that will be added to the config when a card is picked
+  cardConfig?: LovelaceCardConfig;
 }
 
 const importEditCardDialog = () =>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1950,7 +1950,7 @@
             "add": "Add Card",
             "edit": "Edit",
             "delete": "Delete Card",
-            "copy": "Copy Card",
+            "duplicate": "Duplicate Card",
             "move": "Move to View",
             "options": "More options"
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1950,6 +1950,7 @@
             "add": "Add Card",
             "edit": "Edit",
             "delete": "Delete Card",
+            "copy": "Copy Card",
             "move": "Move to View",
             "options": "More options"
           },


### PR DESCRIPTION
## Proposed change

Adds Copy Card to Edit Card Options. This allows the user to copy a card. This brings them to the card editor with the config auto-filled. Once saved the card is added to the end of the view

![c19cf5ee4fccf84c266e0e1289817445](https://user-images.githubusercontent.com/18730868/76928939-47bc9080-68b9-11ea-95dd-f38be69e0fec.gif)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #3890
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
