### PR TITLE
allow for custom state colors

### DIFF
--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -1,5 +1,23 @@
 import { css } from "lit-element";
 
+export interface StateColor {
+  state: string;
+  color?: string;
+}
+
+export const computeStateColor = (
+  state: string,
+  stateColors: StateColor[]
+): string => {
+  for (const stateColor of stateColors) {
+    if (stateColor.state === state) {
+      return stateColor.color || "--paper-item-icon-active-color";
+    }
+  }
+
+  return "";
+};
+
 export const iconColorCSS = css`
   ha-icon[data-domain="alert"][data-state="on"],
   ha-icon[data-domain="automation"][data-state="on"],

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -4,6 +4,7 @@ export interface StateColor {
   state?: string | number;
   color: string;
   below?: number;
+  above?: number;
 }
 
 export const computeCustomStateColor = (
@@ -12,15 +13,21 @@ export const computeCustomStateColor = (
 ): string | undefined => {
   let color;
   const sortableStateColors = stateColors.filter(
-    (stateColor) => stateColor.below
+    (stateColor) => stateColor.below || stateColor.above
   );
 
   sortableStateColors.sort(
-    (a: StateColor, b: StateColor) => (a.below ?? 0) - (b.below ?? 0)
+    (a: StateColor, b: StateColor) =>
+      (a.below ? a.below : a.above ?? 0) - (b.below ? b.below : b.above ?? 0)
   );
 
   for (const stateColor of sortableStateColors) {
-    if (stateColor.below! > Number(state)) {
+    if (stateColor.below && stateColor.below > Number(state)) {
+      color = stateColor.color;
+      break;
+    }
+
+    if (stateColor.above && stateColor.above < Number(state)) {
       color = stateColor.color;
     }
   }

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -35,6 +35,7 @@ export const computeCustomStateColor = (
   for (const stateColor of stateColors) {
     if (stateColor.state === state || stateColor.state === Number(state)) {
       color = stateColor.color;
+      break;
     }
   }
 

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -1,21 +1,37 @@
 import { css } from "lit-element";
 
 export interface StateColor {
-  state: string;
-  color?: string;
+  state?: string | number;
+  color: string;
+  below?: number;
 }
 
 export const computeCustomStateColor = (
-  state: string,
+  state: string | number,
   stateColors: StateColor[]
 ): string | undefined => {
-  for (const stateColor of stateColors) {
-    if (stateColor.state === state) {
-      return stateColor.color || "var(--paper-item-icon-active-color, #fdd835)";
+  let color;
+  const sortableStateColors = stateColors.filter(
+    (stateColor) => stateColor.below
+  );
+
+  sortableStateColors.sort(
+    (a: StateColor, b: StateColor) => (a.below ?? 0) - (b.below ?? 0)
+  );
+
+  for (const stateColor of sortableStateColors) {
+    if (stateColor.below! < Number(state)) {
+      color = stateColor.color;
     }
   }
 
-  return undefined;
+  for (const stateColor of stateColors) {
+    if (stateColor.state === state || stateColor.state === Number(state)) {
+      color = stateColor.color;
+    }
+  }
+
+  return color;
 };
 
 export const iconColorCSS = css`

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -20,7 +20,7 @@ export const computeCustomStateColor = (
   );
 
   for (const stateColor of sortableStateColors) {
-    if (stateColor.below! < Number(state)) {
+    if (stateColor.below! > Number(state)) {
       color = stateColor.color;
     }
   }

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -5,17 +5,17 @@ export interface StateColor {
   color?: string;
 }
 
-export const computeStateColor = (
+export const computeCustomStateColor = (
   state: string,
   stateColors: StateColor[]
-): string => {
+): string | undefined => {
   for (const stateColor of stateColors) {
     if (stateColor.state === state) {
-      return stateColor.color || "--paper-item-icon-active-color";
+      return stateColor.color || "var(--paper-item-icon-active-color, #fdd835)";
     }
   }
 
-  return "";
+  return undefined;
 };
 
 export const iconColorCSS = css`

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -15,7 +15,11 @@ import { styleMap } from "lit-html/directives/style-map";
 import { computeActiveState } from "../../common/entity/compute_active_state";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { stateIcon } from "../../common/entity/state_icon";
-import { iconColorCSS } from "../../common/style/icon_color_css";
+import {
+  computeStateColor,
+  iconColorCSS,
+  StateColor,
+} from "../../common/style/icon_color_css";
 
 import type { HomeAssistant } from "../../types";
 
@@ -24,13 +28,13 @@ import "../ha-icon";
 export class StateBadge extends LitElement {
   public hass?: HomeAssistant;
 
-  @property() public stateObj?: HassEntity;
+  @property({ attribute: false }) public stateObj?: HassEntity;
 
   @property() public overrideIcon?: string;
 
   @property() public overrideImage?: string;
 
-  @property({ type: Boolean }) public stateColor?: boolean;
+  @property({ type: Boolean }) public stateColor?: boolean | StateColor[];
 
   @property({ type: Boolean, reflect: true, attribute: "icon" })
   private _showIcon = true;
@@ -115,6 +119,12 @@ export class StateBadge extends LitElement {
           }
           // lowest brighntess will be around 50% (that's pretty dark)
           iconStyle.filter = `brightness(${(brightness + 245) / 5}%)`;
+        }
+      }
+      if (Array.isArray(this.stateColor)) {
+        const color = computeStateColor(stateObj.state, this.stateColor);
+        if (color) {
+          iconStyle.color = color;
         }
       }
     }

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -16,7 +16,7 @@ import { computeActiveState } from "../../common/entity/compute_active_state";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { stateIcon } from "../../common/entity/state_icon";
 import {
-  computeStateColor,
+  computeCustomStateColor,
   iconColorCSS,
   StateColor,
 } from "../../common/style/icon_color_css";
@@ -122,7 +122,7 @@ export class StateBadge extends LitElement {
         }
       }
       if (Array.isArray(this.stateColor)) {
-        const color = computeStateColor(stateObj.state, this.stateColor);
+        const color = computeCustomStateColor(stateObj.state, this.stateColor);
         if (color) {
           iconStyle.color = color;
         }

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -27,7 +27,7 @@ import { computeStateName } from "../../../common/entity/compute_state_name";
 import { stateIcon } from "../../../common/entity/state_icon";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import {
-  computeStateColor,
+  computeCustomStateColor,
   iconColorCSS,
 } from "../../../common/style/icon_color_css";
 import "../../../components/ha-card";
@@ -302,7 +302,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
 
   private _computeColor(stateObj: HassEntity | LightEntity): string {
     if (Array.isArray(this._config!.state_color)) {
-      const color = computeStateColor(
+      const color = computeCustomStateColor(
         stateObj.state,
         this._config!.state_color
       );

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -26,7 +26,10 @@ import { computeStateDomain } from "../../../common/entity/compute_state_domain"
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { stateIcon } from "../../../common/entity/state_icon";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
-import { iconColorCSS } from "../../../common/style/icon_color_css";
+import {
+  computeStateColor,
+  iconColorCSS,
+} from "../../../common/style/icon_color_css";
 import "../../../components/ha-card";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import { HomeAssistant, LightEntity } from "../../../types";
@@ -298,6 +301,15 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   private _computeColor(stateObj: HassEntity | LightEntity): string {
+    if (Array.isArray(this._config!.state_color)) {
+      const color = computeStateColor(
+        stateObj.state,
+        this._config!.state_color
+      );
+      if (color) {
+        return color;
+      }
+    }
     if (!stateObj.attributes.hs_color || !this._config?.state_color) {
       return "";
     }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -1,3 +1,4 @@
+import { StateColor } from "../../../common/style/icon_color_css";
 import { ActionConfig, LovelaceCardConfig } from "../../../data/lovelace";
 import { FullCalendarView } from "../../../types";
 import { Condition } from "../common/validate-condition";
@@ -56,7 +57,7 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
-  state_color?: boolean;
+  state_color?: boolean | StateColor[];
   show_name?: boolean;
   show_icon?: boolean;
 }
@@ -70,7 +71,7 @@ export interface EntitiesCardConfig extends LovelaceCardConfig {
   icon?: string;
   header?: LovelaceHeaderFooterConfig;
   footer?: LovelaceHeaderFooterConfig;
-  state_color?: boolean;
+  state_color?: boolean | StateColor[];
 }
 
 export interface ButtonCardConfig extends LovelaceCardConfig {
@@ -83,7 +84,7 @@ export interface ButtonCardConfig extends LovelaceCardConfig {
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
-  state_color?: boolean;
+  state_color?: boolean | StateColor[];
   show_state?: boolean;
 }
 
@@ -133,7 +134,7 @@ export interface GlanceConfigEntity extends ConfigEntity {
   show_last_changed?: boolean;
   image?: string;
   show_state?: boolean;
-  state_color?: boolean;
+  state_color?: boolean | StateColor[];
 }
 
 export interface GlanceCardConfig extends LovelaceCardConfig {
@@ -144,7 +145,7 @@ export interface GlanceCardConfig extends LovelaceCardConfig {
   theme?: string;
   entities: Array<string | ConfigEntity>;
   columns?: number;
-  state_color?: boolean;
+  state_color?: boolean | StateColor[];
 }
 
 export interface HumidifierCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
@@ -8,7 +8,15 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
-import { assert, boolean, object, optional, string } from "superstruct";
+import {
+  array,
+  assert,
+  boolean,
+  object,
+  optional,
+  string,
+  union,
+} from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { stateIcon } from "../../../../common/entity/state_icon";
 import { computeRTLDirection } from "../../../../common/util/compute_rtl";
@@ -22,7 +30,11 @@ import "../../components/hui-action-editor";
 import "../../components/hui-entity-editor";
 import "../../components/hui-theme-select-editor";
 import { LovelaceCardEditor } from "../../types";
-import { actionConfigStruct, EditorTarget } from "../types";
+import {
+  actionConfigStruct,
+  EditorTarget,
+  stateColorConfigStruct,
+} from "../types";
 import { configElementStyle } from "./config-elements-style";
 
 const cardConfigStruct = object({
@@ -36,7 +48,7 @@ const cardConfigStruct = object({
   tap_action: optional(actionConfigStruct),
   hold_action: optional(actionConfigStruct),
   theme: optional(string()),
-  show_state: optional(boolean()),
+  state_color: optional(union([boolean(), array(stateColorConfigStruct)])),
 });
 
 const actions = [

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -52,7 +52,7 @@ const cardConfigStruct = object({
   title: optional(union([string(), boolean()])),
   theme: optional(string()),
   show_header_toggle: optional(boolean()),
-  state_color: union([optional(boolean()), array(stateColorConfigStruct)]),
+  state_color: optional(union([boolean(), array(stateColorConfigStruct)])),
   entities: array(entitiesConfigStruct),
   header: optional(headerFooterConfigStructs),
   footer: optional(headerFooterConfigStructs),

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -42,6 +42,7 @@ import {
   EditorTarget,
   EditSubElementEvent,
   entitiesConfigStruct,
+  stateColorConfigStruct,
   SubElementEditorConfig,
 } from "../types";
 import { configElementStyle } from "./config-elements-style";
@@ -51,7 +52,7 @@ const cardConfigStruct = object({
   title: optional(union([string(), boolean()])),
   theme: optional(string()),
   show_header_toggle: optional(boolean()),
-  state_color: optional(boolean()),
+  state_color: union([optional(boolean()), array(stateColorConfigStruct)]),
   entities: array(entitiesConfigStruct),
   header: optional(headerFooterConfigStructs),
   footer: optional(headerFooterConfigStructs),

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -93,7 +93,7 @@ export class HuiGlanceCardEditor extends LitElement
   }
 
   get _state_color(): boolean {
-    return this._config!.state_color ?? true;
+    return Boolean(this._config!.state_color) ?? true;
   }
 
   protected render(): TemplateResult {

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -20,26 +20,26 @@ import {
   string,
   union,
 } from "superstruct";
+
+import type { StateColor } from "../../../../common/style/icon_color_css";
+import type { HomeAssistant } from "../../../../types";
+import type { ConfigEntity, GlanceCardConfig } from "../../cards/types";
+import type { LovelaceCardEditor } from "../../types";
+import type { EditorTarget, EntitiesEditorEvent } from "../types";
+
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { computeRTLDirection } from "../../../../common/util/compute_rtl";
+import { processEditorEntities } from "../process-editor-entities";
+import { entitiesConfigStruct, stateColorConfigStruct } from "../types";
+import { configElementStyle } from "./config-elements-style";
+
 import "../../../../components/entity/state-badge";
 import "../../../../components/ha-card";
 import "../../../../components/ha-formfield";
 import "../../../../components/ha-icon";
 import "../../../../components/ha-switch";
-import { HomeAssistant } from "../../../../types";
-import { ConfigEntity, GlanceCardConfig } from "../../cards/types";
 import "../../components/hui-entity-editor";
 import "../../components/hui-theme-select-editor";
-import { LovelaceCardEditor } from "../../types";
-import { processEditorEntities } from "../process-editor-entities";
-import {
-  EditorTarget,
-  entitiesConfigStruct,
-  EntitiesEditorEvent,
-  stateColorConfigStruct,
-} from "../types";
-import { configElementStyle } from "./config-elements-style";
 
 const cardConfigStruct = object({
   type: string(),
@@ -49,7 +49,7 @@ const cardConfigStruct = object({
   show_name: optional(boolean()),
   show_state: optional(boolean()),
   show_icon: optional(boolean()),
-  state_color: union([optional(boolean()), array(stateColorConfigStruct)]),
+  state_color: optional(union([boolean(), array(stateColorConfigStruct)])),
   entities: array(entitiesConfigStruct),
 });
 
@@ -92,8 +92,8 @@ export class HuiGlanceCardEditor extends LitElement
     return this._config!.show_state || true;
   }
 
-  get _state_color(): boolean {
-    return Boolean(this._config!.state_color) ?? true;
+  get _state_color(): boolean | StateColor[] {
+    return this._config!.state_color ?? true;
   }
 
   protected render(): TemplateResult {

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -37,6 +37,7 @@ import {
   EditorTarget,
   entitiesConfigStruct,
   EntitiesEditorEvent,
+  stateColorConfigStruct,
 } from "../types";
 import { configElementStyle } from "./config-elements-style";
 
@@ -48,7 +49,7 @@ const cardConfigStruct = object({
   show_name: optional(boolean()),
   show_state: optional(boolean()),
   show_icon: optional(boolean()),
-  state_color: optional(boolean()),
+  state_color: union([optional(boolean()), array(stateColorConfigStruct)]),
   entities: array(entitiesConfigStruct),
 });
 

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -181,8 +181,9 @@ const attributeEntitiesRowConfigStruct = object({
 });
 
 export const stateColorConfigStruct = object({
-  state: string(),
-  color: optional(string()),
+  state: optional(union([string(), number()])),
+  color: string(),
+  below: optional(number()),
 });
 
 export const entitiesConfigStruct = union([

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -184,6 +184,7 @@ export const stateColorConfigStruct = object({
   state: optional(union([string(), number()])),
   color: string(),
   below: optional(number()),
+  above: optional(number()),
 });
 
 export const entitiesConfigStruct = union([

--- a/src/panels/lovelace/editor/types.ts
+++ b/src/panels/lovelace/editor/types.ts
@@ -180,6 +180,11 @@ const attributeEntitiesRowConfigStruct = object({
   name: optional(string()),
 });
 
+export const stateColorConfigStruct = object({
+  state: string(),
+  color: optional(string()),
+});
+
 export const entitiesConfigStruct = union([
   object({
     entity: string(),
@@ -188,7 +193,7 @@ export const entitiesConfigStruct = union([
     image: optional(string()),
     secondary_info: optional(string()),
     format: optional(string()),
-    state_color: optional(boolean()),
+    state_color: union([optional(boolean()), array(stateColorConfigStruct)]),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),

--- a/src/panels/lovelace/elements/types.ts
+++ b/src/panels/lovelace/elements/types.ts
@@ -1,3 +1,4 @@
+import { StateColor } from "../../../common/style/icon_color_css";
 import { ActionConfig } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
 import { Condition } from "../common/validate-condition";
@@ -68,7 +69,7 @@ export interface StateIconElementConfig extends LovelaceElementConfigBase {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
   icon?: string;
-  state_color?: boolean;
+  state_color?: boolean | StateColor[];
 }
 
 export interface StateLabelElementConfig extends LovelaceElementConfigBase {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
So I think I have come up with a pretty good solution for allowing for custom state colors in the UI with really little adjustments needed on our end. I don't think this is something I'll ever add to the UI editors as this is pretty advanced stuff here. Let me know what you think. This applies to entities card, picture-elements card, glance card, and button card.
![Peek 2020-11-22 00-11](https://user-images.githubusercontent.com/1287159/99896572-626cb380-2c57-11eb-9f8f-4d4da557d705.gif)

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: button
tap_action:
  action: more-info
entity: sensor.ians_phone_battery
state_color:
  - state: 100
    color: blue
  - above: 29
    color: green
  - below: 30
    color: yellow
  - below: 10
    color: red
```

```yaml
entities:
  - entity: alarm_control_panel.alarm
    state_color:
      - state: disarmed
        color: pink
type: entities
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/6605 https://github.com/home-assistant/frontend/discussions/7391
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
