### PR TITLE
Add Z-Wave device info to OZW device pages

### DIFF
--- a/src/data/ozw.ts
+++ b/src/data/ozw.ts
@@ -1,4 +1,3 @@
-import { HassEntity } from "home-assistant-js-websocket";
 import { HomeAssistant } from "../types";
 
 export interface OZWDevice {

--- a/src/data/ozw.ts
+++ b/src/data/ozw.ts
@@ -1,0 +1,22 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { HomeAssistant } from "../types";
+
+export interface OZWDevice {
+  node_id: number;
+  node_query_stage: string;
+  is_awake: boolean;
+  is_failed: boolean;
+  is_zwave_plus: boolean;
+  ozw_instance: number;
+}
+
+export const fetchOZWNodeStatus = (
+  hass: HomeAssistant,
+  ozw_instance: string,
+  node_id: string
+): Promise<OZWDevice> =>
+  hass.callWS({
+    type: "ozw/node_status",
+    ozw_instance: ozw_instance,
+    node_id: node_id,
+  });

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
@@ -1,0 +1,85 @@
+import {
+  CSSResult,
+  customElement,
+  html,
+  LitElement,
+  property,
+  internalProperty,
+  TemplateResult,
+  css,
+  PropertyValues,
+} from "lit-element";
+import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
+import { haStyle } from "../../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../../types";
+import { OZWDevice, fetchOZWNodeStatus } from "../../../../../../data/ozw";
+
+@customElement("ha-device-info-ozw")
+export class HaDeviceInfoOzw extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public device!: DeviceRegistryEntry;
+
+  @internalProperty() private _ozwDevice?: OZWDevice;
+
+  protected updated(changedProperties: PropertyValues) {
+    if (changedProperties.has("device")) {
+      const ozwConnection = this.device.identifiers.find(
+        (conn) => conn[0] === "ozw"
+      );
+      if (!ozwConnection) {
+        return;
+      }
+      const identifiers = ozwConnection[1].split(".");
+      fetchOZWNodeStatus(this.hass, identifiers[0], identifiers[1]).then(
+        (device) => {
+          this._ozwDevice = device;
+        }
+      );
+    }
+  }
+
+  protected render(): TemplateResult {
+    if (!this._ozwDevice) {
+      return html``;
+    }
+    return html`
+      <h4>
+        ${this.hass.localize("ui.panel.config.ozw.device_info.zwave_info")}
+      </h4>
+      <div>
+        ${this.hass.localize("ui.panel.config.ozw.common.node_id")}:
+        ${this._ozwDevice.node_id}
+      </div>
+      <div>
+        ${this.hass.localize("ui.panel.config.ozw.device_info.stage")}:
+        ${this._ozwDevice.node_query_stage}
+      </div>
+      <div>
+        ${this.hass.localize("ui.panel.config.ozw.common.ozw_instance")}:
+        ${this._ozwDevice.ozw_instance}
+      </div>
+      <div>
+        ${this.hass.localize("ui.panel.config.ozw.device_info.node_failed")}:
+        ${this._ozwDevice.is_failed
+          ? this.hass.localize("ui.common.yes")
+          : this.hass.localize("ui.common.no")}
+      </div>
+    `;
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyle,
+      css`
+        h4 {
+          margin-bottom: 4px;
+        }
+        div {
+          word-break: break-all;
+          margin-top: 2px;
+        }
+      `,
+    ];
+  }
+}

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
@@ -24,13 +24,13 @@ export class HaDeviceInfoOzw extends LitElement {
 
   protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has("device")) {
-      const ozwConnection = this.device.identifiers.find(
-        (conn) => conn[0] === "ozw"
+      const ozwIdentifier = this.device.identifiers.find(
+        (identifier) => identifier[0] === "ozw"
       );
-      if (!ozwConnection) {
+      if (!ozwIdentifier) {
         return;
       }
-      const identifiers = ozwConnection[1].split(".");
+      const identifiers = ozwIdentifier[1].split(".");
       fetchOZWNodeStatus(this.hass, identifiers[0], identifiers[1]).then(
         (device) => {
           this._ozwDevice = device;

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
@@ -24,19 +24,23 @@ export class HaDeviceInfoOzw extends LitElement {
 
   protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has("device")) {
-      const ozwIdentifier = this.device.identifiers.find(
-        (identifier) => identifier[0] === "ozw"
-      );
-      if (!ozwIdentifier) {
-        return;
-      }
-      const identifiers = ozwIdentifier[1].split(".");
-      fetchOZWNodeStatus(this.hass, identifiers[0], identifiers[1]).then(
-        (device) => {
-          this._ozwDevice = device;
-        }
-      );
+      this._fetchNodeDetails(this.device);
     }
+  }
+
+  protected async _fetchNodeDetails(device) {
+    const ozwIdentifier = device.identifiers.find(
+      (identifier) => identifier[0] === "ozw"
+    );
+    if (!ozwIdentifier) {
+      return;
+    }
+    const identifiers = ozwIdentifier[1].split(".");
+    await fetchOZWNodeStatus(this.hass, identifiers[0], identifiers[1]).then(
+      (dev) => {
+        this._ozwDevice = dev;
+      }
+    );
   }
 
   protected render(): TemplateResult {

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
@@ -36,10 +36,10 @@ export class HaDeviceInfoOzw extends LitElement {
       return;
     }
     const identifiers = ozwIdentifier[1].split(".");
-    await fetchOZWNodeStatus(this.hass, identifiers[0], identifiers[1]).then(
-      (dev) => {
-        this._ozwDevice = dev;
-      }
+    this._ozwDevice = await fetchOZWNodeStatus(
+      this.hass,
+      identifiers[0],
+      identifiers[1]
     );
   }
 

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -501,6 +501,15 @@ export class HaConfigDevicePage extends LitElement {
         </div>
       `);
     }
+    if (integrations.includes("ozw")) {
+      import("./device-detail/integration-elements/ozw/ha-device-info-ozw");
+      templates.push(html`
+        <ha-device-info-ozw
+          .hass=${this.hass}
+          .device=${device}
+        ></ha-device-info-ozw>
+      `);
+    }
     if (integrations.includes("zha")) {
       import("./device-detail/integration-elements/zha/ha-device-actions-zha");
       import("./device-detail/integration-elements/zha/ha-device-info-zha");

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -539,7 +539,10 @@
       "sidebar_toggle": "Sidebar Toggle"
     },
     "panel": {
-      "calendar": { "my_calendars": "My Calendars", "today": "Today" },
+      "calendar": {
+        "my_calendars": "My Calendars",
+        "today": "Today"
+      },
       "config": {
         "header": "Configure Home Assistant",
         "introduction": "In this view it is possible to configure your components and Home Assistant. Not everything is possible to configure from the UI yet, but we're working on it.",
@@ -1568,7 +1571,11 @@
           "description": "Manage users",
           "users_privileges_note": "The users group is a work in progress. The user will be unable to administer the instance via the UI. We're still auditing all management API endpoints to ensure that they correctly limit access to administrators.",
           "picker": {
-            "headers": { "name": "Name", "group": "Group", "system": "System" }
+            "headers": {
+              "name": "Name",
+              "group": "Group",
+              "system": "System"
+            }
           },
           "editor": {
             "caption": "View user",
@@ -1610,6 +1617,18 @@
           "start_listening": "Start listening",
           "stop_listening": "Stop listening",
           "message_received": "Message {id} received on {topic} at {time}:"
+        },
+        "ozw": {
+          "common": {
+            "zwave": "Z-Wave",
+            "node_id": "Node ID",
+            "ozw_instance": "OpenZWave Instance"
+          },
+          "device_info": {
+            "zwave_info": "Z-Wave Info",
+            "stage": "Stage",
+            "node_failed": "Node Failed"
+          }
         },
         "zha": {
           "button": "Configure",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Depends on #6507 

Adds some basic Z-Wave device information to the Devices page for OZW devices. Based on code from the ZHA device pages.

![image](https://user-images.githubusercontent.com/7545841/89135778-dc88f900-d4fd-11ea-8441-d0da58eb03a8.png)

Backend PR has been merged: https://github.com/home-assistant/core/pull/38265

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.