### PR TITLE
Allow overriding thermostat card sensor

### DIFF
--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -304,6 +304,7 @@ export interface ThermostatCardConfig extends LovelaceCardConfig {
   entity: string;
   theme?: string;
   name?: string;
+  sensor?: string;
 }
 
 export interface WeatherForecastCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
@@ -22,10 +22,12 @@ const cardConfigStruct = object({
   type: string(),
   entity: string(),
   name: optional(string()),
+  sensor: optional(string()),
   theme: optional(string()),
 });
 
 const includeDomains = ["climate"];
+const sensorDomains = ["sensor"];
 
 @customElement("hui-thermostat-card-editor")
 export class HuiThermostatCardEditor extends LitElement
@@ -45,6 +47,10 @@ export class HuiThermostatCardEditor extends LitElement
 
   get _name(): string {
     return this._config!.name || "";
+  }
+
+  get _sensor(): string {
+    return this._config!.sensor || "";
   }
 
   get _theme(): string {
@@ -81,6 +87,19 @@ export class HuiThermostatCardEditor extends LitElement
           .configValue="${"name"}"
           @value-changed="${this._valueChanged}"
         ></paper-input>
+        <ha-entity-picker
+          .label="${this.hass.localize(
+            "ui.panel.lovelace.editor.card.generic.entity"
+          )} (${this.hass.localize(
+            "ui.panel.lovelace.editor.card.config.optional"
+          )})"
+          .hass=${this.hass}
+          .value="${this._sensor}"
+          .configValue=${"sensor"}
+          .includeDomains=${sensorDomains}
+          @change="${this._valueChanged}"
+          allow-custom-entity
+        ></ha-entity-picker>
         <hui-theme-select-editor
           .hass=${this.hass}
           .value="${this._theme}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Some climate integrations do not have a temperature sensor available to show the current temperature. In these cases, the card shows a big pointless zero as the main element of the card (since a few versions back, I think previously it was just blank, which was better).

Allow to configure a separate temperature sensor to display instead of the current temperature that may or may not be provided by the climate entity. Even if the climate entity, e.g. a A/C unit,m provides a temperature reading, a separate sensor that could be placed away from the heat source could be more relevant.

Display the main temperature value from the following sources, in
order of priority:

1. The state of the new 'sensor' entity configuration, if set.
2. The current_temperature attribute of the climate entity, if available.
3. The target temperature of the climate entity, if it's a single value.
4. An empty placeholder, if the set-point is a range.

If the target temperature is displayed as the main element, do not also
show it below.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: thermostat
entity: climate.living_room
sensor: sensor.living_room_temperature
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7036 
- This PR is related to issue or discussion:
- Link to documentation pull request: home-assistant/home-assistant.io#16034

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
