### PR TITLE
Don't show source select dialog when media player Unavailable.

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -130,7 +130,7 @@ class MoreInfoMediaPlayer extends LitElement {
             </div>
           `
         : ""}
-      ${stateObj.state !== "off" &&
+      ${![UNAVAILABLE, UNKNOWN, "off"].includes(stateObj.state) &&
       supportsFeature(stateObj, SUPPORT_SELECT_SOURCE) &&
       stateObj.attributes.source_list?.length
         ? html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Now select_source is disabled only in 'off' state.
It should be disabled for unavailable and unknown as well.
## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
None

## Additional information
Whole change is just checking !["off", "unavailable"].includes(stateObj.state)
## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
