### PR TITLE
Supervisor dialogs

### DIFF
--- a/hassio/src/addon-view/config/hassio-addon-config.ts
+++ b/hassio/src/addon-view/config/hassio-addon-config.ts
@@ -116,6 +116,7 @@ class HassioAddonConfig extends LitElement {
       title: this.addon.name,
       text: "Are you sure you want to reset all your options?",
       confirmText: "reset options",
+      dismissText: "no",
     });
 
     if (!confirmed) {

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -464,7 +464,7 @@ class HassioAddonInfo extends LitElement {
                 ${this.addon.build
                   ? html`
                       <ha-call-api-button
-                        class="warning"
+                        class="warning right"
                         .hass=${this.hass}
                         .path="hassio/addons/${this.addon.slug}/rebuild"
                       >

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -35,6 +35,7 @@ import { HomeAssistant } from "../../../../src/types";
 import "../../components/hassio-card-content";
 import { showHassioMarkdownDialog } from "../../dialogs/markdown/show-dialog-hassio-markdown";
 import { hassioStyle } from "../../resources/hassio-style";
+import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
 
 const STAGE_ICON = {
   stable: "mdi:check-circle",
@@ -801,9 +802,17 @@ class HassioAddonInfo extends LitElement {
   }
 
   private async _uninstallClicked(): Promise<void> {
-    if (!confirm("Are you sure you want to uninstall this add-on?")) {
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.addon.name,
+      text: "Are you sure you want to uninstall this add-on?",
+      confirmText: "uninstall add-on",
+      dismissText: "no",
+    });
+
+    if (!confirmed) {
       return;
     }
+
     this._error = undefined;
     try {
       await uninstallHassioAddon(this.hass, this.addon.slug);

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -408,35 +408,21 @@ class HassioAddonInfo extends LitElement {
         <div class="card-actions">
           ${this.addon.version
             ? html`
-                <mwc-button class="warning" @click=${this._uninstallClicked}>
-                  Uninstall
-                </mwc-button>
-                ${this.addon.build
-                  ? html`
-                      <ha-call-api-button
-                        class="warning"
-                        .hass=${this.hass}
-                        .path="hassio/addons/${this.addon.slug}/rebuild"
-                      >
-                        Rebuild
-                      </ha-call-api-button>
-                    `
-                  : ""}
                 ${this._computeIsRunning
                   ? html`
-                      <ha-call-api-button
-                        class="warning"
-                        .hass=${this.hass}
-                        .path="hassio/addons/${this.addon.slug}/restart"
-                      >
-                        Restart
-                      </ha-call-api-button>
                       <ha-call-api-button
                         class="warning"
                         .hass=${this.hass}
                         .path="hassio/addons/${this.addon.slug}/stop"
                       >
                         Stop
+                      </ha-call-api-button>
+                      <ha-call-api-button
+                        class="warning"
+                        .hass=${this.hass}
+                        .path="hassio/addons/${this.addon.slug}/restart"
+                      >
+                        Restart
                       </ha-call-api-button>
                     `
                   : html`
@@ -467,6 +453,23 @@ class HassioAddonInfo extends LitElement {
                       <mwc-button class="right" @click=${this._openIngress}>
                         Open web UI
                       </mwc-button>
+                    `
+                  : ""}
+                <mwc-button
+                  class=" right warning"
+                  @click=${this._uninstallClicked}
+                >
+                  Uninstall
+                </mwc-button>
+                ${this.addon.build
+                  ? html`
+                      <ha-call-api-button
+                        class="warning"
+                        .hass=${this.hass}
+                        .path="hassio/addons/${this.addon.slug}/rebuild"
+                      >
+                        Rebuild
+                      </ha-call-api-button>
                     `
                   : ""}
               `

--- a/hassio/src/dialogs/snapshot/dialog-hassio-snapshot.ts
+++ b/hassio/src/dialogs/snapshot/dialog-hassio-snapshot.ts
@@ -26,6 +26,7 @@ import { PolymerChangedEvent } from "../../../../src/polymer-types";
 import { haStyleDialog } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";
 import { HassioSnapshotDialogParams } from "./show-dialog-hassio-snapshot";
+import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
 
 const _computeFolders = (folders) => {
   const list: Array<{ slug: string; name: string; checked: boolean }> = [];
@@ -312,8 +313,15 @@ class HassioSnapshotDialog extends LitElement {
     this._snapshotPassword = ev.detail.value;
   }
 
-  private _partialRestoreClicked() {
-    if (!confirm("Are you sure you want to restore this snapshot?")) {
+  private async _partialRestoreClicked(): Promise<void> {
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.snapshot!.name,
+      text: "Are you sure you want to restore this snapshot?",
+      confirmText: "restore snapshot",
+      dismissText: "no",
+    });
+
+    if (!confirmed) {
       return;
     }
 
@@ -358,8 +366,15 @@ class HassioSnapshotDialog extends LitElement {
       );
   }
 
-  private _fullRestoreClicked() {
-    if (!confirm("Are you sure you want to restore this snapshot?")) {
+  private async _fullRestoreClicked(): Promise<void> {
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.snapshot!.name,
+      text: "Are you sure you want to restore this snapshot?",
+      confirmText: "restore snapshot",
+      dismissText: "no",
+    });
+
+    if (!confirmed) {
       return;
     }
 
@@ -384,8 +399,15 @@ class HassioSnapshotDialog extends LitElement {
       );
   }
 
-  private _deleteClicked() {
-    if (!confirm("Are you sure you want to delete this snapshot?")) {
+  private async _deleteClicked(): Promise<void> {
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.snapshot!.name,
+      text: "Are you sure you want to delete this snapshot?",
+      confirmText: "delete snapshot",
+      dismissText: "no",
+    });
+
+    if (!confirmed) {
       return;
     }
 

--- a/hassio/src/dialogs/snapshot/dialog-hassio-snapshot.ts
+++ b/hassio/src/dialogs/snapshot/dialog-hassio-snapshot.ts
@@ -26,7 +26,6 @@ import { PolymerChangedEvent } from "../../../../src/polymer-types";
 import { haStyleDialog } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";
 import { HassioSnapshotDialogParams } from "./show-dialog-hassio-snapshot";
-import { showConfirmationDialog } from "../../../../src/dialogs/generic/show-dialog-box";
 
 const _computeFolders = (folders) => {
   const list: Array<{ slug: string; name: string; checked: boolean }> = [];
@@ -313,15 +312,8 @@ class HassioSnapshotDialog extends LitElement {
     this._snapshotPassword = ev.detail.value;
   }
 
-  private async _partialRestoreClicked(): Promise<void> {
-    const confirmed = await showConfirmationDialog(this, {
-      title: this.snapshot!.name,
-      text: "Are you sure you want to restore this snapshot?",
-      confirmText: "restore snapshot",
-      dismissText: "no",
-    });
-
-    if (!confirmed) {
+  private _partialRestoreClicked() {
+    if (!confirm("Are you sure you want to restore this snapshot?")) {
       return;
     }
 
@@ -366,15 +358,8 @@ class HassioSnapshotDialog extends LitElement {
       );
   }
 
-  private async _fullRestoreClicked(): Promise<void> {
-    const confirmed = await showConfirmationDialog(this, {
-      title: this.snapshot!.name,
-      text: "Are you sure you want to restore this snapshot?",
-      confirmText: "restore snapshot",
-      dismissText: "no",
-    });
-
-    if (!confirmed) {
+  private _fullRestoreClicked() {
+    if (!confirm("Are you sure you want to restore this snapshot?")) {
       return;
     }
 
@@ -399,15 +384,8 @@ class HassioSnapshotDialog extends LitElement {
       );
   }
 
-  private async _deleteClicked(): Promise<void> {
-    const confirmed = await showConfirmationDialog(this, {
-      title: this.snapshot!.name,
-      text: "Are you sure you want to delete this snapshot?",
-      confirmText: "delete snapshot",
-      dismissText: "no",
-    });
-
-    if (!confirmed) {
+  private _deleteClicked() {
+    if (!confirm("Are you sure you want to delete this snapshot?")) {
       return;
     }
 

--- a/hassio/src/system/hassio-host-info.ts
+++ b/hassio/src/system/hassio-host-info.ts
@@ -214,7 +214,7 @@ class HassioHostInfo extends LitElement {
   private async _shutdownHost(): Promise<void> {
     const confirmed = await showConfirmationDialog(this, {
       title: "Shutdown",
-      text: "Are you sure you want to reboot the host?",
+      text: "Are you sure you want to shutdown the host?",
       confirmText: "shutdown host",
       dismissText: "no",
     });

--- a/hassio/src/system/hassio-supervisor-info.ts
+++ b/hassio/src/system/hassio-supervisor-info.ts
@@ -19,6 +19,7 @@ import {
 import { haStyle } from "../../../src/resources/styles";
 import { HomeAssistant } from "../../../src/types";
 import { hassioStyle } from "../resources/hassio-style";
+import { showConfirmationDialog } from "../../../src/dialogs/generic/show-dialog-box";
 
 @customElement("hassio-supervisor-info")
 class HassioSupervisorInfo extends LitElement {
@@ -142,17 +143,25 @@ class HassioSupervisorInfo extends LitElement {
   }
 
   private async _joinBeta() {
-    if (
-      !confirm(`WARNING:
-Beta releases are for testers and early adopters and can contain unstable code changes. Make sure you have backups of your data before you activate this feature.
+    const confirmed = await showConfirmationDialog(this, {
+      title: "WARNING",
+      text: `Beta releases are for testers and early adopters and can contain unstable code changes. Make sure you have backups of your data before you activate this feature.
 
-This includes beta releases for:
-- Home Assistant Core (Release Candidates)
-- Home Assistant Supervisor
-- Home Assistant Operating System`)
-    ) {
+      This includes beta releases for:
+      - Home Assistant Core (Release Candidates)
+      - Home Assistant Supervisor
+      - Home Assistant Operating System
+
+      Do you want to join the beta channel?
+      `,
+      confirmText: "join beta",
+      dismissText: "no",
+    });
+
+    if (!confirmed) {
       return;
     }
+
     try {
       const data: SupervisorOptions = { channel: "beta" };
       await setSupervisorOption(this.hass, data);

--- a/hassio/src/system/hassio-supervisor-info.ts
+++ b/hassio/src/system/hassio-supervisor-info.ts
@@ -154,7 +154,7 @@ class HassioSupervisorInfo extends LitElement {
         </b>
         <br /><br />
         This includes beta releases for:
-        <li>Home Assistant Core (Release Candidates)</li>
+        <li>Home Assistant Core</li>
         <li>Home Assistant Supervisor</li>
         <li>Home Assistant Operating System</li>
         <br />

--- a/hassio/src/system/hassio-supervisor-info.ts
+++ b/hassio/src/system/hassio-supervisor-info.ts
@@ -145,15 +145,20 @@ class HassioSupervisorInfo extends LitElement {
   private async _joinBeta() {
     const confirmed = await showConfirmationDialog(this, {
       title: "WARNING",
-      text: `Beta releases are for testers and early adopters and can contain unstable code changes. Make sure you have backups of your data before you activate this feature.
-
-      This includes beta releases for:
-      - Home Assistant Core (Release Candidates)
-      - Home Assistant Supervisor
-      - Home Assistant Operating System
-
-      Do you want to join the beta channel?
-      `,
+      text: html` Beta releases are for testers and early adopters and can
+        contain unstable code changes.
+        <br />
+        <b>
+          Make sure you have backups of your data before you activate this
+          feature.
+        </b>
+        <br /><br />
+        This includes beta releases for:
+        <li>Home Assistant Core (Release Candidates)</li>
+        <li>Home Assistant Supervisor</li>
+        <li>Home Assistant Operating System</li>
+        <br />
+        Do you want to join the beta channel?`,
       confirmText: "join beta",
       dismissText: "no",
     });

--- a/src/data/hassio/host.ts
+++ b/src/data/hassio/host.ts
@@ -27,3 +27,23 @@ export const fetchHassioHassOsInfo = async (hass: HomeAssistant) => {
     )
   );
 };
+
+export const rebootHost = async (hass: HomeAssistant) => {
+  return hass.callApi<HassioResponse<void>>("POST", "hassio/host/reboot");
+};
+
+export const shutdownHost = async (hass: HomeAssistant) => {
+  return hass.callApi<HassioResponse<void>>("POST", "hassio/host/shutdown");
+};
+
+export const updateOS = async (hass: HomeAssistant) => {
+  return hass.callApi<HassioResponse<void>>("POST", "hassio/os/update");
+};
+
+export const changeHostOptions = async (hass: HomeAssistant, options: any) => {
+  return hass.callApi<HassioResponse<void>>(
+    "POST",
+    "hassio/host/options",
+    options
+  );
+};


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Implements our custom pretty dialog instead of the default browser provided.
  - dialogs in the snapshot dialog are not changed, I will address that another way.
- Added new dialogs (host rboot, host shutdown, os upgrade)
- Refreshes host info after host name change
- Reorder buttons on addon info card, I think they got misplaced with the TS convertion

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4915, fixes #4417, closes #4981
- This PR is related to issue:
- Link to documentation pull request:

![image](https://user-images.githubusercontent.com/15093472/80915983-11967b80-8d56-11ea-8059-503cc6e90e77.png)
![image](https://user-images.githubusercontent.com/15093472/80915985-13f8d580-8d56-11ea-8eac-b32ca778d497.png)
![image](https://user-images.githubusercontent.com/15093472/80915986-15c29900-8d56-11ea-9ac1-ec80331a68c9.png)
![image](https://user-images.githubusercontent.com/15093472/80915987-16f3c600-8d56-11ea-96fa-05dd423571e5.png)


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
