### PR TITLE
Add option to disable suspend connection when hidden

### DIFF
--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -203,6 +203,7 @@ export const provideHass = (
     translationMetadata: translationMetadata as any,
     dockedSidebar: "auto",
     vibrate: true,
+    suspendWhenHidden: true,
     moreInfoEntityId: null as any,
     // @ts-ignore
     async callService(domain, service, data) {

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -203,7 +203,7 @@ export const provideHass = (
     translationMetadata: translationMetadata as any,
     dockedSidebar: "auto",
     vibrate: true,
-    suspendWhenHidden: true,
+    suspendWhenHidden: false,
     moreInfoEntityId: null as any,
     // @ts-ignore
     async callService(domain, service, data) {

--- a/src/layouts/partial-panel-resolver.ts
+++ b/src/layouts/partial-panel-resolver.ts
@@ -162,6 +162,10 @@ class PartialPanelResolver extends HassRouterPage {
   }
 
   private _checkVisibility() {
+    if (this.hass.suspendWhenHidden === false) {
+      return;
+    }
+
     if (document.hidden) {
       this._onHidden();
     } else {

--- a/src/panels/profile/ha-panel-profile.ts
+++ b/src/panels/profile/ha-panel-profile.ts
@@ -35,6 +35,7 @@ import "./ha-pick-theme-row";
 import "./ha-push-notifications-row";
 import "./ha-refresh-tokens-card";
 import "./ha-set-vibrate-row";
+import "./ha-set-suspend-row";
 
 class HaPanelProfile extends LitElement {
   @property() public hass!: HomeAssistant;
@@ -137,6 +138,10 @@ class HaPanelProfile extends LitElement {
                   ></ha-advanced-mode-row>
                 `
               : ""}
+            <ha-set-suspend-row
+              .narrow=${this.narrow}
+              .hass=${this.hass}
+            ></ha-set-suspend-row>
 
             <div class="card-actions">
               <mwc-button class="warning" @click=${this._handleLogOut}>

--- a/src/panels/profile/ha-set-suspend-row.ts
+++ b/src/panels/profile/ha-set-suspend-row.ts
@@ -5,11 +5,24 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
-import { fireEvent } from "../../common/dom/fire_event";
+import { fireEvent, HASSDomEvent } from "../../common/dom/fire_event";
 import "../../components/ha-switch";
 import type { HaSwitch } from "../../components/ha-switch";
 import type { HomeAssistant } from "../../types";
 import "./ha-settings-row";
+
+declare global {
+  // for fire event
+  interface HASSDomEvents {
+    "hass-suspend-when-hidden": { suspend: HomeAssistant["suspendWhenHidden"] };
+  }
+  // for add event listener
+  interface HTMLElementEventMap {
+    "hass-suspend-when-hidden": HASSDomEvent<{
+      suspend: HomeAssistant["suspendWhenHidden"];
+    }>;
+  }
+}
 
 @customElement("ha-set-suspend-row")
 class HaSetSuspendRow extends LitElement {

--- a/src/panels/profile/ha-set-suspend-row.ts
+++ b/src/panels/profile/ha-set-suspend-row.ts
@@ -1,0 +1,52 @@
+import {
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from "lit-element";
+import { fireEvent } from "../../common/dom/fire_event";
+import "../../components/ha-switch";
+import type { HaSwitch } from "../../components/ha-switch";
+import type { HomeAssistant } from "../../types";
+import "./ha-settings-row";
+
+@customElement("ha-set-suspend-row")
+class HaSetSuspendRow extends LitElement {
+  @property() public hass!: HomeAssistant;
+
+  @property() public narrow!: boolean;
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-settings-row .narrow=${this.narrow}>
+        <span slot="heading">
+          ${this.hass.localize("ui.panel.profile.suspend.header")}
+        </span>
+        <span slot="description">
+          ${this.hass.localize("ui.panel.profile.suspend.description")}
+        </span>
+        <ha-switch
+          .checked=${this.hass.suspendWhenHidden}
+          @change=${this._checkedChanged}
+        ></ha-switch>
+      </ha-settings-row>
+    `;
+  }
+
+  private async _checkedChanged(ev: Event) {
+    const suspend = (ev.target as HaSwitch).checked;
+    if (suspend === this.hass.suspendWhenHidden) {
+      return;
+    }
+    fireEvent(this, "hass-suspend-when-hidden", {
+      suspend,
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-set-suspend-row": HaSetSuspendRow;
+  }
+}

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -47,6 +47,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         translationMetadata,
         dockedSidebar: "docked",
         vibrate: true,
+        suspendWhenHidden: true,
         moreInfoEntityId: null,
         hassUrl: (path = "") => new URL(path, auth.data.hassUrl).toString(),
         callService: async (domain, service, serviceData = {}) => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2106,6 +2106,10 @@
           "header": "Vibrate",
           "description": "Enable or disable vibration on this device when controlling devices."
         },
+        "suspend": {
+          "header": "Automatically close connection",
+          "description": "Should we close the connection to the server after being hidden for 5 minutes?"
+        },
         "push_notifications": {
           "header": "Push Notifications",
           "description": "Send notifications to this device.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,7 +209,7 @@ export interface HomeAssistant {
   resources: Resources;
   localize: LocalizeFunc;
   translationMetadata: TranslationMetadata;
-
+  suspendWhenHidden: boolean;
   vibrate: boolean;
   dockedSidebar: "docked" | "always_hidden" | "auto";
   defaultPanel: string;

--- a/src/util/ha-pref-storage.ts
+++ b/src/util/ha-pref-storage.ts
@@ -5,6 +5,7 @@ const STORED_STATE = [
   "selectedTheme",
   "selectedLanguage",
   "vibrate",
+  "suspendWhenHidden",
   "defaultPanel",
 ];
 const STORAGE = window.localStorage || {};


### PR DESCRIPTION
## Proposed change

Adds a device-specific option to disable the suspend when hidden. We will still prevent reconnects when hidden and suspend when we get frozen.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
