### PR TITLE
Allow multiple states in condition and multiple times in triggers

### DIFF
--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -194,6 +194,7 @@ export class HaEntityPicker extends LitElement {
         .value=${this._value}
         .allowCustomValue=${this.allowCustomEntity}
         .renderer=${rowRenderer}
+        attr-for-value="bind-value"
         @opened-changed=${this._openedChanged}
         @value-changed=${this._valueChanged}
         @filter-changed=${this._filterChanged}

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -194,7 +194,6 @@ export class HaEntityPicker extends LitElement {
         .value=${this._value}
         .allowCustomValue=${this.allowCustomEntity}
         .renderer=${rowRenderer}
-        attr-for-value="bind-value"
         @opened-changed=${this._openedChanged}
         @value-changed=${this._valueChanged}
         @filter-changed=${this._filterChanged}

--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -147,7 +147,7 @@ export interface StateCondition {
   condition: "state";
   entity_id: string;
   attribute?: string;
-  state: string[] | number[];
+  state: string[];
 }
 
 export interface NumericStateCondition {

--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -101,7 +101,7 @@ export interface TagTrigger {
 
 export interface TimeTrigger {
   platform: "time";
-  at: string;
+  at: string[];
 }
 
 export interface TemplateTrigger {
@@ -147,7 +147,7 @@ export interface StateCondition {
   condition: "state";
   entity_id: string;
   attribute?: string;
-  state: string | number;
+  state: string[] | number[];
 }
 
 export interface NumericStateCondition {

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -25,20 +25,15 @@ export interface ConditionElement extends LitElement {
   condition: Condition;
 }
 
-export const handleChangeEvent = (
+export const handleChange = (
   element: ConditionElement,
-  ev: CustomEvent
+  name: string,
+  value: any
 ) => {
-  ev.stopPropagation();
-  const name = (ev.target as any)?.name;
   if (!name) {
     return;
   }
-  const newVal = ev.detail.value;
-
-  if ((element.condition[name] || "") === newVal) {
-    return;
-  }
+  const newVal = value;
 
   let newCondition: Condition;
   if (!newVal) {
@@ -48,6 +43,21 @@ export const handleChangeEvent = (
     newCondition = { ...element.condition, [name]: newVal };
   }
   fireEvent(element, "value-changed", { value: newCondition });
+};
+
+export const handleChangeEvent = (
+  element: ConditionElement,
+  ev: CustomEvent
+) => {
+  ev.stopPropagation();
+  const name = (ev.target as any)?.name;
+  const newVal = ev.detail.value;
+
+  if ((element.condition[name] || "") === newVal) {
+    return;
+  }
+
+  handleChange(element, name, newVal);
 };
 
 @customElement("ha-automation-condition-row")

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -33,14 +33,13 @@ export const handleChange = (
   if (!name) {
     return;
   }
-  const newVal = value;
 
   let newCondition: Condition;
-  if (!newVal) {
+  if (!value) {
     newCondition = { ...element.condition };
     delete newCondition[name];
   } else {
-    newCondition = { ...element.condition, [name]: newVal };
+    newCondition = { ...element.condition, [name]: value };
   }
   fireEvent(element, "value-changed", { value: newCondition });
 };

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -49,29 +49,27 @@ export class HaStateCondition extends LitElement implements ConditionElement {
           )}
           .name=${"state-" + idx}
           .value=${value}
-          @value-changed=${this._valueChanged}
+          @value-changed=${this._stateValueChanged}
         ></paper-input>`
       )}
     `;
   }
 
   private _valueChanged(ev: CustomEvent): void {
-    const name = (ev.target as any)?.name;
+    handleChangeEvent(this, ev);
+  }
 
-    if (name.startsWith("state-")) {
-      ev.stopPropagation();
-      const value = ev.detail.value;
-      const idx = name.split("-").pop();
+  private _stateValueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const value = ev.detail.value;
+    const idx = (ev.target as any)?.name.split("-").pop();
 
-      if ((this.condition.state[idx] || "") === value) {
-        return;
-      }
-
-      this.condition.state[idx] = value;
-      handleChange(this, "state", this.condition.state);
-    } else {
-      handleChangeEvent(this, ev);
+    if ((this.condition.state[idx] || "") === value) {
+      return;
     }
+
+    this.condition.state[idx] = value;
+    handleChange(this, "state", this.condition.state);
   }
 }
 

--- a/src/panels/config/automation/condition/types/ha-automation-condition-time.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-time.ts
@@ -94,6 +94,7 @@ export class HaTimeCondition extends LitElement implements ConditionElement {
             .value=${after?.startsWith("input_datetime.") ? after : ""}
             @value-changed=${this._valueChanged}
             .hass=${this.hass}
+            allow-custom-entity
           ></ha-entity-picker>`
         : html`<paper-input
             .label=${this.hass.localize(

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -63,7 +63,6 @@ import { HaDeviceAction } from "./action/types/ha-automation-action-device_id";
 import "./condition/ha-automation-condition";
 import "./trigger/ha-automation-trigger";
 import { HaDeviceTrigger } from "./trigger/types/ha-automation-trigger-device";
-import { constrainPoint } from "@fullcalendar/core";
 
 const MODES = ["single", "restart", "queued", "parallel"];
 const MODES_MAX = ["queued", "parallel"];

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -59,17 +59,15 @@ export interface TriggerElement extends LitElement {
   trigger: Trigger;
 }
 
-export const handleChangeEvent = (element: TriggerElement, ev: CustomEvent) => {
-  ev.stopPropagation();
-  const name = (ev.target as any)?.name;
+export const handleChange = (
+  element: TriggerElement,
+  name: string,
+  value: any
+) => {
   if (!name) {
     return;
   }
-  const newVal = ev.detail.value;
-
-  if ((element.trigger[name] || "") === newVal) {
-    return;
-  }
+  const newVal = value;
 
   let newTrigger: Trigger;
   if (!newVal) {
@@ -79,6 +77,18 @@ export const handleChangeEvent = (element: TriggerElement, ev: CustomEvent) => {
     newTrigger = { ...element.trigger, [name]: newVal };
   }
   fireEvent(element, "value-changed", { value: newTrigger });
+};
+
+export const handleChangeEvent = (element: TriggerElement, ev: CustomEvent) => {
+  ev.stopPropagation();
+  const name = (ev.target as any)?.name;
+  const newVal = ev.detail.value;
+
+  if ((element.trigger[name] || "") === newVal) {
+    return;
+  }
+
+  handleChange(element, name, newVal);
 };
 
 @customElement("ha-automation-trigger-row")

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-time.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-time.ts
@@ -72,6 +72,7 @@ export class HaTimeTrigger extends LitElement implements TriggerElement {
               .value=${value?.startsWith("input_datetime.") ? value : ""}
               @value-changed=${this._valueChanged}
               .hass=${this.hass}
+              allow-custom-entity
             ></ha-entity-picker>`
           )
         : at.map(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

This PR adds support to properly handle (a) multiple states in automation conditions and (b) multiple times in automation triggers. 

This PR focuses only on properly loading existing automations that already have multiple values and allows changing and saving them. The UI does not yet allow adding more values than were there in the previously saved automation.
If you create a completely new automation for now the only a single field is display. In a later PR buttons to add more fields could be added.

I am sure there will be multiple reviews to cleanup the proposed code and perhaps even revise the complete approach.

![image](https://user-images.githubusercontent.com/114137/96213221-c1fce280-0f78-11eb-9d27-ef55a157220a.png)

![image](https://user-images.githubusercontent.com/114137/96213267-e1940b00-0f78-11eb-8a9e-dca85950b5b8.png)

**Coding notes:**
1. Both parts (multiple states in conditions and multiple times in trigger) follow the same new logic.
2. In `HaAutomationEditor::updated()` I extended the existing normalization coding to ensure that we always work with arrays, even e.g. if the automation only currently contains a single condition state. That way we do not have to check later on for each value change event if we have an array or not.
3. In the HTML rendering, I assign names to the fields, such as "state-0", "state-1", etc. (same with "at-X" for time triggers).
4. Whenever a value changed callback of an input gets triggered I update the corresponding array index (determined again via the name) with the new value.
5. Since we now have multiple fields, e.g. multiple condition states, I need to intercept the `value-changed` event (function `_stateValueChanged()`), read the changed field's name to get the correct internal index of the array. Then I can update the value in the internal property.
6. If we are in one of those two special cases, I am then afterwards no longer calling `handleChangeEvent()` but a similar new function `handleChange()`. It contains most of the logic that previously was in `handleChangeEvent()` (and is now called by `handleChangeEvent()`). The difference is that the new function does not require an event. Since the important part of  the raised value-change event is read-only, I could not modify the event and rather than re-raising a completely new one, I am now just passing directly the relevant change information to the new function `handleChange()`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/6664 fixes https://github.com/home-assistant/frontend/issues/6665
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
