### PR TITLE
Use ha-dialog for dialog-system-log-details, add close icon button

### DIFF
--- a/src/panels/config/logs/dialog-system-log-detail.ts
+++ b/src/panels/config/logs/dialog-system-log-detail.ts
@@ -1,5 +1,5 @@
 import "@material/mwc-icon-button/mwc-icon-button";
-import { mdiContentCopy } from "@mdi/js";
+import { mdiContentCopy, mdiClose } from "@mdi/js";
 import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
 import "@polymer/paper-tooltip/paper-tooltip";
 import type { PaperTooltipElement } from "@polymer/paper-tooltip/paper-tooltip";
@@ -14,7 +14,7 @@ import {
   TemplateResult,
 } from "lit-element";
 import { fireEvent } from "../../../common/dom/fire_event";
-import "../../../components/dialog/ha-paper-dialog";
+import "../../../components/ha-dialog";
 import "../../../components/ha-svg-icon";
 import {
   domainToName,
@@ -23,7 +23,6 @@ import {
   IntegrationManifest,
 } from "../../../data/integration";
 import { getLoggedErrorIntegration } from "../../../data/system_log";
-import type { PolymerChangedEvent } from "../../../polymer-types";
 import { haStyleDialog } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import type { SystemLogDetailDialogParams } from "./show-dialog-system-log-detail";
@@ -36,7 +35,7 @@ class DialogSystemLogDetail extends LitElement {
 
   @internalProperty() private _manifest?: IntegrationManifest;
 
-  @query("paper-tooltip", true) private _toolTip?: PaperTooltipElement;
+  @query("paper-tooltip") private _toolTip?: PaperTooltipElement;
 
   public async showDialog(params: SystemLogDetailDialogParams): Promise<void> {
     this._params = params;
@@ -69,13 +68,9 @@ class DialogSystemLogDetail extends LitElement {
     const integration = getLoggedErrorIntegration(item);
 
     return html`
-      <ha-paper-dialog
-        with-backdrop
-        opened
-        @opened-changed="${this._openedChanged}"
-      >
-        <div class="heading">
-          <h2>
+      <ha-dialog open @closed=${this.closeDialog} hideActions heading=${true}>
+        <div slot="heading" class="heading">
+          <h2 class="title">
             ${this.hass.localize(
               "ui.panel.config.logs.details",
               "level",
@@ -93,8 +88,11 @@ class DialogSystemLogDetail extends LitElement {
             offset="4"
             >${this.hass.localize("ui.common.copied")}</paper-tooltip
           >
+          <mwc-icon-button @click=${this.closeDialog}>
+            <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
+          </mwc-icon-button>
         </div>
-        <paper-dialog-scrollable>
+        <div class="contents">
           <p>
             Logger: ${item.name}<br />
             Source: ${item.source.join(":")}
@@ -150,8 +148,8 @@ class DialogSystemLogDetail extends LitElement {
               `
             : item.message[0]}
           ${item.exception ? html` <pre>${item.exception}</pre> ` : html``}
-        </paper-dialog-scrollable>
-      </ha-paper-dialog>
+        </div>
+      </ha-dialog>
     `;
   }
 
@@ -163,15 +161,9 @@ class DialogSystemLogDetail extends LitElement {
     }
   }
 
-  private _openedChanged(ev: PolymerChangedEvent<boolean>): void {
-    if (!(ev.detail as any).value) {
-      this.closeDialog();
-    }
-  }
-
   private _copyLog(): void {
     const copyElement = this.shadowRoot?.querySelector(
-      "paper-dialog-scrollable"
+      ".contents"
     ) as HTMLElement;
 
     const selection = window.getSelection()!;
@@ -192,9 +184,6 @@ class DialogSystemLogDetail extends LitElement {
     return [
       haStyleDialog,
       css`
-        ha-paper-dialog {
-          direction: ltr;
-        }
         a {
           color: var(--primary-color);
         }
@@ -209,9 +198,20 @@ class DialogSystemLogDetail extends LitElement {
           display: flex;
           align-items: center;
           justify-content: space-between;
+          padding: 8px 12px 8px 24px;
         }
         .heading ha-svg-icon {
           cursor: pointer;
+        }
+        .title {
+          flex-grow: 1;
+          margin: 0;
+        }
+
+        @media all and (min-width: 451px) and (min-height: 501px) {
+          ha-dialog {
+            --mdc-dialog-max-width: 90vw;
+          }
         }
       `,
     ];

--- a/src/panels/config/logs/dialog-system-log-detail.ts
+++ b/src/panels/config/logs/dialog-system-log-detail.ts
@@ -1,6 +1,6 @@
+import "../../../components/ha-header-bar";
 import "@material/mwc-icon-button/mwc-icon-button";
 import { mdiContentCopy, mdiClose } from "@mdi/js";
-import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
 import "@polymer/paper-tooltip/paper-tooltip";
 import type { PaperTooltipElement } from "@polymer/paper-tooltip/paper-tooltip";
 import {
@@ -69,18 +69,22 @@ class DialogSystemLogDetail extends LitElement {
 
     return html`
       <ha-dialog open @closed=${this.closeDialog} hideActions heading=${true}>
-        <div slot="heading" class="heading">
-          <h2 class="title">
+        <ha-header-bar slot="heading">
+          <mwc-icon-button slot="navigationIcon" dialogAction="cancel">
+            <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
+          </mwc-icon-button>
+          <span slot="title">
             ${this.hass.localize(
               "ui.panel.config.logs.details",
               "level",
               item.level
             )}
-          </h2>
-          <mwc-icon-button id="copy" @click=${this._copyLog}>
+          </span>
+          <mwc-icon-button id="copy" @click=${this._copyLog} slot="actionItems">
             <ha-svg-icon .path=${mdiContentCopy}></ha-svg-icon>
           </mwc-icon-button>
           <paper-tooltip
+            slot="actionItems"
             manual-mode
             for="copy"
             position="left"
@@ -88,10 +92,7 @@ class DialogSystemLogDetail extends LitElement {
             offset="4"
             >${this.hass.localize("ui.common.copied")}</paper-tooltip
           >
-          <mwc-icon-button @click=${this.closeDialog}>
-            <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
-          </mwc-icon-button>
-        </div>
+        </ha-header-bar>
         <div class="contents">
           <p>
             Logger: ${item.name}<br />
@@ -194,18 +195,13 @@ class DialogSystemLogDetail extends LitElement {
           margin-bottom: 0;
           font-family: var(--code-font-family, monospace);
         }
-        .heading {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          padding: 8px 12px 8px 24px;
-        }
-        .heading ha-svg-icon {
-          cursor: pointer;
-        }
-        .title {
-          flex-grow: 1;
-          margin: 0;
+
+        ha-header-bar {
+          --mdc-theme-on-primary: var(--primary-text-color);
+          --mdc-theme-primary: var(--mdc-theme-surface);
+          flex-shrink: 0;
+          border-bottom: 1px solid
+            var(--mdc-dialog-scroll-divider-color, rgba(0, 0, 0, 0.12));
         }
 
         @media all and (min-width: 451px) and (min-height: 501px) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This replaces the use of `ha-paper-dialog` with `ha-dialog` for the System Log detail dialog on the System Log page. It also adds a close icon button so the dialog can be closed on mobile devices.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Click on an entry in the Configuration > Log page to view the dialog.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #6138
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
