### PR TITLE
Add translation for `and` word on the integration card

### DIFF
--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -148,7 +148,11 @@ export class HaIntegrationCard extends LitElement {
                         >
                       `
                     : ""}
-                  ${devices.length && entities.length ? "and" : ""}
+                  ${devices.length && entities.length
+                    ? this.hass.localize(
+                        "ui.panel.config.integrations.config_entry.and"
+                      )
+                    : ""}
                   ${entities.length
                     ? html`
                         <a

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -149,9 +149,7 @@ export class HaIntegrationCard extends LitElement {
                       `
                     : ""}
                   ${devices.length && entities.length
-                    ? this.hass.localize(
-                        "ui.panel.config.integrations.config_entry.and"
-                      )
+                    ? this.hass.localize("ui.common.and")
                     : ""}
                   ${entities.length
                     ? html`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1377,6 +1377,7 @@
             "stop_ignore": "Stop ignoring"
           },
           "config_entry": {
+            "and": "and",
             "devices": "{count} {count, plural,\n  one {device}\n  other {devices}\n}",
             "entities": "{count} {count, plural,\n  one {entity}\n  other {entities}\n}",
             "rename": "Rename",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -231,6 +231,7 @@
       }
     },
     "common": {
+      "and": "and",
       "previous": "Previous",
       "loading": "Loading",
       "refresh": "Refresh",
@@ -1377,7 +1378,6 @@
             "stop_ignore": "Stop ignoring"
           },
           "config_entry": {
-            "and": "and",
             "devices": "{count} {count, plural,\n  one {device}\n  other {devices}\n}",
             "entities": "{count} {count, plural,\n  one {entity}\n  other {entities}\n}",
             "rename": "Rename",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds translation for `and` world on the integration card.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
