### PR TITLE
Calendar: Adds an Update Size and Makes list view start today and adds in local for first day of week

### DIFF
--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -44,6 +44,15 @@ declare global {
   }
 }
 
+const getListWeekRange = (currentDate: Date): { start: Date; end: Date } => {
+  const startDate = new Date(currentDate.valueOf());
+  const endDate = new Date(currentDate.valueOf());
+
+  endDate.setDate(endDate.getDate() + 7);
+
+  return { start: startDate, end: endDate };
+};
+
 const defaultFullCalendarConfig: CalendarOptions = {
   headerToolbar: false,
   plugins: [dayGridPlugin, listPlugin, interactionPlugin],
@@ -51,16 +60,21 @@ const defaultFullCalendarConfig: CalendarOptions = {
   dayMaxEventRows: true,
   height: "parent",
   eventDisplay: "list-item",
+  views: {
+    list: {
+      visibleRange: getListWeekRange,
+    },
+  },
 };
 
 const viewButtons: ToggleButton[] = [
   { label: "Month View", value: "dayGridMonth", iconPath: mdiViewModule },
   { label: "Week View", value: "dayGridWeek", iconPath: mdiViewWeek },
   { label: "Day View", value: "dayGridDay", iconPath: mdiViewDay },
-  { label: "List View", value: "listWeek", iconPath: mdiViewAgenda },
+  { label: "List View", value: "list", iconPath: mdiViewAgenda },
 ];
 
-class HAFullCalendar extends LitElement {
+export class HAFullCalendar extends LitElement {
   public hass!: HomeAssistant;
 
   @property({ type: Boolean, reflect: true }) public narrow = false;
@@ -78,6 +92,10 @@ class HAFullCalendar extends LitElement {
   @internalProperty() private calendar?: Calendar;
 
   @internalProperty() private _activeView?: FullCalendarView;
+
+  public updateSize(): void {
+    this.calendar?.updateSize();
+  }
 
   protected render(): TemplateResult {
     const viewToggleButtons = this._viewToggleButtons(this.views);
@@ -243,7 +261,7 @@ class HAFullCalendar extends LitElement {
     this._fireViewChanged();
   }
 
-  private _handleView(ev): void {
+  private _handleView(ev: CustomEvent): void {
     this._activeView = ev.detail.value;
     this.calendar!.changeView(this._activeView!);
     this._fireViewChanged();

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -27,7 +27,7 @@ import memoize from "memoize-one";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-button-toggle-group";
 import "../../components/ha-icon-button";
-import { haStyle, haStyleScrollbar } from "../../resources/styles";
+import { haStyle } from "../../resources/styles";
 import type {
   CalendarEvent,
   CalendarViewChanged,
@@ -292,7 +292,6 @@ export class HAFullCalendar extends LitElement {
   static get styles(): CSSResult[] {
     return [
       haStyle,
-      haStyleScrollbar,
       css`
         ${unsafeCSS(fullcalendarStyle)}
         ${unsafeCSS(daygridStyle)}

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -2,6 +2,7 @@
 import fullcalendarStyle from "@fullcalendar/common/main.css";
 import type { CalendarOptions } from "@fullcalendar/core";
 import { Calendar } from "@fullcalendar/core";
+import allLocales from "@fullcalendar/core/locales-all";
 import dayGridPlugin from "@fullcalendar/daygrid";
 // @ts-ignore
 import daygridStyle from "@fullcalendar/daygrid/main.css";
@@ -60,6 +61,7 @@ const defaultFullCalendarConfig: CalendarOptions = {
   dayMaxEventRows: true,
   height: "parent",
   eventDisplay: "list-item",
+  locales: allLocales,
   views: {
     list: {
       visibleRange: getListWeekRange,

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -206,6 +206,12 @@ export class HAFullCalendar extends LitElement {
       this.calendar!.changeView(this._activeView);
       this._fireViewChanged();
     }
+
+    const oldHass = changedProps.get("hass") as HomeAssistant;
+
+    if (oldHass && oldHass.language !== this.hass.language) {
+      this.calendar.setOption("locale", this.hass.language);
+    }
   }
 
   protected firstUpdated(): void {

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -27,7 +27,7 @@ import memoize from "memoize-one";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-button-toggle-group";
 import "../../components/ha-icon-button";
-import { haStyle } from "../../resources/styles";
+import { haStyle, haStyleScrollbar } from "../../resources/styles";
 import type {
   CalendarEvent,
   CalendarViewChanged,
@@ -182,7 +182,7 @@ export class HAFullCalendar extends LitElement {
             </div>
           `
         : ""}
-      <div id="calendar"></div>
+      <div id="calendar" class="ha-scrollbar"></div>
     `;
   }
 
@@ -292,6 +292,7 @@ export class HAFullCalendar extends LitElement {
   static get styles(): CSSResult[] {
     return [
       haStyle,
+      haStyleScrollbar,
       css`
         ${unsafeCSS(fullcalendarStyle)}
         ${unsafeCSS(daygridStyle)}
@@ -512,6 +513,23 @@ export class HAFullCalendar extends LitElement {
 
         :host([narrow]) .fc-dayGridMonth-view .fc-scrollgrid-sync-table {
           overflow: hidden;
+        }
+
+        .fc-scroller::-webkit-scrollbar {
+          width: 0.4rem;
+          height: 0.4rem;
+        }
+
+        .fc-scroller::-webkit-scrollbar-thumb {
+          -webkit-border-radius: 4px;
+          border-radius: 4px;
+          background: var(--scrollbar-thumb-color);
+        }
+
+        .fc-scroller {
+          overflow-y: auto;
+          scrollbar-color: var(--scrollbar-thumb-color) transparent;
+          scrollbar-width: thin;
         }
       `,
     ];

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -182,7 +182,7 @@ export class HAFullCalendar extends LitElement {
             </div>
           `
         : ""}
-      <div id="calendar" class="ha-scrollbar"></div>
+      <div id="calendar"></div>
     `;
   }
 

--- a/src/panels/lovelace/cards/hui-calendar-card.ts
+++ b/src/panels/lovelace/cards/hui-calendar-card.ts
@@ -7,6 +7,7 @@ import {
   LitElement,
   property,
   PropertyValues,
+  query,
   TemplateResult,
 } from "lit-element";
 import { HA_COLOR_PALETTE } from "../../../common/const";
@@ -24,6 +25,7 @@ import type {
   HomeAssistant,
 } from "../../../types";
 import "../../calendar/ha-full-calendar";
+import type { HAFullCalendar } from "../../calendar/ha-full-calendar";
 import { findEntities } from "../common/find-entites";
 import { installResizeObserver } from "../common/install-resize-observer";
 import "../components/hui-warning";
@@ -70,6 +72,8 @@ export class HuiCalendarCard extends LitElement implements LovelaceCard {
   @internalProperty() private _narrow = false;
 
   @internalProperty() private _veryNarrow = false;
+
+  @query("ha-full-calendar", true) private _calendar?: HAFullCalendar;
 
   private _startDate?: Date;
 
@@ -121,8 +125,8 @@ export class HuiCalendarCard extends LitElement implements LovelaceCard {
     }
 
     const views: FullCalendarView[] = this._veryNarrow
-      ? ["listWeek"]
-      : ["listWeek", "dayGridMonth", "dayGridDay"];
+      ? ["list"]
+      : ["list", "dayGridMonth", "dayGridDay"];
 
     return html`
       <ha-card>
@@ -186,6 +190,8 @@ export class HuiCalendarCard extends LitElement implements LovelaceCard {
     }
     this._narrow = card.offsetWidth < 870;
     this._veryNarrow = card.offsetWidth < 350;
+
+    this._calendar?.updateSize();
   }
 
   private async _attachObserver(): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,7 +153,7 @@ export type FullCalendarView =
   | "dayGridMonth"
   | "dayGridWeek"
   | "dayGridDay"
-  | "listWeek";
+  | "list";
 
 export interface ToggleButton {
   label: string;


### PR DESCRIPTION
## Proposed change

This PR adds the ability to run `updateSize` on the Full Calendar Element. This method tells Full Calendar to rerun its sizing functions to fill the available width and height.

This also changes the list view we have from Week (Starting on the first day of the week and ending the last day of the week regardless of what the current day is) to just a list/agenda view that starts on the current day and spans 7 days in the future

Also, Adds in the locales from Full Calendar so that different starting days and translations work

Also, styles the Full Calendar Scroll bar

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #7064 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.