### PR TITLE
Dismiss dialog if the user clicks outside it or hit the escape button

### DIFF
--- a/hassio/src/dialogs/network/dialog-hassio-network.ts
+++ b/hassio/src/dialogs/network/dialog-hassio-network.ts
@@ -90,7 +90,14 @@ export class DialogHassioNetwork extends LitElement implements HassDialog {
     }
 
     return html`
-      <ha-dialog open .heading=${true} hideActions @closed=${this.closeDialog}>
+      <ha-dialog
+        open
+        scrimClickAction
+        escapeKeyAction
+        .heading=${true}
+        hideActions
+        @closed=${this.closeDialog}
+      >
         <div slot="heading">
           <ha-header-bar>
             <span slot="title">

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -55,6 +55,8 @@ class DialogBox extends LitElement {
     return html`
       <ha-dialog
         open
+        ?scrimClickAction=${this._params.prompt}
+        ?escapeKeyAction=${this._params.prompt}
         @closed=${this._dismiss}
         .heading=${this._params.title
           ? this._params.title

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -55,9 +55,7 @@ class DialogBox extends LitElement {
     return html`
       <ha-dialog
         open
-        scrimClickAction
-        escapeKeyAction
-        @close=${this._close}
+        @closed=${this._dismiss}
         .heading=${this._params.title
           ? this._params.title
           : this._params.confirmation &&


### PR DESCRIPTION
## Proposed change

Dismiss dialog if the user clicks outside it or hit the escape button.

WTH: https://community.home-assistant.io/t/wth-cant-i-click-outside-of-a-dialog-to-close-the-dialog/222756/

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
