### PR TITLE
Allow to set an id and icon when creating new script

### DIFF
--- a/src/common/string/slugify.ts
+++ b/src/common/string/slugify.ts
@@ -1,19 +1,19 @@
 // https://gist.github.com/hagemann/382adfc57adbd5af078dc93feef01fe1
-export const slugify = (value: string) => {
+export const slugify = (value: string, delimiter = "-") => {
   const a =
     "àáäâãåăæąçćčđďèéěėëêęğǵḧìíïîįłḿǹńňñòóöôœøṕŕřßşśšșťțùúüûǘůűūųẃẍÿýźžż·/_,:;";
-  const b =
-    "aaaaaaaaacccddeeeeeeegghiiiiilmnnnnooooooprrsssssttuuuuuuuuuwxyyzzz------";
+  const b = `aaaaaaaaacccddeeeeeeegghiiiiilmnnnnooooooprrsssssttuuuuuuuuuwxyyzzz${delimiter}${delimiter}${delimiter}${delimiter}${delimiter}${delimiter}`;
   const p = new RegExp(a.split("").join("|"), "g");
 
   return value
     .toString()
     .toLowerCase()
-    .replace(/\s+/g, "-") // Replace spaces with -
+    .replace(/\s+/g, delimiter) // Replace spaces with delimiter
     .replace(p, (c) => b.charAt(a.indexOf(c))) // Replace special characters
-    .replace(/&/g, "-and-") // Replace & with 'and'
+    .replace(/&/g, `${delimiter}and${delimiter}`) // Replace & with 'and'
     .replace(/[^\w-]+/g, "") // Remove all non-word characters
-    .replace(/--+/g, "-") // Replace multiple - with single -
-    .replace(/^-+/, "") // Trim - from start of text
-    .replace(/-+$/, ""); // Trim - from end of text
+    .replace(/-/, delimiter) // Replace - with delimiter
+    .replace(new RegExp(`/${delimiter}${delimiter}+/`, "g"), delimiter) // Replace multiple delimiters with single delimiter
+    .replace(new RegExp(`/^${delimiter}+/`), "") // Trim delimiter from start of text
+    .replace(new RegExp(`/-+$/`), ""); // Trim delimiter from end of text
 };

--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -15,8 +15,8 @@ export interface ScriptEntity extends HassEntityBase {
 
 export interface ScriptConfig {
   alias: string;
-  icon: string;
   sequence: Action[];
+  icon?: string;
   mode?: "single" | "restart" | "queued" | "parallel";
   max?: number;
 }

--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -15,6 +15,7 @@ export interface ScriptEntity extends HassEntityBase {
 
 export interface ScriptConfig {
   alias: string;
+  icon: string;
   sequence: Action[];
   mode?: "single" | "restart" | "queued" | "parallel";
   max?: number;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -17,6 +17,7 @@ import { computeObjectId } from "../../../common/entity/compute_object_id";
 import { navigate } from "../../../common/navigate";
 import { computeRTL } from "../../../common/util/compute_rtl";
 import "../../../components/ha-card";
+import "../../../components/ha-icon-input";
 import "@material/mwc-fab";
 import {
   Action,
@@ -117,6 +118,15 @@ export class HaScriptEditor extends LitElement {
                           @change=${this._aliasChanged}
                         >
                         </paper-input>
+                        <ha-icon-input
+                          .label=${this.hass.localize(
+                            "ui.panel.config.script.editor.icon"
+                          )}
+                          .name=${"icon"}
+                          .value=${this._config.icon}
+                          @value-changed=${this._valueChanged}
+                        >
+                        </ha-icon-input>
                         ${!this.scriptEntityId
                           ? html` <paper-input
                               .label=${this.hass.localize(
@@ -329,6 +339,7 @@ export class HaScriptEditor extends LitElement {
   }
 
   private _valueChanged(ev: CustomEvent) {
+    console.log(ev.target.name, ev.target.value);
     ev.stopPropagation();
     const target = ev.target as any;
     const name = target.name;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -339,7 +339,6 @@ export class HaScriptEditor extends LitElement {
   }
 
   private _valueChanged(ev: CustomEvent) {
-    console.log(ev.target.name, ev.target.value);
     ev.stopPropagation();
     const target = ev.target as any;
     const name = target.name;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -320,7 +320,7 @@ export class HaScriptEditor extends LitElement {
     }
     const aliasSlugify = slugify((ev.target as any).value, "_");
     let id = aliasSlugify;
-    let i = 1;
+    let i = 2;
     while (this.hass.states[`script.${id}`]) {
       id = `${aliasSlugify}_${i}`;
       i++;

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -25,6 +25,7 @@ import { showToast } from "../../../util/toast";
 import { configSections } from "../ha-panel-config";
 import "../../../components/ha-svg-icon";
 import { mdiPlus } from "@mdi/js";
+import { stateIcon } from "../../../common/entity/state_icon";
 
 @customElement("ha-script-picker")
 class HaScriptPicker extends LitElement {
@@ -43,6 +44,7 @@ class HaScriptPicker extends LitElement {
       return {
         ...script,
         name: computeStateName(script),
+        icon: stateIcon(script),
       };
     });
   });
@@ -64,6 +66,11 @@ class HaScriptPicker extends LitElement {
                 @click=${(ev: Event) => this._runScript(ev)}
               ></ha-icon-button>
             `,
+        },
+        icon: {
+          title: "",
+          type: "icon",
+          template: (icon) => html` <ha-icon .icon=${icon}></ha-icon> `,
         },
         name: {
           title: this.hass.localize(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1078,6 +1078,7 @@
           },
           "editor": {
             "alias": "Name",
+            "icon": "Icon",
             "id": "Entity ID",
             "id_already_exists_save_error": "You can't save this script because the ID is not unique, pick another ID or leave it black to autogenerate one.",
             "id_already_exists": "This ID already exists",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1080,7 +1080,7 @@
             "alias": "Name",
             "icon": "Icon",
             "id": "Entity ID",
-            "id_already_exists_save_error": "You can't save this script because the ID is not unique, pick another ID or leave it black to autogenerate one.",
+            "id_already_exists_save_error": "You can't save this script because the ID is not unique, pick another ID or leave it blank to automatically generate one.",
             "id_already_exists": "This ID already exists",
             "introduction": "Use scripts to execute a sequence of actions.",
             "header": "Script: {name}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1078,6 +1078,9 @@
           },
           "editor": {
             "alias": "Name",
+            "id": "Entity ID",
+            "id_already_exists_save_error": "You can't save this script because the ID is not unique, pick another ID or leave it black to autogenerate one.",
+            "id_already_exists": "This ID already exists",
             "introduction": "Use scripts to execute a sequence of actions.",
             "header": "Script: {name}",
             "default_name": "New Script",


### PR DESCRIPTION
## Proposed change

Allows to set an ID when creating a script to prevent an ugly timestamp as entity_id.

Also allows to change the icon of a script. https://github.com/home-assistant/frontend/issues/4927

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
