### PR TITLE
Make it very obvious when localization fails

### DIFF
--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -42,7 +42,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         language: getLocalLanguage(),
         selectedLanguage: null,
         resources: null as any,
-        localize: () => "",
+        localize: () => "???",
 
         translationMetadata,
         dockedSidebar: "docked",


### PR DESCRIPTION
I'm debugging an issue where localization intermittently fails (falls back to empty strings). I suspect some sort of race condition deep in the Lit integration.

While I'm here, make it more obvious when localization is failing by returning a string that is more recognizable.

## Proposed change

Return a marker string "???" instead of an empty string if localization fails.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
