### PR TITLE
Use ha-card for dev tool "Services" + visual tweaks

### DIFF
--- a/src/panels/developer-tools/service/developer-tools-service.js
+++ b/src/panels/developer-tools/service/developer-tools-service.js
@@ -7,6 +7,7 @@ import "../../../components/buttons/ha-progress-button";
 import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-code-editor";
 import "../../../components/ha-service-picker";
+import "../../../components/ha-card";
 import { ENTITY_COMPONENT_DOMAINS } from "../../../data/entity";
 import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
 import LocalizeMixin from "../../../mixins/localize-mixin";
@@ -38,17 +39,19 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
           margin-top: 8px;
         }
 
-        .description {
-          margin-top: 24px;
-          white-space: pre-wrap;
+        ha-card {
+          margin-top: 12px;
         }
 
-        .header {
-          @apply --paper-font-title;
+        .description {
+          margin-top: 12px;
+          white-space: pre-wrap;
         }
 
         .attributes th {
           text-align: left;
+          background-color: var(--card-background-color);
+          border-bottom: 1px solid var(--primary-text-color);
         }
 
         :host([rtl]) .attributes th {
@@ -78,10 +81,6 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
           font-family: var(--code-font-family, monospace);
         }
 
-        h1 {
-          white-space: normal;
-        }
-
         td {
           padding: 4px;
         }
@@ -105,7 +104,7 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
       >
       </app-localstorage-document>
       <app-localstorage-document
-        key="[[_computeServicedataKey(domainService)]]"
+        key="[[_computeServiceDataKey(domainService)]]"
         data="{{serviceData}}"
       >
       </app-localstorage-document>
@@ -146,58 +145,59 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
           </ha-progress-button>
         </div>
 
-        <template is="dom-if" if="[[!domainService]]">
-          <h1>
-            [[localize('ui.panel.developer-tools.tabs.services.select_service')]]
-          </h1>
-        </template>
+        <ha-card>
+          <div class="card-header">
+            <template is="dom-if" if="[[!domainService]]">
+                [[localize('ui.panel.developer-tools.tabs.services.select_service')]]
+            </template>
 
-        <template is="dom-if" if="[[domainService]]">
-          <template is="dom-if" if="[[!_description]]">
-            <h1>
-              [[localize('ui.panel.developer-tools.tabs.services.no_description')]]
-            </h1>
-          </template>
-          <template is="dom-if" if="[[_description]]">
-            <div class="desc-container">
-              <h3>[[_description]]</h3>
-            </div>
-
-            <table class="attributes">
-              <tr>
-                <th>
-                  [[localize('ui.panel.developer-tools.tabs.services.column_parameter')]]
-                </th>
-                <th>
-                  [[localize('ui.panel.developer-tools.tabs.services.column_description')]]
-                </th>
-                <th>
-                  [[localize('ui.panel.developer-tools.tabs.services.column_example')]]
-                </th>
-              </tr>
+            <template is="dom-if" if="[[domainService]]">
+              <template is="dom-if" if="[[!_description]]">
+                [[localize('ui.panel.developer-tools.tabs.services.no_description')]]
+              </template>
+              <template is="dom-if" if="[[_description]]">
+                [[_description]]
+              </template>
+            </template>
+          </div>
+          <div class="card-content">
+            <template is="dom-if" if="[[_description]]">
               <template is="dom-if" if="[[!_attributes.length]]">
-                <tr>
-                  <td colspan="3">
-                    [[localize('ui.panel.developer-tools.tabs.services.no_parameters')]]
-                  </td>
-                </tr>
+                [[localize('ui.panel.developer-tools.tabs.services.no_parameters')]]
               </template>
-              <template is="dom-repeat" items="[[_attributes]]" as="attribute">
-                <tr>
-                  <td><pre>[[attribute.key]]</pre></td>
-                  <td>[[attribute.description]]</td>
-                  <td>[[attribute.example]]</td>
-                </tr>
-              </template>
-            </table>
 
-            <template is="dom-if" if="[[_attributes.length]]">
-              <mwc-button on-click="_fillExampleData">
-                [[localize('ui.panel.developer-tools.tabs.services.fill_example_data')]]
-              </mwc-button>
+              <template is="dom-if" if="[[_attributes.length]]">
+                <table class="attributes">
+                  <tr>
+                    <th>
+                      [[localize('ui.panel.developer-tools.tabs.services.column_parameter')]]
+                    </th>
+                    <th>
+                      [[localize('ui.panel.developer-tools.tabs.services.column_description')]]
+                    </th>
+                    <th>
+                      [[localize('ui.panel.developer-tools.tabs.services.column_example')]]
+                    </th>
+                  </tr>
+                  <template is="dom-repeat" items="[[_attributes]]" as="attribute">
+                    <tr>
+                      <td><pre>[[attribute.key]]</pre></td>
+                      <td>[[attribute.description]]</td>
+                      <td>[[attribute.example]]</td>
+                    </tr>
+                  </template>
+                </table>
+              </template>
+
+              <template is="dom-if" if="[[_attributes.length]]">
+                <mwc-button on-click="_fillExampleData">
+                  [[localize('ui.panel.developer-tools.tabs.services.fill_example_data')]]
+                </mwc-button>
+              </template>
             </template>
           </template>
-        </template>
+          </div>
+        </ha-card>
       </div>
     `;
   }
@@ -206,6 +206,7 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
     return {
       hass: {
         type: Object,
+        observer: "hassChanged",
       },
 
       domainService: {
@@ -247,11 +248,16 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
         type: String,
         computed: "_computeDescription(hass, _domain, _service)",
       },
+
       rtl: {
         reflectToAttribute: true,
         computed: "_computeRTL(hass)",
       },
     };
+  }
+
+  hassChanged() {
+    console.log("object: %O", this.hass.services);
   }
 
   _domainServiceChanged() {
@@ -276,7 +282,7 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
     return serviceDomains[domain][service].description;
   }
 
-  _computeServicedataKey(domainService) {
+  _computeServiceDataKey(domainService) {
     return `panel-dev-service-state-servicedata.${domainService}`;
   }
 

--- a/src/panels/developer-tools/service/developer-tools-service.js
+++ b/src/panels/developer-tools/service/developer-tools-service.js
@@ -206,7 +206,6 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
     return {
       hass: {
         type: Object,
-        observer: "hassChanged",
       },
 
       domainService: {
@@ -254,10 +253,6 @@ class HaPanelDevService extends LocalizeMixin(PolymerElement) {
         computed: "_computeRTL(hass)",
       },
     };
-  }
-
-  hassChanged() {
-    console.log("object: %O", this.hass.services);
   }
 
   _domainServiceChanged() {

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -237,6 +237,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         computed:
           "computeEntities(hass, _entityFilter, _stateFilter, _attributeFilter)",
       },
+
       rtl: {
         reflectToAttribute: true,
         computed: "_computeRTL(hass)",

--- a/src/panels/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/developer-tools/template/developer-tools-template.ts
@@ -155,20 +155,20 @@ class HaPanelDevTemplate extends LitElement {
             ? ""
             : this._templateResult.listeners.all
             ? html`
-                <h3 class="all_listeners">
+                <p class="all_listeners">
                   ${this.hass.localize(
                     "ui.panel.developer-tools.tabs.templates.all_listeners"
                   )}
-                </h3>
+                </p>
               `
             : this._templateResult.listeners.domains.length ||
               this._templateResult.listeners.entities.length
             ? html`
-                <h3>
+                <p>
                   ${this.hass.localize(
                     "ui.panel.developer-tools.tabs.templates.listeners"
                   )}
-                </h3>
+                </p>
                 <ul>
                   ${this._templateResult.listeners.domains
                     .sort()

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -47,7 +47,6 @@ documentContainer.innerHTML = `<custom-style>
       --card-background-color: #ffffff;
       --primary-background-color: #fafafa;
       --secondary-background-color: #e5e5e5; /* behind the cards on state */
-      --code-editor-background-color: #e5e5e5;
 
       /* for label-badge */
       --label-badge-red: #DF4C1E;

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -47,6 +47,7 @@ documentContainer.innerHTML = `<custom-style>
       --card-background-color: #ffffff;
       --primary-background-color: #fafafa;
       --secondary-background-color: #e5e5e5; /* behind the cards on state */
+      --code-editor-background-color: #e5e5e5;
 
       /* for label-badge */
       --label-badge-red: #DF4C1E;

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -3,7 +3,7 @@ import { css } from "lit-element";
 export const darkStyles = {
   "primary-background-color": "#111111",
   "card-background-color": "#1c1c1c",
-  "secondary-background-color": "#1e1e1e",
+  "secondary-background-color": "#202020",
   "primary-text-color": "#e1e1e1",
   "secondary-text-color": "#9b9b9b",
   "disabled-text-color": "#6f6f6f",
@@ -12,6 +12,7 @@ export const darkStyles = {
   "switch-unchecked-button-color": "#999999",
   "switch-unchecked-track-color": "#9b9b9b",
   "divider-color": "rgba(225, 225, 225, .12)",
+  "code-editor-background-color": "#202020",
   "codemirror-keyword": "#C792EA",
   "codemirror-operator": "#89DDFF",
   "codemirror-variable": "#f07178",

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -12,7 +12,6 @@ export const darkStyles = {
   "switch-unchecked-button-color": "#999999",
   "switch-unchecked-track-color": "#9b9b9b",
   "divider-color": "rgba(225, 225, 225, .12)",
-  "code-editor-background-color": "#202020",
   "codemirror-keyword": "#C792EA",
   "codemirror-operator": "#89DDFF",
   "codemirror-variable": "#f07178",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

**A few UI cleanup / improvements:**
1. Use `<ha-card>` to display the description and parameters for a service call. This provides some more visual structure for that page.
2. Small tweaks to the page, such as a header line after the table header for additional visual structure.
3. Service parameter table now gets hidden if no parameter info is found.
4. Dark theme: Made secondary background color a bit brighter, so that there is a better visual separation from the regular background.
5. Removed the `<h3>` from the state dev tools since it looked weird as this font size was only slightly larger than the rest of the page, but not enough to look "on purpose". 

**Before:**
![image](https://user-images.githubusercontent.com/114137/96298987-a1be3980-0ff3-11eb-96db-d86b1262b2a1.png)

**After:**
![image](https://user-images.githubusercontent.com/114137/96356020-54bc8f00-10e9-11eb-9ed8-743e16216be2.png)

![image](https://user-images.githubusercontent.com/114137/96356025-58e8ac80-10e9-11eb-9a43-42a117b64b54.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
