### PR TITLE
Replace date picker for entities card

### DIFF
--- a/src/components/ha-date-input.ts
+++ b/src/components/ha-date-input.ts
@@ -1,126 +1,68 @@
-import "@polymer/paper-input/paper-input";
-import type { PaperInputElement } from "@polymer/paper-input/paper-input";
-import {
-  css,
-  customElement,
-  html,
-  LitElement,
-  property,
-  TemplateResult,
-} from "lit-element";
+import "@vaadin/vaadin-date-picker/theme/material/vaadin-date-picker";
 
-@customElement("ha-date-input")
-export class HaDateInput extends LitElement {
-  @property() public year?: string;
+const VaadinDatePicker = customElements.get("vaadin-date-picker");
 
-  @property() public month?: string;
+export class HaDateInput extends VaadinDatePicker {
+  constructor() {
+    super();
 
-  @property() public day?: string;
+    this.i18n.formatDate = this._formatISODate;
+    this.i18n.parseDate = this._parseISODate;
+  }
 
-  @property({ type: Boolean }) public disabled = false;
-
-  static get styles() {
-    return css`
+  ready() {
+    super.ready();
+    const styleEl = document.createElement("style");
+    styleEl.innerHTML = `
       :host {
-        display: block;
-        font-family: var(--paper-font-common-base_-_font-family);
-        -webkit-font-smoothing: var(
-          --paper-font-common-base_-_-webkit-font-smoothing
-        );
-      }
-
-      paper-input {
-        width: 30px;
-        text-align: center;
-        --paper-input-container-shared-input-style_-_-webkit-appearance: textfield;
-        --paper-input-container-input_-_-moz-appearance: textfield;
-        --paper-input-container-shared-input-style_-_appearance: textfield;
-        --paper-input-container-input-webkit-spinner_-_-webkit-appearance: none;
-        --paper-input-container-input-webkit-spinner_-_margin: 0;
-        --paper-input-container-input-webkit-spinner_-_display: none;
-      }
-
-      paper-input#year {
-        width: 50px;
-      }
-
-      .date-input-wrap {
-        display: flex;
-        flex-direction: row;
+        width: 12ex;
+        margin-top: -6px;
+        --material-body-font-size: 16px;
+        --_material-text-field-input-line-opacity: 1;
+        --material-primary-color: #000;
       }
     `;
+    this.shadowRoot.appendChild(styleEl);
+    this._inputElement.querySelector("[part='toggle-button']").style.display =
+      "none";
   }
 
-  protected render(): TemplateResult {
-    return html`
-      <div class="date-input-wrap">
-        <paper-input
-          id="year"
-          type="number"
-          .value=${this.year}
-          @change=${this._formatYear}
-          maxlength="4"
-          max="9999"
-          min="0"
-          .disabled=${this.disabled}
-          no-label-float
-        >
-          <span suffix="" slot="suffix">-</span>
-        </paper-input>
-        <paper-input
-          id="month"
-          type="number"
-          .value=${this.month}
-          @change=${this._formatMonth}
-          maxlength="2"
-          max="12"
-          min="1"
-          .disabled=${this.disabled}
-          no-label-float
-        >
-          <span suffix="" slot="suffix">-</span>
-        </paper-input>
-        <paper-input
-          id="day"
-          type="number"
-          .value=${this.day}
-          @change=${this._formatDay}
-          maxlength="2"
-          max="31"
-          min="1"
-          .disabled=${this.disabled}
-          no-label-float
-        >
-        </paper-input>
-      </div>
-    `;
+  private _formatISODate(d) {
+    return [
+      ("0000" + String(d.year)).slice(-4),
+      ("0" + String(d.month + 1)).slice(-2),
+      ("0" + String(d.day)).slice(-2),
+    ].join("-");
   }
 
-  private _formatYear() {
-    const yearElement = this.shadowRoot!.getElementById(
-      "year"
-    ) as PaperInputElement;
-    this.year = yearElement.value!;
-  }
+  private _parseISODate(text) {
+    const parts = text.split("-");
+    const today = new Date();
+    let date;
+    let month = today.getMonth();
+    let year = today.getFullYear();
+    if (parts.length === 3) {
+      year = parseInt(parts[0]);
+      if (parts[0].length < 3 && year >= 0) {
+        year += year < 50 ? 2000 : 1900;
+      }
+      month = parseInt(parts[1]) - 1;
+      date = parseInt(parts[2]);
+    } else if (parts.length === 2) {
+      month = parseInt(parts[0]) - 1;
+      date = parseInt(parts[1]);
+    } else if (parts.length === 1) {
+      date = parseInt(parts[0]);
+    }
 
-  private _formatMonth() {
-    const monthElement = this.shadowRoot!.getElementById(
-      "month"
-    ) as PaperInputElement;
-    this.month = ("0" + monthElement.value!).slice(-2);
-  }
-
-  private _formatDay() {
-    const dayElement = this.shadowRoot!.getElementById(
-      "day"
-    ) as PaperInputElement;
-    this.day = ("0" + dayElement.value!).slice(-2);
-  }
-
-  get value() {
-    return `${this.year}-${this.month}-${this.day}`;
+    if (date !== undefined) {
+      return { day: date, month, year };
+    }
+    return undefined;
   }
 }
+
+customElements.define("ha-date-input", HaDateInput as any);
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/components/ha-date-input.ts
+++ b/src/components/ha-date-input.ts
@@ -18,8 +18,9 @@ export class HaDateInput extends VaadinDatePicker {
         width: 12ex;
         margin-top: -6px;
         --material-body-font-size: 16px;
+        --_material-text-field-input-line-background-color: var(--primary-text-color);
         --_material-text-field-input-line-opacity: 1;
-        --material-primary-color: #000;
+        --material-primary-color: var(--primary-text-color);
       }
     `;
     this.shadowRoot.appendChild(styleEl);

--- a/src/dialogs/more-info/controls/more-info-input_datetime.js
+++ b/src/dialogs/more-info/controls/more-info-input_datetime.js
@@ -3,7 +3,7 @@ import "@polymer/paper-input/paper-input";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 /* eslint-plugin-disable lit */
 import { PolymerElement } from "@polymer/polymer/polymer-element";
-import "@vaadin/vaadin-date-picker/theme/material/vaadin-date-picker";
+import "../../../components/ha-date-input";
 import { attributeClassNames } from "../../../common/entity/attribute_class_names";
 import "../../../components/ha-relative-time";
 import "../../../components/paper-time-input";
@@ -14,12 +14,12 @@ class DatetimeInput extends PolymerElement {
       <div class$="[[computeClassNames(stateObj)]]">
         <template is="dom-if" if="[[doesHaveDate(stateObj)]]" restamp="">
           <div>
-            <vaadin-date-picker
+            <ha-date-input
               id="dateInput"
               on-value-changed="dateTimeChanged"
               label="Date"
               value="{{selectedDate}}"
-            ></vaadin-date-picker>
+            ></ha-date-input>
           </div>
         </template>
         <template is="dom-if" if="[[doesHaveTime(stateObj)]]" restamp="">

--- a/src/panels/lovelace/entity-rows/hui-input-datetime-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-datetime-entity-row.ts
@@ -57,9 +57,7 @@ class HuiInputDatetimeEntityRow extends LitElement implements LovelaceRow {
           ? html`
               <ha-date-input
                 .disabled=${UNAVAILABLE_STATES.includes(stateObj.state)}
-                .year=${stateObj.attributes.year}
-                .month=${("0" + stateObj.attributes.month).slice(-2)}
-                .day=${("0" + stateObj.attributes.day).slice(-2)}
+                .value=${`${stateObj.attributes.year}-${stateObj.attributes.month}-${stateObj.attributes.day}`}
                 @change=${this._selectedValueChanged}
                 @click=${this._stopEventPropagation}
               ></ha-date-input>


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change
Use the vaadin-date-picker we already have for input_datetime in the entities card too.
I made a wrapper to make is ISO compliant and change the formating a bit so it looks more like the paper-input used for time inputs.

I also replaced the date picker in the more-info dialog with the wrapped version.
![image](https://user-images.githubusercontent.com/1299821/92654149-b5d59380-f2ef-11ea-9cfa-7b36c33bd527.png)


Finally fixes #4866.
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4866 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
