### PR TITLE
Prevent old more info control to be created

### DIFF
--- a/src/common/dom/dynamic-element-directive.ts
+++ b/src/common/dom/dynamic-element-directive.ts
@@ -10,7 +10,7 @@ export const dynamicElement = directive(
 
     let element = part.value as HTMLElement | undefined;
 
-    if (element !== undefined && tag.toUpperCase() === element.tagName) {
+    if (tag === element?.localName) {
       if (properties) {
         Object.entries(properties).forEach(([key, value]) => {
           element![key] = value;

--- a/src/common/dom/dynamic-element-directive.ts
+++ b/src/common/dom/dynamic-element-directive.ts
@@ -10,10 +10,7 @@ export const dynamicElement = directive(
 
     let element = part.value as HTMLElement | undefined;
 
-    if (
-      element !== undefined &&
-      tag.toUpperCase() === (element as HTMLElement).tagName
-    ) {
+    if (element !== undefined && tag.toUpperCase() === element.tagName) {
       if (properties) {
         Object.entries(properties).forEach(([key, value]) => {
           element![key] = value;

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -70,8 +70,21 @@ export class MoreInfoDialog extends LitElement {
     this._entityId = params.entityId;
     if (!this._entityId) {
       this.closeDialog();
+      return;
     }
     this.large = false;
+
+    const stateObj = this.hass.states[this._entityId];
+    if (!stateObj) {
+      return;
+    }
+    if (stateObj.attributes && "custom_ui_more_info" in stateObj.attributes) {
+      this._moreInfoType = stateObj.attributes.custom_ui_more_info;
+    } else {
+      const type = stateMoreInfoType(stateObj);
+      importMoreInfoControl(type);
+      this._moreInfoType = type === "hidden" ? undefined : `more-info-${type}`;
+    }
   }
 
   public closeDialog() {
@@ -92,23 +105,6 @@ export class MoreInfoDialog extends LitElement {
     }
 
     return false;
-  }
-
-  protected updated(changedProperties) {
-    if (!this.hass || !this._entityId || !changedProperties.has("_entityId")) {
-      return;
-    }
-    const stateObj = this.hass.states[this._entityId];
-    if (!stateObj) {
-      return;
-    }
-    if (stateObj.attributes && "custom_ui_more_info" in stateObj.attributes) {
-      this._moreInfoType = stateObj.attributes.custom_ui_more_info;
-    } else {
-      const type = stateMoreInfoType(stateObj);
-      importMoreInfoControl(type);
-      this._moreInfoType = type === "hidden" ? undefined : `more-info-${type}`;
-    }
   }
 
   protected render() {


### PR DESCRIPTION

## Proposed change

Because the more info control tag would be set in updated, we would first load the previous more info dialog control. Moved it to `showDialog`, as that is the only moment the entity id will change.

Alternative would be to set `_moreInfoType` to undefined in `closeDialog`/`showDialog`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
