### PR TITLE
Hide rpi_power entry during onboarding

### DIFF
--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -164,7 +164,9 @@ class OnboardingIntegrations extends LitElement {
     // We filter out the config entry for the local weather.
     // It is one that we create automatically and it will confuse the user
     // if it starts showing up during onboarding.
-    this._entries = entries.filter((entry) => entry.domain !== "met");
+    this._entries = entries.filter(
+      (entry) => entry.domain !== "met" && entry.domain !== "rpi_power"
+    );
   }
 
   private async _finish() {

--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -29,6 +29,8 @@ import { HomeAssistant } from "../types";
 import "./action-badge";
 import "./integration-badge";
 
+const HIDDEN_DOMAINS = new Set(["met", "rpi_power"]);
+
 @customElement("onboarding-integrations")
 class OnboardingIntegrations extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -164,7 +166,6 @@ class OnboardingIntegrations extends LitElement {
     // We filter out the config entry for the local weather and rpi_power.
     // It is one that we create automatically and it will confuse the user
     // if it starts showing up during onboarding.
-    const HIDDEN_DOMAINS = new Set(["met", "rpi_power"]);
     this._entries = entries.filter(
       (entry) => !HIDDEN_DOMAINS.has(entry.domain)
     );

--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -161,7 +161,7 @@ class OnboardingIntegrations extends LitElement {
 
   private async _loadConfigEntries() {
     const entries = await getConfigEntries(this.hass!);
-    // We filter out the config entry for the local weather.
+    // We filter out the config entry for the local weather and rpi_powerEx.
     // It is one that we create automatically and it will confuse the user
     // if it starts showing up during onboarding.
     this._entries = entries.filter(

--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -164,8 +164,9 @@ class OnboardingIntegrations extends LitElement {
     // We filter out the config entry for the local weather and rpi_power.
     // It is one that we create automatically and it will confuse the user
     // if it starts showing up during onboarding.
+    const HIDDEN_DOMAINS = new Set(["met", "rpi_power"]);
     this._entries = entries.filter(
-      (entry) => entry.domain !== "met" && entry.domain !== "rpi_power"
+      (entry) => !HIDDEN_DOMAINS.has(entry.domain)
     );
   }
 

--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -161,7 +161,7 @@ class OnboardingIntegrations extends LitElement {
 
   private async _loadConfigEntries() {
     const entries = await getConfigEntries(this.hass!);
-    // We filter out the config entry for the local weather and rpi_powerEx.
+    // We filter out the config entry for the local weather and rpi_power.
     // It is one that we create automatically and it will confuse the user
     // if it starts showing up during onboarding.
     this._entries = entries.filter(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Hide the rpi_power integration entry during onboarding.
- Requires https://github.com/home-assistant/core/pull/40076

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/40076
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
