### PR TITLE
Fix graph mouse over in more info dialog

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -47,9 +47,11 @@ export class HaDialog extends MwcDialog {
           height: 20px;
         }
         .mdc-dialog .mdc-dialog__content {
+          position: var(--dialog-content-position, relative);
           padding: var(--dialog-content-padding, 20px 24px);
         }
         .mdc-dialog .mdc-dialog__surface {
+          position: var(--dialog-content-position, relative);
           min-height: var(--mdc-dialog-min-height, auto);
         }
         .header_button {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -243,6 +243,10 @@ export class MoreInfoDialog extends LitElement {
     return [
       haStyleDialog,
       css`
+        ha-dialog {
+          --dialog-content-position: static;
+        }
+
         app-toolbar {
           flex-shrink: 0;
           color: var(--primary-text-color);


### PR DESCRIPTION
## Proposed change

Before:
![image](https://user-images.githubusercontent.com/5662298/87233442-cccb3880-c3c7-11ea-8076-79831c2d06b3.png)

After:
![image](https://user-images.githubusercontent.com/5662298/87233431-bb822c00-c3c7-11ea-828c-8a9b5082a530.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
