### PR TITLE
Allow restricting the number of skips allowed in fuzzy sequence matcher

### DIFF
--- a/src/common/string/sequence_matching.ts
+++ b/src/common/string/sequence_matching.ts
@@ -1,21 +1,19 @@
 /**
- * Determine whether a sequence of letters exists in another string,
- *   in that order, allowing for skipping. Ex: "chdr" exists in "chandelier")
+ * Determine whether an ordered sequence of letters exists in another string, allowing
+ * for skipping. Ex: "chdr" exists in "chandelier", in that order, if you skip letters
  *
- * filter => sequence of letters
- * word => Word to check for sequence
- * maxSkips => Number of times algorithm is allowed to skip over characters. Unlimited skipping, by default.
- * immuneDelimiters =>
- *    An array of single-character delimiters that will not count as "skips".
+ * Think of this as a faster, customizable, HA-specific implementation of a regex
+ * search for ".*A.*B.*C.*"
  *
- *    E.g. A user wants to filter on all entities in the "light" domain.
- *         They might use a "." to ensure that all of the letters they type next
- *         will only be checked against the second part of the entity id.
- *         If "." is sent as an "immune delimiter", then matching a "." won't be
- *         considered a "skip" even if we had to skip characters to get there.
+ * Required: filter => Letter sequence to look for in the word
+ * Required: word => Word to check for sequence
+ * Optional: maxSkips => Number of times the algorithm can "skip" characters. Unlimited skipping, by default.
+ * Optional: immuneDelimiters => An array of single-character delimiters that will not count as "skips".
  *
- *         This is a way to maintain the desired "strictness" on skipping, but
- *         still allowing certain natural filtering strategies
+ *                               The primary use-case is for users who want to do an initial filter on the domain
+ *                               portion of an entity_id by leveraging the "." character in an entity_id.
+ *                               E.g. "li" can return entities from any domain, but "li." will return light.*
+ *                               Making the "." immune allows users to do this kind of filter without punishment
  *
  * Returns => true if word contains sequence. false otherwise.
  */
@@ -24,8 +22,11 @@ export const fuzzySequentialMatch = (
   word: string,
   maxSkips: number = Number.MAX_SAFE_INTEGER,
   immuneDelimiters: string[] = []
-) => {
-  return _fuzzySequentialMatch(filter, word, maxSkips, immuneDelimiters);
+): boolean => {
+  return (
+    _fuzzySequentialMatch(filter, word, maxSkips, immuneDelimiters) ||
+    _fuzzySequentialMatch(filter, word, maxSkips, immuneDelimiters, true)
+  );
 };
 
 const _fuzzySequentialMatch = (
@@ -33,9 +34,10 @@ const _fuzzySequentialMatch = (
   word: string,
   skipsLeft: number,
   immuneDelimiters: string[],
-  didSkip: boolean = false
-) => {
-  if (didSkip) {
+  useLongestSubstring: boolean = false,
+  didJustSkip: boolean = false
+): boolean => {
+  if (didJustSkip) {
     skipsLeft -= 1;
     if (skipsLeft < 0) {
       return false;
@@ -47,7 +49,9 @@ const _fuzzySequentialMatch = (
   }
 
   for (let i = 0; i <= filter.length; i++) {
-    const pos = word.indexOf(filter[0]);
+    let pos = useLongestSubstring
+      ? findLongestSubstring(filter, word)
+      : word.indexOf(filter[0]);
 
     if (pos < 0) {
       return false;
@@ -62,9 +66,22 @@ const _fuzzySequentialMatch = (
       newWord,
       skipsLeft,
       immuneDelimiters,
+      false,
       pos > 0 && !immuneDelimiters.includes(previousCharacter)
     );
   }
 
   return true;
+};
+
+export const findLongestSubstring = (filter: string, word: string) => {
+  if (filter === "") {
+    return -1;
+  }
+  const pos = word.indexOf(filter);
+  if (pos >= 0) {
+    return pos;
+  }
+
+  return findLongestSubstring(filter.slice(0, -1), word);
 };

--- a/src/common/string/sequence_matching.ts
+++ b/src/common/string/sequence_matching.ts
@@ -4,10 +4,44 @@
  *
  * filter => sequence of letters
  * word => Word to check for sequence
+ * maxSkips => Number of times algorithm is allowed to skip over characters. Unlimited skipping, by default.
+ * immuneDelimiters =>
+ *    An array of single-character delimiters that will not count as "skips".
  *
- * return true if word contains sequence. Otherwise false.
+ *    E.g. A user wants to filter on all entities in the "light" domain.
+ *         They might use a "." to ensure that all of the letters they type next
+ *         will only be checked against the second part of the entity id.
+ *         If "." is sent as an "immune delimiter", then matching a "." won't be
+ *         considered a "skip" even if we had to skip characters to get there.
+ *
+ *         This is a way to maintain the desired "strictness" on skipping, but
+ *         still allowing certain natural filtering strategies
+ *
+ * Returns => true if word contains sequence. false otherwise.
  */
-export const fuzzySequentialMatch = (filter: string, word: string) => {
+export const fuzzySequentialMatch = (
+  filter: string,
+  word: string,
+  maxSkips: number = Number.MAX_SAFE_INTEGER,
+  immuneDelimiters: string[] = []
+) => {
+  return _fuzzySequentialMatch(filter, word, maxSkips, immuneDelimiters);
+};
+
+const _fuzzySequentialMatch = (
+  filter: string,
+  word: string,
+  skipsLeft: number,
+  immuneDelimiters: string[],
+  didSkip: boolean = false
+) => {
+  if (didSkip) {
+    skipsLeft -= 1;
+    if (skipsLeft < 0) {
+      return false;
+    }
+  }
+
   if (filter === "") {
     return true;
   }
@@ -19,10 +53,17 @@ export const fuzzySequentialMatch = (filter: string, word: string) => {
       return false;
     }
 
+    const previousCharacter = word[pos];
     const newWord = word.substring(pos + 1);
     const newFilter = filter.substring(1);
 
-    return fuzzySequentialMatch(newFilter, newWord);
+    return _fuzzySequentialMatch(
+      newFilter,
+      newWord,
+      skipsLeft,
+      immuneDelimiters,
+      pos > 0 && !immuneDelimiters.includes(previousCharacter)
+    );
   }
 
   return true;

--- a/test-mocha/common/string/sequence_matching.test.ts
+++ b/test-mocha/common/string/sequence_matching.test.ts
@@ -1,0 +1,123 @@
+import { assert } from "chai";
+
+import {
+  fuzzySequentialMatch,
+  findLongestSubstring,
+} from "../../../src/common/string/sequence_matching";
+
+describe("fuzzySequentialMatch", () => {
+  const entityId = "automation.ticker";
+
+  const shouldMatchEntity = {
+    0: ["automation.ticker", "automation.ticke", "automation.", "au", ""],
+    1: ["automationticker", "tion.tick", "ticker", "automation.r", "tick"],
+    2: ["aumatick", "aion.tck", "ioticker"],
+    100: ["atmto.ikr", "uoaintce", "au.tce", "tomaontkr"],
+  };
+
+  describe(`Entity '${entityId}'`, () => {
+    let skipsToTest: number[] = Object.keys(shouldMatchEntity).map(Number);
+
+    for (const maxSkips of skipsToTest) {
+      describe(`with ${maxSkips} allowed skips`, () => {
+        const goodFilters = shouldMatchEntity[maxSkips];
+
+        for (const i in goodFilters) {
+          const goodFilter = goodFilters[i];
+
+          it(`matches with '${goodFilter}'`, () => {
+            const res = fuzzySequentialMatch(goodFilter, entityId, maxSkips);
+            assert.equal(res, true);
+          });
+        }
+
+        const badFilters =
+          maxSkips === skipsToTest[skipsToTest.length - 1]
+            ? []
+            : shouldMatchEntity[maxSkips + 1];
+
+        if (badFilters && badFilters.length > 0) {
+          for (const i in badFilters) {
+            const badFilter = badFilters[i];
+
+            it(`fails to match with '${badFilter}'`, () => {
+              const res = fuzzySequentialMatch(badFilter, entityId, maxSkips);
+              assert.equal(res, false);
+            });
+          }
+        }
+      });
+    }
+
+    describe("When a shorter matching path is found", () => {
+      // Can match "automation.ticker" using either
+      //           "a-t----ion.tick--" (using 2 skips)
+      //           "-----ation.tick--" (using 1 skip)
+      const filter = "ation.tick";
+
+      it(`matches with '${filter}' and 1 skip`, () => {
+        const res = fuzzySequentialMatch(filter, entityId, 1);
+        assert.equal(res, true);
+      });
+
+      it(`matches with '${filter}' and 2 skips`, () => {
+        const res = fuzzySequentialMatch(filter, entityId, 2);
+        assert.equal(res, true);
+      });
+    });
+  });
+
+  describe("with only one skip allowed", () => {
+    const filter = "auto.er";
+
+    describe("without immunity", () => {
+      it(`fails with '${filter}'`, () => {
+        const res = fuzzySequentialMatch(filter, entityId, 1);
+        assert.equal(res, false);
+      });
+    });
+
+    describe("with immunity", () => {
+      it(`matches with '${filter}'`, () => {
+        const res = fuzzySequentialMatch(filter, entityId, 1, ["."]);
+        assert.equal(res, true);
+      });
+    });
+  });
+});
+
+describe("findLongestSubstring", () => {
+  it("For a full substring match", () => {
+    assert.strictEqual(
+      findLongestSubstring("automation.ticker", "automation.ticker"),
+      0
+    );
+
+    assert.strictEqual(
+      findLongestSubstring("automation.ti", "automation.ticker"),
+      0
+    );
+  });
+
+  it("For a full substring match at the end", () => {
+    assert.strictEqual(findLongestSubstring("ticker", "automation.ticker"), 11);
+  });
+
+  it("For a full substring match in middle", () => {
+    assert.strictEqual(
+      findLongestSubstring("tion.tick", "automation.ticker"),
+      6
+    );
+  });
+
+  it("For a partial substring match", () => {
+    assert.strictEqual(
+      findLongestSubstring("toticker", "automation.ticker"),
+      2
+    );
+  });
+
+  it("For a filter that doesn't have a match", () => {
+    assert.strictEqual(findLongestSubstring("x", "automation.ticker"), -1);
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Change the "fuzzy sequence matcher" to allow for customizing the number of "skips" it can use to find a match.

Also can specify a set of "immune delimiters" which won't count against the skip allotment.

Performance test with 10,000 randomly generated "entity ids" and a variety of filters: https://jsbench.me/h5kg49nlxx/1

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
