### PR TITLE
Round values for relative time instead of flooring

### DIFF
--- a/src/common/datetime/relative_time.ts
+++ b/src/common/datetime/relative_time.ts
@@ -20,31 +20,24 @@ export default function relativeTime(
   let delta = (compareTime.getTime() - dateObj.getTime()) / 1000;
   const tense = delta >= 0 ? "past" : "future";
   delta = Math.abs(delta);
-
-  let timeDesc;
+  let roundedDelta = Math.round(delta);
+  let unit = "week";
 
   for (let i = 0; i < tests.length; i++) {
-    if (delta < tests[i]) {
-      delta = Math.floor(delta);
-      timeDesc = localize(
-        `ui.components.relative_time.duration.${langKey[i]}`,
-        "count",
-        delta
-      );
+    if (roundedDelta < tests[i]) {
+      unit = langKey[i];
       break;
     }
 
     delta /= tests[i];
+    roundedDelta = Math.round(delta);
   }
 
-  if (timeDesc === undefined) {
-    delta = Math.floor(delta);
-    timeDesc = localize(
-      "ui.components.relative_time.duration.week",
-      "count",
-      delta
-    );
-  }
+  const timeDesc = localize(
+    `ui.components.relative_time.duration.${unit}`,
+    "count",
+    roundedDelta
+  );
 
   return options.includeTense === false
     ? timeDesc


### PR DESCRIPTION
## Proposed change

Currently, the value used for displaying a relative time is floored before it's interpolated into the localized string. Many times, this has led me to misinterpret the actual value:

* 47 hours ago is displayed as "1 day ago" instead of "2 days ago"
* 13 days in the future is displayed as "in 1 week"

This change modifies the `relativeTime` function to use `Math.round` instead of `Math.floor` so the output more closely matches the actual relative time of the input.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Just put any entity with `device_class: timestamp` on a Lovelace dashboard and fake the state to try out different edge cases. Unfortunately, I could not get a simple template with `relative_time` to work.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
