### PR TITLE
Fix alignment / padding of ha-switch

### DIFF
--- a/src/panels/lovelace/editor/config-elements/config-elements-style.ts
+++ b/src/panels/lovelace/editor/config-elements/config-elements-style.ts
@@ -2,7 +2,7 @@ import { css } from "lit-element";
 
 export const configElementStyle = css`
   ha-switch {
-    padding: 16px 8px;
+    padding: 16px 6px;
   }
   .side-by-side {
     display: flex;

--- a/src/panels/lovelace/editor/config-elements/config-elements-style.ts
+++ b/src/panels/lovelace/editor/config-elements/config-elements-style.ts
@@ -2,7 +2,7 @@ import { css } from "lit-element";
 
 export const configElementStyle = css`
   ha-switch {
-    padding: 16px 0;
+    padding: 16px 8px;
   }
   .side-by-side {
     display: flex;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Previously the `<ha-switch>` was not properly aligned, see the before/after screenshots. I added 8px of padding, since the material guide says increments of 4px ([source](https://material.io/design/layout/spacing-methods.html#spacing)), although here 6px might suffice. 

![image](https://user-images.githubusercontent.com/114137/96108146-8bbe5500-0edd-11eb-9dda-53e0a28992cd.png)

![image](https://user-images.githubusercontent.com/114137/96108161-8e20af00-0edd-11eb-9063-7fda9f0ef9f1.png)

![image](https://user-images.githubusercontent.com/114137/96108168-911b9f80-0edd-11eb-9522-66a3c5eaa554.png)

![image](https://user-images.githubusercontent.com/114137/96108179-937df980-0edd-11eb-8f30-6088912dabfb.png)


There is one visual difference I can spot: The label next to the switch is now a bit farther away. That is because the following selector adds a 4px padding on its own. In other frontend areas where a `<ha-switch>`is used this does not come into play, since there (e.g. enable buttons of automation or the entity enable button) they are not used in combination with a `<ha-formfield>`.

```
.mdc-form-field > label {
    margin-left: 0;
    margin-right: auto;
    padding-left: 4px;
    padding-right: 0;
    order: 0;
}
```

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
