### PR TITLE
Correctly handle  "hours to show" for footer graph

### DIFF
--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -21,7 +21,7 @@ import { LovelaceHeaderFooter, LovelaceHeaderFooterEditor } from "../types";
 import { GraphHeaderFooterConfig } from "./types";
 
 const MINUTE = 60000;
-const DAY = 86400000;
+const HOUR = MINUTE * 60;
 
 @customElement("hui-graph-header-footer")
 export class HuiGraphHeaderFooter extends LitElement
@@ -162,10 +162,25 @@ export class HuiGraphHeaderFooter extends LitElement
         : this._date;
 
     if (this._stateHistory!.length) {
-      this._stateHistory = this._stateHistory!.filter(
-        (entity) =>
-          endTime.getTime() - new Date(entity.last_changed).getTime() <= DAY
+      const inHoursToShow: HassEntity[] = [];
+      const outHoursToShow: HassEntity[] = [];
+      // Split into inside and outside of "hours to show".
+      this._stateHistory!.forEach((entity) =>
+        (endTime.getTime() - new Date(entity.last_changed).getTime() <=
+        this._config!.hours_to_show! * HOUR
+          ? inHoursToShow
+          : outHoursToShow
+        ).push(entity)
       );
+      this._stateHistory = [];
+
+      if (outHoursToShow.length) {
+        // If we have values that are now outside of "hours to show", re-add the last entry. This could e.g. be
+        // the "initial state" from the history backend. Without it, it would look like there is no history data
+        // at the start at all in the database = graph would start suddenly instead of on the left side of the card.
+        this._stateHistory.push(outHoursToShow[outHoursToShow.length - 1]);
+      }
+      this._stateHistory = this._stateHistory.concat(inHoursToShow);
     }
 
     const stateHistory = await fetchRecent(

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -172,15 +172,14 @@ export class HuiGraphHeaderFooter extends LitElement
           : outHoursToShow
         ).push(entity)
       );
-      this._stateHistory = [];
 
       if (outHoursToShow.length) {
         // If we have values that are now outside of "hours to show", re-add the last entry. This could e.g. be
         // the "initial state" from the history backend. Without it, it would look like there is no history data
         // at the start at all in the database = graph would start suddenly instead of on the left side of the card.
-        this._stateHistory.push(outHoursToShow[outHoursToShow.length - 1]);
+        inHoursToShow.push(outHoursToShow[outHoursToShow.length - 1]);
       }
-      this._stateHistory = this._stateHistory.concat(inHoursToShow);
+      this._stateHistory = inHoursToShow;
     }
 
     const stateHistory = await fetchRecent(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

This PR fixes two issues:
1. The old coding did always check against 24 hours to see whether previously loaded history entries should be discarded rather than using the config parameter "hours to show".
2. The old coding did not account for the "initial state" of the history. So if 12 hours should be shown, but only 13 hours ago and then 2 hours ago did state changes occur, the frontend receives also the history entry from 13 hours ago from the backend. So the initial graph rendering was always fine. However, during the subsequent updates (when only the delta of newly recorded history entries is retrieved from the backend), the frontend did discard all cached history entries that lie outside the 12 hours. That would mean that "initial state" history entry would be lost (and effectively only values from 2 hours ago until now would be rendered). 
This PR now ensures that the last previous history entry that now lies outside the "hours to show" is retained so that the graph has a correct "entry value" = value on the left border of the graph.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8055
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
