### PR TITLE
Allow moving card to specific position

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -44,6 +44,12 @@ export class HuiCardOptions extends LitElement {
           </div>
           <div class="secondary-actions">
             <paper-icon-button
+              title="Move card"
+              class="move-arrow"
+              icon="mdi:arrow-all"
+              @mousedown="${this._moveSelect}"
+            ></paper-icon-button>
+            <paper-icon-button
               title="Move card down"
               class="move-arrow"
               icon="hass:arrow-down"
@@ -201,6 +207,70 @@ export class HuiCardOptions extends LitElement {
 
   private _deleteCard(): void {
     confDeleteCard(this, this.hass!, this.lovelace!, this.path!);
+  }
+
+  private _moveSelect(_event): void {
+    if (!cardMoveHandle.moveActive) {
+      cardMoveHandle.sourceCard = this;
+      document.addEventListener("click", moveHandle, false);
+    } else if (cardMoveHandle.sourceCard != this) {
+      this.style.outline = "2px solid var(--google-red-500)";
+      cardMoveHandle.movePositionCard(this.lovelace!, this.path!);
+    }
+  }
+}
+
+class cardMoveHandler {
+  public sourceCard: HuiCardOptions | undefined;
+  public moveActive: boolean;
+
+  constructor() {
+    this.sourceCard = undefined;
+    this.moveActive = false;
+  }
+
+  public clear(): void {
+    if (this.sourceCard!) {
+      this.sourceCard!.style.opacity = "";
+      this.sourceCard!.style.outline = "";
+    }
+    this.sourceCard = undefined;
+    this.moveActive = false;
+    document.removeEventListener("click", moveHandle, false);
+  }
+
+  public movePositionCard(lovelace, targetPath): void {
+    const sourceIndex = this.sourceCard!.path![1];
+    var newCards = [...lovelace.config.views[targetPath[0]].cards!];
+    const sourceCard = newCards[sourceIndex];
+
+    newCards.splice(sourceIndex, 1);
+    newCards.splice(targetPath[1], 0, sourceCard);
+    const newView = {
+      ...lovelace.config.views[targetPath[0]],
+      cards: newCards,
+    };
+
+    const config = {
+      ...lovelace.config,
+      views: lovelace.config.views.map((origView, index) =>
+        index === targetPath[0] ? newView : origView
+      ),
+    };
+    lovelace.saveConfig(config);
+    this.clear();
+  }
+}
+
+var cardMoveHandle = new cardMoveHandler();
+
+function moveHandle(_event): void {
+  if (cardMoveHandle.moveActive && cardMoveHandle.sourceCard) {
+    cardMoveHandle.clear();
+  } else if (cardMoveHandle.sourceCard) {
+    cardMoveHandle.moveActive = true;
+    cardMoveHandle.sourceCard!.style.opacity = "0.5";
+    cardMoveHandle.sourceCard!.style.outline = "2px solid var(--primary-color)";
   }
 }
 

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -213,14 +213,14 @@ export class HuiCardOptions extends LitElement {
     if (!cardMoveHandle.moveActive) {
       cardMoveHandle.sourceCard = this;
       document.addEventListener("click", moveHandle, false);
-    } else if (cardMoveHandle.sourceCard != this) {
+    } else if (cardMoveHandle.sourceCard !== this) {
       this.style.outline = "2px solid var(--google-red-500)";
       cardMoveHandle.movePositionCard(this.lovelace!, this.path!);
     }
   }
 }
 
-class cardMoveHandler {
+class CardMoveHandler {
   public sourceCard: HuiCardOptions | undefined;
   public moveActive: boolean;
 
@@ -241,7 +241,7 @@ class cardMoveHandler {
 
   public movePositionCard(lovelace, targetPath): void {
     const sourceIndex = this.sourceCard!.path![1];
-    var newCards = [...lovelace.config.views[targetPath[0]].cards!];
+    const newCards = [...lovelace.config.views[targetPath[0]].cards!];
     const sourceCard = newCards[sourceIndex];
 
     newCards.splice(sourceIndex, 1);
@@ -262,7 +262,7 @@ class cardMoveHandler {
   }
 }
 
-var cardMoveHandle = new cardMoveHandler();
+const cardMoveHandle = new CardMoveHandler();
 
 function moveHandle(_event): void {
   if (cardMoveHandle.moveActive && cardMoveHandle.sourceCard) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allows moving a card to a specific position/index directly. Currently we have to repeatedly click on the up/down arrows until the card reaches the desired position.

- Adds a move button next to up/down arrows for each card in config view

- When clicking the move button on the card to be moved, the card is selected to be moved.
If the next click is another cards move button, the selected card will take the second cards position.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Tested on Chrome Desktop, Android Chrome + Samsung Browser
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
