### PR TITLE
OZW Panel: Don't show an empty wakeup card

### DIFF
--- a/src/panels/config/integrations/integration-panels/ozw/ozw-node-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/ozw/ozw-node-dashboard.ts
@@ -142,11 +142,15 @@ class OZWNodeDashboard extends LitElement {
                           ${this._metadata.metadata.ResetHelp}
                         </div>
                       </ha-card>
-                      <ha-card class="content" header="WakeUp">
-                        <div class="card-content">
-                          ${this._metadata.metadata.WakeupHelp}
-                        </div>
-                      </ha-card>
+                      ${this._metadata.metadata.WakeupHelp
+                        ? html`
+                            <ha-card class="content" header="WakeUp">
+                              <div class="card-content">
+                                ${this._metadata.metadata.WakeupHelp}
+                              </div>
+                            </ha-card>
+                          `
+                        : ``}
                     `
                   : ``}
               `
@@ -198,6 +202,10 @@ class OZWNodeDashboard extends LitElement {
 
         .content {
           margin-top: 24px;
+        }
+
+        .content:last-child {
+          margin-bottom: 24px;
         }
 
         .sectionHeader {


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Powered nodes don't have wakeup instructions. This PR only shows the WakeUp instruction card if there are wakeup instructions, otherwise the card is hidden. Also adds 24px of margin to the bottom of the last card so its not directly touching the bottom of the window.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
