### PR TITLE
Replace prompt with showPromptDialog

### DIFF
--- a/src/components/ha-push-notifications-toggle.js
+++ b/src/components/ha-push-notifications-toggle.js
@@ -92,7 +92,6 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
       const name = await showPromptDialog(this, {
         title: this.hass.localize("ui.panel.profile.push_notifications.add_device.title"),
         inputLabel: this.hass.localize("ui.panel.profile.push_notifications.add_device.text"),
-        inputType: "string"
       });
       if (name == null) {
         this.pushChecked = false;

--- a/src/components/ha-push-notifications-toggle.js
+++ b/src/components/ha-push-notifications-toggle.js
@@ -3,6 +3,7 @@ import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 import { getAppKey } from "../data/notify_html5";
 import { EventsMixin } from "../mixins/events-mixin";
+import { showPromptDialog } from "../dialogs/generic/show-dialog-box";
 import "./ha-switch";
 
 export const pushSupported =
@@ -88,7 +89,11 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
         browserName = "chrome";
       }
 
-      const name = prompt("What should this device be called ?");
+      const name = await showPromptDialog(this, {
+        title: "What should this device be called ?",
+        inputLabel: "Please enter a name for the device",
+        inputType: "string"
+      });
       if (name == null) {
         this.pushChecked = false;
         return;

--- a/src/components/ha-push-notifications-toggle.js
+++ b/src/components/ha-push-notifications-toggle.js
@@ -90,8 +90,8 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
       }
 
       const name = await showPromptDialog(this, {
-        title: "What should this device be called ?",
-        inputLabel: "Please enter a name for the device",
+        title: this.hass.localize("ui.panel.profile.push_notifications.add_device.title"),
+        inputLabel: this.hass.localize("ui.panel.profile.push_notifications.add_device.text"),
         inputType: "string"
       });
       if (name == null) {

--- a/src/components/ha-push-notifications-toggle.js
+++ b/src/components/ha-push-notifications-toggle.js
@@ -90,8 +90,8 @@ class HaPushNotificationsToggle extends EventsMixin(PolymerElement) {
       }
 
       const name = await showPromptDialog(this, {
-        title: this.hass.localize("ui.panel.profile.push_notifications.add_device.title"),
-        inputLabel: this.hass.localize("ui.panel.profile.push_notifications.add_device.text"),
+        title: this.hass.localize("ui.panel.profile.push_notifications.add_device_prompt.title"),
+        inputLabel: this.hass.localize("ui.panel.profile.push_notifications.add_device_prompt.input_label"),
       });
       if (name == null) {
         this.pushChecked = false;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2675,7 +2675,11 @@
           "error_load_platform": "Configure notify.html5.",
           "error_use_https": "Requires SSL enabled for frontend.",
           "push_notifications": "Push notifications",
-          "link_promo": "Learn more"
+          "link_promo": "Learn more",
+          "add_device": {
+            "title": "What should this device be called?",
+            "text": "Please enter a name for the device"
+          }
         },
         "language": {
           "header": "Language",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2676,9 +2676,9 @@
           "error_use_https": "Requires SSL enabled for frontend.",
           "push_notifications": "Push notifications",
           "link_promo": "Learn more",
-          "add_device": {
+          "add_device_prompt": {
             "title": "What should this device be called?",
-            "text": "Please enter a name for the device"
+            "input_label": "Device name"
           }
         },
         "language": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
None
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Replace the outdated `prompt()` function for the notification device name dialog with a material dialog. 


![Screenshot_2020 10 23_01h36m23s_010_](https://user-images.githubusercontent.com/1368405/96940612-78f4e300-14d0-11eb-8721-b830ee5437f4.png)

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5741
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
