### PR TITLE
Ensure ha-dialog uses correct <a> color

### DIFF
--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -299,6 +299,10 @@ export const haStyleDialog = css`
     color: var(--primary-text-color);
   }
 
+  ha-dialog a {
+    color: var(--primary-color);
+  }
+
   /* make dialog fullscreen on small screens */
   @media all and (max-width: 450px), all and (max-height: 500px) {
     ha-dialog {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -299,7 +299,7 @@ export const haStyleDialog = css`
     color: var(--primary-text-color);
   }
 
-  ha-dialog a {
+  a {
     color: var(--primary-color);
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Previously hyperlinks in a ha-dialog were not styled properly and therefore used the browsers default coloring (dark blue in my case). This e.g. occurred in the entity `persistent_notification.python_version` that appears if python version 3.7 is used.

Now, correctly the primary theme color is used, same as for all other links.

![image](https://user-images.githubusercontent.com/114137/95377644-28cc2d00-08e3-11eb-9469-6388df35cf5b.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
