### PR TITLE
Restored card margin for narrow viewports

### DIFF
--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -394,18 +394,6 @@ export class HUIView extends LitElement {
         left: 16px;
       }
 
-      @media (max-width: 500px) {
-        :host {
-          padding-left: 0;
-          padding-right: 0;
-        }
-
-        .column > * {
-          margin-left: 0;
-          margin-right: 0;
-        }
-      }
-
       @media (max-width: 599px) {
         .column {
           max-width: 600px;


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

This change restores card margins on mobile devices (viewports < 500px).

**Arguments for:**

- Cards can maintain there design elevation even on mobiles [Cards - Material Design](https://material.io/components/cards).
- [Material - Spacing methods](https://material.io/design/layout/spacing-methods.html#spacing)
- Theme builders can be confident their themes will look as intended and consistent across all viewport sizes.
- There are very few occasions when the extra space will actually benefit the card content.
- Vast majority of other smart-home apps/mobile views maintain a card margin.
- Reviewing many mobile apps and design system almost all still maintain an outer margin for a grid system, the exceptions seam to be feed based app where scrolling was infinite like facebook and LinkedIn etc. Even though the main columns are reduced to 1 there is still a nested grid.  This image here shows why the outer margin is still needed to correctly containerise the cards:

<img width="407" alt="grid-no-border" src="https://user-images.githubusercontent.com/2111972/91207299-73616380-e700-11ea-8163-5b1d977371f7.png">

- This image just show really narrow (277px) columns displayed with the current media queries, also for many screen widths 500px is the max col-width which is also exactly the same cut-off we decide the screen is too small to afford a margin.

<img width="946" alt="narrow-cols" src="https://user-images.githubusercontent.com/2111972/91207300-73f9fa00-e700-11ea-8d27-6158b573bd06.png">

**Why no make a theme option?**

Theming is generally reserved for colour, style typography etc.  Size, layout and component structure are all part of the design system that shouldn't be customisable.

Before | After
------------ | -------------
<img width="471" alt="before" src="https://user-images.githubusercontent.com/2111972/88342394-3ab42000-cd37-11ea-83cc-da444813ca4e.png"> | <img width="455" alt="after" src="https://user-images.githubusercontent.com/2111972/88342421-4a336900-cd37-11ea-9d6c-6bc54e682e03.png">

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
