### PR TITLE
Add translations for buttons and error string on the auth page

### DIFF
--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -83,12 +83,21 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
           ${this._renderStep(this._step)}
           <div class="action">
             <mwc-button raised @click=${this._handleSubmit}
-              >${this._step.type === "form" ? "Next" : "Start over"}</mwc-button
+              >${this._step.type === "form"
+                ? this.localize("ui.panel.page-authorize.form.next")
+                : this.localize(
+                    "ui.panel.page-authorize.form.start_over"
+                  )}</mwc-button
             >
           </div>
         `;
       case "error":
-        return html` <div class="error">Error: ${this._errorMessage}</div> `;
+        return html`
+          <div class="error">
+            ${this.localize("ui.panel.page-authorize.form.error")}
+            ${this._errorMessage}
+          </div>
+        `;
       case "loading":
         return html` ${this.localize("ui.panel.page-authorize.form.working")} `;
       default:

--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -94,8 +94,11 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
       case "error":
         return html`
           <div class="error">
-            ${this.localize("ui.panel.page-authorize.form.error")}
-            ${this._errorMessage}
+            ${this.localize(
+              "ui.panel.page-authorize.form.error",
+              "errorMessage",
+              this._errorMessage
+            )}
           </div>
         `;
       case "loading":

--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -96,7 +96,7 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
           <div class="error">
             ${this.localize(
               "ui.panel.page-authorize.form.error",
-              "errorMessage",
+              "error",
               this._errorMessage
             )}
           </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2037,6 +2037,9 @@
         "form": {
           "working": "Please wait",
           "unknown_error": "Something went wrong",
+          "next": "Next",
+          "start_over": "Start over",
+          "error": "Error:",
           "providers": {
             "command_line": {
               "step": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2039,7 +2039,7 @@
           "unknown_error": "Something went wrong",
           "next": "Next",
           "start_over": "Start over",
-          "error": "Error:",
+          "error": "Error: {ErrorMessage}",
           "providers": {
             "command_line": {
               "step": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2039,7 +2039,7 @@
           "unknown_error": "Something went wrong",
           "next": "Next",
           "start_over": "Start over",
-          "error": "Error: {ErrorMessage}",
+          "error": "Error: {error}",
           "providers": {
             "command_line": {
               "step": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds translations for buttons `Next` and `Start over` and for error string on the onboarding page.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
