### PR TITLE
Expand error msg on why yaml defined entities can't be changed from UI

### DIFF
--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -26,6 +26,7 @@ import {
   getExtendedEntityRegistryEntry,
 } from "../../../data/entity_registry";
 import { haStyleDialog } from "../../../resources/styles";
+import { documentationUrl } from "../../util/documentation-url";
 import type { HomeAssistant } from "../../../types";
 import { PLATFORMS_WITH_SETTINGS_TAB } from "./const";
 import "./entity-registry-settings";

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -26,7 +26,7 @@ import {
   getExtendedEntityRegistryEntry,
 } from "../../../data/entity_registry";
 import { haStyleDialog } from "../../../resources/styles";
-import { documentationUrl } from "../../util/documentation-url";
+import { documentationUrl } from "../../../util/documentation-url";
 import type { HomeAssistant } from "../../../types";
 import { PLATFORMS_WITH_SETTINGS_TAB } from "./const";
 import "./entity-registry-settings";

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -170,7 +170,21 @@ export class DialogEntityEditor extends LitElement {
         }
         return html`
           <div class="content">
-            ${this.hass.localize("ui.dialogs.entity_registry.no_unique_id")}
+            ${this.hass.localize(
+              "ui.dialogs.entity_registry.no_unique_id",
+              "faq_link",
+              html`<a
+                href="${documentationUrl(
+                  this.hass,
+                  "/faq/unique_id"
+                )}"
+                target="_blank"
+                rel="noreferrer"
+                >${this.hass.localize(
+                  "ui.dialogs.entity_registry.faq"
+                )}</a
+              >`              
+            )}
           </div>
         `;
       case "tab-related":

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -429,7 +429,7 @@
         "control": "Control",
         "related": "Related",
         "dismiss": "Dismiss",
-        "no_unique_id": "This entity does not have a unique ID, therefore its settings cannot be managed from the UI.",
+        "no_unique_id": "This entity does not have a unique ID, therefore its settings cannot be managed from the UI. This is usually because the entity is defined in configuration.yaml, and settings for those entities must also be done in yaml.",
         "editor": {
           "name": "Name Override",
           "icon": "Icon Override",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -429,8 +429,8 @@
         "control": "Control",
         "related": "Related",
         "dismiss": "Dismiss",
-        "no_unique_id": "This entity does not have a unique ID, therefore its settings cannot be managed from the UI. See {faq_link} for more detail.",
-        "faq": "FAQ",
+        "no_unique_id": "This entity does not have a unique ID, therefore its settings cannot be managed from the UI. See the {faq_link} for more detail.",
+        "faq": "documentation",
         "editor": {
           "name": "Name Override",
           "icon": "Icon Override",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -429,7 +429,7 @@
         "control": "Control",
         "related": "Related",
         "dismiss": "Dismiss",
-        "no_unique_id": "This entity does not have a unique ID, therefore its settings cannot be managed from the UI. This is usually because the entity is defined in configuration.yaml, and settings for those entities must also be done in yaml.",
+        "no_unique_id": "This entity does not have a unique ID, therefore its settings cannot be managed from the UI. See https://www.home-assistant.io/faq/unique_id/",
         "editor": {
           "name": "Name Override",
           "icon": "Icon Override",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -429,7 +429,8 @@
         "control": "Control",
         "related": "Related",
         "dismiss": "Dismiss",
-        "no_unique_id": "This entity does not have a unique ID, therefore its settings cannot be managed from the UI. See https://www.home-assistant.io/faq/unique_id/",
+        "no_unique_id": "This entity does not have a unique ID, therefore its settings cannot be managed from the UI. See {faq_link} for more detail.",
+        "faq": "FAQ",
         "editor": {
           "name": "Name Override",
           "icon": "Icon Override",


### PR DESCRIPTION

## Proposed change

Many users find the "This entity does not have a unique ID, therefore its settings cannot be managed from the UI" message too cryptic. 
Here is one of several threads: https://community.home-assistant.io/t/this-entity-does-not-have-a-unique-id-therefore-its-settings-cannot-be-managed-from-the-ui/182307

I know my proposed wording might not be ideal, so open to other wording!

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
