### PR TITLE
Add a textual label to the "Add Integration" button

### DIFF
--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -475,8 +475,10 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         </div>
         <mwc-fab
           slot="fab"
+          extended
           aria-label=${this.hass.localize("ui.panel.config.integrations.new")}
           title=${this.hass.localize("ui.panel.config.integrations.new")}
+          .label=${this.hass.localize("ui.panel.config.integrations.new_label")}
           @click=${this._createFlow}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1814,6 +1814,7 @@
           "attention": "Attention required",
           "configured": "Configured",
           "new": "Set up a new integration",
+          "new_label": "Add Integration",
           "add_integration": "Add integration",
           "no_integrations": "Seems like you don't have any integations configured yet. Click on the button below to add your first integration!",
           "note_about_integrations": "Not all integrations can be configured via the UI yet.",


### PR DESCRIPTION
The Material "fab" (floating action button) to add a new integration is currently configured without a label.

This leads to a lot of awkward documentation that refers to "the button with the + symbol". It also makes the button a relatively small and inconspicuous target.

I would like to discuss the possibility of adding a textual label to it using the `extended` style for `mwc-fab`. I have tenatively chosen "Add" but I am open to other options.

If this is approved, I am happy to send subsequent PRs for other similar buttons in the frontend.

## Proposed change

Add a textual label to the "add integration" floating action button.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
