### PR TITLE
Fix hui-dialog-edit-card vertical position

### DIFF
--- a/src/components/state-history-chart-line.js
+++ b/src/components/state-history-chart-line.js
@@ -6,6 +6,7 @@ import "./entity/ha-chart-base";
 
 import LocalizeMixin from "../mixins/localize-mixin";
 import { formatDateTimeWithSeconds } from "../common/datetime/format_date_time";
+import { fireEvent } from "../common/dom/fire_event";
 
 class StateHistoryChartLine extends LocalizeMixin(PolymerElement) {
   static get template() {
@@ -311,6 +312,12 @@ class StateHistoryChartLine extends LocalizeMixin(PolymerElement) {
 
       // Concat two arrays
       Array.prototype.push.apply(datasets, data);
+
+      // Fire event to change dialog position
+      // Wait 500ms for the 0.3s transition to finish
+      setTimeout(() => {
+        fireEvent(this, "iron-resize");
+      }, 500);
     });
 
     const formatTooltipTitle = (items, data) => {

--- a/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-editor.ts
@@ -74,6 +74,7 @@ export class HuiCardEditor extends LitElement {
       this._error = undefined;
     } catch (err) {
       this._error = err.message;
+      fireEvent(this, "iron-resize");
     }
     fireEvent(this, "config-changed", {
       config: this.value!,
@@ -218,6 +219,7 @@ export class HuiCardEditor extends LitElement {
 
   private async _updateConfigElement(): Promise<void> {
     if (!this.value) {
+      fireEvent(this, "iron-resize");
       return;
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes the problem that the bottom of the card configuration dialog goes outside the screen. I added `eventFire(this, "iron-resize")` when there is an error in the yaml configuration, the yaml configuration is empty, or the history card is redendered to update the position of the dialog. There could be more but those are all cases I found where the dialog position was not properly updated. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4924 #4320
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
