### PR TITLE
Allow passing the current value to config flow input fields

### DIFF
--- a/src/components/ha-form/ha-form-integer.ts
+++ b/src/components/ha-form/ha-form-integer.ts
@@ -77,7 +77,12 @@ export class HaFormInteger extends LitElement implements HaFormElement {
   }
 
   private get _value() {
-    return this.data || this.schema.default || 0;
+    return (
+      this.data ||
+      this.schema.description?.suggested_value ||
+      this.schema.default ||
+      0
+    );
   }
 
   private _handleCheckboxChange(ev: Event) {

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -30,7 +30,7 @@ export interface HaFormBaseSchema {
   default?: HaFormData;
   required?: boolean;
   optional?: boolean;
-  description?: { suffix?: string; current_value?: any };
+  description?: { suffix?: string; current_value?: HaFormData };
 }
 
 export interface HaFormIntegerSchema extends HaFormBaseSchema {

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -30,7 +30,7 @@ export interface HaFormBaseSchema {
   default?: HaFormData;
   required?: boolean;
   optional?: boolean;
-  description?: { suffix?: string };
+  description?: { suffix?: string; current_value?: any };
 }
 
 export interface HaFormIntegerSchema extends HaFormBaseSchema {

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -30,7 +30,7 @@ export interface HaFormBaseSchema {
   default?: HaFormData;
   required?: boolean;
   optional?: boolean;
-  description?: { suffix?: string; current_value?: HaFormData };
+  description?: { suffix?: string; suggested_value?: HaFormData };
 }
 
 export interface HaFormIntegerSchema extends HaFormBaseSchema {

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -122,7 +122,7 @@ class StepFlowForm extends LitElement {
 
     const data = {};
     this.step.data_schema.forEach((field) => {
-      if ("description" in field && "current_value" in field.description) {
+      if (field?.description?.current_value) {
         data[field.name] = field.description.current_value;
       } else if ("default" in field) {
         data[field.name] = field.default;

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -122,7 +122,7 @@ class StepFlowForm extends LitElement {
 
     const data = {};
     this.step.data_schema.forEach((field) => {
-      if (field?.description?.current_value) {
+      if (field.description?.current_value) {
         data[field.name] = field.description.current_value;
       } else if ("default" in field) {
         data[field.name] = field.default;

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -122,7 +122,9 @@ class StepFlowForm extends LitElement {
 
     const data = {};
     this.step.data_schema.forEach((field) => {
-      if ("default" in field) {
+      if ("description" in field && "current_value" in field.description) {
+        data[field.name] = field.description.current_value;
+      } else if ("default" in field) {
         data[field.name] = field.default;
       }
     });

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -122,8 +122,8 @@ class StepFlowForm extends LitElement {
 
     const data = {};
     this.step.data_schema.forEach((field) => {
-      if (field.description?.current_value) {
-        data[field.name] = field.description.current_value;
+      if (field.description?.suggested_value) {
+        data[field.name] = field.description.suggested_value;
       } else if ("default" in field) {
         data[field.name] = field.default;
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR creates a mechanism for the backend to pass the current value of config flow fields. The existing way of doing this is to set the `default` parameter in the schema, but that has the adverse effect of not being able to remove an optional value, since it will be populated with the default if left empty.
After this PR is merged, the backend can pass the current value without setting a default. An example:

```python
vol.Schema({
  vol.Optional("port", description={"suggested_value": 1234}): int
})
```
If the current value is not present, the default will still be used, so existing integrations would not be broken as a result of this change.

You can also mix and match the current value and the default - the dialog will show the current value, but if left empty, the default will be used.
## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5337 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
