### PR TITLE
Styling fixes for hui-masonry-view

### DIFF
--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -262,7 +262,8 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
         display: block;
         background: var(--lovelace-background);
         padding-top: 4px;
-        height: calc(100% - 4px);
+        height: 100%;
+        box-sizing: border-box;
       }
 
       #badges {

--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -261,7 +261,8 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
       :host {
         display: block;
         background: var(--lovelace-background);
-        height: 100%;
+        padding-top: 4px;
+        height: calc(100% - 4px);
       }
 
       #badges {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adds some styling changes to hui-masonry-view. This returns the amount of padding between the header and view/cards that existed before 0.116 and also fixes empty space that appears when using badges that was introduced with the same changes.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
views:
  - icon: 'mdi:bomb'
    background: dimgrey
    cards:
      - type: gauge
        entity: sensor.connected_clients
        min: 0
        max: 100
  - icon: 'mdi:triforce'
    background: dimgrey
    badges:
      - device_tracker.demo_paulus
    cards:
      - type: gauge
        entity: sensor.connected_clients
        min: 0
        max: 100
```

## Additional information

View with spacing between header and cards before:

<img src="https://user-images.githubusercontent.com/25127328/95025169-e4782d00-0655-11eb-9d50-9e016e5e71ea.png" alt="drawing" width="400"/>

View with spacing between header and cards after:

<img src="https://user-images.githubusercontent.com/25127328/95025187-fb1e8400-0655-11eb-83ef-8a5a37509ad9.png" alt="drawing" width="400"/>

View with badges before:

<img src="https://user-images.githubusercontent.com/25127328/95025125-95ca9300-0655-11eb-962b-082e75ec627b.png" alt="drawing" width="400"/>

View with badges after:

<img src="https://user-images.githubusercontent.com/25127328/95025143-c14d7d80-0655-11eb-8270-bd5aa9be601c.png" alt="drawing" width="400"/>



## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
