### PR TITLE
Disconnect panel after 5 minutes hidden

### DIFF
--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -91,6 +91,20 @@ class PartialPanelResolver extends HassRouterPage {
 
   private _waitForStart = false;
 
+  private _disconnectedPanel?: ChildNode;
+
+  private _hiddenTimeout?: number;
+
+  protected firstUpdated(changedProps: PropertyValues) {
+    super.firstUpdated(changedProps);
+
+    document.addEventListener(
+      "visibilitychange",
+      () => this._handleVisibilityChange(),
+      false
+    );
+  }
+
   protected updated(changedProps: PropertyValues) {
     super.updated(changedProps);
 
@@ -138,6 +152,27 @@ class PartialPanelResolver extends HassRouterPage {
       el.narrow = this.narrow;
       el.route = this.routeTail;
       el.panel = hass.panels[this._currentPage];
+    }
+  }
+
+  private _handleVisibilityChange() {
+    if (document.hidden) {
+      this._hiddenTimeout = window.setTimeout(() => {
+        this._hiddenTimeout = undefined;
+        if (this.lastChild) {
+          this._disconnectedPanel = this.lastChild;
+          this.removeChild(this.lastChild);
+        }
+      }, 300000);
+    } else {
+      if (this._hiddenTimeout) {
+        clearTimeout(this._hiddenTimeout);
+        this._hiddenTimeout = undefined;
+      }
+      if (this._disconnectedPanel) {
+        this.appendChild(this._disconnectedPanel);
+        this._disconnectedPanel = undefined;
+      }
     }
   }
 


### PR DESCRIPTION
## Proposed change

Disconnect the current panel when the document is hidden for 5 minutes.
This calls all disconnects from all elements in the panel so they can clean up, like the camera live streams will stop.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
