### PR TITLE
Add last-updated as a secondaryinfo option to entity rows

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -45,6 +45,7 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
     | "entity-id"
     | "last-changed"
     | "last-triggered"
+    | "last-updated"
     | "position"
     | "tilt-position"
     | "brightness";

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -97,6 +97,13 @@ class HuiGenericEntityRow extends LitElement {
                         .datetime=${stateObj.last_changed}
                       ></ha-relative-time>
                     `
+                  : this.config.secondary_info === "last-updated"
+                  ? html`
+                      <ha-relative-time
+                        .hass=${this.hass}
+                        .datetime=${stateObj.last_updated}
+                      ></ha-relative-time>
+                    `
                   : this.config.secondary_info === "last-triggered"
                   ? stateObj.attributes.last_triggered
                     ? html`

--- a/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
@@ -31,6 +31,7 @@ import { configElementStyle } from "./config-elements-style";
 const SecondaryInfoValues: { [key: string]: { domains?: string[] } } = {
   "entity-id": {},
   "last-changed": {},
+  "last-updated": {},
   "last-triggered": { domains: ["automation", "script"] },
   position: { domains: ["cover"] },
   "tilt-position": { domains: ["cover"] },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2452,7 +2452,8 @@
                 "last-triggered": "Last Triggered",
                 "position": "Position",
                 "tilt-position": "Tilt Position",
-                "brightness": "Brightness"
+                "brightness": "Brightness",
+                "last-updated": "Last Updated"
               },
               "entity_row": {
                 "divider": "Divider",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
entities:
  - entity: light.bed_light
    secondary_info: last-updated
type: entities
show_header_toggle: false
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

![image](https://user-images.githubusercontent.com/1287159/96823156-6d7eba80-13f1-11eb-85ff-e99edc0180d7.png)
