### PR TITLE
Fixes #5300: always show attribute step

### DIFF
--- a/src/panels/config/helpers/forms/ha-input_number-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_number-form.ts
@@ -132,19 +132,16 @@ class HaInputNumberForm extends LitElement {
                   </paper-radio-button>
                 </paper-radio-group>
               </div>
-              ${this._mode === "slider"
-                ? html`
-                    <paper-input
-                      .value=${this._step}
-                      .configValue=${"step"}
-                      type="number"
-                      @value-changed=${this._valueChanged}
-                      .label=${this.hass!.localize(
-                        "ui.dialogs.helper_settings.input_number.step"
-                      )}
-                    ></paper-input>
-                  `
-                : ""}
+              <paper-input
+                .value=${this._step}
+                .configValue=${"step"}
+                type="number"
+                @value-changed=${this._valueChanged}
+                .label=${this.hass!.localize(
+                  "ui.dialogs.helper_settings.input_number.step"
+                )}
+              ></paper-input>
+
               <paper-input
                 .value=${this._unit_of_measurement}
                 .configValue=${"unit_of_measurement"}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -686,7 +686,7 @@
           "mode": "Display mode",
           "box": "Input field",
           "slider": "Slider",
-          "step": "Step size of the slider",
+          "step": "Step size",
           "unit_of_measurement": "Unit of measurement"
         },
         "input_select": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fix #5300 and show the attribute steps always

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
Create input_number via UI

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5300 
- This PR is related to issue: 
- Link to documentation pull request:  home-assistant/home-assistant.io#12471

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
