### PR TITLE
Recreate cards only on config change

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -10,24 +10,29 @@ import {
   LitElement,
   property,
   TemplateResult,
+  queryAssignedNodes,
 } from "lit-element";
-import { LovelaceCardConfig } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
 import { showEditCardDialog } from "../editor/card-editor/show-edit-card-dialog";
 import { showMoveCardViewDialog } from "../editor/card-editor/show-move-card-view-dialog";
 import { swapCard } from "../editor/config-util";
 import { confDeleteCard } from "../editor/delete-card";
-import { Lovelace } from "../types";
+import { Lovelace, LovelaceCard } from "../types";
+import { computeCardSize } from "../common/compute-card-size";
 
 @customElement("hui-card-options")
 export class HuiCardOptions extends LitElement {
-  public cardConfig?: LovelaceCardConfig;
-
   @property() public hass?: HomeAssistant;
 
   @property() public lovelace?: Lovelace;
 
   @property() public path?: [number, number];
+
+  @queryAssignedNodes() private _assignedNodes?: NodeListOf<LovelaceCard>;
+
+  public getCardSize() {
+    return this._assignedNodes ? computeCardSize(this._assignedNodes[0]) : 1;
+  }
 
   protected render(): TemplateResult {
     return html`

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -369,100 +369,6 @@ class HUIRoot extends LitElement {
     `;
   }
 
-  static get styles(): CSSResult[] {
-    return [
-      haStyle,
-      css`
-        :host {
-          --dark-color: #455a64;
-          --text-dark-color: #fff;
-          -ms-user-select: none;
-          -webkit-user-select: none;
-          -moz-user-select: none;
-        }
-
-        ha-app-layout {
-          min-height: 100%;
-        }
-        paper-menu-button {
-          padding: 0;
-        }
-        paper-tabs {
-          margin-left: 12px;
-          --paper-tabs-selection-bar-color: var(--text-primary-color, #fff);
-          text-transform: uppercase;
-        }
-        .edit-mode {
-          background-color: var(--dark-color, #455a64);
-          color: var(--text-dark-color);
-        }
-        .edit-mode div[main-title] {
-          pointer-events: auto;
-        }
-        paper-tab.iron-selected .edit-icon {
-          display: inline-flex;
-        }
-        .edit-icon {
-          color: var(--accent-color);
-          padding-left: 8px;
-          vertical-align: middle;
-          --mdc-theme-text-disabled-on-light: var(--disabled-text-color);
-        }
-        .edit-icon.view {
-          display: none;
-        }
-        #add-view {
-          position: absolute;
-          height: 44px;
-        }
-        #add-view ha-icon {
-          background-color: var(--accent-color);
-          border-radius: 5px;
-          margin-top: 4px;
-        }
-        app-toolbar a {
-          color: var(--text-primary-color, white);
-        }
-        mwc-button.warning:not([disabled]) {
-          color: var(--google-red-500);
-        }
-        #view {
-          min-height: calc(100vh - 112px);
-          /**
-          * Since we only set min-height, if child nodes need percentage
-          * heights they must use absolute positioning so we need relative
-          * positioning here.
-          *
-          * https://www.w3.org/TR/CSS2/visudet.html#the-height-property
-          */
-          position: relative;
-          display: flex;
-        }
-        #view > * {
-          /**
-          * The view could get larger than the window in Firefox
-          * to prevent that we set the max-width to 100%
-          * flex-grow: 1 and flex-basis: 100% should make sure the view
-          * stays full width.
-          *
-          * https://github.com/home-assistant/home-assistant-polymer/pull/3806
-          */
-          flex: 1 1 100%;
-          max-width: 100%;
-        }
-        #view.tabs-hidden {
-          min-height: calc(100vh - 64px);
-        }
-        paper-item {
-          cursor: pointer;
-        }
-        .hide-tab {
-          display: none;
-        }
-      `,
-    ];
-  }
-
   protected updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
 
@@ -527,8 +433,10 @@ class HUIRoot extends LitElement {
           navigate(this, `${this.route?.prefix}/${views[0]?.path || 0}`);
           newSelectView = 0;
         }
-        // On edit mode change, recreate the current view from scratch
-        force = true;
+      }
+
+      if (!force) {
+        huiView.lovelace = this.lovelace;
       }
     }
 
@@ -733,6 +641,100 @@ class HUIRoot extends LitElement {
     root.appendChild(view);
     // Recalculate to see if we need to adjust content area for tab bar
     fireEvent(this, "iron-resize");
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyle,
+      css`
+        :host {
+          --dark-color: #455a64;
+          --text-dark-color: #fff;
+          -ms-user-select: none;
+          -webkit-user-select: none;
+          -moz-user-select: none;
+        }
+
+        ha-app-layout {
+          min-height: 100%;
+        }
+        paper-menu-button {
+          padding: 0;
+        }
+        paper-tabs {
+          margin-left: 12px;
+          --paper-tabs-selection-bar-color: var(--text-primary-color, #fff);
+          text-transform: uppercase;
+        }
+        .edit-mode {
+          background-color: var(--dark-color, #455a64);
+          color: var(--text-dark-color);
+        }
+        .edit-mode div[main-title] {
+          pointer-events: auto;
+        }
+        paper-tab.iron-selected .edit-icon {
+          display: inline-flex;
+        }
+        .edit-icon {
+          color: var(--accent-color);
+          padding-left: 8px;
+          vertical-align: middle;
+          --mdc-theme-text-disabled-on-light: var(--disabled-text-color);
+        }
+        .edit-icon.view {
+          display: none;
+        }
+        #add-view {
+          position: absolute;
+          height: 44px;
+        }
+        #add-view ha-icon {
+          background-color: var(--accent-color);
+          border-radius: 5px;
+          margin-top: 4px;
+        }
+        app-toolbar a {
+          color: var(--text-primary-color, white);
+        }
+        mwc-button.warning:not([disabled]) {
+          color: var(--google-red-500);
+        }
+        #view {
+          min-height: calc(100vh - 112px);
+          /**
+          * Since we only set min-height, if child nodes need percentage
+          * heights they must use absolute positioning so we need relative
+          * positioning here.
+          *
+          * https://www.w3.org/TR/CSS2/visudet.html#the-height-property
+          */
+          position: relative;
+          display: flex;
+        }
+        #view > * {
+          /**
+          * The view could get larger than the window in Firefox
+          * to prevent that we set the max-width to 100%
+          * flex-grow: 1 and flex-basis: 100% should make sure the view
+          * stays full width.
+          *
+          * https://github.com/home-assistant/home-assistant-polymer/pull/3806
+          */
+          flex: 1 1 100%;
+          max-width: 100%;
+        }
+        #view.tabs-hidden {
+          min-height: calc(100vh - 64px);
+        }
+        paper-item {
+          cursor: pointer;
+        }
+        .hide-tab {
+          display: none;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -34,6 +34,7 @@ export interface LovelaceCard extends HTMLElement {
   hass?: HomeAssistant;
   isPanel?: boolean;
   editMode?: boolean;
+  index?: number;
   getCardSize(): number;
   setConfig(config: LovelaceCardConfig): void;
 }

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -125,6 +125,7 @@ export class HUIView extends LitElement {
     }
 
     const hassChanged = changedProperties.has("hass");
+
     let editModeChanged = false;
     let configChanged = false;
 
@@ -151,7 +152,9 @@ export class HUIView extends LitElement {
       this._switchEditMode();
     } else if (changedProperties.has("columns")) {
       this._recreateColumns();
-    } else if (hassChanged) {
+    }
+
+    if (hassChanged && !configChanged) {
       this._cards.forEach((element) => {
         element.hass = this.hass;
       });


### PR DESCRIPTION
## Proposed change

We would recreate the entire view on a change of width (like expanding the side menu) and switching edit mode.

We now only recalculate the columns without recreating the cards, for edit mode we wrap the existing cards with `card-options` instead of recreating the card.

With a lot of cards, and cards that fetch a lot of data on creation like history, this will make a big difference. 

Before:
![before](https://user-images.githubusercontent.com/5662298/81717456-df35fe00-947a-11ea-855c-464cd200a2a5.gif)

After:
![after](https://user-images.githubusercontent.com/5662298/81717496-ebba5680-947a-11ea-9cc8-9bf1404b7fcb.gif)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
