### PR TITLE
Support new description field in automation editor action steps

### DIFF
--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -90,17 +90,23 @@ export interface ChooseAction {
   default?: Action[];
 }
 
-export type Action =
-  | EventAction
-  | DeviceAction
-  | ServiceAction
-  | Condition
-  | DelayAction
-  | SceneAction
-  | WaitAction
-  | WaitForTriggerAction
-  | RepeatAction
-  | ChooseAction;
+export interface StepDescription {
+  description?: string;
+}
+
+export type Action = StepDescription &
+  (
+    | EventAction
+    | DeviceAction
+    | ServiceAction
+    | Condition
+    | DelayAction
+    | SceneAction
+    | WaitAction
+    | WaitForTriggerAction
+    | RepeatAction
+    | ChooseAction
+  );
 
 export const triggerScript = (
   hass: HomeAssistant,

--- a/src/panels/config/automation/action/types/ha-automation-action-service.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-service.ts
@@ -21,11 +21,13 @@ import type { PolymerChangedEvent } from "../../../../../polymer-types";
 import type { HomeAssistant } from "../../../../../types";
 import { EntityId } from "../../../../lovelace/common/structs/is-entity-id";
 import { ActionElement, handleChangeEvent } from "../ha-automation-action-row";
+import { descriptionConfigStruct } from "../../../../lovelace/editor/types";
 
 const actionStruct = object({
   service: optional(string()),
   entity_id: optional(EntityId),
   data: optional(any()),
+  description: descriptionConfigStruct,
 });
 
 @customElement("ha-automation-action-service")

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -76,6 +76,8 @@ export interface CardPickTarget extends EventTarget {
   config: LovelaceCardConfig;
 }
 
+export const descriptionConfigStruct = optional(string());
+
 export const actionConfigStruct = object({
   action: string(),
   navigation_path: optional(string()),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

See [WTH can’t we annotate sequence steps for logging?](https://community.home-assistant.io/t/wth-cant-we-annotate-sequence-steps-for-logging-executing-step-call-service-make-lights-blue/224447)

Adds frontend support (YAML Mode only) for the proposed `description:` field for action steps (see [PR](https://github.com/home-assistant/core/pull/40772)). 

If accepted, I will create a follow-up PR to add the field to UI Mode.

Needs [this PR](https://github.com/home-assistant/core/pull/40772). 

## Screenshots
### YAML Mode (description field can be added and saved)
![image](https://user-images.githubusercontent.com/1480827/94870161-b8fa0600-03fb-11eb-8e93-ccc5978c56f5.png)

### UI Mode (this PR does not add UI elements for field)
![image](https://user-images.githubusercontent.com/1480827/94870175-c4e5c800-03fb-11eb-807e-768c282e5082.png)


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
# Example script.yaml
play_spotify_on_apple_tv:
  alias: Play Spotify On Apple TV
  mode: single
  sequence:
  - description: TURNING ON APPLE TV
    data: {}
    service: script.turn_on_apple_tv
  - description: WAIT FOR APPLE TV TO REPORT ITSELF BEFORE TRYING TO NAVIGATE MENU
     wait_template: '{{ not is_state(''media_player.living_room_tv'', ''off'') and
      is_state(''binary_sensor.is_apple_tv_media_player_on'', ''on'') }}'
     timeout: 00:00:30
    continue_on_timeout: true
  - data: {}
    entity_id: remote.apple_tv
    service: script.navigate_apple_tv_to_top_menu
  - data:
      command: select
    entity_id: remote.apple_tv
    service: remote.send_command
  - description: FORCE UPDATE OF SPOTIFY PLAYER SO APPLE TV APPEARS ON LIST
    service: homeassistant.update_entity
    data: {}
    entity_id: media_player.spotify_donka
  # ...
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to WTH thread: https://community.home-assistant.io/t/wth-cant-we-annotate-sequence-steps-for-logging-executing-step-call-service-make-lights-blue/224447
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
