### PR TITLE
Make two builds of hassio

### DIFF
--- a/build-scripts/bundle.js
+++ b/build-scripts/bundle.js
@@ -170,15 +170,12 @@ module.exports.config = {
   },
 
   hassio({ isProdBuild, latestBuild }) {
-    if (latestBuild) {
-      throw new Error("Hass.io does not support latest build!");
-    }
     return {
       entry: {
         entrypoint: path.resolve(paths.hassio_dir, "src/entrypoint.ts"),
       },
-      outputPath: paths.hassio_output_root,
-      publicPath: paths.hassio_publicPath,
+      outputPath: outputPath(paths.hassio_output_root, latestBuild),
+      publicPath: publicPath(latestBuild, paths.hassio_publicPath),
       isProdBuild,
       latestBuild,
       dontHash: new Set(["entrypoint"]),

--- a/build-scripts/gulp/hassio.js
+++ b/build-scripts/gulp/hassio.js
@@ -13,7 +13,7 @@ require("./rollup.js");
 
 async function writeEntrypointJS() {
   // We ship two builds and we need to do feature detection on what version to load.
-  fs.mkdirSync(paths.hassio_output_root);
+  fs.mkdirSync(paths.hassio_output_root, { recursive: true });
   fs.writeFileSync(
     path.resolve(paths.hassio_output_root, "entrypoint.js"),
     `

--- a/build-scripts/gulp/hassio.js
+++ b/build-scripts/gulp/hassio.js
@@ -1,12 +1,32 @@
 const gulp = require("gulp");
+const fs = require("fs");
+const path = require("path");
 
 const env = require("../env");
+const paths = require("../paths");
 
 require("./clean.js");
 require("./gen-icons-json.js");
 require("./webpack.js");
 require("./compress.js");
 require("./rollup.js");
+
+async function backwardsCompatibility() {
+  // Until Supervisor 228, Home Assistant expected the entrypoint
+  // to be available at /api/hassio/app/entrypoint.js
+  // Then we changed to two builds, so now we have 2 folders.
+  //
+  // We redirect to the ES5 build here.
+  fs.writeFileSync(
+    path.resolve(paths.hassio_output_root, "entrypoint.js"),
+    `
+var el = document.createElement('script');
+el.src = '/api/hassio/app/frontend_es5/entrypoint.js';
+document.body.appendChild(el);
+  `,
+    { encoding: "utf-8" }
+  );
+}
 
 gulp.task(
   "develop-hassio",
@@ -29,6 +49,7 @@ gulp.task(
     "clean-hassio",
     "gen-icons-json",
     env.useRollup() ? "rollup-prod-hassio" : "webpack-prod-hassio",
+    backwardsCompatibility,
     ...// Don't compress running tests
     (env.isTest() ? [] : ["compress-hassio"])
   )

--- a/build-scripts/gulp/rollup.js
+++ b/build-scripts/gulp/rollup.js
@@ -92,11 +92,7 @@ gulp.task("rollup-watch-app", () => {
 });
 
 gulp.task("rollup-watch-hassio", () => {
-  watchRollup(
-    // Force latestBuild = false for hassio config.
-    (conf) => rollupConfig.createHassioConfig({ ...conf, latestBuild: false }),
-    ["hassio/src/**"]
-  );
+  watchRollup(rollupConfig.createHassioConfig, ["hassio/src/**"]);
 });
 
 gulp.task("rollup-dev-server-demo", () => {
@@ -137,12 +133,7 @@ gulp.task(
 );
 
 gulp.task("rollup-prod-hassio", () =>
-  buildRollup(
-    rollupConfig.createHassioConfig({
-      isProdBuild: true,
-      latestBuild: false,
-    })
-  )
+  bothBuilds(rollupConfig.createHassioConfig, { isProdBuild: true })
 );
 
 gulp.task("rollup-prod-gallery", () =>

--- a/build-scripts/gulp/webpack.js
+++ b/build-scripts/gulp/webpack.js
@@ -129,7 +129,7 @@ gulp.task("webpack-watch-hassio", () => {
   webpack(
     createHassioConfig({
       isProdBuild: false,
-      latestBuild: false,
+      latestBuild: true,
     })
   ).watch({}, handler());
 });
@@ -139,9 +139,8 @@ gulp.task(
   () =>
     new Promise((resolve) =>
       webpack(
-        createHassioConfig({
+        bothBuilds(createHassioConfig, {
           isProdBuild: true,
-          latestBuild: false,
         }),
         handler(resolve)
       )

--- a/build-scripts/paths.js
+++ b/build-scripts/paths.js
@@ -34,7 +34,7 @@ module.exports = {
 
   hassio_dir: path.resolve(__dirname, "../hassio"),
   hassio_output_root: path.resolve(__dirname, "../hassio/build"),
-  hassio_publicPath: "/api/hassio/app/",
+  hassio_publicPath: "/api/hassio/app",
 
   translations_src: path.resolve(__dirname, "../src/translations"),
 };

--- a/hassio/webpack.config.js
+++ b/hassio/webpack.config.js
@@ -1,11 +1,8 @@
 const { createHassioConfig } = require("../build-scripts/webpack.js");
-const { isProdBuild } = require("../build-scripts/env.js");
-
-// File just used for stats builds
-
-const latestBuild = false;
+const { isProdBuild, isStatsBuild } = require("../build-scripts/env.js");
 
 module.exports = createHassioConfig({
   isProdBuild: isProdBuild(),
-  latestBuild,
+  isStatsBuild: isStatsBuild(),
+  latestBuild: true,
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently we only publish an ES5 build of Hass.io. This will bring Hass.io builds in line with our other builds and builds two builds: an ES5 build and a latest build. This significantly speeds up the hassio panel.

This is backwards compatible with the old supervisor frontend so it works on old Home Assistant versions.

Tested this with:
 - Home Assistant 0.110
 - Home Assistant 0.112dev with two builds for custom panels enabled and `hassio` updated to use this.

We are now doing our own feature detection for Hass.io, which allows us to decide ourselves what version to serve who.

---

**No longer relevant**

When #6104 is merged, we can update the `hassio` integration to publish two builds.

The reason I have marked this PR as a draft is because what we define as `latest` changes over time. And so this exposes us to the following scenario:

 - We update what we consider `latest` and start shipping this frontend
 - We do a new Hass.io build that somehow relies on these latest changes and ship this supervisor. This supervisor will also end up with older Home Assistant versions.
 - The older Home Assistant versions still have the old `latest` check and will send browsers to the `latest` build of the supervisor that might not be able to render it.

I think that this is a very unlikely scenario because we only change `latest` if there is a syntax that we want that we can't transpile to an older version of Home Assistant or that we don't want to polyfill. 

Currently we have declared dynamic imports (`import(…)`) as our check to serve `latest` and I don't see this changing in the next year or two. Maybe when decorators supports becomes widespread adopted will we change it.

By that time we could put a check in our supervisor loader to guide newer builds to the older es5 build.

Going to take some time to think this over.

Here is the patch for `hassio` integration if we want to move forward with this

```patch
diff --git a/homeassistant/components/hassio/__init__.py b/homeassistant/components/hassio/__init__.py
index 0bd766589a..3837e0c451 100644
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -242,7 +242,8 @@ async def async_setup(hass, config):
         webcomponent_name="hassio-main",
         sidebar_title="Supervisor",
         sidebar_icon="hass:home-assistant",
-        js_url="/api/hassio/app/entrypoint.js",
+        module_url="/api/hassio/app/frontend_latest/entrypoint.js",
+        js_url="/api/hassio/app/frontend_es5/entrypoint.js",
         embed_iframe=True,
         require_admin=True,
     )
```


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
