### PR TITLE
Fix Default Lovelace Panel Title

### DIFF
--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -36,5 +36,5 @@ export const getPanelTitle = (hass: HomeAssistant): string | undefined => {
     return;
   }
 
-  return title;
+  return hass.localize(`panel.${panel.title}`) || panel.title || undefined;
 };

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -32,9 +32,5 @@ export const getPanelTitle = (hass: HomeAssistant): string | undefined => {
 
   const title = hass.localize(`panel.${panel.title}`) || panel.title;
 
-  if (!title) {
-    return;
-  }
-
   return hass.localize(`panel.${panel.title}`) || panel.title || undefined;
 };

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -9,9 +9,9 @@ export const getDefaultPanelUrlPath = () =>
 export const getDefaultPanel = (panels: HomeAssistant["panels"]) =>
   panels[localStorage.defaultPage] || panels[DEFAULT_PANEL];
 
-export const getPanelTitle = (hass: HomeAssistant): string | null => {
+export const getPanelTitle = (hass: HomeAssistant): string | undefined => {
   if (!hass.panels) {
-    return null;
+    return;
   }
 
   const panel = Object.values(hass.panels).find(
@@ -19,7 +19,7 @@ export const getPanelTitle = (hass: HomeAssistant): string | null => {
   );
 
   if (!panel) {
-    return null;
+    return;
   }
 
   if (panel.url_path === "lovelace") {
@@ -30,5 +30,11 @@ export const getPanelTitle = (hass: HomeAssistant): string | null => {
     return hass.localize("panel.profile");
   }
 
-  return hass.localize(`panel.${panel.title}`) || panel.title;
+  const title = hass.localize(`panel.${panel.title}`) || panel.title;
+
+  if (!title) {
+    return;
+  }
+
+  return title;
 };

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -9,9 +9,9 @@ export const getDefaultPanelUrlPath = () =>
 export const getDefaultPanel = (panels: HomeAssistant["panels"]) =>
   panels[localStorage.defaultPage] || panels[DEFAULT_PANEL];
 
-export const getPanelTitle = (hass: HomeAssistant): string | undefined => {
+export const getPanelTitle = (hass: HomeAssistant): string | null => {
   if (!hass.panels) {
-    return;
+    return null;
   }
 
   const panel = Object.values(hass.panels).find(
@@ -19,17 +19,16 @@ export const getPanelTitle = (hass: HomeAssistant): string | undefined => {
   );
 
   if (!panel) {
-    return;
+    return null;
+  }
+
+  if (panel.url_path === "lovelace") {
+    return hass.localize("panel.states");
   }
 
   if (panel.url_path === "profile") {
     return hass.localize("panel.profile");
   }
 
-  return (
-    hass.localize(`panel.${panel.title}`) ||
-    panel.title ||
-    // default panel
-    (hass.panels[localStorage.defaultPage] || hass.panels[DEFAULT_PANEL]).title!
-  );
+  return hass.localize(`panel.${panel.title}`) || panel.title;
 };

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -30,7 +30,5 @@ export const getPanelTitle = (hass: HomeAssistant): string | undefined => {
     return hass.localize("panel.profile");
   }
 
-  const title = hass.localize(`panel.${panel.title}`) || panel.title;
-
   return hass.localize(`panel.${panel.title}`) || panel.title || undefined;
 };

--- a/src/state/panel-title-mixin.ts
+++ b/src/state/panel-title-mixin.ts
@@ -2,7 +2,7 @@ import { getPanelTitle } from "../data/panel";
 import { HassBaseEl } from "./hass-base-mixin";
 import { HomeAssistant, Constructor } from "../types";
 
-const setTitle = (title: string | null) => {
+const setTitle = (title: string | undefined) => {
   document.title = title ? `${title} - Home Assistant` : "Home Assistant";
 };
 

--- a/src/state/panel-title-mixin.ts
+++ b/src/state/panel-title-mixin.ts
@@ -2,7 +2,7 @@ import { getPanelTitle } from "../data/panel";
 import { HassBaseEl } from "./hass-base-mixin";
 import { HomeAssistant, Constructor } from "../types";
 
-const setTitle = (title: string | undefined) => {
+const setTitle = (title: string | null) => {
   document.title = title ? `${title} - Home Assistant` : "Home Assistant";
 };
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the missing panel title on the default lovelace view. I did get this working in #5220 so I'm not sure what's changed since. 

_Could be from the removal of the states ui but I'm unsure_

![Screenshot_20200321_111257](https://user-images.githubusercontent.com/28114703/77225203-f801f180-6b64-11ea-9a5d-2a1317318b08.png)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.
