### PR TITLE
Use translations for alexa

### DIFF
--- a/src/panels/config/cloud/alexa/cloud-alexa.ts
+++ b/src/panels/config/cloud/alexa/cloud-alexa.ts
@@ -131,7 +131,7 @@ class CloudAlexa extends LitElement {
           "not-exposed": !isExposed,
         })}
         .disabled=${!emptyFilter}
-        .title=${this.hass!.localize("ui.panel.config.cloud.google.expose")}
+        .title=${this.hass!.localize("ui.panel.config.cloud.alexa.expose")}
       >
         <ha-svg-icon
           .path=${config.should_expose !== null
@@ -169,7 +169,7 @@ class CloudAlexa extends LitElement {
                     ${iconButton}
                     <mwc-list-item hasMeta>
                       ${this.hass!.localize(
-                        "ui.panel.config.cloud.google.expose_entity"
+                        "ui.panel.config.cloud.alexa.expose_entity"
                       )}
                       <ha-svg-icon
                         class="exposed"
@@ -179,7 +179,7 @@ class CloudAlexa extends LitElement {
                     </mwc-list-item>
                     <mwc-list-item hasMeta>
                       ${this.hass!.localize(
-                        "ui.panel.config.cloud.google.dont_expose_entity"
+                        "ui.panel.config.cloud.alexa.dont_expose_entity"
                       )}
                       <ha-svg-icon
                         class="not-exposed"
@@ -189,7 +189,7 @@ class CloudAlexa extends LitElement {
                     </mwc-list-item>
                     <mwc-list-item hasMeta>
                       ${this.hass!.localize(
-                        "ui.panel.config.cloud.google.follow_domain"
+                        "ui.panel.config.cloud.alexa.follow_domain"
                       )}
                       <ha-svg-icon
                         class=${classMap({


### PR DESCRIPTION
Use the right translations for the alexa panel, not the one for google.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Using the right translations for the alexa panel. Before this change, the translations for the google panel were used.
Fixes the issue 7214: https://github.com/home-assistant/frontend/issues/7214

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 7214 (https://github.com/home-assistant/frontend/issues/7214)
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
