### PR TITLE
Show disabled entities for a config_entry by default + number of hidden entities

### DIFF
--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -82,11 +82,11 @@ export class HaConfigDeviceDashboard extends LitElement {
             filterTexts.push(
               `${this.hass.localize(
                 "ui.panel.config.integrations.integration"
-              )} ${integrationName}${
+              )} "${integrationName}${
                 integrationName !== configEntry.title
                   ? `: ${configEntry.title}`
                   : ""
-              }`
+              }"`
             );
             break;
           }

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -268,12 +268,6 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
       showUnavailable: boolean,
       showReadOnly: boolean
     ): EntityRow[] => {
-      const startLength = entities.length + stateEntities.length;
-
-      if (!showDisabled) {
-        entities = entities.filter((entity) => !entity.disabled_by);
-      }
-
       const result: EntityRow[] = [];
 
       entities = showReadOnly ? entities.concat(stateEntities) : entities;
@@ -287,6 +281,12 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
             break;
         }
       });
+
+      const startLength = entities.length;
+
+      if (!showDisabled) {
+        entities = entities.filter((entity) => !entity.disabled_by);
+      }
 
       for (const entry of entities) {
         const entity = this.hass.states[entry.entity_id];

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -138,11 +138,11 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
             filterTexts.push(
               `${this.hass.localize(
                 "ui.panel.config.integrations.integration"
-              )} ${integrationName}${
+              )} "${integrationName}${
                 integrationName !== configEntry.title
                   ? `: ${configEntry.title}`
                   : ""
-              }`
+              }"`
             );
             break;
           }
@@ -460,11 +460,32 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
                           "ui.panel.config.filtering.filtering_by"
                         )}
                         ${activeFilters.join(", ")}
+                        ${this._numHiddenEntities
+                          ? "(" +
+                            this.hass.localize(
+                              "ui.panel.config.entities.picker.filter.hidden_entities",
+                              "number",
+                              this._numHiddenEntities
+                            ) +
+                            ")"
+                          : ""}
                       </paper-tooltip>
                     </div>`
                   : `${this.hass.localize(
                       "ui.panel.config.filtering.filtering_by"
-                    )} ${activeFilters.join(", ")}`}
+                    )} ${activeFilters.join(", ")}
+                    ${
+                      this._numHiddenEntities
+                        ? "(" +
+                          this.hass.localize(
+                            "ui.panel.config.entities.picker.filter.hidden_entities",
+                            "number",
+                            this._numHiddenEntities
+                          ) +
+                          ")"
+                        : ""
+                    }
+                    `}
                 <mwc-button @click=${this._clearFilter}
                   >${this.hass.localize(
                     "ui.panel.config.filtering.clear"

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -269,6 +269,8 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
       showReadOnly: boolean
     ): EntityRow[] => {
       const result: EntityRow[] = [];
+      // If nothing gets filtered, this is our correct count of entities
+      let startLength = entities.length + stateEntities.length;
 
       entities = showReadOnly ? entities.concat(stateEntities) : entities;
 
@@ -278,11 +280,17 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
             entities = entities.filter(
               (entity) => entity.config_entry_id === value
             );
+            // If we have an active filter and `showReadOnly` is true, the length of `entities` is correct.
+            // If however, the read-only entities were not added before, we need to check how many would
+            // have matched the active filter and add that number to the count.
+            startLength = entities.length;
+            if (!showReadOnly)
+              startLength += stateEntities.filter(
+                (entity) => entity.config_entry_id === value
+              ).length;
             break;
         }
       });
-
-      const startLength = entities.length;
 
       if (!showDisabled) {
         entities = entities.filter((entity) => !entity.disabled_by);
@@ -786,7 +794,6 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
     this._showDisabled = true;
     this._showReadOnly = true;
     this._showUnavailable = true;
-    navigate(this, window.location.pathname, true);
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -118,6 +118,10 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
       filters.forEach((value, key) => {
         switch (key) {
           case "config_entry": {
+            // If we are requested to show the entities for a given config entry,
+            // also show the disabled ones by default.
+            this._showDisabled = true;
+
             if (!entries) {
               this._loadConfigEntries();
               break;

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -284,10 +284,11 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
             // If however, the read-only entities were not added before, we need to check how many would
             // have matched the active filter and add that number to the count.
             startLength = entities.length;
-            if (!showReadOnly)
+            if (!showReadOnly) {
               startLength += stateEntities.filter(
                 (entity) => entity.config_entry_id === value
               ).length;
+            }
             break;
         }
       });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1600,7 +1600,9 @@
               "filter": "Filter",
               "show_disabled": "Show disabled entities",
               "show_unavailable": "Show unavailable entities",
-              "show_readonly": "Show read-only entities"
+              "show_readonly": "Show read-only entities",
+              "hidden_entities": "{number} {number, plural,\n  one {hidden entity}\n  other {hidden entities}\n}",
+              "show_all": "Show all"
             },
             "status": {
               "restored": "Restored",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1601,7 +1601,7 @@
               "show_disabled": "Show disabled entities",
               "show_unavailable": "Show unavailable entities",
               "show_readonly": "Show read-only entities",
-              "hidden_entities": "{number} {number, plural,\n  one {hidden entity}\n  other {hidden entities}\n}",
+              "hidden_entities": "{number} hidden {number, plural,\n  one {entity}\n  other {entities}\n}",
               "show_all": "Show all"
             },
             "status": {

--- a/translations/frontend/en.json
+++ b/translations/frontend/en.json
@@ -1534,9 +1534,7 @@
                             "filter": "Filter",
                             "show_disabled": "Show disabled entities",
                             "show_readonly": "Show read-only entities",
-                            "show_unavailable": "Show unavailable entities",
-                            "hidden_entities": "{number} {number, plural,\n  one {hidden entity}\n  other {hidden entities}\n}",
-                            "show_all": "Show all"
+                            "show_unavailable": "Show unavailable entities"
                         },
                         "header": "Entities",
                         "headers": {

--- a/translations/frontend/en.json
+++ b/translations/frontend/en.json
@@ -1534,7 +1534,9 @@
                             "filter": "Filter",
                             "show_disabled": "Show disabled entities",
                             "show_readonly": "Show read-only entities",
-                            "show_unavailable": "Show unavailable entities"
+                            "show_unavailable": "Show unavailable entities",
+                            "hidden_entities": "{number} {number, plural,\n  one {hidden entity}\n  other {hidden entities}\n}",
+                            "show_all": "Show all"
                         },
                         "header": "Entities",
                         "headers": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Covers both points of the requested feature, to always select the disabled entities automatically be default if the entities for a given config_entry are to be shown. Plus show the number of hidden entities (disabled, unavailable, read-only) including a button to show them all, which stets all three checkboxes in the filter menu.

![image](https://user-images.githubusercontent.com/114137/95660616-51ddff00-0b29-11eb-8d51-0a3125934546.png)

![image](https://user-images.githubusercontent.com/114137/95733020-d17ee180-0c81-11eb-9a23-569082f16f81.png)


- This new information is not shown in a new box, if an active filter for an integration / config_entry is in effect.
- If a filter is in effect, the number of hidden entities is included in it (and only counts the entities that match the filter)
- The visual appearance matches the filter box (in fact currently uses the same CSS classes).


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes  https://github.com/home-assistant/frontend/issues/7299
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
