### PR TITLE
Adjust FAB for blueprint overview + align translations

### DIFF
--- a/src/panels/config/blueprint/ha-blueprint-overview.ts
+++ b/src/panels/config/blueprint/ha-blueprint-overview.ts
@@ -138,9 +138,10 @@ class HaBlueprintOverview extends LitElement {
         </mwc-icon-button>
         <mwc-fab
           slot="fab"
-          title=${this.hass.localize(
+          .label=${this.hass.localize(
             "ui.panel.config.blueprint.overview.add_blueprint"
           )}
+          extended
           @click=${this._addBlueprint}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1450,19 +1450,20 @@
             "headers": {
               "name": "Name"
             },
-            "confirm_delete_header": "Delete this Blueprint?",
-            "confirm_delete_text": "Are you sure you want to delete this Blueprint"
+            "confirm_delete_header": "Delete this blueprint?",
+            "confirm_delete_text": "Are you sure you want to delete this blueprint",
+            "add_blueprint": "Add Blueprint"
           },
           "add": {
             "header": "Add new blueprint",
             "import_header": "Import {name} ({domain})",
-            "import_introduction": "You can import Blueprints of other users from Github and the community forums. Enter the url of the Blueprint below.",
-            "url": "Url of the blueprint",
+            "import_introduction": "You can import blueprints of other users from Github and the community forums. Enter the URL of the blueprint below.",
+            "url": "URL of the blueprint",
             "importing": "Importing blueprint...",
             "import_btn": "Import blueprint",
             "saving": "Saving blueprint...",
             "save_btn": "Save blueprint",
-            "error_no_url": "Please enter the url of the blueprint."
+            "error_no_url": "Please enter the URL of the blueprint."
           }
         },
         "script": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1452,7 +1452,7 @@
             },
             "confirm_delete_header": "Delete this blueprint?",
             "confirm_delete_text": "Are you sure you want to delete this blueprint",
-            "add_blueprint": "Add Blueprint"
+            "add_blueprint": "Add blueprint"
           },
           "add": {
             "header": "Add new blueprint",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Make FAB consistent with the others. Plus two translation changes:
1. Consistently write URL in capital letters
2. Write "blueprint" in lower case, since for the "automation", "script", etc. we do the same.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
