### PR TITLE
Stop image from rendering for camera when disconnected and update when reconnected

### DIFF
--- a/src/panels/lovelace/common/has-changed.ts
+++ b/src/panels/lovelace/common/has-changed.ts
@@ -13,6 +13,7 @@ function hasConfigChanged(element: any, changedProps: PropertyValues): boolean {
   }
 
   if (
+    oldHass.connected !== element.hass!.connected ||
     oldHass.themes !== element.hass!.themes ||
     oldHass.language !== element.hass!.language ||
     oldHass.localize !== element.hass.localize ||

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -165,7 +165,7 @@ export class HuiImage extends LitElement {
         if (this.hass!.connected && this.cameraView !== "live") {
           this._updateCameraImageSrc();
           this._startUpdateCameraInterval();
-        } else {
+        } else if (!this.hass!.connected) {
           this._stopUpdateCameraInterval();
           this._cameraImageSrc = undefined;
           this._loadError = true;

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -161,13 +161,14 @@ export class HuiImage extends LitElement {
   protected updated(changedProps: PropertyValues): void {
     if (changedProps.has("hass")) {
       const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-      if (oldHass && oldHass.connected !== this.hass!.connected) {
+      if (!oldHass || oldHass.connected !== this.hass!.connected) {
         if (this.hass!.connected && this.cameraView !== "live") {
           this._updateCameraImageSrc();
           this._startUpdateCameraInterval();
         } else {
           this._stopUpdateCameraInterval();
-          this._cameraImageSrc = "/static/images/image-broken.svg";
+          this._cameraImageSrc = undefined;
+          this._loadError = true;
         }
       }
     } else if (changedProps.has("cameraImage") && this.cameraView !== "live") {

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -162,7 +162,7 @@ export class HuiImage extends LitElement {
     if (changedProps.has("hass")) {
       const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
       if (oldHass && oldHass.connected !== this.hass!.connected) {
-        if (this.hass!.connected) {
+        if (this.hass!.connected && this.cameraView !== "live") {
           this._updateCameraImageSrc();
           this._startUpdateCameraInterval();
         } else {

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -169,7 +169,9 @@ export class HuiImage extends LitElement {
     );
   }
 
-  private async _connectionChanged(ev: HASSDomEvent<ConnectionStatus>): void {
+  private async _connectionChanged(
+    ev: HASSDomEvent<ConnectionStatus>
+  ): Promise<void> {
     const connected = ev.detail === "connected";
     if (connected) {
       await this._updateCameraImageSrc();


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Potentially fixes disconnection issues where leaving the tab/window open in the background or having a slower device, frontend tries to render image with token that is no longer valid. This listens to the state of the connection, removes the image when disconnected, and updates the image src before rendering when reestablished.

Stops rendering when disconnected:
![image](https://user-images.githubusercontent.com/28114703/90975884-1616b800-e530-11ea-8de0-65cb7f2522b6.png)


No 401 error when going back to the page and the socket is reconnected:
![image](https://user-images.githubusercontent.com/28114703/90975937-95a48700-e530-11ea-9423-9ab878ecf162.png)

_no screenshot of the camera image for security reasons, but logs show no more 401, where they used to._

Tested while off-page also, which was tending to cause this issue as the page had to 'catch up' when coming out of a 'sleep' state.

Also tested on some of the 'slower' devices in my house which used to almost guaranteed, cause the authentication error when switching between tabs and windows. Mobile also tested, and all seem to reconnect, update the src, then render now instead of the update being after the fact.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
helps #3379
helps https://github.com/home-assistant/core/issues/23055
- This PR is related to issue: 
https://github.com/home-assistant/frontend/issues/3379
https://github.com/home-assistant/core/issues/23055

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
