### PR TITLE
Edit Person button in the Person "more info" dialog (fixes #4706)

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -40,7 +40,14 @@ import "./ha-more-info-logbook";
 import "./controls/more-info-default";
 
 const DOMAINS_NO_INFO = ["camera", "configurator"];
-const EDITABLE_DOMAINS_WITH_ID = ["scene", "automation", "person"];
+/**
+ * Entity domains that should be editable *if* they have an id present;
+ * {@see shouldShowEditIcon}.
+ * */
+const EDITABLE_DOMAINS_WITH_ID = ["scene", "automation"];
+/**
+ * Entity Domains that should always be editable; {@see shouldShowEditIcon}.
+ * */
 const EDITABLE_DOMAINS = ["script"];
 
 export interface MoreInfoDialogParams {
@@ -71,6 +78,20 @@ export class MoreInfoDialog extends LitElement {
     this._entityId = undefined;
     this._currTabIndex = 0;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected shouldShowEditIcon(domain, stateObj): boolean {
+    if (EDITABLE_DOMAINS_WITH_ID.includes(domain) && stateObj.attributes.id) {
+      return true;
+    }
+    if (EDITABLE_DOMAINS.includes(domain)) {
+      return true;
+    }
+    if (domain === "person" && stateObj.attributes.editable !== "false") {
+      return true;
+    }
+
+    return false;
   }
 
   protected updated(changedProperties) {
@@ -137,10 +158,7 @@ export class MoreInfoDialog extends LitElement {
                   </mwc-icon-button>
                 `
               : ""}
-            ${this.hass.user!.is_admin &&
-            ((EDITABLE_DOMAINS_WITH_ID.includes(domain) &&
-              stateObj.attributes.id) ||
-              EDITABLE_DOMAINS.includes(domain))
+            ${this.shouldShowEditIcon(domain, stateObj)
               ? html`
                   <mwc-icon-button
                     slot="actionItems"
@@ -283,14 +301,12 @@ export class MoreInfoDialog extends LitElement {
   private _gotoEdit() {
     const stateObj = this.hass.states[this._entityId!];
     const domain = computeDomain(this._entityId!);
-    navigate(
-      this,
-      `/config/${domain}/edit/${
-        EDITABLE_DOMAINS_WITH_ID.includes(domain)
-          ? stateObj.attributes.id
-          : stateObj.entity_id
-      }`
-    );
+    let idToPassThroughUrl = stateObj.entity_id;
+    if (EDITABLE_DOMAINS_WITH_ID.includes(domain) || domain === "person") {
+      idToPassThroughUrl = stateObj.attributes.id;
+    }
+
+    navigate(this, `/config/${domain}/edit/${idToPassThroughUrl}`);
     this.closeDialog();
   }
 

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -40,7 +40,7 @@ import "./ha-more-info-logbook";
 import "./controls/more-info-default";
 
 const DOMAINS_NO_INFO = ["camera", "configurator"];
-const EDITABLE_DOMAINS_WITH_ID = ["scene", "automation"];
+const EDITABLE_DOMAINS_WITH_ID = ["scene", "automation", "person"];
 const EDITABLE_DOMAINS = ["script"];
 
 export interface MoreInfoDialogParams {

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -158,6 +158,22 @@ class HaConfigPerson extends LitElement {
     this._configItems = personData.config.sort((ent1, ent2) =>
       compare(ent1.name, ent2.name)
     );
+    this._openDialogIfPersonSpecifiedInRoute();
+  }
+
+  private _openDialogIfPersonSpecifiedInRoute() {
+    const isPersonSpecifiedInRoute =
+      this.route && this.route.path && this.route.path.indexOf("/edit/") > -1;
+    if (isPersonSpecifiedInRoute) {
+      const routeSegments = this.route.path.split("/edit/");
+      const personId = routeSegments.length > 1 ? routeSegments[1] : null;
+      if (personId) {
+        const personToEdit = this._storageItems!.find((p) => p.id === personId);
+        if (personToEdit) {
+          this._openDialog(personToEdit);
+        }
+      }
+    }
   }
 
   private _createPerson() {

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -162,17 +162,19 @@ class HaConfigPerson extends LitElement {
   }
 
   private _openDialogIfPersonSpecifiedInRoute() {
-    const isPersonSpecifiedInRoute =
-      this.route?.path && this.route.path.includes("/edit/");
-    if (isPersonSpecifiedInRoute) {
-      const routeSegments = this.route.path.split("/edit/");
-      const personId = routeSegments.length > 1 ? routeSegments[1] : null;
-      if (personId) {
-        const personToEdit = this._storageItems!.find((p) => p.id === personId);
-        if (personToEdit) {
-          this._openDialog(personToEdit);
-        }
-      }
+    if (!this.route.path.includes("/edit/")) {
+      return;
+    }
+
+    const routeSegments = this.route.path.split("/edit/");
+    const personId = routeSegments.length > 1 ? routeSegments[1] : null;
+    if (!personId) {
+      return;
+    }
+
+    const personToEdit = this._storageItems!.find((p) => p.id === personId);
+    if (personToEdit) {
+      this._openDialog(personToEdit);
     }
   }
 

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -23,7 +23,10 @@ import {
   updatePerson,
 } from "../../../data/person";
 import { fetchUsers, User } from "../../../data/user";
-import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
+import {
+  showConfirmationDialog,
+  showAlertDialog,
+} from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-loading-screen";
 import "../../../layouts/hass-tabs-subpage";
 import { HomeAssistant, Route } from "../../../types";
@@ -175,6 +178,13 @@ class HaConfigPerson extends LitElement {
     const personToEdit = this._storageItems!.find((p) => p.id === personId);
     if (personToEdit) {
       this._openDialog(personToEdit);
+    } else {
+      showAlertDialog(this, {
+        title: this.hass?.localize(
+          "ui.panel.config.person.person_not_found_title"
+        ),
+        text: this.hass?.localize("ui.panel.config.person.person_not_found"),
+      });
     }
   }
 

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -163,7 +163,7 @@ class HaConfigPerson extends LitElement {
 
   private _openDialogIfPersonSpecifiedInRoute() {
     const isPersonSpecifiedInRoute =
-      this.route && this.route.path && this.route.path.indexOf("/edit/") > -1;
+      this.route?.path && this.route.path.includes("/edit/");
     if (isPersonSpecifiedInRoute) {
       const routeSegments = this.route.path.split("/edit/");
       const personId = routeSegments.length > 1 ? routeSegments[1] : null;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1643,6 +1643,8 @@
           "add_person": "Add Person",
           "confirm_delete": "Are you sure you want to delete this person?",
           "confirm_delete2": "All devices belonging to this person will become unassigned.",
+          "person_not_found_title": "Person Not Found",
+          "person_not_found": "We couldn't find the person you were trying to edit.",
           "detail": {
             "new_person": "New Person",
             "name": "Name",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

In the "more info" for a Person entity, this PR allows the quick-go-to-edit "pencil" button to be shown, which will navigate to the Person config panel. It also adds an after-data-fetch check to the Person config panel for the URL segment added by that navigation indicating a Person that is intended to be edited. If that URL segment is present, and the Person specified matches one of the Person entities that was fetched, then the page will open the "Edit Person" dialog without requiring additional user intervention.

The resulting user flow is that a user can click on a Person entity anywhere in Lovelace to view the "more info" dialog, then click the "pencil" icon (if they're an administrator), which will navigate them to the People config page and automatically open the "edit person" dialog for that Person entity. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Should be verifiable from the default Lovelace view that shows all entities -- click a Person entity to launch the "more info" dialog.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #4706
- This PR is related to issue: #4706
- Link to documentation pull request: (none applicable here, I think?)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
