### PR TITLE
Fix aria label icon name

### DIFF
--- a/src/components/ha-icon-button.ts
+++ b/src/components/ha-icon-button.ts
@@ -25,7 +25,7 @@ export class HaIconButton extends LitElement {
   protected render(): TemplateResult {
     return html`
       <mwc-icon-button
-        .label=${this.label || this.icon}
+        .label=${this.label}
         ?disabled=${this.disabled}
         @click=${this._handleClick}
       >

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -183,7 +183,7 @@ class HUIRoot extends LitElement {
                   ${this._conversation(this.hass.config.components)
                     ? html`
                         <ha-icon-button
-                          aria-label="Start conversation"
+                          label="Start conversation"
                           icon="hass:microphone"
                           @click=${this._showVoiceCommandDialog}
                         ></ha-icon-button>


### PR DESCRIPTION

## Proposed change

Don't expose icon names as `aria-label` like `mwc-icon-button` does as fallback.
#3267

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
