### PR TITLE
Fix race condition in translation loading

### DIFF
--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -221,9 +221,15 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       // loaded resources. This merges the new data on top of the old data for
       // this language, so that the full translation set can be loaded across
       // multiple fragments.
+      //
+      // Beware of a subtle race condition: it is possible to get here twice
+      // before this.hass is even created. In this case our base state comes
+      // from this._pendingHass instead. Otherwise the first set of strings is
+      // overwritten when we call _updateHass the second time!
+      const baseHass = this.hass ?? this._pendingHass;
       const resources = {
         [language]: {
-          ...this.hass?.resources?.[language],
+          ...baseHass?.resources?.[language],
           ...data,
         },
       };


### PR DESCRIPTION
I occasionally observed strings being rendered in un-localized form. Puzzling.

<img width="278" alt="Missing localized strings screenshot" src="https://user-images.githubusercontent.com/97944/98182054-6c0dc180-1eca-11eb-8dc1-9fe1ae3f0d7b.png">

After some digging, I tracked it down to this race condition deep in the translations mixin.

- `panelUrlChanged` may be triggered before `hassConnected`; it even has a helpful comment saying so! This in turn calls `_loadFragmentTranslations`, which calls `_updateResources`.
- `firstUpdated` may also be triggered before `hassConnected`; it calls `_loadCoreTranslations`, which calls `_updateResources`.

If both resources finish loading before `hassConnected`, the second set of strings will completely overwrite the first!

The solution is to reach into the internals and grab `_pendingHass` if `this.hass` is unset. This feels sorta nasty, but I am not yet familiar enough with the codebase to attempt a more sweeping refactor. I might suggest following React's lead: just as [React's `setState` accepts a closure](https://reactjs.org/docs/react-component.html#setstate), `_updateHass` should accept a closure that passes you a non-null `HomeAssistant` instance, and you must return a new `HomeAssistant` computed from that base state (instead of using the nullable `this.hass`).

## Proposed change

Fixes #7596, #7512.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

# Additional information

- This PR fixes or closes issue: fixes #7596, fixes #7512
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
