### PR TITLE
Remove debounce from quick bar until "select all" bug is resolved

### DIFF
--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -29,7 +29,6 @@ import {
   fuzzyFilterSort,
   ScorableTextItem,
 } from "../../common/string/filter/sequence-matching";
-import { debounce } from "../../common/util/debounce";
 import "../../components/ha-circular-progress";
 import "../../components/ha-dialog";
 import "../../components/ha-header-bar";
@@ -237,10 +236,10 @@ export class QuickBar extends LitElement {
 
     if (newFilter.startsWith(">")) {
       this._commandMode = true;
-      this._debouncedSetFilter(newFilter.substring(1));
+      this._filter = newFilter.substring(1);
     } else {
       this._commandMode = false;
-      this._debouncedSetFilter(newFilter);
+      this._filter = newFilter;
     }
 
     if (oldCommandMode !== this._commandMode) {
@@ -248,10 +247,6 @@ export class QuickBar extends LitElement {
       this._focusSet = false;
     }
   }
-
-  private _debouncedSetFilter = debounce((filter: string) => {
-    this._filter = filter;
-  }, 100);
 
   private _setFocusFirstListItem() {
     // @ts-ignore


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Remove the filter debouncing from quick bar (for now).

In its current form, debouncing the quick bar filter causes a bug when a single change would cause -- simultaneously -- a switch of command mode AND a new filter string (e.g., select all text in command mode -> type "L")

I suspect what's happening is this:
1. User types ">reload". (`this._filter` is now "reload")
2. User selects all and replaces it with "L"
3. First, the change in filter fires off a task to change `this._filter` to "L" in 100ms
4. Second, the change of _command mode_  fires off a task to change the filter to "reload" in 100ms.
5. Because it's debounced, the 2nd change wins the race and "L" is lost.

I'm not sure what the best solution is but for now, removing the debounce fixes the issue.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
