### PR TITLE
Support twice daily forecasts in weather-forecast-card

### DIFF
--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -211,7 +211,7 @@ export const weatherSVGStyles = css`
 
 export const getWeatherStateSVG = (
   state: string,
-  daytime?: boolean
+  nighttime?: boolean
 ): SVGTemplateResult => {
   return svg`
   <svg
@@ -239,17 +239,17 @@ export const getWeatherStateSVG = (
       : ""
   }
   ${
-    state === "partlycloudy" && (daytime === undefined || daytime)
-      ? svg`
-          <path
-            class="sun"
-            d="m14.981 4.2112c0 1.9244-1.56 3.4844-3.484 3.4844-1.9244 0-3.4844-1.56-3.4844-3.4844s1.56-3.484 3.4844-3.484c1.924 0 3.484 1.5596 3.484 3.484"
-          />
-        `
-      : state === "partlycloudy" && !daytime
+    state === "partlycloudy" && nighttime
       ? svg`
           <path
             class="moon"
+            d="m14.981 4.2112c0 1.9244-1.56 3.4844-3.484 3.4844-1.9244 0-3.4844-1.56-3.4844-3.4844s1.56-3.484 3.4844-3.484c1.924 0 3.484 1.5596 3.484 3.484"
+          />
+        `
+      : state === "partlycloudy"
+      ? svg`
+          <path
+            class="sun"
             d="m14.981 4.2112c0 1.9244-1.56 3.4844-3.484 3.4844-1.9244 0-3.4844-1.56-3.4844-3.4844s1.56-3.484 3.4844-3.484c1.924 0 3.484 1.5596 3.484 3.484"
           />
         `
@@ -353,7 +353,7 @@ export const getWeatherStateSVG = (
 export const getWeatherStateIcon = (
   state: string,
   element: HTMLElement,
-  daytime?: boolean
+  nighttime?: boolean
 ): TemplateResult | undefined => {
   const userDefinedIcon = getComputedStyle(element).getPropertyValue(
     `--weather-icon-${state}`
@@ -370,7 +370,7 @@ export const getWeatherStateIcon = (
   }
 
   if (weatherSVGs.has(state)) {
-    return html`${getWeatherStateSVG(state, daytime)}`;
+    return html`${getWeatherStateSVG(state, nighttime)}`;
   }
 
   if (state in weatherIcons) {

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -239,7 +239,7 @@ export const getWeatherStateSVG = (
       : ""
   }
   ${
-    state === "partlycloudy" && nighttime
+    state === "partlycloudy" && nightTime
       ? svg`
           <path
             class="moon"

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -211,7 +211,7 @@ export const weatherSVGStyles = css`
 
 export const getWeatherStateSVG = (
   state: string,
-  nighttime?: boolean
+  nightTime?: boolean
 ): SVGTemplateResult => {
   return svg`
   <svg
@@ -353,7 +353,7 @@ export const getWeatherStateSVG = (
 export const getWeatherStateIcon = (
   state: string,
   element: HTMLElement,
-  nighttime?: boolean
+  nightTime?: boolean
 ): TemplateResult | undefined => {
   const userDefinedIcon = getComputedStyle(element).getPropertyValue(
     `--weather-icon-${state}`
@@ -370,7 +370,7 @@ export const getWeatherStateIcon = (
   }
 
   if (weatherSVGs.has(state)) {
-    return html`${getWeatherStateSVG(state, nighttime)}`;
+    return html`${getWeatherStateSVG(state, nightTime)}`;
   }
 
   if (state in weatherIcons) {

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -209,7 +209,10 @@ export const weatherSVGStyles = css`
   }
 `;
 
-export const getWeatherStateSVG = (state: string): SVGTemplateResult => {
+export const getWeatherStateSVG = (
+  state: string,
+  daytime?: boolean
+): SVGTemplateResult => {
   return svg`
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -236,10 +239,17 @@ export const getWeatherStateSVG = (state: string): SVGTemplateResult => {
       : ""
   }
   ${
-    state === "partlycloudy"
+    state === "partlycloudy" && (daytime === undefined || daytime)
       ? svg`
           <path
             class="sun"
+            d="m14.981 4.2112c0 1.9244-1.56 3.4844-3.484 3.4844-1.9244 0-3.4844-1.56-3.4844-3.4844s1.56-3.484 3.4844-3.484c1.924 0 3.484 1.5596 3.484 3.484"
+          />
+        `
+      : state === "partlycloudy" && !daytime
+      ? svg`
+          <path
+            class="moon"
             d="m14.981 4.2112c0 1.9244-1.56 3.4844-3.484 3.4844-1.9244 0-3.4844-1.56-3.4844-3.4844s1.56-3.484 3.4844-3.484c1.924 0 3.484 1.5596 3.484 3.484"
           />
         `
@@ -342,7 +352,8 @@ export const getWeatherStateSVG = (state: string): SVGTemplateResult => {
 
 export const getWeatherStateIcon = (
   state: string,
-  element: HTMLElement
+  element: HTMLElement,
+  daytime?: boolean
 ): TemplateResult | undefined => {
   const userDefinedIcon = getComputedStyle(element).getPropertyValue(
     `--weather-icon-${state}`
@@ -359,7 +370,7 @@ export const getWeatherStateIcon = (
   }
 
   if (weatherSVGs.has(state)) {
-    return html`${getWeatherStateSVG(state)}`;
+    return html`${getWeatherStateSVG(state, daytime)}`;
   }
 
   if (state in weatherIcons) {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -163,6 +163,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         : undefined;
 
     let hourly: boolean | undefined;
+    let multiday: boolean | undefined;
 
     if (forecast?.length && forecast?.length > 2) {
       const date1 = new Date(forecast[1].datetime);
@@ -170,6 +171,14 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       const timeDiff = date2.getTime() - date1.getTime();
 
       hourly = timeDiff < DAY_IN_MILLISECONDS;
+
+      if (hourly) {
+        const date0 = new Date(forecast[0].datetime);
+        const datelast = new Date(forecast[forecast.length - 1].datetime);
+        const dayDiff = datelast.getTime() - date0.getTime();
+
+        multiday = dayDiff > DAY_IN_MILLISECONDS;
+      }
     }
 
     const weatherStateIcon = getWeatherStateIcon(stateObj.state, this);
@@ -235,7 +244,21 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                   (item) => html`
                     <div>
                       <div>
-                        ${hourly
+                        ${multiday
+                          ? html`
+                              ${new Date(item.datetime).toLocaleDateString(
+                                this.hass!.language,
+                                { weekday: "short" }
+                              )}
+                              <br />
+                              ${new Date(item.datetime).toLocaleTimeString(
+                                this.hass!.language,
+                                {
+                                  hour: "numeric",
+                                }
+                              )}
+                            `
+                          : hourly
                           ? html`
                               ${new Date(item.datetime).toLocaleTimeString(
                                 this.hass!.language,

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -276,7 +276,11 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                       ${item.condition !== undefined && item.condition !== null
                         ? html`
                             <div class="forecast-image-icon">
-                              ${getWeatherStateIcon(item.condition, this)}
+                              ${getWeatherStateIcon(
+                                item.condition,
+                                this,
+                                item.daytime
+                              )}
                             </div>
                           `
                         : ""}

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -163,7 +163,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         : undefined;
 
     let hourly: boolean | undefined;
-    let daynight: boolean | undefined;
+    let dayNight: boolean | undefined;
 
     if (forecast?.length && forecast?.length > 2) {
       const date1 = new Date(forecast[1].datetime);

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -251,7 +251,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                                 { weekday: "short" }
                               )}
                               <div class="daynight">
-                                ${new Date(item.datetime).getHours() > 12
+                                ${new Date(item.datetime).getHours() >= 18
                                   ? "Night"
                                   : ""}<br />
                               </div>

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -475,8 +475,6 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         }
 
         .night-icon {
-          position: relative;
-          top: -2px;
           --mdc-icon-size: 12px;
         }
 

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -251,9 +251,9 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                                 { weekday: "short" }
                               )}
                               <div class="daynight">
-                                ${new Date(item.datetime).getHours() >= 18
-                                  ? "Night"
-                                  : ""}<br />
+                                ${item.daytime === undefined || item.daytime
+                                  ? ""
+                                  : "Night"}<br />
                               </div>
                             `
                           : hourly

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -175,7 +175,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       if (hourly) {
         const dateFirst = new Date(forecast[0].datetime);
         const datelast = new Date(forecast[forecast.length - 1].datetime);
-        const dayDiff = datelast.getTime() - date0.getTime();
+        const dayDiff = datelast.getTime() - dateFirst.getTime();
 
         daynight = dayDiff > DAY_IN_MILLISECONDS;
       }

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -250,11 +250,12 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                                 this.hass!.language,
                                 { weekday: "short" }
                               )}
-                              <div class="daynight">
-                                ${item.daytime === undefined || item.daytime
-                                  ? ""
-                                  : "Night"}<br />
-                              </div>
+                              ${item.daytime === undefined || item.daytime
+                                ? ""
+                                : html`<ha-icon
+                                    class="night-icon"
+                                    icon="hass:weather-night"
+                                  ></ha-icon>`}
                             `
                           : hourly
                           ? html`
@@ -465,9 +466,12 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
         .attribute,
         .templow,
-        .daynight,
         .name {
           color: var(--secondary-text-color);
+        }
+
+        .night-icon {
+          --mdc-icon-size: 12px;
         }
 
         .unavailable {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -279,7 +279,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                               ${getWeatherStateIcon(
                                 item.condition,
                                 this,
-                                !item.daytime
+                                !(item.daytime || item.daytime === undefined)
                               )}
                             </div>
                           `

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -252,7 +252,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                               )}
                               <div class="daynight">
                                 ${item.daytime === undefined || item.daytime
-                                  ? ""
+                                  ? "Day"
                                   : "Night"}<br />
                               </div>
                             `

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -279,7 +279,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                               ${getWeatherStateIcon(
                                 item.condition,
                                 this,
-                                item.daytime
+                                !item.daytime
                               )}
                             </div>
                           `

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -250,12 +250,11 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                                 this.hass!.language,
                                 { weekday: "short" }
                               )}
-                              ${item.daytime === undefined || item.daytime
-                                ? ""
-                                : html`<ha-icon
-                                    class="night-icon"
-                                    icon="hass:weather-night"
-                                  ></ha-icon>`}
+                              <div class="daynight">
+                                ${item.daytime === undefined || item.daytime
+                                  ? ""
+                                  : "Night"}<br />
+                              </div>
                             `
                           : hourly
                           ? html`
@@ -470,12 +469,9 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
         .attribute,
         .templow,
+        .daynight,
         .name {
           color: var(--secondary-text-color);
-        }
-
-        .night-icon {
-          --mdc-icon-size: 12px;
         }
 
         .unavailable {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -173,7 +173,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       hourly = timeDiff < DAY_IN_MILLISECONDS;
 
       if (hourly) {
-        const date0 = new Date(forecast[0].datetime);
+        const dateFirst = new Date(forecast[0].datetime);
         const datelast = new Date(forecast[forecast.length - 1].datetime);
         const dayDiff = datelast.getTime() - date0.getTime();
 

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -252,8 +252,8 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                               )}
                               <div class="daynight">
                                 ${item.daytime === undefined || item.daytime
-                                  ? this.hass.localize("ui.card.weather.day")
-                                  : this.hass.localize(
+                                  ? this.hass!.localize("ui.card.weather.day")
+                                  : this.hass!.localize(
                                       "ui.card.weather.night"
                                     )}<br />
                               </div>

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -177,7 +177,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         const datelast = new Date(forecast[forecast.length - 1].datetime);
         const dayDiff = datelast.getTime() - dateFirst.getTime();
 
-        daynight = dayDiff > DAY_IN_MILLISECONDS;
+        dayNight = dayDiff > DAY_IN_MILLISECONDS;
       }
     }
 
@@ -244,7 +244,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                   (item) => html`
                     <div>
                       <div>
-                        ${daynight
+                        ${dayNight
                           ? html`
                               ${new Date(item.datetime).toLocaleDateString(
                                 this.hass!.language,

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -163,7 +163,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         : undefined;
 
     let hourly: boolean | undefined;
-    let multiday: boolean | undefined;
+    let daynight: boolean | undefined;
 
     if (forecast?.length && forecast?.length > 2) {
       const date1 = new Date(forecast[1].datetime);
@@ -177,7 +177,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         const datelast = new Date(forecast[forecast.length - 1].datetime);
         const dayDiff = datelast.getTime() - date0.getTime();
 
-        multiday = dayDiff > DAY_IN_MILLISECONDS;
+        daynight = dayDiff > DAY_IN_MILLISECONDS;
       }
     }
 
@@ -244,19 +244,17 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                   (item) => html`
                     <div>
                       <div>
-                        ${multiday
+                        ${daynight
                           ? html`
                               ${new Date(item.datetime).toLocaleDateString(
                                 this.hass!.language,
                                 { weekday: "short" }
                               )}
-                              <br />
-                              ${new Date(item.datetime).toLocaleTimeString(
-                                this.hass!.language,
-                                {
-                                  hour: "numeric",
-                                }
-                              )}
+                              <div class="daynight">
+                                ${new Date(item.datetime).getHours() > 12
+                                  ? "Night"
+                                  : ""}<br />
+                              </div>
                             `
                           : hourly
                           ? html`
@@ -467,6 +465,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
         .attribute,
         .templow,
+        .daynight,
         .name {
           color: var(--secondary-text-color);
         }

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -471,6 +471,8 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
         }
 
         .night-icon {
+          position: relative;
+          top: -2px;
           --mdc-icon-size: 12px;
         }
 

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -252,8 +252,10 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                               )}
                               <div class="daynight">
                                 ${item.daytime === undefined || item.daytime
-                                  ? "Day"
-                                  : "Night"}<br />
+                                  ? this.hass.localize("ui.card.weather.day")
+                                  : this.hass.localize(
+                                      "ui.card.weather.night"
+                                    )}<br />
                               </div>
                             `
                           : hourly

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -246,6 +246,8 @@
           "wnw": "WNW",
           "wsw": "WSW"
         },
+        "day": "Day",
+        "night": "Night",
         "forecast": "Forecast",
         "high": "High",
         "low": "Low"

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,6 +325,7 @@ interface ForecastAttribute {
   precipitation_probability?: number;
   humidity?: number;
   condition?: string;
+  daytime?: boolean;
 }
 
 export type WeatherEntity = HassEntityBase & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1345,7 +1345,7 @@
     "@babel/runtime" "^7.7.2"
     core-js "^3.4.1"
 
-"@material/animation@8.0.0-canary.096a7a066.0", "@material/animation@8.0.0-canary.a78ceb112.0", "@material/animation@=8.0.0-canary.096a7a066.0":
+"@material/animation@8.0.0-canary.096a7a066.0", "@material/animation@8.0.0-canary.a78ceb112.0":
   version "8.0.0-canary.096a7a066.0"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-8.0.0-canary.096a7a066.0.tgz#9c1b3d31858889e04e722ca8f1ade7ae3c54f7e6"
   integrity sha512-hGL6sMGcyd9JoxcyhRkAhD6KKQwZVRkhaFcra9YMBYHUbWRxfUbfDTjUZ3ZxmLDDcsjL4Hqjblet6Xmtq3Br5g==
@@ -1463,7 +1463,7 @@
     "@material/feature-targeting" "8.0.0-canary.096a7a066.0"
     "@material/theme" "8.0.0-canary.096a7a066.0"
 
-"@material/feature-targeting@8.0.0-canary.096a7a066.0", "@material/feature-targeting@8.0.0-canary.a78ceb112.0", "@material/feature-targeting@=8.0.0-canary.096a7a066.0":
+"@material/feature-targeting@8.0.0-canary.096a7a066.0", "@material/feature-targeting@8.0.0-canary.a78ceb112.0":
   version "8.0.0-canary.096a7a066.0"
   resolved "https://registry.yarnpkg.com/@material/feature-targeting/-/feature-targeting-8.0.0-canary.096a7a066.0.tgz#fca721c287b08e0868467ee60daa5d32aad16430"
   integrity sha512-5nxnG08PjdwhrLMNxfeCOImbdEtP/bVveOVr72hdqldHuwfnzNjp0lwWAAh/QZrpJNl4Ve2Cnp/LkRnlOELIkw==
@@ -1839,7 +1839,7 @@
     "@material/typography" "8.0.0-canary.096a7a066.0"
     tslib "^1.9.3"
 
-"@material/theme@8.0.0-canary.096a7a066.0", "@material/theme@8.0.0-canary.a78ceb112.0", "@material/theme@=8.0.0-canary.096a7a066.0":
+"@material/theme@8.0.0-canary.096a7a066.0", "@material/theme@8.0.0-canary.a78ceb112.0":
   version "8.0.0-canary.096a7a066.0"
   resolved "https://registry.yarnpkg.com/@material/theme/-/theme-8.0.0-canary.096a7a066.0.tgz#f657eaa545797ee3e6a2d96e4a61f844ad3dc425"
   integrity sha512-FdAUEjq7KJ835sobJQL0w0XWD5PabXl77HmBuy5F3bEYbYterWOutvuHbTkAEN6sTzgHCKhdoMubRxMKidqafA==


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add support for twice daily forecasts (like those from the NWS integration) to the weather-forecast card.

Currently, the weather-forecast card lists the day of the week, like Mon, Tue, Wed if the interval between forecast entries is a full day, or just the hour, like 8 AM, 9 AM, etc., if it is less. This is confusing if the interval is less than a day but not hourly. For example, twice daily forecasts show up as "8 AM, 6 PM, 6 AM, 6 PM, 6 AM." 

This PR adds the day of the week to the hour if the forecast spans more than 24 hours. For example, "Wed 8 AM, Wed 6 PM, Thu 6 AM, Thu 6PM." 
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5829
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
