### PR TITLE
Logbook link fix

### DIFF
--- a/src/common/util/compute_rtl.ts
+++ b/src/common/util/compute_rtl.ts
@@ -9,5 +9,9 @@ export function computeRTL(hass: HomeAssistant) {
 }
 
 export function computeRTLDirection(hass: HomeAssistant) {
-  return computeRTL(hass) ? "rtl" : "ltr";
+  return emitRTLDirection(computeRTL(hass));
+}
+
+export function emitRTLDirection(rtl: boolean) {
+  return rtl ? "rtl" : "ltr";
 }

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -42,7 +42,11 @@ class HaLogbook extends LitElement {
   }
 
   protected updated(_changedProps: PropertyValues) {
-    this._rtl = computeRTL(this.hass);
+    const oldHass = _changedProps.get("hass") as HomeAssistant | undefined;
+
+    if (oldHass === undefined || oldHass.language !== this.hass.language) {
+      this._rtl = computeRTL(this.hass);
+    }
   }
 
   protected render(): TemplateResult {

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -19,6 +19,7 @@ import "../../components/ha-icon";
 import { LogbookEntry } from "../../data/logbook";
 import { HomeAssistant } from "../../types";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
+import { classMap } from "lit-html/directives/class-map";
 
 class HaLogbook extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -48,7 +49,7 @@ class HaLogbook extends LitElement {
   protected render(): TemplateResult {
     if (!this.entries?.length) {
       return html`
-        <div class="container">
+        <div class=${classMap({ container: true, rtl: this._rtl })}>
           ${this.hass.localize("ui.panel.logbook.entries_not_found")}
         </div>
       `;
@@ -106,9 +107,8 @@ class HaLogbook extends LitElement {
                     @click=${this._entityClicked}
                     .entityId=${item.entity_id}
                     class="name"
+                    >${item.name}</a
                   >
-                    ${item.name}
-                  </a>
                 `}
             <span
               >${item.message}${item_username
@@ -176,6 +176,9 @@ class HaLogbook extends LitElement {
 
       .container {
         padding: 0 16px;
+      }
+      .container.rtl {
+        direction: rtl;
       }
 
       .uni-virtualizer-host {

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -49,7 +49,7 @@ class HaLogbook extends LitElement {
   protected render(): TemplateResult {
     if (!this.entries?.length) {
       return html`
-        <div class=${classMap({ container: true, rtl: this._rtl })}>
+        <div class="container ${classMap({ rtl: this._rtl })}">
           ${this.hass.localize("ui.panel.logbook.entries_not_found")}
         </div>
       `;

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -14,12 +14,11 @@ import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import { fireEvent } from "../../common/dom/fire_event";
 import { domainIcon } from "../../common/entity/domain_icon";
 import { stateIcon } from "../../common/entity/state_icon";
-import { computeRTL } from "../../common/util/compute_rtl";
+import { computeRTL, emitRTLDirection } from "../../common/util/compute_rtl";
 import "../../components/ha-icon";
 import { LogbookEntry } from "../../data/logbook";
 import { HomeAssistant } from "../../types";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
-import { classMap } from "lit-html/directives/class-map";
 
 class HaLogbook extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -39,7 +38,9 @@ class HaLogbook extends LitElement {
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
     const languageChanged =
       oldHass === undefined || oldHass.language !== this.hass.language;
-    return changedProps.has("entries") || languageChanged;
+    const rtlChanged =
+      oldHass === undefined || computeRTL(oldHass) !== computeRTL(this.hass);
+    return changedProps.has("entries") || languageChanged || rtlChanged;
   }
 
   protected updated(_changedProps: PropertyValues) {
@@ -49,7 +50,7 @@ class HaLogbook extends LitElement {
   protected render(): TemplateResult {
     if (!this.entries?.length) {
       return html`
-        <div class="container ${classMap({ rtl: this._rtl })}">
+        <div class="container" .dir=${emitRTLDirection(this._rtl)}>
           ${this.hass.localize("ui.panel.logbook.entries_not_found")}
         </div>
       `;

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -28,7 +28,6 @@ class HaLogbook extends LitElement {
   @property() public entries: LogbookEntry[] = [];
 
   @property({ attribute: "rtl", type: Boolean, reflect: true })
-  // @ts-ignore
   private _rtl = false;
 
   // @ts-ignore

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -37,9 +37,8 @@ class HaLogbook extends LitElement {
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
     const languageChanged =
       oldHass === undefined || oldHass.language !== this.hass.language;
-    const rtlChanged =
-      oldHass === undefined || computeRTL(oldHass) !== computeRTL(this.hass);
-    return changedProps.has("entries") || languageChanged || rtlChanged;
+
+    return changedProps.has("entries") || languageChanged;
   }
 
   protected updated(_changedProps: PropertyValues) {

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -178,9 +178,6 @@ class HaLogbook extends LitElement {
       .container {
         padding: 0 16px;
       }
-      .container.rtl {
-        direction: rtl;
-      }
 
       .uni-virtualizer-host {
         display: block;


### PR DESCRIPTION
Non RTL fix - breaking of line inside A creates underline of extra space.

RTL fix - show no entries message aligned correctly (actual log book is LTR which is fine)