### PR TITLE
Provide credentials (cookies) when loading Javascript modules

### DIFF
--- a/src/common/dom/load_resource.ts
+++ b/src/common/dom/load_resource.ts
@@ -22,6 +22,7 @@ const _load = (
         (element as HTMLScriptElement).async = true;
         if (type) {
           (element as HTMLScriptElement).type = type;
+          (element as HTMLScriptElement).crossOrigin = "use-credentials";
         }
         break;
       case "link":

--- a/src/common/dom/load_resource.ts
+++ b/src/common/dom/load_resource.ts
@@ -22,6 +22,7 @@ const _load = (
         (element as HTMLScriptElement).async = true;
         if (type) {
           (element as HTMLScriptElement).type = type;
+          // https://github.com/home-assistant/frontend/pull/6328
           (element as HTMLScriptElement).crossOrigin = "use-credentials";
         }
         break;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Browsers like Safari do not follow the current cross-origin spec when loading Javascript modules. See webkit bugs [1](https://trac.webkit.org/changeset/260003/webkit/), [2](https://trac.webkit.org/changeset/260038/webkit/). This can cause problems with third party lovelace cards written as modules (and not scripts).

In my specific case, I have Home Assistant behind Cloudflare Access. In every browser except for Safari & Mobile Safari, the authentication token (cookie) is passed along when the fetch is done allowing the modules to be downloaded. With Safari, those are not passed by default (against the spec), which causes the fetch to fail and the custom cards to not load.

By setting `cross-origin=use-credentials`, credentials are passed along on all browsers and custom cards load normally.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

None

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


I normally contribute to the python backend. Let me know if I missed anything here.