### PR TITLE
Add multi option support to more-info-vacuum

### DIFF
--- a/src/data/vacuum.ts
+++ b/src/data/vacuum.ts
@@ -12,6 +12,7 @@ export const VACUUM_SUPPORT_STATUS = 128;
 export const VACUUM_SUPPORT_LOCATE = 512;
 export const VACUUM_SUPPORT_CLEAN_SPOT = 1024;
 export const VACUUM_SUPPORT_START = 8192;
+export const VACUUM_SUPPORT_OPTION = 16384;
 
 export type VacuumEntity = HassEntityBase & {
   attributes: HassEntityAttributeBase & {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add multi option support so that we can set options other than fan speed in the more info dialog. This PR is to support backend [#34569](https://github.com/home-assistant/core/pull/34569).
![Screenshot from 2020-04-22 19-57-53](https://user-images.githubusercontent.com/7052824/80055164-e732fb80-84d5-11ea-974b-2018929de365.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
