### PR TITLE
Reduce HLS buffer length to 1 minute instead of the default infinity

### DIFF
--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -177,8 +177,7 @@ class HaCameraStream extends LitElement {
     url: string
   ) {
     const hls = new Hls({
-        liveSyncDurationCount: 1,
-        liveBackBufferLength: 60
+      liveBackBufferLength: 60,
     });
     this._hlsPolyfillInstance = hls;
     hls.attachMedia(videoEl);

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -176,10 +176,6 @@ class HaCameraStream extends LitElement {
     Hls: HLSModule,
     url: string
   ) {
-    var config = {
-        liveSyncDurationCount: 1,
-        liveBackBufferLength: 60
-    };
     const hls = new Hls({
         liveSyncDurationCount: 1,
         liveBackBufferLength: 60

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -176,7 +176,11 @@ class HaCameraStream extends LitElement {
     Hls: HLSModule,
     url: string
   ) {
-    const hls = new Hls();
+    var config = {
+        liveSyncDurationCount: 1,
+        liveBackBufferLength: 60
+    };
+    const hls = new Hls(config);
     this._hlsPolyfillInstance = hls;
     hls.attachMedia(videoEl);
     hls.on(Hls.Events.MEDIA_ATTACHED, () => {

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -180,7 +180,10 @@ class HaCameraStream extends LitElement {
         liveSyncDurationCount: 1,
         liveBackBufferLength: 60
     };
-    const hls = new Hls(config);
+    const hls = new Hls({
+        liveSyncDurationCount: 1,
+        liveBackBufferLength: 60
+    });
     this._hlsPolyfillInstance = hls;
     hls.attachMedia(videoEl);
     hls.on(Hls.Events.MEDIA_ATTACHED, () => {


### PR DESCRIPTION
## Breaking change
Not sure anything besides live stream is supported but basically this will not be ideal if streaming a file is supported, since most likely seeking will be impacted.

## Proposed change
Currently we use the default buffer of infinity for hls.js which is not ideal for live streams.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [X] Improvement
## Checklist
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.