### PR TITLE
Weather Card: add icons instead of text

### DIFF
--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -8,6 +8,7 @@ import {
 import { css, html, svg, SVGTemplateResult, TemplateResult } from "lit-element";
 import { styleMap } from "lit-html/directives/style-map";
 import "../components/ha-icon";
+import "../components/ha-svg-icon";
 import type { HomeAssistant, WeatherEntity } from "../types";
 import { roundWithOneDecimal } from "../util/calculate";
 

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -1,6 +1,13 @@
-import { SVGTemplateResult, svg, html, TemplateResult, css } from "lit-element";
+import {
+  mdiGauge,
+  mdiWaterPercent,
+  mdiWeatherFog,
+  mdiWeatherRainy,
+  mdiWeatherWindy,
+} from "@mdi/js";
+import { css, html, svg, SVGTemplateResult, TemplateResult } from "lit-element";
 import { styleMap } from "lit-html/directives/style-map";
-
+import "../components/ha-icon";
 import type { HomeAssistant, WeatherEntity } from "../types";
 import { roundWithOneDecimal } from "../util/calculate";
 
@@ -23,6 +30,15 @@ export const weatherSVGs = new Set<string>([
 
 export const weatherIcons = {
   exceptional: "hass:alert-circle-outline",
+};
+
+export const weatherAttrIcons = {
+  humidity: mdiWaterPercent,
+  wind_bearing: mdiWeatherWindy,
+  wind_speed: mdiWeatherWindy,
+  pressure: mdiGauge,
+  visibility: mdiWeatherFog,
+  precipitation: mdiWeatherRainy,
 };
 
 const cloudyStates = new Set<string>([
@@ -110,6 +126,7 @@ export const getWeatherUnit = (
       return lengthUnit === "km" ? "hPa" : "inHg";
     case "wind_speed":
       return `${lengthUnit}/h`;
+    case "visibility":
     case "length":
       return lengthUnit;
     case "precipitation":
@@ -125,7 +142,7 @@ export const getWeatherUnit = (
 export const getSecondaryWeatherAttribute = (
   hass: HomeAssistant,
   stateObj: WeatherEntity
-): string | undefined => {
+): TemplateResult | undefined => {
   const extrema = getWeatherExtrema(hass, stateObj);
 
   if (extrema) {
@@ -149,17 +166,22 @@ export const getSecondaryWeatherAttribute = (
     return undefined;
   }
 
-  return `
-    ${hass!.localize(
-      `ui.card.weather.attributes.${attribute}`
-    )} ${roundWithOneDecimal(value)} ${getWeatherUnit(hass!, attribute)}
+  const weatherAttrIcon = weatherAttrIcons[attribute];
+
+  return html`
+    ${weatherAttrIcon
+      ? html`
+          <ha-svg-icon class="attr-icon" .path=${weatherAttrIcon}></ha-svg-icon>
+        `
+      : hass!.localize(`ui.card.weather.attributes.${attribute}`)}
+    ${roundWithOneDecimal(value)} ${getWeatherUnit(hass!, attribute)}
   `;
 };
 
 const getWeatherExtrema = (
   hass: HomeAssistant,
   stateObj: WeatherEntity
-): string | undefined => {
+): TemplateResult | undefined => {
   if (!stateObj.attributes.forecast?.length) {
     return undefined;
   }
@@ -189,22 +211,18 @@ const getWeatherExtrema = (
 
   const unit = getWeatherUnit(hass!, "temperature");
 
-  return `
-    ${
-      tempHigh
-        ? `
+  return html`
+    ${tempHigh
+      ? `
             ${tempHigh} ${unit}
           `
-        : ""
-    }
+      : ""}
     ${tempLow && tempHigh ? " / " : ""}
-    ${
-      tempLow
-        ? `
+    ${tempLow
+      ? `
           ${tempLow} ${unit}
         `
-        : ""
-    }
+      : ""}
   `;
 };
 

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -223,7 +223,8 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
               <div class="attribute">
                 ${this._config.secondary_info_attribute !== undefined
                   ? html`
-                      ${this._config.secondary_info_attribute in weatherAttrIcons
+                      ${this._config.secondary_info_attribute in
+                      weatherAttrIcons
                         ? html`
                             <ha-svg-icon
                               class="attr-icon"

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -223,7 +223,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
               <div class="attribute">
                 ${this._config.secondary_info_attribute !== undefined
                   ? html`
-                      ${weatherAttrIcons[this._config.secondary_info_attribute]
+                      ${this._config.secondary_info_attribute in weatherAttrIcons
                         ? html`
                             <ha-svg-icon
                               class="attr-icon"

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -3,9 +3,9 @@ import {
   CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
-  internalProperty,
   PropertyValues,
   TemplateResult,
 } from "lit-element";
@@ -21,19 +21,20 @@ import "../../../components/ha-icon";
 import { UNAVAILABLE } from "../../../data/entity";
 import {
   getSecondaryWeatherAttribute,
-  getWeatherUnit,
   getWeatherStateIcon,
+  getWeatherUnit,
   getWind,
+  weatherAttrIcons,
   weatherSVGStyles,
 } from "../../../data/weather";
 import type { HomeAssistant, WeatherEntity } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { findEntities } from "../common/find-entites";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
+import { installResizeObserver } from "../common/install-resize-observer";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import type { WeatherForecastCardConfig } from "./types";
-import { installResizeObserver } from "../common/install-resize-observer";
 
 const DAY_IN_MILLISECONDS = 86400000;
 
@@ -222,9 +223,18 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
               <div class="attribute">
                 ${this._config.secondary_info_attribute !== undefined
                   ? html`
-                      ${this.hass!.localize(
-                        `ui.card.weather.attributes.${this._config.secondary_info_attribute}`
-                      )}
+                      ${weatherAttrIcons[this._config.secondary_info_attribute]
+                        ? html`
+                            <ha-svg-icon
+                              class="attr-icon"
+                              .path=${weatherAttrIcons[
+                                this._config.secondary_info_attribute
+                              ]}
+                            ></ha-svg-icon>
+                          `
+                        : this.hass!.localize(
+                            `ui.card.weather.attributes.${this._config.secondary_info_attribute}`
+                          )}
                       ${this._config.secondary_info_attribute === "wind_speed"
                         ? getWind(
                             this.hass,
@@ -477,6 +487,10 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
         .forecast-icon {
           --mdc-icon-size: 40px;
+        }
+
+        .attr-icon {
+          --mdc-icon-size: 20px;
         }
 
         .attribute,


### PR DESCRIPTION
## Proposed change


![image](https://user-images.githubusercontent.com/18730868/95669310-2ff27580-0b45-11eb-8762-502dd8adc1fa.png)


## Type of change

- [x] New feature (thank you!)

## Example configuration

```yaml
- attribute: humidity
  entity: weather.dark_sky
  name: Home
  show_forecast: true
  type: weather-forecast
- entity: weather.home
  show_forecast: false
  type: weather-forecast
- entity: weather.dark_sky
  name: 'Chicago, Illinois'
  show_forecast: false
  type: weather-forecast
  secondary_info_attribute: wind_speed
- entity: weather.openweathermap
  name: Open Weather Map
  type: weather-forecast
- entity: weather.dark_sky
  name: 'Chicago, Illinois'
  show_forecast: false
  type: weather-forecast
  secondary_info_attribute: visibility
- entity: weather.dark_sky
  name: 'Chicago, Illinois'
  show_forecast: false
  type: weather-forecast
  secondary_info_attribute: pressure
```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6989, #5923
- Link to documentation pull request:

## Checklist

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
