### PR TITLE
Sort profile refresh tokens by 'last used at' date (#4484)

### DIFF
--- a/src/panels/profile/ha-refresh-tokens-card.ts
+++ b/src/panels/profile/ha-refresh-tokens-card.ts
@@ -24,6 +24,18 @@ import {
 import { haStyle } from "../../resources/styles";
 import { HomeAssistant } from "../../types";
 
+const compareTokenLastUsedAt = (tokenA: RefreshToken, tokenB: RefreshToken) => {
+  const timeA = tokenA.last_used_at ? new Date(tokenA.last_used_at) : 0;
+  const timeB = tokenB.last_used_at ? new Date(tokenB.last_used_at) : 0;
+  if (timeA < timeB) {
+    return 1;
+  } 
+  if (timeA > timeB) {
+    return -1;
+  }
+  return 0;
+}
+
 @customElement("ha-refresh-tokens-card")
 class HaRefreshTokens extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -32,7 +44,7 @@ class HaRefreshTokens extends LitElement {
 
   private _refreshTokens = memoizeOne(
     (refreshTokens: RefreshToken[]): RefreshToken[] =>
-      refreshTokens?.filter((token) => token.type === "normal").reverse()
+      refreshTokens?.filter((token) => token.type === "normal").sort(compareTokenLastUsedAt)
   );
 
   protected render(): TemplateResult {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The user profile page lists are tokens created by/used by said user. It's a bit of a mess when trying to find tokens that were recently used (and clearing out older tokens). This change sorts in ascending order the tokens by their `last used at` date.

Previously there was no sorting mechanism (although it was sorted by chance with `created dated` it appears).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

No configuration change needed.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4484

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- ~Documentation added/updated for [www.home-assistant.io][docs-repository]~ No configuration change needed.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
