### PR TITLE
Get rid of the unwanted tooltip copying

### DIFF
--- a/src/panels/config/info/system-health-card.ts
+++ b/src/panels/config/info/system-health-card.ts
@@ -128,14 +128,24 @@ class SystemHealthCard extends LitElement {
   }
 
   private _copyInfo(): void {
+    // We have to copy title text and content separately, because
+    // copying the whole <ha-card> would also copy the tooltip text.
     const selection = window.getSelection()!;
     selection.removeAllRanges();
 
-    const copyElement = this.shadowRoot?.querySelector(
-      "ha-card"
+    let copyElement = this.shadowRoot?.querySelector(
+      ".card-header-text"
     ) as HTMLElement;
 
-    const range = document.createRange();
+    let range = document.createRange();
+    range.selectNodeContents(copyElement);
+    selection.addRange(range);
+
+    copyElement = this.shadowRoot?.querySelector(
+      ".card-content"
+    ) as HTMLElement;
+
+    range = document.createRange();
     range.selectNodeContents(copyElement);
     selection.addRange(range);
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Follow-up to https://github.com/home-assistant/frontend/pull/7323.

Turns out that I must have had a bad cache when I thought I had successfully verified that the move to `<h1>` as card header had cleared up the tooltip copying issue. 

With this PR I go back to the solution I originally had in place in the previous PR that fixes it.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
