### PR TITLE
fix panel iframe url

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -181,7 +181,8 @@ class HaSidebar extends LitElement {
           this._renderPanel(
             panel.url_path,
             panel.icon,
-            hass.localize(`panel.${panel.title}`) || panel.title
+            hass.localize(`panel.${panel.title}`) || panel.title,
+            panel.config
           )
         )}
         <div class="spacer" disabled></div>
@@ -190,7 +191,8 @@ class HaSidebar extends LitElement {
           this._renderPanel(
             panel.url_path,
             panel.icon,
-            hass.localize(`panel.${panel.title}`) || panel.title
+            hass.localize(`panel.${panel.title}`) || panel.title,
+            panel.config
           )
         )}
         ${this._externalConfig && this._externalConfig.hasSettingsScreen
@@ -443,11 +445,15 @@ class HaSidebar extends LitElement {
     fireEvent(this, "hass-toggle-menu");
   }
 
-  private _renderPanel(urlPath, icon, title) {
+  private _renderPanel(urlPath, icon, title, config) {
+    let url = `/${urlPath}`;
+    if (config && config.url) {
+      url = config.url;
+    }
     return html`
       <a
         aria-role="option"
-        href="${`/${urlPath}`}"
+        href="${url}"
         data-panel="${urlPath}"
         tabindex="-1"
         @mouseenter=${this._itemMouseEnter}

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -175,7 +175,8 @@ class HaSidebar extends LitElement {
         ${this._renderPanel(
           defaultPanel.url_path,
           defaultPanel.icon || "hass:view-dashboard",
-          defaultPanel.title || hass.localize("panel.states")
+          defaultPanel.title || hass.localize("panel.states"),
+          defaultPanel.config
         )}
         ${beforeSpacer.map((panel) =>
           this._renderPanel(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR enables the panel_iframe "url" key to actually do something. As is, the panels in panel_iframe will display the relative URL /foo, where "foo" is the key of the panel as described in panel_iframe.yaml.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

This PR modifies ha-sidebar.ts. It modifies the calls to _renderPanel for both the panel groups contained in beforeSpacer and afterSpacer to pass the config along to _renderPanel. (This config is present in the panel object by virtue of the call to async_register_built_in_panel in home-assistant-core:homeassistant/components/panel_iframe/__init__.py.)

The _renderPanel function will now accept config, and test for its existence, and the existence of the "url" within it. If it's present, it will use that as the href of the link. If not, then `/${urlPath}` will be used (the present behavior).

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io