### PR TITLE
Add the options dark_mode_filter and dark_mode_image to the picture elements card

### DIFF
--- a/src/panels/lovelace/cards/hui-picture-elements-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.ts
@@ -129,7 +129,8 @@ class HuiPictureElementsCard extends LitElement implements LovelaceCard {
             .cameraView=${this._config.camera_view}
             .entity=${this._config.entity}
             .aspectRatio=${this._config.aspect_ratio}
-            .darkMode=${this.hass.themes.darkMode && this._config.dark_mode}
+            .darkModeFilter=${this._config.dark_mode_filter}
+            .darkModeImage=${this._config.dark_mode_image}
           ></hui-image>
           ${this._elements}
         </div>

--- a/src/panels/lovelace/cards/hui-picture-elements-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.ts
@@ -129,6 +129,7 @@ class HuiPictureElementsCard extends LitElement implements LovelaceCard {
             .cameraView=${this._config.camera_view}
             .entity=${this._config.entity}
             .aspectRatio=${this._config.aspect_ratio}
+            .darkMode=${this.hass.themes.darkMode && this._config.dark_mode}
           ></hui-image>
           ${this._elements}
         </div>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -218,6 +218,7 @@ export interface PictureElementsCardConfig extends LovelaceCardConfig {
   entity?: string;
   elements: LovelaceElementConfig[];
   theme?: string;
+  dark_mode?: boolean;
 }
 
 export interface PictureEntityCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -218,7 +218,8 @@ export interface PictureElementsCardConfig extends LovelaceCardConfig {
   entity?: string;
   elements: LovelaceElementConfig[];
   theme?: string;
-  dark_mode?: boolean;
+  dark_mode_image?: string;
+  dark_mode_filter?: string;
 }
 
 export interface PictureEntityCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -21,7 +21,6 @@ import { CameraEntity, HomeAssistant } from "../../../types";
 
 const UPDATE_INTERVAL = 10000;
 const DEFAULT_FILTER = "grayscale(100%)";
-const INVERT_FILTER = "invert(100%)";
 
 export interface StateSpecificConfig {
   [state: string]: string;
@@ -47,7 +46,9 @@ export class HuiImage extends LitElement {
 
   @property() public stateFilter?: StateSpecificConfig;
 
-  @property() public darkMode?: boolean;
+  @property() public darkModeImage?: string;
+
+  @property() public darkModeFilter?: string;
 
   @internalProperty() private _loadError?: boolean;
 
@@ -100,6 +101,8 @@ export class HuiImage extends LitElement {
         imageSrc = this.image;
         imageFallback = true;
       }
+    } else if (this.darkModeImage && this.hass.themes.darkMode) {
+      imageSrc = this.darkModeImage;
     } else {
       imageSrc = this.image;
     }
@@ -110,7 +113,10 @@ export class HuiImage extends LitElement {
 
     // Figure out filter to use
     let filter = this.filter || "";
-    filter += this.darkMode ? INVERT_FILTER : "";
+
+    if (this.hass.themes.darkMode && this.darkModeFilter) {
+      filter += this.darkModeFilter;
+    }
 
     if (this.stateFilter && this.stateFilter[state]) {
       filter += this.stateFilter[state];

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -21,6 +21,7 @@ import { CameraEntity, HomeAssistant } from "../../../types";
 
 const UPDATE_INTERVAL = 10000;
 const DEFAULT_FILTER = "grayscale(100%)";
+const INVERT_FILTER = "invert(100%)";
 
 export interface StateSpecificConfig {
   [state: string]: string;
@@ -45,6 +46,8 @@ export class HuiImage extends LitElement {
   @property() public filter?: string;
 
   @property() public stateFilter?: StateSpecificConfig;
+
+  @property() public darkMode?: boolean;
 
   @internalProperty() private _loadError?: boolean;
 
@@ -107,9 +110,10 @@ export class HuiImage extends LitElement {
 
     // Figure out filter to use
     let filter = this.filter || "";
+    filter += this.darkMode ? INVERT_FILTER : "";
 
     if (this.stateFilter && this.stateFilter[state]) {
-      filter = this.stateFilter[state];
+      filter += this.stateFilter[state];
     }
 
     if (!filter && this.entity) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allows to enable different filters, depending on whether the dark mode is activated or not. You can also use a completely different image. 
This makes the icons better visible and the background colors are more eye-friendly. In addition, you can now read white text like the one below the badge. 

### Before
![grafik](https://user-images.githubusercontent.com/15657682/95668271-026ff100-0b72-11eb-8223-20f6e31deac5.png)

### After
![grafik](https://user-images.githubusercontent.com/15657682/95668279-23384680-0b72-11eb-9299-cdff4e646001.png)

This is necessary when different devices use different color schemes. For example, my smartphone uses dark mode by default, while the computer usually uses light mode. 
This also works combined with `state_filter` since we stack filters in `hui-image.ts`.
I am not really happy with the name of the option. Suggestions are welcome!

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: picture-elements
elements:
  - type: state-badge
    entity: binary_sensor.updater
    style:
      top: 32%
      left: 40%
image: 'https://demo.home-assistant.io/stub_config/t-shirt-promo.png'
dark_mode_image: 'https://demo.home-assistant.io/stub_config/floorplan.png'
dark_mode_filter: 'invert(100%)'
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15169

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
