### PR TITLE
Supervisor add-on revamp and documentation addition

### DIFF
--- a/hassio/src/addon-view/data/hassio-addon-sections.ts
+++ b/hassio/src/addon-view/data/hassio-addon-sections.ts
@@ -8,7 +8,7 @@ export const getAddonSections = memoizeOne(
     const sections: PageNavigation[] = [
       {
         component: "hassio-addon-info",
-        name: "Info",
+        name: "Details",
         path: `/hassio/addon/${addon.slug}/info`,
         icon: "hassio:information-outline",
         core: true,
@@ -21,19 +21,17 @@ export const getAddonSections = memoizeOne(
           component: "hassio-addon-docs",
           name: "Documentation",
           path: `/hassio/addon/${addon.slug}/docs`,
-          icon: "hassio:books",
+          icon: "hassio:book-outline",
           core: true,
         });
       }
-
       sections.push({
         component: "hassio-addon-config",
         name: "Configuration",
         path: `/hassio/addon/${addon.slug}/config`,
-        icon: "hassio:cog-outline",
+        icon: "hassio:settings-outline",
         core: true,
       });
-
       if (addon.audio) {
         sections.push({
           component: "hassio-addon-audio",
@@ -52,15 +50,14 @@ export const getAddonSections = memoizeOne(
           core: true,
         });
       }
+      sections.push({
+        component: "hassio-addon-logs",
+        name: "Logs",
+        path: `/hassio/addon/${addon.slug}/logs`,
+        icon: "hassio:text",
+        core: true,
+      });
     }
-
-    sections.push({
-      component: "hassio-addon-logs",
-      name: "Logs",
-      path: `/hassio/addon/${addon.slug}/logs`,
-      icon: "hassio:cog-outline",
-      core: true,
-    });
 
     return sections;
   }

--- a/hassio/src/addon-view/data/hassio-addon-sections.ts
+++ b/hassio/src/addon-view/data/hassio-addon-sections.ts
@@ -1,0 +1,67 @@
+import memoizeOne from "memoize-one";
+
+import { HassioAddonDetails } from "../../../../src/data/hassio/addon";
+import { PageNavigation } from "../../../../src/layouts/hass-tabs-subpage";
+
+export const getAddonSections = memoizeOne(
+  (addon: HassioAddonDetails): PageNavigation[] => {
+    const sections: PageNavigation[] = [
+      {
+        component: "hassio-addon-info",
+        name: "Info",
+        path: `/hassio/addon/${addon.slug}/info`,
+        icon: "hassio:information-outline",
+        core: true,
+      },
+    ];
+
+    if (addon && addon.version) {
+      if (addon.documentation) {
+        sections.push({
+          component: "hassio-addon-docs",
+          name: "Documentation",
+          path: `/hassio/addon/${addon.slug}/docs`,
+          icon: "hassio:books",
+          core: true,
+        });
+      }
+
+      sections.push({
+        component: "hassio-addon-config",
+        name: "Configuration",
+        path: `/hassio/addon/${addon.slug}/config`,
+        icon: "hassio:cog-outline",
+        core: true,
+      });
+
+      if (addon.audio) {
+        sections.push({
+          component: "hassio-addon-audio",
+          name: "Audio",
+          path: `/hassio/addon/${addon.slug}/audio`,
+          icon: "hassio:speaker",
+          core: true,
+        });
+      }
+      if (addon.network) {
+        sections.push({
+          component: "hassio-addon-network",
+          name: "Network",
+          path: `/hassio/addon/${addon.slug}/network`,
+          icon: "hassio:lan",
+          core: true,
+        });
+      }
+    }
+
+    sections.push({
+      component: "hassio-addon-logs",
+      name: "Logs",
+      path: `/hassio/addon/${addon.slug}/logs`,
+      icon: "hassio:cog-outline",
+      core: true,
+    });
+
+    return sections;
+  }
+);

--- a/hassio/src/addon-view/hassio-addon-audio.ts
+++ b/hassio/src/addon-view/hassio-addon-audio.ts
@@ -28,7 +28,7 @@ import {
 } from "../../../src/data/hassio/hardware";
 import { hassioStyle } from "../resources/hassio-style";
 import { haStyle } from "../../../src/resources/styles";
-import { getAddonSections } from "./data/hassio-addon-sections";
+import { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
 
 import "../../../src/layouts/hass-tabs-subpage";
 
@@ -40,6 +40,7 @@ class HassioAddonAudio extends LitElement {
   @property() public isWide!: boolean;
   @property() public showAdvanced!: boolean;
   @property() public route!: Route;
+  @property() public sections!: PageNavigation[];
   @property() private _error?: string;
   @property() private _inputDevices?: HassioHardwareAudioDevice[];
   @property() private _outputDevices?: HassioHardwareAudioDevice[];
@@ -52,7 +53,7 @@ class HassioAddonAudio extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
-        .tabs=${getAddonSections(this.addon)}
+        .tabs=${this.sections}
         hassio
       >
         <div class="container">
@@ -137,7 +138,6 @@ class HassioAddonAudio extends LitElement {
             min-width: 100%;
           }
         }
-        :host,
         paper-card,
         paper-dropdown-menu {
           display: block;

--- a/hassio/src/addon-view/hassio-addon-audio.ts
+++ b/hassio/src/addon-view/hassio-addon-audio.ts
@@ -16,7 +16,7 @@ import {
   TemplateResult,
 } from "lit-element";
 
-import { HomeAssistant } from "../../../src/types";
+import { HomeAssistant, Route } from "../../../src/types";
 import {
   HassioAddonDetails,
   setHassioAddonOption,
@@ -28,11 +28,18 @@ import {
 } from "../../../src/data/hassio/hardware";
 import { hassioStyle } from "../resources/hassio-style";
 import { haStyle } from "../../../src/resources/styles";
+import { getAddonSections } from "./data/hassio-addon-sections";
+
+import "../../../src/layouts/hass-tabs-subpage";
 
 @customElement("hassio-addon-audio")
 class HassioAddonAudio extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public addon!: HassioAddonDetails;
+  @property() public narrow!: boolean;
+  @property() public isWide!: boolean;
+  @property() public showAdvanced!: boolean;
+  @property() public route!: Route;
   @property() private _error?: string;
   @property() private _inputDevices?: HassioHardwareAudioDevice[];
   @property() private _outputDevices?: HassioHardwareAudioDevice[];
@@ -41,57 +48,69 @@ class HassioAddonAudio extends LitElement {
 
   protected render(): TemplateResult {
     return html`
-      <paper-card heading="Audio">
-        <div class="card-content">
-          ${this._error
-            ? html`
-                <div class="errors">${this._error}</div>
-              `
-            : ""}
+      <hass-tabs-subpage
+        .hass=${this.hass}
+        .narrow=${this.narrow}
+        .route=${this.route}
+        .tabs=${getAddonSections(this.addon)}
+        hassio
+      >
+        <div class="container">
+          <div class="content">
+            <paper-card heading="Audio">
+              <div class="card-content">
+                ${this._error
+                  ? html`
+                      <div class="errors">${this._error}</div>
+                    `
+                  : ""}
 
-          <paper-dropdown-menu
-            label="Input"
-            @iron-select=${this._setInputDevice}
-          >
-            <paper-listbox
-              slot="dropdown-content"
-              attr-for-selected="device"
-              .selected=${this._selectedInput}
-            >
-              ${this._inputDevices &&
-                this._inputDevices.map((item) => {
-                  return html`
-                    <paper-item device=${item.device || ""}
-                      >${item.name}</paper-item
-                    >
-                  `;
-                })}
-            </paper-listbox>
-          </paper-dropdown-menu>
-          <paper-dropdown-menu
-            label="Output"
-            @iron-select=${this._setOutputDevice}
-          >
-            <paper-listbox
-              slot="dropdown-content"
-              attr-for-selected="device"
-              .selected=${this._selectedOutput}
-            >
-              ${this._outputDevices &&
-                this._outputDevices.map((item) => {
-                  return html`
-                    <paper-item device=${item.device || ""}
-                      >${item.name}</paper-item
-                    >
-                  `;
-                })}
-            </paper-listbox>
-          </paper-dropdown-menu>
+                <paper-dropdown-menu
+                  label="Input"
+                  @iron-select=${this._setInputDevice}
+                >
+                  <paper-listbox
+                    slot="dropdown-content"
+                    attr-for-selected="device"
+                    .selected=${this._selectedInput}
+                  >
+                    ${this._inputDevices &&
+                      this._inputDevices.map((item) => {
+                        return html`
+                          <paper-item device=${item.device || ""}
+                            >${item.name}</paper-item
+                          >
+                        `;
+                      })}
+                  </paper-listbox>
+                </paper-dropdown-menu>
+                <paper-dropdown-menu
+                  label="Output"
+                  @iron-select=${this._setOutputDevice}
+                >
+                  <paper-listbox
+                    slot="dropdown-content"
+                    attr-for-selected="device"
+                    .selected=${this._selectedOutput}
+                  >
+                    ${this._outputDevices &&
+                      this._outputDevices.map((item) => {
+                        return html`
+                          <paper-item device=${item.device || ""}
+                            >${item.name}</paper-item
+                          >
+                        `;
+                      })}
+                  </paper-listbox>
+                </paper-dropdown-menu>
+              </div>
+              <div class="card-actions">
+                <mwc-button @click=${this._saveSettings}>Save</mwc-button>
+              </div>
+            </paper-card>
+          </div>
         </div>
-        <div class="card-actions">
-          <mwc-button @click=${this._saveSettings}>Save</mwc-button>
-        </div>
-      </paper-card>
+      </hass-tabs-subpage>
     `;
   }
 
@@ -100,6 +119,24 @@ class HassioAddonAudio extends LitElement {
       haStyle,
       hassioStyle,
       css`
+        .container {
+          display: flex;
+          width: 100%;
+          justify-content: center;
+        }
+        .content {
+          display: flex;
+          width: 600px;
+          margin-bottom: 24px;
+          padding: 24px 0 32px;
+          flex-direction: column;
+        }
+        @media only screen and (max-width: 600px) {
+          .content {
+            max-width: 100%;
+            min-width: 100%;
+          }
+        }
         :host,
         paper-card,
         paper-dropdown-menu {

--- a/hassio/src/addon-view/hassio-addon-config.ts
+++ b/hassio/src/addon-view/hassio-addon-config.ts
@@ -26,7 +26,7 @@ import "../../../src/components/ha-yaml-editor";
 // tslint:disable-next-line: no-duplicate-imports
 import { HaYamlEditor } from "../../../src/components/ha-yaml-editor";
 import { showConfirmationDialog } from "../../../src/dialogs/generic/show-dialog-box";
-import { getAddonSections } from "./data/hassio-addon-sections";
+import { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
 
 import "../../../src/layouts/hass-tabs-subpage";
 
@@ -38,6 +38,7 @@ class HassioAddonConfig extends LitElement {
   @property() public isWide!: boolean;
   @property() public showAdvanced!: boolean;
   @property() public route!: Route;
+  @property() public sections!: PageNavigation[];
   @property() private _error?: string;
   @property({ type: Boolean }) private _configHasChanged = false;
 
@@ -53,7 +54,7 @@ class HassioAddonConfig extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
-        .tabs=${getAddonSections(this.addon)}
+        .tabs=${this.sections}
         hassio
       >
         <div class="container">

--- a/hassio/src/addon-view/hassio-addon-config.ts
+++ b/hassio/src/addon-view/hassio-addon-config.ts
@@ -13,7 +13,7 @@ import {
   query,
 } from "lit-element";
 
-import { HomeAssistant } from "../../../src/types";
+import { HomeAssistant, Route } from "../../../src/types";
 import {
   HassioAddonDetails,
   setHassioAddonOption,
@@ -26,11 +26,18 @@ import "../../../src/components/ha-yaml-editor";
 // tslint:disable-next-line: no-duplicate-imports
 import { HaYamlEditor } from "../../../src/components/ha-yaml-editor";
 import { showConfirmationDialog } from "../../../src/dialogs/generic/show-dialog-box";
+import { getAddonSections } from "./data/hassio-addon-sections";
+
+import "../../../src/layouts/hass-tabs-subpage";
 
 @customElement("hassio-addon-config")
 class HassioAddonConfig extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public addon!: HassioAddonDetails;
+  @property() public narrow!: boolean;
+  @property() public isWide!: boolean;
+  @property() public showAdvanced!: boolean;
+  @property() public route!: Route;
   @property() private _error?: string;
   @property({ type: Boolean }) private _configHasChanged = false;
 
@@ -42,34 +49,46 @@ class HassioAddonConfig extends LitElement {
     const valid = editor ? editor.isValid : true;
 
     return html`
-      <paper-card heading="Config">
-        <div class="card-content">
-          <ha-yaml-editor
-            @value-changed=${this._configChanged}
-          ></ha-yaml-editor>
-          ${this._error
-            ? html`
-                <div class="errors">${this._error}</div>
-              `
-            : ""}
-          ${valid
-            ? ""
-            : html`
-                <div class="errors">Invalid YAML</div>
-              `}
+      <hass-tabs-subpage
+        .hass=${this.hass}
+        .narrow=${this.narrow}
+        .route=${this.route}
+        .tabs=${getAddonSections(this.addon)}
+        hassio
+      >
+        <div class="container">
+          <div class="content">
+            <paper-card heading="Config">
+              <div class="card-content">
+                <ha-yaml-editor
+                  @value-changed=${this._configChanged}
+                ></ha-yaml-editor>
+                ${this._error
+                  ? html`
+                      <div class="errors">${this._error}</div>
+                    `
+                  : ""}
+                ${valid
+                  ? ""
+                  : html`
+                      <div class="errors">Invalid YAML</div>
+                    `}
+              </div>
+              <div class="card-actions">
+                <mwc-button class="warning" @click=${this._resetTapped}>
+                  Reset to defaults
+                </mwc-button>
+                <mwc-button
+                  @click=${this._saveTapped}
+                  .disabled=${!this._configHasChanged || !valid}
+                >
+                  Save
+                </mwc-button>
+              </div>
+            </paper-card>
+          </div>
         </div>
-        <div class="card-actions">
-          <mwc-button class="warning" @click=${this._resetTapped}>
-            Reset to defaults
-          </mwc-button>
-          <mwc-button
-            @click=${this._saveTapped}
-            .disabled=${!this._configHasChanged || !valid}
-          >
-            Save
-          </mwc-button>
-        </div>
-      </paper-card>
+      </hass-tabs-subpage>
     `;
   }
 
@@ -78,8 +97,23 @@ class HassioAddonConfig extends LitElement {
       haStyle,
       hassioStyle,
       css`
-        :host {
-          display: block;
+        .container {
+          display: flex;
+          width: 100%;
+          justify-content: center;
+        }
+        .content {
+          display: flex;
+          width: 600px;
+          margin-bottom: 24px;
+          padding: 24px 0 32px;
+          flex-direction: column;
+        }
+        @media only screen and (max-width: 600px) {
+          .content {
+            max-width: 100%;
+            min-width: 100%;
+          }
         }
         paper-card {
           display: block;

--- a/hassio/src/addon-view/hassio-addon-docs.ts
+++ b/hassio/src/addon-view/hassio-addon-docs.ts
@@ -19,10 +19,10 @@ import {
 import { hassioStyle } from "../resources/hassio-style";
 import { haStyle } from "../../../src/resources/styles";
 import { HomeAssistant, Route } from "../../../src/types";
-import { getAddonSections } from "./data/hassio-addon-sections";
+import { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
 
-import "../../../src/components/ha-markdown";
 import "../../../src/layouts/hass-tabs-subpage";
+import "../../../src/components/ha-markdown";
 
 @customElement("hassio-addon-docs")
 class HassioAddonDocs extends LitElement {
@@ -32,6 +32,7 @@ class HassioAddonDocs extends LitElement {
   @property() public isWide!: boolean;
   @property() public showAdvanced!: boolean;
   @property() public route!: Route;
+  @property() public sections!: PageNavigation[];
 
   private _documentation?: string;
 
@@ -41,14 +42,14 @@ class HassioAddonDocs extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
-        .tabs=${getAddonSections(this.addon)}
+        .tabs=${this.sections}
         hassio
       >
         <div class="container">
           <div class="content">
             ${this._documentation
               ? html`
-                  <paper-card>
+                  <paper-card heading="Documentation">
                     <div class="card-content">
                       <ha-markdown
                         .content=${this._documentation}
@@ -85,6 +86,9 @@ class HassioAddonDocs extends LitElement {
             max-width: 100%;
             min-width: 100%;
           }
+        }
+        .card-content {
+          padding: 0 16px 16px;
         }
         paper-card {
           display: block;

--- a/hassio/src/addon-view/hassio-addon-info.ts
+++ b/hassio/src/addon-view/hassio-addon-info.ts
@@ -13,14 +13,6 @@ import {
 } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 
-import "../../../src/components/buttons/ha-call-api-button";
-import "../../../src/components/buttons/ha-progress-button";
-import "../../../src/components/ha-label-badge";
-import "../../../src/components/ha-markdown";
-import "../../../src/components/ha-switch";
-import "../components/hassio-card-content";
-import "../../../src/layouts/hass-tabs-subpage";
-
 import { fireEvent } from "../../../src/common/dom/fire_event";
 import {
   HassioAddonDetails,
@@ -38,7 +30,15 @@ import { HomeAssistant, Route } from "../../../src/types";
 import { navigate } from "../../../src/common/navigate";
 import { showHassioMarkdownDialog } from "../dialogs/markdown/show-dialog-hassio-markdown";
 import { atLeastVersion } from "../../../src/common/config/version";
-import { getAddonSections } from "./data/hassio-addon-sections";
+import { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
+
+import "../../../src/layouts/hass-tabs-subpage";
+import "../../../src/components/buttons/ha-call-api-button";
+import "../../../src/components/buttons/ha-progress-button";
+import "../../../src/components/ha-label-badge";
+import "../../../src/components/ha-markdown";
+import "../../../src/components/ha-switch";
+import "../components/hassio-card-content";
 
 const PERMIS_DESC = {
   rating: {
@@ -101,6 +101,7 @@ class HassioAddonInfo extends LitElement {
   @property() public isWide!: boolean;
   @property() public showAdvanced!: boolean;
   @property() public route!: Route;
+  @property() public sections!: PageNavigation[];
   @property() private _error?: string;
   @property({ type: Boolean }) private _installing = false;
 
@@ -110,7 +111,7 @@ class HassioAddonInfo extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
-        .tabs=${getAddonSections(this.addon)}
+        .tabs=${this.sections}
         hassio
       >
         <div class="container">
@@ -457,7 +458,7 @@ class HassioAddonInfo extends LitElement {
                               rel="noopener"
                             >
                               <mwc-button>
-                                Open web UI
+                                Open Web UI
                               </mwc-button>
                             </a>
                           `
@@ -468,7 +469,7 @@ class HassioAddonInfo extends LitElement {
                               class="right"
                               @click=${this._openIngress}
                             >
-                              Open web UI
+                              Open Web UI
                             </mwc-button>
                           `
                         : ""}

--- a/hassio/src/addon-view/hassio-addon-info.ts
+++ b/hassio/src/addon-view/hassio-addon-info.ts
@@ -38,7 +38,6 @@ import { HomeAssistant } from "../../../src/types";
 import { navigate } from "../../../src/common/navigate";
 import { showHassioMarkdownDialog } from "../dialogs/markdown/show-dialog-hassio-markdown";
 import { atLeastVersion } from "../../../src/common/config/version";
-import { HassioResponse } from "../../../src/data/hassio/common";
 
 const PERMIS_DESC = {
   rating: {

--- a/hassio/src/addon-view/hassio-addon-logs.ts
+++ b/hassio/src/addon-view/hassio-addon-logs.ts
@@ -18,7 +18,7 @@ import {
 import { ANSI_HTML_STYLE, parseTextToColoredPre } from "../ansi-to-html";
 import { hassioStyle } from "../resources/hassio-style";
 import { haStyle } from "../../../src/resources/styles";
-import { getAddonSections } from "./data/hassio-addon-sections";
+import { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
 
 import "../../../src/layouts/hass-tabs-subpage";
 
@@ -30,6 +30,7 @@ class HassioAddonLogs extends LitElement {
   @property() public isWide!: boolean;
   @property() public showAdvanced!: boolean;
   @property() public route!: Route;
+  @property() public sections!: PageNavigation[];
   @property() private _error?: string;
   @query("#content") private _logContent!: any;
 
@@ -44,18 +45,19 @@ class HassioAddonLogs extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
-        .tabs=${getAddonSections(this.addon)}
+        .tabs=${this.sections}
         hassio
       >
         <div class="container">
           <div class="content">
             <paper-card heading="Log">
-              ${this._error
-                ? html`
-                    <div class="errors">${this._error}</div>
-                  `
-                : ""}
-              <div class="card-content" id="content"></div>
+              <div class="card-content" id="content">
+                ${this._error
+                  ? html`
+                      <div class="errors">${this._error}</div>
+                    `
+                  : ""}
+              </div>
               <div class="card-actions">
                 <mwc-button @click=${this._refresh}>Refresh</mwc-button>
               </div>
@@ -79,7 +81,6 @@ class HassioAddonLogs extends LitElement {
         }
         .content {
           display: flex;
-          width: 600px;
           min-width: 600px;
           max-width: calc(100% - 8px);
           margin-bottom: 24px;
@@ -92,11 +93,11 @@ class HassioAddonLogs extends LitElement {
             min-width: 100%;
           }
         }
-        :host,
         paper-card {
           display: block;
         }
         pre {
+          margin: 0;
           overflow-x: auto;
           white-space: pre-wrap;
           overflow-wrap: break-word;

--- a/hassio/src/addon-view/hassio-addon-network.ts
+++ b/hassio/src/addon-view/hassio-addon-network.ts
@@ -12,7 +12,7 @@ import {
 
 import { PaperInputElement } from "@polymer/paper-input/paper-input";
 
-import { HomeAssistant } from "../../../src/types";
+import { HomeAssistant, Route } from "../../../src/types";
 import {
   HassioAddonDetails,
   HassioAddonSetOptionParams,
@@ -21,6 +21,9 @@ import {
 import { hassioStyle } from "../resources/hassio-style";
 import { haStyle } from "../../../src/resources/styles";
 import { fireEvent } from "../../../src/common/dom/fire_event";
+import { getAddonSections } from "./data/hassio-addon-sections";
+
+import "../../../src/layouts/hass-tabs-subpage";
 
 interface NetworkItem {
   description: string;
@@ -36,6 +39,10 @@ interface NetworkItemInput extends PaperInputElement {
 class HassioAddonNetwork extends LitElement {
   @property() public hass!: HomeAssistant;
   @property() public addon!: HassioAddonDetails;
+  @property() public narrow!: boolean;
+  @property() public isWide!: boolean;
+  @property() public showAdvanced!: boolean;
+  @property() public route!: Route;
   @property() private _error?: string;
   @property() private _config?: NetworkItem[];
 
@@ -45,53 +52,65 @@ class HassioAddonNetwork extends LitElement {
   }
 
   protected render(): TemplateResult {
-    if (!this._config) {
-      return html``;
-    }
-
     return html`
-      <paper-card heading="Network">
-        <div class="card-content">
-          ${this._error
-            ? html`
-                <div class="errors">${this._error}</div>
-              `
-            : ""}
+      <hass-tabs-subpage
+        .hass=${this.hass}
+        .narrow=${this.narrow}
+        .route=${this.route}
+        .tabs=${getAddonSections(this.addon)}
+        hassio
+      >
+        ${this._config
+          ? html`
+              <div class="container">
+                <div class="content">
+                  <paper-card heading="Network">
+                    <div class="card-content">
+                      ${this._error
+                        ? html`
+                            <div class="errors">${this._error}</div>
+                          `
+                        : ""}
 
-          <table>
-            <tbody>
-              <tr>
-                <th>Container</th>
-                <th>Host</th>
-                <th>Description</th>
-              </tr>
-              ${this._config!.map((item) => {
-                return html`
-                  <tr>
-                    <td>${item.container}</td>
-                    <td>
-                      <paper-input
-                        @value-changed=${this._configChanged}
-                        placeholder="disabled"
-                        .value=${item.host}
-                        .container=${item.container}
-                        no-label-float
-                      ></paper-input>
-                    </td>
-                    <td>${item.description}</td>
-                  </tr>
-                `;
-              })}
-            </tbody>
-          </table>
-        </div>
-        <div class="card-actions">
-          <mwc-button class="warning" @click=${this._resetTapped}>
-            Reset to defaults
-          </mwc-button>
-          <mwc-button @click=${this._saveTapped}>Save</mwc-button>
-        </div>
-      </paper-card>
+                      <table>
+                        <tbody>
+                          <tr>
+                            <th>Container</th>
+                            <th>Host</th>
+                            <th>Description</th>
+                          </tr>
+                          ${this._config!.map((item) => {
+                            return html`
+                              <tr>
+                                <td>${item.container}</td>
+                                <td>
+                                  <paper-input
+                                    @value-changed=${this._configChanged}
+                                    placeholder="disabled"
+                                    .value=${item.host}
+                                    .container=${item.container}
+                                    no-label-float
+                                  ></paper-input>
+                                </td>
+                                <td>${item.description}</td>
+                              </tr>
+                            `;
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                    <div class="card-actions">
+                      <mwc-button class="warning" @click=${this._resetTapped}>
+                        Reset to defaults
+                      </mwc-button>
+                      <mwc-button @click=${this._saveTapped}>Save</mwc-button>
+                    </div>
+                  </paper-card>
+                </div>
+              </div>
+            `
+          : ""}
+      </hass-tabs-subpage>
     `;
   }
 
@@ -100,8 +119,23 @@ class HassioAddonNetwork extends LitElement {
       haStyle,
       hassioStyle,
       css`
-        :host {
-          display: block;
+        .container {
+          display: flex;
+          width: 100%;
+          justify-content: center;
+        }
+        .content {
+          display: flex;
+          width: 600px;
+          margin-bottom: 24px;
+          padding: 24px 0 32px;
+          flex-direction: column;
+        }
+        @media only screen and (max-width: 600px) {
+          .content {
+            max-width: 100%;
+            min-width: 100%;
+          }
         }
         paper-card {
           display: block;

--- a/hassio/src/addon-view/hassio-addon-network.ts
+++ b/hassio/src/addon-view/hassio-addon-network.ts
@@ -21,7 +21,7 @@ import {
 import { hassioStyle } from "../resources/hassio-style";
 import { haStyle } from "../../../src/resources/styles";
 import { fireEvent } from "../../../src/common/dom/fire_event";
-import { getAddonSections } from "./data/hassio-addon-sections";
+import { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
 
 import "../../../src/layouts/hass-tabs-subpage";
 
@@ -43,6 +43,7 @@ class HassioAddonNetwork extends LitElement {
   @property() public isWide!: boolean;
   @property() public showAdvanced!: boolean;
   @property() public route!: Route;
+  @property() public sections!: PageNavigation[];
   @property() private _error?: string;
   @property() private _config?: NetworkItem[];
 
@@ -57,7 +58,7 @@ class HassioAddonNetwork extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
-        .tabs=${getAddonSections(this.addon)}
+        .tabs=${this.sections}
         hassio
       >
         ${this._config

--- a/hassio/src/addon-view/hassio-addon-router.ts
+++ b/hassio/src/addon-view/hassio-addon-router.ts
@@ -1,0 +1,82 @@
+import "@polymer/app-route/app-route";
+import { property, customElement } from "lit-element";
+
+import {
+  HassRouterPage,
+  RouterOptions,
+} from "../../../src/layouts/hass-router-page";
+import { HomeAssistant, Route } from "../../../src/types";
+import { HassioAddonDetails } from "../../../src/data/hassio/addon";
+
+@customElement("hassio-addon-router")
+class HaAddonRouter extends HassRouterPage {
+  @property() public hass!: HomeAssistant;
+  @property() public route!: Route;
+  @property() public addon!: HassioAddonDetails;
+  @property() public narrow!: boolean;
+  @property() public isWide!: boolean;
+  @property() public showAdvanced!: boolean;
+
+  protected routerOptions: RouterOptions = {
+    defaultPage: "info",
+    routes: {
+      info: {
+        tag: "hassio-addon-info",
+        load: () =>
+          import(
+            /* webpackChunkName: "hassio-addon-info" */ "./hassio-addon-info"
+          ),
+      },
+      docs: {
+        tag: "hassio-addon-docs",
+        load: () =>
+          import(
+            /* webpackChunkName: "hassio-addon-docs" */ "./hassio-addon-docs"
+          ),
+      },
+      config: {
+        tag: "hassio-addon-config",
+        load: () =>
+          import(
+            /* webpackChunkName: "hassio-addon-config" */ "./hassio-addon-config"
+          ),
+      },
+      audio: {
+        tag: "hassio-addon-audio",
+        load: () =>
+          import(
+            /* webpackChunkName: "hassio-addon-audio" */ "./hassio-addon-audio"
+          ),
+      },
+      network: {
+        tag: "hassio-addon-network",
+        load: () =>
+          import(
+            /* webpackChunkName: "hassio-addon-network" */ "./hassio-addon-network"
+          ),
+      },
+      logs: {
+        tag: "hassio-addon-logs",
+        load: () =>
+          import(
+            /* webpackChunkName: "hassio-addon-logs" */ "./hassio-addon-logs"
+          ),
+      },
+    },
+  };
+
+  protected updatePageEl(pageEl) {
+    pageEl.hass = this.hass;
+    pageEl.route = this.routeTail;
+    pageEl.addon = this.addon;
+    pageEl.narrow = this.narrow;
+    pageEl.isWide = this.isWide;
+    pageEl.showAdvanced = this.showAdvanced;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hassio-addon-router": HaAddonRouter;
+  }
+}

--- a/hassio/src/addon-view/hassio-addon-router.ts
+++ b/hassio/src/addon-view/hassio-addon-router.ts
@@ -7,18 +7,22 @@ import {
 } from "../../../src/layouts/hass-router-page";
 import { HomeAssistant, Route } from "../../../src/types";
 import { HassioAddonDetails } from "../../../src/data/hassio/addon";
+import { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
 
 @customElement("hassio-addon-router")
 class HaAddonRouter extends HassRouterPage {
   @property() public hass!: HomeAssistant;
-  @property() public route!: Route;
   @property() public addon!: HassioAddonDetails;
   @property() public narrow!: boolean;
   @property() public isWide!: boolean;
   @property() public showAdvanced!: boolean;
+  @property() public route!: Route;
+  @property() public sections!: PageNavigation[];
 
   protected routerOptions: RouterOptions = {
     defaultPage: "info",
+    preloadAll: true,
+    showLoading: true,
     routes: {
       info: {
         tag: "hassio-addon-info",
@@ -67,11 +71,12 @@ class HaAddonRouter extends HassRouterPage {
 
   protected updatePageEl(pageEl) {
     pageEl.hass = this.hass;
-    pageEl.route = this.routeTail;
     pageEl.addon = this.addon;
     pageEl.narrow = this.narrow;
     pageEl.isWide = this.isWide;
     pageEl.showAdvanced = this.showAdvanced;
+    pageEl.route = this.routeTail;
+    pageEl.sections = this.sections;
   }
 }
 

--- a/hassio/src/addon-view/hassio-addon-view.ts
+++ b/hassio/src/addon-view/hassio-addon-view.ts
@@ -20,6 +20,8 @@ import {
 } from "../../../src/data/hassio/addon";
 import { hassioStyle } from "../resources/hassio-style";
 import { haStyle } from "../../../src/resources/styles";
+import { PageNavigation } from "../../../src/layouts/hass-tabs-subpage";
+import { getAddonSections } from "./data/hassio-addon-sections";
 
 import "./hassio-addon-router";
 
@@ -46,9 +48,12 @@ class HassioAddonView extends LitElement {
         : "",
     };
 
+    const sections: PageNavigation[] = getAddonSections(this.addon);
+
     return html`
       <hassio-addon-router
         .hass=${this.hass}
+        .sections=${sections}
         .route=${route}
         .addon=${this.addon}
         .narrow=${this.narrow}

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -70,6 +70,7 @@ export interface HassioAddonDetails extends HassioAddonInfo {
   ingress_panel: boolean;
   ingress_entry: null | string;
   ingress_url: null | string;
+  documentation: boolean;
 }
 
 export interface HassioAddonsInfo {
@@ -119,6 +120,17 @@ export const fetchHassioAddonInfo = async (
       `hassio/addons/${slug}/info`
     )
   );
+};
+
+export const fetchHassioAddonDocumentation = async (
+  hass: HomeAssistant,
+  slug: string
+): Promise<HassioResponse<string>> => {
+  const response = await hass.callApi<HassioResponse<any>>(
+    "GET",
+    `hassio/addons/${slug}/documentation`
+  );
+  return response;
 };
 
 export const fetchHassioAddonChangelog = async (

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -100,11 +100,15 @@ export interface HassioAddonSetOptionParams {
   network?: object | null;
 }
 
-export const reloadHassioAddons = async (hass: HomeAssistant) => {
+export const reloadHassioAddons = async (
+  hass: HomeAssistant
+): Promise<void> => {
   await hass.callApi<HassioResponse<void>>("POST", `hassio/addons/reload`);
 };
 
-export const fetchHassioAddonsInfo = async (hass: HomeAssistant) => {
+export const fetchHassioAddonsInfo = async (
+  hass: HomeAssistant
+): Promise<HassioAddonsInfo> => {
   return hassioApiResultExtractor(
     await hass.callApi<HassioResponse<HassioAddonsInfo>>("GET", `hassio/addons`)
   );
@@ -113,7 +117,7 @@ export const fetchHassioAddonsInfo = async (hass: HomeAssistant) => {
 export const fetchHassioAddonInfo = async (
   hass: HomeAssistant,
   slug: string
-) => {
+): Promise<HassioAddonDetails> => {
   return hassioApiResultExtractor(
     await hass.callApi<HassioResponse<HassioAddonDetails>>(
       "GET",
@@ -125,25 +129,21 @@ export const fetchHassioAddonInfo = async (
 export const fetchHassioAddonDocumentation = async (
   hass: HomeAssistant,
   slug: string
-): Promise<HassioResponse<string>> => {
-  const response = await hass.callApi<HassioResponse<any>>(
-    "GET",
-    `hassio/addons/${slug}/documentation`
-  );
-  return response;
+): Promise<string> => {
+  return hass.callApi<string>("GET", `hassio/addons/${slug}/documentation`);
 };
 
 export const fetchHassioAddonChangelog = async (
   hass: HomeAssistant,
   slug: string
-) => {
+): Promise<string> => {
   return hass.callApi<string>("GET", `hassio/addons/${slug}/changelog`);
 };
 
 export const fetchHassioAddonLogs = async (
   hass: HomeAssistant,
   slug: string
-) => {
+): Promise<string> => {
   return hass.callApi<string>("GET", `hassio/addons/${slug}/logs`);
 };
 
@@ -163,7 +163,7 @@ export const setHassioAddonSecurity = async (
   hass: HomeAssistant,
   slug: string,
   data: HassioAddonSetSecurityParams
-) => {
+): Promise<void> => {
   await hass.callApi<HassioResponse<void>>(
     "POST",
     `hassio/addons/${slug}/security`,
@@ -171,7 +171,10 @@ export const setHassioAddonSecurity = async (
   );
 };
 
-export const installHassioAddon = async (hass: HomeAssistant, slug: string) => {
+export const installHassioAddon = async (
+  hass: HomeAssistant,
+  slug: string
+): Promise<HassioResponse<void>> => {
   return hass.callApi<HassioResponse<void>>(
     "POST",
     `hassio/addons/${slug}/install`
@@ -181,7 +184,7 @@ export const installHassioAddon = async (hass: HomeAssistant, slug: string) => {
 export const uninstallHassioAddon = async (
   hass: HomeAssistant,
   slug: string
-) => {
+): Promise<void> => {
   await hass.callApi<HassioResponse<void>>(
     "POST",
     `hassio/addons/${slug}/uninstall`

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -76,7 +76,7 @@ class HassTabsSubpage extends LitElement {
                     <span class="name"
                       >${page.translationKey
                         ? this.hass.localize(page.translationKey)
-                        : name}</span
+                        : page.name}</span
                     >
                   `
                 : ""}


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Convert to hass-tabs-subpage UI
- Splits singular section for add-ons into each respective view/tab
- Adds documentation tab
- Fix and cleanup css

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (thank you!)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
### Not installed
![Screenshot_20200412_150156](https://user-images.githubusercontent.com/28114703/79070586-c2b57300-7cce-11ea-8f2f-1f5192d480dd.png)

### Installed
![Screenshot_20200412_150009](https://user-images.githubusercontent.com/28114703/79070579-bc26fb80-7cce-11ea-9b09-a5fea6c598db.png)
![Screenshot_20200412_150027](https://user-images.githubusercontent.com/28114703/79070581-bdf0bf00-7cce-11ea-9812-d18ecbbec546.png)
![Screenshot_20200412_150034](https://user-images.githubusercontent.com/28114703/79070582-bf21ec00-7cce-11ea-8b74-dea7ac5aec99.png)
![Screenshot_20200412_150048](https://user-images.githubusercontent.com/28114703/79070584-c0531900-7cce-11ea-967f-ca31ef6942ab.png)
![Screenshot_20200412_150114](https://user-images.githubusercontent.com/28114703/79070585-c1844600-7cce-11ea-9698-b30ac2315cf8.png)

### Mobile
![Screenshot_20200412-151049](https://user-images.githubusercontent.com/28114703/79070817-f5ac3680-7ccf-11ea-80e4-17a18793da1f.jpg)


- This PR fixes or closes issue: fixes #4873

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
