### PR TITLE
Grayscale Integration logos when ignored

### DIFF
--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -327,6 +327,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
                         <img
                           src="https://brands.home-assistant.io/${item.domain}/logo.png"
                           referrerpolicy="no-referrer"
+                          class="ignored-image"
                           @error=${this._onImageError}
                           @load=${this._onImageLoad}
                         />
@@ -618,6 +619,9 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         }
         .ignored {
           border: 1px solid var(--light-theme-disabled-color);
+        }
+        .ignored-image {
+          filter: grayscale(1);
         }
         .ignored .header {
           background: var(--light-theme-disabled-color);

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -327,7 +327,6 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
                         <img
                           src="https://brands.home-assistant.io/${item.domain}/logo.png"
                           referrerpolicy="no-referrer"
-                          class="ignored-image"
                           @error=${this._onImageError}
                           @load=${this._onImageLoad}
                         />
@@ -620,7 +619,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         .ignored {
           border: 1px solid var(--light-theme-disabled-color);
         }
-        .ignored-image {
+        .ignored img {
           filter: grayscale(1);
         }
         .ignored .header {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This change is to render logos in grayscale if the _Discovered_ integration has been _Ignored_ - see Feature Request #5667 . This is to detract attention from the logo while the integration is in this state.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5667 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
