### PR TITLE
Improved automation & script menus + show errors in toast

### DIFF
--- a/src/managers/notification-manager.ts
+++ b/src/managers/notification-manager.ts
@@ -86,10 +86,12 @@ class NotificationManager extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
+        padding: 8px 12px;
       }
       mwc-button {
         color: var(--primary-color);
         font-weight: bold;
+        margin-left: 8px;
       }
     `;
   }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -90,6 +90,8 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
 
   @internalProperty() private _dirty = false;
 
+  @internalProperty() private _errors?: string;
+
   @internalProperty() private _entityId?: string;
 
   @internalProperty() private _mode: "gui" | "yaml" = "gui";
@@ -198,6 +200,9 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
                 ? html` <span slot="header">${this._config?.alias}</span> `
                 : ""}
               <div class="content">
+                ${this._errors
+                  ? html` <div class="errors">${this._errors}</div> `
+                  : ""}
                 ${this._mode === "gui"
                   ? html`
                       <ha-config-section .isWide=${this.isWide}>
@@ -590,6 +595,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
 
   private _triggerChanged(ev: CustomEvent): void {
     this._config = { ...this._config!, trigger: ev.detail.value as Trigger[] };
+    this._errors = undefined;
     this._dirty = true;
   }
 
@@ -598,11 +604,13 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
       ...this._config!,
       condition: ev.detail.value as Condition[],
     };
+    this._errors = undefined;
     this._dirty = true;
   }
 
   private _actionChanged(ev: CustomEvent): void {
     this._config = { ...this._config!, action: ev.detail.value as Action[] };
+    this._errors = undefined;
     this._dirty = true;
   }
 
@@ -633,6 +641,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
       return;
     }
     this._config = ev.detail.value;
+    this._errors = undefined;
     this._dirty = true;
   }
 
@@ -724,6 +733,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
         }
       },
       (errors) => {
+        this._errors = errors.body.message;
         showToast(this, {
           message: errors.body.message,
           dismissable: false,

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -736,12 +736,6 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
         this._errors = errors.body.message;
         showToast(this, {
           message: errors.body.message,
-          dismissable: false,
-          duration: 0,
-          action: {
-            action: () => {},
-            text: this.hass.localize("ui.dialogs.generic.ok"),
-          },
         });
         throw errors;
       }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -130,7 +130,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
           >
             ${this.hass.localize("ui.panel.config.automation.editor.edit_ui")}
             ${this._mode === "gui"
-              ? html` <ha-svg-icon
+              ? html`<ha-svg-icon
                   class="selected_menu_item"
                   slot="graphic"
                   .path=${mdiCheck}
@@ -146,7 +146,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
           >
             ${this.hass.localize("ui.panel.config.automation.editor.edit_yaml")}
             ${this._mode === "yaml"
-              ? html` <ha-svg-icon
+              ? html`<ha-svg-icon
                   class="selected_menu_item"
                   slot="graphic"
                   .path=${mdiCheck}

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -91,6 +91,8 @@ export class HaSceneEditor extends SubscribeMixin(
 
   @internalProperty() private _dirty = false;
 
+  @internalProperty() private _errors?: string;
+
   @internalProperty() private _config?: SceneConfig;
 
   @internalProperty() private _entities: string[] = [];
@@ -209,6 +211,7 @@ export class HaSceneEditor extends SubscribeMixin(
                 @click=${this._deleteTapped}
               ></ha-icon-button>
             `}
+        ${this._errors ? html` <div class="errors">${this._errors}</div> ` : ""}
         ${this.narrow ? html` <span slot="header">${name}</span> ` : ""}
         <div
           id="root"
@@ -712,6 +715,7 @@ export class HaSceneEditor extends SubscribeMixin(
         navigate(this, `/config/scene/edit/${id}`, true);
       }
     } catch (err) {
+      this._errors = err.body.message || err.message;
       showToast(this, {
         message: err.body.message || err.message,
         dismissable: false,

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -718,12 +718,6 @@ export class HaSceneEditor extends SubscribeMixin(
       this._errors = err.body.message || err.message;
       showToast(this, {
         message: err.body.message || err.message,
-        dismissable: false,
-        duration: 0,
-        action: {
-          action: () => {},
-          text: this.hass.localize("ui.dialogs.generic.ok"),
-        },
       });
       throw err;
     }

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -57,6 +57,7 @@ import { HomeAssistant, Route } from "../../../types";
 import "../ha-config-section";
 import { configSections } from "../ha-panel-config";
 import "../../../components/ha-svg-icon";
+import { showToast } from "../../../util/toast";
 import { mdiContentSave } from "@mdi/js";
 import { KeyboardShortcutMixin } from "../../../mixins/keyboard-shortcut-mixin";
 
@@ -89,8 +90,6 @@ export class HaSceneEditor extends SubscribeMixin(
   @property() public showAdvanced!: boolean;
 
   @internalProperty() private _dirty = false;
-
-  @internalProperty() private _errors?: string;
 
   @internalProperty() private _config?: SceneConfig;
 
@@ -210,7 +209,6 @@ export class HaSceneEditor extends SubscribeMixin(
                 @click=${this._deleteTapped}
               ></ha-icon-button>
             `}
-        ${this._errors ? html` <div class="errors">${this._errors}</div> ` : ""}
         ${this.narrow ? html` <span slot="header">${name}</span> ` : ""}
         <div
           id="root"
@@ -714,7 +712,15 @@ export class HaSceneEditor extends SubscribeMixin(
         navigate(this, `/config/scene/edit/${id}`, true);
       }
     } catch (err) {
-      this._errors = err.body.message || err.message;
+      showToast(this, {
+        message: err.body.message || err.message,
+        dismissable: false,
+        duration: 0,
+        action: {
+          action: () => {},
+          text: this.hass.localize("ui.dialogs.generic.ok"),
+        },
+      });
       throw err;
     }
   }

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -69,6 +69,8 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
   @internalProperty() private _dirty = false;
 
+  @internalProperty() private _errors?: string;
+
   @internalProperty() private _mode: "gui" | "yaml" = "gui";
 
   @query("ha-yaml-editor", true) private _editor?: HaYamlEditor;
@@ -151,6 +153,9 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
           ? html` <span slot="header">${this._config?.alias}</span> `
           : ""}
         <div class="content">
+          ${this._errors
+            ? html` <div class="errors">${this._errors}</div> `
+            : ""}
           ${this._mode === "gui"
             ? html`
                 <div
@@ -506,6 +511,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
   private _sequenceChanged(ev: CustomEvent): void {
     this._config = { ...this._config!, sequence: ev.detail.value as Action[] };
+    this._errors = undefined;
     this._dirty = true;
   }
 
@@ -525,6 +531,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
       return;
     }
     this._config = ev.detail.value;
+    this._errors = undefined;
     this._dirty = true;
   }
 
@@ -598,6 +605,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
         }
       },
       (errors) => {
+        this._errors = errors.body.message;
         showToast(this, {
           message: errors.body.message,
           dismissable: false,

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -608,12 +608,6 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
         this._errors = errors.body.message;
         showToast(this, {
           message: errors.body.message,
-          dismissable: false,
-          duration: 0,
-          action: {
-            action: () => {},
-            text: this.hass.localize("ui.dialogs.generic.ok"),
-          },
         });
         throw errors;
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

1. Ensure proper icon coloring in automation & script editor menu.
2. Ensure proper coloring of divider.
3. Show errors in toast for automations, scenes and scripts. The small red error text in the top left corner was often not visible when you saved since the page is longer than one screen height and usually you save when you completed entering the data at the bottom (actions in case of automations). Should the toast perhaps even be colored in to make clear it contains an error / warning?
4. Shrunk down the toast size a bit plus added a bit of space between the text and the dismiss button.

**Before:**

![image](https://user-images.githubusercontent.com/114137/96327251-2763d880-1038-11eb-9efb-3a9578dd0d95.png)

**After:**

![image](https://user-images.githubusercontent.com/114137/96327255-2a5ec900-1038-11eb-9e64-39d609c1dc2e.png)

**Toasts:**

![image](https://user-images.githubusercontent.com/114137/96354317-b1ae4a00-10d5-11eb-9cab-c090d71bc0a3.png)

![image](https://user-images.githubusercontent.com/114137/96354334-d73b5380-10d5-11eb-8d73-b21ac554ab8e.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
