### PR TITLE
Call service button feedback

### DIFF
--- a/src/components/buttons/ha-progress-button.ts
+++ b/src/components/buttons/ha-progress-button.ts
@@ -1,4 +1,5 @@
 import "@material/mwc-button";
+import type { Button } from "@material/mwc-button";
 import {
   css,
   CSSResult,
@@ -7,6 +8,7 @@ import {
   LitElement,
   property,
   TemplateResult,
+  query,
 } from "lit-element";
 
 import "../ha-circular-progress";
@@ -17,9 +19,14 @@ class HaProgressButton extends LitElement {
 
   @property({ type: Boolean }) public progress = false;
 
+  @property({ type: Boolean }) public raised = false;
+
+  @query("mwc-button") private _button?: Button;
+
   public render(): TemplateResult {
     return html`
       <mwc-button
+        ?raised=${this.raised}
         .disabled=${this.disabled || this.progress}
         @click=${this._buttonTapped}
       >
@@ -42,9 +49,9 @@ class HaProgressButton extends LitElement {
   }
 
   private _tempClass(className: string): void {
-    this.classList.add(className);
+    this._button!.classList.add(className);
     setTimeout(() => {
-      this.classList.remove(className);
+      this._button!.classList.remove(className);
     }, 1000);
   }
 
@@ -66,16 +73,26 @@ class HaProgressButton extends LitElement {
         transition: all 1s;
       }
 
-      .success mwc-button {
+      mwc-button.success {
         --mdc-theme-primary: white;
         background-color: var(--success-color);
         transition: none;
       }
 
-      .error mwc-button {
+      mwc-button[raised].success {
+        --mdc-theme-primary: var(--success-color);
+        --mdc-theme-on-primary: white;
+      }
+
+      mwc-button.error {
         --mdc-theme-primary: white;
         background-color: var(--error-color);
         transition: none;
+      }
+
+      mwc-button[raised].error {
+        --mdc-theme-primary: var(--error-color);
+        --mdc-theme-on-primary: white;
       }
 
       .progress {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Provide feedback for "Call Service" button.
- Fixes style issues when calling `actionSuccess`/`actionError` on `ha-progress-button`
- Adds `raised` to `ha-progress-button`

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #6748
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
