### PR TITLE
Added entity_id to history graph tooltip

### DIFF
--- a/src/components/entity/ha-chart-base.js
+++ b/src/components/entity/ha-chart-base.js
@@ -79,6 +79,10 @@ class HaChartBase extends mixinBehaviors(
           text-align: center;
           font-weight: 500;
         }
+        .chartTooltip .beforeBody {
+          text-align: center;
+          font-weight: 300;
+        }
         .chartLegend li {
           display: inline-block;
           padding: 0 6px;
@@ -133,6 +137,9 @@ class HaChartBase extends mixinBehaviors(
           style$="opacity:[[tooltip.opacity]]; top:[[tooltip.top]]; left:[[tooltip.left]]; padding:[[tooltip.yPadding]]px [[tooltip.xPadding]]px"
         >
           <div class="title">[[tooltip.title]]</div>
+          <template is="dom-if" if="[[tooltip.beforeBody]]">
+            <div class="beforeBody">[[tooltip.beforeBody]]</div>
+          </template>
           <div>
             <ul>
               <template is="dom-repeat" items="[[tooltip.lines]]">
@@ -263,6 +270,10 @@ class HaChartBase extends mixinBehaviors(
 
     const title = tooltip.title ? tooltip.title[0] || "" : "";
     this.set(["tooltip", "title"], title);
+
+    if (tooltip.beforeBody) {
+        this.set(["tooltip", "beforeBody"], tooltip.beforeBody.join("\n"));
+    }
 
     const bodyLines = tooltip.body.map((n) => n.lines);
 

--- a/src/components/state-history-chart-timeline.js
+++ b/src/components/state-history-chart-timeline.js
@@ -159,7 +159,7 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
       if (prevState !== null) {
         dataRow.push([prevLastChanged, endTime, locState, prevState]);
       }
-      datasets.push({ data: dataRow });
+      datasets.push({ data: dataRow, entity_id: stateInfo.entity_id });
       labels.push(entityDisplay);
     });
 
@@ -172,6 +172,14 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
 
       return [state, start, end];
     };
+    
+    const formatTooltipBeforeBody = (item, data) => {
+      if (!item[0]) {
+        return '';
+      }
+      const values = data.datasets[item[0].datasetIndex];
+      return values.entity_id || '';
+    };
 
     const chartOptions = {
       type: "timeline",
@@ -179,6 +187,7 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
         tooltips: {
           callbacks: {
             label: formatTooltipLabel,
+            beforeBody: formatTooltipBeforeBody,
           },
         },
         scales: {

--- a/src/components/state-history-chart-timeline.js
+++ b/src/components/state-history-chart-timeline.js
@@ -174,7 +174,7 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
     };
 
     const formatTooltipBeforeBody = (item, data) => {
-      if (!item[0]) {
+      if (!this.hass.userData?.showAdvanced || !item[0]) {
         return "";
       }
       // Extract the entity ID from the dataset.

--- a/src/components/state-history-chart-timeline.js
+++ b/src/components/state-history-chart-timeline.js
@@ -174,7 +174,7 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
     };
 
     const formatTooltipBeforeBody = (item, data) => {
-      if (!this.hass.userData?.showAdvanced || !item[0]) {
+      if (!this.hass.userData || !this.hass.userData.showAdvanced || !item[0]) {
         return "";
       }
       // Extract the entity ID from the dataset.

--- a/src/components/state-history-chart-timeline.js
+++ b/src/components/state-history-chart-timeline.js
@@ -172,13 +172,14 @@ class StateHistoryChartTimeline extends LocalizeMixin(PolymerElement) {
 
       return [state, start, end];
     };
-    
+
     const formatTooltipBeforeBody = (item, data) => {
       if (!item[0]) {
-        return '';
+        return "";
       }
+      // Extract the entity ID from the dataset.
       const values = data.datasets[item[0].datasetIndex];
-      return values.entity_id || '';
+      return values.entity_id || "";
     };
 
     const chartOptions = {


### PR DESCRIPTION
## Proposed change

For this year's Hacktoberfest I wanted to finally deep-dive into my favourite open-source project of this year! This is just a minor addition but something that has irked me for a few weeks now.

This PR adds the entity_id as a `beforeBody` text to the timeline history graph tooltip. 

![ha](https://user-images.githubusercontent.com/8600029/95679787-7099cf80-0bd5-11eb-9440-efdf8d1b9626.gif)

If there are entities with the same name (like a group + light or a device_tracker + person), this change makes it easy to identify what data you are looking at.

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New (minor!) feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

This PR makes the Chart.js `beforeBody` property usable in chart tooltips. The property is documented here: https://www.chartjs.org/docs/latest/configuration/tooltip.html
