### PR TITLE
Add "gate" device class for DEVICE_CLASS_GATE

### DIFF
--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -4,17 +4,58 @@ import { domainIcon } from "./domain_icon";
 
 export const coverIcon = (state: HassEntity): string => {
   const open = state.state !== "closed";
+
   switch (state.attributes.device_class) {
     case "garage":
-      return open ? "hass:garage-open" : "hass:garage";
+      switch (state.state) {
+        case "opening":
+          return "hass:arrow-up-bold-box";
+        case "closing":
+          return "hass:arrow-down-bold-box";
+        case "closed":
+          return "hass:garage";
+        default:
+          return "hass:garage-open";
+      }
+    case "gate":
+      switch (state.state) {
+        case "opening":
+        case "closing":
+          return "hass:gate-arrow-right";
+        case "closed":
+          return "hass:gate";
+        default:
+          return "hass:gate-open";
+      }
     case "door":
       return open ? "hass:door-open" : "hass:door-closed";
+    case "damper":
+      return open ? "hass:circle" : "hass:circle-slice-8";
     case "shutter":
       return open ? "hass:window-shutter-open" : "hass:window-shutter";
     case "blind":
-      return open ? "hass:blinds-open" : "hass:blinds";
+    case "curtain":
+      switch (state.state) {
+        case "opening":
+          return "hass:arrow-up-bold-outline";
+        case "closing":
+          return "hass:arrow-down-bold-outline";
+        case "closed":
+          return "hass:blinds";
+        default:
+          return "hass:blinds-open";
+      }
     case "window":
-      return open ? "hass:window-open" : "hass:window-closed";
+      switch (state.state) {
+        case "opening":
+          return "hass:arrow-up-bold-box-outline";
+        case "closing":
+          return "hass:arrow-down-bold-box-outline";
+        case "closed":
+          return "hass:window-closed";
+        default:
+          return "hass:window-open";
+      }
     default:
       return domainIcon("cover", state.state);
   }

--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -9,9 +9,9 @@ export const coverIcon = (state: HassEntity): string => {
     case "garage":
       switch (state.state) {
         case "opening":
-          return "hass:arrow-up-bold-box";
+          return "hass:arrow-up-box";
         case "closing":
-          return "hass:arrow-down-bold-box";
+          return "hass:arrow-down-box";
         case "closed":
           return "hass:garage";
         default:
@@ -37,9 +37,9 @@ export const coverIcon = (state: HassEntity): string => {
     case "curtain":
       switch (state.state) {
         case "opening":
-          return "hass:arrow-up-bold-outline";
+          return "hass:arrow-up-box";
         case "closing":
-          return "hass:arrow-down-bold-outline";
+          return "hass:arrow-down-box";
         case "closed":
           return "hass:blinds";
         default:
@@ -48,9 +48,9 @@ export const coverIcon = (state: HassEntity): string => {
     case "window":
       switch (state.state) {
         case "opening":
-          return "hass:arrow-up-bold-box-outline";
+          return "hass:arrow-up-box";
         case "closing":
-          return "hass:arrow-down-bold-box-outline";
+          return "hass:arrow-down-box";
         case "closed":
           return "hass:window-closed";
         default:

--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -4,17 +4,46 @@ import { domainIcon } from "./domain_icon";
 
 export const coverIcon = (state: HassEntity): string => {
   const open = state.state !== "closed";
+  const opening = state.state === "opening";
+  const closing = state.state === "closing";
+
   switch (state.attributes.device_class) {
     case "garage":
-      return open ? "hass:garage-open" : "hass:garage";
+      return opening
+        ? "hass:arrow-up-bold-box"
+        : closing
+        ? "hass:arrow-down-bold-box"
+        : open ?
+        "hass:garage-open"
+        : "hass:garage";
+    case "gate":
+      return opening || closing
+        ? "hass:gate-arrow-right" :
+        open ? "hass:gate-open"
+        : "hass:gate";
     case "door":
       return open ? "hass:door-open" : "hass:door-closed";
+    case "damper":
+      return open ? "hass:circle" : "hass:circle-slice-8";
     case "shutter":
       return open ? "hass:window-shutter-open" : "hass:window-shutter";
     case "blind":
-      return open ? "hass:blinds-open" : "hass:blinds";
+    case "curtain":
+      return open
+        ? "hass:blinds-open"
+        : opening
+        ? "hass:arrow-up-bold-outline"
+        : closing
+        ? "hass:arrow-down-bold-outline"
+        : "hass:blinds";
     case "window":
-      return open ? "hass:window-open" : "hass:window-closed";
+      return open
+        ? "hass:window-open"
+        : opening
+        ? "hass:arrow-up-bold-box-outline"
+        : closing
+        ? "hass:arrow-down-bold-box-outline"
+        : "hass:window-closed";
     default:
       return domainIcon("cover", state.state);
   }

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -79,9 +79,9 @@ export const domainIcon = (domain: string, state?: string): string => {
     case "cover":
       switch (state) {
         case "opening":
-          return "hass:arrow-up-bold-box-outline";
+          return "hass:arrow-up-box";
         case "closing":
-          return "hass:arrow-down-bold-box-outline";
+          return "hass:arrow-down-box";
         case "closed":
           return "hass:window-closed";
         default:

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -77,7 +77,16 @@ export const domainIcon = (domain: string, state?: string): string => {
         : "hass:checkbox-marked-circle";
 
     case "cover":
-      return state === "closed" ? "hass:window-closed" : "hass:window-open";
+      switch (state) {
+        case "opening":
+          return "hass:arrow-up-bold-box-outline";
+        case "closing":
+          return "hass:arrow-down-bold-box-outline";
+        case "closed":
+          return "hass:window-closed";
+        default:
+          return "hass:window-open";
+      }
 
     case "lock":
       return state && state === "unlocked" ? "hass:lock-open" : "hass:lock";

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -77,7 +77,7 @@ export const domainIcon = (domain: string, state?: string): string => {
         : "hass:checkbox-marked-circle";
 
     case "cover":
-      return state === "closed" ? "hass:window-closed" : "hass:window-open";
+      return state === "closed" ? "hass:window-closed" : state === "closing" ? "hass:arrow-down-bold-box-outline" : state === "opening" ? "hass:arrow-up-bold-box-outline" : "hass:window-open";
 
     case "lock":
       return state && state === "unlocked" ? "hass:lock-open" : "hass:lock";


### PR DESCRIPTION

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Gates are found outside of a structure and are typically part of a fence.

When opening or closing a garage door, it was impossible to tell
if you had hit the button or not even though the underlying state
was reported as "opening". This lead to confusion and multiple
clicks to open a garage door which can cause the door to stop
opening and result in frustration.

Add icons for gate and garage opening and closing states.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io

https://github.com/home-assistant/core/pull/33074
https://github.com/home-assistant/developers.home-assistant/pull/444