### PR TITLE
Add close function to edit card dialog

### DIFF
--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -15,7 +15,8 @@ declare global {
   }
 }
 
-interface HassDialog<T = HASSDomEvents[ValidHassDomEvent]> extends HTMLElement {
+export interface HassDialog<T = HASSDomEvents[ValidHassDomEvent]>
+  extends HTMLElement {
   showDialog(params: T);
   closeDialog?: () => boolean | void;
 }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -11,7 +11,7 @@ import {
   TemplateResult,
   PropertyValues,
 } from "lit-element";
-import type { HASSDomEvent } from "../../../../common/dom/fire_event";
+import { HASSDomEvent, fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-dialog";
 import type {
   LovelaceCardConfig,
@@ -30,6 +30,8 @@ import "./hui-card-preview";
 import type { EditCardDialogParams } from "./show-edit-card-dialog";
 import { getCardDocumentationURL } from "../get-card-documentation-url";
 import { mdiHelpCircle } from "@mdi/js";
+import { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { showConfirmationDialog } from "../../../../dialogs/generic/show-dialog-box";
 
 declare global {
   // for fire event
@@ -43,7 +45,7 @@ declare global {
 }
 
 @customElement("hui-dialog-edit-card")
-export class HuiDialogEditCard extends LitElement {
+export class HuiDialogEditCard extends LitElement implements HassDialog {
   @property() protected hass!: HomeAssistant;
 
   @internalProperty() private _params?: EditCardDialogParams;
@@ -64,6 +66,8 @@ export class HuiDialogEditCard extends LitElement {
 
   @internalProperty() private _documentationURL?: string;
 
+  @internalProperty() private _dirty = false;
+
   public async showDialog(params: EditCardDialogParams): Promise<void> {
     this._params = params;
     this._GUImode = true;
@@ -75,6 +79,20 @@ export class HuiDialogEditCard extends LitElement {
     if (this._cardConfig && !Object.isFrozen(this._cardConfig)) {
       this._cardConfig = deepFreeze(this._cardConfig);
     }
+  }
+
+  public closeDialog(): boolean {
+    if (this._dirty) {
+      this._confirmCancel();
+      return false;
+    }
+    this._params = undefined;
+    this._cardConfig = undefined;
+    this._error = undefined;
+    this._documentationURL = undefined;
+    this._dirty = false;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+    return true;
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -122,7 +140,7 @@ export class HuiDialogEditCard extends LitElement {
         open
         scrimClickAction
         @keydown=${this._ignoreKeydown}
-        @closed=${this._close}
+        @closed=${this._cancel}
         @opened=${this._opened}
         .heading=${html`${heading}
         ${this._documentationURL !== undefined
@@ -197,7 +215,7 @@ export class HuiDialogEditCard extends LitElement {
             `
           : ""}
         <div slot="primaryAction" @click=${this._save}>
-          <mwc-button @click=${this._close}>
+          <mwc-button @click=${this._cancel}>
             ${this.hass!.localize("ui.common.cancel")}
           </mwc-button>
           ${this._cardConfig !== undefined
@@ -214,7 +232,9 @@ export class HuiDialogEditCard extends LitElement {
                           size="small"
                         ></ha-circular-progress>
                       `
-                    : this.hass!.localize("ui.common.save")}
+                    : this._dirty
+                    ? this.hass!.localize("ui.common.save")
+                    : this.hass!.localize("ui.common.close")}
                 </mwc-button>
               `
             : ``}
@@ -344,12 +364,14 @@ export class HuiDialogEditCard extends LitElement {
     }
     this._cardConfig = deepFreeze(config);
     this._error = ev.detail.error;
+    this._dirty = true;
   }
 
   private _handleConfigChanged(ev: HASSDomEvent<ConfigChangedEvent>) {
     this._cardConfig = deepFreeze(ev.detail.config);
     this._error = ev.detail.error;
     this._guiModeAvailable = ev.detail.guiModeAvailable;
+    this._dirty = true;
   }
 
   private _handleGUIModeChanged(ev: HASSDomEvent<GUIModeChangedEvent>): void {
@@ -366,13 +388,6 @@ export class HuiDialogEditCard extends LitElement {
     this._cardEditorEl?.refreshYamlEditor();
   }
 
-  private _close(): void {
-    this._params = undefined;
-    this._cardConfig = undefined;
-    this._error = undefined;
-    this._documentationURL = undefined;
-  }
-
   private get _canSave(): boolean {
     if (this._saving) {
       return false;
@@ -386,8 +401,38 @@ export class HuiDialogEditCard extends LitElement {
     return true;
   }
 
+  private async _confirmCancel() {
+    // Make sure the open state of this dialog is handled before the open state of confirm dialog
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const confirm = await showConfirmationDialog(this, {
+      title: this.hass!.localize(
+        "ui.panel.lovelace.editor.edit_card.unsaved_changes"
+      ),
+      text: this.hass!.localize(
+        "ui.panel.lovelace.editor.edit_card.confirm_cancel"
+      ),
+      dismissText: this.hass!.localize("ui.common.no"),
+      confirmText: this.hass!.localize("ui.common.yes"),
+    });
+    if (confirm) {
+      this._cancel();
+    }
+  }
+
+  private _cancel(ev?: Event) {
+    if (ev) {
+      ev.stopPropagation();
+    }
+    this._dirty = false;
+    this.closeDialog();
+  }
+
   private async _save(): Promise<void> {
-    if (!this._canSave || this._saving) {
+    if (!this._canSave) {
+      return;
+    }
+    if (!this._dirty) {
+      this.closeDialog();
       return;
     }
     this._saving = true;
@@ -405,8 +450,9 @@ export class HuiDialogEditCard extends LitElement {
           )
     );
     this._saving = false;
+    this._dirty = false;
     showSaveSuccessToast(this, this.hass);
-    this._close();
+    this.closeDialog();
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1901,6 +1901,8 @@
             "pick_card": "Which card would you like to add?",
             "pick_card_view_title": "Which card would you like to add to your {name} view?",
             "toggle_editor": "Toggle Editor",
+            "unsaved_changes": "You have unsaved changes",
+            "confirm_cancel": "Are you sure you want to cancel?",
             "show_visual_editor": "Show Visual Editor",
             "show_code_editor": "Show Code Editor",
             "add": "Add Card",


### PR DESCRIPTION
## Proposed change

Adds close function to edit card dialog so the back button can close the dialog, shows a confirmation dialog when there are unsaved changes.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
