### PR TITLE
HA Chips: Input Chips

### DIFF
--- a/src/components/ha-chips.ts
+++ b/src/components/ha-chips.ts
@@ -20,6 +20,7 @@ declare global {
   // for fire event
   interface HASSDomEvents {
     "chip-clicked": { index: number };
+    "chip-removed": { index: number };
   }
 }
 
@@ -82,7 +83,7 @@ export class HaChips extends LitElement {
 
   private _handleRemove(ev: MouseEvent): void {
     ev.stopPropagation();
-    fireEvent(this, "chip-clicked", {
+    fireEvent(this, "chip-removed", {
       index: (ev.currentTarget as any).index,
     });
   }

--- a/src/components/ha-chips.ts
+++ b/src/components/ha-chips.ts
@@ -8,33 +8,43 @@ import {
   customElement,
   unsafeCSS,
 } from "lit-element";
+import { classMap } from "lit-html/directives/class-map";
 import { ripple } from "@material/mwc-ripple/ripple-directive";
 // @ts-ignore
 import chipStyles from "@material/chips/dist/mdc.chips.min.css";
 import { fireEvent } from "../common/dom/fire_event";
 
+import "./ha-icon";
+
 declare global {
   // for fire event
   interface HASSDomEvents {
-    "chip-clicked": { index: string };
+    "chip-clicked": { index: number };
   }
 }
 
 @customElement("ha-chips")
 export class HaChips extends LitElement {
   @property() public items = [];
+  @property() public type: "input" | "choice" = "choice";
 
   protected render(): TemplateResult {
     if (this.items.length === 0) {
       return html``;
     }
+
     return html`
-      <div class="mdc-chip-set">
+      <div
+        class="mdc-chip-set ${classMap({
+          "mdc-chip-set--input": this.type === "input",
+          "mdc-chip-set--choice": this.type === "choice",
+        })}"
+      >
         ${this.items.map(
           (item, idx) =>
             html`
               <div class="mdc-chip" .index=${idx} @click=${this._handleClick}>
-                <div class="mdc-chip__ripple" .ripple="${ripple()}"></div>
+                <div class="mdc-chip__ripple" .ripple=${ripple()}></div>
                 <span role="gridcell">
                   <span
                     role="button"
@@ -44,6 +54,19 @@ export class HaChips extends LitElement {
                     <span class="mdc-chip__text">${item}</span>
                   </span>
                 </span>
+                ${this.type === "input"
+                  ? html`
+                      <span role="gridcell">
+                        <ha-icon
+                          class="mdc-chip__icon mdc-chip__icon--trailing"
+                          icon="mdi:close-circle"
+                          tabindex="-1"
+                          role="button"
+                          @click=${this._handleRemove}
+                        ></ha-icon>
+                      </span>
+                    `
+                  : ""}
               </div>
             `
         )}
@@ -51,9 +74,16 @@ export class HaChips extends LitElement {
     `;
   }
 
-  private _handleClick(ev): void {
+  private _handleClick(ev: MouseEvent): void {
     fireEvent(this, "chip-clicked", {
-      index: ev.currentTarget.index,
+      index: (ev.currentTarget as any).index,
+    });
+  }
+
+  private _handleRemove(ev: MouseEvent): void {
+    ev.stopPropagation();
+    fireEvent(this, "chip-clicked", {
+      index: (ev.currentTarget as any).index,
     });
   }
 


### PR DESCRIPTION
## Proposed change

Adds the ability to specify input type

![image](https://user-images.githubusercontent.com/18730868/78413598-109eec80-75e6-11ea-8223-c89188e41ca8.png)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```html
<ha-chips .items=${["testing", "chips", "these"]} .type=${"input"}></ha-chips>
```

## Additional information

Pre-PR to alarm card redesign


https://github.com/material-components/material-components-web/tree/master/packages/mdc-chips