### PR TITLE
Button Card: Option to show state

### DIFF
--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -36,6 +36,7 @@ import { hasAction } from "../common/has-action";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { LovelaceCard, LovelaceCardEditor } from "../types";
 import { ButtonCardConfig } from "./types";
+import { computeStateDisplay } from "../../../common/entity/compute_state_display";
 
 @customElement("hui-button-card")
 export class HuiButtonCard extends LitElement implements LovelaceCard {
@@ -66,6 +67,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
       hold_action: { action: "more-info" },
       show_icon: true,
       show_name: true,
+      show_state: false,
       entity: foundEntities[0] || "",
     };
   }
@@ -203,6 +205,15 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
               </span>
             `
           : ""}
+        ${this._config.show_state && stateObj
+          ? html`<span class="state">
+              ${computeStateDisplay(
+                this.hass.localize,
+                stateObj,
+                this.hass.language
+              )}
+            </span>`
+          : ""}
         ${this._shouldRenderRipple ? html`<mwc-ripple></mwc-ripple>` : ""}
       </ha-card>
     `;
@@ -280,6 +291,11 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
       ha-icon,
       span {
         outline: none;
+      }
+
+      .state {
+        font-size: 1rem;
+        color: var(--secondary-text-color);
       }
 
       ${iconColorCSS}

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -294,7 +294,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
       }
 
       .state {
-        font-size: 1rem;
+        font-size: 0.9rem;
         color: var(--secondary-text-color);
       }
 

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -71,6 +71,7 @@ export interface ButtonCardConfig extends LovelaceCardConfig {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
   state_color?: boolean;
+  show_state?: boolean;
 }
 
 export interface EntityFilterCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
@@ -38,6 +38,7 @@ const cardConfigStruct = struct({
   tap_action: struct.optional(actionConfigStruct),
   hold_action: struct.optional(actionConfigStruct),
   theme: "string?",
+  show_state: "boolean?",
 });
 
 @customElement("hui-button-card-editor")
@@ -62,6 +63,10 @@ export class HuiButtonCardEditor extends LitElement
 
   get _show_name(): boolean {
     return this._config!.show_name || true;
+  }
+
+  get _show_state(): boolean {
+    return this._config!.show_state || false;
   }
 
   get _icon(): string {
@@ -155,6 +160,20 @@ export class HuiButtonCardEditor extends LitElement
               <ha-switch
                 .checked="${this._config!.show_name !== false}"
                 .configValue="${"show_name"}"
+                @change="${this._valueChanged}"
+              ></ha-switch>
+            </ha-formfield>
+          </div>
+          <div>
+            <ha-formfield
+              .label=${this.hass.localize(
+                "ui.panel.lovelace.editor.card.generic.show_state"
+              )}
+              .dir=${dir}
+            >
+              <ha-switch
+                .checked="${this._config!.show_state !== false}"
+                .configValue="${"show_state"}"
                 @change="${this._valueChanged}"
               ></ha-switch>
             </ha-formfield>

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
@@ -158,7 +158,7 @@ export class HuiButtonCardEditor extends LitElement
               .dir=${dir}
             >
               <ha-switch
-                .checked="${this._config!.show_name !== false}"
+                .checked="${this._show_name !== false}"
                 .configValue="${"show_name"}"
                 @change="${this._valueChanged}"
               ></ha-switch>
@@ -172,9 +172,9 @@ export class HuiButtonCardEditor extends LitElement
               .dir=${dir}
             >
               <ha-switch
-                .checked="${this._config!.show_state !== false}"
-                .configValue="${"show_state"}"
-                @change="${this._valueChanged}"
+                .checked=${this._show_state !== false}
+                .configValue=${"show_state"}
+                @change=${this._valueChanged}
               ></ha-switch>
             </ha-formfield>
           </div>
@@ -186,7 +186,7 @@ export class HuiButtonCardEditor extends LitElement
               .dir=${dir}
             >
               <ha-switch
-                .checked="${this._config!.show_icon !== false}"
+                .checked="${this._show_icon !== false}"
                 .configValue="${"show_icon"}"
                 @change="${this._valueChanged}"
               ></ha-switch>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Give a new option `show_state` to display the state of an entity below the entity's name

![image](https://user-images.githubusercontent.com/1287159/87438471-32304c80-c5b5-11ea-8f3f-2680cff2291a.png)

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: button
tap_action:
  action: toggle
hold_action:
  action: more-info
show_icon: true
show_name: true
show_state: true
entity: input_number.box1
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
