### PR TITLE
Allow editing OZW node numeric and list config options

### DIFF
--- a/src/data/ozw.ts
+++ b/src/data/ozw.ts
@@ -69,8 +69,6 @@ export interface OZWDeviceConfig {
   type: string;
   value: string | number;
   parameter: number;
-  min: number;
-  max: number;
   help: string;
   schema: HaFormSchema;
 }

--- a/src/data/ozw.ts
+++ b/src/data/ozw.ts
@@ -1,3 +1,4 @@
+import { HaFormSchema } from "../components/ha-form/ha-form";
 import { HomeAssistant } from "../types";
 import { DeviceRegistryEntry } from "./device_registry";
 
@@ -71,6 +72,7 @@ export interface OZWDeviceConfig {
   min: number;
   max: number;
   help: string;
+  schema: HaFormSchema;
 }
 
 export const nodeQueryStages = [

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -103,10 +103,6 @@ class OZWNodeConfig extends LitElement {
                 )}
               </em>
             </p>
-            <p>
-              Note: This panel is currently read-only. The ability to change
-              values will come in a later update.
-            </p>
           </div>
           ${this._node
             ? html`
@@ -179,7 +175,6 @@ class OZWNodeConfig extends LitElement {
   }
 
   private _generate_config_block(item) {
-    console.log(item);
     return html` <ha-card class="content" .value=${item.value}>
       <div class="card-content">
         <b>${item.label}</b><br />
@@ -229,6 +224,11 @@ class OZWNodeConfig extends LitElement {
                   </p>
                 `
               )}
+              <p>
+                <em
+                  >This configuration option can't be edited from the UI yet</em
+                >
+              </p>
             `
           : ``}
         ${!["Byte", "Short", "Int", "List", "BitSet"].includes(item.type)
@@ -301,30 +301,42 @@ class OZWNodeConfig extends LitElement {
     }
   }
 
-  private _updateTextConfigOption(ev: Event) {
+  private async _updateTextConfigOption(ev: Event) {
     const el = ev.target!.closest("ha-card").querySelector("paper-input");
-    console.log(el.parameter + "::" + el.value);
-    this.hass.callWS({
-      type: "ozw/set_config_parameter",
-      node_id: this.nodeId,
-      ozw_instance: this.ozwInstance,
-      parameter: el.parameter,
-      value: el.value,
-    });
+    el.errorMessage = undefined;
+    el.invalid = false;
+    try {
+      await this.hass.callWS({
+        type: "ozw/set_config_parameter",
+        node_id: this.nodeId,
+        ozw_instance: this.ozwInstance,
+        parameter: el.parameter,
+        value: el.value,
+      });
+    } catch (e) {
+      el.errorMessage = e.message;
+      el.invalid = true;
+    }
   }
 
-  private _updateListConfigOption(ev: Event) {
+  private async _updateListConfigOption(ev: Event) {
     const el = ev
       .target!.closest("ha-card")
       .querySelector("paper-dropdown-menu");
-    console.log(el.parameter + "::" + el.selectedItem.value);
-    /*  this.hass.callWS({
-      type: "ozw/set_config_parameter",
-      node_id: this.nodeId,
-      ozw_instance: this.ozwInstance,
-      parameter: el.parameter,
-      value: el.value
-    }); */
+    el.errorMessage = undefined;
+    el.invalid = false;
+    try {
+      await this.hass.callWS({
+        type: "ozw/set_config_parameter",
+        node_id: this.nodeId,
+        ozw_instance: this.ozwInstance,
+        parameter: el.parameter,
+        value: el.value,
+      });
+    } catch (e) {
+      el.errorMessage = e.message;
+      el.invalid = true;
+    }
   }
 
   private async _refreshNodeClicked() {

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -1,9 +1,6 @@
 import "../../../../../components/ha-switch";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox/paper-listbox";
-import type { PaperInputElement } from "@polymer/paper-input/paper-input";
-import type { Button } from "@material/mwc-button/mwc-button";
-import type { PaperDropdownMenuElement } from "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-input/paper-input";
 import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@material/mwc-button/mwc-button";

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -206,28 +206,26 @@ class OZWNodeConfig extends LitElement {
                 `
               )}
               <p>
-                <em
-                  >This configuration option can't be edited from the UI yet</em
-                >
+                <em>
+                  This configuration option can't be edited from the UI yet
+                </em>
               </p>
             `
           : ``}
         ${!["Byte", "Short", "Int", "List", "BitSet"].includes(item.type)
-          ? html`<p>${item.value}</p>`
-          : ``}
-        ${item.parameter === 999
-          ? html`<p class="error">
-              This config option can't be edited from the UI due to a current
-              OpenZWave integration issue.
-            </p>`
+          ? html`
+              <p>${item.value}</p>
+              <p>
+                <em>
+                  This configuration option can't be edited from the UI yet
+                </em>
+              </p>
+            `
           : ``}
       </div>
       ${["Byte", "Short", "Int"].includes(item.type)
         ? html` <div class="card-actions">
-            <mwc-button
-              @click=${this._updateTextConfigOption}
-              ?disabled=${item.parameter === 999}
-            >
+            <mwc-button @click=${this._updateTextConfigOption}>
               ${this.hass.localize("ui.panel.config.ozw.node_config.update")}
             </mwc-button>
           </div>`
@@ -235,10 +233,7 @@ class OZWNodeConfig extends LitElement {
       ${item.type === "List"
         ? html`
             <div class="card-actions">
-              <mwc-button
-                @click=${this._updateListConfigOption}
-                ?disabled=${item.parameter === 999}
-              >
+              <mwc-button @click=${this._updateListConfigOption}>
                 ${this.hass.localize("ui.panel.config.ozw.node_config.update")}
               </mwc-button>
             </div>
@@ -410,14 +405,6 @@ export interface ChangeEvent {
     value?: any;
   };
   target?: EventTarget;
-}
-
-export interface OzwConfigInputElement extends PaperInputElement {
-  parameter: number;
-}
-
-export interface OzwConfigDropdownElement extends PaperDropdownMenuElement {
-  parameter: number;
 }
 
 declare global {

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -61,6 +61,8 @@ class OZWNodeConfig extends LitElement {
 
   @internalProperty() private _error?: string;
 
+  @internalProperty() private _errors: { [key: number]: any } = {};
+
   protected firstUpdated() {
     if (!this.ozwInstance) {
       navigate(this, "/config/ozw/dashboard", true);
@@ -191,6 +193,11 @@ class OZWNodeConfig extends LitElement {
             >
             </ha-form>`
           : ``}
+        ${this._errors[item.parameter]
+          ? html`<span class="error"
+              >${this._errors[item.parameter].message}</span
+            >`
+          : ``}
         ${item.type === "BitSet"
           ? html`
               ${item.value.map(
@@ -296,9 +303,12 @@ class OZWNodeConfig extends LitElement {
 
   private async _updateConfigOption(ev: CustomEvent) {
     const parameter = (<OzwConfigFormButton>ev.currentTarget)!.parameter;
-    const value = this._configData[parameter];
+    const value = this._configData[parameter][
+      Object.keys(this._configData[parameter])[0]
+    ];
 
     try {
+      this._errors![parameter] = undefined;
       await this.hass.callWS({
         type: "ozw/set_config_parameter",
         node_id: this.nodeId,
@@ -307,7 +317,7 @@ class OZWNodeConfig extends LitElement {
         value: value,
       });
     } catch (e) {
-      console.log("error", e);
+      this._errors[parameter] = e;
     }
   }
 

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -223,21 +223,12 @@ class OZWNodeConfig extends LitElement {
             `
           : ``}
       </div>
-      ${["Byte", "Short", "Int"].includes(item.type)
+      ${["Byte", "Short", "Int", "List"].includes(item.type)
         ? html` <div class="card-actions">
-            <mwc-button @click=${this._updateTextConfigOption}>
+            <mwc-button @click=${this._updateConfigOption}>
               ${this.hass.localize("ui.panel.config.ozw.node_config.update")}
             </mwc-button>
           </div>`
-        : ``}
-      ${item.type === "List"
-        ? html`
-            <div class="card-actions">
-              <mwc-button @click=${this._updateListConfigOption}>
-                ${this.hass.localize("ui.panel.config.ozw.node_config.update")}
-              </mwc-button>
-            </div>
-          `
         : ``}
     </ha-card>`;
   }
@@ -290,15 +281,11 @@ class OZWNodeConfig extends LitElement {
   private _configValueChanged(ev: CustomEvent) {
     this._configData[ev.currentTarget.parameter] =
       ev.detail.value[Object.keys(ev.detail.value)[0]];
-    console.log(this._configData);
   }
 
-  private async _updateTextConfigOption(ev: Event) {
-    const el = (<Button>ev.currentTarget)
-      .closest("ha-card")!
-      .querySelector("ha-form")!;
-    const value = el.closest("paper-input").value;
-    el.error = undefined;
+  private async _updateConfigOption(ev: CustomEvent) {
+    const parameter = ev.currentTarget.parameter;
+    const value = this._configData[parameter];
     /*
     try {
       await this.hass.callWS({
@@ -312,29 +299,7 @@ class OZWNodeConfig extends LitElement {
       el.errorMessage = e.message;
     }
     */
-    console.log(el.parameter, value);
-  }
-
-  private async _updateListConfigOption(ev: Event) {
-    const el = <OzwConfigDropdownElement>(
-      (<Button>ev.currentTarget)
-        .closest("ha-card")!
-        .querySelector("paper-dropdown-menu")!
-    );
-    el.errorMessage = undefined;
-    el.invalid = false;
-    try {
-      await this.hass.callWS({
-        type: "ozw/set_config_parameter",
-        node_id: this.nodeId,
-        ozw_instance: this.ozwInstance,
-        parameter: el.parameter,
-        value: el.value,
-      });
-    } catch (e) {
-      el.errorMessage = e.message;
-      el.invalid = true;
-    }
+    console.log(ev.currentTarget, value);
   }
 
   private async _refreshNodeClicked() {

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -281,7 +281,7 @@ class OZWNodeConfig extends LitElement {
   }
 
   private _configValueChanged(ev: CustomEvent) {
-    this._configData[(<OzwConfigFormButton>ev.currentTarget)!.parameter] =
+    this._configData[(<OzwHaForm>ev.currentTarget)!.parameter] =
       ev.detail.value[Object.keys(ev.detail.value)[0]];
   }
 
@@ -300,8 +300,6 @@ class OZWNodeConfig extends LitElement {
     } catch (e) {
       console.log("error", e);
     }
-
-    console.log(parameter, value);
   }
 
   private async _refreshNodeClicked() {

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -319,6 +319,7 @@ class OZWNodeConfig extends LitElement {
     } catch (e) {
       this._errors[parameter] = e;
     }
+    this.requestUpdate();
   }
 
   private async _refreshNodeClicked() {

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -34,6 +34,8 @@ import {
 import { ERR_NOT_FOUND } from "../../../../../data/websocket_api";
 import { showOZWRefreshNodeDialog } from "./show-dialog-ozw-refresh-node";
 import { ozwNodeTabs } from "./ozw-node-router";
+import { HaForm } from "../../../../../components/ha-form/ha-form";
+import { Button } from "@material/mwc-button/mwc-button";
 
 @customElement("ozw-node-config")
 class OZWNodeConfig extends LitElement {
@@ -222,7 +224,10 @@ class OZWNodeConfig extends LitElement {
       </div>
       ${["Byte", "Short", "Int", "List"].includes(item.type)
         ? html` <div class="card-actions">
-            <mwc-button @click=${this._updateConfigOption}>
+            <mwc-button
+              @click=${this._updateConfigOption}
+              .parameter=${item.parameter}
+            >
               ${this.hass.localize("ui.panel.config.ozw.node_config.update")}
             </mwc-button>
           </div>`
@@ -276,27 +281,27 @@ class OZWNodeConfig extends LitElement {
   }
 
   private _configValueChanged(ev: CustomEvent) {
-    this._configData[ev.currentTarget.parameter] =
+    this._configData[(<OzwConfigFormButton>ev.currentTarget)!.parameter] =
       ev.detail.value[Object.keys(ev.detail.value)[0]];
   }
 
   private async _updateConfigOption(ev: CustomEvent) {
-    const parameter = ev.currentTarget.parameter;
+    const parameter = (<OzwConfigFormButton>ev.currentTarget)!.parameter;
     const value = this._configData[parameter];
-    /*
+
     try {
       await this.hass.callWS({
         type: "ozw/set_config_parameter",
         node_id: this.nodeId,
         ozw_instance: this.ozwInstance,
-        parameter: el.parameter,
-        value: el.value,
+        parameter: parameter,
+        value: value,
       });
     } catch (e) {
-      el.errorMessage = e.message;
+      console.log("error", e);
     }
-    */
-    console.log(ev.currentTarget, value);
+
+    console.log(parameter, value);
   }
 
   private async _refreshNodeClicked() {
@@ -360,6 +365,14 @@ class OZWNodeConfig extends LitElement {
       `,
     ];
   }
+}
+
+export interface OzwHaForm extends HaForm {
+  parameter: number;
+}
+
+export interface OzwConfigFormButton extends Button {
+  parameter: number;
 }
 
 export interface ChangeEvent {

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -211,7 +211,7 @@ class OZWNodeConfig extends LitElement {
               </p>
             `
           : ``}
-        ${!["Byte", "Short", "Int", "List", "BitSet"].includes(item.type)
+        ${!["Byte", "Short", "Int", "List"].includes(item.type)
           ? html`
               <p>${item.value}</p>
               <p>

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -50,7 +50,7 @@ class OZWNodeConfig extends LitElement {
 
   @property() public nodeId?;
 
-  @property()
+  @internalProperty()
   private _configData: { [key: number]: any } = {};
 
   @internalProperty() private _node?: OZWDevice;
@@ -185,7 +185,7 @@ class OZWNodeConfig extends LitElement {
         ${["Byte", "Short", "Int", "List"].includes(item.type)
           ? html` <ha-form
               .schema=${item.schema}
-              .data=${item.data}
+              .data=${this._configData[item.parameter]}
               .parameter=${item.parameter}
               @value-changed=${this._configValueChanged}
             >
@@ -261,11 +261,13 @@ class OZWNodeConfig extends LitElement {
 
       this._config.forEach((item) => {
         if (item.type === "List") {
-          this._configData[item.parameter] = item.schema[0].options.find(
-            (opt: (number | string)[]) => opt[1] === item.value
-          )[0];
+          this._configData[item.parameter] = {
+            [item.label]: item.schema[0].options.find(
+              (opt: (number | string)[]) => opt[1] === item.value
+            )[0],
+          };
         } else {
-          this._configData[item.parameter] = item.value;
+          this._configData[item.parameter] = { [item.label]: item.value };
         }
       });
     } catch (err) {
@@ -278,8 +280,14 @@ class OZWNodeConfig extends LitElement {
   }
 
   private _configValueChanged(ev: CustomEvent) {
-    this._configData[(<OzwHaForm>ev.currentTarget)!.parameter] =
-      ev.detail.value[Object.keys(ev.detail.value)[0]];
+    this._configData = {
+      ...this._configData,
+      [(<OzwHaForm>ev.currentTarget)!.parameter]: {
+        [Object.keys(
+          this._configData[(<OzwHaForm>ev.currentTarget)!.parameter]
+        )[0]]: ev.detail.value[Object.keys(ev.detail.value)[0]],
+      },
+    };
   }
 
   private async _updateConfigOption(ev: CustomEvent) {

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -203,17 +203,21 @@ class OZWNodeConfig extends LitElement {
               )}
               <p>
                 <em>
-                  This configuration option can't be edited from the UI yet
+                  ${this.hass.localize(
+                    "ui.panel.config.ozw.node_config.cant_edit_from_ui"
+                  )}
                 </em>
               </p>
             `
           : ``}
-        ${!["Byte", "Short", "Int", "List"].includes(item.type)
+        ${!["BitSet", "Byte", "Short", "Int", "List"].includes(item.type)
           ? html`
               <p>${item.value}</p>
               <p>
                 <em>
-                  This configuration option can't be edited from the UI yet
+                  ${this.hass.localize(
+                    "ui.panel.config.ozw.node_config.cant_edit_from_ui"
+                  )}
                 </em>
               </p>
             `

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -264,9 +264,9 @@ class OZWNodeConfig extends LitElement {
 
       this._config.forEach((item) => {
         if (item.type === "List") {
-          this._configData[item.parameter] = Object.values(
-            item.schema[0].options
-          ).find((opt) => opt[1] === item.value)[0];
+          this._configData[item.parameter] = item.schema[0].options.find(
+            (opt: (number | string)[]) => opt[1] === item.value
+          )[0];
         } else {
           this._configData[item.parameter] = item.value;
         }

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -341,6 +341,10 @@ class OZWNodeConfig extends LitElement {
           margin-top: 24px;
         }
 
+        .content:last-child {
+          margin-bottom: 24px;
+        }
+
         .sectionHeader {
           position: relative;
           padding-right: 40px;

--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-config.ts
@@ -1,8 +1,5 @@
 import "../../../../../components/ha-switch";
 import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
-import "@polymer/paper-input/paper-input";
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@material/mwc-button/mwc-button";
 import {
   css,
@@ -34,8 +31,8 @@ import {
 import { ERR_NOT_FOUND } from "../../../../../data/websocket_api";
 import { showOZWRefreshNodeDialog } from "./show-dialog-ozw-refresh-node";
 import { ozwNodeTabs } from "./ozw-node-router";
-import { HaForm } from "../../../../../components/ha-form/ha-form";
-import { Button } from "@material/mwc-button/mwc-button";
+import type { HaForm } from "../../../../../components/ha-form/ha-form";
+import type { Button } from "@material/mwc-button/mwc-button";
 
 @customElement("ozw-node-config")
 class OZWNodeConfig extends LitElement {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2189,7 +2189,8 @@
             "header": "Node Configuration",
             "introduction": "Manage the different configuration parameters for a Z-Wave node.",
             "help_source": "Config parameter descriptions and help text are provided by the OpenZWave project.",
-            "wakeup_help": "Battery powered nodes must be awake to change their configuration. If the node is not awake, OpenZWave will attempt to update the node's configuration the next time it wakes up, which could be multiple hours (or days) later. Follow these steps to wake up your device:"
+            "wakeup_help": "Battery powered nodes must be awake to change their configuration. If the node is not awake, OpenZWave will attempt to update the node's configuration the next time it wakes up, which could be multiple hours (or days) later. Follow these steps to wake up your device:",
+            "update": "Update"
           },
           "node_metadata": {
             "product_manual": "Product Manual"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2190,7 +2190,8 @@
             "introduction": "Manage the different configuration parameters for a Z-Wave node.",
             "help_source": "Config parameter descriptions and help text are provided by the OpenZWave project.",
             "wakeup_help": "Battery powered nodes must be awake to change their configuration. If the node is not awake, OpenZWave will attempt to update the node's configuration the next time it wakes up, which could be multiple hours (or days) later. Follow these steps to wake up your device:",
-            "update": "Update"
+            "update": "Update",
+            "cant_edit_from_ui": "This configuration option can't be edited from the UI yet."
           },
           "node_metadata": {
             "product_manual": "Product Manual"


### PR DESCRIPTION
## Proposed change

Adds support for editing numeric (Int, Byte, Short) and List config items for nodes in the OZW config panel.

![image](https://user-images.githubusercontent.com/7545841/97379242-b8d61480-189a-11eb-8ecb-69fcc509ec3c.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Backend PR: https://github.com/home-assistant/core/pull/43058

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
