### PR TITLE
Quick Bar dark mode, ignore leading white space

### DIFF
--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -110,7 +110,11 @@ export class QuickBar extends LitElement {
                 <ha-icon .icon=${item.icon} slot="graphic"></ha-icon>
                 <span>${item.text}</span>
                 ${item.altText
-                  ? html` <span slot="secondary">${item.altText}</span> `
+                  ? html`
+                      <span slot="secondary" class="secondary"
+                        >${item.altText}</span
+                      >
+                    `
                   : null}
                 ${this._commandTriggered === index
                   ? html`<ha-circular-progress
@@ -186,7 +190,7 @@ export class QuickBar extends LitElement {
         if (altText) {
           values.push(altText);
         }
-        return fuzzySequentialMatch(this._itemFilter, values);
+        return fuzzySequentialMatch(this._itemFilter.trimLeft(), values);
       })
       .sort((itemA, itemB) => compare(itemA.text, itemB.text));
   }
@@ -226,6 +230,11 @@ export class QuickBar extends LitElement {
       css`
         .heading {
           padding: 20px 20px 0px;
+        }
+
+        mwc-list-item span[slot="secondary"],
+        ha-icon[slot="graphic"] {
+          color: var(--secondary-text-color);
         }
 
         ha-dialog {

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -32,6 +32,7 @@ interface QuickBarItem {
   altText?: string;
   icon: string;
   action(data?: any): void;
+  score?: number;
 }
 
 @customElement("ha-quick-bar")
@@ -58,10 +59,7 @@ export class QuickBar extends LitElement {
 
   @query("mwc-list-item", false) private _firstListItem?: HTMLElement;
 
-  @internalProperty() private _isAdmin = false;
-
   public async showDialog(params: QuickBarParams) {
-    this._isAdmin = this.hass.user?.is_admin || false;
     this._commandMode = params.commandMode || false;
     this._opened = true;
     this._commandItems = this._generateCommandItems();
@@ -198,24 +196,7 @@ export class QuickBar extends LitElement {
   }
 
   private _generateCommandItems(): QuickBarItem[] {
-    if (!this._isAdmin) {
-      return this._generateNonAdminPlaceholder();
-    }
-
     return [...this._generateReloadCommands()];
-  }
-
-  private _generateNonAdminPlaceholder() {
-    return [
-      {
-        text: this.hass.localize("ui.dialogs.quick-bar.restricted_label"),
-        altText: this.hass.localize(
-          "ui.dialogs.quick-bar.restricted_more_info"
-        ),
-        icon: "hass:information-outline",
-        action: () => {},
-      },
-    ];
   }
 
   private _generateReloadCommands(): QuickBarItem[] {
@@ -235,10 +216,6 @@ export class QuickBar extends LitElement {
   }
 
   private _generateEntityItems(): QuickBarItem[] {
-    if (!this._isAdmin) {
-      return this._generateNonAdminPlaceholder();
-    }
-
     return Object.keys(this.hass.states).map((entityId) => ({
       text: computeStateName(this.hass.states[entityId]),
       altText: entityId,

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -32,7 +32,6 @@ interface QuickBarItem {
   altText?: string;
   icon: string;
   action(data?: any): void;
-  score?: number;
 }
 
 @customElement("ha-quick-bar")
@@ -59,7 +58,10 @@ export class QuickBar extends LitElement {
 
   @query("mwc-list-item", false) private _firstListItem?: HTMLElement;
 
+  @internalProperty() private _isAdmin = false;
+
   public async showDialog(params: QuickBarParams) {
+    this._isAdmin = this.hass.user?.is_admin || false;
     this._commandMode = params.commandMode || false;
     this._opened = true;
     this._commandItems = this._generateCommandItems();
@@ -196,7 +198,24 @@ export class QuickBar extends LitElement {
   }
 
   private _generateCommandItems(): QuickBarItem[] {
+    if (!this._isAdmin) {
+      return this._generateNonAdminPlaceholder();
+    }
+
     return [...this._generateReloadCommands()];
+  }
+
+  private _generateNonAdminPlaceholder() {
+    return [
+      {
+        text: this.hass.localize("ui.dialogs.quick-bar.restricted_label"),
+        altText: this.hass.localize(
+          "ui.dialogs.quick-bar.restricted_more_info"
+        ),
+        icon: "hass:information-outline",
+        action: () => {},
+      },
+    ];
   }
 
   private _generateReloadCommands(): QuickBarItem[] {
@@ -216,6 +235,10 @@ export class QuickBar extends LitElement {
   }
 
   private _generateEntityItems(): QuickBarItem[] {
+    if (!this._isAdmin) {
+      return this._generateNonAdminPlaceholder();
+    }
+
     return Object.keys(this.hass.states).map((entityId) => ({
       text: computeStateName(this.hass.states[entityId]),
       altText: entityId,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -482,7 +482,9 @@
             "rpi_gpio": "[%key:ui::panel::config::server_control::section::reloading::rpi_gpio%]"
           }
         },
-        "filter_placeholder": "Entity Filter"
+        "filter_placeholder": "Entity Filter",
+        "restricted_label": "This feature only available to admins.",
+        "restricted_more_info": "Contact instance owner or admin for necessary permissions."
       },
       "voice_command": {
         "did_not_hear": "Home Assistant did not hear anything",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -482,9 +482,7 @@
             "rpi_gpio": "[%key:ui::panel::config::server_control::section::reloading::rpi_gpio%]"
           }
         },
-        "filter_placeholder": "Entity Filter",
-        "restricted_label": "This feature only available to admins.",
-        "restricted_more_info": "Contact instance owner or admin for necessary permissions."
+        "filter_placeholder": "Entity Filter"
       },
       "voice_command": {
         "did_not_hear": "Home Assistant did not hear anything",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

1. Support dark mode in Quick Bar results
2. Trim leading space from filter (some users report instinctively wanting to type a space after the ">")

![image](https://user-images.githubusercontent.com/1480827/96412152-817eae00-119e-11eb-8cb2-7b5def2dc9bc.png)


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
