### PR TITLE
Fix: Quick Bar not launching on windows

### DIFF
--- a/src/state/quick-bar-mixin.ts
+++ b/src/state/quick-bar-mixin.ts
@@ -11,13 +11,15 @@ declare global {
   }
 }
 
+const isMacOS = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+
 export default <T extends Constructor<HassElement>>(superClass: T) =>
   class extends superClass {
     protected firstUpdated(changedProps: PropertyValues) {
       super.firstUpdated(changedProps);
 
       document.addEventListener("keydown", (e: KeyboardEvent) => {
-        if (e.code === "KeyP" && e.metaKey) {
+        if (this.isOSCtrlKey(e) && e.code === "KeyP") {
           e.preventDefault();
           const eventParams: QuickBarParams = {};
           if (e.shiftKey) {
@@ -27,5 +29,9 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
           showQuickBar(this, eventParams);
         }
       });
+    }
+
+    private isOSCtrlKey(e: KeyboardEvent) {
+      return isMacOS ? e.metaKey : e.ctrlKey;
     }
   };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fixes bug with Quick Bar on Windows. 

Code was only looking for `e.metaKey` which is true for mac OS's "⌘" but not Windows's Control Key.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
