### PR TITLE
Ensure time_pattern values get stored as numbers and not strings

### DIFF
--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-time_pattern.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-time_pattern.ts
@@ -48,6 +48,11 @@ export class HaTimePatternTrigger extends LitElement implements TriggerElement {
   }
 
   private _valueChanged(ev: CustomEvent): void {
+    // Convert to integers unless we have a leading slash
+    // (used for divisible time pattern specification)
+    if (ev.detail.value.charAt(0) !== "/")
+      ev.detail.value = parseInt(ev.detail.value);
+
     handleChangeEvent(this, ev);
   }
 }

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-time_pattern.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-time_pattern.ts
@@ -48,10 +48,12 @@ export class HaTimePatternTrigger extends LitElement implements TriggerElement {
   }
 
   private _valueChanged(ev: CustomEvent): void {
-    // Convert to integers unless we have a leading slash
-    // (used for divisible time pattern specification)
-    if (ev.detail.value.charAt(0) !== "/")
-      ev.detail.value = parseInt(ev.detail.value);
+    // Convert to integer unless we have a leading slash
+    // (used for divisible time pattern specification) or a wildcard
+    if (ev.detail.value && typeof ev.detail.value === "string") {
+      if (!["/", "*"].includes(ev.detail.value.charAt(0)))
+        ev.detail.value = parseInt(ev.detail.value);
+    }
 
     handleChangeEvent(this, ev);
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Prevent the UI from sending the time_pattern input values for hours, minutes and seconds as strings. If they are strings, the automations will not get triggered correctly.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7087
- This PR is related to issue: 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
