### PR TITLE
Add "quick open" style filtering for entities in developer tools -> state

### DIFF
--- a/src/common/string/compare.ts
+++ b/src/common/string/compare.ts
@@ -11,3 +11,24 @@ export const compare = (a: string, b: string) => {
 
 export const caseInsensitiveCompare = (a: string, b: string) =>
   compare(a.toLowerCase(), b.toLowerCase());
+
+export const fuzzyFilter = (filter: string, word: string) => {
+  if (filter === "") {
+    return false;
+  }
+
+  for (let i = 0; i <= filter.length; i++) {
+    const pos = word.indexOf(filter[0]);
+
+    if (pos < 0) {
+      return true;
+    }
+
+    const newWord = word.substring(pos + 1);
+    const newFilter = filter.substring(1);
+
+    return fuzzyFilter(newFilter, newWord);
+  }
+
+  return false;
+};

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -14,6 +14,7 @@ import LocalizeMixin from "../../../mixins/localize-mixin";
 import "../../../styles/polymer-ha-style";
 import { mdiInformationOutline } from "@mdi/js";
 import { computeRTL } from "../../../common/util/compute_rtl";
+import { fuzzyFilter } from "../../../common/string/compare";
 
 const ERROR_SENTINEL = {};
 /*
@@ -296,7 +297,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         return hass.states[key];
       })
       .filter(function (value) {
-        if (!value.entity_id.includes(_entityFilter.toLowerCase())) {
+        if (fuzzyFilter(_entityFilter.toLowerCase(), value.entity_id)) {
           return false;
         }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Allow (for lack of a better term) "quick open" style filtering on the entity_id column in Developer Tools -> State. 

Similar to "quick open" in VSCode/Chrome Devtools (Here, "hscrd" is matching to "**h**a-**scr**ipt-e**d**itor.js"):
![image](https://user-images.githubusercontent.com/1480827/92315821-4df61480-efa0-11ea-9db2-b48e2c0e9d72.png)

This PR introduces a similar (but far more basic) behavior in Home Assistant:
![image](https://i.imgur.com/3hghhTx.gif)

Algorithmically, it's the same as taking "abc" and putting a wildcard between each letter. E.g. searching for "abc" would match "**a**lpha**b**eti**c**al", "**ab**ra**c**adabra", and "cr**abc**ake".

Note, this is different than "fuzzy matching" which matches when the search word is "close enough" to another word.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
N/A
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
