### PR TITLE
Fixed a couple of mistranslations in Italian

### DIFF
--- a/translations/frontend/it.json
+++ b/translations/frontend/it.json
@@ -75,13 +75,13 @@
             "disarmed": "Disattivo",
             "disarming": "Disattivando",
             "pending": "Sospeso",
-            "triggered": "Attiv."
+            "triggered": "Attivato"
         },
         "default": {
             "entity_not_found": "Entità non trovata!",
             "error": "Errore",
-            "unavailable": "Non disp.",
-            "unknown": "Ignoto"
+            "unavailable": "Non disponibile",
+            "unknown": "Sconosciuto"
         },
         "device_tracker": {
             "home": "A casa",


### PR DESCRIPTION
This PR is aimed at fixing a couple of mistranslations in Italian language.

## Proposed change
This PR addresses a couple of mistranslations to Italian that are present in the current UI.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
N/A

```yaml

```

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
