### PR TITLE
Fix render modifiers - public to protected

### DIFF
--- a/hassio/src/components/hassio-ansi-to-html.ts
+++ b/hassio/src/components/hassio-ansi-to-html.ts
@@ -21,7 +21,7 @@ interface State {
 class HassioAnsiToHtml extends LitElement {
   @property() public content!: string;
 
-  public render(): TemplateResult | void {
+  protected render(): TemplateResult | void {
     return html`${this._parseTextToColoredPre(this.content)}`;
   }
 

--- a/hassio/src/system/hassio-host-info.ts
+++ b/hassio/src/system/hassio-host-info.ts
@@ -1,9 +1,8 @@
 import "@material/mwc-button";
-import "@material/mwc-list/mwc-list-item";
 import { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
+import "@material/mwc-list/mwc-list-item";
 import { mdiDotsVertical } from "@mdi/js";
 import { safeDump } from "js-yaml";
-import memoizeOne from "memoize-one";
 import {
   css,
   CSSResult,
@@ -14,7 +13,11 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
-
+import memoizeOne from "memoize-one";
+import "../../../src/components/ha-button-menu";
+import "../../../src/components/ha-card";
+import "../../../src/components/ha-settings-row";
+import { fetchHassioHardwareInfo } from "../../../src/data/hassio/hardware";
 import {
   changeHostOptions,
   configSyncOS,
@@ -25,26 +28,21 @@ import {
   shutdownHost,
   updateOS,
 } from "../../../src/data/hassio/host";
-import { fetchHassioHardwareInfo } from "../../../src/data/hassio/hardware";
 import {
   fetchNetworkInfo,
   NetworkInfo,
 } from "../../../src/data/hassio/network";
 import { HassioInfo } from "../../../src/data/hassio/supervisor";
-import { hassioStyle } from "../resources/hassio-style";
-import { haStyle } from "../../../src/resources/styles";
-import { HomeAssistant } from "../../../src/types";
 import {
   showAlertDialog,
   showConfirmationDialog,
   showPromptDialog,
 } from "../../../src/dialogs/generic/show-dialog-box";
+import { haStyle } from "../../../src/resources/styles";
+import { HomeAssistant } from "../../../src/types";
 import { showHassioMarkdownDialog } from "../dialogs/markdown/show-dialog-hassio-markdown";
 import { showNetworkDialog } from "../dialogs/network/show-dialog-network";
-
-import "../../../src/components/ha-button-menu";
-import "../../../src/components/ha-card";
-import "../../../src/components/ha-settings-row";
+import { hassioStyle } from "../resources/hassio-style";
 
 @customElement("hassio-host-info")
 class HassioHostInfo extends LitElement {
@@ -58,7 +56,7 @@ class HassioHostInfo extends LitElement {
 
   @internalProperty() public _networkInfo?: NetworkInfo;
 
-  public render(): TemplateResult | void {
+  protected render(): TemplateResult | void {
     const primaryIpAddress = this.hostInfo.features.includes("network")
       ? this._primaryIpAddress(this._networkInfo!)
       : "";

--- a/hassio/src/system/hassio-supervisor-info.ts
+++ b/hassio/src/system/hassio-supervisor-info.ts
@@ -8,11 +8,10 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
-
+import "../../../src/components/ha-card";
+import "../../../src/components/ha-settings-row";
+import "../../../src/components/ha-switch";
 import { HassioHostInfo as HassioHostInfoType } from "../../../src/data/hassio/host";
-import { hassioStyle } from "../resources/hassio-style";
-import { haStyle } from "../../../src/resources/styles";
-import { HomeAssistant } from "../../../src/types";
 import {
   HassioSupervisorInfo as HassioSupervisorInfoType,
   reloadSupervisor,
@@ -24,10 +23,9 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../src/dialogs/generic/show-dialog-box";
-
-import "../../../src/components/ha-card";
-import "../../../src/components/ha-settings-row";
-import "../../../src/components/ha-switch";
+import { haStyle } from "../../../src/resources/styles";
+import { HomeAssistant } from "../../../src/types";
+import { hassioStyle } from "../resources/hassio-style";
 
 @customElement("hassio-supervisor-info")
 class HassioSupervisorInfo extends LitElement {
@@ -37,7 +35,7 @@ class HassioSupervisorInfo extends LitElement {
 
   @property() public hostInfo!: HassioHostInfoType;
 
-  public render(): TemplateResult | void {
+  protected render(): TemplateResult | void {
     return html`
       <ha-card header="Supervisor">
         <div class="card-content">

--- a/hassio/src/system/hassio-supervisor-log.ts
+++ b/hassio/src/system/hassio-supervisor-log.ts
@@ -69,7 +69,7 @@ class HassioSupervisorLog extends LitElement {
     await this._loadData();
   }
 
-  public render(): TemplateResult | void {
+  protected render(): TemplateResult | void {
     return html`
       <ha-card>
         ${this._error ? html` <div class="errors">${this._error}</div> ` : ""}

--- a/hassio/src/system/hassio-system.ts
+++ b/hassio/src/system/hassio-system.ts
@@ -12,8 +12,8 @@ import {
   HassioHostInfo,
 } from "../../../src/data/hassio/host";
 import {
-  HassioSupervisorInfo,
   HassioInfo,
+  HassioSupervisorInfo,
 } from "../../../src/data/hassio/supervisor";
 import "../../../src/layouts/hass-tabs-subpage";
 import { haStyle } from "../../../src/resources/styles";
@@ -40,7 +40,7 @@ class HassioSystem extends LitElement {
 
   @property({ attribute: false }) public hassOsInfo!: HassioHassOSInfo;
 
-  public render(): TemplateResult | void {
+  protected render(): TemplateResult | void {
     return html`
       <hass-tabs-subpage
         .hass=${this.hass}

--- a/src/components/ha-circular-progress.ts
+++ b/src/components/ha-circular-progress.ts
@@ -1,16 +1,16 @@
-import {
-  LitElement,
-  TemplateResult,
-  property,
-  svg,
-  html,
-  customElement,
-  unsafeCSS,
-  SVGTemplateResult,
-  css,
-} from "lit-element";
 // @ts-ignore
 import progressStyles from "@material/circular-progress/dist/mdc.circular-progress.min.css";
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  svg,
+  SVGTemplateResult,
+  TemplateResult,
+  unsafeCSS,
+} from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 
 @customElement("ha-circular-progress")
@@ -24,7 +24,7 @@ export class HaCircularProgress extends LitElement {
   @property()
   public size: "small" | "medium" | "large" = "medium";
 
-  protected render(): TemplateResult | void {
+  protected render(): TemplateResult {
     let indeterminatePart: SVGTemplateResult;
 
     if (this.size === "small") {

--- a/src/panels/config/automation/action/types/ha-automation-action-condition.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-condition.ts
@@ -15,7 +15,7 @@ export class HaConditionAction extends LitElement implements ActionElement {
     return { condition: "state" };
   }
 
-  public render() {
+  protected render() {
     return html`
       <ha-automation-condition-editor
         .condition=${this.action}

--- a/src/panels/config/automation/action/types/ha-automation-action-delay.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-delay.ts
@@ -16,7 +16,7 @@ export class HaDelayAction extends LitElement implements ActionElement {
     return { delay: "" };
   }
 
-  public render() {
+  protected render() {
     const { delay } = this.action;
 
     return html`

--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -1,8 +1,8 @@
 import "@polymer/paper-input/paper-input";
+import "@polymer/paper-input/paper-textarea";
 import { customElement, html, LitElement, property } from "lit-element";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/entity/ha-entity-picker";
-import "@polymer/paper-input/paper-textarea";
 import { NumericStateCondition } from "../../../../../data/automation";
 import { HomeAssistant } from "../../../../../types";
 import { handleChangeEvent } from "../ha-automation-condition-row";
@@ -19,7 +19,7 @@ export default class HaNumericStateCondition extends LitElement {
     };
   }
 
-  public render() {
+  protected render() {
     const { value_template, entity_id, below, above } = this.condition;
 
     return html`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-event.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-event.ts
@@ -19,7 +19,7 @@ export class HaEventTrigger extends LitElement implements TriggerElement {
     return { event_type: "", event_data: {} };
   }
 
-  public render() {
+  protected render() {
     const { event_type, event_data } = this.trigger;
     return html`
       <paper-input

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-homeassistant.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-homeassistant.ts
@@ -18,7 +18,7 @@ export default class HaHassTrigger extends LitElement {
     };
   }
 
-  public render() {
+  protected render() {
     const { event } = this.trigger;
     return html`
       <label id="eventlabel">

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -1,8 +1,8 @@
 import "@polymer/paper-input/paper-input";
+import "@polymer/paper-input/paper-textarea";
 import { customElement, html, LitElement, property } from "lit-element";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/entity/ha-entity-picker";
-import "@polymer/paper-input/paper-textarea";
 import { ForDict, NumericStateTrigger } from "../../../../../data/automation";
 import { HomeAssistant } from "../../../../../types";
 import { handleChangeEvent } from "../ha-automation-trigger-row";
@@ -19,7 +19,7 @@ export default class HaNumericStateTrigger extends LitElement {
     };
   }
 
-  public render() {
+  protected render() {
     const { value_template, entity_id, below, above } = this.trigger;
     let trgFor = this.trigger.for;
 

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -1,34 +1,34 @@
 import "@material/mwc-button";
-import "../../layouts/ha-app-layout";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
-import "../../components/ha-icon-button";
-import "../../components/ha-circular-progress";
 import { safeDump, safeLoad } from "js-yaml";
 import {
   css,
   CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
+import { array, assert, object, optional, string, type } from "superstruct";
 import { computeRTL } from "../../common/util/compute_rtl";
+import "../../components/ha-circular-progress";
 import "../../components/ha-code-editor";
 import type { HaCodeEditor } from "../../components/ha-code-editor";
 import "../../components/ha-icon";
+import "../../components/ha-icon-button";
 import type { LovelaceConfig } from "../../data/lovelace";
 import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../dialogs/generic/show-dialog-box";
+import "../../layouts/ha-app-layout";
 import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import type { Lovelace } from "./types";
-import { optional, array, string, object, type, assert } from "superstruct";
 
 const lovelaceStruct = type({
   title: optional(string()),
@@ -49,7 +49,7 @@ class LovelaceFullConfigEditor extends LitElement {
 
   private _generation = 1;
 
-  public render(): TemplateResult | void {
+  protected render(): TemplateResult | void {
     return html`
       <ha-app-layout>
         <app-header slot="header">


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While looking thru code I noticed that `render()` has sometimes `public` and sometimes `protected` modifiers.
This PR changes all `public` to `protected`.

In the next PR's I'll add return types to those functions, because right now `render()` can look like this:
```
protected render() {
protected render(): TemplateResult {
protected render(): TemplateResult | void {
```

Not sure which one of the last two return types should be used.

Ideally, there should be a rule that checks if render has the `protected` modifier and warn for missing return types.
## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

I have enabled `organizeImports` in my VS Code.

```
{
    "editor.codeActionsOnSave": {
        "source.organizeImports": true
    }
}
```


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
