### PR TITLE
Adds dialog to ask user to restart add-on on configuration changes

### DIFF
--- a/hassio/src/addon-view/config/hassio-addon-audio.ts
+++ b/hassio/src/addon-view/config/hassio-addon-audio.ts
@@ -24,7 +24,7 @@ import {
   fetchHassioHardwareAudio,
   HassioHardwareAudioDevice,
 } from "../../../../src/data/hassio/hardware";
-import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
+import { suggestRestart } from "../../dialogs/suggestRestart";
 import { haStyle } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";
 import { hassioStyle } from "../../resources/hassio-style";
@@ -185,18 +185,11 @@ class HassioAddonAudio extends LitElement {
     } catch {
       this._error = "Failed to set addon audio device";
     }
-    if (this.addon?.state === "started") {
-      const confirmed = await showConfirmationDialog(this, {
-        title: this.addon.name,
-        text: "Do you want to restart the add-on with your changes?",
-        confirmText: "restart add-on",
-      });
-      if (confirmed) {
-        try {
-          await restartHassioAddon(this.hass, this.addon.slug);
-        } catch (err) {
-          this._error = `Failed to restart addon, ${err.body?.message || err}`;
-        }
+    if (!this._error && this.addon?.state === "started") {
+      try {
+        await suggestRestart(this, this.hass, this.addon);
+      } catch (err) {
+        this._error = `Failed to restart addon, ${err.body?.message || err}`;
       }
     }
   }

--- a/hassio/src/addon-view/config/hassio-addon-audio.ts
+++ b/hassio/src/addon-view/config/hassio-addon-audio.ts
@@ -23,7 +23,7 @@ import {
   fetchHassioHardwareAudio,
   HassioHardwareAudioDevice,
 } from "../../../../src/data/hassio/hardware";
-import { suggestRestart } from "../../dialogs/suggestRestart";
+import { suggestAddonRestart } from "../../dialogs/suggestAddonRestart";
 import { haStyle } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";
 import { hassioStyle } from "../../resources/hassio-style";
@@ -185,7 +185,7 @@ class HassioAddonAudio extends LitElement {
       this._error = "Failed to set addon audio device";
     }
     if (!this._error && this.addon?.state === "started") {
-      await suggestRestart(this, this.hass, this.addon);
+      await suggestAddonRestart(this, this.hass, this.addon);
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-audio.ts
+++ b/hassio/src/addon-view/config/hassio-addon-audio.ts
@@ -186,11 +186,7 @@ class HassioAddonAudio extends LitElement {
       this._error = "Failed to set addon audio device";
     }
     if (!this._error && this.addon?.state === "started") {
-      try {
-        await suggestRestart(this, this.hass, this.addon);
-      } catch (err) {
-        this._error = `Failed to restart addon, ${err.body?.message || err}`;
-      }
+      await suggestRestart(this, this.hass, this.addon);
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-audio.ts
+++ b/hassio/src/addon-view/config/hassio-addon-audio.ts
@@ -18,11 +18,13 @@ import {
   HassioAddonDetails,
   HassioAddonSetOptionParams,
   setHassioAddonOption,
+  restartHassioAddon,
 } from "../../../../src/data/hassio/addon";
 import {
   fetchHassioHardwareAudio,
   HassioHardwareAudioDevice,
 } from "../../../../src/data/hassio/hardware";
+import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";
 import { hassioStyle } from "../../resources/hassio-style";
@@ -182,6 +184,20 @@ class HassioAddonAudio extends LitElement {
       await setHassioAddonOption(this.hass, this.addon.slug, data);
     } catch {
       this._error = "Failed to set addon audio device";
+    }
+    if (this.addon?.state === "started") {
+      const confirmed = await showConfirmationDialog(this, {
+        title: this.addon.name,
+        text: "Do you want to restart the add-on with your changes?",
+        confirmText: "restart add-on",
+      });
+      if (confirmed) {
+        try {
+          await restartHassioAddon(this.hass, this.addon.slug);
+        } catch (err) {
+          this._error = `Failed to restart addon, ${err.body?.message || err}`;
+        }
+      }
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-audio.ts
+++ b/hassio/src/addon-view/config/hassio-addon-audio.ts
@@ -18,7 +18,6 @@ import {
   HassioAddonDetails,
   HassioAddonSetOptionParams,
   setHassioAddonOption,
-  restartHassioAddon,
 } from "../../../../src/data/hassio/addon";
 import {
   fetchHassioHardwareAudio,

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -25,7 +25,7 @@ import { haStyle } from "../../../../src/resources/styles";
 import type { HomeAssistant } from "../../../../src/types";
 import { hassioStyle } from "../../resources/hassio-style";
 
-import { suggestRestart } from "../../dialogs/suggestRestart";
+import { suggestAddonRestart } from "../../dialogs/suggestAddonRestart";
 
 @customElement("hassio-addon-config")
 class HassioAddonConfig extends LitElement {
@@ -167,7 +167,7 @@ class HassioAddonConfig extends LitElement {
       }`;
     }
     if (!this._error && this.addon?.state === "started") {
-      await suggestRestart(this, this.hass, this.addon);
+      await suggestAddonRestart(this, this.hass, this.addon);
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -167,11 +167,7 @@ class HassioAddonConfig extends LitElement {
       }`;
     }
     if (!this._error && this.addon?.state === "started") {
-      try {
-        await suggestRestart(this, this.hass, this.addon);
-      } catch (err) {
-        this._error = `Failed to restart addon, ${err.body?.message || err}`;
-      }
+      await suggestRestart(this, this.hass, this.addon);
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -19,12 +19,13 @@ import {
   HassioAddonDetails,
   HassioAddonSetOptionParams,
   setHassioAddonOption,
-  restartHassioAddon,
 } from "../../../../src/data/hassio/addon";
 import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../../src/resources/styles";
 import type { HomeAssistant } from "../../../../src/types";
 import { hassioStyle } from "../../resources/hassio-style";
+
+import { suggestRestart } from "../../dialogs/suggestRestart";
 
 @customElement("hassio-addon-config")
 class HassioAddonConfig extends LitElement {
@@ -165,18 +166,11 @@ class HassioAddonConfig extends LitElement {
         err.body?.message || err
       }`;
     }
-    if (this.addon?.state === "started") {
-      const confirmed = await showConfirmationDialog(this, {
-        title: this.addon.name,
-        text: "Do you want to restart the add-on with your changes?",
-        confirmText: "restart add-on",
-      });
-      if (confirmed) {
-        try {
-          await restartHassioAddon(this.hass, this.addon.slug);
-        } catch (err) {
-          this._error = `Failed to restart addon, ${err.body?.message || err}`;
-        }
+    if (!this._error && this.addon?.state === "started") {
+      try {
+        await suggestRestart(this, this.hass, this.addon);
+      } catch (err) {
+        this._error = `Failed to restart addon, ${err.body?.message || err}`;
       }
     }
   }

--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -19,6 +19,7 @@ import {
   HassioAddonDetails,
   HassioAddonSetOptionParams,
   setHassioAddonOption,
+  restartHassioAddon,
 } from "../../../../src/data/hassio/addon";
 import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../../src/resources/styles";
@@ -163,6 +164,20 @@ class HassioAddonConfig extends LitElement {
       this._error = `Failed to save addon configuration, ${
         err.body?.message || err
       }`;
+    }
+    if (this.addon?.state === "started") {
+      const confirmed = await showConfirmationDialog(this, {
+        title: this.addon.name,
+        text: "Do you want to restart the add-on with your changes?",
+        confirmText: "restart add-on",
+      });
+      if (confirmed) {
+        try {
+          await restartHassioAddon(this.hass, this.addon.slug);
+        } catch (err) {
+          this._error = `Failed to restart addon, ${err.body?.message || err}`;
+        }
+      }
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-network.ts
+++ b/hassio/src/addon-view/config/hassio-addon-network.ts
@@ -16,7 +16,7 @@ import {
   HassioAddonSetOptionParams,
   setHassioAddonOption,
 } from "../../../../src/data/hassio/addon";
-import { suggestRestart } from "../../dialogs/suggestRestart";
+import { suggestAddonRestart } from "../../dialogs/suggestAddonRestart";
 
 import { haStyle } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";
@@ -168,7 +168,7 @@ class HassioAddonNetwork extends LitElement {
       }`;
     }
     if (!this._error && this.addon?.state === "started") {
-      await suggestRestart(this, this.hass, this.addon);
+      await suggestAddonRestart(this, this.hass, this.addon);
     }
   }
 
@@ -197,7 +197,7 @@ class HassioAddonNetwork extends LitElement {
       }`;
     }
     if (!this._error && this.addon?.state === "started") {
-      await suggestRestart(this, this.hass, this.addon);
+      await suggestAddonRestart(this, this.hass, this.addon);
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-network.ts
+++ b/hassio/src/addon-view/config/hassio-addon-network.ts
@@ -15,7 +15,9 @@ import {
   HassioAddonDetails,
   HassioAddonSetOptionParams,
   setHassioAddonOption,
+  restartHassioAddon,
 } from "../../../../src/data/hassio/addon";
+import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";
 import { hassioStyle } from "../../resources/hassio-style";
@@ -165,6 +167,7 @@ class HassioAddonNetwork extends LitElement {
         err.body?.message || err
       }`;
     }
+    await this._restartAddon();
   }
 
   private async _saveTapped(): Promise<void> {
@@ -190,6 +193,24 @@ class HassioAddonNetwork extends LitElement {
       this._error = `Failed to set addon network configuration, ${
         err.body?.message || err
       }`;
+    }
+    await this._restartAddon();
+  }
+
+  private async _restartAddon(): Promise<void> {
+    if (this.addon?.state === "started") {
+      const confirmed = await showConfirmationDialog(this, {
+        title: this.addon.name,
+        text: "Do you want to restart the add-on with your changes?",
+        confirmText: "restart add-on",
+      });
+      if (confirmed) {
+        try {
+          await restartHassioAddon(this.hass, this.addon.slug);
+        } catch (err) {
+          this._error = `Failed to restart addon, ${err.body?.message || err}`;
+        }
+      }
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-network.ts
+++ b/hassio/src/addon-view/config/hassio-addon-network.ts
@@ -168,11 +168,7 @@ class HassioAddonNetwork extends LitElement {
       }`;
     }
     if (!this._error && this.addon?.state === "started") {
-      try {
-        await suggestRestart(this, this.hass, this.addon);
-      } catch (err) {
-        this._error = `Failed to restart addon, ${err.body?.message || err}`;
-      }
+      await suggestRestart(this, this.hass, this.addon);
     }
   }
 
@@ -201,11 +197,7 @@ class HassioAddonNetwork extends LitElement {
       }`;
     }
     if (!this._error && this.addon?.state === "started") {
-      try {
-        await suggestRestart(this, this.hass, this.addon);
-      } catch (err) {
-        this._error = `Failed to restart addon, ${err.body?.message || err}`;
-      }
+      await suggestRestart(this, this.hass, this.addon);
     }
   }
 }

--- a/hassio/src/addon-view/config/hassio-addon-network.ts
+++ b/hassio/src/addon-view/config/hassio-addon-network.ts
@@ -15,9 +15,9 @@ import {
   HassioAddonDetails,
   HassioAddonSetOptionParams,
   setHassioAddonOption,
-  restartHassioAddon,
 } from "../../../../src/data/hassio/addon";
-import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
+import { suggestRestart } from "../../dialogs/suggestRestart";
+
 import { haStyle } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";
 import { hassioStyle } from "../../resources/hassio-style";
@@ -167,7 +167,13 @@ class HassioAddonNetwork extends LitElement {
         err.body?.message || err
       }`;
     }
-    await this._restartAddon();
+    if (!this._error && this.addon?.state === "started") {
+      try {
+        await suggestRestart(this, this.hass, this.addon);
+      } catch (err) {
+        this._error = `Failed to restart addon, ${err.body?.message || err}`;
+      }
+    }
   }
 
   private async _saveTapped(): Promise<void> {
@@ -194,22 +200,11 @@ class HassioAddonNetwork extends LitElement {
         err.body?.message || err
       }`;
     }
-    await this._restartAddon();
-  }
-
-  private async _restartAddon(): Promise<void> {
-    if (this.addon?.state === "started") {
-      const confirmed = await showConfirmationDialog(this, {
-        title: this.addon.name,
-        text: "Do you want to restart the add-on with your changes?",
-        confirmText: "restart add-on",
-      });
-      if (confirmed) {
-        try {
-          await restartHassioAddon(this.hass, this.addon.slug);
-        } catch (err) {
-          this._error = `Failed to restart addon, ${err.body?.message || err}`;
-        }
+    if (!this._error && this.addon?.state === "started") {
+      try {
+        await suggestRestart(this, this.hass, this.addon);
+      } catch (err) {
+        this._error = `Failed to restart addon, ${err.body?.message || err}`;
       }
     }
   }

--- a/hassio/src/dialogs/suggestAddonRestart.ts
+++ b/hassio/src/dialogs/suggestAddonRestart.ts
@@ -9,7 +9,7 @@ import {
   showAlertDialog,
 } from "../../../src/dialogs/generic/show-dialog-box";
 
-export const suggestRestart = async (
+export const suggestAddonRestart = async (
   element: LitElement,
   hass: HomeAssistant,
   addon: HassioAddonDetails

--- a/hassio/src/dialogs/suggestRestart.ts
+++ b/hassio/src/dialogs/suggestRestart.ts
@@ -1,10 +1,13 @@
-import { LitElement } from "lit-element";
+import type { LitElement } from "lit-element";
 import {
   HassioAddonDetails,
   restartHassioAddon,
 } from "../../../src/data/hassio/addon";
 import { HomeAssistant } from "../../../src/types";
-import { showConfirmationDialog } from "../../../src/dialogs/generic/show-dialog-box";
+import {
+  showConfirmationDialog,
+  showAlertDialog,
+} from "../../../src/dialogs/generic/show-dialog-box";
 
 export const suggestRestart = async (
   element: LitElement,
@@ -21,7 +24,10 @@ export const suggestRestart = async (
     try {
       await restartHassioAddon(hass, addon.slug);
     } catch (err) {
-      throw Error(`Failed to restart addon, ${err.body?.message || err}`);
+      showAlertDialog(element, {
+        title: "Faled to restart",
+        text: err.body.message,
+      });
     }
   }
 };

--- a/hassio/src/dialogs/suggestRestart.ts
+++ b/hassio/src/dialogs/suggestRestart.ts
@@ -1,0 +1,27 @@
+import { LitElement } from "lit-element";
+import {
+  HassioAddonDetails,
+  restartHassioAddon,
+} from "../../../src/data/hassio/addon";
+import { HomeAssistant } from "../../../src/types";
+import { showConfirmationDialog } from "../../../src/dialogs/generic/show-dialog-box";
+
+export const suggestRestart = async (
+  element: LitElement,
+  hass: HomeAssistant,
+  addon: HassioAddonDetails
+): Promise<void> => {
+  const confirmed = await showConfirmationDialog(element, {
+    title: addon.name,
+    text: "Do you want to restart the add-on with your changes?",
+    confirmText: "restart add-on",
+    dismissText: "no",
+  });
+  if (confirmed) {
+    try {
+      await restartHassioAddon(hass, addon.slug);
+    } catch (err) {
+      throw Error(`Failed to restart addon, ${err.body?.message || err}`);
+    }
+  }
+};

--- a/hassio/src/dialogs/suggestRestart.ts
+++ b/hassio/src/dialogs/suggestRestart.ts
@@ -25,7 +25,7 @@ export const suggestRestart = async (
       await restartHassioAddon(hass, addon.slug);
     } catch (err) {
       showAlertDialog(element, {
-        title: "Faled to restart",
+        title: "Failed to restart",
         text: err.body.message,
       });
     }

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -175,6 +175,13 @@ export const installHassioAddon = async (hass: HomeAssistant, slug: string) => {
   );
 };
 
+export const restartHassioAddon = async (hass: HomeAssistant, slug: string) => {
+  return hass.callApi<HassioResponse<void>>(
+    "POST",
+    `hassio/addons/${slug}/restart`
+  );
+};
+
 export const uninstallHassioAddon = async (
   hass: HomeAssistant,
   slug: string


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
![image](https://user-images.githubusercontent.com/15093472/80860409-c7cf6780-8c67-11ea-9793-e1e85cab3a51.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #5703
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
