### PR TITLE
Add the Feature of Reordering Shopping List by Moving Up or Down an Item

### DIFF
--- a/src/data/shopping-list.ts
+++ b/src/data/shopping-list.ts
@@ -38,3 +38,21 @@ export const addItem = (
     type: "shopping_list/items/add",
     name,
   });
+
+export const moveUpItem = (
+  hass: HomeAssistant,
+  itemId: string
+): Promise<ShoppingListItem> =>
+  hass.callWS({
+    type: "shopping_list/items/move_up",
+    item_id: itemId,
+  });
+
+export const moveDownItem = (
+  hass: HomeAssistant,
+  itemId: string
+): Promise<ShoppingListItem> =>
+  hass.callWS({
+    type: "shopping_list/items/move_down",
+    item_id: itemId,
+  });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2192,7 +2192,10 @@
           "shopping-list": {
             "checked_items": "Checked items",
             "clear_items": "Clear checked items",
-            "add_item": "Add item"
+            "add_item": "Add item",
+            "reorder_items": "Reorder items",
+            "move_up_item": "Move up item",
+            "move_down_item": "Move down item"
           },
           "picture-elements": {
             "hold": "Hold:",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adding the feature of recording shopping list (in shopping list card) by adding reorder button, move up button and move down button.

The Core Counterpart PR: https://github.com/home-assistant/core/pull/41565

![Kapture 2020-10-09 at 12 04 17](https://user-images.githubusercontent.com/7324708/95611580-a13c0680-0a27-11eb-9420-2edf7b5df03a.gif)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

N/A

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [N/A] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
