### PR TITLE
Make error texts of device automation picker translatable

### DIFF
--- a/src/components/device/ha-device-action-picker.ts
+++ b/src/components/device/ha-device-action-picker.ts
@@ -9,9 +9,17 @@ import { HaDeviceAutomationPicker } from "./ha-device-automation-picker";
 
 @customElement("ha-device-action-picker")
 class HaDeviceActionPicker extends HaDeviceAutomationPicker<DeviceAction> {
-  protected NO_AUTOMATION_TEXT = "No actions";
+  get NO_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.actions.no_actions"
+    );
+  }
 
-  protected UNKNOWN_AUTOMATION_TEXT = "Unknown action";
+  get UNKNOWN_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.actions.unknown_action"
+    );
+  }
 
   constructor() {
     super(

--- a/src/components/device/ha-device-action-picker.ts
+++ b/src/components/device/ha-device-action-picker.ts
@@ -9,13 +9,13 @@ import { HaDeviceAutomationPicker } from "./ha-device-automation-picker";
 
 @customElement("ha-device-action-picker")
 class HaDeviceActionPicker extends HaDeviceAutomationPicker<DeviceAction> {
-  get NO_AUTOMATION_TEXT() {
+  protected get NO_AUTOMATION_TEXT() {
     return this.hass.localize(
       "ui.panel.config.devices.automation.actions.no_actions"
     );
   }
 
-  get UNKNOWN_AUTOMATION_TEXT() {
+  protected get UNKNOWN_AUTOMATION_TEXT() {
     return this.hass.localize(
       "ui.panel.config.devices.automation.actions.unknown_action"
     );

--- a/src/components/device/ha-device-automation-picker.ts
+++ b/src/components/device/ha-device-automation-picker.ts
@@ -33,9 +33,17 @@ export abstract class HaDeviceAutomationPicker<
 
   @property() public value?: T;
 
-  protected NO_AUTOMATION_TEXT = "No automations";
+  get NO_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.actions.no_actions"
+    );
+  }
 
-  protected UNKNOWN_AUTOMATION_TEXT = "Unknown automation";
+  get UNKNOWN_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.actions.unknown_action"
+    );
+  }
 
   @internalProperty() private _automations: T[] = [];
 

--- a/src/components/device/ha-device-automation-picker.ts
+++ b/src/components/device/ha-device-automation-picker.ts
@@ -33,23 +33,23 @@ export abstract class HaDeviceAutomationPicker<
 
   @property() public value?: T;
 
-  get NO_AUTOMATION_TEXT() {
-    return this.hass.localize(
-      "ui.panel.config.devices.automation.actions.no_actions"
-    );
-  }
-
-  get UNKNOWN_AUTOMATION_TEXT() {
-    return this.hass.localize(
-      "ui.panel.config.devices.automation.actions.unknown_action"
-    );
-  }
-
   @internalProperty() private _automations: T[] = [];
 
   // Trigger an empty render so we start with a clean DOM.
   // paper-listbox does not like changing things around.
   @internalProperty() private _renderEmpty = false;
+
+  protected get NO_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.actions.no_actions"
+    );
+  }
+
+  protected get UNKNOWN_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.actions.unknown_action"
+    );
+  }
 
   private _localizeDeviceAutomation: (
     hass: HomeAssistant,

--- a/src/components/device/ha-device-condition-picker.ts
+++ b/src/components/device/ha-device-condition-picker.ts
@@ -11,13 +11,13 @@ import { HaDeviceAutomationPicker } from "./ha-device-automation-picker";
 class HaDeviceConditionPicker extends HaDeviceAutomationPicker<
   DeviceCondition
 > {
-  get NO_AUTOMATION_TEXT() {
+  protected get NO_AUTOMATION_TEXT() {
     return this.hass.localize(
       "ui.panel.config.devices.automation.conditions.no_conditions"
     );
   }
 
-  get UNKNOWN_AUTOMATION_TEXT() {
+  protected get UNKNOWN_AUTOMATION_TEXT() {
     return this.hass.localize(
       "ui.panel.config.devices.automation.conditions.unknown_condition"
     );

--- a/src/components/device/ha-device-condition-picker.ts
+++ b/src/components/device/ha-device-condition-picker.ts
@@ -11,9 +11,17 @@ import { HaDeviceAutomationPicker } from "./ha-device-automation-picker";
 class HaDeviceConditionPicker extends HaDeviceAutomationPicker<
   DeviceCondition
 > {
-  protected NO_AUTOMATION_TEXT = "No conditions";
+  get NO_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.conditions.no_conditions"
+    );
+  }
 
-  protected UNKNOWN_AUTOMATION_TEXT = "Unknown condition";
+  get UNKNOWN_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.conditions.unknown_condition"
+    );
+  }
 
   constructor() {
     super(

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -9,9 +9,17 @@ import { HaDeviceAutomationPicker } from "./ha-device-automation-picker";
 
 @customElement("ha-device-trigger-picker")
 class HaDeviceTriggerPicker extends HaDeviceAutomationPicker<DeviceTrigger> {
-  protected NO_AUTOMATION_TEXT = "No triggers";
+  get NO_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.triggers.no_triggers"
+    );
+  }
 
-  protected UNKNOWN_AUTOMATION_TEXT = "Unknown trigger";
+  get UNKNOWN_AUTOMATION_TEXT() {
+    return this.hass.localize(
+      "ui.panel.config.devices.automation.triggers.unknown_trigger"
+    );
+  }
 
   constructor() {
     super(

--- a/src/components/device/ha-device-trigger-picker.ts
+++ b/src/components/device/ha-device-trigger-picker.ts
@@ -9,13 +9,13 @@ import { HaDeviceAutomationPicker } from "./ha-device-automation-picker";
 
 @customElement("ha-device-trigger-picker")
 class HaDeviceTriggerPicker extends HaDeviceAutomationPicker<DeviceTrigger> {
-  get NO_AUTOMATION_TEXT() {
+  protected get NO_AUTOMATION_TEXT() {
     return this.hass.localize(
       "ui.panel.config.devices.automation.triggers.no_triggers"
     );
   }
 
-  get UNKNOWN_AUTOMATION_TEXT() {
+  protected get UNKNOWN_AUTOMATION_TEXT() {
     return this.hass.localize(
       "ui.panel.config.devices.automation.triggers.unknown_trigger"
     );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1595,15 +1595,22 @@
           "automation": {
             "automations": "Automations",
             "no_automations": "No automations",
+            "unknown_automation": "Unknown automation",
             "create": "Create automation with device",
             "triggers": {
-              "caption": "Do something when..."
+              "caption": "Do something when...",
+              "no_triggers": "No triggers",
+              "unknown_trigger": "Unknown trigger"
             },
             "conditions": {
-              "caption": "Only do something if..."
+              "caption": "Only do something if...",
+              "no_conditions": "No conditions",
+              "unknown_condition": "Unknown condition"
             },
             "actions": {
-              "caption": "When something is triggered..."
+              "caption": "When something is triggered...",
+              "no_actions": "No actions",
+              "unknown_action": "Unknown action"
             },
             "no_device_automations": "There are no automations available for this device."
           },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The default texts were hard-coded and not yet translatable. With this PR they now are, while keeping the generic device-automation-picker logic = the translated strings are retrieved via indirect function calls that are passed along to the super() constructor.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
