### PR TITLE
20200930.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="home-assistant-frontend",
-    version="20200930.1",
+    version="20200930.0",
     description="The Home Assistant frontend",
     url="https://github.com/home-assistant/home-assistant-polymer",
     author="The Home Assistant Authors",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="home-assistant-frontend",
-    version="20200930.0",
+    version="20200930.1",
     description="The Home Assistant frontend",
     url="https://github.com/home-assistant/home-assistant-polymer",
     author="The Home Assistant Authors",

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -93,6 +93,8 @@ export class HaEntityPicker extends LitElement {
 
   @property() public entityFilter?: HaEntityPickerEntityFilterFunc;
 
+  @property({ type: Boolean }) public hideClearIcon = false;
+
   @property({ type: Boolean }) private _opened = false;
 
   @query("vaadin-combo-box-light") private _comboBox!: HTMLElement;
@@ -204,7 +206,7 @@ export class HaEntityPicker extends LitElement {
           autocorrect="off"
           spellcheck="false"
         >
-          ${this.value
+          ${this.value && !this.hideClearIcon
             ? html`
                 <ha-icon-button
                   aria-label=${this.hass.localize(

--- a/src/components/ha-icon.ts
+++ b/src/components/ha-icon.ts
@@ -31,9 +31,7 @@ interface DeprecatedIcon {
   };
 }
 
-const mdiDeprecatedIcons: DeprecatedIcon = {
-  scooter: { removeIn: "117", newName: "human-scooter" },
-};
+const mdiDeprecatedIcons: DeprecatedIcon = {};
 
 const chunks: Chunks = {};
 

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -92,6 +92,7 @@ export interface LovelaceViewElement extends HTMLElement {
   index?: number;
   cards?: Array<LovelaceCard | HuiErrorCard>;
   badges?: LovelaceBadge[];
+  setConfig(config: LovelaceCardConfig): void;
 }
 
 export interface ShowViewConfig {

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -92,7 +92,7 @@ export interface LovelaceViewElement extends HTMLElement {
   index?: number;
   cards?: Array<LovelaceCard | HuiErrorCard>;
   badges?: LovelaceBadge[];
-  setConfig(config: LovelaceCardConfig): void;
+  setConfig(config: LovelaceViewConfig): void;
 }
 
 export interface ShowViewConfig {

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -136,6 +136,7 @@ export const configSections: { [name: string]: PageNavigation[] } = {
       translationKey: "ui.panel.config.users.caption",
       iconPath: mdiBadgeAccountHorizontal,
       core: true,
+      advancedOnly: true,
     },
   ],
   general: [

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -1,6 +1,7 @@
 import { mdiPlus } from "@mdi/js";
 import "@polymer/paper-item/paper-icon-item";
 import "@polymer/paper-item/paper-item-body";
+import "@material/mwc-fab";
 import {
   css,
   CSSResult,
@@ -222,6 +223,9 @@ class HaConfigPerson extends LitElement {
         } catch (err) {
           return false;
         }
+      },
+      refreshUsers: () => {
+        this._usersLoad = fetchUsers(this.hass!);
       },
     });
   }

--- a/src/panels/config/person/show-dialog-person-detail.ts
+++ b/src/panels/config/person/show-dialog-person-detail.ts
@@ -5,6 +5,7 @@ import { User } from "../../../data/user";
 export interface PersonDetailDialogParams {
   entry?: Person;
   users: User[];
+  refreshUsers: () => void;
   createEntry: (values: PersonMutableParams) => Promise<unknown>;
   updateEntry: (updates: Partial<PersonMutableParams>) => Promise<unknown>;
   removeEntry: () => Promise<boolean>;

--- a/src/panels/config/users/dialog-add-user.ts
+++ b/src/panels/config/users/dialog-add-user.ts
@@ -50,15 +50,24 @@ export class DialogAddUser extends LitElement {
 
   @internalProperty() private _isAdmin?: boolean;
 
+  @internalProperty() private _allowChangeName = true;
+
   public showDialog(params: AddUserDialogParams) {
     this._params = params;
-    this._name = "";
+    this._name = this._params.name || "";
     this._username = "";
     this._password = "";
     this._passwordConfirm = "";
     this._isAdmin = false;
     this._error = undefined;
     this._loading = false;
+
+    if (this._params.name) {
+      this._allowChangeName = false;
+      this._maybePopulateUsername();
+    } else {
+      this._allowChangeName = true;
+    }
   }
 
   protected firstUpdated(changedProperties: PropertyValues) {
@@ -84,19 +93,22 @@ export class DialogAddUser extends LitElement {
       >
         <div>
           ${this._error ? html` <div class="error">${this._error}</div> ` : ""}
-          <paper-input
-            class="name"
-            name="name"
-            .label=${this.hass.localize("ui.panel.config.users.add_user.name")}
-            .value=${this._name}
-            required
-            auto-validate
-            autocapitalize="on"
-            .errorMessage=${this.hass.localize("ui.common.error_required")}
-            @value-changed=${this._handleValueChanged}
-            @blur=${this._maybePopulateUsername}
-          ></paper-input>
-
+          ${this._allowChangeName
+            ? html` <paper-input
+                class="name"
+                name="name"
+                .label=${this.hass.localize(
+                  "ui.panel.config.users.add_user.name"
+                )}
+                .value=${this._name}
+                required
+                auto-validate
+                autocapitalize="on"
+                .errorMessage=${this.hass.localize("ui.common.error_required")}
+                @value-changed=${this._handleValueChanged}
+                @blur=${this._maybePopulateUsername}
+              ></paper-input>`
+            : ""}
           <paper-input
             class="username"
             name="username"

--- a/src/panels/config/users/dialog-user-detail.ts
+++ b/src/panels/config/users/dialog-user-detail.ts
@@ -47,7 +47,7 @@ class DialogUserDetail extends LitElement {
     this._params = params;
     this._error = undefined;
     this._name = params.entry.name || "";
-    this._isAdmin = params.entry.group_ids[0] === SYSTEM_GROUP_ID_ADMIN;
+    this._isAdmin = params.entry.group_ids.includes(SYSTEM_GROUP_ID_ADMIN);
     await this.updateComplete;
   }
 
@@ -112,7 +112,7 @@ class DialogUserDetail extends LitElement {
               .dir=${computeRTLDirection(this.hass)}
             >
               <ha-switch
-                .disabled=${user.system_generated}
+                .disabled=${user.system_generated || user.is_owner}
                 .checked=${this._isAdmin}
                 @change=${this._adminChanged}
               >

--- a/src/panels/config/users/show-dialog-add-user.ts
+++ b/src/panels/config/users/show-dialog-add-user.ts
@@ -3,6 +3,7 @@ import { User } from "../../../data/user";
 
 export interface AddUserDialogParams {
   userAddedCallback: (user: User) => void;
+  name?: string;
 }
 
 export const loadAddUserDialog = () =>

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -244,8 +244,7 @@ class HaLogbook extends LitElement {
           line-height: 2em;
           padding: 8px 16px;
           box-sizing: border-box;
-          border-top: 1px solid
-            var(--mdc-dialog-scroll-divider-color, rgba(0, 0, 0, 0.12));
+          border-top: 1px solid var(--divider-color);
         }
 
         .entry.no-entity,

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -3,7 +3,11 @@ import { FullCalendarView } from "../../../types";
 import { Condition } from "../common/validate-condition";
 import { HuiImage } from "../components/hui-image";
 import { LovelaceElementConfig } from "../elements/types";
-import { EntityConfig, EntityFilterEntityConfig } from "../entity-rows/types";
+import {
+  EntityConfig,
+  EntityFilterEntityConfig,
+  LovelaceRowConfig,
+} from "../entity-rows/types";
 import { LovelaceHeaderFooterConfig } from "../header-footer/types";
 
 export interface AlarmPanelCardConfig extends LovelaceCardConfig {
@@ -60,7 +64,7 @@ export interface EntitiesCardConfig extends LovelaceCardConfig {
   type: "entities";
   show_header_toggle?: boolean;
   title?: string;
-  entities: Array<EntitiesCardEntityConfig | string>;
+  entities: Array<LovelaceRowConfig | string>;
   theme?: string;
   icon?: string;
   header?: LovelaceHeaderFooterConfig;

--- a/src/panels/lovelace/common/has-changed.ts
+++ b/src/panels/lovelace/common/has-changed.ts
@@ -56,6 +56,7 @@ export function hasConfigOrEntitiesChanged(
 
   return entities.some(
     (entity) =>
+      "entity" in entity &&
       oldHass.states[entity.entity] !== element.hass!.states[entity.entity]
   );
 }

--- a/src/panels/lovelace/common/process-config-entities.ts
+++ b/src/panels/lovelace/common/process-config-entities.ts
@@ -1,8 +1,10 @@
 // Parse array of entity objects from config
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
-import { EntityConfig } from "../entity-rows/types";
+import { EntityConfig, LovelaceRowConfig } from "../entity-rows/types";
 
-export const processConfigEntities = <T extends EntityConfig>(
+export const processConfigEntities = <
+  T extends EntityConfig | LovelaceRowConfig
+>(
   entities: Array<T | string>
 ): T[] => {
   if (!entities || !Array.isArray(entities)) {
@@ -24,7 +26,7 @@ export const processConfigEntities = <T extends EntityConfig>(
       if (typeof entityConf === "string") {
         config = { entity: entityConf } as T;
       } else if (typeof entityConf === "object" && !Array.isArray(entityConf)) {
-        if (!entityConf.entity) {
+        if (!("entity" in entityConf)) {
           throw new Error(
             `Entity object at position ${index} is missing entity field.`
           );
@@ -34,9 +36,11 @@ export const processConfigEntities = <T extends EntityConfig>(
         throw new Error(`Invalid entity specified at position ${index}.`);
       }
 
-      if (!isValidEntityId(config.entity)) {
+      if (!isValidEntityId((config as EntityConfig).entity!)) {
         throw new Error(
-          `Invalid entity ID at position ${index}: ${config.entity}`
+          `Invalid entity ID at position ${index}: ${
+            (config as EntityConfig).entity
+          }`
         );
       }
 

--- a/src/panels/lovelace/create-element/create-element-base.ts
+++ b/src/panels/lovelace/create-element/create-element-base.ts
@@ -16,6 +16,7 @@ import {
   LovelaceCard,
   LovelaceCardConstructor,
   LovelaceHeaderFooter,
+  LovelaceRowConstructor,
 } from "../types";
 
 const TIMEOUT = 2000;
@@ -39,7 +40,7 @@ interface CreateElementConfigTypes {
   row: {
     config: LovelaceRowConfig;
     element: LovelaceRow;
-    constructor: unknown;
+    constructor: LovelaceRowConstructor;
   };
   "header-footer": {
     config: LovelaceHeaderFooterConfig;

--- a/src/panels/lovelace/create-element/create-row-element.ts
+++ b/src/panels/lovelace/create-element/create-row-element.ts
@@ -4,11 +4,14 @@ import "../entity-rows/hui-script-entity-row";
 import "../entity-rows/hui-sensor-entity-row";
 import "../entity-rows/hui-text-entity-row";
 import "../entity-rows/hui-toggle-entity-row";
-import { EntityConfig } from "../entity-rows/types";
+import { LovelaceRowConfig } from "../entity-rows/types";
 import "../special-rows/hui-attribute-row";
 import "../special-rows/hui-button-row";
 import "../special-rows/hui-call-service-row";
-import { createLovelaceElement } from "./create-element-base";
+import {
+  createLovelaceElement,
+  getLovelaceElementClass,
+} from "./create-element-base";
 
 const ALWAYS_LOADED_TYPES = new Set([
   "media-player-entity",
@@ -74,7 +77,7 @@ const DOMAIN_TO_ELEMENT_TYPE = {
   weather: "weather",
 };
 
-export const createRowElement = (config: EntityConfig) =>
+export const createRowElement = (config: LovelaceRowConfig) =>
   createLovelaceElement(
     "row",
     config,
@@ -83,3 +86,12 @@ export const createRowElement = (config: EntityConfig) =>
     DOMAIN_TO_ELEMENT_TYPE,
     undefined
   );
+
+export const getRowElementClass = (type: string) => {
+  return getLovelaceElementClass(
+    type,
+    "row",
+    ALWAYS_LOADED_TYPES,
+    LAZY_LOAD_TYPES
+  );
+};

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -1,42 +1,42 @@
+import { mdiHelpCircle } from "@mdi/js";
 import deepFreeze from "deep-freeze";
 import {
   css,
   CSSResultArray,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
+  PropertyValues,
   query,
   TemplateResult,
-  PropertyValues,
 } from "lit-element";
-import { mdiHelpCircle } from "@mdi/js";
-
-import { fireEvent } from "../../../../common/dom/fire_event";
-import { haStyleDialog } from "../../../../resources/styles";
-import { showSaveSuccessToast } from "../../../../util/toast-saved-success";
-import { addCard, replaceCard } from "../config-util";
-import { getCardDocumentationURL } from "../get-card-documentation-url";
-import { computeRTLDirection } from "../../../../common/util/compute_rtl";
-import { showConfirmationDialog } from "../../../../dialogs/generic/show-dialog-box";
-
-import type { HomeAssistant } from "../../../../types";
-import type { GUIModeChangedEvent } from "../types";
-import type { ConfigChangedEvent, HuiCardEditor } from "./hui-card-editor";
-import type { EditCardDialogParams } from "./show-edit-card-dialog";
-import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import type { HASSDomEvent } from "../../../../common/dom/fire_event";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeRTLDirection } from "../../../../common/util/compute_rtl";
+import "../../../../components/ha-circular-progress";
+import "../../../../components/ha-dialog";
+import "../../../../components/ha-header-bar";
 import type {
   LovelaceCardConfig,
   LovelaceViewConfig,
 } from "../../../../data/lovelace";
-
-import "./hui-card-editor";
+import { showConfirmationDialog } from "../../../../dialogs/generic/show-dialog-box";
+import type { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyleDialog } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import { showSaveSuccessToast } from "../../../../util/toast-saved-success";
+import { addCard, replaceCard } from "../config-util";
+import { getCardDocumentationURL } from "../get-card-documentation-url";
+import "../hui-element-editor";
+import type {
+  ConfigChangedEvent,
+  HuiElementEditor,
+} from "../hui-element-editor";
+import type { GUIModeChangedEvent } from "../types";
 import "./hui-card-preview";
-import "../../../../components/ha-dialog";
-import "../../../../components/ha-header-bar";
-import "../../../../components/ha-circular-progress";
+import type { EditCardDialogParams } from "./show-edit-card-dialog";
 
 declare global {
   // for fire event
@@ -65,7 +65,7 @@ export class HuiDialogEditCard extends LitElement implements HassDialog {
 
   @internalProperty() private _guiModeAvailable? = true;
 
-  @query("hui-card-editor") private _cardEditorEl?: HuiCardEditor;
+  @query("hui-element-editor") private _cardEditorEl?: HuiElementEditor;
 
   @internalProperty() private _GUImode = true;
 
@@ -183,14 +183,14 @@ export class HuiDialogEditCard extends LitElement implements HassDialog {
         </div>
         <div class="content">
           <div class="element-editor">
-            <hui-card-editor
+            <hui-element-editor
               .hass=${this.hass}
               .lovelace=${this._params.lovelaceConfig}
               .value=${this._cardConfig}
               @config-changed=${this._handleConfigChanged}
               @GUImode-changed=${this._handleGUIModeChanged}
               @editor-save=${this._save}
-            ></hui-card-editor>
+            ></hui-element-editor>
           </div>
           <div class="element-preview">
             <hui-card-preview
@@ -364,6 +364,8 @@ export class HuiDialogEditCard extends LitElement implements HassDialog {
         @media all and (min-width: 850px) {
           ha-dialog {
             --mdc-dialog-min-width: 845px;
+            --dialog-surface-top: 40px;
+            --mdc-dialog-max-height: calc(100% - 72px);
           }
         }
 
@@ -402,6 +404,9 @@ export class HuiDialogEditCard extends LitElement implements HassDialog {
           ha-dialog {
             --mdc-dialog-max-width: calc(100% - 32px);
             --mdc-dialog-min-width: 1000px;
+            --dialog-surface-position: fixed;
+            --dialog-surface-top: 40px;
+            --mdc-dialog-max-height: calc(100% - 72px);
           }
 
           .content {

--- a/src/panels/lovelace/editor/config-elements/config-elements-style.ts
+++ b/src/panels/lovelace/editor/config-elements/config-elements-style.ts
@@ -1,19 +1,17 @@
-import { html } from "lit-element";
+import { css } from "lit-element";
 
-export const configElementStyle = html`
-  <style>
-    ha-switch {
-      padding: 16px 0;
-    }
-    .side-by-side {
-      display: flex;
-    }
-    .side-by-side > * {
-      flex: 1;
-      padding-right: 4px;
-    }
-    .suffix {
-      margin: 0 8px;
-    }
-  </style>
+export const configElementStyle = css`
+  ha-switch {
+    padding: 16px 0;
+  }
+  .side-by-side {
+    display: flex;
+  }
+  .side-by-side > * {
+    flex: 1;
+    padding-right: 4px;
+  }
+  .suffix {
+    margin: 0 8px;
+  }
 `;

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -3,14 +3,15 @@ import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 import {
   css,
-  CSSResult,
+  CSSResultArray,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import { array, assert, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
 import "../../../../components/ha-icon";
@@ -20,7 +21,6 @@ import "../../components/hui-theme-select-editor";
 import { LovelaceCardEditor } from "../../types";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { assert, object, string, optional, array } from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -68,7 +68,6 @@ export class HuiAlarmPanelCardEditor extends LitElement
     const states = ["arm_home", "arm_away", "arm_night", "arm_custom_bypass"];
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -128,22 +127,25 @@ export class HuiAlarmPanelCardEditor extends LitElement
     `;
   }
 
-  static get styles(): CSSResult {
-    return css`
-      .states {
-        display: flex;
-        flex-direction: row;
-      }
-      .deleteState {
-        visibility: hidden;
-      }
-      .states:hover > .deleteState {
-        visibility: visible;
-      }
-      ha-icon {
-        padding-top: 12px;
-      }
-    `;
+  static get styles(): CSSResultArray {
+    return [
+      configElementStyle,
+      css`
+        .states {
+          display: flex;
+          flex-direction: row;
+        }
+        .deleteState {
+          visibility: hidden;
+        }
+        .states:hover > .deleteState {
+          visibility: visible;
+        }
+        ha-icon {
+          padding-top: 12px;
+        }
+      `,
+    ];
   }
 
   private _stateRemoved(ev: EntitiesEditorEvent): void {

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
@@ -1,5 +1,6 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
   internalProperty,
@@ -109,7 +110,6 @@ export class HuiButtonCardEditor extends LitElement
     const dir = computeRTLDirection(this.hass!);
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -292,6 +292,10 @@ export class HuiButtonCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: newConfig });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-calendar-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-calendar-card-editor.ts
@@ -1,4 +1,5 @@
 import {
+  CSSResult,
   customElement,
   html,
   internalProperty,
@@ -68,7 +69,6 @@ export class HuiCalendarCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <div class="side-by-side">
           <paper-input
@@ -173,6 +173,10 @@ export class HuiCalendarCardEditor extends LitElement
       };
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -2,28 +2,30 @@ import "@polymer/paper-tabs";
 import "@polymer/paper-tabs/paper-tab";
 import {
   css,
-  CSSResult,
+  CSSResultArray,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   query,
   TemplateResult,
 } from "lit-element";
+import { any, array, assert, object, optional, string } from "superstruct";
 import { fireEvent, HASSDomEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
-import { LovelaceConfig } from "../../../../data/lovelace";
+import { LovelaceCardConfig, LovelaceConfig } from "../../../../data/lovelace";
 import { HomeAssistant } from "../../../../types";
 import { ConditionalCardConfig } from "../../cards/types";
 import { LovelaceCardEditor } from "../../types";
-import {
-  ConfigChangedEvent,
-  HuiCardEditor,
-} from "../card-editor/hui-card-editor";
 import "../card-editor/hui-card-picker";
+import "../hui-element-editor";
+import type {
+  ConfigChangedEvent,
+  HuiElementEditor,
+} from "../hui-element-editor";
 import { GUIModeChangedEvent } from "../types";
-import { string, any, object, optional, array, assert } from "superstruct";
+import { configElementStyle } from "./config-elements-style";
 
 const conditionStruct = object({
   entity: string(),
@@ -51,7 +53,7 @@ export class HuiConditionalCardEditor extends LitElement
 
   @internalProperty() private _cardTab = false;
 
-  @query("hui-card-editor") private _cardEditorEl?: HuiCardEditor;
+  @query("hui-element-editor") private _cardEditorEl?: HuiElementEditor;
 
   public setConfig(config: ConditionalCardConfig): void {
     assert(config, cardConfigStruct);
@@ -106,13 +108,13 @@ export class HuiConditionalCardEditor extends LitElement
                         )}</mwc-button
                       >
                     </div>
-                    <hui-card-editor
+                    <hui-element-editor
                       .hass=${this.hass}
                       .value=${this._config.card}
                       .lovelace=${this.lovelace}
                       @config-changed=${this._handleCardChanged}
                       @GUImode-changed=${this._handleGUIModeChanged}
-                    ></hui-card-editor>
+                    ></hui-element-editor>
                   `
                 : html`
                     <hui-card-picker
@@ -227,7 +229,10 @@ export class HuiConditionalCardEditor extends LitElement
     if (!this._config) {
       return;
     }
-    this._config = { ...this._config, card: ev.detail.config };
+    this._config = {
+      ...this._config,
+      card: ev.detail.config as LovelaceCardConfig,
+    };
     this._guiModeAvailable = ev.detail.guiModeAvailable;
     fireEvent(this, "config-changed", { config: this._config });
   }
@@ -292,52 +297,55 @@ export class HuiConditionalCardEditor extends LitElement
     fireEvent(this, "config-changed", { config: this._config });
   }
 
-  static get styles(): CSSResult {
-    return css`
-      paper-tabs {
-        --paper-tabs-selection-bar-color: var(--primary-color);
-        --paper-tab-ink: var(--primary-color);
-        border-bottom: 1px solid var(--divider-color);
-      }
-      .conditions {
-        margin-top: 8px;
-      }
-      .condition {
-        margin-top: 8px;
-        border: 1px solid var(--divider-color);
-        padding: 12px;
-      }
-      .condition .state {
-        display: flex;
-        align-items: flex-end;
-      }
-      .condition .state paper-dropdown-menu {
-        margin-right: 16px;
-      }
-      .condition .state paper-input {
-        flex-grow: 1;
-      }
-
-      .card {
-        margin-top: 8px;
-        border: 1px solid var(--divider-color);
-        padding: 12px;
-      }
-      @media (max-width: 450px) {
-        .card,
-        .condition {
-          margin: 8px -12px 0;
+  static get styles(): CSSResultArray {
+    return [
+      configElementStyle,
+      css`
+        paper-tabs {
+          --paper-tabs-selection-bar-color: var(--primary-color);
+          --paper-tab-ink: var(--primary-color);
+          border-bottom: 1px solid var(--divider-color);
         }
-      }
-      .card .card-options {
-        display: flex;
-        justify-content: flex-end;
-        width: 100%;
-      }
-      .gui-mode-button {
-        margin-right: auto;
-      }
-    `;
+        .conditions {
+          margin-top: 8px;
+        }
+        .condition {
+          margin-top: 8px;
+          border: 1px solid var(--divider-color);
+          padding: 12px;
+        }
+        .condition .state {
+          display: flex;
+          align-items: flex-end;
+        }
+        .condition .state paper-dropdown-menu {
+          margin-right: 16px;
+        }
+        .condition .state paper-input {
+          flex-grow: 1;
+        }
+
+        .card {
+          margin-top: 8px;
+          border: 1px solid var(--divider-color);
+          padding: 12px;
+        }
+        @media (max-width: 450px) {
+          .card,
+          .condition {
+            margin: 8px -12px 0;
+          }
+        }
+        .card .card-options {
+          display: flex;
+          justify-content: flex-end;
+          width: 100%;
+        }
+        .gui-mode-button {
+          margin-right: auto;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-card-editor.ts
@@ -1,5 +1,6 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
   internalProperty,
@@ -75,7 +76,6 @@ export class HuiEntityCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -185,6 +185,10 @@ export class HuiEntityCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -1,7 +1,7 @@
 import "@polymer/paper-input/paper-input";
 import {
   css,
-  CSSResult,
+  CSSResultArray,
   customElement,
   html,
   internalProperty,
@@ -81,7 +81,6 @@ export class HuiGaugeCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -197,23 +196,26 @@ export class HuiGaugeCardEditor extends LitElement
     `;
   }
 
-  static get styles(): CSSResult {
-    return css`
-      .severity {
-        display: none;
-        width: 100%;
-        padding-left: 16px;
-        flex-direction: row;
-        flex-wrap: wrap;
-      }
-      .severity > * {
-        flex: 1 0 30%;
-        padding-right: 4px;
-      }
-      ha-switch[checked] ~ .severity {
-        display: flex;
-      }
-    `;
+  static get styles(): CSSResultArray {
+    return [
+      configElementStyle,
+      css`
+        .severity {
+          display: none;
+          width: 100%;
+          padding-left: 16px;
+          flex-direction: row;
+          flex-wrap: wrap;
+        }
+        .severity > * {
+          flex: 1 0 30%;
+          padding-right: 4px;
+        }
+        ha-switch[checked] ~ .severity {
+          display: flex;
+        }
+      `,
+    ];
   }
 
   private _toggleSeverity(ev: EntitiesEditorEvent): void {

--- a/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
@@ -1,0 +1,173 @@
+import "@polymer/paper-input/paper-input";
+import {
+  CSSResult,
+  customElement,
+  html,
+  internalProperty,
+  LitElement,
+  property,
+  TemplateResult,
+} from "lit-element";
+import { assert } from "superstruct";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeDomain } from "../../../../common/entity/compute_domain";
+import { stateIcon } from "../../../../common/entity/state_icon";
+import "../../../../components/ha-formfield";
+import "../../../../components/ha-icon-input";
+import "../../../../components/ha-switch";
+import { HomeAssistant } from "../../../../types";
+import { EntitiesCardEntityConfig } from "../../cards/types";
+import "../../components/hui-action-editor";
+import "../../components/hui-entity-editor";
+import "../../components/hui-theme-select-editor";
+import { LovelaceRowEditor } from "../../types";
+import {
+  EditorTarget,
+  entitiesConfigStruct,
+  EntitiesEditorEvent,
+} from "../types";
+import { configElementStyle } from "./config-elements-style";
+
+const SecondaryInfoValues: { [key: string]: { domains?: string[] } } = {
+  "entity-id": {},
+  "last-changed": {},
+  "last-triggered": { domains: ["automation", "script"] },
+  position: { domains: ["cover"] },
+  "tilt-position": { domains: ["cover"] },
+  brightness: { domains: ["light"] },
+};
+
+@customElement("hui-generic-entity-row-editor")
+export class HuiGenericEntityRowEditor extends LitElement
+  implements LovelaceRowEditor {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @internalProperty() private _config?: EntitiesCardEntityConfig;
+
+  public setConfig(config: EntitiesCardEntityConfig): void {
+    assert(config, entitiesConfigStruct);
+    this._config = config;
+  }
+
+  get _entity(): string {
+    return this._config!.entity || "";
+  }
+
+  get _name(): string {
+    return this._config!.name || "";
+  }
+
+  get _icon(): string {
+    return this._config!.icon || "";
+  }
+
+  get _secondary_info(): string {
+    return this._config!.secondary_info || "";
+  }
+
+  protected render(): TemplateResult {
+    if (!this.hass || !this._config) {
+      return html``;
+    }
+
+    const domain = computeDomain(this._config.entity);
+
+    return html`
+      <div class="card-config">
+        <ha-entity-picker
+          allow-custom-entity
+          .hass=${this.hass}
+          .value=${this._config.entity}
+          .configValue=${"entity"}
+          @change=${this._valueChanged}
+        ></ha-entity-picker>
+        <div class="side-by-side">
+          <paper-input
+            .label=${this.hass!.localize(
+              "ui.panel.lovelace.editor.card.generic.name"
+            )}
+            .value=${this._config.name}
+            .configValue=${"name"}
+            @value-changed=${this._valueChanged}
+          ></paper-input>
+          <ha-icon-input
+            .label=${this.hass!.localize(
+              "ui.panel.lovelace.editor.card.generic.icon"
+            )}
+            .value=${this._config.icon}
+            .placeholder=${stateIcon(this.hass!.states[this._config.entity])}
+            .configValue=${"icon"}
+            @value-changed=${this._valueChanged}
+          ></ha-icon-input>
+        </div>
+        <paper-dropdown-menu .label=${"Secondary Info"}>
+          <paper-listbox
+            slot="dropdown-content"
+            attr-for-selected="value"
+            .selected=${this._config.secondary_info || "none"}
+            .configValue=${"secondary_info"}
+            @iron-select=${this._valueChanged}
+          >
+            <paper-item value=""
+              >${this.hass!.localize(
+                "ui.panel.lovelace.editor.card.entities.secondary_info_values.none"
+              )}</paper-item
+            >
+            ${Object.keys(SecondaryInfoValues).map((info) => {
+              if (
+                !("domains" in SecondaryInfoValues[info]) ||
+                ("domains" in SecondaryInfoValues[info] &&
+                  SecondaryInfoValues[info].domains!.includes(domain))
+              ) {
+                return html`
+                  <paper-item .value=${info}
+                    >${this.hass!.localize(
+                      `ui.panel.lovelace.editor.card.entities.secondary_info_values.${info}`
+                    )}</paper-item
+                  >
+                `;
+              }
+              return "";
+            })}
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </div>
+    `;
+  }
+
+  private _valueChanged(ev: EntitiesEditorEvent): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+    const target = ev.target! as EditorTarget;
+    const value = target.value || ev.detail?.item?.value;
+
+    if (this[`_${target.configValue}`] === value) {
+      return;
+    }
+
+    if (target.configValue) {
+      if (value === "" || !value) {
+        this._config = { ...this._config };
+        delete this._config[target.configValue!];
+      } else {
+        this._config = {
+          ...this._config,
+          [target.configValue!]: value,
+        };
+      }
+    }
+
+    fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-generic-entity-row-editor": HuiGenericEntityRowEditor;
+  }
+}

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -2,19 +2,31 @@ import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 import {
+  CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import {
+  array,
+  assert,
+  boolean,
+  number,
+  object,
+  optional,
+  string,
+  union,
+} from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 import "../../../../components/entity/state-badge";
 import "../../../../components/ha-card";
+import "../../../../components/ha-formfield";
 import "../../../../components/ha-icon";
 import "../../../../components/ha-switch";
-import "../../../../components/ha-formfield";
 import { HomeAssistant } from "../../../../types";
 import { ConfigEntity, GlanceCardConfig } from "../../cards/types";
 import "../../components/hui-entity-editor";
@@ -27,17 +39,6 @@ import {
   EntitiesEditorEvent,
 } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { computeRTLDirection } from "../../../../common/util/compute_rtl";
-import {
-  string,
-  union,
-  object,
-  optional,
-  number,
-  boolean,
-  assert,
-  array,
-} from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -102,7 +103,6 @@ export class HuiGlanceCardEditor extends LitElement
     const dir = computeRTLDirection(this.hass!);
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label="${this.hass.localize(
@@ -233,6 +233,10 @@ export class HuiGlanceCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
@@ -1,31 +1,32 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import {
+  array,
+  assert,
+  number,
+  object,
+  optional,
+  string,
+  union,
+} from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { HomeAssistant } from "../../../../types";
 import { HistoryGraphCardConfig } from "../../cards/types";
+import { EntityId } from "../../common/structs/is-entity-id";
 import "../../components/hui-entity-editor";
 import { EntityConfig } from "../../entity-rows/types";
 import { LovelaceCardEditor } from "../../types";
 import { processEditorEntities } from "../process-editor-entities";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import {
-  assert,
-  union,
-  optional,
-  string,
-  object,
-  array,
-  number,
-} from "superstruct";
-import { EntityId } from "../../common/structs/is-entity-id";
 
 const entitiesConfigStruct = union([
   object({
@@ -80,7 +81,6 @@ export class HuiHistoryGraphCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label="${this.hass.localize(
@@ -155,6 +155,10 @@ export class HuiHistoryGraphCardEditor extends LitElement
     }
 
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-humidifier-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-humidifier-card-editor.ts
@@ -1,12 +1,14 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import { assert, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
 import { HomeAssistant } from "../../../../types";
@@ -15,7 +17,6 @@ import "../../components/hui-theme-select-editor";
 import { LovelaceCardEditor } from "../../types";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { string, object, optional, assert } from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -56,7 +57,6 @@ export class HuiHumidifierCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -109,6 +109,10 @@ export class HuiHumidifierCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-iframe-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-iframe-card-editor.ts
@@ -1,19 +1,20 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import { assert, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { HomeAssistant } from "../../../../types";
 import { IframeCardConfig } from "../../cards/types";
 import { LovelaceCardEditor } from "../../types";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { string, assert, object, optional } from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -52,7 +53,6 @@ export class HuiIframeCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label="${this.hass.localize(
@@ -109,6 +109,10 @@ export class HuiIframeCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-light-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-light-card-editor.ts
@@ -1,5 +1,6 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
   internalProperty,
@@ -84,7 +85,6 @@ export class HuiLightCardEditor extends LitElement
     ];
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -182,6 +182,10 @@ export class HuiLightCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -1,15 +1,27 @@
 import "@polymer/paper-input/paper-input";
 import {
   css,
-  CSSResult,
+  CSSResultArray,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import {
+  array,
+  assert,
+  boolean,
+  number,
+  object,
+  optional,
+  string,
+} from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeRTLDirection } from "../../../../common/util/compute_rtl";
+import "../../../../components/ha-formfield";
+import "../../../../components/ha-switch";
 import { PolymerChangedEvent } from "../../../../polymer-types";
 import { HomeAssistant } from "../../../../types";
 import { MapCardConfig } from "../../cards/types";
@@ -23,19 +35,7 @@ import {
   entitiesConfigStruct,
   EntitiesEditorEvent,
 } from "../types";
-import "../../../../components/ha-switch";
-import "../../../../components/ha-formfield";
 import { configElementStyle } from "./config-elements-style";
-import { computeRTLDirection } from "../../../../common/util/compute_rtl";
-import {
-  string,
-  optional,
-  object,
-  number,
-  boolean,
-  array,
-  assert,
-} from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -94,7 +94,6 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label="${this.hass.localize(
@@ -216,12 +215,15 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     fireEvent(this, "config-changed", { config: this._config });
   }
 
-  static get styles(): CSSResult {
-    return css`
-      .geo_location_sources {
-        padding-left: 20px;
-      }
-    `;
+  static get styles(): CSSResultArray {
+    return [
+      configElementStyle,
+      css`
+        .geo_location_sources {
+          padding-left: 20px;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-markdown-card-editor.ts
@@ -1,13 +1,15 @@
 import "@polymer/paper-input/paper-input";
 import "@polymer/paper-input/paper-textarea";
 import {
+  CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import { assert, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { HomeAssistant } from "../../../../types";
 import { MarkdownCardConfig } from "../../cards/types";
@@ -15,7 +17,6 @@ import "../../components/hui-theme-select-editor";
 import { LovelaceCardEditor } from "../../types";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { string, assert, object, optional } from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -54,7 +55,6 @@ export class HuiMarkdownCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label="${this.hass.localize(
@@ -115,6 +115,10 @@ export class HuiMarkdownCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
@@ -1,5 +1,6 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
   internalProperty,
@@ -62,7 +63,6 @@ export class HuiPictureCardEditor extends LitElement
     const actions = ["navigate", "url", "call-service", "none"];
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label="${this.hass.localize(
@@ -132,6 +132,10 @@ export class HuiPictureCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
@@ -3,6 +3,7 @@ import "@polymer/paper-input/paper-input";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 import {
+  CSSResult,
   customElement,
   html,
   internalProperty,
@@ -108,7 +109,6 @@ export class HuiPictureEntityCardEditor extends LitElement
     const dir = computeRTLDirection(this.hass!);
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -292,6 +292,10 @@ export class HuiPictureEntityCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
@@ -3,6 +3,7 @@ import "@polymer/paper-input/paper-input";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 import {
+  CSSResult,
   customElement,
   html,
   internalProperty,
@@ -111,7 +112,6 @@ export class HuiPictureGlanceCardEditor extends LitElement
     const views = ["auto", "live"];
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label="${this.hass.localize(
@@ -256,6 +256,10 @@ export class HuiPictureGlanceCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-plant-status-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-plant-status-card-editor.ts
@@ -1,12 +1,14 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import { assert, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
 import "../../../../components/ha-icon";
@@ -16,7 +18,6 @@ import "../../components/hui-theme-select-editor";
 import { LovelaceCardEditor } from "../../types";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { assert, object, string, optional } from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -57,7 +58,6 @@ export class HuiPlantStatusCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -112,6 +112,10 @@ export class HuiPlantStatusCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-sensor-card-editor.ts
@@ -3,6 +3,7 @@ import "@polymer/paper-input/paper-input";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
 import {
+  CSSResult,
   customElement,
   html,
   internalProperty,
@@ -90,7 +91,6 @@ export class HuiSensorCardEditor extends LitElement
     const graphs = ["line", "none"];
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -237,6 +237,10 @@ export class HuiSensorCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
@@ -1,4 +1,3 @@
-import "../../../../components/ha-icon-button";
 import "@polymer/paper-tabs";
 import "@polymer/paper-tabs/paper-tab";
 import {
@@ -6,24 +5,26 @@ import {
   CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   query,
   TemplateResult,
 } from "lit-element";
+import { any, array, assert, object, optional, string } from "superstruct";
 import { fireEvent, HASSDomEvent } from "../../../../common/dom/fire_event";
-import { LovelaceConfig } from "../../../../data/lovelace";
+import "../../../../components/ha-icon-button";
+import { LovelaceCardConfig, LovelaceConfig } from "../../../../data/lovelace";
 import { HomeAssistant } from "../../../../types";
 import { StackCardConfig } from "../../cards/types";
 import { LovelaceCardEditor } from "../../types";
-import {
-  ConfigChangedEvent,
-  HuiCardEditor,
-} from "../card-editor/hui-card-editor";
 import "../card-editor/hui-card-picker";
+import "../hui-element-editor";
+import type {
+  ConfigChangedEvent,
+  HuiElementEditor,
+} from "../hui-element-editor";
 import { GUIModeChangedEvent } from "../types";
-import { assert, object, string, array, any, optional } from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -46,7 +47,7 @@ export class HuiStackCardEditor extends LitElement
 
   @internalProperty() private _guiModeAvailable? = true;
 
-  @query("hui-card-editor") private _cardEditorEl?: HuiCardEditor;
+  @query("hui-element-editor") private _cardEditorEl?: HuiElementEditor;
 
   public setConfig(config: Readonly<StackCardConfig>): void {
     assert(config, cardConfigStruct);
@@ -128,13 +129,13 @@ export class HuiStackCardEditor extends LitElement
                   ></ha-icon-button>
                 </div>
 
-                <hui-card-editor
+                <hui-element-editor
                   .hass=${this.hass}
                   .value=${this._config.cards[selected]}
                   .lovelace=${this.lovelace}
                   @config-changed=${this._handleConfigChanged}
                   @GUImode-changed=${this._handleGUIModeChanged}
-                ></hui-card-editor>
+                ></hui-element-editor>
               `
             : html`
                 <hui-card-picker
@@ -164,7 +165,7 @@ export class HuiStackCardEditor extends LitElement
       return;
     }
     const cards = [...this._config.cards];
-    cards[this._selectedCard] = ev.detail.config;
+    cards[this._selectedCard] = ev.detail.config as LovelaceCardConfig;
     this._config = { ...this._config, cards };
     this._guiModeAvailable = ev.detail.guiModeAvailable;
     fireEvent(this, "config-changed", { config: this._config });

--- a/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
@@ -1,12 +1,14 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import { assert, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
 import { HomeAssistant } from "../../../../types";
@@ -15,7 +17,6 @@ import "../../components/hui-theme-select-editor";
 import { LovelaceCardEditor } from "../../types";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { object, string, optional, assert } from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -56,7 +57,6 @@ export class HuiThermostatCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -109,6 +109,10 @@ export class HuiThermostatCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -1,23 +1,24 @@
 import {
+  CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
+import { assert, boolean, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 import "../../../../components/entity/ha-entity-picker";
-import "../../../../components/ha-switch";
 import "../../../../components/ha-formfield";
+import "../../../../components/ha-switch";
 import { HomeAssistant } from "../../../../types";
 import { WeatherForecastCardConfig } from "../../cards/types";
 import "../../components/hui-theme-select-editor";
 import { LovelaceCardEditor } from "../../types";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { computeRTLDirection } from "../../../../common/util/compute_rtl";
-import { object, string, optional, boolean, assert } from "superstruct";
 
 const cardConfigStruct = object({
   type: string(),
@@ -68,7 +69,6 @@ export class HuiWeatherForecastCardEditor extends LitElement
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <ha-entity-picker
           .label="${this.hass.localize(
@@ -150,6 +150,10 @@ export class HuiWeatherForecastCardEditor extends LitElement
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/hui-detail-editor-base.ts
+++ b/src/panels/lovelace/editor/hui-detail-editor-base.ts
@@ -1,0 +1,86 @@
+import "@material/mwc-button";
+import "@material/mwc-icon-button";
+import { mdiArrowLeft } from "@mdi/js";
+import {
+  css,
+  CSSResult,
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from "lit-element";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-svg-icon";
+import { HomeAssistant } from "../../../types";
+
+declare global {
+  interface HASSDomEvents {
+    "go-back": undefined;
+    "toggle-gui-mode": undefined;
+  }
+}
+
+@customElement("hui-detail-editor-base")
+export class HuiDetailEditorBase extends LitElement {
+  public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public guiModeAvailable? = true;
+
+  @property({ type: Boolean }) public guiMode? = true;
+
+  protected render(): TemplateResult {
+    return html`
+      <div class="header">
+        <div class="back-title">
+          <mwc-icon-button @click=${this._goBack}>
+            <ha-svg-icon .path=${mdiArrowLeft}></ha-svg-icon>
+          </mwc-icon-button>
+          <slot name="title"></slot>
+        </div>
+        <mwc-button
+          slot="secondaryAction"
+          class="gui-mode-button"
+          .disabled=${!this.guiModeAvailable}
+          @click=${this._toggleMode}
+        >
+          ${this.hass.localize(
+            this.guiMode
+              ? "ui.panel.lovelace.editor.edit_card.show_code_editor"
+              : "ui.panel.lovelace.editor.edit_card.show_visual_editor"
+          )}
+        </mwc-button>
+      </div>
+      <slot></slot>
+    `;
+  }
+
+  private _goBack(): void {
+    fireEvent(this, "go-back");
+  }
+
+  private _toggleMode(): void {
+    fireEvent(this, "toggle-gui-mode");
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .back-title {
+        display: flex;
+        align-items: center;
+        font-size: 18px;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-detail-editor-base": HuiDetailEditorBase;
+  }
+}

--- a/src/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -1,4 +1,5 @@
-import { mdiClose, mdiDrag } from "@mdi/js";
+import "@material/mwc-icon-button";
+import { mdiClose, mdiDrag, mdiPencil } from "@mdi/js";
 import {
   css,
   CSSResult,
@@ -19,7 +20,7 @@ import Sortable, {
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/ha-entity-picker";
 import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
-import "../../../components/ha-icon-button";
+import "../../../components/ha-svg-icon";
 import { sortableStyles } from "../../../resources/ha-sortable-style";
 import { HomeAssistant } from "../../../types";
 import { EntityConfig, LovelaceRowConfig } from "../entity-rows/types";
@@ -85,26 +86,38 @@ export class HuiEntitiesCardRowEditor extends LitElement {
                                 )}</span
                               >
                             </div>
-                            <mwc-icon-button
-                              aria-label=${this.hass!.localize(
-                                "ui.components.entity.entity-picker.clear"
-                              )}
-                              .index=${index}
-                              @click=${this._removeSpecialRow}
-                            >
-                              <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
-                            </mwc-icon-button>
                           </div>
                         `
                       : html`
                           <ha-entity-picker
                             allow-custom-entity
+                            hideClearIcon
                             .hass=${this.hass}
                             .value=${(entityConf as EntityConfig).entity}
                             .index=${index}
                             @value-changed=${this._valueChanged}
                           ></ha-entity-picker>
                         `}
+                    <mwc-icon-button
+                      aria-label=${this.hass!.localize(
+                        "ui.components.entity.entity-picker.clear"
+                      )}
+                      class="remove-icon"
+                      .index=${index}
+                      @click=${this._removeRow}
+                    >
+                      <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
+                    </mwc-icon-button>
+                    <mwc-icon-button
+                      aria-label=${this.hass!.localize(
+                        "ui.components.entity.entity-picker.edit"
+                      )}
+                      class="edit-icon"
+                      .index=${index}
+                      @click=${this._editRow}
+                    >
+                      <ha-svg-icon .path=${mdiPencil}></ha-svg-icon>
+                    </mwc-icon-button>
                   </div>
                 `;
               })
@@ -164,7 +177,7 @@ export class HuiEntitiesCardRowEditor extends LitElement {
       animation: 150,
       fallbackClass: "sortable-fallback",
       handle: ".handle",
-      onEnd: async (evt: SortableEvent) => this._entityMoved(evt),
+      onEnd: async (evt: SortableEvent) => this._rowMoved(evt),
     });
   }
 
@@ -180,7 +193,7 @@ export class HuiEntitiesCardRowEditor extends LitElement {
     fireEvent(this, "entities-changed", { entities: newConfigEntities });
   }
 
-  private _entityMoved(ev: SortableEvent): void {
+  private _rowMoved(ev: SortableEvent): void {
     if (ev.oldIndex === ev.newIndex) {
       return;
     }
@@ -192,7 +205,7 @@ export class HuiEntitiesCardRowEditor extends LitElement {
     fireEvent(this, "entities-changed", { entities: newEntities });
   }
 
-  private _removeSpecialRow(ev: CustomEvent): void {
+  private _removeRow(ev: CustomEvent): void {
     const index = (ev.currentTarget as any).index;
     const newConfigEntities = this.entities!.concat();
 
@@ -218,6 +231,12 @@ export class HuiEntitiesCardRowEditor extends LitElement {
     fireEvent(this, "entities-changed", { entities: newConfigEntities });
   }
 
+  private _editRow(ev: CustomEvent): void {
+    fireEvent(this, "edit-row", {
+      index: (ev.currentTarget as any).index,
+    });
+  }
+
   static get styles(): CSSResult[] {
     return [
       sortableStyles,
@@ -226,13 +245,16 @@ export class HuiEntitiesCardRowEditor extends LitElement {
           display: flex;
           align-items: center;
         }
+
         .entity .handle {
           padding-right: 8px;
           cursor: move;
         }
+
         .entity ha-entity-picker {
           flex-grow: 1;
         }
+
         .special-row {
           height: 60px;
           font-size: 16px;
@@ -247,7 +269,8 @@ export class HuiEntitiesCardRowEditor extends LitElement {
           flex-direction: column;
         }
 
-        .special-row mwc-icon-button {
+        .remove-icon,
+        .edit-icon {
           --mdc-icon-button-size: 36px;
           color: var(--secondary-text-color);
         }

--- a/src/panels/lovelace/editor/lovelace-editor/hui-lovelace-editor.ts
+++ b/src/panels/lovelace/editor/lovelace-editor/hui-lovelace-editor.ts
@@ -1,5 +1,6 @@
 import "@polymer/paper-input/paper-input";
 import {
+  CSSResult,
   customElement,
   html,
   LitElement,
@@ -35,7 +36,6 @@ export class HuiLovelaceEditor extends LitElement {
 
   protected render(): TemplateResult {
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label=${this.hass.localize(
@@ -70,6 +70,10 @@ export class HuiLovelaceEditor extends LitElement {
     }
 
     fireEvent(this, "lovelace-config-changed", { config: newConfig });
+  }
+
+  static get styles(): CSSResult {
+    return configElementStyle;
   }
 }
 

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -2,6 +2,7 @@ import {
   any,
   array,
   boolean,
+  number,
   object,
   optional,
   string,
@@ -13,8 +14,6 @@ import {
   LovelaceViewConfig,
   ShowViewConfig,
 } from "../../../data/lovelace";
-import { EntityId } from "../common/structs/is-entity-id";
-import { Icon } from "../common/structs/is-icon";
 import { EntityConfig } from "../entity-rows/types";
 
 export interface YamlChangedEvent extends Event {
@@ -51,6 +50,7 @@ export interface ConfigError {
 export interface EntitiesEditorEvent {
   detail?: {
     entities?: EntityConfig[];
+    item?: any;
   };
   target?: EventTarget;
 }
@@ -95,19 +95,19 @@ const buttonEntitiesRowConfigStruct = object({
 
 const castEntitiesRowConfigStruct = object({
   type: string(),
-  view: string(),
+  view: union([string(), number()]),
   dashboard: optional(string()),
   name: optional(string()),
   icon: optional(string()),
-  hide_if_unavailable: optional(string()),
+  hide_if_unavailable: optional(boolean()),
 });
 
 const callServiceEntitiesRowConfigStruct = object({
   type: string(),
   name: string(),
+  service: string(),
   icon: optional(string()),
   action_name: optional(string()),
-  service: string(),
   service_data: optional(any()),
 });
 
@@ -150,7 +150,7 @@ const buttonsEntitiesRowConfigStruct = object({
         image: optional(string()),
         name: optional(string()),
       }),
-      EntityId,
+      string(),
     ])
   ),
 });
@@ -166,9 +166,9 @@ const attributeEntitiesRowConfigStruct = object({
 
 export const entitiesConfigStruct = union([
   object({
-    entity: EntityId,
+    entity: string(),
     name: optional(string()),
-    icon: optional(Icon),
+    icon: optional(string()),
     image: optional(string()),
     secondary_info: optional(string()),
     format: optional(string()),
@@ -177,7 +177,7 @@ export const entitiesConfigStruct = union([
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),
   }),
-  EntityId,
+  string(),
   buttonEntitiesRowConfigStruct,
   castEntitiesRowConfigStruct,
   conditionalEntitiesRowConfigStruct,

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -1,25 +1,25 @@
 import "@polymer/paper-input/paper-input";
 import {
   css,
-  CSSResult,
+  CSSResultArray,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   TemplateResult,
 } from "lit-element";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { slugify } from "../../../../common/string/slugify";
-import "../../../../components/ha-switch";
+import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 import "../../../../components/ha-formfield";
 import "../../../../components/ha-icon-input";
+import "../../../../components/ha-switch";
 import { LovelaceViewConfig } from "../../../../data/lovelace";
 import { HomeAssistant } from "../../../../types";
 import "../../components/hui-theme-select-editor";
 import { configElementStyle } from "../config-elements/config-elements-style";
 import { EditorTarget } from "../types";
-import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 
 declare global {
   interface HASSDomEvents {
@@ -84,7 +84,6 @@ export class HuiViewEditor extends LitElement {
     }
 
     return html`
-      ${configElementStyle}
       <div class="card-config">
         <paper-input
           .label="${this.hass.localize(
@@ -182,13 +181,16 @@ export class HuiViewEditor extends LitElement {
     fireEvent(this, "view-config-changed", { config });
   }
 
-  static get styles(): CSSResult {
-    return css`
-      .panel {
-        color: var(--secondary-text-color);
-        display: block;
-      }
-    `;
+  static get styles(): CSSResultArray {
+    return [
+      configElementStyle,
+      css`
+        .panel {
+          color: var(--secondary-text-color);
+          display: block;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -5,7 +5,6 @@ import {
   LitElement,
   property,
   internalProperty,
-  PropertyValues,
   TemplateResult,
 } from "lit-element";
 import { domainToName } from "../../data/integration";
@@ -46,16 +45,12 @@ class LovelacePanel extends LitElement {
 
   @property() public route?: Route;
 
-  @internalProperty() private _columns?: number;
-
   @property()
   private _state?: "loading" | "loaded" | "error" | "yaml-editor" = "loading";
 
   @internalProperty() private _errorMsg?: string;
 
   @internalProperty() private lovelace?: Lovelace;
-
-  private mqls?: MediaQueryList[];
 
   private _ignoreNextUpdateEvent = false;
 
@@ -105,7 +100,6 @@ class LovelacePanel extends LitElement {
           .hass=${this.hass}
           .lovelace=${this.lovelace}
           .route=${this.route}
-          .columns=${this._columns}
           .narrow=${this.narrow}
           @config-refresh=${this._forceFetchConfig}
         ></hui-root>
@@ -144,25 +138,6 @@ class LovelacePanel extends LitElement {
     `;
   }
 
-  protected updated(changedProps: PropertyValues): void {
-    super.updated(changedProps);
-
-    if (changedProps.has("narrow")) {
-      this._updateColumns();
-      return;
-    }
-
-    if (!changedProps.has("hass")) {
-      return;
-    }
-
-    const oldHass = changedProps.get("hass") as this["hass"];
-
-    if (oldHass && this.hass!.dockedSidebar !== oldHass.dockedSidebar) {
-      this._updateColumns();
-    }
-  }
-
   protected firstUpdated() {
     this._fetchConfig(false);
     if (!this._unsubUpdates) {
@@ -174,13 +149,6 @@ class LovelacePanel extends LitElement {
         this._fetchConfig(false);
       }
     });
-    this._updateColumns = this._updateColumns.bind(this);
-    this.mqls = [300, 600, 900, 1200].map((width) => {
-      const mql = matchMedia(`(min-width: ${width}px)`);
-      mql.addListener(this._updateColumns);
-      return mql;
-    });
-    this._updateColumns();
   }
 
   private async _regenerateConfig() {
@@ -199,19 +167,6 @@ class LovelacePanel extends LitElement {
 
   private _closeEditor() {
     this._state = "loaded";
-  }
-
-  private _updateColumns() {
-    const matchColumns = this.mqls!.reduce(
-      (cols, mql) => cols + Number(mql.matches),
-      0
-    );
-    // Do -1 column if the menu is docked and open
-    this._columns = Math.max(
-      1,
-      matchColumns -
-        Number(!this.narrow && this.hass!.dockedSidebar === "docked")
-    );
   }
 
   private _lovelaceChanged() {

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -4,6 +4,7 @@ import {
   LovelaceConfig,
 } from "../../data/lovelace";
 import { Constructor, HomeAssistant } from "../../types";
+import { LovelaceRow, LovelaceRowConfig } from "./entity-rows/types";
 import { LovelaceHeaderFooterConfig } from "./header-footer/types";
 
 declare global {
@@ -48,6 +49,10 @@ export interface LovelaceCardConstructor extends Constructor<LovelaceCard> {
   getConfigElement?: () => LovelaceCardEditor;
 }
 
+export interface LovelaceRowConstructor extends Constructor<LovelaceRow> {
+  getConfigElement?: () => LovelaceRowEditor;
+}
+
 export interface LovelaceHeaderFooter extends HTMLElement {
   hass?: HomeAssistant;
   getCardSize(): number | Promise<number>;
@@ -58,5 +63,11 @@ export interface LovelaceCardEditor extends HTMLElement {
   hass?: HomeAssistant;
   lovelace?: LovelaceConfig;
   setConfig(config: LovelaceCardConfig): void;
+  refreshYamlEditor?: (focus: boolean) => void;
+}
+
+export interface LovelaceRowEditor extends HTMLElement {
+  hass?: HomeAssistant;
+  setConfig(config: LovelaceRowConfig): void;
   refreshYamlEditor?: (focus: boolean) => void;
 }

--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -98,11 +98,13 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
   }
 
   protected firstUpdated(): void {
+    this._updateColumns = this._updateColumns.bind(this);
     this._mqls = [300, 600, 900, 1200].map((width) => {
       const mql = matchMedia(`(min-width: ${width}px)`);
       mql.addEventListener("change", this._updateColumns);
       return mql;
     });
+    this._updateColumns();
   }
 
   protected updated(changedProperties: PropertyValues): void {
@@ -130,11 +132,14 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
       }
     }
 
-    const oldLovelace = changedProperties.get("lovelace") as Lovelace;
+    const oldLovelace = changedProperties.get("lovelace") as
+      | Lovelace
+      | undefined;
 
     if (
-      oldLovelace?.config !== this.lovelace?.config ||
-      oldLovelace?.editMode !== this.lovelace?.editMode ||
+      (changedProperties.has("lovelace") && (
+        oldLovelace?.config !== this.lovelace?.config ||
+        oldLovelace?.editMode !== this.lovelace?.editMode)) ||
       changedProperties.has("_columns")
     ) {
       this._createColumns();
@@ -237,6 +242,9 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
   }
 
   private _updateColumns() {
+    if (!this._mqls) {
+      return;
+    }
     const matchColumns = this._mqls!.reduce(
       (cols, mql) => cols + Number(mql.matches),
       0
@@ -260,6 +268,8 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
         display: flex;
         flex-direction: row;
         justify-content: center;
+        margin-left: 4px;
+        margin-right: 4px;
       }
 
       .column {
@@ -288,11 +298,6 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
       }
 
       @media (max-width: 500px) {
-        :host {
-          padding-left: 0;
-          padding-right: 0;
-        }
-
         .column > * {
           margin-left: 0;
           margin-right: 0;

--- a/src/panels/lovelace/views/hui-panel-view.ts
+++ b/src/panels/lovelace/views/hui-panel-view.ts
@@ -57,7 +57,13 @@ export class PanelView extends LitElement implements LovelaceViewElement {
       );
     }
 
-    const oldLovelace = changedProperties.get("lovelace") as Lovelace;
+    if (!changedProperties.has("lovelace")) {
+      return;
+    }
+
+    const oldLovelace = changedProperties.get("lovelace") as
+      | Lovelace
+      | undefined;
 
     if (
       oldLovelace?.config !== this.lovelace?.config ||

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -86,6 +86,7 @@ export const derivedStyles = {
   "mdc-radio-disabled-color": "var(--disabled-text-color)",
   "mdc-tab-text-label-color-default": "var(--primary-text-color)",
   "mdc-button-disabled-ink-color": "var(--disabled-text-color)",
+  "mdc-dialog-scroll-divider-color": "var(--divider-color)",
 };
 
 export const haStyle = css`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2331,6 +2331,16 @@
               "description": "The Entities card is the most common type of card. It groups items together into lists.",
               "special_row": "special row",
               "edit_special_row": "Edit row using the code editor",
+              "entity_row_editor": "Entity Row Editor",
+              "secondary_info_values": {
+                "none": "No Secondary Info",
+                "entity-id": "Entity ID",
+                "last-changed": "Last Changed",
+                "last-triggered": "Last Triggered",
+                "position": "Position",
+                "tilt-position": "Tilt Position",
+                "brightness": "Brightness"
+              },
               "entity_row": {
                 "divider": "Divider",
                 "call-service": "Call Service",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1656,7 +1656,10 @@
             "device_tracker_pick": "Pick device to track",
             "delete": "Delete",
             "create": "Create",
-            "update": "Update"
+            "update": "Update",
+            "confirm_delete_user": "Are you sure you want to delete the user account for {name}? You can still track the user, but the person will no longer be able to login.",
+            "admin": "[%key:ui::panel::config::users::editor::admin%]",
+            "allow_login": "Allow person to login"
           }
         },
         "zone": {
@@ -1676,7 +1679,7 @@
             "new_zone": "New Zone",
             "name": "Name",
             "icon": "Icon",
-            "icon_error_msg": "Icon should be in the format prefix:iconname, for example: mdi:home",
+            "icon_error_msg": "Icon should be in the format ''prefix:iconname'', for example: ''mdi:home''",
             "radius": "Radius",
             "latitude": "Latitude",
             "longitude": "Longitude",


### PR DESCRIPTION
## What's Changed

* Set correct type for setConfig (#7173) @zsarnett
* Set logbook border to divider color (#7172) @bramkragten
* Fix updating columns (#7171) @bramkragten
* Entities Card: Entity Row Editor (#7134) @zsarnett
* Integrate user management in person (#7170) @bramkragten
* Change exoplayer payload type (#7010) @uvjustin
* Remove scooter from icon deprecation (#7169) @ludeeus
* 20200930.0 (#7168) @bramkragten
* Custom Lovelace View Layouts (#6557) @zsarnett
* Fix safari issues and move scrollable to own container (#7029) @bramkragten
* Add media player to cast app (#7160) @bramkragten
* Logbook: Localize Message & Style updates (#6978) @zsarnett
* Expand error msg on why yaml defined entities can't be changed from UI (#6689) @mrand
* Use ieee for zha.remove service data (#7163) @Adminiuga
* Calendar Card: Fix Calendar not updating events on config change (#7165) @zsarnett
* Add default to action editor (#7006) @zsarnett
* Add last_updated tooltip to more info dialog (#6926) @pszafer
* Add unit_of_measurement to input-number-entity-row (#6965) @ludeeus
* Restore snapshot from onboarding (#7132) @ludeeus
* More-Info Dialog Logbook Bug Fix (#7152) @Brahmah
* Change "persons" to "people" (#7037) @sampl
* Hide rpi_power entry during onboarding (#7001) @MartinHjelmare
* Add timeout to dev template renders (#7141) @bdraco
* Bring back lazy load more info + helper (#7131) @bramkragten
* Add --ha-card-border-width (#7021) @KTibow
* Add weekday to time contidion editor  (#6848) @Misiu
* Calendar Card: Initial View Editor (#7135) @zsarnett
* Allow initial View in Calendar Card (#6982) @zsarnett
* Add upload snapshot dialog (#7115) @ludeeus
* Added icon for power device class  (#7124) @chemelli74
* Card Editor: Special Row doesn't show warning (#7093) @zsarnett
* Add humidifier entity row (#6213) @Shulyaka
* Support twice daily forecasts in weather-forecast-card (#6065) @rajlaud
* Humidifier icon for off state (#7113) @Shulyaka
* Merge ha-paper-slider into ha-slider (#7114) @thomasloven
* Added icon for timestamp device class (#7117) @chemelli74
* Prevent deletion of the owner user (#7116) @ludeeus
* cloud-webhooks cleanup (#7118) @ludeeus
* Adds hassio-system-metrics (#7105) @ludeeus
* Fix sensor card from not working with detail (#7060) @zsarnett
* Show message when there are no add-ons (#7101) @ludeeus
* Optimize images (#7091) @nvllsvm
* Use absolute URL for background image in media-control card (#7100) @thomasloven
* Update Material Design Icons to v5.6.55 (#7081) @goyney
* fix media icon diff (#7071) @zsarnett
* Fix for NOT IN / IN Operators (#7061) @b3nj1
* Add actions to entities config struct (#7063) @zsarnett
* Add Hours to show to the cache key (#7072) @zsarnett
* Fix outline on mouseover in firefox (#7052) @thomasloven
* Adopt --code-font-family (#6997) @KTibow
* Media Player Browser: Fix child names add tooltip (#7020) @zsarnett