### PR TITLE
Fix add card dialog error logs

### DIFF
--- a/src/panels/lovelace/create-element/create-card-element.ts
+++ b/src/panels/lovelace/create-element/create-card-element.ts
@@ -13,6 +13,7 @@ import "../cards/hui-weather-forecast-card";
 import { LovelaceCardConfig } from "../../../data/lovelace";
 import {
   createLovelaceElement,
+  tryCreateLovelaceElement,
   getLovelaceElementClass,
 } from "./create-element-base";
 
@@ -51,8 +52,12 @@ const LAZY_LOAD_TYPES = {
   picture: () => import("../cards/hui-picture-card"),
 };
 
-export const createCardElement = (config: LovelaceCardConfig) =>
-  createLovelaceElement(
+export const createCardElement = (
+  config: LovelaceCardConfig,
+  handleErr: boolean = true // handles create error and returns HuiErrorCard
+) => {
+  const fCreate = handleErr ? createLovelaceElement : tryCreateLovelaceElement;
+  return fCreate(
     "card",
     config,
     ALWAYS_LOADED_TYPES,
@@ -60,6 +65,7 @@ export const createCardElement = (config: LovelaceCardConfig) =>
     undefined,
     undefined
   );
+};
 
 export const getCardElementClass = (type: string) =>
   getLovelaceElementClass(type, "card", ALWAYS_LOADED_TYPES, LAZY_LOAD_TYPES);

--- a/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-picker.ts
@@ -262,7 +262,7 @@ export class HuiCardPicker extends LitElement {
   }
 
   private _createCardElement(cardConfig: LovelaceCardConfig) {
-    const element = createCardElement(cardConfig) as LovelaceCard;
+    const element = createCardElement(cardConfig, false) as LovelaceCard;
     element.hass = this.hass;
     element.addEventListener(
       "ll-rebuild",
@@ -300,7 +300,11 @@ export class HuiCardPicker extends LitElement {
       );
 
       if (!noElement || customCard?.preview) {
-        element = this._createCardElement(cardConfig);
+        try {
+          element = this._createCardElement(cardConfig);
+        } catch (_e) {
+          // ignore exceptions
+        }
       }
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes the problem that the "Add Card" dialog printed error messages to the console log. This is becuase the `hui-card-picker` always trying to create a sample card element even if there is no entity exists. This is fixed by checking if there is an entity before actually create the sample card.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5458
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
