### PR TITLE
Refactor brands url to single location

### DIFF
--- a/src/dialogs/config-flow/step-flow-pick-handler.ts
+++ b/src/dialogs/config-flow/step-flow-pick-handler.ts
@@ -23,6 +23,7 @@ import { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
 import { FlowConfig } from "./show-dialog-data-entry-flow";
 import { configFlowContentStyles } from "./styles";
+import { brandsUrl } from "../../util/brands-url";
 
 interface HandlerObj {
   name: string;
@@ -102,7 +103,7 @@ class StepFlowPickHandler extends LitElement {
                 <img
                   slot="item-icon"
                   loading="lazy"
-                  src="https://brands.home-assistant.io/_/${handler.slug}/icon.png"
+                  src="${brandsUrl(handler.slug, "icon", true)}"
                   referrerpolicy="no-referrer"
                 />
 

--- a/src/onboarding/integration-badge.ts
+++ b/src/onboarding/integration-badge.ts
@@ -8,6 +8,7 @@ import {
   TemplateResult,
 } from "lit-element";
 import "../components/ha-icon";
+import { brandsUrl } from "../util/brands-url";
 
 @customElement("integration-badge")
 class IntegrationBadge extends LitElement {
@@ -23,7 +24,7 @@ class IntegrationBadge extends LitElement {
     return html`
       <div class="icon">
         <img
-          src="https://brands.home-assistant.io/${this.domain}/icon.png"
+          src="${brandsUrl(this.domain, "icon")}"
           referrerpolicy="no-referrer"
         />
         ${this.badgeIcon

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -45,6 +45,7 @@ import { configSections } from "../ha-panel-config";
 import "./device-detail/ha-device-entities-card";
 import "./device-detail/ha-device-info-card";
 import { showDeviceAutomationDialog } from "./device-detail/show-dialog-device-automation";
+import { brandsUrl } from "../../../util/brands-url";
 
 export interface EntityRegistryStateEntry extends EntityRegistryEntry {
   stateName?: string | null;
@@ -223,9 +224,7 @@ export class HaConfigDevicePage extends LitElement {
                       : ""
                   }
                   <img
-                    src="https://brands.home-assistant.io/${
-                      integrations[0]
-                    }/logo.png"
+                    src="${brandsUrl(integrations[0], "logo")}"
                     referrerpolicy="no-referrer"
                     @load=${this._onImageLoad}
                     @error=${this._onImageError}

--- a/src/panels/config/info/integrations-card.ts
+++ b/src/panels/config/info/integrations-card.ts
@@ -17,6 +17,7 @@ import {
   IntegrationManifest,
 } from "../../../data/integration";
 import { HomeAssistant } from "../../../types";
+import { brandsUrl } from "../../../util/brands-url";
 
 @customElement("integrations-card")
 class IntegrationsCard extends LitElement {
@@ -50,7 +51,7 @@ class IntegrationsCard extends LitElement {
                     <td>
                       <img
                         loading="lazy"
-                        src="https://brands.home-assistant.io/_/${domain}/icon.png"
+                        src="${brandsUrl(domain, "icon", true)}"
                         referrerpolicy="no-referrer"
                       />
                     </td>

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -67,6 +67,7 @@ import type {
   ConfigEntryUpdatedEvent,
   HaIntegrationCard,
 } from "./ha-integration-card";
+import { brandsUrl } from "../../../util/brands-url";
 
 interface DataEntryFlowProgressExtended extends DataEntryFlowProgress {
   localized_title?: string;
@@ -330,7 +331,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
                     <div class="card-content">
                       <div class="image">
                         <img
-                          src="https://brands.home-assistant.io/${item.domain}/logo.png"
+                          src="${brandsUrl(item.domain, "logo")}"
                           referrerpolicy="no-referrer"
                           @error=${this._onImageError}
                           @load=${this._onImageLoad}
@@ -378,7 +379,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
                       <div class="card-content">
                         <div class="image">
                           <img
-                            src="https://brands.home-assistant.io/${flow.handler}/logo.png"
+                            src="${brandsUrl(flow.handler, "logo")}"
                             referrerpolicy="no-referrer"
                             @error=${this._onImageError}
                             @load=${this._onImageLoad}

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -31,6 +31,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { mdiDotsVertical, mdiOpenInNew } from "@mdi/js";
 import type { RequestSelectedDetail } from "@material/mwc-list/mwc-list-item";
 import { shouldHandleRequestSelectedEvent } from "../../../common/mwc/handle-request-selected-event";
+import { brandsUrl } from "../../../util/brands-url";
 
 export interface ConfigEntryUpdatedEvent {
   entry: ConfigEntry;
@@ -107,7 +108,7 @@ export class HaIntegrationCard extends LitElement {
       <ha-card outlined class="group">
         <div class="group-header">
           <img
-            src="https://brands.home-assistant.io/${this.domain}/icon.png"
+            src="${brandsUrl(this.domain, "icon")}"
             referrerpolicy="no-referrer"
             @error=${this._onImageError}
             @load=${this._onImageLoad}
@@ -157,7 +158,7 @@ export class HaIntegrationCard extends LitElement {
         <div class="card-content">
           <div class="image">
             <img
-              src="https://brands.home-assistant.io/${item.domain}/logo.png"
+              src="${brandsUrl(item.domain, "logo")}"
               referrerpolicy="no-referrer"
               @error=${this._onImageError}
               @load=${this._onImageLoad}

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -1,29 +1,9 @@
-const brandsBaseUrl = "https://brands.home-assistant.io/";
-const imageSuffix = ".png";
-
 export const brandsUrl = (
   domain: string,
   type: "icon" | "logo",
   useFallback?: boolean
 ) => {
-  let brandUrl = brandsBaseUrl;
-
-  if (useFallback) {
-    brandUrl += "_/";
-  }
-
-  brandUrl += domain + "/";
-
-  switch (type) {
-    case "icon":
-      brandUrl += "icon";
-      break;
-    case "logo":
-      brandUrl += "logo";
-      break;
-  }
-
-  brandUrl += imageSuffix;
-
-  return brandUrl;
+  return `https://brands.home-assistant.io/${
+    useFallback ? "_/" : ""
+  }${domain}/${type}.png`;
 };

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -1,0 +1,29 @@
+const brandsBaseUrl = "https://brands.home-assistant.io/";
+const imageSuffix = ".png";
+
+export const brandsUrl = (
+  domain: string,
+  type: "icon" | "logo",
+  useFallback?: boolean
+) => {
+  let brandUrl = brandsBaseUrl;
+
+  if (useFallback) {
+    brandUrl += "_/";
+  }
+
+  brandUrl += domain + "/";
+
+  switch (type) {
+    case "icon":
+      brandUrl += "icon";
+      break;
+    case "logo":
+      brandUrl += "logo";
+      break;
+  }
+
+  brandUrl += imageSuffix;
+
+  return brandUrl;
+};

--- a/test-mocha/util/generate-brands-url-spec.ts
+++ b/test-mocha/util/generate-brands-url-spec.ts
@@ -1,0 +1,33 @@
+import * as assert from "assert";
+import { brandsUrl } from "../../src/util/brands-url";
+
+describe("Generate brands Url", function () {
+  it("Generate logo brands url for cloud component without fallback", function () {
+    assert.strictEqual(
+      // @ts-ignore
+      brandsUrl("cloud", "logo"),
+      "https://brands.home-assistant.io/cloud/logo.png"
+    );
+  });
+  it("Generate icon brands url for cloud component without fallback", function () {
+    assert.strictEqual(
+      // @ts-ignore
+      brandsUrl("cloud", "icon"),
+      "https://brands.home-assistant.io/cloud/icon.png"
+    );
+  });
+  it("Generate logo brands url for cloud component with fallback", function () {
+    assert.strictEqual(
+      // @ts-ignore
+      brandsUrl("cloud", "logo", true),
+      "https://brands.home-assistant.io/_/cloud/logo.png"
+    );
+  });
+  it("Generate icon brands url for cloud component with fallback", function () {
+    assert.strictEqual(
+      // @ts-ignore
+      brandsUrl("cloud", "icon", true),
+      "https://brands.home-assistant.io/_/cloud/icon.png"
+    );
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR moves all hardcoded instances of the `brands.home-assistant.io` URL to a single location.
It's basically the same as [documentation-url.ts](https://github.com/home-assistant/frontend/blob/dev/src/util/documentation-url.ts)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

In the long run, my goal is to solve [WTH - Why are brand icons a cloud dependency?](https://community.home-assistant.io/t/wth-why-are-brand-icons-a-cloud-dependency/226359)

Since however I'm not sure how to properly get the base URL from the frontend component configuration to the frontend itself and there might be discussions around this whole thing, I've decided to split this into (at least) two parts.

Pointers for the next part much appreciated

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
