### PR TITLE
Ignore proxy-polyfill in workers

### DIFF
--- a/build-scripts/bundle.js
+++ b/build-scripts/bundle.js
@@ -11,15 +11,18 @@ module.exports.ignorePackages = ({ latestBuild }) => [
 ];
 
 // Files from NPM packages that we should replace with empty file
-module.exports.emptyPackages = ({ latestBuild }) => [
-  // Contains all color definitions for all material color sets.
-  // We don't use it
-  require.resolve("@polymer/paper-styles/color.js"),
-  require.resolve("@polymer/paper-styles/default-theme.js"),
-  // Loads stuff from a CDN
-  require.resolve("@polymer/font-roboto/roboto.js"),
-  require.resolve("@vaadin/vaadin-material-styles/font-roboto.js"),
-];
+module.exports.emptyPackages = ({ latestBuild }) =>
+  [
+    // Contains all color definitions for all material color sets.
+    // We don't use it
+    require.resolve("@polymer/paper-styles/color.js"),
+    require.resolve("@polymer/paper-styles/default-theme.js"),
+    // Loads stuff from a CDN
+    require.resolve("@polymer/font-roboto/roboto.js"),
+    require.resolve("@vaadin/vaadin-material-styles/font-roboto.js"),
+    // Polyfill only needed for ES5 workers so filter out in latestBuild
+    latestBuild && require.resolve("proxy-polyfill/src/index.js"),
+  ].filter(Boolean);
 
 module.exports.definedVars = ({ isProdBuild, latestBuild, defineOverlay }) => ({
   __DEV__: !isProdBuild,

--- a/build-scripts/rollup-plugins/worker-plugin.js
+++ b/build-scripts/rollup-plugins/worker-plugin.js
@@ -25,7 +25,7 @@ const defaultOpts = {
   // A RegExp to find `new Workers()` calls. The second capture group _must_
   // capture the provided file name without the quotes.
   workerRegexp: /new Worker\((["'])(.+?)\1(,[^)]+)?\)/g,
-  plugins: ["node-resolve", "commonjs", "babel"],
+  plugins: ["node-resolve", "commonjs", "babel", "terser", "ignore"],
 };
 
 async function getBundledWorker(workerPath, rollupOptions) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

proxy-polyfill is only necessary in ES5 workers. Filter it out for latest build workers. Also minify workers in Rollup prod builds. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
