### PR TITLE
Fix ha-card outline box shadow in firefox

### DIFF
--- a/src/components/buttons/ha-progress-button.js
+++ b/src/components/buttons/ha-progress-button.js
@@ -8,6 +8,9 @@ class HaProgressButton extends PolymerElement {
   static get template() {
     return html`
       <style>
+        :host {
+          outline: none;
+        }
         .container {
           position: relative;
           display: inline-block;

--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -35,7 +35,7 @@ class HaCard extends LitElement {
       }
 
       :host([outlined]) {
-        box-shadow: 0 0 0 0;
+        box-shadow: none;
         border-width: 1px;
         border-style: solid;
         border-color: var(

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -54,7 +54,7 @@ class HaMarkdown extends LitElement {
       }
       ha-markdown-element code,
       pre {
-        background-color: var(--markdown-code-background-color, #f6f8fa);
+        background-color: var(--markdown-code-background-color, none);
         border-radius: 3px;
       }
       ha-markdown-element code {

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -86,6 +86,9 @@ documentContainer.innerHTML = `<custom-style>
       /* set our slider style */
       --ha-paper-slider-pin-font-size: 15px;
 
+      /* markdown styles */
+      --markdown-code-background-color: #f6f8fa;
+
       /* rgb */
       --rgb-primary-color: 3, 169, 244;
       --rgb-accent-color: 255, 152, 0;


### PR DESCRIPTION
## Proposed change

And removed the ugly outline of the `ha-progress-button`

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
