### PR TITLE
add more-info actions

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -138,6 +138,7 @@ export interface UrlActionConfig extends BaseActionConfig {
 
 export interface MoreInfoActionConfig extends BaseActionConfig {
   action: "more-info";
+  actions?: ActionConfig[];
 }
 
 export interface NoActionConfig extends BaseActionConfig {
@@ -150,6 +151,7 @@ export interface CustomActionConfig extends BaseActionConfig {
 
 export interface BaseActionConfig {
   confirmation?: ConfirmationRestrictionConfig;
+  name?: string;
 }
 
 export interface ConfirmationRestrictionConfig {

--- a/src/dialogs/more-info/controls/more-info-person.ts
+++ b/src/dialogs/more-info/controls/more-info-person.ts
@@ -65,7 +65,7 @@ class MoreInfoPerson extends LitElement {
       latitude: this.stateObj!.attributes.latitude,
       longitude: this.stateObj!.attributes.longitude,
     });
-    fireEvent(this, "hass-more-info", { entityId: null });
+    fireEvent(this, "hass-more-info", { entityId: undefined });
   }
 
   static get styles(): CSSResult {

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -72,7 +72,6 @@ export class MoreInfoDialog extends LitElement {
   public showDialog(params: MoreInfoDialogParams) {
     this._entityId = params.entityId;
     this._actions = params.actions;
-    console.log(params);
     if (!this._entityId) {
       this.closeDialog();
       return;

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -60,9 +60,11 @@ export const handleAction = (
 
   switch (actionConfig.action) {
     case "more-info": {
+      console.log(actionConfig.actions);
       if (config.entity || config.camera_image) {
         fireEvent(node, "hass-more-info", {
           entityId: config.entity ? config.entity : config.camera_image!,
+          actions: actionConfig.actions,
         });
       }
       break;

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -60,7 +60,6 @@ export const handleAction = (
 
   switch (actionConfig.action) {
     case "more-info": {
-      console.log(actionConfig.actions);
       if (config.entity || config.camera_image) {
         fireEvent(node, "hass-more-info", {
           entityId: config.entity ? config.entity : config.camera_image!,

--- a/src/state/more-info-mixin.ts
+++ b/src/state/more-info-mixin.ts
@@ -39,6 +39,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         "ha-more-info-dialog",
         {
           entityId: ev.detail.entityId,
+          actions: ev.detail.actions,
         },
         importMoreInfo
       );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -547,6 +547,7 @@
         "crop": "Crop"
       },
       "more_info_control": {
+        "actions": "Actions",
         "dismiss": "Dismiss dialog",
         "settings": "Entity settings",
         "edit": "Edit entity",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Continuation of https://github.com/home-assistant/frontend/pull/7464 as I'm awful at mocking things out but this was easy to code :)
Adds a new Actions tab to the more-info dialog if a list of actions is given
![Peek 2020-11-21 23-55](https://user-images.githubusercontent.com/1287159/99896323-1b7dbe80-2c55-11eb-904d-4b29a848c236.gif)
Not sure on which tab it should be. Starting to think the last or first tab.
Also not sure if there should be an option to default to the actions tab or just the details tab. Right now I'm defaulting to the Actions tab if actions are defined which seems simple enough for me.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
entity: light.kitchen_lights
tap_action:
  action: more-info
  actions:
    - name: Turn On Kitchen Lights
      action: call-service
      service: light.turn_on
      service_data:
        entity_id: light.kitchen_lights
    - name: Turn Off Kitchen Lights
      action: call-service
      service: light.turn_off
      service_data:
        entity_id: light.kitchen_lights
    - name: Set Kitchen Lights to 1%
      action: call-service
      service: light.turn_on
      service_data:
        entity_id: light.kitchen_lights
        brightness_pct: 1
    - name: Set Kitchen Lights to 50%
      action: call-service
      service: light.turn_on
      service_data:
        entity_id: light.kitchen_lights
        brightness_pct: 50
    - name: Set Kitchen Lights to 100%
      action: call-service
      service: light.turn_on
      service_data:
        entity_id: light.kitchen_lights
        brightness_pct: 100
show_icon: true
show_name: true
show_state: true
type: button
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/frontend/discussions/7434
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
