### PR TITLE
Add secondary option for cover entities

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -29,7 +29,12 @@ export interface EntityCardConfig extends LovelaceCardConfig {
 
 export interface EntitiesCardEntityConfig extends EntityConfig {
   type?: string;
-  secondary_info?: "entity-id" | "last-changed";
+  secondary_info?:
+    | "entity-id"
+    | "last-changed"
+    | "last-triggered"
+    | "position"
+    | "tilt-position";
   action_name?: string;
   service?: string;
   service_data?: object;

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -112,6 +112,16 @@ class HuiGenericEntityRow extends LitElement {
                     : this.hass.localize(
                         "ui.panel.lovelace.cards.entities.never_triggered"
                       )
+                  : this.config.secondary_info === "position" &&
+                    stateObj.attributes.current_position
+                  ? this.hass.localize("ui.card.cover.position") +
+                    ": " +
+                    stateObj.attributes.current_position
+                  : this.config.secondary_info === "tilt-position" &&
+                    stateObj.attributes.current_tilt_position
+                  ? this.hass.localize("ui.card.cover.tilt_position") +
+                    ": " +
+                    stateObj.attributes.current_tilt_position
                   : "")}
               </div>
             `

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -114,14 +114,14 @@ class HuiGenericEntityRow extends LitElement {
                       )
                   : this.config.secondary_info === "position" &&
                     stateObj.attributes.current_position
-                  ? this.hass.localize("ui.card.cover.position") +
-                    ": " +
-                    stateObj.attributes.current_position
+                  ? `${this.hass.localize("ui.card.cover.position")}: ${
+                      stateObj.attributes.current_position
+                    }`
                   : this.config.secondary_info === "tilt-position" &&
                     stateObj.attributes.current_tilt_position
-                  ? this.hass.localize("ui.card.cover.tilt_position") +
-                    ": " +
-                    stateObj.attributes.current_tilt_position
+                  ? `${this.hass.localize("ui.card.cover.tilt_position")}: ${
+                      stateObj.attributes.current_tilt_position
+                    }`
                   : "")}
               </div>
             `

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -113,12 +113,12 @@ class HuiGenericEntityRow extends LitElement {
                         "ui.panel.lovelace.cards.entities.never_triggered"
                       )
                   : this.config.secondary_info === "position" &&
-                    stateObj.attributes.current_position
+                    stateObj.attributes.current_position !== undefined
                   ? `${this.hass.localize("ui.card.cover.position")}: ${
                       stateObj.attributes.current_position
                     }`
                   : this.config.secondary_info === "tilt-position" &&
-                    stateObj.attributes.current_tilt_position
+                    stateObj.attributes.current_tilt_position !== undefined
                   ? `${this.hass.localize("ui.card.cover.tilt_position")}: ${
                       stateObj.attributes.current_tilt_position
                     }`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add `position` and `tilt-position` for cover as options for secondary_info.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
# Config
cover:
  - platform: demo

# ui-lovelace
- type: entities
  title: Cover
  entities:
    - entity: cover.hall_window
      secondary_info: position
    - entity: cover.living_room_window
      secondary_info: tilt-position
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Since `last-triggered` was added as an option (#4222), I think cover-position and tilt-position are useful as well.
![Cover_secondary_line](https://user-images.githubusercontent.com/30130371/79472231-dda42200-8003-11ea-8ed4-f4b61f33aa40.png)


- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13009

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
