### PR TITLE
Add OZW Refresh Node Dialog

### DIFF
--- a/src/data/ozw.ts
+++ b/src/data/ozw.ts
@@ -39,6 +39,26 @@ export interface OZWDeviceMetaData {
   ProductPicBase64: string;
 }
 
+export const nodeQueryStages = [
+  "ProtocolInfo",
+  "Probe",
+  "WakeUp",
+  "ManufacturerSpecific1",
+  "NodeInfo",
+  "NodePlusInfo",
+  "ManufacturerSpecific2",
+  "Versions",
+  "Instances",
+  "Static",
+  "CacheLoad",
+  "Associations",
+  "Neighbors",
+  "Session",
+  "Dynamic",
+  "Configuration",
+  "Complete",
+];
+
 export const getIdentifiersFromDevice = function (
   device: DeviceRegistryEntry
 ): OZWNodeIdentifiers | undefined {

--- a/src/data/ozw.ts
+++ b/src/data/ozw.ts
@@ -41,14 +41,16 @@ export interface OZWDeviceMetaData {
 
 export const getIdentifiersFromDevice = function (
   device: DeviceRegistryEntry
-): OZWNodeIdentifiers | false {
-  if (typeof device === "undefined") return false;
+): OZWNodeIdentifiers | undefined {
+  if (!device) {
+    return undefined;
+  }
 
   const ozwIdentifier = device.identifiers.find(
     (identifier) => identifier[0] === "ozw"
   );
   if (!ozwIdentifier) {
-    return false;
+    return undefined;
   }
 
   const identifiers = ozwIdentifier[1].split(".");

--- a/src/data/ozw.ts
+++ b/src/data/ozw.ts
@@ -1,4 +1,10 @@
 import { HomeAssistant } from "../types";
+import { DeviceRegistryEntry } from "./device_registry";
+
+export interface OZWNodeIdentifiers {
+  ozw_instance: number;
+  node_id: number;
+}
 
 export interface OZWDevice {
   node_id: number;
@@ -7,15 +13,80 @@ export interface OZWDevice {
   is_failed: boolean;
   is_zwave_plus: boolean;
   ozw_instance: number;
+  event: string;
 }
+
+export interface OZWDeviceMetaDataResponse {
+  node_id: number;
+  ozw_instance: number;
+  metadata: OZWDeviceMetaData;
+}
+
+export interface OZWDeviceMetaData {
+  OZWInfoURL: string;
+  ZWAProductURL: string;
+  ProductPic: string;
+  Description: string;
+  ProductManualURL: string;
+  ProductPageURL: string;
+  InclusionHelp: string;
+  ExclusionHelp: string;
+  ResetHelp: string;
+  WakeupHelp: string;
+  ProductSupportURL: string;
+  Frequency: string;
+  Name: string;
+  ProductPicBase64: string;
+}
+
+export const getIdentifiersFromDevice = function (
+  device: DeviceRegistryEntry
+): OZWNodeIdentifiers | false {
+  if (typeof device === "undefined") return false;
+
+  const ozwIdentifier = device.identifiers.find(
+    (identifier) => identifier[0] === "ozw"
+  );
+  if (!ozwIdentifier) {
+    return false;
+  }
+
+  const identifiers = ozwIdentifier[1].split(".");
+  return {
+    node_id: parseInt(identifiers[1]),
+    ozw_instance: parseInt(identifiers[0]),
+  };
+};
 
 export const fetchOZWNodeStatus = (
   hass: HomeAssistant,
-  ozw_instance: string,
-  node_id: string
+  ozw_instance: number,
+  node_id: number
 ): Promise<OZWDevice> =>
   hass.callWS({
     type: "ozw/node_status",
+    ozw_instance: ozw_instance,
+    node_id: node_id,
+  });
+
+export const fetchOZWNodeMetadata = (
+  hass: HomeAssistant,
+  ozw_instance: number,
+  node_id: number
+): Promise<OZWDeviceMetaDataResponse> =>
+  hass.callWS({
+    type: "ozw/node_metadata",
+    ozw_instance: ozw_instance,
+    node_id: node_id,
+  });
+
+export const refreshNodeInfo = (
+  hass: HomeAssistant,
+  ozw_instance: number,
+  node_id: number
+): Promise<OZWDevice> =>
+  hass.callWS({
+    type: "ozw/refresh_node_info",
     ozw_instance: ozw_instance,
     node_id: node_id,
   });

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
@@ -90,7 +90,10 @@ export class HaDeviceInfoOzw extends LitElement {
   }
 
   private async _refreshNodeClicked() {
-    showOZWRefreshNodeDialog(this, { device: this.device });
+    showOZWRefreshNodeDialog(this, {
+      node_id: this.node_id,
+      ozw_instance: this.ozw_instance,
+    });
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
@@ -36,10 +36,12 @@ export class HaDeviceInfoOzw extends LitElement {
 
   protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has("device")) {
-      const identifiers: OZWNodeIdentifiers | false = getIdentifiersFromDevice(
-        this.device
-      );
-      if (!identifiers) return;
+      const identifiers:
+        | OZWNodeIdentifiers
+        | undefined = getIdentifiersFromDevice(this.device);
+      if (!identifiers) {
+        return;
+      }
       this.ozw_instance = identifiers.ozw_instance;
       this.node_id = identifiers.node_id;
 

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -110,7 +110,6 @@ class DialogOZWRefreshNode extends LitElement {
     return html`
       <ha-dialog
         open
-        hideActions
         @closing="${this._close}"
         .heading=${createCloseHeading(
           this.hass,
@@ -124,7 +123,7 @@ class DialogOZWRefreshNode extends LitElement {
                   "ui.panel.config.ozw.refresh_node.complete"
                 )}
               </p>
-              <mwc-button @click=${this._close}>
+              <mwc-button slot="primaryAction" @click=${this._close}>
                 ${this.hass.localize("ui.common.close")}
               </mwc-button>
             `
@@ -195,7 +194,10 @@ class DialogOZWRefreshNode extends LitElement {
                 : ""}
               ${!this._active
                 ? html`
-                    <mwc-button @click=${this._startRefresh}>
+                    <mwc-button
+                      slot="primaryAction"
+                      @click=${this._startRefresh}
+                    >
                       ${this.hass.localize(
                         "ui.panel.config.ozw.refresh_node.start_refresh_button"
                       )}

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -27,11 +27,9 @@ import {
 class DialogOZWRefreshNode extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property()
-  private node_id: number | undefined;
+  @internalProperty() private _node_id?: number;
 
-  @property()
-  private ozw_instance = 1;
+  @internalProperty() private _ozw_instance = 1;
 
   @internalProperty() private _nodeMetaData?: OZWDeviceMetaData;
 
@@ -58,26 +56,26 @@ class DialogOZWRefreshNode extends LitElement {
   }
 
   private async _fetchData() {
-    if (!this.node_id) {
+    if (!this._node_id) {
       return;
     }
     const metaDataResponse = await fetchOZWNodeMetadata(
       this.hass,
-      this.ozw_instance,
-      this.node_id
+      this._ozw_instance,
+      this._node_id
     );
 
     this._nodeMetaData = metaDataResponse.metadata;
   }
 
   public async showDialog(params: OZWRefreshNodeDialogParams): Promise<void> {
-    this.node_id = params.node_id;
-    this.ozw_instance = params.ozw_instance;
+    this._node_id = params.node_id;
+    this._ozw_instance = params.ozw_instance;
     this._fetchData();
   }
 
   protected render(): TemplateResult {
-    if (!this.node_id) {
+    if (!this._node_id) {
       return html``;
     }
 
@@ -157,10 +155,10 @@ class DialogOZWRefreshNode extends LitElement {
                       ${this.hass.localize(
                         "ui.panel.config.ozw.refresh_node.wakeup_header"
                       )}
-                      ${this._nodeMetaData?.Name}
+                      ${this._nodeMetaData!.Name}
                     </b>
                     <blockquote>
-                      ${this._nodeMetaData?.WakeupHelp}
+                      ${this._nodeMetaData!.WakeupHelp}
                       <br />
                       <em>
                         ${this.hass.localize(
@@ -221,8 +219,8 @@ class DialogOZWRefreshNode extends LitElement {
       (message) => this._handleMessage(message),
       {
         type: "ozw/refresh_node_info",
-        node_id: this.node_id,
-        ozw_instance: this.ozw_instance,
+        node_id: this._node_id,
+        ozw_instance: this._ozw_instance,
       }
     );
     this._refreshDevicesTimeoutHandle = window.setTimeout(
@@ -233,7 +231,7 @@ class DialogOZWRefreshNode extends LitElement {
 
   private _close(): void {
     this._complete = false;
-    this.node_id = undefined;
+    this._node_id = undefined;
     this._node = undefined;
   }
 

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -115,26 +115,30 @@ class DialogOZWRefreshNode extends LitElement {
                             )}
                           </b>
                         </p>
-                        <p>
-                          ${this.hass.localize(
-                            "ui.panel.config.ozw.refresh_node.node_status"
-                          )}:
-                          ${this._node!.node_query_stage}
-                          (${this.hass.localize(
-                            "ui.panel.config.ozw.refresh_node.step"
-                          )}
-                          ${nodeQueryStages.indexOf(
-                            this._node!.node_query_stage
-                          ) + 1}/17)
-                        </p>
-                        <p>
-                          <em>
-                            ${this.hass.localize(
-                              "ui.panel.config.ozw.node_query_stages." +
-                                this._node!.node_query_stage.toLowerCase()
-                            )}</em
-                          >
-                        </p>
+                        ${this._node
+                          ? html`
+                              <p>
+                                ${this.hass.localize(
+                                  "ui.panel.config.ozw.refresh_node.node_status"
+                                )}:
+                                ${this._node.node_query_stage}
+                                (${this.hass.localize(
+                                  "ui.panel.config.ozw.refresh_node.step"
+                                )}
+                                ${nodeQueryStages.indexOf(
+                                  this._node.node_query_stage
+                                ) + 1}/17)
+                              </p>
+                              <p>
+                                <em>
+                                  ${this.hass.localize(
+                                    "ui.panel.config.ozw.node_query_stages." +
+                                      this._node.node_query_stage.toLowerCase()
+                                  )}</em
+                                >
+                              </p>
+                            `
+                          : ``}
                       </div>
                     </div>
                   `

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -112,13 +112,20 @@ class DialogOZWRefreshNode extends LitElement {
         open
         hideActions
         @closing="${this._close}"
-        .heading=${createCloseHeading(this.hass, "Refresh Node Information")}
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass.localize("ui.panel.config.ozw.refresh_node.title")
+        )}
       >
         ${this._complete
           ? html`
-              <p>Node Refresh complete</p>
+              <p>
+                ${this.hass.localize(
+                  "ui.panel.config.ozw.refresh_node.complete"
+                )}
+              </p>
               <mwc-button @click=${this._close}>
-                Close
+                ${this.hass.localize("ui.common.close")}
               </mwc-button>
             `
           : html`
@@ -127,16 +134,28 @@ class DialogOZWRefreshNode extends LitElement {
                     <div class="flex-container">
                       <ha-circular-progress active></ha-circular-progress>
                       <div>
-                        <p><b>Refreshing node information...</b></p>
                         <p>
-                          Node Status: ${this._node!.node_query_stage} (Step
+                          <b>
+                            ${this.hass.localize(
+                              "ui.panel.config.ozw.refresh_node.refreshing_description"
+                            )}
+                          </b>
+                        </p>
+                        <p>
+                          ${this.hass.localize(
+                            "ui.panel.config.ozw.refresh_node.node_status"
+                          )}:
+                          ${this._node!.node_query_stage}
+                          (${this.hass.localize(
+                            "ui.panel.config.ozw.refresh_node.step"
+                          )}
                           ${this._progress.indexOf(
                             this._node!.node_query_stage
                           ) + 1}/17)
                         </p>
                         <p>
-                          <em
-                            >${this.hass.localize(
+                          <em>
+                            ${this.hass.localize(
                               "ui.panel.config.ozw.node_query_stages." +
                                 this._node!.node_query_stage.toLowerCase()
                             )}</em
@@ -146,22 +165,30 @@ class DialogOZWRefreshNode extends LitElement {
                     </div>
                   `
                 : html`
-                    This will tell OpenZWave to re-interview a node and update
-                    the node's command classes, capabilities, and values.
+                    ${this.hass.localize(
+                      "ui.panel.config.ozw.refresh_node.description"
+                    )}
                     <p>
-                      If the node is battery powered, be sure to wake it before
-                      proceeding.
+                      ${this.hass.localize(
+                        "ui.panel.config.ozw.refresh_node.battery_note"
+                      )}
                     </p>
                   `}
               ${this._nodeMetaData?.WakeupHelp !== ""
                 ? html`
-                    <b>Wakeup Instructions for ${this._nodeMetaData?.Name}</b>
+                    <b>
+                      ${this.hass.localize(
+                        "ui.panel.config.ozw.refresh_node.wakeup_header"
+                      )}
+                      ${this._nodeMetaData?.Name}
+                    </b>
                     <blockquote>
                       ${this._nodeMetaData?.WakeupHelp}
                       <br />
                       <em>
-                        Wakeup instructions are sourced from the OpenZWave
-                        community device database.
+                        ${this.hass.localize(
+                          "ui.panel.config.ozw.refresh_node.wakeup_instructions_source"
+                        )}
                       </em>
                     </blockquote>
                   `
@@ -169,7 +196,9 @@ class DialogOZWRefreshNode extends LitElement {
               ${!this._active
                 ? html`
                     <mwc-button @click=${this._startRefresh}>
-                      Start Refresh
+                      ${this.hass.localize(
+                        "ui.panel.config.ozw.refresh_node.start_refresh_button"
+                      )}
                     </mwc-button>
                   `
                 : html``}

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -65,7 +65,7 @@ class DialogOZWRefreshNode extends LitElement {
     "Complete",
   ];
 
-  private _addDevicesTimeoutHandle: any = undefined;
+  private _refreshDevicesTimeoutHandle?: number;
 
   private _subscribed?: Promise<() => Promise<void>>;
 
@@ -82,9 +82,9 @@ class DialogOZWRefreshNode extends LitElement {
   }
 
   private async _fetchData(device) {
-    const identifiers: OZWNodeIdentifiers | false = getIdentifiersFromDevice(
-      device
-    );
+    const identifiers:
+      | OZWNodeIdentifiers
+      | undefined = getIdentifiersFromDevice(device);
     if (!identifiers) return;
     this.ozw_instance = identifiers.ozw_instance;
     this.node_id = identifiers.node_id;
@@ -223,8 +223,8 @@ class DialogOZWRefreshNode extends LitElement {
 
   private _unsubscribe(): void {
     this._active = false;
-    if (this._addDevicesTimeoutHandle) {
-      clearTimeout(this._addDevicesTimeoutHandle);
+    if (this._refreshDevicesTimeoutHandle) {
+      clearTimeout(this._refreshDevicesTimeoutHandle);
     }
     if (this._subscribed) {
       this._subscribed.then((unsub) => unsub());
@@ -237,14 +237,16 @@ class DialogOZWRefreshNode extends LitElement {
       return;
     }
     this._active = true;
-    const data: any = { type: "ozw/refresh_node_info" };
-    data.node_id = this.node_id;
-    data.ozw_instance = this.ozw_instance;
+    const data: any = {
+      type: "ozw/refresh_node_info",
+      node_id: this.node_id,
+      ozw_instance: this.ozw_instance,
+    };
     this._subscribed = this.hass.connection.subscribeMessage(
       (message) => this._handleMessage(message),
       data
     );
-    this._addDevicesTimeoutHandle = setTimeout(
+    this._refreshDevicesTimeoutHandle = window.setTimeout(
       () => this._unsubscribe(),
       120000
     );

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -1,0 +1,263 @@
+import {
+  CSSResult,
+  customElement,
+  html,
+  LitElement,
+  property,
+  internalProperty,
+  TemplateResult,
+  PropertyValues,
+  css,
+} from "lit-element";
+import "../../../../../components/ha-code-editor";
+import "../../../../../components/ha-circular-progress";
+import { createCloseHeading } from "../../../../../components/ha-dialog";
+import { haStyleDialog } from "../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../types";
+import { OZWRefreshNodeDialogParams } from "./show-dialog-ozw-refresh-node";
+
+import {
+  OZWNodeIdentifiers,
+  getIdentifiersFromDevice,
+  fetchOZWNodeMetadata,
+  OZWDeviceMetaData,
+  OZWDevice,
+} from "../../../../../data/ozw";
+import { DeviceRegistryEntry } from "../../../../../data/device_registry";
+
+@customElement("dialog-ozw-refresh-node")
+class DialogOZWRefreshNode extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property()
+  private node_id = 0;
+
+  @property()
+  private ozw_instance = 1;
+
+  @internalProperty() private _device?: DeviceRegistryEntry;
+
+  @internalProperty() private _nodeMetaData?: OZWDeviceMetaData;
+
+  @internalProperty() private _node?: OZWDevice;
+
+  @internalProperty() private _active = false;
+
+  @internalProperty() private _complete = false;
+
+  @internalProperty() private _progress = [
+    "ProtocolInfo",
+    "Probe",
+    "WakeUp",
+    "ManufacturerSpecific1",
+    "NodeInfo",
+    "NodePlusInfo",
+    "ManufacturerSpecific2",
+    "Versions",
+    "Instances",
+    "Static",
+    "CacheLoad",
+    "Associations",
+    "Neighbors",
+    "Session",
+    "Dynamic",
+    "Configuration",
+    "Complete",
+  ];
+
+  private _addDevicesTimeoutHandle: any = undefined;
+
+  private _subscribed?: Promise<() => Promise<void>>;
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._unsubscribe();
+  }
+
+  protected updated(changedProperties: PropertyValues): void {
+    super.update(changedProperties);
+    if (changedProperties.has("_device")) {
+      this._fetchData(this._device);
+    }
+  }
+
+  private async _fetchData(device) {
+    const identifiers: OZWNodeIdentifiers | false = getIdentifiersFromDevice(
+      device
+    );
+    if (!identifiers) return;
+    this.ozw_instance = identifiers.ozw_instance;
+    this.node_id = identifiers.node_id;
+
+    const metaDataResponse = await fetchOZWNodeMetadata(
+      this.hass,
+      this.ozw_instance,
+      this.node_id
+    );
+
+    this._nodeMetaData = metaDataResponse.metadata;
+  }
+
+  public async showDialog(params: OZWRefreshNodeDialogParams): Promise<void> {
+    this._device = params.device;
+  }
+
+  protected render(): TemplateResult {
+    if (!this._device) {
+      return html``;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        hideActions
+        @closing="${this._close}"
+        .heading=${createCloseHeading(this.hass, "Refresh Node Information")}
+      >
+        ${this._complete
+          ? html`
+              <p>Node Refresh complete</p>
+              <mwc-button @click=${this._close}>
+                Close
+              </mwc-button>
+            `
+          : html`
+              ${this._active
+                ? html`
+                    <div class="flex-container">
+                      <ha-circular-progress active></ha-circular-progress>
+                      <div>
+                        <p><b>Refreshing node information...</b></p>
+                        <p>
+                          Node Status: ${this._node!.node_query_stage} (Step
+                          ${this._progress.indexOf(
+                            this._node!.node_query_stage
+                          ) + 1}/17)
+                        </p>
+                        <p>
+                          <em
+                            >${this.hass.localize(
+                              "ui.panel.config.ozw.node_query_stages." +
+                                this._node!.node_query_stage.toLowerCase()
+                            )}</em
+                          >
+                        </p>
+                      </div>
+                    </div>
+                  `
+                : html`
+                    This will tell OpenZWave to re-interview a node and update
+                    the node's command classes, capabilities, and values.
+                    <p>
+                      If the node is battery powered, be sure to wake it before
+                      proceeding.
+                    </p>
+                  `}
+              ${this._nodeMetaData?.WakeupHelp !== ""
+                ? html`
+                    <b>Wakeup Instructions for ${this._nodeMetaData?.Name}</b>
+                    <blockquote>
+                      ${this._nodeMetaData?.WakeupHelp}
+                      <br />
+                      <em>
+                        Wakeup instructions are sourced from the OpenZWave
+                        community device database.
+                      </em>
+                    </blockquote>
+                  `
+                : ""}
+              ${!this._active
+                ? html`
+                    <mwc-button @click=${this._startRefresh}>
+                      Start Refresh
+                    </mwc-button>
+                  `
+                : html``}
+            `}
+      </ha-dialog>
+    `;
+  }
+
+  private _startRefresh(): void {
+    this._subscribe();
+  }
+
+  private _handleMessage(message: any): void {
+    if (message.type === "node_updated") {
+      this._node = message;
+      if (message.node_query_stage === "Complete") {
+        this._unsubscribe();
+        this._complete = true;
+      }
+    }
+  }
+
+  private _unsubscribe(): void {
+    this._active = false;
+    if (this._addDevicesTimeoutHandle) {
+      clearTimeout(this._addDevicesTimeoutHandle);
+    }
+    if (this._subscribed) {
+      this._subscribed.then((unsub) => unsub());
+      this._subscribed = undefined;
+    }
+  }
+
+  private _subscribe(): void {
+    if (!this.hass) {
+      return;
+    }
+    this._active = true;
+    const data: any = { type: "ozw/refresh_node_info" };
+    data.node_id = this.node_id;
+    data.ozw_instance = this.ozw_instance;
+    this._subscribed = this.hass.connection.subscribeMessage(
+      (message) => this._handleMessage(message),
+      data
+    );
+    this._addDevicesTimeoutHandle = setTimeout(
+      () => this._unsubscribe(),
+      120000
+    );
+  }
+
+  private _close(): void {
+    this._device = undefined;
+    this._complete = false;
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        blockquote {
+          display: block;
+          background-color: #ddd;
+          padding: 8px;
+          margin: 8px 0;
+          font-size: 0.9em;
+        }
+
+        blockquote em {
+          font-size: 0.9em;
+          margin-top: 6px;
+        }
+
+        .flex-container {
+          display: flex;
+          align-items: center;
+        }
+
+        .flex-container ha-circular-progress {
+          margin-right: 20px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-ozw-refresh-node": DialogOZWRefreshNode;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -22,7 +22,6 @@ import {
   OZWDevice,
   nodeQueryStages,
 } from "../../../../../data/ozw";
-import { DeviceRegistryEntry } from "../../../../../data/device_registry";
 
 @customElement("dialog-ozw-refresh-node")
 class DialogOZWRefreshNode extends LitElement {

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -22,6 +22,7 @@ import {
   fetchOZWNodeMetadata,
   OZWDeviceMetaData,
   OZWDevice,
+  nodeQueryStages,
 } from "../../../../../data/ozw";
 import { DeviceRegistryEntry } from "../../../../../data/device_registry";
 
@@ -44,26 +45,6 @@ class DialogOZWRefreshNode extends LitElement {
   @internalProperty() private _active = false;
 
   @internalProperty() private _complete = false;
-
-  @internalProperty() private _progress = [
-    "ProtocolInfo",
-    "Probe",
-    "WakeUp",
-    "ManufacturerSpecific1",
-    "NodeInfo",
-    "NodePlusInfo",
-    "ManufacturerSpecific2",
-    "Versions",
-    "Instances",
-    "Static",
-    "CacheLoad",
-    "Associations",
-    "Neighbors",
-    "Session",
-    "Dynamic",
-    "Configuration",
-    "Complete",
-  ];
 
   private _refreshDevicesTimeoutHandle?: number;
 
@@ -148,7 +129,7 @@ class DialogOZWRefreshNode extends LitElement {
                           (${this.hass.localize(
                             "ui.panel.config.ozw.refresh_node.step"
                           )}
-                          ${this._progress.indexOf(
+                          ${nodeQueryStages.indexOf(
                             this._node!.node_query_stage
                           ) + 1}/17)
                         </p>

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -236,6 +236,7 @@ class DialogOZWRefreshNode extends LitElement {
   private _close(): void {
     this._complete = false;
     this.node_id = undefined;
+    this._node = undefined;
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/dialog-ozw-refresh-node.ts
@@ -218,14 +218,13 @@ class DialogOZWRefreshNode extends LitElement {
       return;
     }
     this._active = true;
-    const data: any = {
-      type: "ozw/refresh_node_info",
-      node_id: this.node_id,
-      ozw_instance: this.ozw_instance,
-    };
     this._subscribed = this.hass.connection.subscribeMessage(
       (message) => this._handleMessage(message),
-      data
+      {
+        type: "ozw/refresh_node_info",
+        node_id: this.node_id,
+        ozw_instance: this.ozw_instance,
+      }
     );
     this._refreshDevicesTimeoutHandle = window.setTimeout(
       () => this._unsubscribe(),

--- a/src/panels/config/integrations/integration-panels/ozw/show-dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/show-dialog-ozw-refresh-node.ts
@@ -1,0 +1,22 @@
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import { DeviceRegistryEntry } from "../../../../../data/device_registry";
+
+export interface OZWRefreshNodeDialogParams {
+  device: DeviceRegistryEntry;
+}
+
+export const loadRefreshNodeDialog = () =>
+  import(
+    /* webpackChunkName: "dialog-ozw-refresh-node" */ "./dialog-ozw-refresh-node"
+  );
+
+export const showOZWRefreshNodeDialog = (
+  element: HTMLElement,
+  refreshNodeDialogParams: OZWRefreshNodeDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-ozw-refresh-node",
+    dialogImport: loadRefreshNodeDialog,
+    dialogParams: refreshNodeDialogParams,
+  });
+};

--- a/src/panels/config/integrations/integration-panels/ozw/show-dialog-ozw-refresh-node.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/show-dialog-ozw-refresh-node.ts
@@ -1,8 +1,8 @@
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import { DeviceRegistryEntry } from "../../../../../data/device_registry";
 
 export interface OZWRefreshNodeDialogParams {
-  device: DeviceRegistryEntry;
+  ozw_instance: number;
+  node_id: number;
 }
 
 export const loadRefreshNodeDialog = () =>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1066,7 +1066,9 @@
                   "label": "Repeat",
                   "type_select": "Repeat type",
                   "type": {
-                    "count": { "label": "Count" },
+                    "count": {
+                      "label": "Count"
+                    },
                     "while": {
                       "label": "While",
                       "conditions": "While conditions"
@@ -1628,6 +1630,25 @@
             "zwave_info": "Z-Wave Info",
             "stage": "Stage",
             "node_failed": "Node Failed"
+          },
+          "node_query_stages": {
+            "protocolinfo": "Obtaining basic Z-Wave capabilities of this node from the controller",
+            "probe": "Checking if the node is awake/alive",
+            "wakeup": "Setting up support for wakeup queues and messages",
+            "manufacturerspecific1": "Obtaining manufacturer and product ID codes from the node",
+            "nodeinfo": "Obtaining supported command classes from the node",
+            "nodeplusinfo": "Obtaining Z-Wave+ information from the node",
+            "manufacturerspecific2": "Obtaining additional manufacturer and product ID codes from the node",
+            "versions": "Obtaining information about firmware and command class versions",
+            "instances": "Obtaining details about what instances or channels a device supports",
+            "static": "Obtaining static values from the device",
+            "cacheload": "Loading information from the OpenZWave cache file. Battery nodes will stay at this stage until the node wakes up.",
+            "associations": "Refreshing association groups and memberships",
+            "neighbors": "Obtaining a list of the node's neighbors",
+            "session": "Obtaining infrequently changing values from the node",
+            "dynamic": "Obtaining frequently changing values from the node",
+            "configuration": "Obtaining configuration values from the node",
+            "complete": "Interview process is complete"
           }
         },
         "zha": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1649,6 +1649,18 @@
             "dynamic": "Obtaining frequently changing values from the node",
             "configuration": "Obtaining configuration values from the node",
             "complete": "Interview process is complete"
+          },
+          "refresh_node": {
+            "title": "Refresh Node Information",
+            "complete": "Node Refresh Complete",
+            "description": "This will tell OpenZWave to re-interview a node and update the node's command classes, capabilities, and values.",
+            "battery_note": "If the node is battery powered, be sure to wake it before proceeding",
+            "wakeup_header": "Wakeup Instructions for",
+            "wakeup_instructions_source": "Wakeup instructions are sourced from the OpenZWave community device database.",
+            "start_refresh_button": "Start Refresh",
+            "refreshing_description": "Refreshing node information...",
+            "node_status": "Node Status",
+            "step": "Step"
           }
         },
         "zha": {


### PR DESCRIPTION
## Proposed change
Adds a Refresh Node button to OZW Device pages that opens a dialog to walk a user through triggering the refresh. Based on code from the ZHA dialogs and add node panel.

![image](https://user-images.githubusercontent.com/7545841/89467413-7db4c100-d743-11ea-8e5d-5031e5fd32ee.png)

![image](https://user-images.githubusercontent.com/7545841/89467347-6a095a80-d743-11ea-8bc2-8f04983ffab1.png)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Backend PR https://github.com/home-assistant/core/pull/38573

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
