### PR TITLE
Update group reload string

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1062,7 +1062,7 @@
               "input_select": "Reload input selects",
               "template": "Reload template entities",
               "universal": "Reload universal media player entities",
-              "rest": "Reload rest entities and notify services",
+              "rest": "Reload rest entities, and rest notify services",
               "command_line": "Reload command line entities",
               "filter": "Reload filter entities",
               "statistics": "Reload statistics entities",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1049,7 +1049,7 @@
               "introduction": "Some parts of Home Assistant can reload without requiring a restart. Hitting reload will unload their current YAML configuration and load the new one.",
               "reload": "Reload {domain}",
               "core": "Reload location & customizations",
-              "group": "Reload groups, group entities, and notify services",
+              "group": "Reload groups, group entities and notify services",
               "automation": "Reload automations",
               "script": "Reload scripts",
               "scene": "Reload scenes",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1049,7 +1049,7 @@
               "introduction": "Some parts of Home Assistant can reload without requiring a restart. Hitting reload will unload their current YAML configuration and load the new one.",
               "reload": "Reload {domain}",
               "core": "Reload location & customizations",
-              "group": "Reload groups, group entities and notify services",
+              "group": "Reload groups, group entities, and group notify services",
               "automation": "Reload automations",
               "script": "Reload scripts",
               "scene": "Reload scenes",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Update string for group reload service in server control. Especially if this entry is the only one mentioning `notify services`, a user could assume that it would reload the `notify` component. See below. Removing the comma makes it clear that it's the `group notify services` which will be reloaded. It will also be more consistent with other reload strings, eg. for rest https://github.com/home-assistant/frontend/blob/ffc19e591d60e3ccacc3ed9277570b414be13878/src/translations/en.json#L1065

<img width="626" alt="Screen Shot 2020-12-10 at 13 05 02" src="https://user-images.githubusercontent.com/30130371/101770909-78002b00-3ae9-11eb-8054-b57e191bb8e5.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

--

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

--

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
