### PR TITLE
Move data_entry_flow_progressed event subscriber

### DIFF
--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -22,7 +22,10 @@ import {
   AreaRegistryEntry,
   subscribeAreaRegistry,
 } from "../../data/area_registry";
-import type { DataEntryFlowStep } from "../../data/data_entry_flow";
+import type {
+  DataEntryFlowProgressedEvent,
+  DataEntryFlowStep,
+} from "../../data/data_entry_flow";
 import {
   DeviceRegistryEntry,
   subscribeDeviceRegistry,
@@ -224,6 +227,19 @@ class DataEntryFlowDialog extends LitElement {
 
   protected firstUpdated(changedProps: PropertyValues) {
     super.firstUpdated(changedProps);
+    this.hass.connection.subscribeEvents<DataEntryFlowProgressedEvent>(
+      async (ev) => {
+        if (ev.data.flow_id !== this._step?.flow_id) {
+          return;
+        }
+        const step = await this._params!.flowConfig.fetchFlow(
+          this.hass,
+          this._step?.flow_id
+        );
+        this._processStep(step);
+      },
+      "data_entry_flow_progressed"
+    );
     this.addEventListener("flow-update", (ev) => {
       const { step, stepPromise } = (ev as any).detail;
       this._processStep(step || stepPromise);
@@ -266,6 +282,7 @@ class DataEntryFlowDialog extends LitElement {
   private async _processStep(
     step: DataEntryFlowStep | undefined | Promise<DataEntryFlowStep>
   ): Promise<void> {
+    console.log("new step", step);
     if (step instanceof Promise) {
       this._loading = true;
       try {

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -282,7 +282,6 @@ class DataEntryFlowDialog extends LitElement {
   private async _processStep(
     step: DataEntryFlowStep | undefined | Promise<DataEntryFlowStep>
   ): Promise<void> {
-    console.log("new step", step);
     if (step instanceof Promise) {
       this._loading = true;
       try {

--- a/src/dialogs/config-flow/step-flow-external.ts
+++ b/src/dialogs/config-flow/step-flow-external.ts
@@ -8,11 +8,7 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
-import { fireEvent } from "../../common/dom/fire_event";
-import {
-  DataEntryFlowProgressedEvent,
-  DataEntryFlowStepExternal,
-} from "../../data/data_entry_flow";
+import { DataEntryFlowStepExternal } from "../../data/data_entry_flow";
 import { HomeAssistant } from "../../types";
 import { FlowConfig } from "./show-dialog-data-entry-flow";
 import { configFlowContentStyles } from "./styles";
@@ -51,18 +47,6 @@ class StepFlowExternal extends LitElement {
 
   protected firstUpdated(changedProps) {
     super.firstUpdated(changedProps);
-    this.hass.connection.subscribeEvents<DataEntryFlowProgressedEvent>(
-      async (ev) => {
-        if (ev.data.flow_id !== this.step.flow_id) {
-          return;
-        }
-
-        fireEvent(this, "flow-update", {
-          stepPromise: this.flowConfig.fetchFlow(this.hass, this.step.flow_id),
-        });
-      },
-      "data_entry_flow_progressed"
-    );
     window.open(this.step.url);
   }
 

--- a/src/dialogs/config-flow/step-flow-progress.ts
+++ b/src/dialogs/config-flow/step-flow-progress.ts
@@ -8,12 +8,8 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
-import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-circular-progress";
-import {
-  DataEntryFlowProgressedEvent,
-  DataEntryFlowStepProgress,
-} from "../../data/data_entry_flow";
+import { DataEntryFlowStepProgress } from "../../data/data_entry_flow";
 import { HomeAssistant } from "../../types";
 import { FlowConfig } from "./show-dialog-data-entry-flow";
 import { configFlowContentStyles } from "./styles";
@@ -41,22 +37,6 @@ class StepFlowProgress extends LitElement {
         )}
       </div>
     `;
-  }
-
-  protected firstUpdated(changedProps) {
-    super.firstUpdated(changedProps);
-    this.hass.connection.subscribeEvents<DataEntryFlowProgressedEvent>(
-      async (ev) => {
-        if (ev.data.flow_id !== this.step.flow_id) {
-          return;
-        }
-
-        fireEvent(this, "flow-update", {
-          stepPromise: this.flowConfig.fetchFlow(this.hass, this.step.flow_id),
-        });
-      },
-      "data_entry_flow_progressed"
-    );
   }
 
   static get styles(): CSSResult[] {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Moves the `data_entry_flow_progressed` event subscriber form both the "external" and the "progress" steps to the parrent element.

When they where in their sub-elements , the subscriber attached too late which resulted in not responding to the `data_entry_flow_progressed` emitted by the backend.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
