### PR TITLE
Dont recreate resize observers and replace polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "node-vibrant": "^3.1.5",
     "proxy-polyfill": "^0.3.1",
     "regenerator-runtime": "^0.13.2",
-    "resize-observer": "^1.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "roboto-fontface": "^0.10.0",
     "superstruct": "^0.6.1",
     "unfetch": "^4.1.0",

--- a/src/data/area_registry.ts
+++ b/src/data/area_registry.ts
@@ -2,6 +2,7 @@ import { Connection, createCollection } from "home-assistant-js-websocket";
 import { compare } from "../common/string/compare";
 import { debounce } from "../common/util/debounce";
 import { HomeAssistant } from "../types";
+import { Store } from "home-assistant-js-websocket/dist/store";
 
 export interface AreaRegistryEntry {
   area_id: string;
@@ -38,18 +39,27 @@ export const deleteAreaRegistryEntry = (hass: HomeAssistant, areaId: string) =>
     area_id: areaId,
   });
 
-const fetchAreaRegistry = (conn) =>
+const fetchAreaRegistry = (conn: Connection) =>
   conn
     .sendMessagePromise({
       type: "config/area_registry/list",
     })
-    .then((areas) => areas.sort((ent1, ent2) => compare(ent1.name, ent2.name)));
+    .then((areas) =>
+      (areas as AreaRegistryEntry[]).sort((ent1, ent2) =>
+        compare(ent1.name, ent2.name)
+      )
+    );
 
-const subscribeAreaRegistryUpdates = (conn, store) =>
+const subscribeAreaRegistryUpdates = (
+  conn: Connection,
+  store: Store<AreaRegistryEntry[]>
+) =>
   conn.subscribeEvents(
     debounce(
       () =>
-        fetchAreaRegistry(conn).then((areas) => store.setState(areas, true)),
+        fetchAreaRegistry(conn).then((areas: AreaRegistryEntry[]) =>
+          store.setState(areas, true)
+        ),
       500,
       true
     ),

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -236,10 +236,12 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
   }
 
   private async _attachObserver(): Promise<void> {
-    await installResizeObserver();
-
-    this._resizeObserver = new ResizeObserver(this._debouncedMeasure);
-
+    if (!this._resizeObserver) {
+      await installResizeObserver();
+      this._resizeObserver = new ResizeObserver(
+        debounce(() => this._measureCard(), 250, false)
+      );
+    }
     const card = this.shadowRoot!.querySelector("ha-card");
     // If we show an error or warning there is no ha-card
     if (!card) {
@@ -247,8 +249,6 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
     }
     this._resizeObserver.observe(card);
   }
-
-  private _debouncedMeasure = debounce(() => this._measureCard(), 250, true);
 
   private _measureCard() {
     if (!this.isConnected) {

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -175,6 +175,7 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
   }
 
   protected firstUpdated(): void {
+    this._measureCard();
     this._attachObserver();
   }
 

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -618,8 +618,6 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
     );
   }
 
-  private _debouncedMeasure = debounce(() => this._measureCard(), 250, true);
-
   private _measureCard() {
     const card = this.shadowRoot!.querySelector("ha-card");
     if (!card) {
@@ -631,9 +629,12 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
   }
 
   private async _attachObserver(): Promise<void> {
-    await installResizeObserver();
-    this._resizeObserver = new ResizeObserver(this._debouncedMeasure);
-
+    if (!this._resizeObserver) {
+      await installResizeObserver();
+      this._resizeObserver = new ResizeObserver(
+        debounce(() => this._measureCard(), 250, false)
+      );
+    }
     const card = this.shadowRoot!.querySelector("ha-card");
     // If we show an error or warning there is no ha-card
     if (!card) {

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -431,6 +431,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
   }
 
   protected firstUpdated(): void {
+    this._measureCard();
     this._attachObserver();
   }
 

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -292,7 +292,9 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   private async _attachObserver(): Promise<void> {
     if (!this._resizeObserver) {
       await installResizeObserver();
-      this._resizeObserver = new ResizeObserver(this._debouncedMeasure);
+      this._resizeObserver = new ResizeObserver(
+        debounce(() => this._measureCard(), 250, false)
+      );
     }
     const card = this.shadowRoot!.querySelector("ha-card");
     // If we show an error or warning there is no ha-card
@@ -301,8 +303,6 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
     }
     this._resizeObserver.observe(card);
   }
-
-  private _debouncedMeasure = debounce(() => this._measureCard(), 250, true);
 
   private _measureCard() {
     if (!this.isConnected) {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -102,6 +102,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   }
 
   protected firstUpdated(): void {
+    this._measureCard();
     this._attachObserver();
   }
 

--- a/src/panels/lovelace/common/install-resize-observer.ts
+++ b/src/panels/lovelace/common/install-resize-observer.ts
@@ -1,6 +1,6 @@
 export const installResizeObserver = async () => {
   if (typeof ResizeObserver !== "function") {
-    const modules = await import("resize-observer");
-    modules.install();
+    const modules = await import("resize-observer-polyfill");
+    window.ResizeObserver = modules.default;
   }
 };

--- a/src/panels/lovelace/common/install-resize-observer.ts
+++ b/src/panels/lovelace/common/install-resize-observer.ts
@@ -1,6 +1,5 @@
 export const installResizeObserver = async () => {
   if (typeof ResizeObserver !== "function") {
-    const modules = await import("resize-observer-polyfill");
-    window.ResizeObserver = modules.default;
+    window.ResizeObserver = (await import("resize-observer-polyfill")).default;
   }
 };

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -65,6 +65,7 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
   }
 
   protected firstUpdated(): void {
+    this._measureCard();
     this._attachObserver();
   }
 
@@ -207,20 +208,18 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
     if (!this._resizeObserver) {
       await installResizeObserver();
       this._resizeObserver = new ResizeObserver(
-        debounce(
-          () => {
-            if (!this.isConnected) {
-              return;
-            }
-            this._narrow = (this.clientWidth || 0) < 300;
-            this._veryNarrow = (this.clientWidth || 0) < 225;
-          },
-          250,
-          false
-        )
+        debounce(() => this._measureCard(), 250, false)
       );
     }
     this._resizeObserver.observe(this);
+  }
+
+  private _measureCard() {
+    if (!this.isConnected) {
+      return;
+    }
+    this._narrow = (this.clientWidth || 0) < 300;
+    this._veryNarrow = (this.clientWidth || 0) < 225;
   }
 
   private _computeControlIcon(stateObj: HassEntity): string {

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -47,15 +47,6 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
 
   private _resizeObserver?: ResizeObserver;
 
-  private _debouncedResizeListener = debounce(
-    () => {
-      this._narrow = (this.clientWidth || 0) < 300;
-      this._veryNarrow = (this.clientWidth || 0) < 225;
-    },
-    250,
-    true
-  );
-
   public setConfig(config: EntityConfig): void {
     if (!config || !config.entity) {
       throw new Error("Invalid Configuration: 'entity' required");
@@ -66,9 +57,7 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
 
   public connectedCallback(): void {
     super.connectedCallback();
-    if (!this._resizeObserver) {
-      this._attachObserver();
-    }
+    this._attachObserver();
   }
 
   public disconnectedCallback(): void {
@@ -214,12 +203,24 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
     `;
   }
 
-  private _attachObserver(): void {
-    installResizeObserver().then(() => {
-      this._resizeObserver = new ResizeObserver(this._debouncedResizeListener);
-
-      this._resizeObserver.observe(this);
-    });
+  private async _attachObserver(): Promise<void> {
+    if (!this._resizeObserver) {
+      await installResizeObserver();
+      this._resizeObserver = new ResizeObserver(
+        debounce(
+          () => {
+            if (!this.isConnected) {
+              return;
+            }
+            this._narrow = (this.clientWidth || 0) < 300;
+            this._veryNarrow = (this.clientWidth || 0) < 225;
+          },
+          250,
+          false
+        )
+      );
+    }
+    this._resizeObserver.observe(this);
   }
 
   private _computeControlIcon(stateObj: HassEntity): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12758,11 +12758,6 @@ resize-observer-polyfill@^1.5.1:
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
-resize-observer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/resize-observer/-/resize-observer-1.0.0.tgz#4f8380b73b411af4ed7d916fe85a2d59900e71ef"
-  integrity sha512-D7UFShDm2TgrEDEyeg+/tTEbvOgPWlvPAfJtxiKp+qutu6HowmcGJKjECgGru0PPDIj3SAucn3ZPpOx54fF7DQ==
-
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
## Proposed change

Replace the polyfill we use with a far more popular one.

And only create a resizeObserver once instead of on every firstUpdate/connect.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
