### PR TITLE
"Add Card", "Add Dashboard" labels for floating action buttons

### DIFF
--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -225,7 +225,8 @@ export class HaConfigLovelaceDashboards extends LitElement {
       >
         <mwc-fab
           slot="fab"
-          title="${this.hass.localize(
+          extended
+          .label="${this.hass.localize(
             "ui.panel.config.lovelace.dashboards.picker.add_dashboard"
           )}"
           @click=${this._addDashboard}

--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -84,7 +84,8 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
       ${this.lovelace?.editMode
         ? html`
             <mwc-fab
-              title=${this.hass!.localize(
+              extended
+              .label=${this.hass!.localize(
                 "ui.panel.lovelace.editor.edit_card.add"
               )}
               @click=${this._addCard}

--- a/src/panels/lovelace/views/hui-panel-view.ts
+++ b/src/panels/lovelace/views/hui-panel-view.ts
@@ -78,7 +78,8 @@ export class PanelView extends LitElement implements LovelaceViewElement {
       ${this.lovelace?.editMode && this.cards.length === 0
         ? html`
             <mwc-fab
-              title=${this.hass!.localize(
+              extended
+              .label=${this.hass!.localize(
                 "ui.panel.lovelace.editor.edit_card.add"
               )}
               @click=${this._addCard}


### PR DESCRIPTION
Similar to #7604. It seems that the design sketches for Home Assistant include using labels for most floating action buttons... here's two more places we can do that.

This is especially important for "Add Card" in my opinion since there are *two* "+" buttons on that screen - one to add a view, and one to add a card.

## Proposed change

Labels for floating action buttons.

![add_dash](https://user-images.githubusercontent.com/97944/98395497-f61c6e00-2021-11eb-809a-0c1016348cdd.png)

![add-card](https://user-images.githubusercontent.com/97944/98395507-fa488b80-2021-11eb-98b1-5182b78eedc8.png)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
