### PR TITLE
Add Volume Controls to Media Control Card

### DIFF
--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -32,17 +32,18 @@ import { contrast } from "../common/color/contrast";
 import { findEntities } from "../common/find-entites";
 import { UNAVAILABLE, UNKNOWN } from "../../../data/entity";
 import {
-  SUPPORT_PAUSE,
-  SUPPORT_TURN_ON,
-  SUPPORT_PREVIOUS_TRACK,
-  SUPPORT_NEXT_TRACK,
-  SUPPORTS_PLAY,
-  SUPPORT_STOP,
-  SUPPORT_SEEK,
+  computeMediaDescription,
   CONTRAST_RATIO,
   getCurrentProgress,
-  computeMediaDescription,
+  SUPPORT_NEXT_TRACK,
+  SUPPORT_PAUSE,
+  SUPPORT_PREVIOUS_TRACK,
+  SUPPORT_SEEK,
+  SUPPORT_STOP,
   SUPPORT_TURN_OFF,
+  SUPPORT_TURN_ON,
+  SUPPORT_VOLUME_BUTTONS,
+  SUPPORTS_PLAY,
 } from "../../../data/media-player";
 
 import "../../../components/ha-card";
@@ -505,40 +506,28 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
       return undefined;
     }
 
-    if (state === "off") {
-      return supportsFeature(stateObj, SUPPORT_TURN_ON)
-        ? [
-            {
-              icon: "hass:power",
-              action: "turn_on",
-            },
-          ]
-        : undefined;
-    }
-
-    if (state === "on") {
-      return supportsFeature(stateObj, SUPPORT_TURN_OFF)
-        ? [
-            {
-              icon: "hass:power",
-              action: "turn_off",
-            },
-          ]
-        : undefined;
-    }
-
-    if (state === "idle") {
-      return supportsFeature(stateObj, SUPPORTS_PLAY)
-        ? [
-            {
-              icon: "hass:play",
-              action: "media_play",
-            },
-          ]
-        : undefined;
-    }
-
     const buttons: ControlButton[] = [];
+
+    if (state === "off" && supportsFeature(stateObj, SUPPORT_TURN_ON)) {
+      buttons.push({
+        icon: "hass:power",
+        action: "turn_on",
+      });
+    }
+
+    if (state === "on" && supportsFeature(stateObj, SUPPORT_TURN_OFF)) {
+      buttons.push({
+        icon: "hass:power",
+        action: "turn_off",
+      });
+    }
+
+    if (state === "idle" && supportsFeature(stateObj, SUPPORTS_PLAY)) {
+      buttons.push({
+        icon: "hass:play",
+        action: "media_play",
+      });
+    }
 
     if (supportsFeature(stateObj, SUPPORT_PREVIOUS_TRACK)) {
       buttons.push({
@@ -568,6 +557,17 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
       buttons.push({
         icon: "hass:skip-next",
         action: "media_next_track",
+      });
+    }
+
+    if (supportsFeature(stateObj, SUPPORT_VOLUME_BUTTONS)) {
+      buttons.push({
+        icon: "hass:volume-medium",
+        action: "volume_down",
+      });
+      buttons.push({
+        icon: "hass:volume-high",
+        action: "volume_up",
       });
     }
 


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds volume controls for those that support control.

![Screenshot_20200321_141944](https://user-images.githubusercontent.com/28114703/77228399-11179c00-6b7f-11ea-8c46-027fe4916bb6.png)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (thank you!)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

