### PR TITLE
Add last-updated to state info tooltip 

### DIFF
--- a/src/components/entity/state-info.js
+++ b/src/components/entity/state-info.js
@@ -59,6 +59,27 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
           @apply --paper-font-common-nowrap;
           color: var(--secondary-text-color);
         }
+
+        .row {
+          display: flex;
+          flex-direction: row;
+          flex-wrap: no-wrap;
+          width: 100%;
+        }
+        .column-name,
+        .column-value {
+          display: flex;
+          flex-direction: column;
+          flex-basis: 100%;
+          flex: 1;
+          padding: 2px;
+        }
+        .column-name {
+          align-items: flex-start;
+        }
+        .column-value {
+          align-items: flex-end;
+        }
       </style>
     `;
   }
@@ -81,30 +102,30 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
               datetime="[[stateObj.last_changed]]"
             ></ha-relative-time>
             <paper-tooltip animation-delay="0" for="last_changed">
-              <table>
-                <tr>
-                  <td>
+              <div>
+                <div class="row">
+                  <div class="column-name">
                     [[localize('ui.dialogs.more_info_control.last_changed')]]:
-                  </td>
-                  <td>
+                  </div>
+                  <div class="column-value">
                     <ha-relative-time
                       hass="[[hass]]"
                       datetime="[[stateObj.last_changed]]"
                     ></ha-relative-time>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="column-name">
                     [[localize('ui.dialogs.more_info_control.last_updated')]]:
-                  </td>
-                  <td>
+                  </div>
+                  <div class="column-value">
                     <ha-relative-time
                       hass="[[hass]]"
                       datetime="[[stateObj.last_updated]]"
                     ></ha-relative-time>
-                  </td>
-                </tr>
-              </table>
+                  </div>
+                </div>
+              </div>
             </paper-tooltip>
           </div>
         </template>

--- a/src/components/entity/state-info.js
+++ b/src/components/entity/state-info.js
@@ -65,20 +65,8 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
           flex-direction: row;
           flex-wrap: no-wrap;
           width: 100%;
-        }
-        .column-name,
-        .column-value {
-          display: flex;
-          flex-direction: column;
-          flex-basis: 100%;
-          flex: 1;
-          padding: 2px;
-        }
-        .column-name {
-          align-items: flex-start;
-        }
-        .column-value {
-          align-items: flex-end;
+          justify-content: space-between;
+          margin-right: 2px;
         }
       </style>
     `;
@@ -103,27 +91,23 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
             ></ha-relative-time>
             <paper-tooltip animation-delay="0" for="last_changed">
               <div>
-                <div class="row">
-                  <div class="column-name">
+                <div class="row" style="margin-bottom: 2px">
+                  <span class="column-name">
                     [[localize('ui.dialogs.more_info_control.last_changed')]]:
-                  </div>
-                  <div class="column-value">
-                    <ha-relative-time
-                      hass="[[hass]]"
-                      datetime="[[stateObj.last_changed]]"
-                    ></ha-relative-time>
-                  </div>
+                  </span>
+                  <ha-relative-time
+                    hass="[[hass]]"
+                    datetime="[[stateObj.last_changed]]"
+                  ></ha-relative-time>
                 </div>
                 <div class="row">
-                  <div class="column-name">
+                  <span>
                     [[localize('ui.dialogs.more_info_control.last_updated')]]:
-                  </div>
-                  <div class="column-value">
-                    <ha-relative-time
-                      hass="[[hass]]"
-                      datetime="[[stateObj.last_updated]]"
-                    ></ha-relative-time>
-                  </div>
+                  </span>
+                  <ha-relative-time
+                    hass="[[hass]]"
+                    datetime="[[stateObj.last_updated]]"
+                  ></ha-relative-time>
                 </div>
               </div>
             </paper-tooltip>

--- a/src/components/entity/state-info.js
+++ b/src/components/entity/state-info.js
@@ -66,7 +66,11 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
           flex-wrap: no-wrap;
           width: 100%;
           justify-content: space-between;
-          margin-right: 2px;
+          margin: 0 2px 4px 0;
+        }
+
+        .row:last-child {
+          margin-bottom: 0px;
         }
       </style>
     `;
@@ -91,7 +95,7 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
             ></ha-relative-time>
             <paper-tooltip animation-delay="0" for="last_changed">
               <div>
-                <div class="row" style="margin-bottom: 2px">
+                <div class="row">
                   <span class="column-name">
                     [[localize('ui.dialogs.more_info_control.last_changed')]]:
                   </span>

--- a/src/components/entity/state-info.js
+++ b/src/components/entity/state-info.js
@@ -81,17 +81,30 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
               datetime="[[stateObj.last_changed]]"
             ></ha-relative-time>
             <paper-tooltip animation-delay="0" for="last_changed">
-              [[localize('ui.dialogs.more_info_control.last_changed')]]:
-              <ha-relative-time
-                hass="[[hass]]"
-                datetime="[[stateObj.last_changed]]"
-              ></ha-relative-time>
-              <br />
-              [[localize('ui.dialogs.more_info_control.last_updated')]]:
-              <ha-relative-time
-                hass="[[hass]]"
-                datetime="[[stateObj.last_updated]]"
-              ></ha-relative-time>
+              <table>
+                <tr>
+                  <td>
+                    [[localize('ui.dialogs.more_info_control.last_changed')]]:
+                  </td>
+                  <td>
+                    <ha-relative-time
+                      hass="[[hass]]"
+                      datetime="[[stateObj.last_changed]]"
+                    ></ha-relative-time>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    [[localize('ui.dialogs.more_info_control.last_updated')]]:
+                  </td>
+                  <td>
+                    <ha-relative-time
+                      hass="[[hass]]"
+                      datetime="[[stateObj.last_updated]]"
+                    ></ha-relative-time>
+                  </td>
+                </tr>
+              </table>
             </paper-tooltip>
           </div>
         </template>

--- a/src/components/entity/state-info.js
+++ b/src/components/entity/state-info.js
@@ -81,6 +81,12 @@ class StateInfo extends LocalizeMixin(PolymerElement) {
               datetime="[[stateObj.last_changed]]"
             ></ha-relative-time>
             <paper-tooltip animation-delay="0" for="last_changed">
+              [[localize('ui.dialogs.more_info_control.last_changed')]]:
+              <ha-relative-time
+                hass="[[hass]]"
+                datetime="[[stateObj.last_changed]]"
+              ></ha-relative-time>
+              <br />
               [[localize('ui.dialogs.more_info_control.last_updated')]]:
               <ha-relative-time
                 hass="[[hass]]"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -518,6 +518,7 @@
         "details": "Details",
         "history": "History",
         "last_updated": "Last updated",
+        "last_changed": "Last changed",
         "script": {
           "last_action": "Last Action",
           "last_triggered": "Last Triggered"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

I think for new users it currently might be a bit confusing/weird what the relative time below the name means, especially given that the tooltip is linked to the "last changed" field, but then only displays the "last updated" time currently.

My idea would be show both last-changed and last-updated to clear up that confusion:

![image](https://user-images.githubusercontent.com/114137/97040569-69c47280-156e-11eb-86c2-4274a4160bb3.png)

![image](https://user-images.githubusercontent.com/114137/97040886-ee16f580-156e-11eb-82e5-2665e83a98f4.png)

Without that clarification, a user might think that something is bugged ("Why are two conflicting information shown?").

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
