### PR TITLE
Fix color and overlap in close dialog header

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -10,7 +10,7 @@ import { computeRTLDirection } from "../common/util/compute_rtl";
 const MwcDialog = customElements.get("mwc-dialog") as Constructor<Dialog>;
 
 export const createCloseHeading = (hass: HomeAssistant, title: string) => html`
-  ${title}
+  <div class="header_title">${title}</div>
   <mwc-icon-button
     aria-label=${hass.localize("ui.dialogs.generic.close")}
     dialogAction="close"
@@ -63,15 +63,22 @@ export class HaDialog extends MwcDialog {
           min-height: var(--mdc-dialog-min-height, auto);
         }
         .header_button {
+          color: var(--text-primary-color);
           position: absolute;
           right: 16px;
           top: 10px;
           text-decoration: none;
-          color: inherit;
+        }
+        .header_title {
+          margin-right: 40px;
+          color: var(--text-primary-color);
         }
         [dir="rtl"].header_button {
           right: auto;
           left: 16px;
+        }
+        [dir="rtl"].header_title {
+          margin-left: 40px;
         }
       `,
     ];

--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -10,7 +10,7 @@ import { computeRTLDirection } from "../common/util/compute_rtl";
 const MwcDialog = customElements.get("mwc-dialog") as Constructor<Dialog>;
 
 export const createCloseHeading = (hass: HomeAssistant, title: string) => html`
-  <div class="header_title">${title}</div>
+  ${title}
   <mwc-icon-button
     aria-label=${hass.localize("ui.dialogs.generic.close")}
     dialogAction="close"
@@ -63,22 +63,15 @@ export class HaDialog extends MwcDialog {
           min-height: var(--mdc-dialog-min-height, auto);
         }
         .header_button {
-          color: var(--text-primary-color);
           position: absolute;
           right: 16px;
           top: 10px;
           text-decoration: none;
-        }
-        .header_title {
-          margin-right: 40px;
-          color: var(--text-primary-color);
+          color: inherit;
         }
         [dir="rtl"].header_button {
           right: auto;
           left: 16px;
-        }
-        [dir="rtl"].header_title {
-          margin-left: 40px;
         }
       `,
     ];

--- a/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
+++ b/src/panels/lovelace/editor/select-view/hui-dialog-select-view.ts
@@ -4,13 +4,14 @@ import {
   LitElement,
   internalProperty,
   TemplateResult,
-  CSSResult,
   css,
+  CSSResultArray,
 } from "lit-element";
 import "../../../../components/dialog/ha-paper-dialog";
 import "../../components/hui-views-list";
 import type { SelectViewDialogParams } from "./show-select-view-dialog";
 import { HomeAssistant } from "../../../../types";
+import { haStyleDialog } from "../../../../resources/styles";
 import { createCloseHeading } from "../../../../components/ha-dialog";
 import "../../../../components/ha-paper-dropdown-menu";
 import "@polymer/paper-item/paper-item";
@@ -135,12 +136,15 @@ export class HuiDialogSelectView extends LitElement {
     this.closeDialog();
   }
 
-  static get styles(): CSSResult {
-    return css`
-      ha-paper-dropdown-menu {
-        width: 100%;
-      }
-    `;
+  static get styles(): CSSResultArray {
+    return [
+      haStyleDialog,
+      css`
+        ha-paper-dropdown-menu {
+          width: 100%;
+        }
+      `,
+    ];
   }
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6535
- This PR is related to issue:
- Link to documentation pull request:

### Before

![image](https://user-images.githubusercontent.com/15093472/89499235-f5283600-d7bf-11ea-922c-309e1c64a4b6.png)

### After

![image](https://user-images.githubusercontent.com/15093472/89499155-d4f87700-d7bf-11ea-926f-5ba127380039.png)


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
