### PR TITLE
Ensure push notification description reacts to language change

### DIFF
--- a/src/panels/profile/ha-push-notifications-row.js
+++ b/src/panels/profile/ha-push-notifications-row.js
@@ -25,7 +25,7 @@ class HaPushNotificationsRow extends LocalizeMixin(PolymerElement) {
           >[[localize('ui.panel.profile.push_notifications.header')]]</span
         >
         <span slot="description">
-          [[_description(_platformLoaded, _pushSupported)]]
+          [[localize(_descrLocalizeKey)]]
           <a
             href="[[_computeDocumentationUrl(hass)]]"
             target="_blank"
@@ -45,6 +45,10 @@ class HaPushNotificationsRow extends LocalizeMixin(PolymerElement) {
     return {
       hass: Object,
       narrow: Boolean,
+      _descrLocalizeKey: {
+        type: String,
+        computed: "_descriptionKey(_platformLoaded, _pushSupported)",
+      },
       _platformLoaded: {
         type: Boolean,
         computed: "_compPlatformLoaded(hass)",
@@ -72,7 +76,7 @@ class HaPushNotificationsRow extends LocalizeMixin(PolymerElement) {
     return !platformLoaded || !pushSupported_;
   }
 
-  _description(platformLoaded, pushSupported_) {
+  _descriptionKey(platformLoaded, pushSupported_) {
     let key;
     if (!pushSupported_) {
       key = "error_use_https";
@@ -81,7 +85,7 @@ class HaPushNotificationsRow extends LocalizeMixin(PolymerElement) {
     } else {
       key = "description";
     }
-    return this.localize(`ui.panel.profile.push_notifications.${key}`);
+    return `ui.panel.profile.push_notifications.${key}`;
   }
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The language switch did not trigger the method that dynamically determines the language key to be used for the push notification config row. As a result, during a language switch in the user profile, the text did not update correctly.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/6757
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
