### PR TITLE
Treat zero as String in number selector

### DIFF
--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -73,7 +73,7 @@ export class HaNumberSelector extends LitElement {
   }
 
   private _handleSliderChange(ev) {
-    const value = ev.target.value;
+    const value = ev.target.value || "0";
     if (this._value === value) {
       return;
     }

--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -73,7 +73,7 @@ export class HaNumberSelector extends LitElement {
   }
 
   private _handleSliderChange(ev) {
-    const value = ev.target.value || "0";
+    const value = ev.target.value;
     if (this._value === value) {
       return;
     }

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -165,7 +165,7 @@ export class HaBlueprintAutomationEditor extends LitElement {
                                 .selector=${value.selector}
                                 .key=${key}
                                 .value=${(this.config.use_blueprint.input &&
-                                  this.config.use_blueprint.input[key]) ||
+                                  this.config.use_blueprint.input[key]) ??
                                 value?.default}
                                 @value-changed=${this._inputChanged}
                               ></ha-selector>`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The problem is that currently the slider change returns `0` which leads to a reset to the default value, I assume here:

https://github.com/home-assistant/frontend/blob/f684531315552aa2b679097ae4e0696719dd72d7/src/panels/config/automation/blueprint-automation-editor.ts#L167-L169

We now check for "??" before applying the default value again, so that falsy values such as "0" do no longer get overwritten.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8054
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
