### PR TITLE
Close dialogs on history back

### DIFF
--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -35,6 +35,7 @@ import "./step-flow-external";
 import "./step-flow-form";
 import "./step-flow-loading";
 import "./step-flow-pick-handler";
+import { fireEvent } from "../../common/dom/fire_event";
 
 let instance = 0;
 
@@ -113,6 +114,17 @@ class DataEntryFlowDialog extends LitElement {
     this._loading = false;
   }
 
+  public closeDialog() {
+    if (this._step) {
+      this._flowDone();
+    } else if (this._step === null) {
+      // Flow aborted during picking flow
+      this._step = undefined;
+      this._params = undefined;
+    }
+    fireEvent(this, "dialog-closed");
+  }
+
   protected render(): TemplateResult {
     if (!this._params) {
       return html``;
@@ -121,7 +133,7 @@ class DataEntryFlowDialog extends LitElement {
     return html`
       <ha-dialog
         open
-        @closing=${this._close}
+        @closed=${this.closeDialog}
         scrimClickAction
         escapeKeyAction
         hideActions
@@ -292,16 +304,6 @@ class DataEntryFlowDialog extends LitElement {
     if (this._unsubDevices) {
       this._unsubDevices();
       this._unsubDevices = undefined;
-    }
-  }
-
-  private _close(): void {
-    if (this._step) {
-      this._flowDone();
-    } else if (this._step === null) {
-      // Flow aborted during picking flow
-      this._step = undefined;
-      this._params = undefined;
     }
   }
 

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -123,7 +123,7 @@ class DataEntryFlowDialog extends LitElement {
       this._step = undefined;
       this._params = undefined;
     }
-    fireEvent(this, "dialog-closed");
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected render(): TemplateResult {

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -33,7 +33,7 @@ class DialogBox extends LitElement {
     }
   }
 
-  public closeDialog(): boolean | void {
+  public closeDialog(): boolean {
     if (this._params?.confirmation || this._params?.prompt) {
       this._dismiss();
       return true;

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -134,7 +134,7 @@ class DialogBox extends LitElement {
 
   private _close(): void {
     this._params = undefined;
-    fireEvent(this, "dialog-closed");
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   static get styles(): CSSResult[] {

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -16,6 +16,7 @@ import { PolymerChangedEvent } from "../../polymer-types";
 import { haStyleDialog } from "../../resources/styles";
 import { HomeAssistant } from "../../types";
 import { DialogParams } from "./show-dialog-box";
+import { fireEvent } from "../../common/dom/fire_event";
 
 @customElement("dialog-box")
 class DialogBox extends LitElement {
@@ -30,6 +31,17 @@ class DialogBox extends LitElement {
     if (params.prompt) {
       this._value = params.defaultValue;
     }
+  }
+
+  public closeDialog(): boolean | void {
+    if (this._params?.confirmation || this._params?.prompt) {
+      this._dismiss();
+      return true;
+    }
+    if (this._params) {
+      return false;
+    }
+    return true;
   }
 
   protected render(): TemplateResult {
@@ -100,11 +112,11 @@ class DialogBox extends LitElement {
     this._value = ev.detail.value;
   }
 
-  private async _dismiss(): Promise<void> {
+  private _dismiss(): void {
     if (this._params!.cancel) {
       this._params!.cancel();
     }
-    this._params = undefined;
+    this._close();
   }
 
   private _handleKeyUp(ev: KeyboardEvent) {
@@ -113,15 +125,16 @@ class DialogBox extends LitElement {
     }
   }
 
-  private async _confirm(): Promise<void> {
+  private _confirm(): void {
     if (this._params!.confirm) {
       this._params!.confirm(this._value);
     }
-    this._dismiss();
+    this._close();
   }
 
   private _close(): void {
     this._params = undefined;
+    fireEvent(this, "dialog-closed");
   }
 
   static get styles(): CSSResult[] {

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -6,12 +6,12 @@ declare global {
   interface HASSDomEvents {
     "show-dialog": ShowDialogParams<unknown>;
     "close-dialog": undefined;
-    "dialog-closed": undefined;
+    "dialog-closed": DialogClosedParams;
   }
   // for add event listener
   interface HTMLElementEventMap {
     "show-dialog": HASSDomEvent<ShowDialogParams<unknown>>;
-    "dialog-closed": HASSDomEvent<undefined>;
+    "dialog-closed": HASSDomEvent<DialogClosedParams>;
   }
 }
 
@@ -24,6 +24,10 @@ interface ShowDialogParams<T> {
   dialogTag: keyof HTMLElementTagNameMap;
   dialogImport: () => Promise<unknown>;
   dialogParams: T;
+}
+
+export interface DialogClosedParams {
+  dialog: string;
 }
 
 export interface DialogState {

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -43,6 +43,41 @@ export const showDialog = async (
   }
   const dialogElement = await LOADED[dialogTag];
   dialogElement.showDialog(dialogParams);
+  if (dialogElement.closeDialog) {
+    history.replaceState(
+      {
+        dialog: dialogTag,
+        open: false,
+        oldState:
+          history.state?.open && history.state?.dialog !== dialogTag
+            ? history.state
+            : null,
+      },
+      ""
+    );
+    try {
+      history.pushState(
+        { dialog: dialogTag, dialogParams: dialogParams, open: true },
+        ""
+      );
+    } catch (err) {
+      // dialogParams could not be cloned, probably contains callback
+      history.pushState(
+        { dialog: dialogTag, dialogParams: null, open: true },
+        ""
+      );
+    }
+  }
+};
+
+export const closeDialog = async (dialogTag: string) => {
+  if (!(dialogTag in LOADED)) {
+    return;
+  }
+  const dialogElement = await LOADED[dialogTag];
+  if (dialogElement.closeDialog) {
+    dialogElement.closeDialog();
+  }
 };
 
 export const makeDialogManager = (

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -1,5 +1,6 @@
 import { HASSDomEvent, ValidHassDomEvent } from "../common/dom/fire_event";
 import { ProvideHassElement } from "../mixins/provide-hass-lit-mixin";
+import { MoreInfoDialogParams } from "./more-info/ha-more-info-dialog";
 
 declare global {
   // for fire event

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -1,6 +1,5 @@
 import { HASSDomEvent, ValidHassDomEvent } from "../common/dom/fire_event";
 import { ProvideHassElement } from "../mixins/provide-hass-lit-mixin";
-import { MoreInfoDialogParams } from "./more-info/ha-more-info-dialog";
 
 declare global {
   // for fire event
@@ -8,7 +7,6 @@ declare global {
     "show-dialog": ShowDialogParams<unknown>;
     "close-dialog": undefined;
     "dialog-closed": undefined;
-    "hass-more-info": MoreInfoDialogParams;
   }
   // for add event listener
   interface HTMLElementEventMap {
@@ -34,11 +32,6 @@ export interface DialogState {
   oldState: null | DialogState;
   dialogParams?: unknown;
 }
-
-const importMoreInfo = () =>
-  import(
-    /* webpackChunkName: "more-info-dialog" */ "./more-info/ha-more-info-dialog"
-  );
 
 const LOADED = {};
 
@@ -104,20 +97,6 @@ export const makeDialogManager = (
   element: HTMLElement & ProvideHassElement,
   root: ShadowRoot | HTMLElement
 ) => {
-  importMoreInfo();
-
-  element.addEventListener("hass-more-info", (e) =>
-    showDialog(
-      element,
-      root,
-      "ha-more-info-dialog",
-      {
-        entityId: e.detail.entityId,
-      },
-      importMoreInfo
-    )
-  );
-
   element.addEventListener(
     "show-dialog",
     (e: HASSDomEvent<ShowDialogParams<unknown>>) => {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -2,6 +2,7 @@ import "@material/mwc-button";
 import "@material/mwc-icon-button";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
+import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-dialog";
 import "../../components/ha-svg-icon";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
@@ -70,6 +71,14 @@ export class MoreInfoDialog extends LitElement {
     }
   }
 
+  public closeDialog() {
+    this._entityId = undefined;
+    this._stateHistory = undefined;
+    clearInterval(this._historyRefreshInterval);
+    this._historyRefreshInterval = undefined;
+    fireEvent(this, "dialog-closed");
+  }
+
   protected render() {
     if (!this.hass.moreInfoEntityId) {
       return html``;
@@ -85,7 +94,7 @@ export class MoreInfoDialog extends LitElement {
     return html`
       <ha-dialog
         open
-        @closed=${this._close}
+        @closed=${this.closeDialog}
         .heading=${true}
         hideActions
         data-domain=${domain}
@@ -233,10 +242,6 @@ export class MoreInfoDialog extends LitElement {
       }`
     );
     this._close();
-  }
-
-  private _close() {
-    fireEvent(this, "hass-more-info", { entityId: null });
   }
 
   static get styles() {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -1,9 +1,9 @@
 import "@material/mwc-button";
+import "@material/mwc-icon-button";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
-import "../../components/ha-icon-button";
-import type { HaDialog } from "../../components/ha-dialog";
 import "../../components/ha-dialog";
+import "../../components/ha-svg-icon";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { DOMAINS_MORE_INFO_NO_HISTORY } from "../../common/const";
 import { computeStateName } from "../../common/entity/compute_state_name";

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -71,7 +71,7 @@ export class MoreInfoDialog extends LitElement {
     this._stateHistory = undefined;
     clearInterval(this._historyRefreshInterval);
     this._historyRefreshInterval = undefined;
-    fireEvent(this, "dialog-closed");
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected render() {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -71,7 +71,7 @@ export class MoreInfoDialog extends LitElement {
     this._stateHistory = undefined;
     clearInterval(this._historyRefreshInterval);
     this._historyRefreshInterval = undefined;
-    fireEvent("dialog-closed");
+    fireEvent(this, "dialog-closed");
   }
 
   protected render() {

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -15,7 +15,6 @@ import {
 import { cache } from "lit-html/directives/cache";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { dynamicElement } from "../../../common/dom/dynamic-element-directive";
-import { fireEvent } from "../../../common/dom/fire_event";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/ha-dialog";
 import "../../../components/ha-svg-icon";

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -13,6 +13,7 @@ import {
   TemplateResult,
 } from "lit-element";
 import { cache } from "lit-html/directives/cache";
+import { fireEvent } from "../../../common/dom/fire_event";
 import { dynamicElement } from "../../../common/dom/dynamic-element-directive";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeStateName } from "../../../common/entity/compute_state_name";

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -73,6 +73,7 @@ export class DialogEntityEditor extends LitElement {
 
   public closeDialog(): void {
     this._params = undefined;
+    fireEvent(this, "dialog-closed");
   }
 
   protected render(): TemplateResult {

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -72,7 +72,7 @@ export class DialogEntityEditor extends LitElement {
 
   public closeDialog(): void {
     this._params = undefined;
-    fireEvent(this, "dialog-closed");
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected render(): TemplateResult {

--- a/src/panels/config/logs/dialog-system-log-detail.ts
+++ b/src/panels/config/logs/dialog-system-log-detail.ts
@@ -20,6 +20,7 @@ import { haStyleDialog } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
 import { SystemLogDetailDialogParams } from "./show-dialog-system-log-detail";
 import { formatSystemLogTime } from "./util";
+import { fireEvent } from "../../../common/dom/fire_event";
 
 class DialogSystemLogDetail extends LitElement {
   @property() public hass!: HomeAssistant;
@@ -32,6 +33,11 @@ class DialogSystemLogDetail extends LitElement {
     this._params = params;
     this._manifest = undefined;
     await this.updateComplete;
+  }
+
+  public closeDialog() {
+    this._params = undefined;
+    fireEvent(this, "dialog-closed");
   }
 
   protected updated(changedProps) {
@@ -137,7 +143,7 @@ class DialogSystemLogDetail extends LitElement {
 
   private _openedChanged(ev: PolymerChangedEvent<boolean>): void {
     if (!(ev.detail as any).value) {
-      this._params = undefined;
+      this.closeDialog();
     }
   }
 

--- a/src/panels/config/logs/dialog-system-log-detail.ts
+++ b/src/panels/config/logs/dialog-system-log-detail.ts
@@ -37,7 +37,7 @@ class DialogSystemLogDetail extends LitElement {
 
   public closeDialog() {
     this._params = undefined;
-    fireEvent(this, "dialog-closed");
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected updated(changedProps) {

--- a/src/panels/config/zone/dialog-zone-detail.ts
+++ b/src/panels/config/zone/dialog-zone-detail.ts
@@ -79,7 +79,7 @@ class DialogZoneDetail extends LitElement {
 
   public closeDialog(): void {
     this._params = undefined;
-    fireEvent(this, "dialog-closed");
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected render(): TemplateResult {

--- a/src/panels/config/zone/dialog-zone-detail.ts
+++ b/src/panels/config/zone/dialog-zone-detail.ts
@@ -8,6 +8,7 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
+import { fireEvent } from "../../../common/dom/fire_event";
 import { addDistanceToCoord } from "../../../common/location/add_distance_to_coord";
 import { createCloseHeading } from "../../../components/ha-dialog";
 import "../../../components/ha-switch";
@@ -45,7 +46,7 @@ class DialogZoneDetail extends LitElement {
 
   @property() private _submitting = false;
 
-  public async showDialog(params: ZoneDetailDialogParams): Promise<void> {
+  public showDialog(params: ZoneDetailDialogParams): void {
     this._params = params;
     this._error = undefined;
     if (this._params.entry) {
@@ -74,7 +75,11 @@ class DialogZoneDetail extends LitElement {
       this._passive = false;
       this._radius = 100;
     }
-    await this.updateComplete;
+  }
+
+  public closeDialog(): void {
+    this._params = undefined;
+    fireEvent(this, "dialog-closed");
   }
 
   protected render(): TemplateResult {
@@ -93,7 +98,7 @@ class DialogZoneDetail extends LitElement {
     return html`
       <ha-dialog
         open
-        @closing="${this._close}"
+        @closed="${this.closeDialog}"
         scrimClickAction=""
         escapeKeyAction=""
         .heading=${createCloseHeading(
@@ -274,10 +279,6 @@ class DialogZoneDetail extends LitElement {
     } finally {
       this._submitting = false;
     }
-  }
-
-  private _close(): void {
-    this._params = undefined;
   }
 
   static get styles(): CSSResult[] {

--- a/src/state/dialog-manager-mixin.ts
+++ b/src/state/dialog-manager-mixin.ts
@@ -2,6 +2,7 @@ import { HASSDomEvent } from "../common/dom/fire_event";
 import { makeDialogManager, showDialog } from "../dialogs/make-dialog-manager";
 import { Constructor } from "../types";
 import { HassBaseEl } from "./hass-base-mixin";
+import { PropertyValues } from "lit-element";
 
 interface RegisterDialogParams {
   dialogShowEvent: keyof HASSDomEvents;
@@ -24,7 +25,7 @@ export const dialogManagerMixin = <T extends Constructor<HassBaseEl>>(
   superClass: T
 ) =>
   class extends superClass {
-    protected firstUpdated(changedProps) {
+    protected firstUpdated(changedProps: PropertyValues) {
       super.firstUpdated(changedProps);
       // deprecated
       this.addEventListener("register-dialog", (e) =>

--- a/src/state/dialog-manager-mixin.ts
+++ b/src/state/dialog-manager-mixin.ts
@@ -42,9 +42,9 @@ export const dialogManagerMixin = <T extends Constructor<HassBaseEl>>(
         showDialog(
           this,
           this.shadowRoot!,
-          dialogImport,
           dialogTag,
-          (showEv as HASSDomEvent<unknown>).detail
+          (showEv as HASSDomEvent<unknown>).detail,
+          dialogImport
         );
       });
     }

--- a/src/state/more-info-mixin.ts
+++ b/src/state/more-info-mixin.ts
@@ -1,35 +1,46 @@
-import { Constructor } from "../types";
-import { HassBaseEl } from "./hass-base-mixin";
+import { showDialog } from "../dialogs/make-dialog-manager";
+import type { Constructor } from "../types";
+import type { HassBaseEl } from "./hass-base-mixin";
+import type { MoreInfoDialogParams } from "../dialogs/more-info/ha-more-info-dialog";
+import type { PropertyValues } from "lit-element";
+import type { HASSDomEvent } from "../common/dom/fire_event";
 
 declare global {
   // for fire event
   interface HASSDomEvents {
-    "hass-more-info": {
-      entityId: string | null;
-    };
+    "hass-more-info": MoreInfoDialogParams;
   }
 }
 
+let moreInfoImportPromise;
+const importMoreInfo = () => {
+  if (!moreInfoImportPromise) {
+    moreInfoImportPromise = import(
+      /* webpackChunkName: "more-info-dialog" */ "../dialogs/more-info/ha-more-info-dialog"
+    );
+  }
+  return moreInfoImportPromise;
+};
+
 export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
   class extends superClass {
-    private _moreInfoEl?: any;
-
-    protected firstUpdated(changedProps) {
+    protected firstUpdated(changedProps: PropertyValues) {
       super.firstUpdated(changedProps);
-      this.addEventListener("hass-more-info", (e) => this._handleMoreInfo(e));
+      this.addEventListener("hass-more-info", (ev) => this._handleMoreInfo(ev));
 
       // Load it once we are having the initial rendering done.
-      import(
-        /* webpackChunkName: "more-info-dialog" */ "../dialogs/more-info/ha-more-info-dialog"
-      );
+      importMoreInfo();
     }
 
-    private async _handleMoreInfo(ev) {
-      if (!this._moreInfoEl) {
-        this._moreInfoEl = document.createElement("ha-more-info-dialog");
-        this.shadowRoot!.appendChild(this._moreInfoEl);
-        this.provideHass(this._moreInfoEl);
-      }
-      this._updateHass({ moreInfoEntityId: ev.detail.entityId });
+    private async _handleMoreInfo(ev: HASSDomEvent<MoreInfoDialogParams>) {
+      showDialog(
+        this,
+        this.shadowRoot!,
+        "ha-more-info-dialog",
+        {
+          entityId: ev.detail.entityId,
+        },
+        importMoreInfo
+      );
     }
   };

--- a/src/state/url-sync-mixin.ts
+++ b/src/state/url-sync-mixin.ts
@@ -3,6 +3,7 @@ import {
   closeDialog,
   showDialog,
   DialogState,
+  DialogClosedParams,
 } from "../dialogs/make-dialog-manager";
 import { Constructor } from "../types";
 import { HassBaseEl } from "./hass-base-mixin";
@@ -31,12 +32,13 @@ export const urlSyncMixin = <T extends Constructor<HassBaseEl>>(
           this.removeEventListener("dialog-closed", this._dialogClosedListener);
         }
 
-        private _dialogClosedListener = (ev: HASSDomEvent<undefined>) => {
-          const dialogElement = ev.composedPath()[0] as Element;
+        private _dialogClosedListener = (
+          ev: HASSDomEvent<DialogClosedParams>
+        ) => {
           // If not closed by navigating back, and not a new dialog is open, remove the open state from history
           if (
             history.state?.open &&
-            history.state?.dialog === dialogElement.localName
+            history.state?.dialog === ev.detail.dialog
           ) {
             this._ignoreNextPopState = true;
             history.back();


### PR DESCRIPTION
## Proposed change

A start on closing dialogs on history back like we already did for the more info dialog.

Extra bonus, going forward in the browser history will reopen the dialog (if possible).
If you open a dialog from another dialog, going back from the second dialog will reopen the first dialog.

Dialogs should implement a `closeDialog` function, that should take care of closing the dialog and then fire the event `dialog-closed`.

You can prevent a dialog from closing on back by returning false from `closeDialog` (for a dialog that should not be closed without a specific action of that doesn't have a cancel/close button).

Dialogs that don't implement `closeDialog` yet, won't be closed on back, and the history will be a little screwed up (first back will not do anything, second back will give the current behavior).
So we should add `closeDialog` to all dialogs 😄 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
