### PR TITLE
Fix tab focus issue in entity picker and password form.

### DIFF
--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -215,6 +215,7 @@ export class HaEntityPicker extends LitElement {
                   slot="suffix"
                   class="clear-button"
                   icon="hass:close"
+                  tabindex="-1"
                   @click=${this._clearValue}
                   no-ripple
                 >
@@ -230,6 +231,7 @@ export class HaEntityPicker extends LitElement {
             slot="suffix"
             class="toggle-button"
             .icon=${this._opened ? "hass:menu-up" : "hass:menu-down"}
+            tabindex="-1"
           >
             Toggle
           </ha-icon-button>

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -55,6 +55,7 @@ export class HaFormString extends LitElement implements HaFormElement {
               id="iconButton"
               title="Click to toggle between masked and clear password"
               @click=${this._toggleUnmaskedPassword}
+              tabindex="-1"
             >
             </ha-icon-button>
           </paper-input>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This sets the `tab-index` of button elements inside `paper-inputs` to `-1`. This fixes the issue of the tab key not moving on to the next element as it should. Since you can press down to show entities and delete the contents via keyboard it would be unnecessary to be able to tab to those button elements for accessibility. This also sets `tab-index="-1"` for the password field's unmask button to fix the same issue on login form.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

## Additional information

- This PR fixes or closes issue: fixes #7206
- This PR fixes or closes issue: fixes #4689
- This PR is related to issue: 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
