### PR TITLE
Use ha-progress-button for update cards

### DIFF
--- a/hassio/src/dashboard/hassio-update.ts
+++ b/hassio/src/dashboard/hassio-update.ts
@@ -10,7 +10,7 @@ import {
   internalProperty,
   TemplateResult,
 } from "lit-element";
-import "../../../src/components/buttons/ha-call-api-button";
+import "../../../src/components/buttons/ha-progress-button";
 import "../../../src/components/ha-card";
 import "../../../src/components/ha-svg-icon";
 import { HassioHassOSInfo } from "../../../src/data/hassio/host";
@@ -131,13 +131,14 @@ export class HassioUpdate extends LitElement {
           <a href="${releaseNotesUrl}" target="_blank" rel="noreferrer">
             <mwc-button>Release notes</mwc-button>
           </a>
-          <mwc-button
-            label="Update"
+          <ha-progress-button
             .apiPath=${apiPath}
             .name=${name}
             .version=${lastVersion}
             @click=${this._confirmUpdate}
-          ></mwc-button>
+          >
+            Update
+          </ha-progress-button>
         </div>
       </ha-card>
     `;
@@ -145,6 +146,7 @@ export class HassioUpdate extends LitElement {
 
   private async _confirmUpdate(ev): Promise<void> {
     const item = ev.target;
+    item.progress = true;
     const confirmed = await showConfirmationDialog(this, {
       title: `Update ${item.name}`,
       text: `Are you sure you want to upgrade ${item.name} to version ${item.version}?`,
@@ -153,6 +155,7 @@ export class HassioUpdate extends LitElement {
     });
 
     if (!confirmed) {
+      item.progress = false;
       return;
     }
     try {
@@ -163,6 +166,7 @@ export class HassioUpdate extends LitElement {
         text:
           typeof err === "object" ? err.body?.message || "Unkown error" : err,
       });
+      item.progress = false;
     }
   }
 

--- a/hassio/src/dashboard/hassio-update.ts
+++ b/hassio/src/dashboard/hassio-update.ts
@@ -166,8 +166,8 @@ export class HassioUpdate extends LitElement {
         text:
           typeof err === "object" ? err.body?.message || "Unkown error" : err,
       });
-      item.progress = false;
     }
+    item.progress = false;
   }
 
   static get styles(): CSSResult[] {


### PR DESCRIPTION
## Proposed change

Use ha-progress-button to show "progress" during updates.

![image](https://user-images.githubusercontent.com/15093472/91537252-47b7c680-e916-11ea-83b8-1adf93629c57.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
