### PR TITLE
Make enter key execute first filtered item in Quick Bar

### DIFF
--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -174,12 +174,21 @@ export class QuickBar extends LitElement {
   }
 
   private _focusInputField(ev: KeyboardEvent) {
+    const re = new RegExp("[a-z0-9._]");
+
     if (ev.code === "ArrowUp") {
       ev.preventDefault();
       const inputField = this.shadowRoot?.querySelector(
         "paper-input"
       ) as HTMLElement;
       inputField.focus();
+    } else if (ev.key.length === 1 && re.test(ev.key)) {
+      ev.preventDefault();
+      const inputField = this.shadowRoot?.querySelector(
+        "paper-input"
+      ) as HTMLElement;
+      inputField.focus();
+      inputField.value += ev.key;
     }
   }
 

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -48,6 +48,8 @@ export class QuickBar extends LitElement {
 
   @internalProperty() private _topCommandResult?: CommandItem;
 
+  @internalProperty() private _selectedIndex?: number;
+
   public async showDialog(params: QuickBarParams) {
     this._commandMode = params.commandMode || false;
     this._opened = true;
@@ -81,7 +83,7 @@ export class QuickBar extends LitElement {
           )}
           type="search"
           value=${this._commandMode ? `>${this._itemFilter}` : this._itemFilter}
-          @keydown=${this._activateFirstItem}
+          @keydown=${this._focusFirstElement}
         ></paper-input>
         ${this._commandMode
           ? this.renderCommandsList(this._itemFilter)
@@ -101,7 +103,9 @@ export class QuickBar extends LitElement {
           (item, index) => html`
             <mwc-list-item
               .activated=${index === 0}
+              .selected=${index === this._selectedIndex}
               .item=${item}
+              @keydown=${this._focusInputField}
               graphic="icon"
             >
               <ha-icon
@@ -131,6 +135,7 @@ export class QuickBar extends LitElement {
               .entityId=${entity.entity_id}
               .activated=${index === 0}
               graphic="avatar"
+              @keydown=${this._focusInputField}
             >
               <ha-icon .icon=${domainIcon(domain)} slot="graphic"></ha-icon>
               ${entity.attributes?.friendly_name
@@ -152,13 +157,29 @@ export class QuickBar extends LitElement {
     `;
   });
 
-  private _activateFirstItem(ev: KeyboardEvent) {
+  private _focusFirstElement(ev: KeyboardEvent) {
     if (ev.code === "Enter") {
       if (this._commandMode) {
         this._runCommandAndCloseDialog(this._topCommandResult);
       } else {
         this._launchMoreInfoDialog(this._topEntityIdResult);
       }
+    } else if (ev.code === "ArrowDown") {
+      ev.preventDefault();
+      const listItem = this.shadowRoot?.querySelector(
+        "mwc-list-item"
+      ) as HTMLElement;
+      listItem.focus();
+    }
+  }
+
+  private _focusInputField(ev: KeyboardEvent) {
+    if (ev.code === "ArrowUp") {
+      ev.preventDefault();
+      const inputField = this.shadowRoot?.querySelector(
+        "paper-input"
+      ) as HTMLElement;
+      inputField.focus();
     }
   }
 


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

In other "quick bars", the user can:
* Hit "Enter" at any time to select the top-most result
* Arrow down into the list
* Continue typing even when arrowed into the list

This PR adds these abilities to HA's Quick Bar.
![DEMO_quickbarenterkey](https://user-images.githubusercontent.com/1480827/96020501-f9e21980-0e02-11eb-8a90-a23f270a47c6.gif)
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
