### PR TITLE
Migrate card preview to UpdatingElement

### DIFF
--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -248,18 +248,11 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
-    if (changedProps.has("_setTemp")) {
-      return true;
-    }
     return hasConfigOrEntityChanged(this, changedProps);
   }
 
   protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
-
-    if (changedProps.has("_setTemp")) {
-      this.rescale_svg();
-    }
 
     if (
       !this._config ||
@@ -283,23 +276,18 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
       applyThemesOnElement(this, this.hass.themes, this._config.theme);
     }
 
-    const stateObj = this.hass!.states[this._config!.entity];
+    const stateObj = this.hass.states[this._config.entity];
     if (!stateObj) {
       return;
     }
-    const newTemp = this._getSetTemp(stateObj);
-    if (
-      Array.isArray(this._setTemp) &&
-      Array.isArray(newTemp) &&
-      (this._setTemp[0] !== newTemp[0] || this._setTemp[1] !== newTemp[1])
-    ) {
-      this._setTemp = newTemp;
-    } else if (this._setTemp !== newTemp) {
-      this._setTemp = newTemp;
+
+    if (!oldHass || oldHass.states[this._config.entity] !== stateObj) {
+      this._setTemp = this._getSetTemp(stateObj);
+      this._rescale_svg();
     }
   }
 
-  private rescale_svg() {
+  private _rescale_svg() {
     // Set the viewbox of the SVG containing the set temperature to perfectly
     // fit the text
     // That way it will auto-scale correctly

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -4,7 +4,6 @@ import { LovelaceCardConfig } from "../../../../data/lovelace";
 import { HomeAssistant } from "../../../../types";
 import { createCardElement } from "../../create-element/create-card-element";
 import { LovelaceCard } from "../../types";
-import { ConfigError } from "../types";
 import { createErrorCardConfig } from "../../create-element/create-element-base";
 import { property, PropertyValues, UpdatingElement } from "lit-element";
 
@@ -13,7 +12,7 @@ export class HuiCardPreview extends UpdatingElement {
 
   @property() public config?: LovelaceCardConfig;
 
-  @property() private _element?: LovelaceCard;
+  private _element?: LovelaceCard;
 
   private get _error() {
     return this._element?.tagName === "HUI-ERROR-CARD";
@@ -29,13 +28,9 @@ export class HuiCardPreview extends UpdatingElement {
     });
   }
 
-  set error(error: ConfigError) {
-    this._createCard(
-      createErrorCardConfig(`${error.type}: ${error.message}`, undefined)
-    );
-  }
+  protected update(changedProperties: PropertyValues) {
+    super.update(changedProperties);
 
-  protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has("config")) {
       const oldConfig = changedProperties.get("config") as
         | undefined

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -25,6 +25,7 @@ import type { ConfigChangedEvent, HuiCardEditor } from "./hui-card-editor";
 import "./hui-card-picker";
 import "./hui-card-preview";
 import type { EditCardDialogParams } from "./show-edit-card-dialog";
+import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
 
 declare global {
   // for fire event


### PR DESCRIPTION
## Proposed change

We would call `setConfig` on every update of hass in the preview. Now only if the config changes.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
