### PR TITLE
Add tests for fuzzy sequence matcher

### DIFF
--- a/test-mocha/common/string/sequence_matching.test.ts
+++ b/test-mocha/common/string/sequence_matching.test.ts
@@ -1,0 +1,52 @@
+import { assert } from "chai";
+
+import { fuzzySequentialMatch } from "../../../src/common/string/sequence_matching";
+
+describe("fuzzySequentialMatch", () => {
+  const entityId = "automation.ticker";
+
+  const shouldMatchEntity = [
+    "",
+    "automation.ticker",
+    "automation.ticke",
+    "automation.",
+    "au",
+    "automationticker",
+    "tion.tick",
+    "ticker",
+    "automation.r",
+    "tick",
+    "aumatick",
+    "aion.tck",
+    "ioticker",
+    "atmto.ikr",
+    "uoaintce",
+    "au.tce",
+    "tomaontkr",
+  ];
+
+  const shouldNotMatchEntity = [
+    " ",
+    "abcdefghijklmnopqrstuvwxyz",
+    "automation.tickerz",
+    "automation. ticke",
+    "1",
+    "noitamotua",
+  ];
+
+  describe(`Entity '${entityId}'`, () => {
+    for (const goodFilter of shouldMatchEntity) {
+      it(`matches with '${goodFilter}'`, () => {
+        const res = fuzzySequentialMatch(goodFilter, entityId);
+        assert.equal(res, true);
+      });
+    }
+
+    for (const badFilter of shouldNotMatchEntity) {
+      it(`fails to match with '${badFilter}'`, () => {
+        const res = fuzzySequentialMatch(badFilter, entityId);
+        assert.equal(res, false);
+      });
+    }
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

The fuzzy sequence matcher is a bit tricky to describe, and a few upcoming features may be adding new features like "maximum number of skips allowed". In addition, some PRs are already looking at borrowing this function for other things like the entity picker: https://github.com/home-assistant/frontend/pull/7291.

Having tests for something like this helps give "implicit documentation" for expected behavior of the matcher, and also ensures we don't break other things in HA that might be using it.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
