### PR TITLE
Fix spinner and 'Configuration' text in navigation commands

### DIFF
--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -205,6 +205,7 @@ export class QuickBar extends LitElement {
       <mwc-list-item
         .twoline=${Boolean(item.altText)}
         .item=${item}
+        hasMeta
         index=${ifDefined(index)}
         graphic="icon"
         class=${this._commandMode ? "command-item" : ""}
@@ -427,9 +428,9 @@ export class QuickBar extends LitElement {
         `ui.dialogs.quick-bar.commands.navigation.${page.component}`
       );
 
-      if (page.translationKey) {
+      if (page.translationKey && shortCaption) {
         const caption = this.hass.localize(
-          "ui.dialogs.quick-bar.commands.navigation.navigate_to_config",
+          "ui.dialogs.quick-bar.commands.navigation.navigate_to",
           "panel",
           shortCaption
         );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -288,7 +288,6 @@
       "overflow_menu": "Overflow menu",
       "successfully_saved": "Successfully saved",
       "successfully_deleted": "Successfully deleted",
-
       "error_required": "Required",
       "copied": "Copied"
     },
@@ -507,7 +506,6 @@
           },
           "navigation": {
             "navigate_to": "Navigate to {panel}",
-            "navigate_to_config": "Navigate to {panel} configuration",
             "logs": "[%key:ui::panel::config::logs::caption%]",
             "automation": "[%key:ui::panel::config::automation::caption%]",
             "script": "[%key:ui::panel::config::script::caption%]",
@@ -525,6 +523,7 @@
             "users": "[%key:ui::panel::config::users::caption%]",
             "info": "[%key:ui::panel::config::info::caption%]",
             "customize": "[%key:ui::panel::config::customize::caption%]",
+            "blueprint": "[%key:ui::panel::config::blueprint::caption%]",
             "server_control": "[%key:ui::panel::config::server_control::caption%]"
           }
         },
@@ -1118,8 +1117,9 @@
           "dialog_new": {
             "header": "Create a new automation",
             "how": "How do you want to create your new automation?",
-
-            "blueprint": { "use_blueprint": "Use a blueprint" },
+            "blueprint": {
+              "use_blueprint": "Use a blueprint"
+            },
             "thingtalk": {
               "header": "Describe the automation you want to create",
               "intro": "And we will try to create it for you. For example: Turn the lights off when I leave.",


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This PR:
1. Removes the "Navigate to ____ Configuration" dynamic translation entirely (there are way too many items with "Configuration" at the end)
2. Fixes a regression from https://github.com/home-assistant/frontend/pull/7590 that stopped the loading spinner from being rendered.

## Old
<img src="https://user-images.githubusercontent.com/1480827/99854280-60143780-2b39-11eb-9c1f-96256b729d16.png" width=50% />

## New
<img src="https://user-images.githubusercontent.com/1480827/99855859-9bfccc00-2b3c-11eb-97da-ab6f2c12ff8d.png" width=50% />

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
