### PR TITLE
Custom Door controls

### DIFF
--- a/src/components/ha-cover-controls.js
+++ b/src/components/ha-cover-controls.js
@@ -65,6 +65,7 @@ class HaCoverControls extends PolymerElement {
   computeOpenIcon(stateObj) {
     switch (stateObj.attributes.device_class) {
       case "awning":
+      case "door":
       case "gate":
         return "hass:arrow-expand-horizontal";
       default:
@@ -75,6 +76,7 @@ class HaCoverControls extends PolymerElement {
   computeCloseIcon(stateObj) {
     switch (stateObj.attributes.device_class) {
       case "awning":
+      case "door":
       case "gate":
         return "hass:arrow-collapse-horizontal";
       default:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Default cover control icons are `arrow-up` and `arrow-down`. While it makes sense for most of the device classes like `curtain` or `shutter`, the same icons used for `door` seem confusing.
![door-cover-old](https://user-images.githubusercontent.com/4460766/85132483-2c0ab280-b239-11ea-8577-51905e1523b8.png)

Users don't know what `arrow-up` and `arrow-down` actually mean in this context. This PR sets different icons for door device class, which make in my opinion more sense.
![door-cover-new](https://user-images.githubusercontent.com/4460766/85132627-712ee480-b239-11ea-9001-c7a9084a7cae.png)

The code affects only the door device class (it's similar to the `awning` or `gate` use-case, which use custom icons too). I think these icons suit much better. However, I'm open to discussion.

Thanks!


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
cover:
  - platform: mqtt
    command_topic: "home-assistant/cover/set"
    device_class: door
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
