### PR TITLE
Add CSS variable for Card spacing

### DIFF
--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -148,7 +148,7 @@ export class HUIView extends LitElement {
 
         .column > * {
           display: block;
-          margin: var(--hui-view-column-margin);
+          margin: var(--hui-view-column-margin, 4px 4px 8px);
         }
 
         ha-fab {

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -148,7 +148,7 @@ export class HUIView extends LitElement {
 
         .column > * {
           display: block;
-          margin: 4px 4px 8px;
+          margin: var(--hui-view-column-margin);
         }
 
         ha-fab {

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -148,7 +148,7 @@ export class HUIView extends LitElement {
 
         .column > * {
           display: block;
-          margin: var(--hui-view-column-margin, 4px 4px 8px);
+          margin: var(--view-column-margin, 4px 4px 8px);
         }
 
         ha-fab {

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -92,8 +92,6 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-primary-text-color: 33, 33, 33;
       --rgb-secondary-text-color: 114, 114, 114;
       --rgb-text-primary-color: 255, 255, 255;
-      /* other */
-      --hui-column-margin:4px 4px 8px;
 
       ${Object.entries(derivedStyles)
         .map(([key, value]) => `--${key}: ${value};`)

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -92,6 +92,8 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-primary-text-color: 33, 33, 33;
       --rgb-secondary-text-color: 114, 114, 114;
       --rgb-text-primary-color: 255, 255, 255;
+      /* other */
+      --hui-column-margin:4px 4px 8px;
 
       ${Object.entries(derivedStyles)
         .map(([key, value]) => `--${key}: ${value};`)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Card spacing cannot be customized, which affects the play of custom themes, such as shadows.
This change provides a CSS variable with adjustable spacing
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
