### PR TITLE
Apply existing theme variables to unthemed items 

### DIFF
--- a/src/dialogs/notifications/notification-item-template.ts
+++ b/src/dialogs/notifications/notification-item-template.ts
@@ -46,7 +46,7 @@ export class HuiNotificationItemTemplate extends LitElement {
       }
 
       .actions {
-        border-top: 1px solid #e8e8e8;
+        border-top: 1px solid var(--divider-color, #e8e8e8);
         padding: 5px 16px;
       }
 

--- a/src/panels/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/developer-tools/ha-panel-developer-tools.ts
@@ -30,6 +30,18 @@ class PanelDeveloperTools extends LitElement {
   protected firstUpdated(changedProps) {
     super.firstUpdated(changedProps);
     this.hass.loadBackendTranslation("title");
+    this.style.setProperty(
+      "--app-header-background-color",
+      "var(--sidebar-background-color)"
+    );
+    this.style.setProperty(
+      "--app-header-text-color",
+      "var(--sidebar-text-color)"
+    );
+    this.style.setProperty(
+      "--app-header-border-bottom",
+      "1px solid var(--divider-color)"
+    );
   }
 
   protected render(): TemplateResult {

--- a/src/panels/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/developer-tools/ha-panel-developer-tools.ts
@@ -30,18 +30,6 @@ class PanelDeveloperTools extends LitElement {
   protected firstUpdated(changedProps) {
     super.firstUpdated(changedProps);
     this.hass.loadBackendTranslation("title");
-    this.style.setProperty(
-      "--app-header-background-color",
-      "var(--sidebar-background-color)"
-    );
-    this.style.setProperty(
-      "--app-header-text-color",
-      "var(--sidebar-text-color)"
-    );
-    this.style.setProperty(
-      "--app-header-border-bottom",
-      "1px solid var(--divider-color)"
-    );
   }
 
   protected render(): TemplateResult {
@@ -121,7 +109,7 @@ class PanelDeveloperTools extends LitElement {
         ha-tabs {
           margin-left: max(env(safe-area-inset-left), 24px);
           margin-right: max(env(safe-area-inset-right), 24px);
-          --paper-tabs-selection-bar-color: #fff;
+          --paper-tabs-selection-bar-color: var(--text-primary-color, #fff);
           text-transform: uppercase;
         }
       `,


### PR DESCRIPTION
I've found what appears to be two unthemed items:

1) Developers Tools header tab selection / lower-border color:

![image](https://user-images.githubusercontent.com/435987/100522734-b522ff80-3170-11eb-86ce-c5d964eacf8f.png)


Same for the divider on notifications:

![image](https://user-images.githubusercontent.com/435987/100523595-45644300-3177-11eb-9af7-bbaf59aaec34.png)


## Proposed change

For the header, I copied the theme code from https://github.com/home-assistant/frontend/blob/dev/src/panels/config/ha-panel-config.ts

## Type of change


- [ ] Dependency upgrade
- [ X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

I don't have a development environment set-up right now.

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
