### PR TITLE
Allow to filter history by GPS accuracy

### DIFF
--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -436,7 +436,13 @@ class HuiMapCard extends LitElement implements LovelaceCard {
             const latitude = state.attributes.latitude;
             const longitude = state.attributes.longitude;
             if (latitude && longitude) {
-              accumulator.push([latitude, longitude] as LatLngTuple);
+              let accurateEnough = true;
+              if (state.attributes.gps_accuracy && this._config!.max_gps_accuracy) {
+                accurateEnough = state.attributes.gps_accuracy < this._config!.max_gps_accuracy;
+              }
+              if (accurateEnough) {
+                accumulator.push([latitude, longitude] as LatLngTuple);
+              }
             }
             return accumulator;
           },

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -45,6 +45,7 @@ const cardConfigStruct = object({
   dark_mode: optional(boolean()),
   entities: array(entitiesConfigStruct),
   hours_to_show: optional(number()),
+  max_gps_accuracy: optional(number()),
   geo_location_sources: optional(array()),
 });
 
@@ -82,6 +83,10 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
 
   get _hours_to_show(): number {
     return this._config!.hours_to_show || 0;
+  }
+
+  get _max_gps_accuracy(): number {
+    return this._config!.max_gps_accuracy || 0;
   }
 
   get _dark_mode(): boolean {
@@ -150,6 +155,17 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
             type="number"
             .value="${this._hours_to_show}"
             .configValue="${"hours_to_show"}"
+            @value-changed="${this._valueChanged}"
+          ></paper-input>
+          <paper-input
+            .label="${this.hass.localize(
+              "ui.panel.lovelace.editor.card.map.max_gps_accuracy"
+            )} (${this.hass.localize(
+              "ui.panel.lovelace.editor.card.config.optional"
+            )})"
+            type="number"
+            .value="${this._max_gps_accuracy}"
+            .configValue="${"max_gps_accuracy"}"
             @value-changed="${this._valueChanged}"
           ></paper-input>
         </div>

--- a/translations/frontend/en.json
+++ b/translations/frontend/en.json
@@ -2806,6 +2806,7 @@
                             "description": "The Map card that allows you to display entities on a map.",
                             "geo_location_sources": "Geolocation Sources",
                             "hours_to_show": "Hours to Show",
+                            "max_gps_accuracy": "Max GPS Accuracy Threshold",
                             "name": "Map",
                             "source": "Source"
                         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This lets you add a maximum GPS accuracy so that inaccurate GPS points don't show up.
## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
Use the states panel to test that it works, wait >1 sec in between setting fake `device_tracker` states
```yaml

```

## Additional information
**My personal checklist:** I need to test that it works, then add a UI editor for it, and then add a translation for the UI editor, and then get feedback
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #7601
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
