### PR TITLE
Fix issue with toggles blocking dialog and dialog launching on mobile

### DIFF
--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -81,6 +81,7 @@ export class HaCodeEditor extends UpdatingElement {
 
   protected firstUpdated(changedProps: PropertyValues): void {
     super.firstUpdated(changedProps);
+    this._blockKeyboardShortcuts();
     this._load();
   }
 
@@ -230,6 +231,10 @@ export class HaCodeEditor extends UpdatingElement {
     });
     this._setScrollBarDirection();
     this.codemirror!.on("changes", () => this._onChange());
+  }
+
+  private _blockKeyboardShortcuts() {
+    this.addEventListener("keydown", (ev) => ev.stopPropagation());
   }
 
   private _onChange(): void {

--- a/src/state/quick-bar-mixin.ts
+++ b/src/state/quick-bar-mixin.ts
@@ -36,27 +36,41 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
     }
 
     private _showQuickBar(e: KeyboardEvent, commandMode = false) {
-      if (
-        !this.hass?.user?.is_admin ||
-        !this.hass.enableShortcuts ||
-        this._inInputField(e)
-      ) {
+      if (!this._canShowQuickBar(e)) {
         return;
       }
 
       showQuickBar(this, { commandMode });
     }
 
-    private _inInputField(e: KeyboardEvent) {
-      const el = e.composedPath()[0] as any;
+    private _canShowQuickBar(e: KeyboardEvent) {
       return (
-        el.tagName === "TEXTAREA" ||
-        (el.tagName === "INPUT" &&
-          ["TEXT", "NUMBER"].includes(this._getInputType(el)))
+        this.hass?.user?.is_admin &&
+        this.hass.enableShortcuts &&
+        this._canOverrideAlphanumericInput(e)
       );
     }
 
-    private _getInputType(el) {
-      return el.type && el.type.toUpperCase();
+    private _canOverrideAlphanumericInput(e: KeyboardEvent) {
+      const el = e.composedPath()[0] as any;
+
+      if (el.tagName === "TEXTAREA") {
+        return false;
+      }
+
+      if (el.tagName !== "INPUT") {
+        return true;
+      }
+
+      switch (el.type) {
+        case "button":
+        case "checkbox":
+        case "hidden":
+        case "radio":
+        case "range":
+          return true;
+        default:
+          return false;
+      }
     }
   };

--- a/src/state/quick-bar-mixin.ts
+++ b/src/state/quick-bar-mixin.ts
@@ -48,8 +48,15 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
     }
 
     private _inInputField(e: KeyboardEvent) {
-      return ["INPUT", "TEXTAREA"].includes(
-        (e.composedPath()[0] as HTMLElement).tagName
+      const el = e.composedPath()[0] as any;
+      return (
+        el.tagName === "TEXTAREA" ||
+        (el.tagName === "INPUT" &&
+          ["TEXT", "NUMBER"].includes(this._getInputType(el)))
       );
+    }
+
+    private _getInputType(el) {
+      return el.type && el.type.toUpperCase();
     }
   };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

1. Be more granular about which input fields should block dialog if focused. Fixes a bug where toggle buttons (which are inputs of type "checkbox") will block dialog launching if just clicked.
2. Block dialog from launching on mobile devices (using detection code from http://detectmobilebrowsers.com/). Fixes an issue where iOS users currently in template / call service data field / automation editor fields will launch the dialog if they type `e` or `c`.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/7517
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
