### PR TITLE
Prevent recreation of entities row on every update of hass

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -35,11 +35,11 @@ export class HaDeviceEntitiesCard extends LitElement {
   @queryAll("#entities > *") private _entityRows?: LovelaceRow[];
 
   protected shouldUpdate(changedProps: PropertyValues) {
-    if (changedProps.size === 1 && changedProps.has("hass")) {
+    if (changedProps.has("hass")) {
       this._entityRows?.forEach((element) => {
         element.hass = this.hass;
       });
-      return false;
+      return changedProps.size > 1;
     }
     return true;
   }

--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -28,24 +28,20 @@ import { EntityRegistryStateEntry } from "../ha-config-device-page";
 export class HaDeviceEntitiesCard extends LitElement {
   @property() public hass!: HomeAssistant;
 
-  @property() public deviceId!: string;
-
   @property() public entities!: EntityRegistryStateEntry[];
-
-  @property() public narrow!: boolean;
 
   @property() private _showDisabled = false;
 
   @queryAll("#entities > *") private _entityRows?: LovelaceRow[];
 
-  protected updated(changedProps: PropertyValues): void {
-    super.updated(changedProps);
-    if (!changedProps.has("hass")) {
-      return;
+  protected shouldUpdate(changedProps: PropertyValues) {
+    if (changedProps.size === 1 && changedProps.has("hass")) {
+      this._entityRows?.forEach((element) => {
+        element.hass = this.hass;
+      });
+      return false;
     }
-    this._entityRows?.forEach((element) => {
-      element.hass = this.hass;
-    });
+    return true;
   }
 
   protected render(): TemplateResult {


### PR DESCRIPTION
## Proposed change

The entity row would be recreated on every update of hass, that's not good!

Now only when the entities change or when you toggle disabled entities.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
