### PR TITLE
Add fix to more-info for media players without play/pause state

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -309,11 +309,16 @@ class MoreInfoMediaPlayer extends LitElement {
       (state === "playing" &&
         (supportsFeature(stateObj, SUPPORT_PAUSE) ||
           supportsFeature(stateObj, SUPPORT_STOP))) ||
-      (state === "paused" && supportsFeature(stateObj, SUPPORTS_PLAY))
+      (state === "paused" && supportsFeature(stateObj, SUPPORTS_PLAY)) ||
+      (state === "on" &&
+        supportsFeature(stateObj, SUPPORTS_PLAY) &&
+        supportsFeature(stateObj, SUPPORT_PAUSE))
     ) {
       buttons.push({
         icon:
-          state !== "playing"
+          state === "on"
+            ? "hass:play-pause"
+            : state !== "playing"
             ? "hass:play"
             : supportsFeature(stateObj, SUPPORT_PAUSE)
             ? "hass:pause"

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -311,7 +311,7 @@ class MoreInfoMediaPlayer extends LitElement {
           supportsFeature(stateObj, SUPPORT_STOP))) ||
       (state === "paused" && supportsFeature(stateObj, SUPPORTS_PLAY)) ||
       (state === "on" &&
-        supportsFeature(stateObj, SUPPORTS_PLAY) &&
+        supportsFeature(stateObj, SUPPORTS_PLAY) ||
         supportsFeature(stateObj, SUPPORT_PAUSE))
     ) {
       buttons.push({

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -323,7 +323,7 @@ class MoreInfoMediaPlayer extends LitElement {
             : supportsFeature(stateObj, SUPPORT_PAUSE)
             ? "hass:pause"
             : "hass:stop",
-        action: "media_play_pause",
+        action: state === "playing" && !supportsFeature(stateObj, SUPPORT_PAUSE) ? "media_stop" : "media_play_pause",
       });
     }
 


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This corrects issue #7074 introduced in 0.115, and allows media players that do not show playing or paused states to still have a play/pause button if supported.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

N/A
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7074 
- This PR is related to issue:
- Link to documentation pull request:

I do not have a media player that *does* support playing/pause states available in my dev environment.  If someone could please test this fix with a Google Home or similar device to ensure functionality does not change for these devices, it'd be greatly appreciated.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- N/A [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- N/A [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
