### PR TITLE
Filter add-ons in the store based on advanced mode

### DIFF
--- a/hassio/src/addon-store/hassio-addon-repository.ts
+++ b/hassio/src/addon-store/hassio-addon-repository.ts
@@ -64,52 +64,57 @@ class HassioAddonRepositoryEl extends LitElement {
         <div class="card-group">
           ${addons.map(
             (addon) => html`
-              <paper-card
-                .addon=${addon}
-                class=${addon.available ? "" : "not_available"}
-                @click=${this._addonTapped}
-              >
-                <div class="card-content">
-                  <hassio-card-content
-                    .hass=${this.hass}
-                    .title=${addon.name}
-                    .description=${addon.description}
-                    .available=${addon.available}
-                    .icon=${addon.installed && addon.installed !== addon.version
-                      ? "hassio:arrow-up-bold-circle"
-                      : "hassio:puzzle"}
-                    .iconTitle=${addon.installed
-                      ? addon.installed !== addon.version
-                        ? "New version available"
-                        : "Add-on is installed"
-                      : addon.available
-                      ? "Add-on is not installed"
-                      : "Add-on is not available on your system"}
-                    .iconClass=${addon.installed
-                      ? addon.installed !== addon.version
-                        ? "update"
-                        : "installed"
-                      : !addon.available
-                      ? "not_available"
-                      : ""}
-                    .iconImage=${atLeastVersion(
-                      this.hass.config.version,
-                      0,
-                      105
-                    ) && addon.icon
-                      ? `/api/hassio/addons/${addon.slug}/icon`
-                      : undefined}
-                    .showTopbar=${addon.installed || !addon.available}
-                    .topbarClass=${addon.installed
-                      ? addon.installed !== addon.version
-                        ? "update"
-                        : "installed"
-                      : !addon.available
-                      ? "unavailable"
-                      : ""}
-                  ></hassio-card-content>
-                </div>
-              </paper-card>
+              ${addon.advanced && !this.hass.userData?.showAdvanced
+                ? ""
+                : html`
+                    <paper-card
+                      .addon=${addon}
+                      class=${addon.available ? "" : "not_available"}
+                      @click=${this._addonTapped}
+                    >
+                      <div class="card-content">
+                        <hassio-card-content
+                          .hass=${this.hass}
+                          .title=${addon.name}
+                          .description=${addon.description}
+                          .available=${addon.available}
+                          .icon=${addon.installed &&
+                          addon.installed !== addon.version
+                            ? "hassio:arrow-up-bold-circle"
+                            : "hassio:puzzle"}
+                          .iconTitle=${addon.installed
+                            ? addon.installed !== addon.version
+                              ? "New version available"
+                              : "Add-on is installed"
+                            : addon.available
+                            ? "Add-on is not installed"
+                            : "Add-on is not available on your system"}
+                          .iconClass=${addon.installed
+                            ? addon.installed !== addon.version
+                              ? "update"
+                              : "installed"
+                            : !addon.available
+                            ? "not_available"
+                            : ""}
+                          .iconImage=${atLeastVersion(
+                            this.hass.config.version,
+                            0,
+                            105
+                          ) && addon.icon
+                            ? `/api/hassio/addons/${addon.slug}/icon`
+                            : undefined}
+                          .showTopbar=${addon.installed || !addon.available}
+                          .topbarClass=${addon.installed
+                            ? addon.installed !== addon.version
+                              ? "update"
+                              : "installed"
+                            : !addon.available
+                            ? "unavailable"
+                            : ""}
+                        ></hassio-card-content>
+                      </div>
+                    </paper-card>
+                  `}
             `
           )}
         </div>

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -12,6 +12,7 @@ export interface HassioAddonInfo {
   detached: boolean;
   available: boolean;
   build: boolean;
+  advanced: boolean;
   url: string | null;
   icon: boolean;
   logo: boolean;


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Uses the users advaced mode to hide add-ons from the store that are marked as advanced if the user has not enabled that in their profile.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4875
- This PR is related to issue: 
- Link to documentation pull request: 

### Simple user:
![image](https://user-images.githubusercontent.com/15093472/78703626-d2b60700-790a-11ea-97bf-93bd6a06568d.png)

### Advanced user:
![image](https://user-images.githubusercontent.com/15093472/78703641-d8abe800-790a-11ea-8ca7-20c87f4830e4.png)


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->
[docs-repository]: https://github.com/home-assistant/home-assistant.io
