### PR TITLE
Adding the ability to handle more complex forms by ha-form - Step 1 - dictionaries

### DIFF
--- a/src/components/ha-form/ha-form-dictionary.ts
+++ b/src/components/ha-form/ha-form-dictionary.ts
@@ -24,6 +24,8 @@ import type {
 export class HaFormDictionary extends LitElement implements HaFormElement {
   @property() public schema!: HaFormDictionarySchema;
 
+  @property() public error;
+
   @property() public data!: HaFormDictionaryData;
 
   @property() public label!: string;
@@ -68,6 +70,7 @@ export class HaFormDictionary extends LitElement implements HaFormElement {
             <ha-form
               .schema=${this.schema.dictionary}
               .data=${this.data}
+              .error=${this.error}
               @value-changed=${this._valueChanged}
               .computeError=${this.computeError}
               .computeLabel=${this.computeLabel}

--- a/src/components/ha-form/ha-form-dictionary.ts
+++ b/src/components/ha-form/ha-form-dictionary.ts
@@ -16,7 +16,6 @@ import type {
   HaFormElement,
   HaFormDictionaryData,
   HaFormDictionarySchema,
-  HaFormData,
   HaFormSchema,
   HaFormBooleanSchema,
 } from "./ha-form";

--- a/src/components/ha-form/ha-form-dictionary.ts
+++ b/src/components/ha-form/ha-form-dictionary.ts
@@ -1,0 +1,89 @@
+import "../ha-icon-button";
+import "@polymer/paper-input/paper-input";
+import {
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from "lit-element";
+import { fireEvent } from "../../common/dom/fire_event";
+import type {
+  HaFormElement,
+  HaFormDictionaryData,
+  HaFormDictionarySchema,
+  HaFormData,
+  HaFormSchema,
+} from "./ha-form";
+
+@customElement("ha-form-dictionary")
+export class HaFormDictionary extends LitElement implements HaFormElement {
+  @property() public schema!: HaFormDictionarySchema;
+
+  @property() public data!: HaFormDictionaryData;
+
+  @property() public label!: string;
+
+  @property() public suffix!: string;
+
+  @property() public computeError?: (schema: HaFormSchema, error) => string;
+
+  @property() public computeLabel?: (nesting: string) => string;
+
+  @property() public computeSuffix?: (schema: HaFormSchema) => string;
+
+  @property() public nesting = "";
+
+  protected render(): TemplateResult {
+    const boolSchema = { type: "boolean" };
+    console.log(
+      "XXX HERE schema=%s data=%s",
+      JSON.stringify(this.schema),
+      JSON.stringify(this.data)
+    );
+    console.log("XXX dictionary nesting=%s", JSON.stringify(this.nesting));
+    if (this.schema.optional) console.log("XXX OPTIONAL");
+    return html`
+      ${this.schema.optional
+        ? html` <ha-form-boolean .schema=${boolSchema}></ha-form-boolean> `
+        : ""}
+      <ha-form
+        .schema=${this.schema.dictionary}
+        .data=${this.data || {}}
+        @value-changed=${this._valueChanged}
+        .computeError=${this.computeError}
+        .computeLabel=${this.computeLabel}
+        .computeSuffix=${this.computeSuffix}
+        .nesting=${this.nesting}
+      >
+      </ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    if (!this.data) this.data = new Map<string, HaFormData>(); // XXX need to match different params either as list or map
+    console.log("XXX A");
+    ev.stopPropagation();
+    console.log("XXX B %s", JSON.stringify(ev.target as HaFormElement));
+    const schema = (ev.target as HaFormElement).schema as HaFormSchema;
+    console.log("XXX C");
+    const data = this.data as HaFormDictionaryData;
+    console.log(
+      "XXX D schema.name=%s value=%s",
+      schema.name,
+      JSON.stringify(ev.detail.value)
+    );
+    data[schema.name] = ev.detail.value;
+    console.log("XXX E");
+    fireEvent(this, "value-changed", {
+      value: { ...ev.detail.value },
+    });
+    console.log("XXX G");
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-form-dictionary": HaFormDictionary;
+  }
+}

--- a/src/components/ha-form/ha-form-dictionary.ts
+++ b/src/components/ha-form/ha-form-dictionary.ts
@@ -58,7 +58,7 @@ export class HaFormDictionary extends LitElement implements HaFormElement {
               .schema=${boolSchema}
               .data=${this._showParams}
               label=${this._computeLabel("optional") ||
-              `Configure ${this.nesting}`}
+              `Configure ${this._computeLabel("title")}`}
               @value-changed=${this._showParamsChanged}
             ></ha-form-boolean>
           `

--- a/src/components/ha-form/ha-form-dictionary.ts
+++ b/src/components/ha-form/ha-form-dictionary.ts
@@ -32,7 +32,7 @@ export class HaFormDictionary extends LitElement implements HaFormElement {
 
   @property() public computeError?: (schema: HaFormSchema, error) => string;
 
-  @property() public computeLabel?: (nesting: string) => string;
+  @property() public computeLabel?: (nesting: string, param?: string) => string;
 
   @property() public computeSuffix?: (schema: HaFormSchema) => string;
 
@@ -104,7 +104,7 @@ export class HaFormDictionary extends LitElement implements HaFormElement {
   }
 
   private _computeLabel(param: string) {
-    if (this.computeLabel) return this.computeLabel(`${this.nesting}.${param}`);
+    if (this.computeLabel) return this.computeLabel(this.nesting, param);
     return param || "";
   }
 

--- a/src/components/ha-form/ha-form-dictionary.ts
+++ b/src/components/ha-form/ha-form-dictionary.ts
@@ -41,7 +41,7 @@ export class HaFormDictionary extends LitElement implements HaFormElement {
 
   @internalProperty() private _showParams = true;
 
-  private _saveData = this.data || new Map<string, HaFormData>();
+  private _saveData = this.data || ({} as HaFormDictionaryData);
 
   protected render(): TemplateResult {
     const boolSchema = { type: "boolean" } as HaFormBooleanSchema;

--- a/src/components/ha-form/ha-form-dictionary.ts
+++ b/src/components/ha-form/ha-form-dictionary.ts
@@ -48,7 +48,7 @@ export class HaFormDictionary extends LitElement implements HaFormElement {
     return html`
       ${this._showParams
         ? html`
-            <hr />
+            <hr></hr>
             <h4>${this._computeLabel("title")}</h4>
             ${this._computeLabel("description")}
           `

--- a/src/components/ha-form/ha-form-dictionary.ts
+++ b/src/components/ha-form/ha-form-dictionary.ts
@@ -77,7 +77,7 @@ export class HaFormDictionary extends LitElement implements HaFormElement {
               id="inner-form"
             >
             </ha-form>
-            <hr />
+            <hr></hr>
           `
         : ""}
     `;

--- a/src/components/ha-form/ha-form-integer.ts
+++ b/src/components/ha-form/ha-form-integer.ts
@@ -98,9 +98,8 @@ export class HaFormInteger extends LitElement implements HaFormElement {
   private _valueChanged(ev: Event) {
     const rawValue = (ev.target as PaperInputElement | PaperSliderElement)
       .value;
-    const value = ["", undefined].includes(rawValue)
-      ? rawValue
-      : Number(rawValue);
+    const value =
+      rawValue === "" || rawValue === undefined ? rawValue : Number(rawValue);
     if (this._value === value) {
       return;
     }

--- a/src/components/ha-form/ha-form-integer.ts
+++ b/src/components/ha-form/ha-form-integer.ts
@@ -98,7 +98,9 @@ export class HaFormInteger extends LitElement implements HaFormElement {
   private _valueChanged(ev: Event) {
     const rawValue = (ev.target as PaperInputElement | PaperSliderElement)
       .value;
-    const value = rawValue === "" ? "" : Number(rawValue);
+    const value = ["", undefined].includes(rawValue)
+      ? rawValue
+      : Number(rawValue);
     if (this._value === value) {
       return;
     }

--- a/src/components/ha-form/ha-form-integer.ts
+++ b/src/components/ha-form/ha-form-integer.ts
@@ -84,7 +84,7 @@ export class HaFormInteger extends LitElement implements HaFormElement {
       this.data ||
       this.schema.description?.suggested_value ||
       this.schema.default ||
-      0
+      ""
     );
   }
 
@@ -96,9 +96,9 @@ export class HaFormInteger extends LitElement implements HaFormElement {
   }
 
   private _valueChanged(ev: Event) {
-    const value = Number(
-      (ev.target as PaperInputElement | PaperSliderElement).value
-    );
+    const rawValue = (ev.target as PaperInputElement | PaperSliderElement)
+      .value;
+    const value = rawValue === "" ? "" : Number(rawValue);
     if (this._value === value) {
       return;
     }

--- a/src/components/ha-form/ha-form-integer.ts
+++ b/src/components/ha-form/ha-form-integer.ts
@@ -84,7 +84,7 @@ export class HaFormInteger extends LitElement implements HaFormElement {
       this.data ||
       this.schema.description?.suggested_value ||
       this.schema.default ||
-      ""
+      undefined
     );
   }
 

--- a/src/components/ha-form/ha-form-integer.ts
+++ b/src/components/ha-form/ha-form-integer.ts
@@ -80,12 +80,11 @@ export class HaFormInteger extends LitElement implements HaFormElement {
   }
 
   private get _value() {
-    return (
-      this.data ||
-      this.schema.description?.suggested_value ||
-      this.schema.default ||
-      undefined
-    );
+    if (this.data !== undefined) return this.data;
+    if (this.schema.description?.suggested_value !== undefined)
+      return this.schema.description?.suggested_value;
+    if (this.schema.default !== undefined) return this.schema.default;
+    return undefined;
   }
 
   private _handleCheckboxChange(ev: Event) {

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -183,6 +183,7 @@ export class HaForm extends LitElement implements HaFormElement {
       ${dynamicElement(`ha-form-${this.schema.type}`, {
         schema: this.schema,
         data: this.data,
+        error: this.error,
         label: this._computeLabel(this.nesting),
         suffix: this._computeSuffix(this.schema),
         id: "child-form",

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -101,7 +101,7 @@ export type HaFormFloatData = number;
 export type HaFormBooleanData = boolean;
 export type HaFormSelectData = string;
 export type HaFormMultiSelectData = string[];
-export type HaFormDictionaryData = { [key: string]: HaFormData };
+export type HaFormDictionaryData = HaFormDataContainer;
 export interface HaFormTimeData {
   hours?: number;
   minutes?: number;

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -101,7 +101,7 @@ export type HaFormFloatData = number;
 export type HaFormBooleanData = boolean;
 export type HaFormSelectData = string;
 export type HaFormMultiSelectData = string[];
-export type HaFormDictionaryData = Map<string, HaFormData>;
+export type HaFormDictionaryData = { [key: string]: HaFormData };
 export interface HaFormTimeData {
   hours?: number;
   minutes?: number;

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -128,7 +128,7 @@ export class HaForm extends LitElement implements HaFormElement {
 
   @property() public computeError?: (schema: HaFormSchema, error) => string;
 
-  @property() public computeLabel?: (nesting: string) => string;
+  @property() public computeLabel?: (nesting: string, param?: string) => string;
 
   @property() public computeSuffix?: (schema: HaFormSchema) => string;
 

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -255,7 +255,7 @@ export class HaForm extends LitElement implements HaFormElement {
   private _valueChanged(ev: CustomEvent) {
     ev.stopPropagation();
     const schema = (ev.target as HaFormElement).schema as HaFormSchema;
-    const data = this.data as HaFormDataContainer;
+    const data = (this.data || {}) as HaFormDataContainer;
     const value = ev.detail.value;
     if (value !== "") data[schema.name] = ev.detail.value;
     else delete data[schema.name];

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -257,8 +257,8 @@ export class HaForm extends LitElement implements HaFormElement {
     const schema = (ev.target as HaFormElement).schema as HaFormSchema;
     const data = (this.data || {}) as HaFormDataContainer;
     const value = ev.detail.value;
-    if (value !== "") data[schema.name] = ev.detail.value;
-    else delete data[schema.name];
+    if (["", undefined].includes(value)) delete data[schema.name];
+    else data[schema.name] = value;
     fireEvent(this, "value-changed", {
       value: { ...data },
     });

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -173,7 +173,7 @@ export class HaForm extends LitElement implements HaFormElement {
     }
 
     return html`
-      ${this.error
+      ${this.error && this.schema.type !== "dictionary"
         ? html`
             <div class="error">
               ${this._computeError(this.error, this.schema)}

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -104,7 +104,6 @@ class DataEntryFlowDialog extends LitElement {
     const step = await (params.continueFlowId
       ? params.flowConfig.fetchFlow(this.hass, params.continueFlowId)
       : params.flowConfig.createFlow(this.hass, params.startFlowHandler!));
-    console.log("step=%s", JSON.stringify(step));
     // Happens if second showDialog called
     if (curInstance !== this._instance) {
       return;

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -104,7 +104,7 @@ class DataEntryFlowDialog extends LitElement {
     const step = await (params.continueFlowId
       ? params.flowConfig.fetchFlow(this.hass, params.continueFlowId)
       : params.flowConfig.createFlow(this.hass, params.startFlowHandler!));
-
+    console.log("step=%s", JSON.stringify(step));
     // Happens if second showDialog called
     if (curInstance !== this._instance) {
       return;

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -104,6 +104,7 @@ class DataEntryFlowDialog extends LitElement {
     const step = await (params.continueFlowId
       ? params.flowConfig.fetchFlow(this.hass, params.continueFlowId)
       : params.flowConfig.createFlow(this.hass, params.startFlowHandler!));
+
     // Happens if second showDialog called
     if (curInstance !== this._instance) {
       return;

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -88,7 +88,7 @@ export const showConfigFlowDialog = (
 
     renderShowFormStepFieldLabel(hass, step, field) {
       return hass.localize(
-        `component.${step.handler}.config.step.${step.step_id}.data.${field.name}`
+        `component.${step.handler}.config.step.${step.step_id}.data.${field}`
       );
     },
 

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -88,7 +88,9 @@ export const showConfigFlowDialog = (
 
     renderShowFormStepFieldLabel(hass, step, nesting) {
       return hass.localize(
-        `component.${step.handler}.config.step.${step.step_id}.data.${nesting}`
+        `component.${step.handler}.config.step.${
+          step.step_id
+        }.data.${nesting.split(".").join(".data.")}`
       );
     },
 

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -86,9 +86,9 @@ export const showConfigFlowDialog = (
         : "";
     },
 
-    renderShowFormStepFieldLabel(hass, step, field) {
+    renderShowFormStepFieldLabel(hass, step, nesting) {
       return hass.localize(
-        `component.${step.handler}.config.step.${step.step_id}.data.${field}`
+        `component.${step.handler}.config.step.${step.step_id}.data.${nesting}`
       );
     },
 

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -1,6 +1,5 @@
 import { TemplateResult } from "lit-html";
 import { fireEvent } from "../../common/dom/fire_event";
-import { HaFormSchema } from "../../components/ha-form/ha-form";
 import {
   DataEntryFlowStep,
   DataEntryFlowStepAbort,
@@ -45,7 +44,7 @@ export interface FlowConfig {
   renderShowFormStepFieldLabel(
     hass: HomeAssistant,
     step: DataEntryFlowStepForm,
-    field: HaFormSchema
+    nesting: string
   ): string;
 
   renderShowFormStepFieldError(

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -44,7 +44,8 @@ export interface FlowConfig {
   renderShowFormStepFieldLabel(
     hass: HomeAssistant,
     step: DataEntryFlowStepForm,
-    nesting: string
+    nesting: string,
+    param?: string
   ): string;
 
   renderShowFormStepFieldError(

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -86,10 +86,6 @@ export const showOptionsFlowDialog = (
       },
 
       renderShowFormStepFieldLabel(hass, step, field) {
-        const orig = `component.${configEntry.domain}.options.step.${step.step_id}.data.${field}`;
-        const calc = hass.localize(orig);
-        console.log("orig=%s calc=%s", orig, calc);
-        return calc;
         return hass.localize(
           `component.${configEntry.domain}.options.step.${step.step_id}.data.${field}`
         );

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -86,8 +86,12 @@ export const showOptionsFlowDialog = (
       },
 
       renderShowFormStepFieldLabel(hass, step, field) {
+        const orig = `component.${configEntry.domain}.options.step.${step.step_id}.data.${field}`;
+        const calc = hass.localize(orig);
+        console.log("orig=%s calc=%s", orig, calc);
+        return calc;
         return hass.localize(
-          `component.${configEntry.domain}.options.step.${step.step_id}.data.${field.name}`
+          `component.${configEntry.domain}.options.step.${step.step_id}.data.${field}`
         );
       },
 

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -85,9 +85,13 @@ export const showOptionsFlowDialog = (
           : "";
       },
 
-      renderShowFormStepFieldLabel(hass, step, nesting) {
+      renderShowFormStepFieldLabel(hass, step, nesting, param) {
         return hass.localize(
-          `component.${configEntry.domain}.options.step.${step.step_id}.data.${nesting}`
+          `component.${configEntry.domain}.options.step.${
+            step.step_id
+          }.data.${nesting.split(".").join(".data.")}${
+            param ? `.${param}` : ""
+          }`
         );
       },
 

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -85,9 +85,9 @@ export const showOptionsFlowDialog = (
           : "";
       },
 
-      renderShowFormStepFieldLabel(hass, step, field) {
+      renderShowFormStepFieldLabel(hass, step, nesting) {
         return hass.localize(
-          `component.${configEntry.domain}.options.step.${step.step_id}.data.${field}`
+          `component.${configEntry.domain}.options.step.${step.step_id}.data.${nesting}`
         );
       },
 

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -13,7 +13,6 @@ import {
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-circular-progress";
 import "../../components/ha-form/ha-form";
-import type { HaFormSchema } from "../../components/ha-form/ha-form";
 import "../../components/ha-markdown";
 import type { DataEntryFlowStepForm } from "../../data/data_entry_flow";
 import type { HomeAssistant } from "../../types";
@@ -177,8 +176,8 @@ class StepFlowForm extends LitElement {
     this._stepData = ev.detail.value;
   }
 
-  private _labelCallback = (field: HaFormSchema): string =>
-    this.flowConfig.renderShowFormStepFieldLabel(this.hass, this.step, field);
+  private _labelCallback = (nesting: string): string =>
+    this.flowConfig.renderShowFormStepFieldLabel(this.hass, this.step, nesting);
 
   private _errorCallback = (error: string) =>
     this.flowConfig.renderShowFormStepFieldError(this.hass, this.step, error);

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -126,6 +126,7 @@ class StepFlowForm extends LitElement {
         data[field.name] = field.default;
       }
     });
+
     this._stepData = data;
     return data;
   }
@@ -146,6 +147,7 @@ class StepFlowForm extends LitElement {
         toSendData[key] = value;
       }
     });
+
     try {
       const step = await this.flowConfig.handleFlowStep(
         this.hass,

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -176,8 +176,13 @@ class StepFlowForm extends LitElement {
     this._stepData = ev.detail.value;
   }
 
-  private _labelCallback = (nesting: string): string =>
-    this.flowConfig.renderShowFormStepFieldLabel(this.hass, this.step, nesting);
+  private _labelCallback = (nesting: string, param?: string): string =>
+    this.flowConfig.renderShowFormStepFieldLabel(
+      this.hass,
+      this.step,
+      nesting,
+      param
+    );
 
   private _errorCallback = (error: string) =>
     this.flowConfig.renderShowFormStepFieldError(this.hass, this.step, error);

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -155,9 +155,9 @@ export class MoreInfoLogbook extends LitElement {
           overflow: auto;
         }
         @media all and (max-width: 450px), all and (max-height: 500px) {
-         ha-logbook {
-           max-height: unset;
-         }
+          ha-logbook {
+            max-height: unset;
+          }
         }
         ha-circular-progress {
           display: flex;

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_template.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_template.ts
@@ -40,7 +40,9 @@ export class HaWaitAction extends LitElement implements ActionElement {
       ></paper-input>
       <br />
       <ha-formfield
-        .label=${this.hass.localize("ui.panel.config.automation.editor.actions.type.wait_template.continue_timeout")}
+        .label=${this.hass.localize(
+          "ui.panel.config.automation.editor.actions.type.wait_template.continue_timeout"
+        )}
       >
         <ha-switch
           .checked=${continue_on_timeout}

--- a/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-actions-ozw.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/ozw/ha-device-actions-ozw.ts
@@ -31,7 +31,6 @@ export class HaDeviceActionsOzw extends LitElement {
   @property()
   private ozw_instance = 1;
 
-
   protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has("device")) {
       const identifiers:

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -175,16 +175,11 @@ export class DialogEntityEditor extends LitElement {
               "ui.dialogs.entity_registry.no_unique_id",
               "faq_link",
               html`<a
-                href="${documentationUrl(
-                  this.hass,
-                  "/faq/unique_id"
-                )}"
+                href="${documentationUrl(this.hass, "/faq/unique_id")}"
                 target="_blank"
                 rel="noreferrer"
-                >${this.hass.localize(
-                  "ui.dialogs.entity_registry.faq"
-                )}</a
-              >`              
+                >${this.hass.localize("ui.dialogs.entity_registry.faq")}</a
+              >`
             )}
           </div>
         `;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not a breaking change
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some integrations have more complex configurations then ha-form can handle. there are some impressive designs using ha-form (konnected and alarmdecoder are good examples), but this is complex to code and debug, and creates a sub optimal user flow that could be better served (IMO) by giving more generic forms.

This PR generalizes the ha-form to include forms with fixed dictionaries nested inside {"a": {"b":1, "c":2}}. The next step will be maps with variable keys (e.g. schema({str:int})), but this PR is already big enough so prefer to start with the smaller part.

Note that for this to run, a change (https://github.com/home-assistant-libs/voluptuous-serialize/pull/18) to voluptuous-serialize is needed to be able to serialize the complex schemas. I used "pip install -e" to run with this version but i did not get it reviewed yet so not clear when this will be able to run against the normal dev branch of core

A bit of explanation about what I did here:
- voluptuous-serialize lib - added the ability to serialize static and dynamic dictionaries
- python (core) side - no changes needed but i will create a sample PR that shows a setup using these forms and will update here
- frontend side - the intention was to generalize ha-form and this is the majority of what i did. however, when doing it, i discovered that there are a few things that needed minor tweaking. I will try to explain them:

- ha-form-dictionary - this is for a form field that is a sub-dictionary. it has an inside ha-form with the inside schema and is quite simple. if it is a required parameter, it is simply a section (with title/description). if it is optional, there is a bool switch and only if it is turned on, the parameters are shown. this is useful for example in the case of a backup server, that is optional, but if configured, it has required parameters (user / pass?). in any case, everything is nested so i needed to change the label function to accept the nested name ("section.param") so I made the change that it gets the name and not the schema (the schema is unaware of the path to it).

- ha-form-integer - this one only had a small change for a misbehavior that is insiginificant in flat forms, but in the dictionary it was creating a problem. when there was no suggested value or default, it becomes 0. instead it should be empty and the schema can handle it, so this changes empty parameters to ""

- ha-form - a few changes there:
1.  added the normal extension of the form type to the dictionary type. nothing special there
2. added a property nesting that gets moved down. If an ha-form's nesting is "section.subsection" and it has a param "abc", the nested value for that "abc" will be "section.subsection.abc". changed the label computing functions accordingly
3. created a method that shows whether the required parameters are filled. This was done in step-flow-form, but is really a generic form property. it was ok there when it was simple, but with dictionaries (and after this map), better to have that logic in one place. it checks recursively if it has child dictionaries
4. moved to explicitly delete from the data fields which are "" so instead of pointing to "", they will just not be in the dictionary (and if they are required, will show an error). this was currently done in step-flow-form, but as the logic gets more complex, it should be in the ha-form IMO

- show-dialog-data-entry-flow, show-dialog-config-flow and show-dialog-options-flow - changed the label compute functions according to the nesting.

- step-flow-form - i took out the stuff from the form regarding the pre-submit cleanup and the check whether params are filled. now there is an internalproperty that gets evaluated after each update so it accordingly tracks whether the form is submittable or not

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
