### PR TITLE
Ensure all <mwc-fab> set a label for ARIA

### DIFF
--- a/src/panels/config/areas/ha-config-areas-dashboard.ts
+++ b/src/panels/config/areas/ha-config-areas-dashboard.ts
@@ -126,12 +126,10 @@ export class HaConfigAreasDashboard extends LitElement {
         ></ha-icon-button>
         <mwc-fab
           slot="fab"
-          title="${this.hass.localize(
+          .label="${this.hass.localize(
             "ui.panel.config.areas.picker.create_area"
           )}"
-          label="${this.hass.localize(
-            "ui.panel.config.areas.picker.create_area"
-          )}"
+          extended
           @click=${this._createArea}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/areas/ha-config-areas-dashboard.ts
+++ b/src/panels/config/areas/ha-config-areas-dashboard.ts
@@ -129,6 +129,9 @@ export class HaConfigAreasDashboard extends LitElement {
           title="${this.hass.localize(
             "ui.panel.config.areas.picker.create_area"
           )}"
+          label="${this.hass.localize(
+            "ui.panel.config.areas.picker.create_area"
+          )}"
           @click=${this._createArea}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/areas/ha-config-areas-dashboard.ts
+++ b/src/panels/config/areas/ha-config-areas-dashboard.ts
@@ -126,9 +126,9 @@ export class HaConfigAreasDashboard extends LitElement {
         ></ha-icon-button>
         <mwc-fab
           slot="fab"
-          .label="${this.hass.localize(
+          .label=${this.hass.localize(
             "ui.panel.config.areas.picker.create_area"
-          )}"
+          )}
           extended
           @click=${this._createArea}
         >

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -473,6 +473,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
           slot="fab"
           class=${classMap({ dirty: this._dirty })}
           .title=${this.hass.localize("ui.panel.config.automation.editor.save")}
+          label=${this.hass.localize("ui.panel.config.automation.editor.save")}
           @click=${this._saveAutomation}
         >
           <ha-svg-icon slot="icon" .path=${mdiContentSave}></ha-svg-icon>

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -472,8 +472,8 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
         <mwc-fab
           slot="fab"
           class=${classMap({ dirty: this._dirty })}
-          .title=${this.hass.localize("ui.panel.config.automation.editor.save")}
-          label=${this.hass.localize("ui.panel.config.automation.editor.save")}
+          .label=${this.hass.localize("ui.panel.config.automation.editor.save")}
+          extended
           @click=${this._saveAutomation}
         >
           <ha-svg-icon slot="icon" .path=${mdiContentSave}></ha-svg-icon>

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -176,12 +176,10 @@ class HaAutomationPicker extends LitElement {
         </mwc-icon-button>
         <mwc-fab
           slot="fab"
-          title=${this.hass.localize(
+          .label=${this.hass.localize(
             "ui.panel.config.automation.picker.add_automation"
           )}
-          label=${this.hass.localize(
-            "ui.panel.config.automation.picker.add_automation"
-          )}
+          extended
           @click=${this._createNew}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -179,6 +179,9 @@ class HaAutomationPicker extends LitElement {
           title=${this.hass.localize(
             "ui.panel.config.automation.picker.add_automation"
           )}
+          label=${this.hass.localize(
+            "ui.panel.config.automation.picker.add_automation"
+          )}
           @click=${this._createNew}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -160,9 +160,9 @@ export class HaConfigHelpers extends LitElement {
       >
         <mwc-fab
           slot="fab"
-          .label="${this.hass.localize(
+          .label=${this.hass.localize(
             "ui.panel.config.helpers.picker.add_helper"
-          )}"
+          )}
           extended
           @click=${this._createHelpler}
         >

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -163,6 +163,9 @@ export class HaConfigHelpers extends LitElement {
           title="${this.hass.localize(
             "ui.panel.config.helpers.picker.add_helper"
           )}"
+          label="${this.hass.localize(
+            "ui.panel.config.helpers.picker.add_helper"
+          )}"
           @click=${this._createHelpler}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -160,12 +160,10 @@ export class HaConfigHelpers extends LitElement {
       >
         <mwc-fab
           slot="fab"
-          title="${this.hass.localize(
+          .label="${this.hass.localize(
             "ui.panel.config.helpers.picker.add_helper"
           )}"
-          label="${this.hass.localize(
-            "ui.panel.config.helpers.picker.add_helper"
-          )}"
+          extended
           @click=${this._createHelpler}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -475,7 +475,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         </div>
         <mwc-fab
           slot="fab"
-          aria-label=${this.hass.localize("ui.panel.config.integrations.new")}
+          label=${this.hass.localize("ui.panel.config.integrations.new")}
           title=${this.hass.localize("ui.panel.config.integrations.new")}
           @click=${this._createFlow}
         >

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -475,8 +475,10 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         </div>
         <mwc-fab
           slot="fab"
-          label=${this.hass.localize("ui.panel.config.integrations.new")}
-          title=${this.hass.localize("ui.panel.config.integrations.new")}
+          .label=${this.hass.localize(
+            "ui.panel.config.integrations.add_integration"
+          )}
+          extended
           @click=${this._createFlow}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -84,8 +84,8 @@ class ZHAConfigDashboard extends LitElement {
         </ha-card>
         <a href="/config/zha/add" slot="fab">
           <mwc-fab
-            title=${this.hass.localize("ui.panel.config.zha.add_device")}
-            label=${this.hass.localize("ui.panel.config.zha.add_device")}
+            .label=${this.hass.localize("ui.panel.config.zha.add_device")}
+            extended
             ?rtl=${computeRTL(this.hass)}
           >
             <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -85,6 +85,7 @@ class ZHAConfigDashboard extends LitElement {
         <a href="/config/zha/add" slot="fab">
           <mwc-fab
             title=${this.hass.localize("ui.panel.config.zha.add_device")}
+            label=${this.hass.localize("ui.panel.config.zha.add_device")}
             ?rtl=${computeRTL(this.hass)}
           >
             <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/integrations/integration-panels/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-groups-dashboard.ts
@@ -129,6 +129,7 @@ export class ZHAGroupsDashboard extends LitElement {
         <a href="/config/zha/group-add" slot="fab">
           <mwc-fab
             title=${this.hass!.localize("ui.panel.config.zha.groups.add_group")}
+            label=${this.hass!.localize("ui.panel.config.zha.groups.add_group")}
           >
             <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
           </mwc-fab>

--- a/src/panels/config/integrations/integration-panels/zha/zha-groups-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-groups-dashboard.ts
@@ -128,8 +128,10 @@ export class ZHAGroupsDashboard extends LitElement {
       >
         <a href="/config/zha/group-add" slot="fab">
           <mwc-fab
-            title=${this.hass!.localize("ui.panel.config.zha.groups.add_group")}
-            label=${this.hass!.localize("ui.panel.config.zha.groups.add_group")}
+            .label=${this.hass!.localize(
+              "ui.panel.config.zha.groups.add_group"
+            )}
+            extended
           >
             <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
           </mwc-fab>

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -225,9 +225,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
       >
         <mwc-fab
           slot="fab"
-          .label="${this.hass.localize(
+          .label=${this.hass.localize(
             "ui.panel.config.lovelace.dashboards.picker.add_dashboard"
-          )}"
+          )}
           extended
           @click=${this._addDashboard}
         >

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -228,6 +228,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
           title="${this.hass.localize(
             "ui.panel.config.lovelace.dashboards.picker.add_dashboard"
           )}"
+          label="${this.hass.localize(
+            "ui.panel.config.lovelace.dashboards.picker.add_dashboard"
+          )}"
           @click=${this._addDashboard}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -225,12 +225,10 @@ export class HaConfigLovelaceDashboards extends LitElement {
       >
         <mwc-fab
           slot="fab"
-          title="${this.hass.localize(
+          .label="${this.hass.localize(
             "ui.panel.config.lovelace.dashboards.picker.add_dashboard"
           )}"
-          label="${this.hass.localize(
-            "ui.panel.config.lovelace.dashboards.picker.add_dashboard"
-          )}"
+          extended
           @click=${this._addDashboard}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
+++ b/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
@@ -105,12 +105,10 @@ export class HaConfigLovelaceRescources extends LitElement {
       >
         <mwc-fab
           slot="fab"
-          title=${this.hass.localize(
+          .label=${this.hass.localize(
             "ui.panel.config.lovelace.resources.picker.add_resource"
           )}
-          label=${this.hass.localize(
-            "ui.panel.config.lovelace.resources.picker.add_resource"
-          )}
+          extended
           @click=${this._addResource}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
+++ b/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
@@ -108,6 +108,9 @@ export class HaConfigLovelaceRescources extends LitElement {
           title=${this.hass.localize(
             "ui.panel.config.lovelace.resources.picker.add_resource"
           )}
+          label=${this.hass.localize(
+            "ui.panel.config.lovelace.resources.picker.add_resource"
+          )}
           @click=${this._addResource}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -148,8 +148,8 @@ class HaConfigPerson extends LitElement {
         </ha-config-section>
         <mwc-fab
           slot="fab"
-          title="${hass.localize("ui.panel.config.person.add_person")}"
-          label="${hass.localize("ui.panel.config.person.add_person")}"
+          .label="${hass.localize("ui.panel.config.person.add_person")}"
+          extended
           @click=${this._createPerson}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -149,6 +149,7 @@ class HaConfigPerson extends LitElement {
         <mwc-fab
           slot="fab"
           title="${hass.localize("ui.panel.config.person.add_person")}"
+          label="${hass.localize("ui.panel.config.person.add_person")}"
           @click=${this._createPerson}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -148,7 +148,7 @@ class HaConfigPerson extends LitElement {
         </ha-config-section>
         <mwc-fab
           slot="fab"
-          .label="${hass.localize("ui.panel.config.person.add_person")}"
+          .label=${hass.localize("ui.panel.config.person.add_person")}
           extended
           @click=${this._createPerson}
         >

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -156,6 +156,9 @@ class HaSceneDashboard extends LitElement {
             title=${this.hass.localize(
               "ui.panel.config.scene.picker.add_scene"
             )}
+            label=${this.hass.localize(
+              "ui.panel.config.scene.picker.add_scene"
+            )}
           >
             <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
           </mwc-fab>

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -153,12 +153,10 @@ class HaSceneDashboard extends LitElement {
         </mwc-icon-button>
         <a href="/config/scene/edit/new" slot="fab">
           <mwc-fab
-            title=${this.hass.localize(
+            .label=${this.hass.localize(
               "ui.panel.config.scene.picker.add_scene"
             )}
-            label=${this.hass.localize(
-              "ui.panel.config.scene.picker.add_scene"
-            )}
+            extended
           >
             <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
           </mwc-fab>

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -406,6 +406,7 @@ export class HaSceneEditor extends SubscribeMixin(
         <mwc-fab
           slot="fab"
           .title=${this.hass.localize("ui.panel.config.scene.editor.save")}
+          label=${this.hass.localize("ui.panel.config.scene.editor.save")}
           @click=${this._saveScene}
           class=${classMap({ dirty: this._dirty })}
         >

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -405,8 +405,8 @@ export class HaSceneEditor extends SubscribeMixin(
         </div>
         <mwc-fab
           slot="fab"
-          .title=${this.hass.localize("ui.panel.config.scene.editor.save")}
-          label=${this.hass.localize("ui.panel.config.scene.editor.save")}
+          .label=${this.hass.localize("ui.panel.config.scene.editor.save")}
+          extended
           @click=${this._saveScene}
           class=${classMap({ dirty: this._dirty })}
         >

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -370,6 +370,9 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
           .title=${this.hass.localize(
             "ui.panel.config.script.editor.save_script"
           )}
+          label=${this.hass.localize(
+            "ui.panel.config.script.editor.save_script"
+          )}
           @click=${this._saveScript}
           class=${classMap({
             dirty: this._dirty,

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -367,12 +367,10 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
         </div>
         <mwc-fab
           slot="fab"
-          .title=${this.hass.localize(
+          .label=${this.hass.localize(
             "ui.panel.config.script.editor.save_script"
           )}
-          label=${this.hass.localize(
-            "ui.panel.config.script.editor.save_script"
-          )}
+          extended
           @click=${this._saveScript}
           class=${classMap({
             dirty: this._dirty,

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -152,6 +152,9 @@ class HaScriptPicker extends LitElement {
             title="${this.hass.localize(
               "ui.panel.config.script.picker.create_new_script"
             )}"
+            label="${this.hass.localize(
+              "ui.panel.config.script.picker.create_new_script"
+            )}"
             ?rtl=${computeRTL(this.hass)}
           >
             <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -149,12 +149,10 @@ class HaScriptPicker extends LitElement {
           <mwc-fab
             ?is-wide=${this.isWide}
             ?narrow=${this.narrow}
-            title="${this.hass.localize(
-              "ui.panel.config.script.picker.create_new_script"
+            .label="${this.hass.localize(
+              "ui.panel.config.script.picker.add_script"
             )}"
-            label="${this.hass.localize(
-              "ui.panel.config.script.picker.create_new_script"
-            )}"
+            extended
             ?rtl=${computeRTL(this.hass)}
           >
             <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -149,9 +149,9 @@ class HaScriptPicker extends LitElement {
           <mwc-fab
             ?is-wide=${this.isWide}
             ?narrow=${this.narrow}
-            .label="${this.hass.localize(
+            .label=${this.hass.localize(
               "ui.panel.config.script.picker.add_script"
-            )}"
+            )}
             extended
             ?rtl=${computeRTL(this.hass)}
           >

--- a/src/panels/config/tags/ha-config-tags.ts
+++ b/src/panels/config/tags/ha-config-tags.ts
@@ -209,8 +209,8 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
         </mwc-icon-button>
         <mwc-fab
           slot="fab"
-          title=${this.hass.localize("ui.panel.config.tags.add_tag")}
-          label=${this.hass.localize("ui.panel.config.tags.add_tag")}
+          .label=${this.hass.localize("ui.panel.config.tags.add_tag")}
+          extended
           @click=${this._addTag}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/tags/ha-config-tags.ts
+++ b/src/panels/config/tags/ha-config-tags.ts
@@ -210,6 +210,7 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
         <mwc-fab
           slot="fab"
           title=${this.hass.localize("ui.panel.config.tags.add_tag")}
+          label=${this.hass.localize("ui.panel.config.tags.add_tag")}
           @click=${this._addTag}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/users/ha-config-users.ts
+++ b/src/panels/config/users/ha-config-users.ts
@@ -100,8 +100,8 @@ export class HaConfigUsers extends LitElement {
       >
         <mwc-fab
           slot="fab"
-          .title=${this.hass.localize("ui.panel.config.users.picker.add_user")}
-          label=${this.hass.localize("ui.panel.config.users.picker.add_user")}
+          .label=${this.hass.localize("ui.panel.config.users.picker.add_user")}
+          extended
           @click=${this._addUser}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/users/ha-config-users.ts
+++ b/src/panels/config/users/ha-config-users.ts
@@ -101,6 +101,7 @@ export class HaConfigUsers extends LitElement {
         <mwc-fab
           slot="fab"
           .title=${this.hass.localize("ui.panel.config.users.picker.add_user")}
+          label=${this.hass.localize("ui.panel.config.users.picker.add_user")}
           @click=${this._addUser}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/zone/ha-config-zone.ts
+++ b/src/panels/config/zone/ha-config-zone.ts
@@ -257,8 +257,8 @@ export class HaConfigZone extends SubscribeMixin(LitElement) {
           : ""}
         <mwc-fab
           slot="fab"
-          title=${hass.localize("ui.panel.config.zone.add_zone")}
-          label=${hass.localize("ui.panel.config.zone.add_zone")}
+          .label=${hass.localize("ui.panel.config.zone.add_zone")}
+          extended
           @click=${this._createZone}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/config/zone/ha-config-zone.ts
+++ b/src/panels/config/zone/ha-config-zone.ts
@@ -258,6 +258,7 @@ export class HaConfigZone extends SubscribeMixin(LitElement) {
         <mwc-fab
           slot="fab"
           title=${hass.localize("ui.panel.config.zone.add_zone")}
+          label=${hass.localize("ui.panel.config.zone.add_zone")}
           @click=${this._createZone}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
+++ b/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
@@ -110,6 +110,7 @@ export class HuiUnusedEntities extends LitElement {
       >
         <mwc-fab
           .label=${this.hass.localize("ui.panel.lovelace.editor.edit_card.add")}
+          extended
           @click=${this._addToLovelaceView}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -87,6 +87,9 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
               title=${this.hass!.localize(
                 "ui.panel.lovelace.editor.edit_card.add"
               )}
+              label=${this.hass!.localize(
+                "ui.panel.lovelace.editor.edit_card.add"
+              )}
               @click=${this._addCard}
               class=${classMap({
                 rtl: computeRTL(this.hass!),

--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -84,12 +84,10 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
       ${this.lovelace?.editMode
         ? html`
             <mwc-fab
-              title=${this.hass!.localize(
+              .label=${this.hass!.localize(
                 "ui.panel.lovelace.editor.edit_card.add"
               )}
-              label=${this.hass!.localize(
-                "ui.panel.lovelace.editor.edit_card.add"
-              )}
+              extended
               @click=${this._addCard}
               class=${classMap({
                 rtl: computeRTL(this.hass!),

--- a/src/panels/lovelace/views/hui-panel-view.ts
+++ b/src/panels/lovelace/views/hui-panel-view.ts
@@ -78,12 +78,10 @@ export class PanelView extends LitElement implements LovelaceViewElement {
       ${this.lovelace?.editMode && this.cards.length === 0
         ? html`
             <mwc-fab
-              title=${this.hass!.localize(
+              .label=${this.hass!.localize(
                 "ui.panel.lovelace.editor.edit_card.add"
               )}
-              label=${this.hass!.localize(
-                "ui.panel.lovelace.editor.edit_card.add"
-              )}
+              extended
               @click=${this._addCard}
               class=${classMap({
                 rtl: computeRTL(this.hass!),

--- a/src/panels/lovelace/views/hui-panel-view.ts
+++ b/src/panels/lovelace/views/hui-panel-view.ts
@@ -81,6 +81,9 @@ export class PanelView extends LitElement implements LovelaceViewElement {
               title=${this.hass!.localize(
                 "ui.panel.lovelace.editor.edit_card.add"
               )}
+              label=${this.hass!.localize(
+                "ui.panel.lovelace.editor.edit_card.add"
+              )}
               @click=${this._addCard}
               class=${classMap({
                 rtl: computeRTL(this.hass!),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1357,7 +1357,7 @@
             "introduction": "The script editor allows you to create and edit scripts. Please follow the link below to read the instructions to make sure that you have configured Home Assistant correctly.",
             "learn_more": "Learn more about scripts",
             "no_scripts": "We couldn’t find any editable scripts",
-            "add_script": "Create new script",
+            "add_script": "Add script",
             "show_info": "Show info about script",
             "trigger_script": "Trigger script",
             "run_script": "Run script",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

`<mwc-fab>` uses the `label` attribute to set the `aria-label` for its included elements (= the actual button). This PR ensure that we set it for all `<mwc-fab>`.

https://npm.io/package/@material/mwc-fab

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/issues/3267
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
