### PR TITLE
Entities & Glance Card: Add state color to editors

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -115,7 +115,7 @@ export class HuiEntitiesCardEditor extends LitElement
           </ha-formfield>
           <ha-formfield
             .label=${this.hass.localize(
-              "ui.panel.lovelace.editor.card.entities.state_color"
+              "ui.panel.lovelace.editor.card.generic.state_color"
             )}
             .dir=${computeRTLDirection(this.hass)}
           >

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -47,6 +47,7 @@ const cardConfigStruct = object({
   title: optional(union([string(), boolean()])),
   theme: optional(string()),
   show_header_toggle: optional(boolean()),
+  state_color: optional(boolean()),
   entities: array(entitiesConfigStruct),
   header: optional(headerFooterConfigStructs),
   footer: optional(headerFooterConfigStructs),
@@ -89,33 +90,47 @@ export class HuiEntitiesCardEditor extends LitElement
           )} (${this.hass.localize(
             "ui.panel.lovelace.editor.card.config.optional"
           )})"
-          .value="${this._title}"
-          .configValue="${"title"}"
-          @value-changed="${this._valueChanged}"
+          .value=${this._title}
+          .configValue=${"title"}
+          @value-changed=${this._valueChanged}
         ></paper-input>
         <hui-theme-select-editor
           .hass=${this.hass}
-          .value="${this._theme}"
-          .configValue="${"theme"}"
-          @value-changed="${this._valueChanged}"
+          .value=${this._theme}
+          .configValue=${"theme"}
+          @value-changed=${this._valueChanged}
         ></hui-theme-select-editor>
-        <ha-formfield
-          .label=${this.hass.localize(
-            "ui.panel.lovelace.editor.card.entities.show_header_toggle"
-          )}
-          .dir=${computeRTLDirection(this.hass)}
-        >
-          <ha-switch
-            .checked="${this._config!.show_header_toggle !== false}"
-            .configValue="${"show_header_toggle"}"
-            @change="${this._valueChanged}"
-          ></ha-switch>
-        </ha-formfield>
+        <div class="side-by-side">
+          <ha-formfield
+            .label=${this.hass.localize(
+              "ui.panel.lovelace.editor.card.entities.show_header_toggle"
+            )}
+            .dir=${computeRTLDirection(this.hass)}
+          >
+            <ha-switch
+              .checked=${this._config!.show_header_toggle !== false}
+              .configValue=${"show_header_toggle"}
+              @change=${this._valueChanged}
+            ></ha-switch>
+          </ha-formfield>
+          <ha-formfield
+            .label=${this.hass.localize(
+              "ui.panel.lovelace.editor.card.entities.state_color"
+            )}
+            .dir=${computeRTLDirection(this.hass)}
+          >
+            <ha-switch
+              .checked=${this._config!.state_color}
+              .configValue=${"state_color"}
+              @change=${this._valueChanged}
+            ></ha-switch>
+          </ha-formfield>
+        </div>
       </div>
       <hui-entity-editor
         .hass=${this.hass}
-        .entities="${this._configEntities}"
-        @entities-changed="${this._valueChanged}"
+        .entities=${this._configEntities}
+        @entities-changed=${this._valueChanged}
       ></hui-entity-editor>
     `;
   }

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -47,6 +47,7 @@ const cardConfigStruct = object({
   show_name: optional(boolean()),
   show_state: optional(boolean()),
   show_icon: optional(boolean()),
+  state_color: optional(boolean()),
   entities: array(entitiesConfigStruct),
 });
 
@@ -89,6 +90,10 @@ export class HuiGlanceCardEditor extends LitElement
     return this._config!.show_state || true;
   }
 
+  get _state_color(): boolean {
+    return Boolean(this._config!.state_color);
+  }
+
   protected render(): TemplateResult {
     if (!this.hass || !this._config) {
       return html``;
@@ -105,16 +110,16 @@ export class HuiGlanceCardEditor extends LitElement
           )} (${this.hass.localize(
             "ui.panel.lovelace.editor.card.config.optional"
           )})"
-          .value="${this._title}"
-          .configValue="${"title"}"
-          @value-changed="${this._valueChanged}"
+          .value=${this._title}
+          .configValue=${"title"}
+          @value-changed=${this._valueChanged}
         ></paper-input>
         <div class="side-by-side">
           <hui-theme-select-editor
             .hass=${this.hass}
-            .value="${this._theme}"
-            .configValue="${"theme"}"
-            @value-changed="${this._valueChanged}"
+            .value=${this._theme}
+            .configValue=${"theme"}
+            @value-changed=${this._valueChanged}
           ></hui-theme-select-editor>
           <paper-input
             .label="${this.hass.localize(
@@ -123,9 +128,9 @@ export class HuiGlanceCardEditor extends LitElement
               "ui.panel.lovelace.editor.card.config.optional"
             )})"
             type="number"
-            .value="${this._columns}"
-            .configValue="${"columns"}"
-            @value-changed="${this._valueChanged}"
+            .value=${this._columns}
+            .configValue=${"columns"}
+            @value-changed=${this._valueChanged}
           ></paper-input>
         </div>
         <div class="side-by-side">
@@ -138,8 +143,8 @@ export class HuiGlanceCardEditor extends LitElement
             >
               <ha-switch
                 .checked=${this._config!.show_name !== false}
-                .configValue="${"show_name"}"
-                @change="${this._valueChanged}"
+                .configValue=${"show_name"}
+                @change=${this._valueChanged}
               ></ha-switch>
             </ha-formfield>
           </div>
@@ -152,8 +157,8 @@ export class HuiGlanceCardEditor extends LitElement
             >
               <ha-switch
                 .checked=${this._config!.show_icon !== false}
-                .configValue="${"show_icon"}"
-                @change="${this._valueChanged}"
+                .configValue=${"show_icon"}
+                @change=${this._valueChanged}
               >
               </ha-switch>
             </ha-formfield>
@@ -167,18 +172,30 @@ export class HuiGlanceCardEditor extends LitElement
             >
               <ha-switch
                 .checked=${this._config!.show_state !== false}
-                .configValue="${"show_state"}"
-                @change="${this._valueChanged}"
+                .configValue=${"show_state"}
+                @change=${this._valueChanged}
               >
               </ha-switch>
             </ha-formfield>
           </div>
         </div>
+        <ha-formfield
+          .label=${this.hass.localize(
+            "ui.panel.lovelace.editor.card.glance.state_color"
+          )}
+          .dir=${computeRTLDirection(this.hass)}
+        >
+          <ha-switch
+            .checked=${this._config!.state_color}
+            .configValue=${"state_color"}
+            @change=${this._valueChanged}
+          ></ha-switch>
+        </ha-formfield>
       </div>
       <hui-entity-editor
         .hass=${this.hass}
-        .entities="${this._configEntities}"
-        @entities-changed="${this._valueChanged}"
+        .entities=${this._configEntities}
+        @entities-changed=${this._valueChanged}
       ></hui-entity-editor>
     `;
   }

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -91,7 +91,7 @@ export class HuiGlanceCardEditor extends LitElement
   }
 
   get _state_color(): boolean {
-    return Boolean(this._config!.state_color);
+    return this._config!.state_color ?? true;
   }
 
   protected render(): TemplateResult {
@@ -181,7 +181,7 @@ export class HuiGlanceCardEditor extends LitElement
         </div>
         <ha-formfield
           .label=${this.hass.localize(
-            "ui.panel.lovelace.editor.card.glance.state_color"
+            "ui.panel.lovelace.editor.card.generic.state_color"
           )}
           .dir=${computeRTLDirection(this.hass)}
         >

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2164,7 +2164,7 @@
             "entities": {
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
-              "state_color": "Show State Color?",
+              "state_color": "Color icons based on state",
               "toggle": "Toggle entities.",
               "description": "The Entities card is the most common type of card. It groups items together into lists."
             },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2164,7 +2164,6 @@
             "entities": {
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
-              "state_color": "Color icons based on state?",
               "toggle": "Toggle entities.",
               "description": "The Entities card is the most common type of card. It groups items together into lists."
             },
@@ -2193,7 +2192,6 @@
             "glance": {
               "name": "Glance",
               "columns": "Columns",
-              "state_color": "Color icons based on state?",
               "description": "The Glance card is useful to group multiple sensors in a compact overview."
             },
             "history-graph": {
@@ -2246,7 +2244,8 @@
               "url": "Url",
               "state": "State",
               "secondary_info_attribute": "Secondary Info Attribute",
-              "search": "Search"
+              "search": "Search",
+              "state_color": "Color icons based on state?"
             },
             "map": {
               "name": "Map",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2164,7 +2164,7 @@
             "entities": {
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
-              "state_color": "Color icons based on state",
+              "state_color": "Color icons based on state?",
               "toggle": "Toggle entities.",
               "description": "The Entities card is the most common type of card. It groups items together into lists."
             },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2193,7 +2193,7 @@
             "glance": {
               "name": "Glance",
               "columns": "Columns",
-              "state_color": "Color icons based on state",
+              "state_color": "Color icons based on state?",
               "description": "The Glance card is useful to group multiple sensors in a compact overview."
             },
             "history-graph": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2164,6 +2164,7 @@
             "entities": {
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
+              "state_color": "Show State Color?",
               "toggle": "Toggle entities.",
               "description": "The Entities card is the most common type of card. It groups items together into lists."
             },
@@ -2192,6 +2193,7 @@
             "glance": {
               "name": "Glance",
               "columns": "Columns",
+              "state_color": "Show State Color?",
               "description": "The Glance card is useful to group multiple sensors in a compact overview."
             },
             "history-graph": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2193,7 +2193,7 @@
             "glance": {
               "name": "Glance",
               "columns": "Columns",
-              "state_color": "Show State Color?",
+              "state_color": "Color icons based on state",
               "description": "The Glance card is useful to group multiple sensors in a compact overview."
             },
             "history-graph": {


### PR DESCRIPTION

## Proposed change

![image](https://user-images.githubusercontent.com/18730868/91509546-37fd9b00-e8a0-11ea-9785-bd8fe372e469.png)

![image](https://user-images.githubusercontent.com/18730868/91509585-5368a600-e8a0-11ea-92c0-71806d6d8c22.png)


## Type of change

- [x] New feature (thank you!)

## Additional information

- This PR fixes or closes issue: fixes #6621
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
