### PR TITLE
Added forceLTR attribute on a column in ha-data-table

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -69,6 +69,7 @@ export interface DataTableColumnData extends DataTableSortColumnData {
   width?: string;
   maxWidth?: string;
   grows?: boolean;
+  forceLTR?: boolean;
 }
 
 export interface DataTableRowData {
@@ -352,6 +353,7 @@ export class HaDataTable extends LitElement {
                                     column.type === "icon-button"
                                   ),
                                   grows: Boolean(column.grows),
+                                  forceLTR: Boolean(column.forceLTR),
                                 })}"
                                 style=${column.width
                                   ? styleMap({
@@ -854,6 +856,9 @@ export class HaDataTable extends LitElement {
       .grows {
         flex-grow: 1;
         flex-shrink: 1;
+      }
+      .forceLTR {
+        direction: ltr;
       }
     `;
   }

--- a/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
+++ b/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
@@ -65,6 +65,7 @@ export class HaConfigLovelaceRescources extends LitElement {
           filterable: true,
           direction: "asc",
           grows: true,
+          forceLTR: true,
         },
         type: {
           title: this.hass.localize(


### PR DESCRIPTION
Some columns should not be RTL even when viewing RTL - for example the resource URL in the resources list in lovelace dashboards.
Added forceLTR attribute and applied it to the URL column