### PR TITLE
Use --error-color instead of a fixed color

### DIFF
--- a/src/panels/lovelace/cards/hui-error-card.ts
+++ b/src/panels/lovelace/cards/hui-error-card.ts
@@ -44,7 +44,7 @@ export class HuiErrorCard extends LitElement implements LovelaceCard {
       :host {
         display: block;
         background-color: var(--error-color);
-        color: white;
+        color: var(--error-card-text-color, white);
         padding: 8px;
         font-weight: 500;
         user-select: text;

--- a/src/panels/lovelace/cards/hui-error-card.ts
+++ b/src/panels/lovelace/cards/hui-error-card.ts
@@ -43,7 +43,7 @@ export class HuiErrorCard extends LitElement implements LovelaceCard {
     return css`
       :host {
         display: block;
-        background-color: #ef5350;
+        background-color: var(--error-color);
         color: white;
         padding: 8px;
         font-weight: 500;

--- a/src/panels/lovelace/cards/hui-error-card.ts
+++ b/src/panels/lovelace/cards/hui-error-card.ts
@@ -44,7 +44,7 @@ export class HuiErrorCard extends LitElement implements LovelaceCard {
       :host {
         display: block;
         background-color: var(--error-color);
-        color: var(--error-card-text-color, white);
+        color: var(--on-error-color, white);
         padding: 8px;
         font-weight: 500;
         user-select: text;

--- a/src/panels/lovelace/cards/hui-error-card.ts
+++ b/src/panels/lovelace/cards/hui-error-card.ts
@@ -44,7 +44,7 @@ export class HuiErrorCard extends LitElement implements LovelaceCard {
       :host {
         display: block;
         background-color: var(--error-color);
-        color: var(--on-error-color, white);
+        color: var(--color-on-error, white);
         padding: 8px;
         font-weight: 500;
         user-select: text;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This makes the error-card use `--error-color` as the background color, instead of a set one, so you can theme it.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
frontend:
  themes:
    errorblues:
      error-color: blue
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
