### PR TITLE
Add to conditional card le,ge conditions

### DIFF
--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -5,6 +5,8 @@ export interface Condition {
   entity: string;
   state?: string;
   state_not?: string;
+  value?: string;
+  operator?: string;
 }
 
 export function checkConditionsMet(
@@ -15,13 +17,50 @@ export function checkConditionsMet(
     const state = hass.states[c.entity]
       ? hass!.states[c.entity].state
       : UNAVAILABLE;
+    if (!c.operator) {
+      if (c.state && state !== c.state) {
+        return false;
+      }
+      if (c.state_not && state === c.state_not) {
+        return false;
+      }
+      return true;
+    }
 
-    return c.state ? state === c.state : state !== c.state_not;
+    if (!c.value) {
+      // error state must be defined when operator is defined too
+      return false;
+    }
+
+    if (c.operator === "==") {
+      return state === c.value;
+    }
+    if (c.operator === "!=") {
+      return state !== c.value;
+    }
+    if (c.operator === ">") {
+      return Number(state) > Number(c.value);
+    }
+    if (c.operator === "<") {
+      return Number(state) < Number(c.value);
+    }
+    if (c.operator === ">=") {
+      return Number(state) >= Number(c.value);
+    }
+    if (c.operator === "<=") {
+      return Number(state) <= Number(c.value);
+    }
+    // unknown operator
+    return false;
   });
 }
 
 export function validateConditionalConfig(conditions: Condition[]): boolean {
   return conditions.every(
-    (c) => ((c.entity && (c.state || c.state_not)) as unknown) as boolean
+    (c) =>
+      ((c.entity &&
+        (c.state ||
+          c.state_not ||
+          (c.operator && c.value))) as unknown) as boolean
   );
 }

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -54,7 +54,7 @@ export class HuiConditionalBase extends UpdatingElement {
     this._element.editMode = this.editMode;
 
     const visible =
-      this.editMode || checkConditionsMet(this._config.conditions, this.hass);
+      this.editMode || checkConditionsMet(this.hass, this._config.conditions);
 
     this.style.setProperty("display", visible ? "" : "none");
 

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -119,6 +119,8 @@ const conditionalEntitiesRowConfigStruct = object({
       entity: string(),
       state: optional(string()),
       state_not: optional(string()),
+      value: optional(string()),
+      operator: optional(string()),
     })
   ),
 });

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -119,8 +119,6 @@ const conditionalEntitiesRowConfigStruct = object({
       entity: string(),
       state: optional(string()),
       state_not: optional(string()),
-      value: optional(string()),
-      operator: optional(string()),
     })
   ),
 });

--- a/src/panels/lovelace/elements/hui-conditional-element.ts
+++ b/src/panels/lovelace/elements/hui-conditional-element.ts
@@ -58,7 +58,7 @@ class HuiConditionalElement extends HTMLElement implements LovelaceElement {
       return;
     }
 
-    const visible = checkConditionsMet(this._config.conditions, this._hass);
+    const visible = checkConditionsMet(this._hass, this._config.conditions);
 
     this._elements.forEach((el: LovelaceElement) => {
       if (visible) {


### PR DESCRIPTION
Lovelace conditional card now supports conditions operators
* operator '=='  as equal
* operator '!='  as not equal
* operator '>'  as greater
* operator '<'  as less
* operator '>='  as greater or equal
* operator '<='  as less or equal

UI editor is not supported now

Alternative (simpler) version added here https://github.com/home-assistant/frontend/pull/7688

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Lovelace conditional card supports only 'equal' or 'not equal', so this patch adds operator where user can specify operation.
UI editor is not supported.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: conditional
  - entity: sensor.elektromer_l1
    operator: '<'
    value: 10
  - entity: sensor.elektromer_l1
    state: 20
card:
...
```


## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15302
- Related discussions: 
https://community.home-assistant.io/t/conditional-card-with-and-as-conditions/182771
https://community.home-assistant.io/t/support-numeric-state-for-conditional-card-in-lovelace/79563

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
