### PR TITLE
Update reloadables to include telegram/smtp/mqtt

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -829,7 +829,7 @@
               "introduction": "Some parts of Home Assistant can reload without requiring a restart. Hitting reload will unload their current YAML configuration and load the new one.",
               "reload": "Reload {domain}",
               "core": "Reload location & customizations",
-              "group": "Reload groups",
+              "group": "Reload groups, group entities, and notify services",
               "automation": "Reload automations",
               "script": "Reload scripts",
               "scene": "Reload scenes",
@@ -842,7 +842,7 @@
               "input_select": "Reload input selects",
               "template": "Reload template entities",
               "universal": "Reload universal media player entities",
-              "rest": "Reload rest entities",
+              "rest": "Reload rest entities and notify services",
               "command_line": "Reload command line entities",
               "filter": "Reload filter entities",
               "statistics": "Reload statistics entities",
@@ -853,7 +853,10 @@
               "history_stats": "Reload history stats entities",
               "trend": "Reload trend entities",
               "ping": "Reload ping binary sensor entities",
-              "filesize": "Reload file size entities"
+              "filesize": "Reload file size entities",
+              "telegram": "Reload telegram notify services",
+              "smtp": "Reload smtp notify services",
+              "mqtt": "Reload mqtt entities"
             },
             "server_management": {
               "heading": "Server management",


### PR DESCRIPTION
This should be safe to merge now as its no longer waiting for any backend changes to merge that would appear unexpectedly.

https://github.com/home-assistant/core/pull/39531
https://github.com/home-assistant/core/pull/39530
https://github.com/home-assistant/core/pull/39529
https://github.com/home-assistant/core/pull/39527
https://github.com/home-assistant/core/pull/39511

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update reloadables to include telegram/smtp/mqtt

rest and group now support reloading notify
services as well.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
