### PR TITLE
Weather Card: Ability to choose Secondary Attribute

### DIFF
--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -200,7 +200,15 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                 >
               </div>
               <div class="attribute">
-                ${getSecondaryWeatherAttribute(this.hass, stateObj)}
+                ${this._config.attribute !== undefined
+                  ? html`
+                      ${this.hass!.localize(
+                        `ui.card.weather.attributes.${this._config.attribute}`
+                      )}
+                      ${stateObj.attributes[this._config.attribute]}
+                      ${getWeatherUnit(this.hass, this._config.attribute)}
+                    `
+                  : getSecondaryWeatherAttribute(this.hass, stateObj)}
               </div>
             </div>
           </div>

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -200,13 +200,18 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                 >
               </div>
               <div class="attribute">
-                ${this._config.attribute !== undefined
+                ${this._config.secondary_info_attribute !== undefined
                   ? html`
                       ${this.hass!.localize(
-                        `ui.card.weather.attributes.${this._config.attribute}`
+                        `ui.card.weather.attributes.${this._config.secondary_info_attribute}`
                       )}
-                      ${stateObj.attributes[this._config.attribute]}
-                      ${getWeatherUnit(this.hass, this._config.attribute)}
+                      ${stateObj.attributes[
+                        this._config.secondary_info_attribute
+                      ]}
+                      ${getWeatherUnit(
+                        this.hass,
+                        this._config.secondary_info_attribute
+                      )}
                     `
                   : getSecondaryWeatherAttribute(this.hass, stateObj)}
               </div>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -275,4 +275,5 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
   show_forecast?: boolean;
+  attribute?: string;
 }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -275,5 +275,5 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
   show_forecast?: boolean;
-  attribute?: string;
+  secondary_info_attribute?: string;
 }

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -22,7 +22,7 @@ const cardConfigStruct = struct({
   name: "string?",
   theme: "string?",
   show_forecast: "boolean?",
-  attribute: "string?",
+  secondary_info_attribute: "string?",
 });
 
 const includeDomains = ["weather"];

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -22,6 +22,7 @@ const cardConfigStruct = struct({
   name: "string?",
   theme: "string?",
   show_forecast: "boolean?",
+  attribute: "string?",
 });
 
 const includeDomains = ["weather"];
@@ -52,6 +53,10 @@ export class HuiWeatherForecastCardEditor extends LitElement
 
   get _show_forecast(): boolean {
     return this._config!.show_forecast || true;
+  }
+
+  get _attribute(): string {
+    return this._config!.attribute || "";
   }
 
   protected render(): TemplateResult {
@@ -93,12 +98,24 @@ export class HuiWeatherForecastCardEditor extends LitElement
             @value-changed=${this._valueChanged}
           ></hui-theme-select-editor>
         </div>
-        <ha-switch
-          .checked=${this._config!.show_forecast !== false}
-          .configValue=${"show_forecast"}
-          @change=${this._valueChanged}
-          >Show forecast</ha-switch
-        >
+        <div class="side-by-side">
+          <paper-input
+            .label="${this.hass.localize(
+              "ui.panel.lovelace.editor.card.generic.attribute"
+            )} (${this.hass.localize(
+              "ui.panel.lovelace.editor.card.config.optional"
+            )})"
+            .value=${this._attribute}
+            .configValue=${"attribute"}
+            @value-changed=${this._valueChanged}
+          ></paper-input>
+          <ha-switch
+            .checked=${this._config!.show_forecast !== false}
+            .configValue=${"show_forecast"}
+            @change=${this._valueChanged}
+            >Show forecast</ha-switch
+          >
+        </div>
       </div>
     `;
   }

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -55,8 +55,8 @@ export class HuiWeatherForecastCardEditor extends LitElement
     return this._config!.show_forecast || true;
   }
 
-  get _attribute(): string {
-    return this._config!.attribute || "";
+  get _secondary_info_attribute(): string {
+    return this._config!.secondary_info_attribute || "";
   }
 
   protected render(): TemplateResult {
@@ -101,19 +101,21 @@ export class HuiWeatherForecastCardEditor extends LitElement
         <div class="side-by-side">
           <paper-input
             .label="${this.hass.localize(
-              "ui.panel.lovelace.editor.card.generic.attribute"
+              "ui.panel.lovelace.editor.card.generic.secondary_info_attribute"
             )} (${this.hass.localize(
               "ui.panel.lovelace.editor.card.config.optional"
             )})"
-            .value=${this._attribute}
-            .configValue=${"attribute"}
+            .value=${this._secondary_info_attribute}
+            .configValue=${"secondary_info_attribute"}
             @value-changed=${this._valueChanged}
           ></paper-input>
           <ha-switch
             .checked=${this._config!.show_forecast !== false}
             .configValue=${"show_forecast"}
             @change=${this._valueChanged}
-            >Show forecast</ha-switch
+            >${this.hass.localize(
+              "ui.panel.lovelace.editor.card.weather.show_forecast"
+            )}</ha-switch
           >
         </div>
       </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1841,7 +1841,8 @@
               "no_theme": "No theme",
               "unit": "Unit",
               "url": "Url",
-              "state": "State"
+              "state": "State",
+              "secondary_info_attribute": "Secondary Info Attribute"
             },
             "map": {
               "name": "Map",
@@ -1902,7 +1903,8 @@
             },
             "weather-forecast": {
               "name": "Weather Forecast",
-              "description": "The Weather Forecast card displays the weather. Very useful to include on interfaces that people display on the wall."
+              "description": "The Weather Forecast card displays the weather. Very useful to include on interfaces that people display on the wall.",
+              "show_forecast": "Show Forecast"
             }
           },
           "view": {


### PR DESCRIPTION
## Proposed change

![image](https://user-images.githubusercontent.com/18730868/81451654-f4491f00-9152-11ea-9bf4-192bd30cb20c.png)

## Type of change

- [x] New feature (thank you!)

## Example configuration

```yaml
- type: weather-forecast
  entity: weather.dark_sky
  name: 'Austin, Texas'
  show_forecast: true
  attribute: humidity
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5764
- This PR is related to issue: #5676
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/13395

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
