### PR TITLE
Ensure attribute values are consistently right aligned

### DIFF
--- a/src/components/ha-attributes.ts
+++ b/src/components/ha-attributes.ts
@@ -63,6 +63,7 @@ class HaAttributes extends LitElement {
       .data-entry .value {
         max-width: 200px;
         overflow-wrap: break-word;
+        text-align: right;
       }
       .key:first-letter {
         text-transform: capitalize;

--- a/src/components/ha-attributes.ts
+++ b/src/components/ha-attributes.ts
@@ -70,7 +70,7 @@ class HaAttributes extends LitElement {
       }
       .attribution {
         color: var(--secondary-text-color);
-        text-align: right;
+        text-align: center;
       }
       pre {
         font-family: inherit;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Most attribute values are automatically right aligned in the more-info popup, since they only need a single line. However, multi line attribute values break this visually.

**Before:**
![image](https://user-images.githubusercontent.com/114137/96993347-7bd0f180-152b-11eb-8831-4485de893339.png)

**After:**
![image](https://user-images.githubusercontent.com/114137/96993342-78d60100-152b-11eb-89cf-44b208bbbdba.png)

Also: Consistently show the optional attribution text centered, as the weather card already does, to be consistent.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
