### PR TITLE
Fix get card size for lazy elements

### DIFF
--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -152,7 +152,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
       columns.url_path = {
         title: "",
         filterable: true,
-        width: "75px",
+        width: "100px",
         template: (urlPath) =>
           narrow
             ? html`

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -75,9 +75,9 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
 
   @query("#alarmCode") private _input?: PaperInputElement;
 
-  public getCardSize(): number {
+  public async getCardSize(): Promise<number> {
     if (!this._config || !this.hass) {
-      return 0;
+      return 3;
     }
 
     const stateObj = this.hass.states[this._config.entity];

--- a/src/panels/lovelace/cards/hui-conditional-card.ts
+++ b/src/panels/lovelace/cards/hui-conditional-card.ts
@@ -34,8 +34,8 @@ class HuiConditionalCard extends HuiConditionalBase implements LovelaceCard {
     this._element = this._createCardElement(config.card);
   }
 
-  public getCardSize(): number {
-    return computeCardSize(this._element as LovelaceCard);
+  public async getCardSize(): Promise<number> {
+    return await computeCardSize(this._element as LovelaceCard);
   }
 
   private _createCardElement(cardConfig: LovelaceCardConfig) {

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -86,7 +86,10 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
       return 0;
     }
     // +1 for the header
-    return (this._config.title ? 1 : 0) + this._config.entities.length;
+    return (
+      (this._config.title || this._showHeaderToggle ? 1 : 0) +
+      this._config.entities.length
+    );
   }
 
   public setConfig(config: EntitiesCardConfig): void {

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -26,8 +26,8 @@ class EntityFilterCard extends UpdatingElement implements LovelaceCard {
 
   private _oldEntities?: EntityFilterEntityConfig[];
 
-  public async getCardSize(): Promise<number> {
-    return this._element ? await computeCardSize(this._element) : 1;
+  public getCardSize(): number | Promise<number> {
+    return this._element ? computeCardSize(this._element) : 1;
   }
 
   public setConfig(config: EntityFilterCardConfig): void {

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -26,8 +26,8 @@ class EntityFilterCard extends UpdatingElement implements LovelaceCard {
 
   private _oldEntities?: EntityFilterEntityConfig[];
 
-  public getCardSize(): number {
-    return this._element ? computeCardSize(this._element) : 1;
+  public async getCardSize(): Promise<number> {
+    return this._element ? await computeCardSize(this._element) : 1;
   }
 
   public setConfig(config: EntityFilterCardConfig): void {

--- a/src/panels/lovelace/cards/hui-horizontal-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-horizontal-stack-card.ts
@@ -8,7 +8,7 @@ class HuiHorizontalStackCard extends HuiStackCard {
       return 0;
     }
 
-    const promises: Promise<number>[] = [];
+    const promises: Array<Promise<number> | number> = [];
 
     for (const element of this._cards) {
       promises.push(computeCardSize(element));

--- a/src/panels/lovelace/cards/hui-horizontal-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-horizontal-stack-card.ts
@@ -3,17 +3,20 @@ import { computeCardSize } from "../common/compute-card-size";
 import { HuiStackCard } from "./hui-stack-card";
 
 class HuiHorizontalStackCard extends HuiStackCard {
-  public getCardSize(): number {
-    let totalSize = 0;
-
-    if (this._cards) {
-      for (const element of this._cards) {
-        const elementSize = computeCardSize(element);
-        totalSize = elementSize > totalSize ? elementSize : totalSize;
-      }
+  public async getCardSize(): Promise<number> {
+    if (!this._cards) {
+      return 0;
     }
 
-    return totalSize;
+    const promises: Promise<number>[] = [];
+
+    for (const element of this._cards) {
+      promises.push(computeCardSize(element));
+    }
+
+    const results = await Promise.all(promises);
+
+    return Math.max(...results);
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -66,7 +66,7 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
   private _brightnessTimout?: number;
 
   public getCardSize(): number {
-    return 2;
+    return 4;
   }
 
   public setConfig(config: LightCardConfig): void {

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -47,7 +47,8 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
     return this._config === undefined
       ? 3
       : this._config.card_size === undefined
-      ? this._config.content.split("\n").length + (this._config.title ? 1 : 0)
+      ? Math.round(this._config.content.split("\n").length / 2) +
+        (this._config.title ? 1 : 0)
       : this._config.card_size;
   }
 

--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -33,7 +33,7 @@ export abstract class HuiStackCard extends LitElement implements LovelaceCard {
 
   @property() private _config?: StackCardConfig;
 
-  public getCardSize(): number {
+  public getCardSize(): number | Promise<number> {
     return 1;
   }
 

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -77,7 +77,7 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
   @property() private _setTemp?: number | number[];
 
   public getCardSize(): number {
-    return 4;
+    return 5;
   }
 
   public setConfig(config: ThermostatCardConfig): void {

--- a/src/panels/lovelace/cards/hui-vertical-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-vertical-stack-card.ts
@@ -3,18 +3,20 @@ import { computeCardSize } from "../common/compute-card-size";
 import { HuiStackCard } from "./hui-stack-card";
 
 class HuiVerticalStackCard extends HuiStackCard {
-  public getCardSize() {
-    let totalSize = 0;
-
+  public async getCardSize() {
     if (!this._cards) {
-      return totalSize;
+      return 0;
     }
+
+    const promises: Promise<number>[] = [];
 
     for (const element of this._cards) {
-      totalSize += computeCardSize(element);
+      promises.push(computeCardSize(element));
     }
 
-    return totalSize;
+    const results = await Promise.all(promises);
+
+    return results.reduce((partial_sum, a) => partial_sum + a, 0);
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/lovelace/cards/hui-vertical-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-vertical-stack-card.ts
@@ -8,7 +8,7 @@ class HuiVerticalStackCard extends HuiStackCard {
       return 0;
     }
 
-    const promises: Promise<number>[] = [];
+    const promises: Array<Promise<number> | number> = [];
 
     for (const element of this._cards) {
       promises.push(computeCardSize(element));

--- a/src/panels/lovelace/common/compute-card-size.ts
+++ b/src/panels/lovelace/common/compute-card-size.ts
@@ -7,7 +7,6 @@ export const computeCardSize = async (card: LovelaceCard): Promise<number> => {
   if (customElements.get(card.localName)) {
     return 1;
   }
-  return customElements.whenDefined(card.localName).then(() => {
-    return computeCardSize(card);
-  });
+  await customElements.whenDefined(card.localName);
+  return computeCardSize(card);
 };

--- a/src/panels/lovelace/common/compute-card-size.ts
+++ b/src/panels/lovelace/common/compute-card-size.ts
@@ -1,12 +1,15 @@
 import { LovelaceCard } from "../types";
 
-export const computeCardSize = async (card: LovelaceCard): Promise<number> => {
+export const computeCardSize = (
+  card: LovelaceCard
+): number | Promise<number> => {
   if (typeof card.getCardSize === "function") {
     return card.getCardSize();
   }
   if (customElements.get(card.localName)) {
     return 1;
   }
-  await customElements.whenDefined(card.localName);
-  return computeCardSize(card);
+  return customElements
+    .whenDefined(card.localName)
+    .then(() => computeCardSize(card));
 };

--- a/src/panels/lovelace/common/compute-card-size.ts
+++ b/src/panels/lovelace/common/compute-card-size.ts
@@ -1,5 +1,13 @@
 import { LovelaceCard } from "../types";
 
-export const computeCardSize = (card: LovelaceCard): number => {
-  return typeof card.getCardSize === "function" ? card.getCardSize() : 4;
+export const computeCardSize = async (card: LovelaceCard): Promise<number> => {
+  if (typeof card.getCardSize === "function") {
+    return card.getCardSize();
+  }
+  if (customElements.get(card.localName)) {
+    return 1;
+  }
+  return customElements.whenDefined(card.localName).then(() => {
+    return computeCardSize(card);
+  });
 };

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -34,7 +34,7 @@ export interface LovelaceCard extends HTMLElement {
   hass?: HomeAssistant;
   isPanel?: boolean;
   editMode?: boolean;
-  getCardSize(): number;
+  getCardSize(): number | Promise<number>;
   setConfig(config: LovelaceCardConfig): void;
 }
 

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -252,7 +252,7 @@ export class HUIView extends LitElement {
         });
       }
 
-      let wait = false;
+      let waitProm: Promise<unknown> | undefined;
 
       // We should work for max 16ms (60fps) before allowing a frame to render
       if (start === undefined) {
@@ -260,13 +260,13 @@ export class HUIView extends LitElement {
         start = new Date();
       } else if (new Date().getTime() - start.getTime() > 16) {
         // We are working too long, we will prevent a render, wait to allow for a render
-        wait = true;
+        waitProm = tillNextRender;
       }
 
       const cardSizeProm = computeCardSize(el);
       // @ts-ignore
       // eslint-disable-next-line no-await-in-loop
-      const [cardSize] = await Promise.all([cardSizeProm, tillNextRender]);
+      const [cardSize] = await Promise.all([cardSizeProm, waitProm]);
 
       if (iteration !== this._createColumnsIteration) {
         // An other create columns is started, abort this one

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -245,15 +245,15 @@ export class HUIView extends LitElement {
       let waitProm: Promise<unknown>;
       if (cardsAdded > 5) {
         waitProm = nextRender();
-        if (iteration !== this._createColumnsIteration) {
-          return;
-        }
         cardsAdded = 0;
       } else {
         waitProm = Promise.resolve();
       }
       // eslint-disable-next-line no-await-in-loop
       const [cardSize] = await Promise.all([cardSizeProm, waitProm]);
+      if (iteration !== this._createColumnsIteration) {
+        return;
+      }
       cardsAdded++;
       const colIndex = getColumnIndex(columnEntityCount, cardSize as number);
       this._addCardToColumn(

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -252,24 +252,21 @@ export class HUIView extends LitElement {
         });
       }
 
-      let waitProm;
+      let wait = false;
 
       // We should work for max 16ms (60fps) before allowing a frame to render
       if (start === undefined) {
         // Save the time we start for this frame, no need to wait yet
         start = new Date();
-        waitProm = Promise.resolve();
       } else if (new Date().getTime() - start.getTime() > 16) {
         // We are working too long, we will prevent a render, wait to allow for a render
-        waitProm = tillNextRender;
-      } else {
-        // We don't need to wait, we are within our budget
-        waitProm = Promise.resolve();
+        wait = true;
       }
 
       const cardSizeProm = computeCardSize(el);
+      // @ts-ignore
       // eslint-disable-next-line no-await-in-loop
-      const [cardSize] = await Promise.all([cardSizeProm, waitProm]);
+      const [cardSize] = await Promise.all([cardSizeProm, tillNextRender]);
 
       if (iteration !== this._createColumnsIteration) {
         // An other create columns is started, abort this one


### PR DESCRIPTION
## Proposed change

`getCardSize` can now be an async function. `computeCardSize` will wait till an element is defined and then call `getCardSize`. This makes sure that the correct card size is reported at first load for all our built-in cards.

When building the view we will first add all columns (unlike before, where we would first calculate the columns based on card size) and then start filling them waiting for `getCardSize` for every card, or the next render after every 5 cards added.

Adding all columns does mean that the layout will jump if we have to remove a column at the end. This usually is not a big deal as that is the case with a small number of cards and that should render quickly.

Fixes https://github.com/home-assistant/frontend/issues/5321

For custom cards that would not be defined yet when the card is created, this still does not work correctly yet, but never has worked correctly. It would always get the size of the error card when the element was not defined yet.

I will check for a solution for that next.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
