### PR TITLE
Simplify custom icon set, return only 1 icon per call

### DIFF
--- a/src/components/ha-icon.ts
+++ b/src/components/ha-icon.ts
@@ -10,7 +10,7 @@ import {
   CSSResult,
 } from "lit-element";
 import "./ha-svg-icon";
-import { customIconsets, CustomIcons } from "../data/custom_iconsets";
+import { customIconsets, CustomIcon } from "../data/custom_iconsets";
 import {
   Chunks,
   MDI_PREFIXES,
@@ -68,7 +68,7 @@ export class HaIcon extends LitElement {
       if (iconPrefix in customIconsets) {
         const customIconset = customIconsets[iconPrefix];
         if (customIconset) {
-          this._setCustomPath(customIconset(iconName), iconName);
+          this._setCustomPath(customIconset(iconName));
         }
         return;
       }
@@ -97,13 +97,10 @@ export class HaIcon extends LitElement {
     debouncedWriteCache();
   }
 
-  private async _setCustomPath(
-    promise: Promise<CustomIcons>,
-    iconName: string
-  ) {
-    const iconPack = await promise;
-    this._path = iconPack[iconName].path;
-    this._viewBox = iconPack[iconName].viewBox;
+  private async _setCustomPath(promise: Promise<CustomIcon>) {
+    const icon = await promise;
+    this._path = icon.path;
+    this._viewBox = icon.viewBox;
   }
 
   private async _setPath(promise: Promise<Icons>, iconName: string) {

--- a/src/components/ha-icon.ts
+++ b/src/components/ha-icon.ts
@@ -64,6 +64,11 @@ export class HaIcon extends LitElement {
       return;
     }
     const [iconPrefix, iconName] = this.icon.split(":", 2);
+
+    if (!iconPrefix || !iconName) {
+      return;
+    }
+
     if (!MDI_PREFIXES.includes(iconPrefix)) {
       if (iconPrefix in customIconsets) {
         const customIconset = customIconsets[iconPrefix];

--- a/src/data/custom_iconsets.ts
+++ b/src/data/custom_iconsets.ts
@@ -1,9 +1,10 @@
-export interface CustomIcons {
-  [key: string]: { path: string; viewBox?: string };
+export interface CustomIcon {
+  path: string;
+  viewBox?: string;
 }
 
 export interface CustomIconsetsWindow {
-  customIconsets?: { [key: string]: (name: string) => Promise<CustomIcons> };
+  customIconsets?: { [key: string]: (name: string) => Promise<CustomIcon> };
 }
 
 const customIconsetsWindow = window as CustomIconsetsWindow;


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Breaking change for unreleased version.
Custom iconsets should return 1 icon instead of an object with icons.


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
