### PR TITLE
Show error if no OZW instances are detected

### DIFF
--- a/src/panels/config/integrations/integration-panels/ozw/ozw-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-config-dashboard.ts
@@ -29,6 +29,7 @@ import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../../../types";
 import "../../../ha-config-section";
 import "../../../../../layouts/hass-error-screen";
+import "../../../../../layouts/hass-loading-screen";
 
 export const ozwTabs: PageNavigation[] = [];
 
@@ -44,16 +45,18 @@ class OZWConfigDashboard extends LitElement {
 
   @property() public configEntryId?: string;
 
-  @internalProperty() private _instances: OZWInstance[] = [];
-
-  @internalProperty() private _firstFetch = false;
+  @internalProperty() private _instances?: OZWInstance[];
 
   protected firstUpdated() {
     this._fetchData();
   }
 
   protected render(): TemplateResult {
-    if (this._instances.length === 0 && this._firstFetch) {
+    if (!this._instances) {
+      return html`<hass-loading-screen></hass-loading-screen>`;
+    }
+
+    if (this._instances && this._instances.length === 0) {
       return html`<hass-error-screen
         .error="${this.hass.localize(
           "ui.panel.config.ozw.select_instance.none_found"
@@ -147,7 +150,6 @@ class OZWConfigDashboard extends LitElement {
 
   private async _fetchData() {
     this._instances = await fetchOZWInstances(this.hass!);
-    this._firstFetch = true;
     if (this._instances.length === 1) {
       navigate(
         this,

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-config-dashboard.ts
@@ -56,7 +56,7 @@ class OZWConfigDashboard extends LitElement {
       return html`<hass-loading-screen></hass-loading-screen>`;
     }
 
-    if (this._instances && this._instances.length === 0) {
+    if (this._instances.length === 0) {
       return html`<hass-error-screen
         .error="${this.hass.localize(
           "ui.panel.config.ozw.select_instance.none_found"

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-config-dashboard.ts
@@ -28,6 +28,7 @@ import type { PageNavigation } from "../../../../../layouts/hass-tabs-subpage";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../../../types";
 import "../../../ha-config-section";
+import "../../../../../layouts/hass-error-screen";
 
 export const ozwTabs: PageNavigation[] = [];
 
@@ -45,11 +46,21 @@ class OZWConfigDashboard extends LitElement {
 
   @internalProperty() private _instances: OZWInstance[] = [];
 
+  @internalProperty() private _firstFetch = false;
+
   protected firstUpdated() {
     this._fetchData();
   }
 
   protected render(): TemplateResult {
+    if (this._instances.length === 0 && this._firstFetch) {
+      return html`<hass-error-screen
+        .error="${this.hass.localize(
+          "ui.panel.config.ozw.select_instance.none_found"
+        )}"
+      ></hass-error-screen>`;
+    }
+
     return html`
       <hass-tabs-subpage
         .hass=${this.hass}
@@ -136,6 +147,7 @@ class OZWConfigDashboard extends LitElement {
 
   private async _fetchData() {
     this._instances = await fetchOZWInstances(this.hass!);
+    this._firstFetch = true;
     if (this._instances.length === 1) {
       navigate(
         this,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1894,7 +1894,8 @@
           },
           "select_instance": {
             "header": "Select an OpenZWave Instance",
-            "introduction": "You have more than one OpenZWave instance running. Which instance would you like to manage?"
+            "introduction": "You have more than one OpenZWave instance running. Which instance would you like to manage?",
+            "none_found": "No OpenZWave instances were found. Please make sure the OpenZWave daemon and your MQTT broker are running."
           },
           "network": {
             "header": "Network Management",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1895,7 +1895,7 @@
           "select_instance": {
             "header": "Select an OpenZWave Instance",
             "introduction": "You have more than one OpenZWave instance running. Which instance would you like to manage?",
-            "none_found": "No OpenZWave instances were found. Please make sure the OpenZWave daemon and your MQTT broker are running."
+            "none_found": "We couldn't find an OpenZWave instance. If you believe this is incorrect, check your OpenZWave and MQTT setups and ensure that Home Assistant can communicate with your MQTT broker."
           },
           "network": {
             "header": "Network Management",


### PR DESCRIPTION
## Proposed change
Currently the OZW config panel shows a "Select an OpenZWave Instance" page with nothing to select if there are no instances detected (like if MQTT is offline). This PR updates the panel to show an error page instead. Error message suggested by @masonevans


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7088
- This PR is related to issue: https://github.com/home-assistant/core/issues/4073
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
