### PR TITLE
Ensure visual gap in dark panel mode between header and content

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -831,7 +831,8 @@ class HUIRoot extends LitElement {
           color: var(--error-color);
         }
         #view {
-          min-height: calc(100vh - var(--header-height));
+          /** -8 to account for the gap between content and app header */
+          min-height: calc(100vh - var(--header-height) - 8);
           /**
           * Since we only set min-height, if child nodes need percentage
           * heights they must use absolute positioning so we need relative

--- a/src/panels/lovelace/views/hui-panel-view.ts
+++ b/src/panels/lovelace/views/hui-panel-view.ts
@@ -132,7 +132,7 @@ export class PanelView extends LitElement implements LovelaceViewElement {
       :host {
         display: block;
         height: 100%;
-        /** Ensure gap between content and header for visual separation */
+        /** Ensure gap between content and app header for visual separation */
         margin-top: 8px;
       }
 

--- a/src/panels/lovelace/views/hui-panel-view.ts
+++ b/src/panels/lovelace/views/hui-panel-view.ts
@@ -132,6 +132,8 @@ export class PanelView extends LitElement implements LovelaceViewElement {
       :host {
         display: block;
         height: 100%;
+        /** Ensure gap between content and header for visual separation */
+        margin-top: 8px;
       }
 
       mwc-fab {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

In dark mode the background color of the header and for a card are the same (medium dark gray). As there was no gap/space between header and content in panel mode, there was no visual bottom of the header. In the light theme, that missing gap is not an issue since header is blue, but card background is white.

I now added the same 8px gap that we have in non panel views.

**Before:**

![image](https://user-images.githubusercontent.com/114137/96992292-f6990d00-1529-11eb-8437-4d6cdef10764.png)

**After:**

![image](https://user-images.githubusercontent.com/114137/96992300-fac52a80-1529-11eb-8682-2446c0ccf95c.png)

**Comparison to non panel mode:**

![image](https://user-images.githubusercontent.com/114137/96992315-fef14800-1529-11eb-9593-d3cd3775303b.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
