### PR TITLE
Formats number state with selected language in compute_state_display

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -5,6 +5,7 @@ import { formatDateTime } from "../datetime/format_date_time";
 import { formatTime } from "../datetime/format_time";
 import { LocalizeFunc } from "../translations/localize";
 import { computeStateDomain } from "./compute_state_domain";
+import { numberFormat } from "../string/number-format";
 
 export const computeStateDisplay = (
   localize: LocalizeFunc,
@@ -19,12 +20,9 @@ export const computeStateDisplay = (
   }
 
   if (stateObj.attributes.unit_of_measurement) {
-    if (!Number.isNaN(Number(compareState))) {
-      return `${new Intl.NumberFormat(language).format(Number(compareState))} ${
-        stateObj.attributes.unit_of_measurement
-      }`;
-    }
-    return `${compareState} ${stateObj.attributes.unit_of_measurement}`;
+    return `${numberFormat(compareState, language)} ${
+      stateObj.attributes.unit_of_measurement
+    }`;
   }
 
   const domain = computeStateDomain(stateObj);

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -19,6 +19,11 @@ export const computeStateDisplay = (
   }
 
   if (stateObj.attributes.unit_of_measurement) {
+    if (!Number.isNaN(Number(compareState))) {
+      return `${new Intl.NumberFormat(language).format(Number(compareState))} ${
+        stateObj.attributes.unit_of_measurement
+      }`;
+    }
     return `${compareState} ${stateObj.attributes.unit_of_measurement}`;
   }
 

--- a/src/common/string/number-format.ts
+++ b/src/common/string/number-format.ts
@@ -12,7 +12,7 @@ export const numberFormat = (
   Number.isNaN =
     Number.isNaN ||
     function isNaN(input) {
-      return typeof input === "number" && input !== input;
+      return typeof input === "number" && isNaN(input);
     };
 
   if (!Number.isNaN(Number(num)) && window.Intl) {

--- a/src/common/string/number-format.ts
+++ b/src/common/string/number-format.ts
@@ -1,0 +1,22 @@
+/**
+ * Formats a number based on the specified language with thousands separator(s) and decimal character for better legibility.
+ *
+ * @param num The number to format
+ * @param language The language to use when formatting the number
+ */
+export const numberFormat = (
+  num: string | number,
+  language: string
+): string => {
+  // Polyfill for Number.isNaN, which is more reliable that the global isNaN()
+  Number.isNaN =
+    Number.isNaN ||
+    function isNaN(input) {
+      return typeof input === "number" && input !== input;
+    };
+
+  if (!Number.isNaN(Number(num)) && window.Intl) {
+    return new Intl.NumberFormat(language).format(Number(num));
+  }
+  return num.toString();
+};

--- a/src/common/string/number-format.ts
+++ b/src/common/string/number-format.ts
@@ -15,7 +15,7 @@ export const numberFormat = (
       return typeof input === "number" && isNaN(input);
     };
 
-  if (!Number.isNaN(Number(num)) && window.Intl) {
+  if (!Number.isNaN(Number(num)) && Intl) {
     return new Intl.NumberFormat(language).format(Number(num));
   }
   return num.toString();

--- a/test-mocha/common/entity/compute_state_display.ts
+++ b/test-mocha/common/entity/compute_state_display.ts
@@ -64,6 +64,20 @@ describe("computeStateDisplay", () => {
     assert.strictEqual(computeStateDisplay(localize, stateObj, "en"), "123 m");
   });
 
+  it("Localizes and formats numeric sensor value with units", () => {
+    const stateObj: any = {
+      entity_id: "sensor.test",
+      state: "1234.5",
+      attributes: {
+        unit_of_measurement: "m",
+      },
+    };
+    assert.strictEqual(
+      computeStateDisplay(localize, stateObj, "en"),
+      "1,234.5 m"
+    );
+  });
+
   it("Localizes unknown sensor value with units", () => {
     const altLocalize = (message, ...args) => {
       if (message === "state.sensor.unknown") {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This updates the `computeStateDisplay` function to format numbers using the browser's `Intl.NumberFormat` feature based on the selected language in Home Assistant. This results in language-specific thousands separator and decimal characters when displaying a state that is valid number.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Add an integration that creates entities that use a number state value with a unit of measurement. The Coronavirus integration is a quick and easy way to test this. When rendered in lovelace, more info dialogs, or anywhere the `computeStateDisplay` is used, the value should use language-specific comma separators and decimal characters.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/issues/3928
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
