### PR TITLE
Change minimum width to show numbers in EntityRow to 300px

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -142,6 +142,15 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
 
   private async _initialLoad(): Promise<void> {
     this._loaded = true;
+    await this.updateComplete;
+    const element = this.shadowRoot!.querySelector(".state") as HTMLElement;
+
+    if (!element || !this.parentElement) {
+      return;
+    }
+
+    // TODO: This should update when resizeObserver detects a change.
+    element.hidden = this.parentElement.clientWidth <= 300;
   }
 
   private get _inputElement(): { value: string } {

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -142,14 +142,6 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
 
   private async _initialLoad(): Promise<void> {
     this._loaded = true;
-    await this.updateComplete;
-    const element = this.shadowRoot!.querySelector(".state") as HTMLElement;
-
-    if (!element || !this.parentElement) {
-      return;
-    }
-
-    element.hidden = this.parentElement.clientWidth <= 350;
   }
 
   private get _inputElement(): { value: string } {


### PR DESCRIPTION
## Proposed change

Remove hard-coded check on column width of 350px to hide certain elements.

DISCLAIMER: I'm new to hass.io and am not aware of the all the implications this change will have. Therefore I'm filing the PR to get such input -> please advise.

At the moment, the only effect of this code I'm aware of is the buggy behavior described below.

## Additional information

- This PR is related to the discussion at: [https://community.home-assistant.io/t/input-number-slider-not-showing-number/118241/12](https://community.home-assistant.io/t/input-number-slider-not-showing-number/118241/12) (numbers on sliders being hidden depending on browser width):

Summary: Depending on the screen or browser width during initial load, the values next to sliders are shown or hidden.
- This behavior toggles multiple times accross different browser widths (because the arrangement changes from 2 to 3 columns and the check is done on column width).
- It kicks in at different widths than column arrangement changes (which feel arbitrary)
- As far as I can tell, the space where the number should be is still there, so nothing is gained by hiding the number.
- The hiding persists, even if the browser width (or mobile device orientation) is changed subsequently.
- There is no way to disable this random hiding mechanism

The proposed change removes the check during load, which effectively always renders the numbers. This is the behavior I personally want (as well as others in the discussion linked above), but might not be the best solution for everyone (or have other side effects?).

Other solutions could include:
- providing a configuration option to disable this hiding mechanism (easy workaround for users)
- changing the check to coincide with the width at which column layout changes (would feel less random)
- adapting the hiding mechanism when the browser width changes (would feel less random)

## Checklist

- [ ] The code change is tested.
- [X] The code change works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
