### PR TITLE
Close notification drawer after dismissing last notification

### DIFF
--- a/src/dialogs/notifications/notification-drawer.js
+++ b/src/dialogs/notifications/notification-drawer.js
@@ -88,7 +88,7 @@ export class HuiNotificationDrawer extends EventsMixin(
       notifications: {
         type: Array,
         computed: "_computeNotifications(open, hass, _notificationsBackend)",
-        notify: true,
+        observer: "_notificationsChanged",
       },
       _notificationsBackend: {
         type: Array,
@@ -123,31 +123,22 @@ export class HuiNotificationDrawer extends EventsMixin(
         this.hass.connection,
         (notifications) => {
           this._notificationsBackend = notifications;
-          this.addEventListener(
-            "notifications-changed",
-            this._onNotificationsChanged
-          );
         }
       );
-    } else {
-      this.removeEventListener(
-        "notifications-changed",
-        this._onNotificationsChanged
-      );
-      if (this._unsubNotifications) {
-        this._unsubNotifications();
-        this._unsubNotifications = undefined;
-      }
+    } else if (this._unsubNotifications) {
+      this._unsubNotifications();
+      this._unsubNotifications = undefined;
     }
   }
 
-  _onNotificationsChanged(ev) {
-    if (this.notifications.length === 0 && this.open) {
-      // without the timeout, this.removeEventListener('notifications-changed') does not take effect
-      // we have to wait for the next cycle to trigger closing the drawer and removing the event listener successfully
-      setTimeout(() => {
-        this.open = false;
-      }, 0);
+  _notificationsChanged(newNotifications, oldNotifications) {
+    // automatically close drawer when last notification has been dismissed
+    if (
+      this.open &&
+      oldNotifications.length > 0 &&
+      !newNotifications.length === 0
+    ) {
+      this.open = false;
     }
   }
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change adds a listener to any changes of the notifications property once the notification drawer opens. After the last notification is dismissed, the notification drawer closes automatically, and the listener is removed.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #7223, #4983 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
