### PR TITLE
Show actual error path/key in YAML card editor

### DIFF
--- a/src/panels/lovelace/common/structs/handle-errors.ts
+++ b/src/panels/lovelace/common/structs/handle-errors.ts
@@ -8,7 +8,7 @@ export const handleStructError = (err: Error): string[] => {
   for (const failure of err.failures()) {
     if (failure.type === "never") {
       errors.push(
-        `Key "${failure.path[0]}" is not supported by the UI editor.`
+        `Key "${failure.path.join(" -> ")}" is not supported by the UI editor.`
       );
     } else {
       errors.push(

--- a/src/panels/lovelace/common/structs/handle-errors.ts
+++ b/src/panels/lovelace/common/structs/handle-errors.ts
@@ -8,7 +8,7 @@ export const handleStructError = (err: Error): string[] => {
   for (const failure of err.failures()) {
     if (failure.type === "never") {
       errors.push(
-        `Key "${failure.path.join(" -> ")}" is not supported by the UI editor.`
+        `Key "${failure.path.join(".")}" is not supported by the UI editor.`
       );
     } else {
       errors.push(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The card editor currently shows the wrong / incomplete error path. This is quite confusing.

Before the PR it only stated "tap_action" as the error path which is of course wrong, since it's the "confirmation" that we do not (yet) support. After the PR it looks like this:
![image](https://user-images.githubusercontent.com/114137/103485734-cb1f8200-4df8-11eb-8578-50d19c0b3928.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
