### PR TITLE
Add attribute 'hidden' to DataTableColumnData

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -74,6 +74,7 @@ export interface DataTableColumnData extends DataTableSortColumnData {
   width?: string;
   maxWidth?: string;
   grows?: boolean;
+  hidden?: boolean;
 }
 
 export interface DataTableRowData {
@@ -225,50 +226,52 @@ export class HaDataTable extends LitElement {
                   </div>
                 `
               : ""}
-            ${Object.entries(this.columns).map((columnEntry) => {
-              const [key, column] = columnEntry;
-              const sorted = key === this._sortColumn;
-              const classes = {
-                "mdc-data-table__header-cell--numeric": Boolean(
-                  column.type === "numeric"
-                ),
-                "mdc-data-table__header-cell--icon": Boolean(
-                  column.type === "icon"
-                ),
-                "mdc-data-table__header-cell--icon-button": Boolean(
-                  column.type === "icon-button"
-                ),
-                sortable: Boolean(column.sortable),
-                "not-sorted": Boolean(column.sortable && !sorted),
-                grows: Boolean(column.grows),
-              };
-              return html`
-                <div
-                  class="mdc-data-table__header-cell ${classMap(classes)}"
-                  style=${column.width
-                    ? styleMap({
-                        [column.grows ? "minWidth" : "width"]: column.width,
-                        maxWidth: column.maxWidth || "",
-                      })
-                    : ""}
-                  role="columnheader"
-                  scope="col"
-                  @click=${this._handleHeaderClick}
-                  .columnId=${key}
-                >
-                  ${column.sortable
-                    ? html`
-                        <ha-icon
-                          .icon=${sorted && this._sortDirection === "desc"
-                            ? "hass:arrow-down"
-                            : "hass:arrow-up"}
-                        ></ha-icon>
-                      `
-                    : ""}
-                  <span>${column.title}</span>
-                </div>
-              `;
-            })}
+            ${Object.entries(this.columns)
+              .filter((columnEntry) => !columnEntry[1].hidden)
+              .map((columnEntry) => {
+                const [key, column] = columnEntry;
+                const sorted = key === this._sortColumn;
+                const classes = {
+                  "mdc-data-table__header-cell--numeric": Boolean(
+                    column.type === "numeric"
+                  ),
+                  "mdc-data-table__header-cell--icon": Boolean(
+                    column.type === "icon"
+                  ),
+                  "mdc-data-table__header-cell--icon-button": Boolean(
+                    column.type === "icon-button"
+                  ),
+                  sortable: Boolean(column.sortable),
+                  "not-sorted": Boolean(column.sortable && !sorted),
+                  grows: Boolean(column.grows),
+                };
+                return html`
+                  <div
+                    class="mdc-data-table__header-cell ${classMap(classes)}"
+                    style=${column.width
+                      ? styleMap({
+                          [column.grows ? "minWidth" : "width"]: column.width,
+                          maxWidth: column.maxWidth || "",
+                        })
+                      : ""}
+                    role="columnheader"
+                    scope="col"
+                    @click=${this._handleHeaderClick}
+                    .columnId=${key}
+                  >
+                    ${column.sortable
+                      ? html`
+                          <ha-icon
+                            .icon=${sorted && this._sortDirection === "desc"
+                              ? "hass:arrow-down"
+                              : "hass:arrow-up"}
+                          ></ha-icon>
+                        `
+                      : ""}
+                    <span>${column.title}</span>
+                  </div>
+                `;
+              })}
           </div>
           ${!this._filteredData.length
             ? html`
@@ -325,39 +328,41 @@ export class HaDataTable extends LitElement {
                                 </div>
                               `
                             : ""}
-                          ${Object.entries(this.columns).map((columnEntry) => {
-                            const [key, column] = columnEntry;
-                            return html`
-                              <div
-                                class="mdc-data-table__cell ${classMap({
-                                  "mdc-data-table__cell--numeric": Boolean(
-                                    column.type === "numeric"
-                                  ),
-                                  "mdc-data-table__cell--icon": Boolean(
-                                    column.type === "icon"
-                                  ),
-                                  "mdc-data-table__cell--icon-button": Boolean(
-                                    column.type === "icon-button"
-                                  ),
-                                  grows: Boolean(column.grows),
-                                })}"
-                                style=${column.width
-                                  ? styleMap({
-                                      [column.grows
-                                        ? "minWidth"
-                                        : "width"]: column.width,
-                                      maxWidth: column.maxWidth
-                                        ? column.maxWidth
-                                        : "",
-                                    })
-                                  : ""}
-                              >
-                                ${column.template
-                                  ? column.template(row[key], row)
-                                  : row[key]}
-                              </div>
-                            `;
-                          })}
+                          ${Object.entries(this.columns)
+                            .filter((columnEntry) => !columnEntry[1].hidden)
+                            .map((columnEntry) => {
+                              const [key, column] = columnEntry;
+                              return html`
+                                <div
+                                  class="mdc-data-table__cell ${classMap({
+                                    "mdc-data-table__cell--numeric": Boolean(
+                                      column.type === "numeric"
+                                    ),
+                                    "mdc-data-table__cell--icon": Boolean(
+                                      column.type === "icon"
+                                    ),
+                                    "mdc-data-table__cell--icon-button": Boolean(
+                                      column.type === "icon-button"
+                                    ),
+                                    grows: Boolean(column.grows),
+                                  })}"
+                                  style=${column.width
+                                    ? styleMap({
+                                        [column.grows
+                                          ? "minWidth"
+                                          : "width"]: column.width,
+                                        maxWidth: column.maxWidth
+                                          ? column.maxWidth
+                                          : "",
+                                      })
+                                    : ""}
+                                >
+                                  ${column.template
+                                    ? column.template(row[key], row)
+                                    : row[key]}
+                                </div>
+                              `;
+                            })}
                         </div>
                       `;
                     },

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -123,117 +123,88 @@ export class HaConfigDeviceDashboard extends LitElement {
   );
 
   private _columns = memoizeOne(
-    (narrow: boolean): DataTableColumnContainer =>
-      narrow
-        ? {
-            name: {
-              title: "Device",
-              sortable: true,
-              filterable: true,
-              direction: "asc",
-              grows: true,
-              template: (name, device: DataTableRowData) => {
-                return html`
-                  ${name}
-                  <div class="secondary">
-                    ${device.area} | ${device.integration}
-                  </div>
+    (narrow: boolean): DataTableColumnContainer => {
+      const columns: DataTableColumnContainer = {
+        name: {
+          title: this.hass.localize(
+            "ui.panel.config.devices.data_table.device"
+          ),
+          sortable: true,
+          filterable: true,
+          grows: true,
+          direction: "asc",
+        },
+        manufacturer: {
+          title: this.hass.localize(
+            "ui.panel.config.devices.data_table.manufacturer"
+          ),
+          sortable: true,
+          filterable: !narrow,
+          hidden: narrow,
+          width: "15%",
+        },
+        model: {
+          title: this.hass.localize("ui.panel.config.devices.data_table.model"),
+          sortable: true,
+          filterable: !narrow,
+          hidden: narrow,
+          width: "15%",
+        },
+        area: {
+          title: this.hass.localize("ui.panel.config.devices.data_table.area"),
+          sortable: true,
+          filterable: true,
+          hidden: narrow,
+          width: "15%",
+        },
+        integration: {
+          title: this.hass.localize(
+            "ui.panel.config.devices.data_table.integration"
+          ),
+          sortable: true,
+          filterable: true,
+          hidden: narrow,
+          width: "15%",
+        },
+        battery_entity: {
+          title: this.hass.localize(
+            "ui.panel.config.devices.data_table.battery"
+          ),
+          sortable: true,
+          hidden: narrow,
+          type: "numeric",
+          width: narrow ? "90px" : "15%",
+          maxWidth: "90px",
+          template: (batteryEntity: string) => {
+            const battery = batteryEntity
+              ? this.hass.states[batteryEntity]
+              : undefined;
+            return battery && !isNaN(battery.state as any)
+              ? html`
+                  ${battery.state}%
+                  <ha-state-icon
+                    .hass=${this.hass!}
+                    .stateObj=${battery}
+                  ></ha-state-icon>
+                `
+              : html`
+                  -
                 `;
-              },
-            },
-            battery_entity: {
-              title: this.hass.localize(
-                "ui.panel.config.devices.data_table.battery"
-              ),
-              sortable: true,
-              type: "numeric",
-              width: "90px",
-              template: (batteryEntity: string) => {
-                const battery = batteryEntity
-                  ? this.hass.states[batteryEntity]
-                  : undefined;
-                return battery
-                  ? html`
-                      ${isNaN(battery.state as any) ? "-" : battery.state}%
-                      <ha-state-icon
-                        .hass=${this.hass!}
-                        .stateObj=${battery}
-                      ></ha-state-icon>
-                    `
-                  : html`
-                      -
-                    `;
-              },
-            },
-          }
-        : {
-            name: {
-              title: this.hass.localize(
-                "ui.panel.config.devices.data_table.device"
-              ),
-              sortable: true,
-              filterable: true,
-              grows: true,
-              direction: "asc",
-            },
-            manufacturer: {
-              title: this.hass.localize(
-                "ui.panel.config.devices.data_table.manufacturer"
-              ),
-              sortable: true,
-              filterable: true,
-              width: "15%",
-            },
-            model: {
-              title: this.hass.localize(
-                "ui.panel.config.devices.data_table.model"
-              ),
-              sortable: true,
-              filterable: true,
-              width: "15%",
-            },
-            area: {
-              title: this.hass.localize(
-                "ui.panel.config.devices.data_table.area"
-              ),
-              sortable: true,
-              filterable: true,
-              width: "15%",
-            },
-            integration: {
-              title: this.hass.localize(
-                "ui.panel.config.devices.data_table.integration"
-              ),
-              sortable: true,
-              filterable: true,
-              width: "15%",
-            },
-            battery_entity: {
-              title: this.hass.localize(
-                "ui.panel.config.devices.data_table.battery"
-              ),
-              sortable: true,
-              type: "numeric",
-              width: "15%",
-              maxWidth: "90px",
-              template: (batteryEntity: string) => {
-                const battery = batteryEntity
-                  ? this.hass.states[batteryEntity]
-                  : undefined;
-                return battery && !isNaN(battery.state as any)
-                  ? html`
-                      ${battery.state}%
-                      <ha-state-icon
-                        .hass=${this.hass!}
-                        .stateObj=${battery}
-                      ></ha-state-icon>
-                    `
-                  : html`
-                      -
-                    `;
-              },
-            },
-          }
+          },
+        },
+      };
+      if (narrow) {
+        columns.name.template = (name, device: DataTableRowData) => {
+          return html`
+            ${name}
+            <div class="secondary">
+              ${device.area} | ${device.integration}
+            </div>
+          `;
+        };
+      }
+      return columns;
+    }
   );
 
   protected render(): TemplateResult {

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -159,8 +159,6 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
               entity.platform}
           `;
         };
-        columns.status = statusColumn;
-        return columns;
       }
 
       columns.entity_id = {
@@ -169,6 +167,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         ),
         sortable: true,
         filterable: true,
+        hidden: narrow,
         width: "25%",
       };
       columns.platform = {
@@ -177,6 +176,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         ),
         sortable: true,
         filterable: true,
+        hidden: narrow,
         width: "20%",
         template: (platform) =>
           this.hass.localize(`component.${platform}.config.title`) || platform,

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -70,16 +70,15 @@ export class HaConfigHelpers extends LitElement {
             `,
         },
       };
-      if (!narrow) {
-        columns.entity_id = {
-          title: this.hass.localize(
-            "ui.panel.config.helpers.picker.headers.entity_id"
-          ),
-          sortable: true,
-          filterable: true,
-          width: "25%",
-        };
-      }
+      columns.entity_id = {
+        title: this.hass.localize(
+          "ui.panel.config.helpers.picker.headers.entity_id"
+        ),
+        sortable: true,
+        filterable: true,
+        hidden: narrow,
+        width: "25%",
+      };
       columns.type = {
         title: this.hass.localize(
           "ui.panel.config.helpers.picker.headers.type"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds 'hidden' attribute to `DataTableColumnData` to fix #5435. With this new attribute, columns that are not going to be rendered on mobile can also be passed into `ha-data-table` so that they can be used by the filter. Besides the Entities page mentioned in the issure, more pages like devices and automations also need to be fixed. I'll do it later.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5435 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
