### PR TITLE
hassio-addon-info feedback

### DIFF
--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -39,7 +39,6 @@ import {
 } from "../../../../src/data/hassio/addon";
 import { atLeastVersion } from "../../../../src/common/config/version";
 import { fireEvent } from "../../../../src/common/dom/fire_event";
-import "../../../../src/components/buttons/ha-progress-button";
 import { hassioStyle } from "../../resources/hassio-style";
 import { haStyle } from "../../../../src/resources/styles";
 import { HomeAssistant } from "../../../../src/types";

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -790,11 +790,13 @@ class HassioAddonInfo extends LitElement {
         options: this.addon.options,
       });
     } catch (err) {
-      showAlertDialog(this, {
-        title: "Configruation validation faled!",
+      showConfirmationDialog(this, {
+        title: "Failed to start addon - configruation validation faled!",
         text:
           typeof err === "object" ? err.body.message || "Unkown error" : err,
         confirm: () => console.log("confirm"),
+        confirmText: "Go to configruation",
+        dismissText: "Cancel",
       });
       button.progress = false;
       return;

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -26,32 +26,9 @@ import {
   TemplateResult,
 } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
-
-import {
-  fetchHassioAddonChangelog,
-  HassioAddonDetails,
-  HassioAddonSetOptionParams,
-  HassioAddonSetSecurityParams,
-  installHassioAddon,
-  setHassioAddonOption,
-  setHassioAddonSecurity,
-  uninstallHassioAddon,
-  startHassioAddon,
-  validateHassioAddonOption,
-  fetchHassioAddonInfo,
-} from "../../../../src/data/hassio/addon";
 import { atLeastVersion } from "../../../../src/common/config/version";
 import { fireEvent } from "../../../../src/common/dom/fire_event";
-import { hassioStyle } from "../../resources/hassio-style";
-import { haStyle } from "../../../../src/resources/styles";
-import { HomeAssistant } from "../../../../src/types";
 import { navigate } from "../../../../src/common/navigate";
-import {
-  showConfirmationDialog,
-  showAlertDialog,
-} from "../../../../src/dialogs/generic/show-dialog-box";
-import { showHassioMarkdownDialog } from "../../dialogs/markdown/show-dialog-hassio-markdown";
-
 import "../../../../src/components/buttons/ha-call-api-button";
 import "../../../../src/components/buttons/ha-progress-button";
 import "../../../../src/components/ha-card";
@@ -60,8 +37,29 @@ import "../../../../src/components/ha-markdown";
 import "../../../../src/components/ha-settings-row";
 import "../../../../src/components/ha-svg-icon";
 import "../../../../src/components/ha-switch";
-import "../../components/hassio-card-content";
+import {
+  fetchHassioAddonChangelog,
+  fetchHassioAddonInfo,
+  HassioAddonDetails,
+  HassioAddonSetOptionParams,
+  HassioAddonSetSecurityParams,
+  installHassioAddon,
+  setHassioAddonOption,
+  setHassioAddonSecurity,
+  startHassioAddon,
+  uninstallHassioAddon,
+  validateHassioAddonOption,
+} from "../../../../src/data/hassio/addon";
 import { extractApiErrorMessage } from "../../../../src/data/hassio/common";
+import {
+  showAlertDialog,
+  showConfirmationDialog,
+} from "../../../../src/dialogs/generic/show-dialog-box";
+import { haStyle } from "../../../../src/resources/styles";
+import { HomeAssistant } from "../../../../src/types";
+import "../../components/hassio-card-content";
+import { showHassioMarkdownDialog } from "../../dialogs/markdown/show-dialog-hassio-markdown";
+import { hassioStyle } from "../../resources/hassio-style";
 
 const STAGE_ICON = {
   stable: mdiCheckCircle,

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -406,7 +406,7 @@ class HassioAddonInfo extends LitElement {
                     ></ha-switch>
                   </ha-settings-row>
 
-                  ${this.hass.userData?.showAdvanced
+                  ${this.addon.startup !== "once"
                     ? html`
                         <ha-settings-row ?three-line=${this.narrow}>
                           <span slot="heading">

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -793,14 +793,25 @@ class HassioAddonInfo extends LitElement {
     const button = ev.target as any;
     button.progress = true;
     try {
-      await validateHassioAddonOption(this.hass, this.addon.slug);
+      const validate = await validateHassioAddonOption(
+        this.hass,
+        this.addon.slug
+      );
+      if (validate.data.message) {
+        await showConfirmationDialog(this, {
+          title: "Failed to start addon - configruation validation faled!",
+          text: validate.data.message.split(" Got ")[0],
+          confirm: () => this._openConfiguration(),
+          confirmText: "Go to configruation",
+          dismissText: "Cancel",
+        });
+        button.progress = false;
+        return;
+      }
     } catch (err) {
-      await showConfirmationDialog(this, {
-        title: "Failed to start addon - configruation validation faled!",
-        text: extractApiErrorMessage(err).split("Got ")[0],
-        confirm: () => this._openConfiguration(),
-        confirmText: "Go to configruation",
-        dismissText: "Cancel",
+      showAlertDialog(this, {
+        title: "Failed to validate addon configuration",
+        text: extractApiErrorMessage(err),
       });
       button.progress = false;
       return;

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -790,14 +790,14 @@ class HassioAddonInfo extends LitElement {
   }
 
   private async _startClicked(ev: CustomEvent): Promise<void> {
-    const button = ev.target as any;
+    const button = ev.currentTarget as any;
     button.progress = true;
     try {
       const validate = await validateHassioAddonOption(
         this.hass,
         this.addon.slug
       );
-      if (validate.data.message) {
+      if (!validate.data.valid) {
         await showConfirmationDialog(this, {
           title: "Failed to start addon - configruation validation faled!",
           text: validate.data.message.split(" Got ")[0],

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -51,6 +51,7 @@ export interface HassioAddonDetails extends HassioAddonInfo {
   changelog: boolean;
   hassio_api: boolean;
   hassio_role: "default" | "homeassistant" | "manager" | "admin";
+  startup: "initialize" | "system" | "services" | "application" | "once";
   homeassistant_api: boolean;
   auth_api: boolean;
   full_access: boolean;

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -163,7 +163,7 @@ export const validateHassioAddonOption = async (
   hass: HomeAssistant,
   slug: string
 ) => {
-  await hass.callApi<HassioResponse<void>>(
+  return await hass.callApi<HassioResponse<{ message: string }>>(
     "POST",
     `hassio/addons/${slug}/options/validate`
   );

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -158,6 +158,16 @@ export const setHassioAddonOption = async (
   );
 };
 
+export const validateHassioAddonOption = async (
+  hass: HomeAssistant,
+  slug: string
+) => {
+  await hass.callApi<HassioResponse<void>>(
+    "POST",
+    `hassio/addons/${slug}/options/validate`
+  );
+};
+
 export const startHassioAddon = async (hass: HomeAssistant, slug: string) => {
   return hass.callApi<string>("POST", `hassio/addons/${slug}/start`);
 };

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -158,6 +158,10 @@ export const setHassioAddonOption = async (
   );
 };
 
+export const startHassioAddon = async (hass: HomeAssistant, slug: string) => {
+  return hass.callApi<string>("POST", `hassio/addons/${slug}/start`);
+};
+
 export const setHassioAddonSecurity = async (
   hass: HomeAssistant,
   slug: string,

--- a/src/data/hassio/addon.ts
+++ b/src/data/hassio/addon.ts
@@ -163,10 +163,9 @@ export const validateHassioAddonOption = async (
   hass: HomeAssistant,
   slug: string
 ) => {
-  return await hass.callApi<HassioResponse<{ message: string }>>(
-    "POST",
-    `hassio/addons/${slug}/options/validate`
-  );
+  return await hass.callApi<
+    HassioResponse<{ message: string; valid: boolean }>
+  >("POST", `hassio/addons/${slug}/options/validate`);
 };
 
 export const startHassioAddon = async (hass: HomeAssistant, slug: string) => {

--- a/src/data/hassio/common.ts
+++ b/src/data/hassio/common.ts
@@ -9,7 +9,7 @@ export const hassioApiResultExtractor = <T>(response: HassioResponse<T>) =>
 export const extractApiErrorMessage = (error: any): string => {
   return typeof error === "object"
     ? typeof error.body === "object"
-      ? error.body.message
-      : error.body || "Unkown error"
+      ? error.body.message || "Unkown error, see logs"
+      : error.body || "Unkown error, see logs"
     : error;
 };

--- a/src/data/hassio/common.ts
+++ b/src/data/hassio/common.ts
@@ -5,3 +5,11 @@ export interface HassioResponse<T> {
 
 export const hassioApiResultExtractor = <T>(response: HassioResponse<T>) =>
   response.data;
+
+export const extractApiErrorMessage = (error: any): string => {
+  return typeof error === "object"
+    ? typeof error.body === "object"
+      ? error.body.message
+      : error.body || "Unkown error"
+    : error;
+};


### PR DESCRIPTION
## Proposed change

- Uses ha-progress-button to give the user feedback when needed.
- Errors that make sense as a dialog are now in a dialog.
- Validate config before the start.
- Fetch info on start action.
- Add error message extract helper.

NB!: Requires https://github.com/home-assistant/supervisor/pull/1996

![image](https://user-images.githubusercontent.com/15093472/91642865-11ba3580-ea2f-11ea-945e-0a6bcdb2b9a9.png)


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
