### PR TITLE
Add dialog-box warning support 

### DIFF
--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -99,20 +99,16 @@ class DialogBox extends LitElement {
           <mwc-button @click=${this._dismiss} slot="secondaryAction">
             ${this._params.dismissText
               ? this._params.dismissText
-              : this._params.question
-              ? this.hass.localize("ui.dialogs.generic.no")
               : this.hass.localize("ui.dialogs.generic.cancel")}
           </mwc-button>
         `}
         <mwc-button
           @click=${this._confirm}
-          ?dialogInitialFocus=${!this._params.prompt && !this._params.question}
+          ?dialogInitialFocus=${!this._params.prompt}
           slot="primaryAction"
         >
           ${this._params.confirmText
             ? this._params.confirmText
-            : this._params.question
-            ? this.hass.localize("ui.dialogs.generic.yes")
             : this.hass.localize("ui.dialogs.generic.ok")}
         </mwc-button>
       </ha-dialog>

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -70,6 +70,7 @@ class DialogBox extends LitElement {
                 <p
                   class=${classMap({
                     "no-bottom-padding": Boolean(this._params.prompt),
+                    warning: Boolean(this._params.warning),
                   })}
                 >
                   ${this._params.text}
@@ -98,16 +99,20 @@ class DialogBox extends LitElement {
           <mwc-button @click=${this._dismiss} slot="secondaryAction">
             ${this._params.dismissText
               ? this._params.dismissText
+              : this._params.question
+              ? this.hass.localize("ui.dialogs.generic.no")
               : this.hass.localize("ui.dialogs.generic.cancel")}
           </mwc-button>
         `}
         <mwc-button
           @click=${this._confirm}
-          ?dialogInitialFocus=${!this._params.prompt}
+          ?dialogInitialFocus=${!this._params.prompt && !this._params.question}
           slot="primaryAction"
         >
           ${this._params.confirmText
             ? this._params.confirmText
+            : this._params.question
+            ? this.hass.localize("ui.dialogs.generic.yes")
             : this.hass.localize("ui.dialogs.generic.ok")}
         </mwc-button>
       </ha-dialog>
@@ -179,6 +184,9 @@ class DialogBox extends LitElement {
         ha-dialog {
           /* Place above other dialogs */
           --dialog-z-index: 104;
+        }
+        .warning {
+          color: var(--warning-color);
         }
       `,
     ];

--- a/src/dialogs/generic/show-dialog-box.ts
+++ b/src/dialogs/generic/show-dialog-box.ts
@@ -30,6 +30,8 @@ export interface DialogParams
   confirm?: (out?: string) => void;
   confirmation?: boolean;
   prompt?: boolean;
+  question?: boolean;
+  warning?: boolean;
 }
 
 export const loadGenericDialog = () =>
@@ -41,6 +43,7 @@ const showDialogHelper = (
   extra?: {
     confirmation?: DialogParams["confirmation"];
     prompt?: DialogParams["prompt"];
+    question?: DialogParams["question"];
   }
 ) =>
   new Promise((resolve) => {
@@ -76,11 +79,20 @@ export const showAlertDialog = (
 
 export const showConfirmationDialog = (
   element: HTMLElement,
-  dialogParams: ConfirmationDialogParams
+  dialogParams: DialogParams
 ) =>
   showDialogHelper(element, dialogParams, { confirmation: true }) as Promise<
     boolean
   >;
+
+export const showQuestionDialog = (
+  element: HTMLElement,
+  dialogParams: DialogParams
+) =>
+  showDialogHelper(element, dialogParams, {
+    question: true,
+    confirmation: true,
+  }) as Promise<boolean>;
 
 export const showPromptDialog = (
   element: HTMLElement,

--- a/src/dialogs/generic/show-dialog-box.ts
+++ b/src/dialogs/generic/show-dialog-box.ts
@@ -5,6 +5,7 @@ interface BaseDialogParams {
   confirmText?: string;
   text?: string | TemplateResult;
   title?: string;
+  warning?: boolean;
 }
 
 export interface AlertDialogParams extends BaseDialogParams {
@@ -30,8 +31,6 @@ export interface DialogParams
   confirm?: (out?: string) => void;
   confirmation?: boolean;
   prompt?: boolean;
-  question?: boolean;
-  warning?: boolean;
 }
 
 export const loadGenericDialog = () =>
@@ -43,7 +42,6 @@ const showDialogHelper = (
   extra?: {
     confirmation?: DialogParams["confirmation"];
     prompt?: DialogParams["prompt"];
-    question?: DialogParams["question"];
   }
 ) =>
   new Promise((resolve) => {
@@ -79,20 +77,11 @@ export const showAlertDialog = (
 
 export const showConfirmationDialog = (
   element: HTMLElement,
-  dialogParams: DialogParams
+  dialogParams: ConfirmationDialogParams
 ) =>
   showDialogHelper(element, dialogParams, { confirmation: true }) as Promise<
     boolean
   >;
-
-export const showQuestionDialog = (
-  element: HTMLElement,
-  dialogParams: DialogParams
-) =>
-  showDialogHelper(element, dialogParams, {
-    question: true,
-    confirmation: true,
-  }) as Promise<boolean>;
 
 export const showPromptDialog = (
   element: HTMLElement,

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -36,7 +36,7 @@ import {
   loadDeviceRegistryDetailDialog,
   showDeviceRegistryDetailDialog,
 } from "../../../dialogs/device-registry-detail/show-dialog-device-registry-detail";
-import { showQuestionDialog } from "../../../dialogs/generic/show-dialog-box";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-error-screen";
 import "../../../layouts/hass-tabs-subpage";
 import { HomeAssistant, Route } from "../../../types";
@@ -567,13 +567,15 @@ export class HaConfigDevicePage extends LitElement {
 
         const renameEntityid =
           this.showAdvanced &&
-          (await showQuestionDialog(this, {
+          (await showConfirmationDialog(this, {
             title: this.hass.localize(
               "ui.panel.config.devices.confirm_rename_entity_ids"
             ),
             text: this.hass.localize(
               "ui.panel.config.devices.confirm_rename_entity_ids_warning"
             ),
+            confirmText: this.hass.localize("ui.common.yes"),
+            dismissText: this.hass.localize("ui.common.no"),
             warning: true,
           }));
 

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -36,7 +36,7 @@ import {
   loadDeviceRegistryDetailDialog,
   showDeviceRegistryDetailDialog,
 } from "../../../dialogs/device-registry-detail/show-dialog-device-registry-detail";
-import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
+import { showQuestionDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../layouts/hass-error-screen";
 import "../../../layouts/hass-tabs-subpage";
 import { HomeAssistant, Route } from "../../../types";
@@ -567,13 +567,14 @@ export class HaConfigDevicePage extends LitElement {
 
         const renameEntityid =
           this.showAdvanced &&
-          (await showConfirmationDialog(this, {
+          (await showQuestionDialog(this, {
             title: this.hass.localize(
               "ui.panel.config.devices.confirm_rename_entity_ids"
             ),
             text: this.hass.localize(
               "ui.panel.config.devices.confirm_rename_entity_ids_warning"
             ),
+            warning: true,
           }));
 
         const updateProms = entities.map((entity) => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -495,6 +495,8 @@
       "generic": {
         "cancel": "Cancel",
         "ok": "OK",
+        "yes": "Yes",
+        "no": "No",
         "default_confirmation_title": "Are you sure?",
         "close": "close"
       },
@@ -1637,8 +1639,8 @@
           },
           "scripts": "Scripts",
           "scenes": "Scenes",
-          "confirm_rename_entity_ids": "Do you also want to rename the entity id's of your entities?",
-          "confirm_rename_entity_ids_warning": "This will not change any configuration (like automations, scripts, scenes, Lovelace) that is currently using these entities, you will have to update them yourself.",
+          "confirm_rename_entity_ids": "Do you also want to rename the entity IDs of your entities?",
+          "confirm_rename_entity_ids_warning": "This will not change any configuration (like automations, scripts, scenes, dashboards) that is currently using these entities! You will have to update them yourself to use the new entity IDs!",
           "data_table": {
             "device": "Device",
             "manufacturer": "Manufacturer",
@@ -2352,7 +2354,7 @@
           "migrate": {
             "header": "Configuration Incompatible",
             "para_no_id": "This element doesn't have an ID. Please add an ID to this element in 'ui-lovelace.yaml'.",
-            "para_migrate": "Home Assistant can add ID's to all your cards and views automatically for you by pressing the 'Migrate configuration' button.",
+            "para_migrate": "Home Assistant can add IDs to all your cards and views automatically for you by pressing the 'Migrate configuration' button.",
             "migrate": "Migrate configuration"
           },
           "action-editor": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -495,8 +495,6 @@
       "generic": {
         "cancel": "Cancel",
         "ok": "OK",
-        "yes": "Yes",
-        "no": "No",
         "default_confirmation_title": "Are you sure?",
         "close": "close"
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Helper function to create a question dialog with default Yes/No option (no button selection so user has to purposely select an option). The confirm and dismiss texts can still be override as before. 
Also added the option to flag a dialog as containing a warning so that the matching CSS class gets applied.

The idea came to me when I changed the name of a device. The user then gets asked whether the entity IDs should also be changed. I saw two issues here:
1. It was a Yes / Cancel dialog, but you cannot actually cancel anything here (the device renaming already happened, so Yes/No is correct IMHO).
2. Clicking Yes here has a comparably big impact and to make sure a user is aware of the potential ramifications, this should be visually highlighted.

![image](https://user-images.githubusercontent.com/114137/96198714-ded3ee80-0f55-11eb-8e81-2b7c470ccb33.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
