### PR TITLE
Added options to Lovelace evaluate filter

### DIFF
--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -20,7 +20,26 @@ export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
       return state > value;
     case "!=":
       return state !== value;
+    case "in":
+      if (Array.isArray(state) || typeof state === typeof "string") {
+        return state.includes(value);
+      }
+      return false;
+    case "not in":
+      if (Array.isArray(state) || typeof state === typeof "string") {
+        return !state.includes(value);
+      }
+      return false;
     case "regex": {
+      if (
+        typeof state !== typeof "string" &&
+        typeof state !== typeof 1 &&
+        typeof state !== typeof true &&
+        state !== null &&
+        typeof state !== typeof undefined
+      ) {
+        return state.match(JSON.stringify(value));
+      }
       return state.match(value);
     }
     default:

--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -21,26 +21,20 @@ export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
     case "!=":
       return state !== value;
     case "in":
-      if (Array.isArray(state) || typeof state === typeof "string") {
+      if (Array.isArray(state) || typeof state === "string") {
         return state.includes(value);
       }
       return false;
     case "not in":
-      if (Array.isArray(state) || typeof state === typeof "string") {
+      if (Array.isArray(state) || typeof state === "string") {
         return !state.includes(value);
       }
       return false;
     case "regex": {
-      if (
-        typeof state !== typeof "string" &&
-        typeof state !== typeof 1 &&
-        typeof state !== typeof true &&
-        state !== null &&
-        typeof state !== typeof undefined
-      ) {
-        return (JSON.stringify(state) as any).match(value);
+      if (state !== null && typeof state === "object") {
+        return RegExp(value).test(JSON.stringify(state));
       }
-      return state.match(value);
+      return RegExp(value).test(state);
     }
     default:
       return false;

--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -38,7 +38,7 @@ export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
         state !== null &&
         typeof state !== typeof undefined
       ) {
-        return state.match(JSON.stringify(value));
+        return (JSON.stringify(state) as any).match(value);
       }
       return state.match(value);
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the ability to filter arrays, JSON objects, and sub-strings in Lovelace cards that use the evaluate-filter common function. This is executed by adding "in" and "not in" to the list of allowed operators and  testing if the state or state attribute is an array.  If it is an array, it tests if the array includes a value of (or does not include a value of for "not in") the filter.value parameter. If the state or state.attribute is a string it will see if the filter.value is a sub-string of (contains) the state or state.attribute.  The "regex" operator is modified to evaluate if the state or state.attribute is an array or JSON object and then converts it to a string using JSON.stringify() so regex can be used to evaluate it.  The "regex" operator is unchanged for all other types.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
# Value is in an array attribute
- type: entity-filter
  entities:
    - media_player.sonos_1
    - media_player.sonos_2
    - media_player.sonos_3
  state_filter:
    - attribute: sonos_group
      operator: in
      value: media_player.sonos_1

# Value is not in an array attribute
- type: entity-filter
  entities:
    - media_player.sonos_1
    - media_player.sonos_2
    - media_player.sonos_3
  state_filter:
    - attribute: sonos_group
      operator: not in
      value: media_player.sonos_1

# Regex evaluation on array attribute
- type: entity-filter
  entities:
    - media_player.sonos_1
    - media_player.sonos_2
    - media_player.sonos_3
  state_filter:
    - attribute: sonos_group
      operator: regex
      value: '.*sonos_1'

# Regex evaluation on JSON/object attribute
- type: entity-filter
  entities:
    - weather.city_1
    - weather.city_2
  state_filter:
    - attribute: forecast
      operator: regex
      value: '"condition": "rainy"'
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13254

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
