### PR TITLE
Ensure more consistent lovelace config errors

### DIFF
--- a/src/panels/lovelace/badges/hui-entity-filter-badge.ts
+++ b/src/panels/lovelace/badges/hui-entity-filter-badge.ts
@@ -24,8 +24,8 @@ class EntityFilterBadge extends UpdatingElement implements LovelaceBadge {
   private _oldEntities?: EntityFilterEntityConfig[];
 
   public setConfig(config: EntityFilterBadgeConfig): void {
-    if (!config.entities || !Array.isArray(config.entities)) {
-      throw new Error("entities must be specified.");
+    if (!config.entities.length || !Array.isArray(config.entities)) {
+      throw new Error("Entities must be specified");
     }
 
     if (
@@ -37,7 +37,7 @@ class EntityFilterBadge extends UpdatingElement implements LovelaceBadge {
           Array.isArray(entity.state_filter)
       )
     ) {
-      throw new Error("Incorrect filter config.");
+      throw new Error("Incorrect filter config");
     }
 
     while (this.lastChild) {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -94,7 +94,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       !config.entity ||
       config.entity.split(".")[0] !== "alarm_control_panel"
     ) {
-      throw new Error("Invalid card configuration");
+      throw new Error("Invalid configuration");
     }
 
     const defaults = {

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -85,8 +85,11 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: ButtonCardConfig): void {
+    if (!config.entity) {
+      throw new Error("Entity must be specified");
+    }
     if (config.entity && !isValidEntityId(config.entity)) {
-      throw new Error("Invalid Entity");
+      throw new Error("Invalid entity");
     }
 
     this._config = {

--- a/src/panels/lovelace/cards/hui-calendar-card.ts
+++ b/src/panels/lovelace/cards/hui-calendar-card.ts
@@ -83,7 +83,7 @@ export class HuiCalendarCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: CalendarCardConfig): void {
     if (!config.entities?.length) {
-      throw new Error("Entities must be defined");
+      throw new Error("Entities must be specified");
     }
 
     if (!Array.isArray(config.entities)) {

--- a/src/panels/lovelace/cards/hui-conditional-card.ts
+++ b/src/panels/lovelace/cards/hui-conditional-card.ts
@@ -28,7 +28,7 @@ class HuiConditionalCard extends HuiConditionalBase implements LovelaceCard {
     this.validateConfig(config);
 
     if (!config.card) {
-      throw new Error("No card configured.");
+      throw new Error("No card configured");
     }
 
     this._element = this._createCardElement(config.card);

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -111,6 +111,10 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: EntitiesCardConfig): void {
+    if (!config || !config.entities.length) {
+      throw new Error("Entities must be specified");
+    }
+
     const entities = processConfigEntities(config.entities);
 
     this._config = config;
@@ -172,7 +176,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   protected render(): TemplateResult {
-    if (!this._config || !this._hass) {
+    if (!this._config || !this._hass || this._configEntities?.length === 0) {
       return html``;
     }
 

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -176,7 +176,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   protected render(): TemplateResult {
-    if (!this._config || !this._hass || this._configEntities?.length === 0) {
+    if (!this._config || !this._hass) {
       return html``;
     }
 

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -68,8 +68,11 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
   private _footerElement?: HuiErrorCard | LovelaceHeaderFooter;
 
   public setConfig(config: EntityCardConfig): void {
+    if (!config.entity) {
+      throw new Error("Entity must be specified");
+    }
     if (config.entity && !isValidEntityId(config.entity)) {
-      throw new Error("Invalid Entity");
+      throw new Error("Invalid entity");
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -36,8 +36,8 @@ class EntityFilterCard extends UpdatingElement implements LovelaceCard {
   }
 
   public setConfig(config: EntityFilterCardConfig): void {
-    if (!config.entities || !Array.isArray(config.entities)) {
-      throw new Error("entities must be specified.");
+    if (!config.entities.length || !Array.isArray(config.entities)) {
+      throw new Error("Entities must be specified");
     }
 
     if (
@@ -49,7 +49,7 @@ class EntityFilterCard extends UpdatingElement implements LovelaceCard {
           Array.isArray(entity.state_filter)
       )
     ) {
-      throw new Error("Incorrect filter config.");
+      throw new Error("Incorrect filter config");
     }
 
     this._configEntities = processConfigEntities(config.entities);

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -18,6 +18,7 @@ import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import "../../../components/ha-card";
 import "../../../components/ha-gauge";
 import type { HomeAssistant } from "../../../types";
+import { UNAVAILABLE } from "../../../data/entity";
 import { findEntities } from "../common/find-entites";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
@@ -72,12 +73,13 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: GaugeCardConfig): void {
-    if (!config || !config.entity) {
-      throw new Error("Invalid card configuration");
+    if (!config.entity) {
+      throw new Error("Entity must be specified");
     }
     if (!isValidEntityId(config.entity)) {
-      throw new Error("Invalid Entity");
+      throw new Error("Invalid entity");
     }
+
     this._config = { min: 0, max: 100, ...config };
   }
 
@@ -97,6 +99,18 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
     }
 
     const state = Number(stateObj.state);
+
+    if (stateObj.state === UNAVAILABLE) {
+      return html`
+        <hui-warning
+          >${this.hass.localize(
+            "ui.panel.lovelace.warning.entity_unavailable",
+            "entity",
+            this._config.entity
+          )}</hui-warning
+        >
+      `;
+    }
 
     if (isNaN(state)) {
       return html`

--- a/src/panels/lovelace/cards/hui-humidifier-card.ts
+++ b/src/panels/lovelace/cards/hui-humidifier-card.ts
@@ -66,7 +66,7 @@ export class HuiHumidifierCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: HumidifierCardConfig): void {
     if (!config.entity || config.entity.split(".")[0] !== "humidifier") {
-      throw new Error("Specify an entity from within the humidifier domain.");
+      throw new Error("Specify an entity from within the humidifier domain");
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -73,7 +73,7 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: LightCardConfig): void {
     if (!config.entity || config.entity.split(".")[0] !== "light") {
-      throw new Error("Specify an entity from within the light domain.");
+      throw new Error("Specify an entity from within the light domain");
     }
 
     this._config = {

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -76,6 +76,10 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: LogbookCardConfig): void {
+    if (!config.entities.length) {
+      throw new Error("Entities must be specified");
+    }
+
     this._configEntities = processConfigEntities<EntityConfig>(config.entities);
 
     this._config = {

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -137,9 +137,9 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       throw new Error("Error in card configuration.");
     }
 
-    if (!config.entities && !config.geo_location_sources) {
+    if (!config.entities?.length && !config.geo_location_sources) {
       throw new Error(
-        "Either entities or geo_location_sources must be defined"
+        "Either entities or geo_location_sources must be specified"
       );
     }
     if (config.entities && !Array.isArray(config.entities)) {

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -58,7 +58,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: MarkdownCardConfig): void {
     if (!config.content) {
-      throw new Error("Invalid Configuration: Content Required");
+      throw new Error("Content required");
     }
 
     if (this._config?.content !== config.content) {

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -213,7 +213,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: MediaControlCardConfig): void {
     if (!config.entity || config.entity.split(".")[0] !== "media_player") {
-      throw new Error("Specify an entity from within the media_player domain.");
+      throw new Error("Specify an entity from within the media_player domain");
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-picture-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-card.ts
@@ -48,7 +48,7 @@ export class HuiPictureCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: PictureCardConfig): void {
     if (!config || !config.image) {
-      throw new Error("Invalid Configuration: 'image' required");
+      throw new Error("Image required");
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-picture-elements-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-elements-card.ts
@@ -62,14 +62,14 @@ class HuiPictureElementsCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: PictureElementsCardConfig): void {
     if (!config) {
-      throw new Error("Invalid Configuration");
+      throw new Error("Invalid configuration");
     } else if (
       !(config.image || config.camera_image || config.state_image) ||
       (config.state_image && !config.entity)
     ) {
-      throw new Error("Invalid Configuration: image required");
+      throw new Error("Image required");
     } else if (!Array.isArray(config.elements)) {
-      throw new Error("Invalid Configuration: elements required");
+      throw new Error("Elements required");
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-picture-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-entity-card.ts
@@ -69,7 +69,7 @@ class HuiPictureEntityCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: PictureEntityCardConfig): void {
     if (!config || !config.entity) {
-      throw new Error("Invalid Configuration: 'entity' required");
+      throw new Error("Entity must be specified");
     }
 
     if (
@@ -78,7 +78,7 @@ class HuiPictureEntityCard extends LitElement implements LovelaceCard {
       !config.state_image &&
       !config.camera_image
     ) {
-      throw new Error("No image source configured.");
+      throw new Error("No image source configured");
     }
 
     this._config = { show_name: true, show_state: true, ...config };

--- a/src/panels/lovelace/cards/hui-picture-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-picture-glance-card.ts
@@ -86,7 +86,7 @@ class HuiPictureGlanceCard extends LitElement implements LovelaceCard {
       !(config.image || config.camera_image || config.state_image) ||
       (config.state_image && !config.entity)
     ) {
-      throw new Error("Invalid card configuration");
+      throw new Error("Invalid configuration");
     }
 
     const entities = processConfigEntities(config.entities);

--- a/src/panels/lovelace/cards/hui-plant-status-card.ts
+++ b/src/panels/lovelace/cards/hui-plant-status-card.ts
@@ -68,7 +68,7 @@ class HuiPlantStatusCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: PlantStatusCardConfig): void {
     if (!config.entity || config.entity.split(".")[0] !== "plant") {
-      throw new Error("Specify an entity from within the plant domain.");
+      throw new Error("Specify an entity from within the plant domain");
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-sensor-card.ts
+++ b/src/panels/lovelace/cards/hui-sensor-card.ts
@@ -44,7 +44,7 @@ class HuiSensorCard extends HuiEntityCard {
 
   public setConfig(config: SensorCardConfig): void {
     if (!config.entity || config.entity.split(".")[0] !== "sensor") {
-      throw new Error("Specify an entity from within the sensor domain.");
+      throw new Error("Specify an entity from within the sensor domain");
     }
 
     const { graph, detail, hours_to_show, ...cardConfig } = config;

--- a/src/panels/lovelace/cards/hui-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-stack-card.ts
@@ -42,7 +42,7 @@ export abstract class HuiStackCard<T extends StackCardConfig = StackCardConfig>
 
   public setConfig(config: T): void {
     if (!config || !config.cards || !Array.isArray(config.cards)) {
-      throw new Error("Card config incorrect");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
     this._cards = config.cards.map((card) => {

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -87,7 +87,7 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
 
   public setConfig(config: ThermostatCardConfig): void {
     if (!config.entity || config.entity.split(".")[0] !== "climate") {
-      throw new Error("Specify an entity from within the climate domain.");
+      throw new Error("Specify an entity from within the climate domain");
     }
 
     this._config = config;

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -90,11 +90,11 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: WeatherForecastCardConfig): void {
-    if (!config || !config.entity) {
-      throw new Error("Invalid card configuration");
+    if (!config.entity) {
+      throw new Error("Entity must be specified");
     }
     if (!isValidEntityId(config.entity)) {
-      throw new Error("Invalid Entity");
+      throw new Error("Invalid entity");
     }
 
     this._config = config;

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -27,15 +27,15 @@ export class HuiConditionalBase extends UpdatingElement {
     config: ConditionalCardConfig | ConditionalRowConfig
   ): void {
     if (!config.conditions) {
-      throw new Error("No conditions configured.");
+      throw new Error("No conditions configured");
     }
 
     if (!Array.isArray(config.conditions)) {
-      throw new Error("Conditions should be in an array.");
+      throw new Error("Conditions need to be an array");
     }
 
     if (!validateConditionalConfig(config.conditions)) {
-      throw new Error("Conditions are invalid.");
+      throw new Error("Conditions are invalid");
     }
 
     if (this.lastChild) {

--- a/src/panels/lovelace/components/hui-warning.ts
+++ b/src/panels/lovelace/components/hui-warning.ts
@@ -17,7 +17,7 @@ export const createEntityNotFoundWarning = (
     ? hass.localize(
         "ui.panel.lovelace.warning.entity_not_found",
         "entity",
-        entityId
+        entityId || "[empty]"
       )
     : hass.localize("ui.panel.lovelace.warning.starting");
 };

--- a/src/panels/lovelace/create-element/create-element-base.ts
+++ b/src/panels/lovelace/create-element/create-element-base.ts
@@ -197,7 +197,7 @@ export const tryCreateLovelaceElement = <
     // If domain types is given, we can derive a type from "entity"
     (!domainTypes || !("entity" in config))
   ) {
-    throw new Error("No card type configured.");
+    throw new Error("No card type configured");
   }
 
   const customTag = config.type ? _getCustomTag(config.type) : undefined;
@@ -219,7 +219,7 @@ export const tryCreateLovelaceElement = <
   }
 
   if (type === undefined) {
-    throw new Error("No type specified.");
+    throw new Error("No type specified");
   }
 
   const tag = `hui-${type}-${tagSuffix}`;

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
@@ -115,7 +115,7 @@ export class HuiButtonCardEditor extends LitElement
           .label="${this.hass.localize(
             "ui.panel.lovelace.editor.card.generic.entity"
           )} (${this.hass.localize(
-            "ui.panel.lovelace.editor.card.config.optional"
+            "ui.panel.lovelace.editor.card.config.required"
           )})"
           .hass=${this.hass}
           .value=${this._entity}

--- a/src/panels/lovelace/editor/config-elements/hui-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-card-editor.ts
@@ -81,7 +81,7 @@ export class HuiEntityCardEditor extends LitElement
           .label="${this.hass.localize(
             "ui.panel.lovelace.editor.card.generic.entity"
           )} (${this.hass.localize(
-            "ui.panel.lovelace.editor.card.config.optional"
+            "ui.panel.lovelace.editor.card.config.required"
           )})"
           .hass=${this.hass}
           .value=${this._entity}

--- a/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
@@ -178,7 +178,7 @@ export class HuiPictureGlanceCardEditor extends LitElement
         </div>
         <ha-entity-picker
           .label="${this.hass.localize(
-            "ui.panel.lovelace.editor.card.generic.entity"
+            "ui.panel.lovelace.editor.card.picture-glance.state_entity"
           )} (${this.hass.localize(
             "ui.panel.lovelace.editor.card.config.optional"
           )})"

--- a/src/panels/lovelace/elements/hui-conditional-element.ts
+++ b/src/panels/lovelace/elements/hui-conditional-element.ts
@@ -25,7 +25,7 @@ class HuiConditionalElement extends HTMLElement implements LovelaceElement {
       !Array.isArray(config.elements) ||
       !validateConditionalConfig(config.conditions)
     ) {
-      throw new Error("Error in card configuration.");
+      throw new Error("Invalid configuration");
     }
 
     if (this._elements.length > 0) {

--- a/src/panels/lovelace/elements/hui-icon-element.ts
+++ b/src/panels/lovelace/elements/hui-icon-element.ts
@@ -25,7 +25,7 @@ export class HuiIconElement extends LitElement implements LovelaceElement {
 
   public setConfig(config: IconElementConfig): void {
     if (!config.icon) {
-      throw Error("Invalid Configuration: 'icon' required");
+      throw Error("Icon required");
     }
 
     this._config = { hold_action: { action: "more-info" }, ...config };

--- a/src/panels/lovelace/elements/hui-image-element.ts
+++ b/src/panels/lovelace/elements/hui-image-element.ts
@@ -26,7 +26,7 @@ export class HuiImageElement extends LitElement implements LovelaceElement {
 
   public setConfig(config: ImageElementConfig): void {
     if (!config) {
-      throw Error("Error in element configuration");
+      throw Error("Invalid configuration");
     }
 
     this._config = { hold_action: { action: "more-info" }, ...config };

--- a/src/panels/lovelace/elements/hui-service-button-element.ts
+++ b/src/panels/lovelace/elements/hui-service-button-element.ts
@@ -24,19 +24,17 @@ export class HuiServiceButtonElement extends LitElement
 
   public setConfig(config: ServiceButtonElementConfig): void {
     if (!config || !config.service) {
-      throw Error("Invalid Configuration: 'service' required");
+      throw Error("Service required");
     }
 
     [this._domain, this._service] = config.service.split(".", 2);
 
     if (!this._domain) {
-      throw Error("Invalid Configuration: 'service' does not have a domain");
+      throw Error("Service does not have a service domain");
     }
 
     if (!this._service) {
-      throw Error(
-        "Invalid Configuration: 'service' does not have a service name"
-      );
+      throw Error("Service does not have a service name");
     }
 
     this._config = config;

--- a/src/panels/lovelace/elements/hui-state-badge-element.ts
+++ b/src/panels/lovelace/elements/hui-state-badge-element.ts
@@ -29,7 +29,7 @@ export class HuiStateBadgeElement extends LitElement
 
   public setConfig(config: StateBadgeElementConfig): void {
     if (!config.entity) {
-      throw Error("Invalid Configuration: 'entity' required");
+      throw Error("Entity required");
     }
 
     this._config = { hold_action: { action: "more-info" }, ...config };

--- a/src/panels/lovelace/elements/hui-state-icon-element.ts
+++ b/src/panels/lovelace/elements/hui-state-icon-element.ts
@@ -30,7 +30,7 @@ export class HuiStateIconElement extends LitElement implements LovelaceElement {
 
   public setConfig(config: StateIconElementConfig): void {
     if (!config.entity) {
-      throw Error("Invalid Configuration: 'entity' required");
+      throw Error("Entity required");
     }
 
     this._config = {

--- a/src/panels/lovelace/elements/hui-state-label-element.ts
+++ b/src/panels/lovelace/elements/hui-state-label-element.ts
@@ -30,7 +30,7 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
 
   public setConfig(config: StateLabelElementConfig): void {
     if (!config.entity) {
-      throw Error("Invalid Configuration: 'entity' required");
+      throw Error("Entity required");
     }
 
     this._config = { hold_action: { action: "more-info" }, ...config };

--- a/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-climate-entity-row.ts
@@ -24,7 +24,7 @@ class HuiClimateEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config || !config.entity) {
-      throw new Error("Invalid Configuration: 'entity' required");
+      throw new Error("Entity must be specified");
     }
 
     this._config = config;

--- a/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-cover-entity-row.ts
@@ -26,7 +26,7 @@ class HuiCoverEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-group-entity-row.ts
@@ -38,7 +38,7 @@ class HuiGroupEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-humidifier-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-humidifier-entity-row.ts
@@ -21,7 +21,7 @@ class HuiHumidifierEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config || !config.entity) {
-      throw new Error("Invalid Configuration: 'entity' required");
+      throw new Error("Entity must be specified");
     }
 
     this._config = config;

--- a/src/panels/lovelace/entity-rows/hui-input-datetime-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-datetime-entity-row.ts
@@ -27,7 +27,7 @@ class HuiInputDatetimeEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -32,7 +32,7 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -40,7 +40,7 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntitiesCardEntityConfig): void {
     if (!config || !config.entity) {
-      throw new Error("Invalid Configuration: 'entity' required");
+      throw new Error("Entity must be specified");
     }
 
     this._config = config;

--- a/src/panels/lovelace/entity-rows/hui-input-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-text-entity-row.ts
@@ -24,7 +24,7 @@ class HuiInputTextEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-lock-entity-row.ts
@@ -25,7 +25,7 @@ class HuiLockEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -51,7 +51,7 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config || !config.entity) {
-      throw new Error("Invalid Configuration: 'entity' required");
+      throw new Error("Entity must be specified");
     }
 
     this._config = config;

--- a/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-scene-entity-row.ts
@@ -27,7 +27,7 @@ class HuiSceneEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: ActionRowConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-script-entity-row.ts
@@ -26,7 +26,7 @@ class HuiScriptEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: ActionRowConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -36,7 +36,7 @@ class HuiSensorEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: SensorEntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-text-entity-row.ts
@@ -32,7 +32,7 @@ class HuiTextEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntitiesCardEntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
@@ -28,7 +28,7 @@ class HuiTimerEntityRow extends LitElement {
 
   public setConfig(config: EntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
@@ -24,7 +24,7 @@ class HuiToggleEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntityConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
@@ -44,7 +44,7 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: EntitiesCardEntityConfig): void {
     if (!config?.entity) {
-      throw new Error("Invalid Configuration: 'entity' required");
+      throw new Error("Entity must be specified");
     }
 
     this._config = config;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -81,7 +81,7 @@ export class HuiGraphHeaderFooter extends LitElement
   public setConfig(config: GraphHeaderFooterConfig): void {
     if (!config?.entity || config.entity.split(".")[0] !== "sensor") {
       throw new Error(
-        "Invalid Configuration: An entity from within the sensor domain required"
+        "Invalid configuration: An entity from within the sensor domain required"
       );
     }
 

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -80,9 +80,7 @@ export class HuiGraphHeaderFooter extends LitElement
 
   public setConfig(config: GraphHeaderFooterConfig): void {
     if (!config?.entity || config.entity.split(".")[0] !== "sensor") {
-      throw new Error(
-        "Invalid configuration: An entity from within the sensor domain required"
-      );
+      throw new Error("Specify an entity from within the sensor domain");
     }
 
     const cardConfig = {

--- a/src/panels/lovelace/header-footer/hui-picture-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-picture-header-footer.ts
@@ -41,7 +41,7 @@ export class HuiPictureHeaderFooter extends LitElement
 
   public setConfig(config: PictureHeaderFooterConfig): void {
     if (!config || !config.image) {
-      throw new Error("Invalid Configuration: 'image' required");
+      throw new Error("Image required");
     }
 
     this._config = config;

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -23,13 +23,13 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: AttributeRowConfig): void {
     if (!config) {
-      throw new Error("Configuration error");
+      throw new Error("Invalid configuration");
     }
     if (!config.entity) {
-      throw new Error("Entity not defined");
+      throw new Error("Entity not specified");
     }
     if (!config.attribute) {
-      throw new Error("Attribute not defined");
+      throw new Error("Attribute not specified");
     }
     this._config = config;
   }

--- a/src/panels/lovelace/special-rows/hui-button-row.ts
+++ b/src/panels/lovelace/special-rows/hui-button-row.ts
@@ -26,11 +26,11 @@ export class HuiButtonRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: ButtonRowConfig): void {
     if (!config) {
-      throw new Error("Error in card configuration.");
+      throw new Error("Invalid configuration");
     }
 
     if (!config.name) {
-      throw new Error("Error in card configuration. No name specified.");
+      throw new Error("No name specified");
     }
 
     this._config = {

--- a/src/panels/lovelace/special-rows/hui-call-service-row.ts
+++ b/src/panels/lovelace/special-rows/hui-call-service-row.ts
@@ -8,15 +8,15 @@ export class HuiCallServiceRow extends HuiButtonRow {
     const callServiceConfig: CallServiceConfig = config;
 
     if (!callServiceConfig) {
-      throw new Error("Error in card configuration.");
+      throw new Error("Invalid configuration");
     }
 
     if (!callServiceConfig.name) {
-      throw new Error("Error in card configuration. No name specified.");
+      throw new Error("No name specified");
     }
 
     if (!callServiceConfig.service) {
-      throw new Error("Error in card configuration. No service specified.");
+      throw new Error("No service specified");
     }
 
     super.setConfig({

--- a/src/panels/lovelace/special-rows/hui-cast-row.ts
+++ b/src/panels/lovelace/special-rows/hui-cast-row.ts
@@ -32,7 +32,7 @@ class HuiCastRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: CastConfig): void {
     if (!config || config.view === undefined || config.view === null) {
-      throw new Error("Invalid Configuration: 'view' required");
+      throw new Error("View required");
     }
 
     this._config = {

--- a/src/panels/lovelace/special-rows/hui-conditional-row.ts
+++ b/src/panels/lovelace/special-rows/hui-conditional-row.ts
@@ -9,7 +9,7 @@ class HuiConditionalRow extends HuiConditionalBase implements LovelaceRow {
     this.validateConfig(config);
 
     if (!config.row) {
-      throw new Error("No row configured.");
+      throw new Error("No row configured");
     }
 
     this._element = createRowElement(config.row) as LovelaceRow;

--- a/src/panels/lovelace/special-rows/hui-section-row.ts
+++ b/src/panels/lovelace/special-rows/hui-section-row.ts
@@ -19,7 +19,7 @@ class HuiSectionRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: SectionConfig): void {
     if (!config) {
-      throw new Error("Error in card configuration.");
+      throw new Error("Invalid configuration");
     }
 
     this._config = config;

--- a/src/panels/lovelace/special-rows/hui-text-row.ts
+++ b/src/panels/lovelace/special-rows/hui-text-row.ts
@@ -16,7 +16,7 @@ class HuiTextRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: TextConfig): void {
     if (!config || !config.name || !config.text) {
-      throw new Error("Invalid Configuration: 'name' and 'text' required");
+      throw new Error("Name and text required");
     }
 
     this._config = config;

--- a/src/panels/lovelace/special-rows/hui-weblink-row.ts
+++ b/src/panels/lovelace/special-rows/hui-weblink-row.ts
@@ -19,7 +19,7 @@ class HuiWeblinkRow extends LitElement implements LovelaceRow {
 
   public setConfig(config: WeblinkConfig): void {
     if (!config || !config.url) {
-      throw new Error("Invalid Configuration: 'url' required");
+      throw new Error("URL required");
     }
 
     this._config = {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2721,7 +2721,8 @@
             },
             "picture-glance": {
               "name": "Picture Glance",
-              "description": "The Picture Glance card shows an image and corresponding entity states as an icon. The entities on the right side allow toggle actions, others show the more information dialog."
+              "description": "The Picture Glance card shows an image and corresponding entity states as an icon. The entities on the right side allow toggle actions, others show the more information dialog.",
+              "state_entity": "State Entity"
             },
             "plant-status": {
               "name": "Plant Status",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -65,7 +65,7 @@
       "unknown": "Unk",
       "unavailable": "Unavai",
       "error": "Error",
-      "entity_not_found": "Entity Not Found"
+      "entity_not_found": "Entity not found"
     },
     "alarm_control_panel": {
       "armed": "Armed",
@@ -1959,8 +1959,8 @@
             "hub": "Connected via",
             "firmware": "Firmware: {version}",
             "unnamed_entry": "Unnamed entry",
-            "device_unavailable": "device unavailable",
-            "entity_unavailable": "entity unavailable",
+            "device_unavailable": "Device unavailable",
+            "entity_unavailable": "Entity unavailable",
             "area": "In {area}",
             "no_area": "No Area"
           },
@@ -2795,7 +2795,7 @@
           "attribute_not_found": "Attribute {attribute} not available in: {entity}",
           "entity_not_found": "Entity not available: {entity}",
           "entity_non_numeric": "Entity is non-numeric: {entity}",
-          "entity_unavailable": "{entity} is currently unavailable",
+          "entity_unavailable": "Entity is currently unavailable: {entity}",
           "starting": "Home Assistant is starting, not everything may be available yet"
         },
         "changed_toast": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

1. Added proper errors where entity is required, rather than not having an empty, but still space using card
2. Check array length where multiple entities can be specified (a simple check for existance or is-array not sufficient since during initial editor creation all have an entity set, but user can remove it)
3. Mark entity input fields as required (where previously incorrectly marked as optional)
4. Consistent wording of errors

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
