### PR TITLE
Delete Card: Add Card Preview to Dialog

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -32,6 +32,7 @@ export class HuiDialogDeleteCard extends LitElement {
       this._cardConfig = deepFreeze(this._cardConfig);
     }
     await this.updateComplete;
+    fireEvent(this, "iron-resize");
   }
 
   protected render(): TemplateResult {
@@ -66,10 +67,6 @@ export class HuiDialogDeleteCard extends LitElement {
         </div>
       </ha-paper-dialog>
     `;
-  }
-
-  protected updated(): void {
-    fireEvent(this, "iron-resize");
   }
 
   static get styles(): CSSResultArray {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -40,6 +40,10 @@ export class HuiDialogDeleteCard extends LitElement {
   }
 
   protected render(): TemplateResult {
+    if (!this._params) {
+      return html``;
+    }
+
     return html`
       <ha-paper-dialog with-backdrop opened>
         <h2>
@@ -61,7 +65,7 @@ export class HuiDialogDeleteCard extends LitElement {
           <mwc-button @click="${this._close}">
             ${this.hass!.localize("ui.common.cancel")}
           </mwc-button>
-          <mwc-button class="delete" @click="${this._delete}">
+          <mwc-button class="warning" @click="${this._delete}">
             ${this.hass!.localize("ui.common.delete")}
           </mwc-button>
         </div>
@@ -73,53 +77,29 @@ export class HuiDialogDeleteCard extends LitElement {
     return [
       haStyleDialog,
       css`
-        @media all and (max-width: 450px), all and (max-height: 500px) {
-          /* overrule the ha-style-dialog max-height on small screens */
-          ha-paper-dialog {
-            max-height: 100%;
-            height: 100%;
-          }
-        }
-        @media all and (min-width: 850px) {
-          ha-paper-dialog {
-            width: 845px;
-          }
-        }
-        ha-paper-dialog {
-          max-width: 845px;
-        }
         .element-preview {
           position: relative;
         }
         hui-card-preview {
-          padding-top: 8px;
           margin: 4px auto;
           max-width: 500px;
           display: block;
           width: 100%;
-        }
-        .delete {
-          --mdc-theme-primary: red;
         }
       `,
     ];
   }
 
   private _close(): void {
-    this._dialog!.close();
     this._params = undefined;
     this._cardConfig = undefined;
   }
 
   private _delete(): void {
-    if (
-      !this._params?.lovelaceConfig ||
-      !this._params?.path ||
-      !this._params?.deleteCard
-    ) {
+    if (!this._params?.deleteCard) {
       return;
     }
-    this._params.deleteCard(this._params.lovelaceConfig, this._params.path);
+    this._params.deleteCard();
     this._close();
   }
 }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -6,7 +6,6 @@ import {
   CSSResultArray,
   customElement,
   property,
-  query,
 } from "lit-element";
 
 import "./hui-card-preview";
@@ -14,19 +13,17 @@ import "../../../../components/dialog/ha-paper-dialog";
 
 import deepFreeze from "deep-freeze";
 
-// tslint:disable-next-line
-import { HaPaperDialog } from "../../../../components/dialog/ha-paper-dialog";
 import { HomeAssistant } from "../../../../types";
 import { LovelaceCardConfig } from "../../../../data/lovelace";
 import { haStyleDialog } from "../../../../resources/styles";
 import { DeleteCardDialogParams } from "./show-delete-card-dialog";
+import { fireEvent } from "../../../../common/dom/fire_event";
 
 @customElement("hui-dialog-delete-card")
 export class HuiDialogDeleteCard extends LitElement {
   @property() protected hass!: HomeAssistant;
   @property() private _params?: DeleteCardDialogParams;
   @property() private _cardConfig?: LovelaceCardConfig;
-  @query("ha-paper-dialog") private _dialog?: HaPaperDialog;
 
   public async showDialog(params: DeleteCardDialogParams): Promise<void> {
     this._params = params;
@@ -34,9 +31,7 @@ export class HuiDialogDeleteCard extends LitElement {
     if (!Object.isFrozen(this._cardConfig)) {
       this._cardConfig = deepFreeze(this._cardConfig);
     }
-    if (this._dialog) {
-      this._dialog.open();
-    }
+    await this.updateComplete;
   }
 
   protected render(): TemplateResult {
@@ -71,6 +66,10 @@ export class HuiDialogDeleteCard extends LitElement {
         </div>
       </ha-paper-dialog>
     `;
+  }
+
+  protected updated(): void {
+    fireEvent(this, "iron-resize");
   }
 
   static get styles(): CSSResultArray {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -6,6 +6,7 @@ import {
   CSSResultArray,
   customElement,
   property,
+  query,
 } from "lit-element";
 
 import "./hui-card-preview";
@@ -13,6 +14,8 @@ import "../../../../components/dialog/ha-paper-dialog";
 
 import deepFreeze from "deep-freeze";
 
+// tslint:disable-next-line: no-duplicate-imports
+import { HaPaperDialog } from "../../../../components/dialog/ha-paper-dialog";
 import { HomeAssistant } from "../../../../types";
 import { LovelaceCardConfig } from "../../../../data/lovelace";
 import { haStyleDialog } from "../../../../resources/styles";
@@ -24,6 +27,7 @@ export class HuiDialogDeleteCard extends LitElement {
   @property() protected hass!: HomeAssistant;
   @property() private _params?: DeleteCardDialogParams;
   @property() private _cardConfig?: LovelaceCardConfig;
+  @query("ha-paper-dialog") private _dialog!: HaPaperDialog;
 
   public async showDialog(params: DeleteCardDialogParams): Promise<void> {
     this._params = params;
@@ -32,7 +36,7 @@ export class HuiDialogDeleteCard extends LitElement {
       this._cardConfig = deepFreeze(this._cardConfig);
     }
     await this.updateComplete;
-    fireEvent(this, "iron-resize");
+    fireEvent(this._dialog as HTMLElement, "iron-resize");
   }
 
   protected render(): TemplateResult {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -94,7 +94,7 @@ export class HuiDialogDeleteCard extends LitElement {
         hui-card-preview {
           padding-top: 8px;
           margin: 4px auto;
-          max-width: 390px;
+          max-width: 500px;
           display: block;
           width: 100%;
         }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -1,0 +1,131 @@
+import {
+  css,
+  html,
+  LitElement,
+  TemplateResult,
+  CSSResultArray,
+  customElement,
+  property,
+  query,
+} from "lit-element";
+
+import "./hui-card-preview";
+import "../../../../components/dialog/ha-paper-dialog";
+
+import deepFreeze from "deep-freeze";
+
+// tslint:disable-next-line
+import { HaPaperDialog } from "../../../../components/dialog/ha-paper-dialog";
+import { HomeAssistant } from "../../../../types";
+import { LovelaceCardConfig } from "../../../../data/lovelace";
+import { haStyleDialog } from "../../../../resources/styles";
+import { DeleteCardDialogParams } from "./show-delete-card-dialog";
+
+@customElement("hui-dialog-delete-card")
+export class HuiDialogDeleteCard extends LitElement {
+  @property() protected hass!: HomeAssistant;
+  @property() private _params?: DeleteCardDialogParams;
+  @property() private _cardConfig?: LovelaceCardConfig;
+  @query("ha-paper-dialog") private _dialog?: HaPaperDialog;
+
+  public async showDialog(params: DeleteCardDialogParams): Promise<void> {
+    this._params = params;
+    this._cardConfig = params.cardConfig;
+    if (!Object.isFrozen(this._cardConfig)) {
+      this._cardConfig = deepFreeze(this._cardConfig);
+    }
+    if (this._dialog) {
+      this._dialog.open();
+    }
+  }
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-paper-dialog with-backdrop opened>
+        <h2>
+          ${this.hass.localize("ui.panel.lovelace.cards.confirm_delete")}
+        </h2>
+        <paper-dialog-scrollable>
+          ${this._cardConfig
+            ? html`
+                <div class="element-preview">
+                  <hui-card-preview
+                    .hass=${this.hass}
+                    .config="${this._cardConfig}"
+                  ></hui-card-preview>
+                </div>
+              `
+            : ""}
+        </paper-dialog-scrollable>
+        <div class="paper-dialog-buttons">
+          <mwc-button @click="${this._close}">
+            ${this.hass!.localize("ui.common.cancel")}
+          </mwc-button>
+          <mwc-button class="delete" @click="${this._delete}">
+            ${this.hass!.localize("ui.common.delete")}
+          </mwc-button>
+        </div>
+      </ha-paper-dialog>
+    `;
+  }
+
+  static get styles(): CSSResultArray {
+    return [
+      haStyleDialog,
+      css`
+        @media all and (max-width: 450px), all and (max-height: 500px) {
+          /* overrule the ha-style-dialog max-height on small screens */
+          ha-paper-dialog {
+            max-height: 100%;
+            height: 100%;
+          }
+        }
+        @media all and (min-width: 850px) {
+          ha-paper-dialog {
+            width: 845px;
+          }
+        }
+        ha-paper-dialog {
+          max-width: 845px;
+        }
+        .element-preview {
+          position: relative;
+        }
+        hui-card-preview {
+          padding-top: 8px;
+          margin: 4px auto;
+          max-width: 390px;
+          display: block;
+          width: 100%;
+        }
+        .delete {
+          --mdc-theme-primary: red;
+        }
+      `,
+    ];
+  }
+
+  private _close(): void {
+    this._dialog!.close();
+    this._params = undefined;
+    this._cardConfig = undefined;
+  }
+
+  private _delete(): void {
+    if (
+      !this._params?.lovelaceConfig ||
+      !this._params?.path ||
+      !this._params?.deleteCard
+    ) {
+      return;
+    }
+    this._params.deleteCard(this._params.lovelaceConfig, this._params.path);
+    this._close();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-dialog-delete-card": HuiDialogDeleteCard;
+  }
+}

--- a/src/panels/lovelace/editor/card-editor/show-delete-card-dialog.ts
+++ b/src/panels/lovelace/editor/card-editor/show-delete-card-dialog.ts
@@ -1,10 +1,8 @@
 import { fireEvent } from "../../../../common/dom/fire_event";
-import { LovelaceConfig, LovelaceCardConfig } from "../../../../data/lovelace";
+import { LovelaceCardConfig } from "../../../../data/lovelace";
 
 export interface DeleteCardDialogParams {
-  lovelaceConfig: LovelaceConfig;
-  deleteCard: (config: LovelaceConfig, path: [number, number]) => void;
-  path: [number, number];
+  deleteCard: () => void;
   cardConfig?: LovelaceCardConfig;
 }
 

--- a/src/panels/lovelace/editor/card-editor/show-delete-card-dialog.ts
+++ b/src/panels/lovelace/editor/card-editor/show-delete-card-dialog.ts
@@ -1,0 +1,25 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { LovelaceConfig, LovelaceCardConfig } from "../../../../data/lovelace";
+
+export interface DeleteCardDialogParams {
+  lovelaceConfig: LovelaceConfig;
+  deleteCard: (config: LovelaceConfig, path: [number, number]) => void;
+  path: [number, number];
+  cardConfig?: LovelaceCardConfig;
+}
+
+const importDeleteCardDialog = () =>
+  import(
+    /* webpackChunkName: "hui-dialog-delete-card" */ "./hui-dialog-delete-card"
+  );
+
+export const showDeleteCardDialog = (
+  element: HTMLElement,
+  deleteCardDialogParams: DeleteCardDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "hui-dialog-delete-card",
+    dialogImport: importDeleteCardDialog,
+    dialogParams: deleteCardDialogParams,
+  });
+};

--- a/src/panels/lovelace/editor/delete-card.ts
+++ b/src/panels/lovelace/editor/delete-card.ts
@@ -1,10 +1,9 @@
 import { Lovelace } from "../types";
 import { deleteCard } from "./config-util";
-import {
-  showAlertDialog,
-  showConfirmationDialog,
-} from "../../../dialogs/generic/show-dialog-box";
+import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import { HomeAssistant } from "../../../types";
+import { showDeleteCardDialog } from "./card-editor/show-delete-card-dialog";
+import { showDeleteSuccessToast } from "../../../util/toast-deleted-success";
 
 export async function confDeleteCard(
   element: HTMLElement,
@@ -12,11 +11,15 @@ export async function confDeleteCard(
   lovelace: Lovelace,
   path: [number, number]
 ): Promise<void> {
-  showConfirmationDialog(element, {
-    text: hass.localize("ui.panel.lovelace.cards.confirm_delete"),
-    confirm: async () => {
+  const cardConfig = lovelace.config.views[path[0]].cards![path[1]];
+  showDeleteCardDialog(element, {
+    lovelaceConfig: lovelace!.config,
+    cardConfig,
+    path,
+    deleteCard: async (config, cardPath) => {
       try {
-        await lovelace.saveConfig(deleteCard(lovelace.config, path));
+        await lovelace.saveConfig(deleteCard(config, cardPath));
+        showDeleteSuccessToast(element, hass!);
       } catch (err) {
         showAlertDialog(element, {
           text: `Deleting failed: ${err.message}`,

--- a/src/panels/lovelace/editor/delete-card.ts
+++ b/src/panels/lovelace/editor/delete-card.ts
@@ -13,12 +13,10 @@ export async function confDeleteCard(
 ): Promise<void> {
   const cardConfig = lovelace.config.views[path[0]].cards![path[1]];
   showDeleteCardDialog(element, {
-    lovelaceConfig: lovelace!.config,
     cardConfig,
-    path,
-    deleteCard: async (config, cardPath) => {
+    deleteCard: async () => {
       try {
-        await lovelace.saveConfig(deleteCard(config, cardPath));
+        await lovelace.saveConfig(deleteCard(lovelace.config, path));
         showDeleteSuccessToast(element, hass!);
       } catch (err) {
         showAlertDialog(element, {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -519,11 +519,13 @@
     "common": {
       "loading": "Loading",
       "cancel": "Cancel",
+      "delete": "Delete",
       "close": "Close",
       "save": "Save",
       "yes": "Yes",
       "no": "No",
-      "successfully_saved": "Successfully saved"
+      "successfully_saved": "Successfully saved",
+      "successfully_deleted": "Successfully deleted"
     },
     "components": {
       "entity": {

--- a/src/util/toast-deleted-success.ts
+++ b/src/util/toast-deleted-success.ts
@@ -1,0 +1,7 @@
+import { showToast } from "./toast";
+import { HomeAssistant } from "../types";
+
+export const showDeleteSuccessToast = (el: HTMLElement, hass: HomeAssistant) =>
+  showToast(el, {
+    message: hass!.localize("ui.common.successfully_deleted"),
+  });


### PR DESCRIPTION
## Proposed change

Instead of a simple confirmation dialog. Enrich the delete card dialog with a card preview so you can be sure this is the card you want to delete.

![image](https://user-images.githubusercontent.com/18730868/77368313-54fed280-6d32-11ea-96d1-a0464928c6ee.png)

## Type of change

- [x] New feature (thank you!)

## Additional information

- This PR fixes or closes issue: fixes #4555

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.