### PR TITLE
Add loading for initial state on graph

### DIFF
--- a/src/panels/lovelace/common/graph/get-history-coordinates.ts
+++ b/src/panels/lovelace/common/graph/get-history-coordinates.ts
@@ -7,7 +7,7 @@ export const getHistoryCoordinates = async (
   entity: string,
   hours: number,
   detail: number
-): Promise<number[][] | undefined> => {
+): Promise<number[][]> => {
   const endTime = new Date();
   const startTime = new Date();
   startTime.setHours(endTime.getHours() - hours);
@@ -15,10 +15,14 @@ export const getHistoryCoordinates = async (
   const stateHistory = await fetchRecent(hass, entity, startTime, endTime);
 
   if (stateHistory.length < 1 || stateHistory[0].length < 1) {
-    return undefined;
+    return [];
   }
 
   const coords = coordinates(stateHistory[0], hours, 500, detail);
+
+  if (!coords) {
+    return [];
+  }
 
   return coords;
 };

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -115,7 +115,7 @@ export class HuiGraphHeaderFooter extends LitElement
       paper-spinner {
         position: absolute;
         top: calc(50% - 28px);
-        left: calc(50% - 12px);
+        left: calc(50% - 14px);
       }
       .container {
         position: relative;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -118,6 +118,8 @@ export class HuiGraphHeaderFooter extends LitElement
         left: calc(50% - 14px);
       }
       .container {
+        display: flex;
+        justify-content: center;
         position: relative;
         padding-bottom: 20%;
       }

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -30,7 +30,6 @@ export class HuiGraphHeaderFooter extends LitElement
   @property() protected _config?: GraphHeaderFooterConfig;
   @property() private _coordinates?: number[][];
 
-  private _loadingInitialData: boolean = true;
   private _date?: Date;
 
   public setConfig(config: GraphHeaderFooterConfig): void {
@@ -60,7 +59,7 @@ export class HuiGraphHeaderFooter extends LitElement
       return html``;
     }
 
-    if (this._loadingInitialData) {
+    if (!this._coordinates) {
       return html`
         <div class="spinner-container">
           <paper-spinner class="spinner" active></paper-spinner>
@@ -68,10 +67,12 @@ export class HuiGraphHeaderFooter extends LitElement
       `;
     }
 
-    if (!this._coordinates) {
+    if (this._coordinates.length < 1) {
       return html`
-        <div class="info">
-          No state history found.
+        <div class="info-container">
+          <div class="info">
+            No state history found.
+          </div>
         </div>
       `;
     }
@@ -106,7 +107,6 @@ export class HuiGraphHeaderFooter extends LitElement
     );
 
     this._date = new Date();
-    this._loadingInitialData = false;
   }
 
   static get styles(): CSSResult {
@@ -120,10 +120,16 @@ export class HuiGraphHeaderFooter extends LitElement
         top: calc(50% - 28px);
         left: calc(50% - 12px);
       }
+      .info-container {
+        position: relative;
+        padding-bottom: 20%;
+      }
       .info {
-        text-align: center;
-        line-height: 58px;
+        position: absolute;
+        width: 100%;
+        top: calc(50% - 16px);
         color: var(--secondary-text-color);
+        text-align: center;
       }
     `;
   }

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -94,7 +94,6 @@ export class HuiGraphHeaderFooter extends LitElement
     } else if (Date.now() - this._date!.getTime() >= MINUTE) {
       this._getCoordinates();
     }
-    this._loadingInitialData = false;
   }
 
   private async _getCoordinates(): Promise<void> {
@@ -106,6 +105,7 @@ export class HuiGraphHeaderFooter extends LitElement
     );
 
     this._date = new Date();
+    this._loadingInitialData = false;
   }
 
   static get styles(): CSSResult {

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -115,7 +115,6 @@ export class HuiGraphHeaderFooter extends LitElement
       paper-spinner {
         position: absolute;
         top: calc(50% - 28px);
-        left: calc(50% - 14px);
       }
       .container {
         display: flex;
@@ -125,10 +124,8 @@ export class HuiGraphHeaderFooter extends LitElement
       }
       .info {
         position: absolute;
-        width: 100%;
         top: calc(50% - 16px);
         color: var(--secondary-text-color);
-        text-align: center;
       }
     `;
   }

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -112,8 +112,9 @@ export class HuiGraphHeaderFooter extends LitElement
   static get styles(): CSSResult {
     return css`
       .spinner {
-        height: 58px;
-        text-align: center;
+        display: flex;
+        height: 98px;
+        justify-content: center;
       }
       .info {
         text-align: center;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -26,9 +26,8 @@ export class HuiGraphHeaderFooter extends LitElement
   @property() public hass?: HomeAssistant;
 
   @property() protected _config?: GraphHeaderFooterConfig;
-
-  @property() private _coordinates?: any;
-
+  @property() private _coordinates?: number[][];
+  @property() private _loadingInitialData: boolean = true;
   private _date?: Date;
 
   public setConfig(config: GraphHeaderFooterConfig): void {

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -62,8 +62,8 @@ export class HuiGraphHeaderFooter extends LitElement
 
     if (this._loadingInitialData) {
       return html`
-        <div class="spinner">
-          <paper-spinner active></paper-spinner>
+        <div class="spinner-container">
+          <paper-spinner class="spinner" active></paper-spinner>
         </div>
       `;
     }
@@ -111,10 +111,12 @@ export class HuiGraphHeaderFooter extends LitElement
 
   static get styles(): CSSResult {
     return css`
+      .spinner-container {
+        margin-bottom: 20%;
+      }
       .spinner {
-        display: flex;
-        height: 98px;
-        justify-content: center;
+        position: absolute;
+        left: calc(50% - 12px);
       }
       .info {
         text-align: center;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -10,6 +10,8 @@ import {
 } from "lit-element";
 import { HomeAssistant } from "../../../types";
 import { getHistoryCoordinates } from "../common/graph/get-history-coordinates";
+
+import "@polymer/paper-spinner/paper-spinner";
 import "../components/hui-graph-base";
 import { LovelaceHeaderFooter } from "../types";
 import { GraphHeaderFooterConfig } from "./types";
@@ -57,6 +59,14 @@ export class HuiGraphHeaderFooter extends LitElement
       return html``;
     }
 
+    if (this._loadingInitialData) {
+      return html`
+        <div class="spinner">
+          <paper-spinner active></paper-spinner>
+        </div>
+      `;
+    }
+
     if (!this._coordinates) {
       return html`
         <div class="info">
@@ -84,6 +94,7 @@ export class HuiGraphHeaderFooter extends LitElement
     } else if (Date.now() - this._date!.getTime() >= MINUTE) {
       this._getCoordinates();
     }
+    this._loadingInitialData = false;
   }
 
   private async _getCoordinates(): Promise<void> {
@@ -99,6 +110,10 @@ export class HuiGraphHeaderFooter extends LitElement
 
   static get styles(): CSSResult {
     return css`
+      .spinner {
+        height: 58px;
+        text-align: center;
+      }
       .info {
         text-align: center;
         line-height: 58px;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -112,10 +112,12 @@ export class HuiGraphHeaderFooter extends LitElement
   static get styles(): CSSResult {
     return css`
       .spinner-container {
-        margin-bottom: 20%;
+        position: relative;
+        padding-bottom: 20%;
       }
       .spinner {
         position: absolute;
+        top: calc(50% - 12px);
         left: calc(50% - 12px);
       }
       .info {

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -117,7 +117,7 @@ export class HuiGraphHeaderFooter extends LitElement
       }
       .spinner {
         position: absolute;
-        top: calc(50% - 12px);
+        top: calc(50% - 28px);
         left: calc(50% - 12px);
       }
       .info {

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -29,7 +29,8 @@ export class HuiGraphHeaderFooter extends LitElement
 
   @property() protected _config?: GraphHeaderFooterConfig;
   @property() private _coordinates?: number[][];
-  @property() private _loadingInitialData: boolean = true;
+
+  private _loadingInitialData: boolean = true;
   private _date?: Date;
 
   public setConfig(config: GraphHeaderFooterConfig): void {

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -61,15 +61,15 @@ export class HuiGraphHeaderFooter extends LitElement
 
     if (!this._coordinates) {
       return html`
-        <div class="spinner-container">
-          <paper-spinner class="spinner" active></paper-spinner>
+        <div class="container">
+          <paper-spinner active></paper-spinner>
         </div>
       `;
     }
 
     if (this._coordinates.length < 1) {
       return html`
-        <div class="info-container">
+        <div class="container">
           <div class="info">
             No state history found.
           </div>
@@ -111,16 +111,12 @@ export class HuiGraphHeaderFooter extends LitElement
 
   static get styles(): CSSResult {
     return css`
-      .spinner-container {
-        position: relative;
-        padding-bottom: 20%;
-      }
-      .spinner {
+      paper-spinner {
         position: absolute;
         top: calc(50% - 28px);
         left: calc(50% - 12px);
       }
-      .info-container {
+      .container {
         position: relative;
         padding-bottom: 20%;
       }

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -28,6 +28,7 @@ export class HuiGraphHeaderFooter extends LitElement
   @property() public hass?: HomeAssistant;
 
   @property() protected _config?: GraphHeaderFooterConfig;
+
   @property() private _coordinates?: number[][];
 
   private _date?: Date;


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When loading history for the graph initially, there is a window of time where the graph states there is no state history, whilst the data is being loaded initially. This adds a spinner to be shown whilst this is loading.

![loading](https://user-images.githubusercontent.com/28114703/78436733-9f574c00-766e-11ea-8d12-fcc5676be07c.gif)
_This is only usually seen by the human eye when you have a lot of cards on a production server. This gif is using a setTimeout to slow this down as the local dev instance is much quicker._

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (thank you!)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.
