### PR TITLE
Enhance ZHA device pairing feedback

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -27,6 +27,7 @@ export interface ZHADevice {
   device_type: string;
   signature: any;
   neighbors: Neighbor[];
+  pairing_status?: string;
 }
 
 export interface Neighbor {

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -271,3 +271,23 @@ export const addGroup = (
     group_name: groupName,
     members: membersToAdd,
   });
+
+export const INITIALIZED = "INITIALIZED";
+export const INTERVIEW_COMPLETE = "INTERVIEW_COMPLETE";
+export const CONFIGURED = "CONFIGURED";
+export const PAIRED = "PAIRED";
+export const INCOMPLETE_PAIRING_STATUSES = [
+  PAIRED,
+  CONFIGURED,
+  INTERVIEW_COMPLETE,
+];
+
+export const DEVICE_JOINED = "device_joined";
+export const RAW_DEVICE_INITIALIZED = "raw_device_initialized";
+export const DEVICE_FULLY_INITIALIZED = "device_fully_initialized";
+export const DEVICE_MESSAGE_TYPES = [
+  DEVICE_JOINED,
+  RAW_DEVICE_INITIALIZED,
+  DEVICE_FULLY_INITIALIZED,
+];
+export const LOG_OUTPUT = "log_output";

--- a/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
@@ -20,6 +20,7 @@ import { HomeAssistant, Route } from "../../../../../types";
 import "./zha-device-pairing-status-card";
 import { zhaTabs } from "./zha-config-dashboard";
 import { IronAutogrowTextareaElement } from "@polymer/iron-autogrow-textarea";
+import { DEVICE_MESSAGE_TYPES, LOG_OUTPUT } from "../../../../../data/zha";
 
 @customElement("zha-add-devices-page")
 class ZHAAddDevicesPage extends LitElement {
@@ -163,7 +164,7 @@ class ZHAAddDevicesPage extends LitElement {
   }
 
   private _handleMessage(message: any): void {
-    if (message.type === "log_output") {
+    if (message.type === LOG_OUTPUT) {
       this._formattedEvents += message.log_entry.message + "\n";
       if (this.shadowRoot) {
         const paperTextArea = this.shadowRoot.querySelector("paper-textarea");
@@ -174,14 +175,7 @@ class ZHAAddDevicesPage extends LitElement {
         }
       }
     }
-    if (
-      message.type &&
-      [
-        "device_joined",
-        "raw_device_initialized",
-        "device_fully_initialized",
-      ].includes(message.type)
-    ) {
+    if (message.type && DEVICE_MESSAGE_TYPES.includes(message.type)) {
       this._discoveredDevices[message.device_info.ieee] = message.device_info;
     }
   }

--- a/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
@@ -17,7 +17,7 @@ import "@polymer/paper-input/paper-textarea";
 import "../../../../../layouts/hass-tabs-subpage";
 import { haStyle } from "../../../../../resources/styles";
 import { HomeAssistant, Route } from "../../../../../types";
-import "./zha-device-card";
+import "./zha-device-pairing-status-card";
 import { zhaTabs } from "./zha-config-dashboard";
 import { IronAutogrowTextareaElement } from "@polymer/iron-autogrow-textarea";
 
@@ -134,13 +134,13 @@ class ZHAAddDevicesPage extends LitElement {
             : html`
                 ${Object.values(this._discoveredDevices).map(
                   (device) => html`
-                    <zha-device-card
+                    <zha-device-pairing-status-card
                       class="card"
                       .hass=${this.hass}
                       .device=${device}
                       .narrow=${this.narrow}
                       .showHelp=${this._showHelp}
-                    ></zha-device-card>
+                    ></zha-device-pairing-status-card>
                   `
                 )}
               `}

--- a/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
@@ -20,7 +20,11 @@ import { HomeAssistant, Route } from "../../../../../types";
 import "./zha-device-pairing-status-card";
 import { zhaTabs } from "./zha-config-dashboard";
 import { IronAutogrowTextareaElement } from "@polymer/iron-autogrow-textarea";
-import { DEVICE_MESSAGE_TYPES, LOG_OUTPUT } from "../../../../../data/zha";
+import {
+  DEVICE_MESSAGE_TYPES,
+  LOG_OUTPUT,
+  ZHADevice,
+} from "../../../../../data/zha";
 
 @customElement("zha-add-devices-page")
 class ZHAAddDevicesPage extends LitElement {
@@ -34,7 +38,10 @@ class ZHAAddDevicesPage extends LitElement {
 
   @internalProperty() private _error?: string;
 
-  @internalProperty() private _discoveredDevices = {};
+  @internalProperty() private _discoveredDevices: Record<
+    string,
+    ZHADevice
+  > = {};
 
   @internalProperty() private _formattedEvents = "";
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
@@ -14,7 +14,6 @@ import {
 } from "lit-element";
 import "../../../../../components/ha-service-description";
 import "@polymer/paper-input/paper-textarea";
-import { ZHADevice } from "../../../../../data/zha";
 import "../../../../../layouts/hass-tabs-subpage";
 import { haStyle } from "../../../../../resources/styles";
 import { HomeAssistant, Route } from "../../../../../types";
@@ -34,7 +33,7 @@ class ZHAAddDevicesPage extends LitElement {
 
   @internalProperty() private _error?: string;
 
-  @internalProperty() private _discoveredDevices: ZHADevice[] = [];
+  @internalProperty() private _discoveredDevices = {};
 
   @internalProperty() private _formattedEvents = "";
 
@@ -64,7 +63,7 @@ class ZHAAddDevicesPage extends LitElement {
     super.disconnectedCallback();
     this._unsubscribe();
     this._error = undefined;
-    this._discoveredDevices = [];
+    this._discoveredDevices = {};
     this._formattedEvents = "";
   }
 
@@ -115,7 +114,7 @@ class ZHAAddDevicesPage extends LitElement {
         </div>
         ${this._error ? html` <div class="error">${this._error}</div> ` : ""}
         <div class="content">
-          ${this._discoveredDevices.length < 1
+          ${Object.keys(this._discoveredDevices).length < 1
             ? html`
                 <div class="discovery-text">
                   <h4>
@@ -133,7 +132,7 @@ class ZHAAddDevicesPage extends LitElement {
                 </div>
               `
             : html`
-                ${this._discoveredDevices.map(
+                ${Object.values(this._discoveredDevices).map(
                   (device) => html`
                     <zha-device-card
                       class="card"
@@ -175,8 +174,15 @@ class ZHAAddDevicesPage extends LitElement {
         }
       }
     }
-    if (message.type && message.type === "device_fully_initialized") {
-      this._discoveredDevices.push(message.device_info);
+    if (
+      message.type &&
+      [
+        "device_joined",
+        "raw_device_initialized",
+        "device_fully_initialized",
+      ].includes(message.type)
+    ) {
+      this._discoveredDevices[message.device_info.ieee] = message.device_info;
     }
   }
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -32,7 +32,7 @@ import {
 import memoizeOne from "memoize-one";
 import { EntityRegistryStateEntry } from "../../../devices/ha-config-device-page";
 import { compare } from "../../../../../common/string/compare";
-import { getIeeeTail, formatAsPaddedHex } from "./functions";
+import { getIeeeTail } from "./functions";
 import { slugify } from "../../../../../common/string/slugify";
 
 @customElement("zha-device-card")
@@ -80,67 +80,45 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
       this._entities
     );
 
-    const header =
-      this.device.pairing_status === "PAIRED"
-        ? "Device Discovered"
-        : this.device.pairing_status === "INTERVIEW_COMPLETE"
-        ? "Device Interview Complete"
-        : this.device.user_given_name || this.device.name;
-
     return html`
-      <ha-card .header=${header}>
+      <ha-card .header=${this.device.user_given_name || this.device.name}>
         <div class="card-content">
           <div class="info">
-            ${this.device.pairing_status === "PAIRED"
-              ? html`
-                  <div class="model">IEEE: ${this.device.ieee}</div>
-                  <div class="model">
-                    NWK: ${formatAsPaddedHex(this.device.nwk)}
-                  </div>
-                `
-              : html`
-                  <div class="model">${this.device.model}</div>
-                  <div class="manuf">
-                    ${this.hass.localize(
-                      "ui.dialogs.zha_device_info.manuf",
-                      "manufacturer",
-                      this.device.manufacturer
-                    )}
-                  </div>
-                `}
+            <div class="model">${this.device.model}</div>
+            <div class="manuf">
+              ${this.hass.localize(
+                "ui.dialogs.zha_device_info.manuf",
+                "manufacturer",
+                this.device.manufacturer
+              )}
+            </div>
           </div>
 
-          ${this.device.pairing_status === "CONFIGURED" ||
-          this.device.pairing_status === "INITIALIZED" ||
-          this.device.pairing_status === null
-            ? html`
-                <div class="device-entities">
-                  ${entities.map(
-                    (entity) => html`
-                      <state-badge
-                        @click="${this._openMoreInfo}"
-                        .title=${entity.stateName!}
-                        .stateObj="${this.hass!.states[entity.entity_id]}"
-                        slot="item-icon"
-                      ></state-badge>
-                    `
-                  )}
-                </div>
-                <paper-input
-                  type="string"
-                  @change=${this._rename}
-                  .value=${this.device.user_given_name || this.device.name}
-                  .label=${this.hass.localize(
-                    "ui.dialogs.zha_device_info.zha_device_card.device_name_placeholder"
-                  )}
-                ></paper-input>
-                <ha-area-picker
-                  .hass=${this.hass}
-                  .device=${this.device.device_reg_id}
-                  @value-changed=${this._areaPicked}
-                ></ha-area-picker>
+          <div class="device-entities">
+            ${entities.map(
+              (entity) => html`
+                <state-badge
+                  @click="${this._openMoreInfo}"
+                  .title=${entity.stateName!}
+                  .stateObj="${this.hass!.states[entity.entity_id]}"
+                  slot="item-icon"
+                ></state-badge>
               `
-            : html``}
+            )}
+          </div>
+          <paper-input
+            type="string"
+            @change=${this._rename}
+            .value=${this.device.user_given_name || this.device.name}
+            .label=${this.hass.localize(
+              "ui.dialogs.zha_device_info.zha_device_card.device_name_placeholder"
+            )}
+          ></paper-input>
+          <ha-area-picker
+            .hass=${this.hass}
+            .device=${this.device.device_reg_id}
+            @value-changed=${this._areaPicked}
+          ></ha-area-picker>
         </div>
       </ha-card>
     `;

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -50,9 +50,7 @@ class ZHADevicePairingStatusCard extends LitElement {
           initialized: this.device.pairing_status === INITIALIZED,
         })}"
         ><div
-          class="header ${classMap({
-            success: this.device.pairing_status === INITIALIZED,
-          })}"
+          class="header"
         >
           <h1>
             ${this.hass!.localize(

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -26,6 +26,7 @@ import { HomeAssistant } from "../../../../../types";
 import "../../../../../components/ha-area-picker";
 import { formatAsPaddedHex } from "./functions";
 import "./zha-device-card";
+import { classMap } from "lit-html/directives/class-map";
 
 @customElement("zha-device-pairing-status-card")
 class ZHADevicePairingStatusCard extends LitElement {
@@ -45,10 +46,14 @@ class ZHADevicePairingStatusCard extends LitElement {
     return html`
       <ha-card
         outlined
-        class=${this.device.pairing_status === INITIALIZED
-          ? "discovered"
-          : "discovered-progress"}
-        ><div class="header">
+        class="discovered-progress ${classMap({
+          discovered: this.device.pairing_status === INITIALIZED,
+        })}"
+        ><div
+          class="header ${classMap({
+            success: this.device.pairing_status === INITIALIZED,
+          })}"
+        >
           <h1>
             ${this.hass!.localize(
               `ui.panel.config.zha.device_pairing_card.${this.device.pairing_status}`
@@ -61,8 +66,9 @@ class ZHADevicePairingStatusCard extends LitElement {
           </h4>
         </div>
         <div class="card-content">
-          ${this.device.pairing_status === INTERVIEW_COMPLETE ||
-          this.device.pairing_status === CONFIGURED
+          ${[INTERVIEW_COMPLETE, CONFIGURED].includes(
+            this.device.pairing_status!
+          )
             ? html`
                 <div class="model">${this.device.model}</div>
                 <div class="manuf">
@@ -104,25 +110,22 @@ class ZHADevicePairingStatusCard extends LitElement {
     return [
       haStyle,
       css`
-        .discovered {
-          --ha-card-border-color: var(--success-color);
-        }
-        .discovered .header {
-          background: var(--success-color);
-          color: var(--text-primary-color);
-          padding: 8px;
-          text-align: center;
-          margin-bottom: 20px;
-        }
         .discovered-progress {
           --ha-card-border-color: var(--primary-color);
         }
-        .discovered-progress .header {
+        .discovered-progress.discovered {
+          --ha-card-border-color: var(--success-color);
+        }
+        .discovered-progress .header,
+        .discovered .header {
           background: var(--primary-color);
           color: var(--text-primary-color);
           padding: 8px;
           text-align: center;
           margin-bottom: 20px;
+        }
+        .discovered .header.success {
+          background: var(--success-color);
         }
         h1 {
           margin: 0;

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -108,13 +108,12 @@ class ZHADevicePairingStatusCard extends LitElement {
     return [
       haStyle,
       css`
-        .discovered-progress {
+        .discovered {
           --ha-card-border-color: var(--primary-color);
         }
-        .discovered-progress.discovered {
+        .discovered.initialized {
           --ha-card-border-color: var(--success-color);
         }
-        .discovered-progress .header,
         .discovered .header {
           background: var(--primary-color);
           color: var(--text-primary-color);
@@ -122,7 +121,7 @@ class ZHADevicePairingStatusCard extends LitElement {
           text-align: center;
           margin-bottom: 20px;
         }
-        .discovered .header.success {
+        .discovered.initialized .header {
           background: var(--success-color);
         }
         h1 {

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -46,7 +46,7 @@ class ZHADevicePairingStatusCard extends LitElement {
     return html`
       <ha-card
         outlined
-        class="discovered-progress ${classMap({
+        class="discovered ${classMap({
           discovered: this.device.pairing_status === INITIALIZED,
         })}"
         ><div

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -1,0 +1,129 @@
+import "@polymer/paper-input/paper-input";
+import "@polymer/paper-listbox/paper-listbox";
+import {
+  css,
+  CSSResult,
+  customElement,
+  html,
+  LitElement,
+  property,
+  internalProperty,
+  TemplateResult,
+} from "lit-element";
+import "../../../../../components/buttons/ha-call-service-button";
+import "../../../../../components/entity/state-badge";
+import "../../../../../components/ha-card";
+import "../../../../../components/ha-service-description";
+import { ZHADevice } from "../../../../../data/zha";
+import { haStyle } from "../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../types";
+import "../../../../../components/ha-area-picker";
+import { formatAsPaddedHex } from "./functions";
+import "./zha-device-card";
+
+@customElement("zha-device-pairing-status-card")
+class ZHADevicePairingStatusCard extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public device?: ZHADevice;
+
+  @property({ type: Boolean }) public narrow?: boolean;
+
+  @internalProperty() private _showHelp = false;
+
+  protected render(): TemplateResult {
+    if (!this.hass || !this.device) {
+      return html``;
+    }
+
+    return html`
+      <ha-card outlined class="discovered"
+        ><div class="header">
+          <h1>
+            ${this.hass!.localize(
+              `ui.panel.config.zha.device_pairing_card.${this.device.pairing_status}`
+            )}
+          </h1>
+          <h4>
+            ${this.hass!.localize(
+              `ui.panel.config.zha.device_pairing_card.${this.device.pairing_status}_status_text`
+            )}
+          </h4>
+        </div>
+        <div class="card-content">
+          ${this.device.pairing_status === "INTERVIEW_COMPLETE" ||
+          this.device.pairing_status === "CONFIGURED"
+            ? html`
+                <div class="model">${this.device.model}</div>
+                <div class="manuf">
+                  ${this.hass.localize(
+                    "ui.dialogs.zha_device_info.manuf",
+                    "manufacturer",
+                    this.device.manufacturer
+                  )}
+                </div>
+              `
+            : html``}
+          <div class="info">
+            ${["PAIRED", "CONFIGURED", "INTERVIEW_COMPLETE"].includes(
+              this.device.pairing_status!
+            )
+              ? html`
+                  <div class="text">IEEE: ${this.device.ieee}</div>
+                  <div class="text">
+                    NWK: ${formatAsPaddedHex(this.device.nwk)}
+                  </div>
+                `
+              : html``}
+          </div>
+          ${this.device.pairing_status === "INITIALIZED"
+            ? html`
+                <zha-device-card
+                  class="card"
+                  .hass=${this.hass}
+                  .device=${this.device}
+                  .narrow=${this.narrow}
+                  .showHelp=${this._showHelp}
+                ></zha-device-card>
+              `
+            : html``}
+        </div>
+      </ha-card>
+    `;
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyle,
+      css`
+        .discovered {
+          --ha-card-border-color: var(--primary-color);
+        }
+        .discovered .header {
+          background: var(--primary-color);
+          color: var(--text-primary-color);
+          padding: 8px;
+          text-align: center;
+          margin-bottom: 20px;
+        }
+        h1 {
+          margin: 0;
+        }
+        h4 {
+          margin: 0;
+        }
+        .text,
+        .manuf,
+        .model {
+          color: var(--secondary-text-color);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "zha-device-pairing-status-card": ZHADevicePairingStatusCard;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -14,7 +14,13 @@ import "../../../../../components/buttons/ha-call-service-button";
 import "../../../../../components/entity/state-badge";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-service-description";
-import { ZHADevice } from "../../../../../data/zha";
+import {
+  CONFIGURED,
+  INCOMPLETE_PAIRING_STATUSES,
+  INITIALIZED,
+  INTERVIEW_COMPLETE,
+  ZHADevice,
+} from "../../../../../data/zha";
 import { haStyle } from "../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../types";
 import "../../../../../components/ha-area-picker";
@@ -39,7 +45,7 @@ class ZHADevicePairingStatusCard extends LitElement {
     return html`
       <ha-card
         outlined
-        class=${this.device.pairing_status === "INITIALIZED"
+        class=${this.device.pairing_status === INITIALIZED
           ? "discovered"
           : "discovered-progress"}
         ><div class="header">
@@ -55,8 +61,8 @@ class ZHADevicePairingStatusCard extends LitElement {
           </h4>
         </div>
         <div class="card-content">
-          ${this.device.pairing_status === "INTERVIEW_COMPLETE" ||
-          this.device.pairing_status === "CONFIGURED"
+          ${this.device.pairing_status === INTERVIEW_COMPLETE ||
+          this.device.pairing_status === CONFIGURED
             ? html`
                 <div class="model">${this.device.model}</div>
                 <div class="manuf">
@@ -69,9 +75,7 @@ class ZHADevicePairingStatusCard extends LitElement {
               `
             : html``}
           <div class="info">
-            ${["PAIRED", "CONFIGURED", "INTERVIEW_COMPLETE"].includes(
-              this.device.pairing_status!
-            )
+            ${INCOMPLETE_PAIRING_STATUSES.includes(this.device.pairing_status!)
               ? html`
                   <div class="text">IEEE: ${this.device.ieee}</div>
                   <div class="text">
@@ -80,7 +84,7 @@ class ZHADevicePairingStatusCard extends LitElement {
                 `
               : html``}
           </div>
-          ${this.device.pairing_status === "INITIALIZED"
+          ${this.device.pairing_status === INITIALIZED
             ? html`
                 <zha-device-card
                   class="card"

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -37,7 +37,11 @@ class ZHADevicePairingStatusCard extends LitElement {
     }
 
     return html`
-      <ha-card outlined class="discovered"
+      <ha-card
+        outlined
+        class=${this.device.pairing_status === "INITIALIZED"
+          ? "discovered"
+          : "discovered-progress"}
         ><div class="header">
           <h1>
             ${this.hass!.localize(
@@ -97,9 +101,19 @@ class ZHADevicePairingStatusCard extends LitElement {
       haStyle,
       css`
         .discovered {
-          --ha-card-border-color: var(--primary-color);
+          --ha-card-border-color: var(--success-color);
         }
         .discovered .header {
+          background: var(--success-color);
+          color: var(--text-primary-color);
+          padding: 8px;
+          text-align: center;
+          margin-bottom: 20px;
+        }
+        .discovered-progress {
+          --ha-card-border-color: var(--primary-color);
+        }
+        .discovered-progress .header {
           background: var(--primary-color);
           color: var(--text-primary-color);
           padding: 8px;

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -47,7 +47,7 @@ class ZHADevicePairingStatusCard extends LitElement {
       <ha-card
         outlined
         class="discovered ${classMap({
-          discovered: this.device.pairing_status === INITIALIZED,
+          initialized: this.device.pairing_status === INITIALIZED,
         })}"
         ><div
           class="header ${classMap({

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2197,6 +2197,16 @@
             "issue_zigbee_command": "Issue Zigbee Command",
             "help_command_dropdown": "Select a command to interact with."
           },
+          "device_pairing_card": {
+            "PAIRED": "Device Found",
+            "PAIRED_status_text": "Starting Interview",
+            "INTERVIEW_COMPLETE": "Interview Complete",
+            "INTERVIEW_COMPLETE_status_text": "Configuring",
+            "CONFIGURED": "Configuration Complete",
+            "CONFIGURED_status_text": "Initializing",
+            "INITIALIZED": "Initialization Complete",
+            "INITIALIZED_status_text": "The device is ready to use"
+          },
           "network": {
             "caption": "Network"
           },


### PR DESCRIPTION
# Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR enhances the visual feedback presented to the user when pairing devices in the ZHA configuration panel. Feedback is given as soon as a device joins the network and pairing progress is updated as the device is interviewed and configured.

Fixes: #6620

**Requires:** https://github.com/home-assistant/core/pull/43729

![device_pairing](https://user-images.githubusercontent.com/1335687/100519971-41312900-3169-11eb-98f1-18f51513640e.gif)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6620
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
