### PR TITLE
Add support for "all" as entity ID in action "service"

### DIFF
--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -187,7 +187,7 @@ export default class HaAutomationActionRow extends LitElement {
                 <ul>
                   ${this._warnings.map((warning) => html`<li>${warning}</li>`)}
                 </ul>
-                You can still edit your config in yaml.
+                You can still edit your config in YAML.
               </div>`
             : ""}
           ${yamlMode

--- a/src/panels/config/automation/action/types/ha-automation-action-service.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-service.ts
@@ -19,12 +19,12 @@ import type { HaYamlEditor } from "../../../../../components/ha-yaml-editor";
 import { ServiceAction } from "../../../../../data/script";
 import type { PolymerChangedEvent } from "../../../../../polymer-types";
 import type { HomeAssistant } from "../../../../../types";
-import { EntityId } from "../../../../lovelace/common/structs/is-entity-id";
+import { EntityIdOrAll } from "../../../../lovelace/common/structs/is-entity-id";
 import { ActionElement, handleChangeEvent } from "../ha-automation-action-row";
 
 const actionStruct = object({
   service: optional(string()),
-  entity_id: optional(EntityId),
+  entity_id: optional(EntityIdOrAll),
   data: optional(any()),
 });
 

--- a/src/panels/lovelace/common/structs/is-entity-id.ts
+++ b/src/panels/lovelace/common/structs/is-entity-id.ts
@@ -7,7 +7,7 @@ const isEntityId = (value: unknown, context: StructContext): StructResult => {
   if (!value.includes(".")) {
     return [
       context.fail({
-        type: "entity id should be in the format 'domain.entity'",
+        type: "entity ID should be in the format 'domain.entity'",
       }),
     ];
   }
@@ -15,3 +15,14 @@ const isEntityId = (value: unknown, context: StructContext): StructResult => {
 };
 
 export const EntityId = struct("entity-id", isEntityId);
+
+const isEntityIdOrAll = (
+  value: unknown,
+  context: StructContext
+): StructResult => {
+  if (typeof value === "string" && value === "all") return true;
+
+  return isEntityId(value, context);
+};
+
+export const EntityIdOrAll = struct("entity-id", isEntityIdOrAll);

--- a/src/panels/lovelace/common/structs/is-entity-id.ts
+++ b/src/panels/lovelace/common/structs/is-entity-id.ts
@@ -7,7 +7,7 @@ const isEntityId = (value: unknown, context: StructContext): StructResult => {
   if (!value.includes(".")) {
     return [
       context.fail({
-        type: "entity ID should be in the format 'domain.entity'",
+        type: "Entity ID should be in the format 'domain.entity'",
       }),
     ];
   }
@@ -20,9 +20,11 @@ const isEntityIdOrAll = (
   value: unknown,
   context: StructContext
 ): StructResult => {
-  if (typeof value === "string" && value === "all") return true;
+  if (typeof value === "string" && value === "all") {
+    return true;
+  }
 
   return isEntityId(value, context);
 };
 
-export const EntityIdOrAll = struct("entity-id", isEntityIdOrAll);
+export const EntityIdOrAll = struct("entity-id-all", isEntityIdOrAll);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Add support for "all" as entity ID for service calls in automation actions.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/6617
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
