### PR TITLE
Improve spacing in entity rows + secondary ellipsis

### DIFF
--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -164,7 +164,8 @@ class HuiGenericEntityRow extends LitElement {
       }
       .info {
         margin-left: 16px;
-        flex: 1 0 60px;
+        margin-right: 8px;
+        flex: 1 0 30%;
       }
       .info,
       .info > * {
@@ -181,7 +182,6 @@ class HuiGenericEntityRow extends LitElement {
       }
       .secondary,
       ha-relative-time {
-        display: block;
         color: var(--secondary-text-color);
       }
       state-badge {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Three CSS changes, addressing various aspects of the linked issue:

1. Allow secondary info line to display ellipsis to be consistent with the main info + prevent abrupt cuts.
2. Add a bit of space in between name and value. Otherwise there is no separation. Only visually comes into effect for very long names.
**Before:**
![image](https://user-images.githubusercontent.com/114137/102818989-f656aa00-43d2-11eb-8339-ac13dc20e63c.png)
**After:**
![image](https://user-images.githubusercontent.com/114137/102818979-f0f95f80-43d2-11eb-926b-e7823cca224c.png)
3. Increase the flex base size of the name from 60px to 30%. In most cases this has no effect as many entity/sensor values are way shorter, which means there is enough space for the flex-grow to consume to display enough letters of the name. However, in case of long values (e.g. address strings as in the referenced issue), the names are reduced to unusable lengths. Since the value can with out problem use up two lines, there is no downside to giving the name more space.
**Before:**
![image](https://user-images.githubusercontent.com/114137/102819250-6a914d80-43d3-11eb-80f5-44d2a8d03dc1.png)
**After:**
![image](https://user-images.githubusercontent.com/114137/102819243-682ef380-43d3-11eb-90a9-96fc49f620bc.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8017
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
