### PR TITLE
Improve messaging of empty device info cards

### DIFF
--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -309,9 +309,8 @@ export class HaConfigDevicePage extends LitElement {
                         : html`
                             <paper-item class="no-link">
                               ${this.hass.localize(
-                                "ui.panel.config.devices.automation.no_automations_device"
+                                "ui.panel.config.devices.automation.no_automations"
                               )}
-                              ${" "}
                               ${this.hass.localize(
                                 "ui.panel.config.devices.add_prompt"
                               )}
@@ -381,9 +380,8 @@ export class HaConfigDevicePage extends LitElement {
                             : html`
                                 <paper-item class="no-link">
                                   ${this.hass.localize(
-                                    "ui.panel.config.devices.scene.no_scenes_device"
+                                    "ui.panel.config.devices.scene.no_scenes"
                                   )}
-                                  ${" "}
                                   ${this.hass.localize(
                                     "ui.panel.config.devices.add_prompt"
                                   )}
@@ -436,9 +434,8 @@ export class HaConfigDevicePage extends LitElement {
                           : html`
                               <paper-item class="no-link">
                                 ${this.hass.localize(
-                                  "ui.panel.config.devices.script.no_scripts_device"
+                                  "ui.panel.config.devices.script.no_scripts"
                                 )}
-                                ${" "}
                                 ${this.hass.localize(
                                   "ui.panel.config.devices.add_prompt"
                                 )}

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -309,10 +309,11 @@ export class HaConfigDevicePage extends LitElement {
                         : html`
                             <paper-item class="no-link">
                               ${this.hass.localize(
-                                "ui.panel.config.devices.automation.no_automations"
-                              )}
-                              ${this.hass.localize(
-                                "ui.panel.config.devices.add_prompt"
+                                "ui.panel.config.devices.add_prompt",
+                                "name",
+                                this.hass.localize(
+                                  "ui.panel.config.devices.automation.automations"
+                                )
                               )}
                             </paper-item>
                           `}
@@ -380,10 +381,11 @@ export class HaConfigDevicePage extends LitElement {
                             : html`
                                 <paper-item class="no-link">
                                   ${this.hass.localize(
-                                    "ui.panel.config.devices.scene.no_scenes"
-                                  )}
-                                  ${this.hass.localize(
-                                    "ui.panel.config.devices.add_prompt"
+                                    "ui.panel.config.devices.add_prompt",
+                                    "name",
+                                    this.hass.localize(
+                                      "ui.panel.config.devices.scene.scenes"
+                                    )
                                   )}
                                 </paper-item>
                               `
@@ -434,10 +436,11 @@ export class HaConfigDevicePage extends LitElement {
                           : html`
                               <paper-item class="no-link">
                                 ${this.hass.localize(
-                                  "ui.panel.config.devices.script.no_scripts"
-                                )}
-                                ${this.hass.localize(
-                                  "ui.panel.config.devices.add_prompt"
+                                  "ui.panel.config.devices.add_prompt",
+                                  "name",
+                                  this.hass.localize(
+                                    "ui.panel.config.devices.script.scripts"
+                                  )
                                 )}
                               </paper-item>
                             `}

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -307,11 +307,15 @@ export class HaConfigDevicePage extends LitElement {
                               : "";
                           })
                         : html`
-                            <paper-item class="no-link"
-                              >${this.hass.localize(
-                                "ui.panel.config.devices.automation.no_automations"
-                              )}</paper-item
-                            >
+                            <paper-item class="no-link">
+                              ${this.hass.localize(
+                                "ui.panel.config.devices.automation.no_automations_device"
+                              )}
+                              ${" "}
+                              ${this.hass.localize(
+                                "ui.panel.config.devices.add_prompt"
+                              )}
+                            </paper-item>
                           `}
                     </ha-card>
                   `
@@ -375,11 +379,15 @@ export class HaConfigDevicePage extends LitElement {
                                   : "";
                               })
                             : html`
-                                <paper-item class="no-link"
-                                  >${this.hass.localize(
-                                    "ui.panel.config.devices.scene.no_scenes"
-                                  )}</paper-item
-                                >
+                                <paper-item class="no-link">
+                                  ${this.hass.localize(
+                                    "ui.panel.config.devices.scene.no_scenes_device"
+                                  )}
+                                  ${" "}
+                                  ${this.hass.localize(
+                                    "ui.panel.config.devices.add_prompt"
+                                  )}
+                                </paper-item>
                               `
                         }
                       </ha-card>
@@ -428,9 +436,13 @@ export class HaConfigDevicePage extends LitElement {
                           : html`
                               <paper-item class="no-link">
                                 ${this.hass.localize(
-                                  "ui.panel.config.devices.script.no_scripts"
-                                )}</paper-item
-                              >
+                                  "ui.panel.config.devices.script.no_scripts_device"
+                                )}
+                                ${" "}
+                                ${this.hass.localize(
+                                  "ui.panel.config.devices.add_prompt"
+                                )}
+                              </paper-item>
                             `}
                       </ha-card>
                     `
@@ -700,6 +712,10 @@ export class HaConfigDevicePage extends LitElement {
       a {
         text-decoration: none;
         color: var(--primary-color);
+      }
+
+      ha-card {
+        padding-bottom: 8px;
       }
 
       ha-card a {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1339,7 +1339,7 @@
           }
         },
         "devices": {
-          "add_prompt": " have been added using this device yet. You can add one by clicking the + button above.",
+          "add_prompt": "No {name} have been added using this device yet. You can add one by clicking the + button above.",
           "caption": "Devices",
           "description": "Manage connected devices",
           "device_info": "Device info",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1339,7 +1339,7 @@
           }
         },
         "devices": {
-          "add_prompt": "You can add one by clicking the + button above.",
+          "add_prompt": " have been added using this device yet. You can add one by clicking the + button above.",
           "caption": "Devices",
           "description": "Manage connected devices",
           "device_info": "Device info",
@@ -1351,7 +1351,6 @@
           "automation": {
             "automations": "Automations",
             "no_automations": "No automations",
-            "no_automations_device": "No automations have been added to this device yet.",
             "create": "Create automation with device",
             "triggers": {
               "caption": "Do something when..."
@@ -1367,13 +1366,11 @@
           "script": {
             "scripts": "Scripts",
             "no_scripts": "No scripts",
-            "no_scripts_device": "No scripts have been added to this device yet.",
             "create": "Create script with device"
           },
           "scene": {
             "scenes": "Scenes",
             "no_scenes": "No scenes",
-            "no_scenes_device": "No scenes have been added to this device yet.",
             "create": "Create scene with device"
           },
           "cant_edit": "You can only edit items that are created in the UI.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1339,6 +1339,7 @@
           }
         },
         "devices": {
+          "add_prompt": "You can add one by clicking the + button above.",
           "caption": "Devices",
           "description": "Manage connected devices",
           "device_info": "Device info",
@@ -1350,6 +1351,7 @@
           "automation": {
             "automations": "Automations",
             "no_automations": "No automations",
+            "no_automations_device": "No automations have been added to this device yet.",
             "create": "Create automation with device",
             "triggers": {
               "caption": "Do something when..."
@@ -1365,11 +1367,13 @@
           "script": {
             "scripts": "Scripts",
             "no_scripts": "No scripts",
+            "no_scripts_device": "No scripts have been added to this device yet.",
             "create": "Create script with device"
           },
           "scene": {
             "scenes": "Scenes",
             "no_scenes": "No scenes",
+            "no_scenes_device": "No scenes have been added to this device yet.",
             "create": "Create scene with device"
           },
           "cant_edit": "You can only edit items that are created in the UI.",


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improves messaging on device info page for empty cards

![image](https://user-images.githubusercontent.com/28114703/90423752-ee010200-e0b4-11ea-92e9-ddd0633e7730.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4679

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
