### PR TITLE
Remove "(deprecated)" warning from JS module resource types in polish translation.

### DIFF
--- a/translations/frontend/pl.json
+++ b/translations/frontend/pl.json
@@ -1667,7 +1667,7 @@
                             "css": "Arkusz stylów",
                             "html": "HTML (przestarzałe)",
                             "js": "Plik JavaScript (przestarzałe)",
-                            "module": "Moduł JavaScript (przestarzałe)"
+                            "module": "Moduł JavaScript"
                         }
                     }
                 },


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Remove "(deprecated)" warning from JS module resource types in polish translations.
This looks like inconsistency with english translations as only standalone (non-module) JS resources are deprecated.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

## Additional information

- This PR fixes translations

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
