### PR TITLE
Add CSS Variables for Menu

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -772,9 +772,9 @@ class HaSidebar extends LitElement {
           border-bottom: 1px solid transparent;
           white-space: nowrap;
           font-weight: 400;
-          color: var(--menu-text-color, --primary-text-color);
+          color: var(--sidebar-menu-button-text-color, --primary-text-color);
           border-bottom: 1px solid var(--divider-color);
-          background-color: var(--menu-background-color, --primary-background-color);
+          background-color: var(--sidebar-menu-button-background-color, --primary-background-color);
           font-size: 20px;
           align-items: center;
           padding-left: calc(4px + env(safe-area-inset-left));

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -772,9 +772,9 @@ class HaSidebar extends LitElement {
           border-bottom: 1px solid transparent;
           white-space: nowrap;
           font-weight: 400;
-          color: var(--primary-text-color);
+          color: var(--menu-text-color, --primary-text-color);
           border-bottom: 1px solid var(--divider-color);
-          background-color: var(--primary-background-color);
+          background-color: var(--menu-background-color, --primary-background-color);
           font-size: 20px;
           align-items: center;
           padding-left: calc(4px + env(safe-area-inset-left));


### PR DESCRIPTION
Add CSS Variables for Menu - Fallback value is as default (primary-text-color and primary-background-color). This allows for the menu to have a color/background that is decoupled from the main pages color/background.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Creates CSS variables for the menu's background & text colour (the part which contains the hamburger menu icon). This allows for these to be specified separately, and not be the same as the main pages.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Breaking change (fix/feature causing existing functionality to break)

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

For example:
From: 
![fix3](https://user-images.githubusercontent.com/11828103/101277344-c3b38b80-37ee-11eb-9f61-7afb91a7e4c8.png)
To:
 ![fix2](https://user-images.githubusercontent.com/11828103/101277345-c4e4b880-37ee-11eb-9265-10daddb3480f.png)



## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
