### PR TITLE
Use ha-dialog for dialog-area-registry-detail

### DIFF
--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -10,7 +10,8 @@ import {
   internalProperty,
   TemplateResult,
 } from "lit-element";
-import "../../../components/dialog/ha-paper-dialog";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-dialog";
 import { AreaRegistryEntryMutableParams } from "../../../data/area_registry";
 import { PolymerChangedEvent } from "../../../polymer-types";
 import { haStyleDialog } from "../../../resources/styles";
@@ -37,6 +38,12 @@ class DialogAreaDetail extends LitElement {
     await this.updateComplete;
   }
 
+  public closeDialog(): void {
+    this._error = "";
+    this._params = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
   protected render(): TemplateResult {
     if (!this._params) {
       return html``;
@@ -44,17 +51,14 @@ class DialogAreaDetail extends LitElement {
     const entry = this._params.entry;
     const nameInvalid = this._name.trim() === "";
     return html`
-      <ha-paper-dialog
-        with-backdrop
-        opened
-        @opened-changed="${this._openedChanged}"
+      <ha-dialog
+        open
+        @closed=${this.closeDialog}
+        .heading=${entry
+          ? entry.name
+          : this.hass.localize("ui.panel.config.areas.editor.default_name")}
       >
-        <h2>
-          ${entry
-            ? entry.name
-            : this.hass.localize("ui.panel.config.areas.editor.default_name")}
-        </h2>
-        <paper-dialog-scrollable>
+        <div>
           ${this._error ? html` <div class="error">${this._error}</div> ` : ""}
           <div class="form">
             ${entry
@@ -78,29 +82,29 @@ class DialogAreaDetail extends LitElement {
               .invalid=${nameInvalid}
             ></paper-input>
           </div>
-        </paper-dialog-scrollable>
-        <div class="paper-dialog-buttons">
-          ${entry
-            ? html`
-                <mwc-button
-                  class="warning"
-                  @click="${this._deleteEntry}"
-                  .disabled=${this._submitting}
-                >
-                  ${this.hass.localize("ui.panel.config.areas.editor.delete")}
-                </mwc-button>
-              `
-            : html``}
-          <mwc-button
-            @click="${this._updateEntry}"
-            .disabled=${nameInvalid || this._submitting}
-          >
-            ${entry
-              ? this.hass.localize("ui.panel.config.areas.editor.update")
-              : this.hass.localize("ui.panel.config.areas.editor.create")}
-          </mwc-button>
         </div>
-      </ha-paper-dialog>
+        ${entry
+          ? html`
+              <mwc-button
+                slot="secondaryAction"
+                class="warning"
+                @click="${this._deleteEntry}"
+                .disabled=${this._submitting}
+              >
+                ${this.hass.localize("ui.panel.config.areas.editor.delete")}
+              </mwc-button>
+            `
+          : html``}
+        <mwc-button
+          slot="primaryAction"
+          @click="${this._updateEntry}"
+          .disabled=${nameInvalid || this._submitting}
+        >
+          ${entry
+            ? this.hass.localize("ui.panel.config.areas.editor.update")
+            : this.hass.localize("ui.panel.config.areas.editor.create")}
+        </mwc-button>
+      </ha-dialog>
     `;
   }
 
@@ -141,21 +145,12 @@ class DialogAreaDetail extends LitElement {
     }
   }
 
-  private _openedChanged(ev: PolymerChangedEvent<boolean>): void {
-    if (!(ev.detail as any).value) {
-      this._params = undefined;
-    }
-  }
-
   static get styles(): CSSResult[] {
     return [
       haStyleDialog,
       css`
         .form {
           padding-bottom: 24px;
-        }
-        mwc-button.warning {
-          margin-right: auto;
         }
         .error {
           color: var(--error-color);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This replaces the use of `ha-paper-dialog` with `ha-dialog` for the Area settings dialog on the Area registry detail page. It also adds a public `closeDialog` method per #6138

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Create a new area on the Areas page, or click on an area on the Areas page, then click on the gear icon in the top right corner to open the new dialog.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6138
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
