### PR TITLE
Use client_id if no client_name in delete dialog

### DIFF
--- a/src/panels/profile/ha-refresh-tokens-card.ts
+++ b/src/panels/profile/ha-refresh-tokens-card.ts
@@ -106,7 +106,7 @@ class HaRefreshTokens extends LitElement {
         text: this.hass.localize(
           "ui.panel.profile.refresh_tokens.confirm_delete",
           "name",
-          token.client_name
+          token.client_name || token.client_id
         ),
       }))
     ) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When deleting a refresh token the dialog shows an empty name since it's searching for `token.client_name`, but only long lived tokens have that attribute. This will use token.client_id in those cases.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->


## Additional information

Before:
<img src="https://user-images.githubusercontent.com/11339500/94995123-1f049b80-056a-11eb-9a8c-9c1aeef0bec7.png" alt="drawing" width="400"/>

After:
<img src="https://user-images.githubusercontent.com/25127328/95034563-3f2e7a80-0690-11eb-9a84-d3e46ef4c00a.png" alt="drawing" width="400"/>



- This PR fixes or closes issue: fixes #7215 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
