### PR TITLE
Proposal: Lovelace strategies

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -2,6 +2,8 @@ import {
   Connection,
   getCollection,
   HassEventBase,
+  HassConfig,
+  HassEntities,
 } from "home-assistant-js-websocket";
 import { HASSDomEvent } from "../common/dom/fire_event";
 import { HuiErrorCard } from "../panels/lovelace/cards/hui-error-card";
@@ -11,6 +13,10 @@ import {
   LovelaceCard,
 } from "../panels/lovelace/types";
 import { HomeAssistant } from "../types";
+import { AreaRegistryEntry } from "./area_registry";
+import { DeviceRegistryEntry } from "./device_registry";
+import { EntityRegistryEntry } from "./entity_registry";
+import { LocalizeFunc } from "../common/translations/localize";
 
 export interface LovelacePanelConfig {
   mode: "yaml" | "storage";
@@ -18,6 +24,11 @@ export interface LovelacePanelConfig {
 
 export interface LovelaceConfig {
   title?: string;
+  // When specified, we ignore views but instead execute strategy
+  strategy?: {
+    name: string;
+    options: { [key: string]: unknown };
+  };
   views: LovelaceViewConfig[];
   background?: string;
 }
@@ -76,6 +87,11 @@ export interface LovelaceViewConfig {
   index?: number;
   title?: string;
   type?: string;
+  // When specified, we ignore badges + cards but instead execute strategy
+  strategy?: {
+    name: string;
+    options: { [key: string]: unknown };
+  };
   badges?: Array<string | LovelaceBadgeConfig>;
   cards?: LovelaceCardConfig[];
   path?: string;
@@ -176,6 +192,31 @@ type LovelaceUpdatedEvent = HassEventBase & {
     mode: "yaml" | "storage";
   };
 };
+
+export interface LovelaceDashboardStrategy {
+  generateDashboard(info: {
+    lovelace: LovelaceConfig;
+    config: HassConfig;
+    areaEntries: AreaRegistryEntry[];
+    deviceEntries: DeviceRegistryEntry[];
+    entityEntries: EntityRegistryEntry[];
+    entities: HassEntities;
+    localize: LocalizeFunc;
+  }): Partial<LovelaceConfig>;
+}
+
+export interface LovelaceViewStrategy {
+  generateView(info: {
+    view: LovelaceViewConfig;
+    lovelace: LovelaceConfig;
+    config: HassConfig;
+    areaEntries: AreaRegistryEntry[];
+    deviceEntries: DeviceRegistryEntry[];
+    entityEntries: EntityRegistryEntry[];
+    entities: HassEntities;
+    localize: LocalizeFunc;
+  }): Partial<LovelaceViewConfig>;
+}
 
 export const fetchResources = (conn: Connection): Promise<LovelaceResource[]> =>
   conn.sendMessagePromise({

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -24,7 +24,7 @@ export interface LovelacePanelConfig {
 
 export interface LovelaceConfig {
   title?: string;
-  // When specified, we ignore views but instead execute strategy
+  // When specified, we execute strategy and merge into config on top level (no deep merge)
   strategy?: {
     name: string;
     options: { [key: string]: unknown };
@@ -87,7 +87,7 @@ export interface LovelaceViewConfig {
   index?: number;
   title?: string;
   type?: string;
-  // When specified, we ignore badges + cards but instead execute strategy
+  // When specified, we execute strategy and merge into view config on top level (no deep merge)
   strategy?: {
     name: string;
     options: { [key: string]: unknown };
@@ -197,7 +197,7 @@ export interface LovelaceDashboardStrategy {
   generateDashboard(info: {
     lovelace: LovelaceConfig;
     hass: HomeAssistant;
-  }): Partial<LovelaceConfig>;
+  }): Promise<Partial<LovelaceConfig>>;
 }
 
 export interface LovelaceViewStrategy {
@@ -205,7 +205,7 @@ export interface LovelaceViewStrategy {
     view: LovelaceViewConfig;
     lovelace: LovelaceConfig;
     hass: HomeAssistant;
-  }): Partial<LovelaceViewConfig>;
+  }): Promise<Partial<LovelaceViewConfig>>;
 }
 
 export const fetchResources = (conn: Connection): Promise<LovelaceResource[]> =>

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -196,12 +196,7 @@ type LovelaceUpdatedEvent = HassEventBase & {
 export interface LovelaceDashboardStrategy {
   generateDashboard(info: {
     lovelace: LovelaceConfig;
-    config: HassConfig;
-    areaEntries: AreaRegistryEntry[];
-    deviceEntries: DeviceRegistryEntry[];
-    entityEntries: EntityRegistryEntry[];
-    entities: HassEntities;
-    localize: LocalizeFunc;
+    hass: HomeAssistant;
   }): Partial<LovelaceConfig>;
 }
 
@@ -209,12 +204,7 @@ export interface LovelaceViewStrategy {
   generateView(info: {
     view: LovelaceViewConfig;
     lovelace: LovelaceConfig;
-    config: HassConfig;
-    areaEntries: AreaRegistryEntry[];
-    deviceEntries: DeviceRegistryEntry[];
-    entityEntries: EntityRegistryEntry[];
-    entities: HassEntities;
-    localize: LocalizeFunc;
+    hass: HomeAssistant;
   }): Partial<LovelaceViewConfig>;
 }
 

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -21,7 +21,7 @@ export interface LovelaceConfig {
   // When specified, we execute strategy and merge into config on top level (no deep merge)
   strategy?: {
     name: string;
-    options: { [key: string]: unknown };
+    options?: { [key: string]: unknown };
   };
   views: LovelaceViewConfig[];
   background?: string;
@@ -84,7 +84,7 @@ export interface LovelaceViewConfig {
   // When specified, we execute strategy and merge into view config on top level (no deep merge)
   strategy?: {
     name: string;
-    options: { [key: string]: unknown };
+    options?: { [key: string]: unknown };
   };
   badges?: Array<string | LovelaceBadgeConfig>;
   cards?: LovelaceCardConfig[];

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -2,8 +2,6 @@ import {
   Connection,
   getCollection,
   HassEventBase,
-  HassConfig,
-  HassEntities,
 } from "home-assistant-js-websocket";
 import { HASSDomEvent } from "../common/dom/fire_event";
 import { HuiErrorCard } from "../panels/lovelace/cards/hui-error-card";
@@ -13,10 +11,6 @@ import {
   LovelaceCard,
 } from "../panels/lovelace/types";
 import { HomeAssistant } from "../types";
-import { AreaRegistryEntry } from "./area_registry";
-import { DeviceRegistryEntry } from "./device_registry";
-import { EntityRegistryEntry } from "./entity_registry";
-import { LocalizeFunc } from "../common/translations/localize";
 
 export interface LovelacePanelConfig {
   mode: "yaml" | "storage";

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -232,7 +232,7 @@ const computeDefaultViewStates = (
   return states;
 };
 
-const generateViewConfig = (
+export const generateViewConfig = (
   localize: LocalizeFunc,
   path: string,
   title: string | undefined,

--- a/src/panels/lovelace/strategies/default-strategy.ts
+++ b/src/panels/lovelace/strategies/default-strategy.ts
@@ -1,0 +1,106 @@
+import { STATE_NOT_RUNNING } from "home-assistant-js-websocket";
+import { subscribeOne } from "../../../common/util/subscribe-one";
+import { subscribeAreaRegistry } from "../../../data/area_registry";
+import { subscribeDeviceRegistry } from "../../../data/device_registry";
+import { subscribeEntityRegistry } from "../../../data/entity_registry";
+import {
+  LovelaceConfig,
+  LovelaceDashboardStrategy,
+  LovelaceViewConfig,
+  LovelaceViewStrategy,
+} from "../../../data/lovelace";
+import { HomeAssistant } from "../../../types";
+import { generateDefaultViewConfig } from "../common/generate-lovelace-config";
+
+let subscribedRegistries = false;
+
+export class DefaultStrategy extends HTMLElement
+  implements LovelaceDashboardStrategy, LovelaceViewStrategy {
+  async generateView(info: {
+    view: LovelaceViewConfig;
+    lovelace: LovelaceConfig;
+    hass: HomeAssistant;
+  }): Promise<Partial<LovelaceViewConfig>> {
+    if (!subscribedRegistries) {
+      subscribedRegistries = true;
+      subscribeAreaRegistry(info.hass.connection, () => undefined);
+      subscribeDeviceRegistry(info.hass.connection, () => undefined);
+      subscribeEntityRegistry(info.hass.connection, () => undefined);
+    }
+
+    const [areaEntries, deviceEntries, entityEntries] = await Promise.all([
+      subscribeOne(info.hass.connection, subscribeAreaRegistry),
+      subscribeOne(info.hass.connection, subscribeDeviceRegistry),
+      subscribeOne(info.hass.connection, subscribeEntityRegistry),
+    ]);
+
+    const entities = info.hass.states;
+    const config = info.hass.config;
+    const localize = info.hass.localize;
+
+    // User can override default view. If they didn't, we will add one
+    // that contains all entities.
+    const view = generateDefaultViewConfig(
+      areaEntries,
+      deviceEntries,
+      entityEntries,
+      entities,
+      localize
+    );
+
+    // Add map of geo locations to default view if loaded
+    if (config.components.includes("geo_location")) {
+      if (view && view.cards) {
+        view.cards.push({
+          type: "map",
+          geo_location_sources: ["all"],
+        });
+      }
+    }
+
+    // User has no entities
+    if (view.cards!.length === 0) {
+      view.cards!.push({
+        type: "empty-state",
+      });
+    }
+
+    return view;
+  }
+
+  async generateDashboard(info: {
+    lovelace: LovelaceConfig;
+    hass: HomeAssistant;
+  }): Promise<Partial<LovelaceConfig>> {
+    if (info.hass.config.state === STATE_NOT_RUNNING) {
+      return {
+        title: info.hass.config.location_name,
+        views: [
+          {
+            cards: [{ type: "starting" }],
+          },
+        ],
+      };
+    }
+
+    if (info.hass.config.safe_mode) {
+      return {
+        title: info.hass.config.location_name,
+        views: [
+          {
+            cards: [{ type: "safe-mode" }],
+          },
+        ],
+      };
+    }
+
+    return {
+      views: [
+        {
+          strategy: { name: "default" },
+          title: "default",
+        },
+      ],
+    };
+  }
+}

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -1,0 +1,49 @@
+import { LovelaceDashboardStrategy } from "../../../data/lovelace";
+
+const CUSTOM_PREFIX = "custom:";
+
+const strategies: { [key: string]: () => Promise<any> } = {
+  default: () => Promise.resolve(SingleViewLovelaceDashboardStrategy),
+  by_view: () => import("./by_view").ByViewLovelaceDashboardStrategy,
+};
+
+export const getLovelaceDashboardStrategy = (
+  name: string
+): Promise<LovelaceDashboardStrategy> => {
+  if (name in strategies) {
+    return strategies[name]();
+  }
+
+  if (!name.startsWith(CUSTOM_PREFIX)) {
+    // This will just generate a view with a single error card
+    return errorStrategy(`Unknown strategy specified: ${name}`);
+  }
+
+  const tag = `ll-strategy-${name.substr(CUSTOM_PREFIX.length)}`;
+
+  return customElements.whenDefined(tag).then(() => customElements.get(tag));
+};
+
+// To define a custom strategy
+customElements.define(
+  "ll-strategy-paulus",
+  class extends HTMLElement {
+    static generateDashboard(info) {
+      return {
+        views: [
+          {
+            strategy: {
+              name: "custom:paulus",
+            },
+          },
+        ],
+      };
+    }
+
+    static generateView(info) {
+      return {
+        cards: [],
+      };
+    }
+  }
+);

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { LovelaceDashboardStrategy } from "../../../data/lovelace";
 
 const CUSTOM_PREFIX = "custom:";

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -1,23 +1,21 @@
-// @ts-nocheck
 import { LovelaceDashboardStrategy } from "../../../data/lovelace";
 
 const CUSTOM_PREFIX = "custom:";
 
-const strategies: { [key: string]: () => Promise<any> } = {
-  default: () => Promise.resolve(SingleViewLovelaceDashboardStrategy),
-  by_view: () => import("./by_view").ByViewLovelaceDashboardStrategy,
+const strategies = {
+  default: import("./default-strategy"),
 };
 
 export const getLovelaceDashboardStrategy = (
   name: string
 ): Promise<LovelaceDashboardStrategy> => {
   if (name in strategies) {
-    return strategies[name]();
+    return strategies[name].generateDashboard();
   }
 
   if (!name.startsWith(CUSTOM_PREFIX)) {
     // This will just generate a view with a single error card
-    return errorStrategy(`Unknown strategy specified: ${name}`);
+    // return errorStrategy(`Unknown strategy specified: ${name}`);
   }
 
   const tag = `ll-strategy-${name.substr(CUSTOM_PREFIX.length)}`;
@@ -26,25 +24,25 @@ export const getLovelaceDashboardStrategy = (
 };
 
 // To define a custom strategy
-customElements.define(
-  "ll-strategy-paulus",
-  class extends HTMLElement {
-    static async generateDashboard(info) {
-      return {
-        views: [
-          {
-            strategy: {
-              name: "custom:paulus",
-            },
-          },
-        ],
-      };
-    }
+// customElements.define(
+//   "ll-strategy-paulus",
+//   class extends HTMLElement {
+//     static async generateDashboard(info) {
+//       return {
+//         views: [
+//           {
+//             strategy: {
+//               name: "custom:paulus",
+//             },
+//           },
+//         ],
+//       };
+//     }
 
-    static async generateView(info) {
-      return {
-        cards: [],
-      };
-    }
-  }
-);
+//     static async generateView(info) {
+//       return {
+//         cards: [],
+//       };
+//     }
+//   }
+// );

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -28,7 +28,7 @@ export const getLovelaceDashboardStrategy = (
 customElements.define(
   "ll-strategy-paulus",
   class extends HTMLElement {
-    static generateDashboard(info) {
+    static async generateDashboard(info) {
       return {
         views: [
           {
@@ -40,7 +40,7 @@ customElements.define(
       };
     }
 
-    static generateView(info) {
+    static async generateView(info) {
       return {
         cards: [],
       };


### PR DESCRIPTION
The other day I was on a call with @bramkragten and @zsarnett and we were talking frontend and we talked about LL dashboard generate strategies. Here is a proposal of how this could work. I just created the types, no actual implementations.

Adds:
 - Strategy to define dashboard
 - Strategy to define views
 - Allows defining custom strategies

This would allow people to share strategies that will create cards. People can add as many crazy options to their strategies as they wish. 

The idea of strategies already exists in our codebase. If no Lovelace config exists, we will automatically generate one.
