### PR TITLE
Put automation/script editor actions in a menu

### DIFF
--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -62,6 +62,9 @@ export class HaButtonMenu extends LitElement {
         display: inline-block;
         position: relative;
       }
+      ::slotted([disabled]) {
+        color: var(--disabled-text-color);
+      }
     `;
   }
 }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -113,7 +113,7 @@ export class HaAutomationEditor extends LitElement {
           </mwc-icon-button>
 
           <mwc-list-item
-            ?disabled=${!this.automationId}
+            .disabled=${!this.automationId}
             aria-label=${this.hass.localize(
               "ui.panel.config.automation.picker.duplicate_automation"
             )}
@@ -129,7 +129,7 @@ export class HaAutomationEditor extends LitElement {
           </mwc-list-item>
 
           <mwc-list-item
-            ?disabled=${!this.automationId}
+            .disabled=${!this.automationId}
             aria-label=${this.hass.localize(
               "ui.panel.config.automation.picker.delete_automation"
             )}

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -1,9 +1,16 @@
 import "@material/mwc-fab";
-import { mdiContentDuplicate, mdiContentSave, mdiDelete } from "@mdi/js";
+import {
+  mdiContentDuplicate,
+  mdiContentSave,
+  mdiDelete,
+  mdiDotsVertical,
+} from "@mdi/js";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
 import "@polymer/paper-input/paper-textarea";
+import "@material/mwc-list/mwc-list-item";
+import { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
 import { PaperListboxElement } from "@polymer/paper-listbox";
 import {
   css,
@@ -17,6 +24,7 @@ import {
 } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 import { navigate } from "../../../common/navigate";
+import "../../../components/ha-button-menu";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-svg-icon";
@@ -92,29 +100,48 @@ export class HaAutomationEditor extends LitElement {
         .backCallback=${() => this._backTapped()}
         .tabs=${configSections.automation}
       >
-        ${!this.automationId
-          ? ""
-          : html`
-              <mwc-icon-button
-                slot="toolbar-icon"
-                title="${this.hass.localize(
-                  "ui.panel.config.automation.picker.duplicate_automation"
-                )}"
-                @click=${this._duplicate}
-              >
-                <ha-svg-icon .path=${mdiContentDuplicate}></ha-svg-icon>
-              </mwc-icon-button>
-              <mwc-icon-button
-                class="warning"
-                slot="toolbar-icon"
-                title="${this.hass.localize(
-                  "ui.panel.config.automation.picker.delete_automation"
-                )}"
-                @click=${this._deleteConfirm}
-              >
-                <ha-svg-icon .path=${mdiDelete}></ha-svg-icon>
-              </mwc-icon-button>
-            `}
+        <ha-button-menu
+          corner="BOTTOM_START"
+          slot="toolbar-icon"
+          @action=${this._handleMenuAction}
+        >
+          <mwc-icon-button
+            slot="trigger"
+            .title=${this.hass.localize("ui.common.menu")}
+            .label=${this.hass.localize("ui.common.overflow_menu")}
+            ><ha-svg-icon path=${mdiDotsVertical}></ha-svg-icon>
+          </mwc-icon-button>
+
+          <mwc-list-item
+            ?disabled=${!this.automationId}
+            aria-label=${this.hass.localize(
+              "ui.panel.config.automation.picker.duplicate_automation"
+            )}
+            graphic="icon"
+          >
+            ${this.hass.localize(
+              "ui.panel.config.automation.picker.duplicate_automation"
+            )}
+            <ha-svg-icon
+              slot="graphic"
+              .path=${mdiContentDuplicate}
+            ></ha-svg-icon>
+          </mwc-list-item>
+
+          <mwc-list-item
+            ?disabled=${!this.automationId}
+            aria-label=${this.hass.localize(
+              "ui.panel.config.automation.picker.delete_automation"
+            )}
+            class=${classMap({ warning: this.automationId })}
+            graphic="icon"
+          >
+            ${this.hass.localize(
+              "ui.panel.config.automation.picker.delete_automation"
+            )}
+            <ha-svg-icon slot="graphic" .path=${mdiDelete}></ha-svg-icon>
+          </mwc-list-item>
+        </ha-button-menu>
         ${this._config
           ? html`
               ${this.narrow
@@ -538,6 +565,17 @@ export class HaAutomationEditor extends LitElement {
   private async _delete() {
     await deleteAutomation(this.hass, this.automationId);
     history.back();
+  }
+
+  private async _handleMenuAction(ev: CustomEvent<ActionDetail>) {
+    switch (ev.detail.index) {
+      case 0:
+        this._duplicate();
+        break;
+      case 1:
+        this._deleteConfirm();
+        break;
+    }
   }
 
   private _saveAutomation(): void {

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -1,8 +1,10 @@
 import "@material/mwc-fab";
-import { mdiContentSave } from "@mdi/js";
+import { mdiContentSave, mdiDelete, mdiDotsVertical } from "@mdi/js";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
+import "@material/mwc-list/mwc-list-item";
+import { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
 import { PaperListboxElement } from "@polymer/paper-listbox";
 import {
   css,
@@ -19,6 +21,7 @@ import { computeObjectId } from "../../../common/entity/compute_object_id";
 import { navigate } from "../../../common/navigate";
 import { slugify } from "../../../common/string/slugify";
 import { computeRTL } from "../../../common/util/compute_rtl";
+import "../../../components/ha-button-menu";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-icon-input";
@@ -73,19 +76,32 @@ export class HaScriptEditor extends LitElement {
         .backCallback=${() => this._backTapped()}
         .tabs=${configSections.automation}
       >
-        ${!this.scriptEntityId
-          ? ""
-          : html`
-              <ha-icon-button
-                class="warning"
-                slot="toolbar-icon"
-                title="${this.hass.localize(
-                  "ui.panel.config.script.editor.delete_script"
-                )}"
-                icon="hass:delete"
-                @click=${this._deleteConfirm}
-              ></ha-icon-button>
-            `}
+        <ha-button-menu
+          corner="BOTTOM_START"
+          slot="toolbar-icon"
+          @action=${this._handleMenuAction}
+        >
+          <mwc-icon-button
+            slot="trigger"
+            .title=${this.hass.localize("ui.common.menu")}
+            .label=${this.hass.localize("ui.common.overflow_menu")}
+            ><ha-svg-icon path=${mdiDotsVertical}></ha-svg-icon>
+          </mwc-icon-button>
+
+          <mwc-list-item
+            ?disabled=${!this.scriptEntityId}
+            aria-label=${this.hass.localize(
+              "ui.panel.config.automation.picker.delete_automation"
+            )}
+            class=${classMap({ warning: this.scriptEntityId })}
+            graphic="icon"
+          >
+            ${this.hass.localize(
+              "ui.panel.config.automation.picker.delete_automation"
+            )}
+            <ha-svg-icon slot="graphic" .path=${mdiDelete}></ha-svg-icon>
+          </mwc-list-item>
+        </ha-button-menu>
         ${this.narrow
           ? html` <span slot="header">${this._config?.alias}</span> `
           : ""}
@@ -429,6 +445,14 @@ export class HaScriptEditor extends LitElement {
   private async _delete() {
     await deleteScript(this.hass, computeObjectId(this.scriptEntityId));
     history.back();
+  }
+
+  private async _handleMenuAction(ev: CustomEvent<ActionDetail>) {
+    switch (ev.detail.index) {
+      case 0:
+        this._deleteConfirm();
+        break;
+    }
   }
 
   private _saveScript(): void {

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -89,7 +89,7 @@ export class HaScriptEditor extends LitElement {
           </mwc-icon-button>
 
           <mwc-list-item
-            ?disabled=${!this.scriptEntityId}
+            .disabled=${!this.scriptEntityId}
             aria-label=${this.hass.localize(
               "ui.panel.config.automation.picker.delete_automation"
             )}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A step on the way towards #6986.

![image](https://user-images.githubusercontent.com/1299821/95350493-81d69980-08c0-11eb-8a3c-95899d7a3f9a.png)

The changes in `ha-button-menu` is to make disabled actions more clearly disabled:
![image](https://user-images.githubusercontent.com/1299821/95350600-9fa3fe80-08c0-11eb-9c4c-e81ebfc72784.png)


End vision:
![Skärmavbild 2020-10-07 kl  17 05 59](https://user-images.githubusercontent.com/1299821/95350634-acc0ed80-08c0-11eb-9f91-b083793f889c.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
