### PR TITLE
Change exoplayer payload type

### DIFF
--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -105,7 +105,7 @@ class HaHLSPlayer extends LitElement {
     const videoEl = this._videoEl;
     const url = this.url;
     const useExoPlayerPromise = this._getUseExoPlayer();
-    const masterPlaylistPromise = await fetch(url);
+    const masterPlaylistPromise = fetch(url);
 
     const hls = ((await import(
       /* webpackChunkName: "hls.js" */ "hls.js"
@@ -125,10 +125,12 @@ class HaHLSPlayer extends LitElement {
     }
 
     this._useExoPlayer = await useExoPlayerPromise;
-    const hevcRegexp = /CODECS=".*?((hev1)|(hvc1))\..*?"/;
-    const masterPlaylist = await masterPlaylistPromise.text();
-    if (hevcRegexp.test(masterPlaylist) && this._useExoPlayer) {
-      this._renderHLSExoPlayer(url);
+    if (this._useExoPlayer) {
+      const hevcRegexp = /CODECS=".*?((hev1)|(hvc1))\..*?"/;
+      const masterPlaylist = await (await masterPlaylistPromise).text();
+      if (hevcRegexp.test(masterPlaylist)) {
+        this._renderHLSExoPlayer(url);
+      }
     } else if (hls.isSupported()) {
       this._renderHLSPolyfill(videoEl, hls, url);
     } else {

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -12,6 +12,7 @@ import {
 } from "lit-element";
 import { fireEvent } from "../common/dom/fire_event";
 import { nextRender } from "../common/util/render-status";
+import { getExternalConfig } from "../external_app/external_config";
 import type { HomeAssistant } from "../types";
 
 type HLSModule = typeof import("hls.js");
@@ -34,8 +35,7 @@ class HaHLSPlayer extends LitElement {
   @property({ type: Boolean, attribute: "playsinline" })
   public playsInline = false;
 
-  @property({ type: Boolean, attribute: "allow-exoplayer" })
-  public allowExoPlayer = false;
+  @property({ attribute: false }) public allowExoPlayer = false;
 
   @query("video") private _videoEl!: HTMLVideoElement;
 
@@ -93,7 +93,11 @@ class HaHLSPlayer extends LitElement {
   }
 
   private async _getUseExoPlayer(): Promise<boolean> {
-    return false;
+    if (!this.hass!.auth.external || !this.allowExoPlayer) {
+      return false;
+    }
+    const externalConfig = await getExternalConfig(this.hass!.auth.external);
+    return externalConfig && externalConfig.hasExoPlayer;
   }
 
   private async _startHls(): Promise<void> {

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -35,7 +35,8 @@ class HaHLSPlayer extends LitElement {
   @property({ type: Boolean, attribute: "playsinline" })
   public playsInline = false;
 
-  @property({ attribute: false }) public allowExoPlayer = false;
+  @property({ type: Boolean, attribute: "allow-exoplayer" })
+  public allowExoPlayer = false;
 
   @query("video") private _videoEl!: HTMLVideoElement;
 

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -125,12 +125,15 @@ class HaHLSPlayer extends LitElement {
     }
 
     this._useExoPlayer = await useExoPlayerPromise;
+    let hevcRegexp: RegExp;
+    let masterPlaylist: string;
     if (this._useExoPlayer) {
-      const hevcRegexp = /CODECS=".*?((hev1)|(hvc1))\..*?"/;
-      const masterPlaylist = await (await masterPlaylistPromise).text();
-      if (hevcRegexp.test(masterPlaylist)) {
-        this._renderHLSExoPlayer(url);
-      }
+      hevcRegexp = /CODECS=".*?((hev1)|(hvc1))\..*?"/;
+      masterPlaylist = await (await masterPlaylistPromise).text();
+    }
+    // @ts-ignore
+    if (this._useExoPlayer && hevcRegexp.test(masterPlaylist)) {
+      this._renderHLSExoPlayer(url);
     } else if (hls.isSupported()) {
       this._renderHLSPolyfill(videoEl, hls, url);
     } else {

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -103,9 +103,9 @@ class HaHLSPlayer extends LitElement {
 
   private async _startHls(): Promise<void> {
     const videoEl = this._videoEl;
-    const url = this.url;
+    const url = this.url.replace("master_playlist", "playlist");
     const useExoPlayerPromise = this._getUseExoPlayer();
-    const masterPlaylistPromise = fetch(url);
+    const masterPlaylistPromise = fetch(this.url);
 
     const hls = ((await import(
       /* webpackChunkName: "hls.js" */ "hls.js"

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -131,8 +131,7 @@ class HaHLSPlayer extends LitElement {
       hevcRegexp = /CODECS=".*?((hev1)|(hvc1))\..*?"/;
       masterPlaylist = await (await masterPlaylistPromise).text();
     }
-    // @ts-ignore
-    if (this._useExoPlayer && hevcRegexp.test(masterPlaylist)) {
+    if (this._useExoPlayer && hevcRegexp!.test(masterPlaylist!)) {
       this._renderHLSExoPlayer(playlist_url);
     } else if (hls.isSupported()) {
       this._renderHLSPolyfill(videoEl, hls, playlist_url);

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -103,7 +103,7 @@ class HaHLSPlayer extends LitElement {
 
   private async _startHls(): Promise<void> {
     const videoEl = this._videoEl;
-    const url = this.url.replace("master_playlist", "playlist");
+    const playlist_url = this.url.replace("master_playlist", "playlist");
     const useExoPlayerPromise = this._getUseExoPlayer();
     const masterPlaylistPromise = fetch(this.url);
 
@@ -133,11 +133,11 @@ class HaHLSPlayer extends LitElement {
     }
     // @ts-ignore
     if (this._useExoPlayer && hevcRegexp.test(masterPlaylist)) {
-      this._renderHLSExoPlayer(url);
+      this._renderHLSExoPlayer(playlist_url);
     } else if (hls.isSupported()) {
-      this._renderHLSPolyfill(videoEl, hls, url);
+      this._renderHLSPolyfill(videoEl, hls, playlist_url);
     } else {
-      this._renderHLSNative(videoEl, url);
+      this._renderHLSNative(videoEl, playlist_url);
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The frontend may need to send additional options to the exoplayer/play_hls interface such as whether to be muted or not: home-assistant/frontend#6857 . With that in mind it is probably better to use a JSONObject instead of a String for the payload.
Have also opened up a corresponding PR on the Android side (https://github.com/home-assistant/android/pull/932). If we make the change it is probably better to do it before 0.115 before any of the exoplayer stuff is officially added.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6857
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
