### PR TITLE
Play HLS with Exoplayer on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "roboto-fontface": "^0.10.0",
     "superstruct": "^0.10.12",
     "unfetch": "^4.1.0",
+    "url-toolkit": "^2.2.0",
     "vue": "^2.6.11",
     "vue2-daterange-picker": "^0.5.1",
     "web-animations-js": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "roboto-fontface": "^0.10.0",
     "superstruct": "^0.10.12",
     "unfetch": "^4.1.0",
-    "url-toolkit": "^2.2.0",
     "vue": "^2.6.11",
     "vue2-daterange-picker": "^0.5.1",
     "web-animations-js": "^2.3.2",

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -43,12 +43,14 @@ class HaCameraStream extends LitElement {
   private _useExoPlayer = false; 
 
   private async _getUseExoPlayer(): Promise<boolean> {
-    if (this.hass!.auth.external) {
-      const externalConfig = await getExternalConfig(this.hass!.auth.external);
-      if (externalConfig && externalConfig.hasExoPlayer)
-        return true
+    if (!this.hass!.auth.external) {
+      return false;
     }
-    return false
+    const externalConfig = await getExternalConfig(this.hass!.auth.external);
+    if (externalConfig && externalConfig.hasExoPlayer) {
+      return true
+    }
+    return false;
   }
   
   private _resizeExoPlayerListener;

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -181,7 +181,7 @@ class HaCameraStream extends LitElement {
 
   private async _renderHLSExoPlayer(url: string) {
     window.addEventListener("resize", this._resizeExoPlayer);
-    setTimeout(this._resizeExoPlayer, 200);
+    this.updateComplete.then(this._resizeExoPlayer);
     this._videoEl.style.visibility = "hidden";
     await this.hass!.auth.external!.sendMessage({
       type: "exoplayer/play_hls",

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -143,7 +143,7 @@ class HaCameraStream extends LitElement {
 
   private async _startHls(): Promise<void> {
     // eslint-disable-next-line
-    var hls;
+    let hls;
     const videoEl = this._videoEl;
     this._useExoPlayer = await this._getUseExoPlayer()
     if (!this._useExoPlayer) {
@@ -188,7 +188,9 @@ class HaCameraStream extends LitElement {
   private async _renderHLSExoPlayer(url: string) {
     this._resizeExoPlayerListener=() => this._resizeExoPlayer();
     window.addEventListener('resize', this._resizeExoPlayerListener);
-    this._resizeExoPlayer();
+    // https://github.com/typescript-eslint/typescript-eslint/issues/1642
+    // eslint-disable-next-line
+    setTimeout(this._resizeExoPlayerListener,200);
     this._videoEl.style.visibility = "hidden";
     this.hass!.auth.external!.fireMessage({
       type: "play_hls",

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -12,6 +12,7 @@ import {
 import { fireEvent } from "../common/dom/fire_event";
 import { computeStateName } from "../common/entity/compute_state_name";
 import { supportsFeature } from "../common/entity/supports-feature";
+import { nextRender } from "../common/util/render-status";
 import { getExternalConfig } from "../external_app/external_config";
 import {
   CAMERA_SUPPORT_STREAM,
@@ -181,7 +182,7 @@ class HaCameraStream extends LitElement {
 
   private async _renderHLSExoPlayer(url: string) {
     window.addEventListener("resize", this._resizeExoPlayer);
-    this.updateComplete.then(this._resizeExoPlayer);
+    this.updateComplete.then(() => nextRender()).then(this._resizeExoPlayer);
     this._videoEl.style.visibility = "hidden";
     await this.hass!.auth.external!.sendMessage({
       type: "exoplayer/play_hls",

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -42,14 +42,6 @@ class HaCameraStream extends LitElement {
 
   private _useExoPlayer = false; 
 
-  private async _getUseExoPlayer(): Promise<boolean> {
-    if (!this.hass!.auth.external) {
-      return false;
-    }
-    const externalConfig = await getExternalConfig(this.hass!.auth.external);
-    return externalConfig && externalConfig.hasExoPlayer;
-  }
-  
   private _resizeExoPlayerListener;
 
   public connectedCallback() {
@@ -140,6 +132,14 @@ class HaCameraStream extends LitElement {
     return this.shadowRoot!.querySelector("video")!;
   }
 
+  private async _getUseExoPlayer(): Promise<boolean> {
+    if (!this.hass!.auth.external) {
+      return false;
+    }
+    const externalConfig = await getExternalConfig(this.hass!.auth.external);
+    return externalConfig && externalConfig.hasExoPlayer;
+  }
+
   private async _startHls(): Promise<void> {
     // eslint-disable-next-line
     let hls;
@@ -185,7 +185,7 @@ class HaCameraStream extends LitElement {
   }
 
   private async _renderHLSExoPlayer(url: string) {
-    this._resizeExoPlayerListener=() => this._resizeExoPlayer();
+    this._resizeExoPlayerListener = () => this._resizeExoPlayer();
     window.addEventListener('resize', this._resizeExoPlayerListener);
     // https://github.com/typescript-eslint/typescript-eslint/issues/1642
     // eslint-disable-next-line
@@ -235,7 +235,7 @@ class HaCameraStream extends LitElement {
     fireEvent(this, "iron-resize");
   }
 
-  private async _destroyPolyfill(): Promise<void> {
+  private _destroyPolyfill() {
     if (this._hlsPolyfillInstance) {
       this._hlsPolyfillInstance.destroy();
       this._hlsPolyfillInstance = undefined;

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -47,10 +47,8 @@ class HaCameraStream extends LitElement {
       return false;
     }
     const externalConfig = await getExternalConfig(this.hass!.auth.external);
-    if (externalConfig && externalConfig.hasExoPlayer) {
-      return true
-    }
-    return false;
+    return externalConfig && externalConfig.hasExoPlayer;
+
   }
   
   private _resizeExoPlayerListener;

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -48,7 +48,6 @@ class HaCameraStream extends LitElement {
     }
     const externalConfig = await getExternalConfig(this.hass!.auth.external);
     return externalConfig && externalConfig.hasExoPlayer;
-
   }
   
   private _resizeExoPlayerListener;

--- a/src/external_app/external_config.ts
+++ b/src/external_app/external_config.ts
@@ -3,6 +3,7 @@ import { ExternalMessaging } from "./external_messaging";
 export interface ExternalConfig {
   hasSettingsScreen: boolean;
   canWriteTag: boolean;
+  hasExoPlayer: boolean;
 }
 
 export const getExternalConfig = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

See also: home-assistant/core#38125 & home-assistant/android/pull/739
H.265 videos are not supported through Chromium or Webview on Android. We can work around this for Android by using Exoplayer which supports H.265 if the codecs are available on the device. This PR uses the externalApp interface to test whether Exoplayer is available from the config and uses the interface to send the requests to Exoplayer if available. I will open another PR on the Mobile App repository to implement the Exoplayer interface on the Android side.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
