### PR TITLE
Add "last_changed" and "last_updated" to dev tools state view

### DIFF
--- a/src/components/entity/state-info.js
+++ b/src/components/entity/state-info.js
@@ -80,6 +80,13 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
               hass="[[hass]]"
               datetime="[[stateObj.last_changed]]"
             ></ha-relative-time>
+            <paper-tooltip animation-delay="0" for="last_changed">
+              [[localize('ui.dialogs.more_info_control.last_updated')]]:
+              <ha-relative-time
+                hass="[[hass]]"
+                datetime="[[stateObj.last_updated]]"
+              ></ha-relative-time>
+            </paper-tooltip>
           </div>
         </template>
         <template is="dom-if" if="[[!inDialog]]">

--- a/src/components/entity/state-info.js
+++ b/src/components/entity/state-info.js
@@ -80,13 +80,6 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
               hass="[[hass]]"
               datetime="[[stateObj.last_changed]]"
             ></ha-relative-time>
-            <paper-tooltip animation-delay="0" for="last_changed">
-              [[localize('ui.dialogs.more_info_control.last_updated')]]:
-              <ha-relative-time
-                hass="[[hass]]"
-                datetime="[[stateObj.last_updated]]"
-              ></ha-relative-time>
-            </paper-tooltip>
           </div>
         </template>
         <template is="dom-if" if="[[!inDialog]]">

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -177,12 +177,10 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
             </td>
             <td>
               [[entity.state]]<br /><br />
-              <span class="secondary"
-                >last_changed: [[lastChangedString(entity)]]</span
-              ><br />
-              <span class="secondary"
-                >last_updated: [[lastUpdatedString(entity)]]</span
-              >
+              <span class="secondary">
+                last_changed: [[lastChangedString(entity)]]<br />
+                last_updated: [[lastUpdatedString(entity)]]
+              </span>
             </td>
             <template
               is="dom-if"

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -42,6 +42,9 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
         .entities th {
           text-align: left;
+          font-size: var(
+            --paper-input-container-shared-input-style_-_font-size
+          );
         }
 
         :host([rtl]) .entities th {
@@ -77,6 +80,10 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
         .entities a {
           color: var(--primary-color);
+        }
+
+        .secondary {
+          color: var(--secondary-text-color);
         }
       </style>
 
@@ -169,9 +176,13 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>
             </td>
             <td>
-              [[entity.state]]<br />
-              last_changed: [[lastChangedString(entity)]]<br />
-              last_updated: [[lastUpdatedString(entity)]]
+              [[entity.state]]<br /><br />
+              <span class="secondary"
+                >last_changed: [[lastChangedString(entity)]]</span
+              ><br />
+              <span class="secondary"
+                >last_updated: [[lastUpdatedString(entity)]]</span
+              >
             </td>
             <template
               is="dom-if"

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -62,7 +62,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         }
         .entities td {
           padding: 4px;
-          min-width: 200px;
+          min-width: 220px;
           word-break: break-word;
         }
         .entities ha-svg-icon {
@@ -168,7 +168,11 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               ></ha-svg-icon>
               <a href="#" on-click="entitySelected">[[entity.entity_id]]</a>
             </td>
-            <td>[[entity.state]]</td>
+            <td>
+              [[entity.state]]<br />
+              last_changed: [[lastChangedString(entity)]]<br />
+              last_updated: [[lastUpdatedString(entity)]]
+            </td>
             <template
               is="dom-if"
               if="[[computeShowAttributes(narrow, _showAttributes)]]"
@@ -378,6 +382,14 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
       output += `${key}: ${value}\n`;
     }
     return output;
+  }
+
+  lastChangedString(entity) {
+    return new Date(entity.last_changed).toISOString();
+  }
+
+  lastUpdatedString(entity) {
+    return new Date(entity.last_updated).toISOString();
   }
 
   formatAttributeValue(value) {

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -81,10 +81,6 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         .entities a {
           color: var(--primary-color);
         }
-
-        .secondary {
-          color: var(--secondary-text-color);
-        }
       </style>
 
       <div class="inputs">

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -507,6 +507,7 @@
         "edit": "Edit entity",
         "details": "Details",
         "history": "History",
+        "last_changed": "Last changed",
         "last_updated": "Last updated",
         "script": {
           "last_action": "Last Action",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Currently there is no easy way to see those timestamps. Now there is. I decided against formatting the values and instead just added the default ISO format since we are talking about dev tools.

The filter for the state column still only looks at the actual state value, so no negative impact here.

![image](https://user-images.githubusercontent.com/114137/96354212-71020100-10d4-11eb-8fe6-cd7f2ddd974c.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
