### PR TITLE
Provide credentials to relative links only

### DIFF
--- a/src/common/dom/load_resource.ts
+++ b/src/common/dom/load_resource.ts
@@ -23,7 +23,11 @@ const _load = (
         if (type) {
           (element as HTMLScriptElement).type = type;
           // https://github.com/home-assistant/frontend/pull/6328
-          (element as HTMLScriptElement).crossOrigin = "use-credentials";
+          if (isUrlAbsolute(url)) {
+            (element as HTMLScriptElement).crossOrigin = "anonymous";
+          } else {
+            (element as HTMLScriptElement).crossOrigin = "use-credentials";
+          }
         }
         break;
       case "link":
@@ -38,6 +42,10 @@ const _load = (
     document[parent].appendChild(element);
   });
 };
+
+// From: https://stackoverflow.com/a/38979205
+const isUrlAbsolute = (url) =>
+  url.indexOf("://") > 0 || url.indexOf("//") === 0;
 
 export const loadCSS = (url: string) => _load("link", url);
 export const loadJS = (url: string) => _load("script", url);

--- a/src/common/dom/load_resource.ts
+++ b/src/common/dom/load_resource.ts
@@ -23,11 +23,7 @@ const _load = (
         if (type) {
           (element as HTMLScriptElement).type = type;
           // https://github.com/home-assistant/frontend/pull/6328
-          if (isUrlAbsolute(url)) {
-            (element as HTMLScriptElement).crossOrigin = "anonymous";
-          } else {
-            (element as HTMLScriptElement).crossOrigin = "use-credentials";
-          }
+          (element as HTMLScriptElement).crossOrigin = url.substr(0, 1) === "/" ? "use-credentials" : "anonymous";
         }
         break;
       case "link":
@@ -42,10 +38,6 @@ const _load = (
     document[parent].appendChild(element);
   });
 };
-
-// From: https://stackoverflow.com/a/38979205
-const isUrlAbsolute = (url) =>
-  url.indexOf("://") > 0 || url.indexOf("//") === 0;
 
 export const loadCSS = (url: string) => _load("link", url);
 export const loadJS = (url: string) => _load("script", url);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #6328, I added functionality to set  `cross-origin=use-credentials`, to pass along credentials when loading Javascript Modules to work around some bugs in Safari.

@bramkragten noticed [that this would](https://github.com/home-assistant/frontend/pull/6328/files#r451333872) be applied to requests that are actually going cross origin which was not the intent.

In this PR, I modified the code to check if the url is relative before setting `cross-origin=use-credentials`. If it's absolute i set it to `cross-origin=anonymous`, per @balloob's idea.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

None

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
