### PR TITLE
Add above,below,attribute to conditional card

### DIFF
--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -1,27 +1,51 @@
 import { HomeAssistant } from "../../../types";
-import { UNAVAILABLE } from "../../../data/entity";
 
 export interface Condition {
   entity: string;
+  attribute?: string;
   state?: string;
   state_not?: string;
+  above?: any;
+  below?: any;
 }
 
 export function checkConditionsMet(
   conditions: Condition[],
   hass: HomeAssistant
 ): boolean {
-  return conditions.every((c) => {
-    const state = hass.states[c.entity]
-      ? hass!.states[c.entity].state
-      : UNAVAILABLE;
+  return conditions.every((condition) => {
+    const stateObj = hass.states[condition.entity];
+    if (!stateObj) {
+      return false;
+    }
 
-    return c.state ? state === c.state : state !== c.state_not;
+    const state = condition.attribute
+      ? stateObj.attributes[condition.attribute]
+      : stateObj.state;
+
+    if (condition.state && state !== condition.state) {
+      return false;
+    }
+    if (condition.state_not && state === condition.state_not) {
+      return false;
+    }
+    if (condition.above != null && state <= condition.above) {
+      return false;
+    }
+    if (condition.below != null && state >= condition.below) {
+      return false;
+    }
+    return true;
   });
 }
 
 export function validateConditionalConfig(conditions: Condition[]): boolean {
   return conditions.every(
-    (c) => ((c.entity && (c.state || c.state_not)) as unknown) as boolean
+    (c) =>
+      ((c.entity &&
+        (c.state ||
+          c.state_not ||
+          c.above != null ||
+          c.below != null)) as unknown) as boolean
   );
 }


### PR DESCRIPTION
add conditional card support:
* above state
* below state
* use attribute instedad of the state

This is alternate version of https://github.com/home-assistant/frontend/pull/7381

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Lovelace conditional card supports only 'equal' or 'not equal', so this patch adds also `above`, `below` conditions.  
Also add support for `attribute`,  inspired by filter card.
UI editor is not supported.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: conditional
conditions:
  - entity: light.bed_light
    state: "on"
  - entity: switch.decorative_lights
    state_not: "off"
  - entity: sun.sun
    attribute: "elevation"
    above: 10
    below: 80
card:
  type: entities
  entities:
    - device_tracker.demo_paulus
    - cover.kitchen_window
    - group.kitchen
    - lock.kitchen_door
    - light.bed_light
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/conditional-card-with-and-as-conditions/182771
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/15648

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
