### PR TITLE
Omit header items from non-admin users

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -202,14 +202,12 @@ class HUIRoot extends LitElement {
                           dir="${computeRTLDirection(this.hass!)}"
                         >
                           ${this.lovelace!.config.views.map((view) =>
-                            Boolean(
-                              view.visible !== undefined &&
-                                ((Array.isArray(view.visible) &&
-                                  !view.visible.some(
-                                    (e) => e.user === this.hass!.user!.id
-                                  )) ||
-                                  view.visible === false)
-                            )
+                            view.visible !== undefined &&
+                            ((Array.isArray(view.visible) &&
+                              !view.visible.some(
+                                (e) => e.user === this.hass!.user!.id
+                              )) ||
+                              view.visible === false)
                               ? ""
                               : html`
                                   <paper-tab aria-label="${view.title}">

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -201,37 +201,37 @@ class HUIRoot extends LitElement {
                           @iron-activate="${this._handleViewSelected}"
                           dir="${computeRTLDirection(this.hass!)}"
                         >
-                          ${this.lovelace!.config.views.map(
-                            (view) => html`
-                              <paper-tab
-                                aria-label="${view.title}"
-                                class="${classMap({
-                                  "hide-tab": Boolean(
-                                    view.visible !== undefined &&
-                                      ((Array.isArray(view.visible) &&
-                                        !view.visible.some(
-                                          (e) => e.user === this.hass!.user!.id
-                                        )) ||
-                                        view.visible === false)
-                                  ),
-                                })}"
-                              >
-                                ${view.icon
-                                  ? html`
-                                      <ha-icon
-                                        title="${view.title}"
-                                        .icon="${view.icon}"
-                                      ></ha-icon>
-                                    `
-                                  : view.title || "Unnamed view"}
-                              </paper-tab>
-                            `
+                          ${this.lovelace!.config.views.map((view) =>
+                            Boolean(
+                              view.visible !== undefined &&
+                                ((Array.isArray(view.visible) &&
+                                  !view.visible.some(
+                                    (e) => e.user === this.hass!.user!.id
+                                  )) ||
+                                  view.visible === false)
+                            )
+                              ? ""
+                              : html`
+                                  <paper-tab aria-label="${view.title}">
+                                    ${view.icon
+                                      ? html`
+                                          <ha-icon
+                                            title="${view.title}"
+                                            .icon="${view.icon}"
+                                          ></ha-icon>
+                                        `
+                                      : view.title || "Unnamed view"}
+                                  </paper-tab>
+                                `
                           )}
                         </ha-tabs>
                       `
                     : html`<div main-title>${this.config.title}</div>`}
-                  ${!this.narrow &&
-                  this._conversation(this.hass.config.components)
+                  ${(!this.narrow &&
+                    this._conversation(this.hass.config.components)) ||
+                  (!this.hass!.user?.is_admin &&
+                    !this._yamlMode &&
+                    this._conversation(this.hass.config.components))
                     ? html`
                         <mwc-icon-button
                           .label=${this.hass!.localize(
@@ -243,135 +243,149 @@ class HUIRoot extends LitElement {
                         </mwc-icon-button>
                       `
                     : ""}
-                  <ha-button-menu corner="BOTTOM_START">
-                    <mwc-icon-button
-                      slot="trigger"
-                      .label=${this.hass!.localize(
-                        "ui.panel.lovelace.editor.menu.open"
-                      )}
-                      .title="${this.hass!.localize(
-                        "ui.panel.lovelace.editor.menu.open"
-                      )}"
-                    >
-                      <ha-svg-icon .path=${mdiDotsVertical}></ha-svg-icon>
-                    </mwc-icon-button>
-                    ${this.narrow &&
-                    this._conversation(this.hass.config.components)
-                      ? html`
-                          <mwc-list-item
-                            .label=${this.hass!.localize(
-                              "ui.panel.lovelace.menu.start_conversation"
-                            )}
-                            graphic="icon"
-                            @request-selected=${this._showVoiceCommandDialog}
-                          >
-                            <span
-                              >${this.hass!.localize(
-                                "ui.panel.lovelace.menu.start_conversation"
-                              )}</span
-                            >
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiMicrophone}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                        `
-                      : ""}
-                    ${this._yamlMode
-                      ? html`
-                          <mwc-list-item
-                            aria-label=${this.hass!.localize(
-                              "ui.common.refresh"
-                            )}
-                            graphic="icon"
-                            @request-selected="${this._handleRefresh}"
-                          >
-                            <span
-                              >${this.hass!.localize("ui.common.refresh")}</span
-                            >
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiRefresh}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                          <mwc-list-item
-                            aria-label=${this.hass!.localize(
-                              "ui.panel.lovelace.unused_entities.title"
-                            )}
-                            graphic="icon"
-                            @request-selected="${this._handleUnusedEntities}"
-                          >
-                            <span
-                              >${this.hass!.localize(
-                                "ui.panel.lovelace.unused_entities.title"
-                              )}</span
-                            >
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiShape}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                        `
-                      : ""}
-                    ${(this.hass.panels.lovelace?.config as LovelacePanelConfig)
-                      ?.mode === "yaml"
-                      ? html`
-                          <mwc-list-item
-                            graphic="icon"
-                            aria-label=${this.hass!.localize(
-                              "ui.panel.lovelace.menu.reload_resources"
-                            )}
-                            @request-selected=${this._handleReloadResources}
-                          >
-                            ${this.hass!.localize(
-                              "ui.panel.lovelace.menu.reload_resources"
-                            )}
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiRefresh}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                        `
-                      : ""}
-                    ${this.hass!.user?.is_admin && !this.hass!.config.safe_mode
-                      ? html`
-                          <mwc-list-item
-                            graphic="icon"
-                            aria-label=${this.hass!.localize(
-                              "ui.panel.lovelace.menu.configure_ui"
-                            )}
-                            @request-selected=${this._handleEnableEditMode}
-                          >
-                            ${this.hass!.localize(
-                              "ui.panel.lovelace.menu.configure_ui"
-                            )}
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiCog}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                        `
-                      : ""}
-                    <a
-                      href="${documentationUrl(this.hass, "/lovelace/")}"
-                      rel="noreferrer"
-                      class="menu-link"
-                      target="_blank"
-                    >
-                      <mwc-list-item
-                        graphic="icon"
-                        aria-label=${this.hass!.localize(
-                          "ui.panel.lovelace.menu.help"
-                        )}
-                      >
-                        ${this.hass!.localize("ui.panel.lovelace.menu.help")}
-                        <ha-svg-icon
-                          slot="graphic"
-                          .path=${mdiHelp}
-                        ></ha-svg-icon>
-                      </mwc-list-item>
-                    </a>
-                  </ha-button-menu>
+                  ${this._yamlMode || this.hass!.user?.is_admin
+                    ? html`<ha-button-menu corner="BOTTOM_START">
+                        <mwc-icon-button
+                          slot="trigger"
+                          .label=${this.hass!.localize(
+                            "ui.panel.lovelace.editor.menu.open"
+                          )}
+                          .title="${this.hass!.localize(
+                            "ui.panel.lovelace.editor.menu.open"
+                          )}"
+                        >
+                          <ha-svg-icon .path=${mdiDotsVertical}></ha-svg-icon>
+                        </mwc-icon-button>
+                        ${this.narrow &&
+                        this._conversation(this.hass.config.components)
+                          ? html`
+                              <mwc-list-item
+                                .label=${this.hass!.localize(
+                                  "ui.panel.lovelace.menu.start_conversation"
+                                )}
+                                graphic="icon"
+                                @request-selected=${this
+                                  ._showVoiceCommandDialog}
+                              >
+                                <span
+                                  >${this.hass!.localize(
+                                    "ui.panel.lovelace.menu.start_conversation"
+                                  )}</span
+                                >
+                                <ha-svg-icon
+                                  slot="graphic"
+                                  .path=${mdiMicrophone}
+                                ></ha-svg-icon>
+                              </mwc-list-item>
+                            `
+                          : ""}
+                        ${this._yamlMode
+                          ? html`
+                              <mwc-list-item
+                                aria-label=${this.hass!.localize(
+                                  "ui.common.refresh"
+                                )}
+                                graphic="icon"
+                                @request-selected="${this._handleRefresh}"
+                              >
+                                <span
+                                  >${this.hass!.localize(
+                                    "ui.common.refresh"
+                                  )}</span
+                                >
+                                <ha-svg-icon
+                                  slot="graphic"
+                                  .path=${mdiRefresh}
+                                ></ha-svg-icon>
+                              </mwc-list-item>
+                              ${this.hass!.user?.is_admin
+                                ? html`<mwc-list-item
+                                    aria-label=${this.hass!.localize(
+                                      "ui.panel.lovelace.unused_entities.title"
+                                    )}
+                                    graphic="icon"
+                                    @request-selected="${this
+                                      ._handleUnusedEntities}"
+                                  >
+                                    <span
+                                      >${this.hass!.localize(
+                                        "ui.panel.lovelace.unused_entities.title"
+                                      )}</span
+                                    >
+                                    <ha-svg-icon
+                                      slot="graphic"
+                                      .path=${mdiShape}
+                                    ></ha-svg-icon>
+                                  </mwc-list-item>`
+                                : ""}
+                            `
+                          : ""}
+                        ${(this.hass.panels.lovelace
+                          ?.config as LovelacePanelConfig)?.mode === "yaml"
+                          ? html`
+                              <mwc-list-item
+                                graphic="icon"
+                                aria-label=${this.hass!.localize(
+                                  "ui.panel.lovelace.menu.reload_resources"
+                                )}
+                                @request-selected=${this._handleReloadResources}
+                              >
+                                ${this.hass!.localize(
+                                  "ui.panel.lovelace.menu.reload_resources"
+                                )}
+                                <ha-svg-icon
+                                  slot="graphic"
+                                  .path=${mdiRefresh}
+                                ></ha-svg-icon>
+                              </mwc-list-item>
+                            `
+                          : ""}
+                        ${this.hass!.user?.is_admin &&
+                        !this.hass!.config.safe_mode
+                          ? html`
+                              <mwc-list-item
+                                graphic="icon"
+                                aria-label=${this.hass!.localize(
+                                  "ui.panel.lovelace.menu.configure_ui"
+                                )}
+                                @request-selected=${this._handleEnableEditMode}
+                              >
+                                ${this.hass!.localize(
+                                  "ui.panel.lovelace.menu.configure_ui"
+                                )}
+                                <ha-svg-icon
+                                  slot="graphic"
+                                  .path=${mdiCog}
+                                ></ha-svg-icon>
+                              </mwc-list-item>
+                              <a
+                                href="${documentationUrl(
+                                  this.hass,
+                                  "/lovelace/"
+                                )}"
+                                rel="noreferrer"
+                                class="menu-link"
+                                target="_blank"
+                              >
+                                <mwc-list-item
+                                  graphic="icon"
+                                  aria-label=${this.hass!.localize(
+                                    "ui.panel.lovelace.menu.help"
+                                  )}
+                                >
+                                  ${this.hass!.localize(
+                                    "ui.panel.lovelace.menu.help"
+                                  )}
+                                  <ha-svg-icon
+                                    slot="graphic"
+                                    .path=${mdiHelp}
+                                  ></ha-svg-icon>
+                                </mwc-list-item>
+                              </a>
+                            `
+                          : ""}
+                      </ha-button-menu>`
+                    : ""}
                 </app-toolbar>
               `}
           ${this._editMode

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -54,7 +54,6 @@ import {
 import { showVoiceCommandDialog } from "../../dialogs/voice-command-dialog/show-ha-voice-command-dialog";
 import "../../layouts/ha-app-layout";
 import type { haAppLayout } from "../../layouts/ha-app-layout";
-import type { HaTabs } from "../../components/ha-tabs";
 import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
@@ -77,8 +76,6 @@ class HUIRoot extends LitElement {
   @internalProperty() private _curView?: number | "hass-unused-entities";
 
   @query("ha-app-layout", true) private _appLayout!: haAppLayout;
-
-  @query("ha-tabs", true) private _haTabs!: HaTabs;
 
   private _viewCache?: { [viewId: string]: HUIView };
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -452,10 +452,8 @@ class HUIRoot extends LitElement {
     let views = this._visibleViews;
     const viewPath = this.route!.path.split("/")[1];
     const hiddenView =
-      (!isNaN(+viewPath) && +viewPath < views.length) ||
-      views.some((view) => view.path === viewPath)
-        ? false
-        : true;
+      !views.some((v) => v.path === viewPath) ||
+      (!isNaN(+viewPath) && +viewPath >= views.length);
 
     if (changedProperties.has("route")) {
       if (!viewPath && views.length) {
@@ -470,7 +468,6 @@ class HUIRoot extends LitElement {
       } else if (viewPath) {
         let selectedView = viewPath as any;
         if (hiddenView && !this._editMode) {
-          console.log("hidden view");
           views = this.config.views;
           selectedView = isNaN(+viewPath) ? viewPath : 0;
         }
@@ -497,18 +494,16 @@ class HUIRoot extends LitElement {
       }
 
       if (!oldLovelace || oldLovelace.editMode !== this.lovelace!.editMode) {
-        const views = this._visibleViews;
-
         // Leave unused entities when leaving edit mode
         if (
           this.lovelace!.mode === "storage" &&
           viewPath === "hass-unused-entities"
         ) {
-          newSelectView = views.findIndex(this._isVisible);
+          newSelectView = this._visibleViews.findIndex(this._isVisible);
           navigate(
             this,
             `${this.route!.prefix}/${
-              views[newSelectView].path || newSelectView
+              this._visibleViews[newSelectView].path || newSelectView
             }`,
             true
           );

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -450,7 +450,10 @@ class HUIRoot extends LitElement {
     const viewPath = this.route!.path.split("/")[1];
 
     if (changedProperties.has("route")) {
-      const views = this.config.views;
+      const views =
+        !this._editMode && this._visibleViews.length > 0
+          ? this._visibleViews
+          : this.config.views;
 
       if (!viewPath && views.length) {
         newSelectView = views.findIndex(this._isVisible);
@@ -486,7 +489,10 @@ class HUIRoot extends LitElement {
       }
 
       if (!oldLovelace || oldLovelace.editMode !== this.lovelace!.editMode) {
-        const views = this.config && this.config.views;
+        const views =
+          !this._editMode && this._visibleViews.length > 0
+            ? this._visibleViews
+            : this.config && this.config.views;
 
         fireEvent(this, "iron-resize");
 
@@ -653,9 +659,13 @@ class HUIRoot extends LitElement {
 
   private _handleViewSelected(ev) {
     const viewIndex = ev.detail.selected as number;
+    const views =
+      !this._editMode && this._visibleViews.length > 0
+        ? this._visibleViews
+        : this.config.views;
 
     if (viewIndex !== this._curView) {
-      const path = this.config.views[viewIndex].path || viewIndex;
+      const path = views[viewIndex].path || viewIndex;
       navigate(this, `${this.route?.prefix}/${path}`);
     }
     scrollToTarget(this, this._layout.header.scrollTarget);

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -496,6 +496,10 @@ class HUIRoot extends LitElement {
 
         fireEvent(this, "iron-resize");
 
+        if (!views.includes(this.config.views[this._curView as number])) {
+          navigate(this, `${this.route?.prefix}/0`);
+        }
+
         // Leave unused entities when leaving edit mode
         if (
           this.lovelace!.mode === "storage" &&

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -108,7 +108,7 @@ class HUIRoot extends LitElement {
         })}
         id="layout"
       >
-        <app-header slot="header" effects="waterfall" fixed condenses>
+        <app-header slot="header" effects="waterfall" fixed>
           ${this._editMode
             ? html`
                 <app-toolbar class="edit-mode">
@@ -891,9 +891,6 @@ class HUIRoot extends LitElement {
           */
           flex: 1 1 100%;
           max-width: 100%;
-        }
-        .hide-tab {
-          display: none;
         }
         .menu-link {
           text-decoration: none;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Instead of styling non-visible tabs to be hidden, this just doesn't create them in the first place. Now a user cannot easily visit a hidden tab without knowing the path (can no longer see a hidden tab via index, like `/lovelace/3`, or by modifying CSS). Using a tab's index in the URL still works for visible tabs, using the index number corresponding to the current tabs in the header. 

This also removes a few other elements that shouldn't exist as a non-admin user. It removes the overflow menu completely for non-admin users when in storage mode. The only option that still exists in that menu for users is the link to the help page, but that page isn't really relevant to users. The overflow menu remains for YAML mode users for the "refresh" and "reload resources" options, but "Unused Entities" has been removed. Users shouldn't have access to that and they don't in storage mode currently.

#### In Storage Mode
* Don't create tabs for or allow navigation to views that are hidden without using it's path
* Still show all views in edit mode
* Remove overflow menu for non-admins

#### In YAML Mode
* Don't create tabs for or allow navigation to views that are hidden without using it's path
* Don't add unused entities to overflow menu for non-admin users

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This retains the moving of conversation icon into overflow menu on sidebar visibility if overflow menu is visible, otherwise conversation icon is always visible.

* This PR is related to issue or discussion: https://github.com/home-assistant/frontend/discussions/7614

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
