### PR TITLE
Add node details shortcut to OZW device pages

### DIFF
--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-actions-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-actions-ozw.ts
@@ -14,13 +14,15 @@ import { haStyle } from "../../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../../types";
 import {
   OZWDevice,
-  fetchOZWNodeStatus,
   getIdentifiersFromDevice,
   OZWNodeIdentifiers,
 } from "../../../../../../data/ozw";
+import { showOZWRefreshNodeDialog } from "../../../../integrations/integration-panels/ozw/show-dialog-ozw-refresh-node";
+import { navigate } from "../../../../../../common/navigate";
+import "@material/mwc-button/mwc-button";
 
-@customElement("ha-device-info-ozw")
-export class HaDeviceInfoOzw extends LitElement {
+@customElement("ha-device-actions-ozw")
+export class HaDeviceActionsOzw extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property() public device!: DeviceRegistryEntry;
@@ -43,58 +45,45 @@ export class HaDeviceInfoOzw extends LitElement {
       }
       this.ozw_instance = identifiers.ozw_instance;
       this.node_id = identifiers.node_id;
-
-      this._fetchNodeDetails();
     }
-  }
-
-  protected async _fetchNodeDetails() {
-    this._ozwDevice = await fetchOZWNodeStatus(
-      this.hass,
-      this.ozw_instance,
-      this.node_id
-    );
   }
 
   protected render(): TemplateResult {
-    if (!this._ozwDevice) {
+    if (!this.ozw_instance || !this.node_id) {
       return html``;
     }
     return html`
-      <h4>
-        ${this.hass.localize("ui.panel.config.ozw.device_info.zwave_info")}
-      </h4>
-      <div>
-        ${this.hass.localize("ui.panel.config.ozw.common.node_id")}:
-        ${this._ozwDevice.node_id}
-      </div>
-      <div>
-        ${this.hass.localize("ui.panel.config.ozw.device_info.stage")}:
-        ${this._ozwDevice.node_query_stage}
-      </div>
-      <div>
-        ${this.hass.localize("ui.panel.config.ozw.common.ozw_instance")}:
-        ${this._ozwDevice.ozw_instance}
-      </div>
-      <div>
-        ${this.hass.localize("ui.panel.config.ozw.device_info.node_failed")}:
-        ${this._ozwDevice.is_failed
-          ? this.hass.localize("ui.common.yes")
-          : this.hass.localize("ui.common.no")}
-      </div>
+      <mwc-button @click=${this._nodeDetailsClicked}>
+        ${this.hass.localize("ui.panel.config.ozw.node.button")}
+      </mwc-button>
+      <mwc-button @click=${this._refreshNodeClicked}>
+        ${this.hass.localize("ui.panel.config.ozw.refresh_node.button")}
+      </mwc-button>
     `;
+  }
+
+  private async _refreshNodeClicked() {
+    showOZWRefreshNodeDialog(this, {
+      node_id: this.node_id,
+      ozw_instance: this.ozw_instance,
+    });
+  }
+
+  private async _nodeDetailsClicked() {
+    navigate(
+      this,
+      `/config/ozw/network/${this.ozw_instance}/node/${this.node_id}/dashboard`
+    );
   }
 
   static get styles(): CSSResult[] {
     return [
       haStyle,
       css`
-        h4 {
-          margin-bottom: 4px;
-        }
-        div {
-          word-break: break-all;
-          margin-top: 2px;
+        :host {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
         }
       `,
     ];

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-actions-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-actions-ozw.ts
@@ -4,7 +4,6 @@ import {
   html,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
   css,
   PropertyValues,
@@ -13,7 +12,6 @@ import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
 import { haStyle } from "../../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../../types";
 import {
-  OZWDevice,
   getIdentifiersFromDevice,
   OZWNodeIdentifiers,
 } from "../../../../../../data/ozw";

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-actions-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-actions-ozw.ts
@@ -33,7 +33,6 @@ export class HaDeviceActionsOzw extends LitElement {
   @property()
   private ozw_instance = 1;
 
-  @internalProperty() private _ozwDevice?: OZWDevice;
 
   protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has("device")) {

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-info-ozw.ts
@@ -19,6 +19,8 @@ import {
   OZWNodeIdentifiers,
 } from "../../../../../../data/ozw";
 import { showOZWRefreshNodeDialog } from "../../../../integrations/integration-panels/ozw/show-dialog-ozw-refresh-node";
+import { navigate } from "../../../../../../common/navigate";
+import "@material/mwc-button/mwc-button";
 
 @customElement("ha-device-info-ozw")
 export class HaDeviceInfoOzw extends LitElement {
@@ -83,8 +85,11 @@ export class HaDeviceInfoOzw extends LitElement {
           ? this.hass.localize("ui.common.yes")
           : this.hass.localize("ui.common.no")}
       </div>
+      <mwc-button @click=${this._nodeDetailsClicked}>
+        ${this.hass.localize("ui.panel.config.ozw.node.button")}
+      </mwc-button>
       <mwc-button @click=${this._refreshNodeClicked}>
-        Refresh Node
+        ${this.hass.localize("ui.panel.config.ozw.refresh_node.button")}
       </mwc-button>
     `;
   }
@@ -94,6 +99,13 @@ export class HaDeviceInfoOzw extends LitElement {
       node_id: this.node_id,
       ozw_instance: this.ozw_instance,
     });
+  }
+
+  private async _nodeDetailsClicked() {
+    navigate(
+      this,
+      `/config/ozw/network/${this.ozw_instance}/node/${this.node_id}/dashboard`
+    );
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -517,12 +517,19 @@ export class HaConfigDevicePage extends LitElement {
       `);
     }
     if (integrations.includes("ozw")) {
+      import("./device-detail/integration-elements/ozw/ha-device-actions-ozw");
       import("./device-detail/integration-elements/ozw/ha-device-info-ozw");
       templates.push(html`
         <ha-device-info-ozw
           .hass=${this.hass}
           .device=${device}
         ></ha-device-info-ozw>
+        <div class="card-actions" slot="actions">
+          <ha-device-actions-ozw
+            .hass=${this.hass}
+            .device=${device}
+          ></ha-device-actions-ozw>
+        </div>
       `);
     }
     if (integrations.includes("zha")) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1759,6 +1759,7 @@
             "complete": "Interview process is complete"
           },
           "refresh_node": {
+            "button": "Refresh Node",
             "title": "Refresh Node Information",
             "complete": "Node Refresh Complete",
             "description": "This will tell OpenZWave to re-interview a node and update the node's command classes, capabilities, and values.",
@@ -1813,6 +1814,7 @@
             "failed": "Failed"
           },
           "node": {
+            "button": "Node Details",
             "not_found": "Node not found"
           },
           "services": {


### PR DESCRIPTION
## Proposed change
Adds a "Node Details" button to the device pages for OZW devices that takes you to the details page for that node in the OZW config panel. Also fixes a translation for the Refresh Node button.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
