### PR TITLE
Switch header sizes for ZHA pairing status card

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -49,19 +49,17 @@ class ZHADevicePairingStatusCard extends LitElement {
         class="discovered ${classMap({
           initialized: this.device.pairing_status === INITIALIZED,
         })}"
-        ><div
-          class="header"
-        >
-          <h1>
+        ><div class="header">
+          <h4>
             ${this.hass!.localize(
               `ui.panel.config.zha.device_pairing_card.${this.device.pairing_status}`
             )}
-          </h1>
-          <h4>
+          </h4>
+          <h1>
             ${this.hass!.localize(
               `ui.panel.config.zha.device_pairing_card.${this.device.pairing_status}_status_text`
             )}
-          </h4>
+          </h1>
         </div>
         <div class="card-content">
           ${[INTERVIEW_COMPLETE, CONFIGURED].includes(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Since the top title on the ZHA device pairing status card shows the result of the previous step ("Interview Complete", "Configuration Complete", etc), while the second title shows the current step ("Configuring", "Initializing", etc), having the top title bigger would draw attention to it. So a user could see "Configuration Complete" and assume pairing is done.

This change makes the second title bigger than the top one, so that the user focus on the step that is in progress.

**Before**:
![image](https://user-images.githubusercontent.com/974569/103486828-a7f4d280-4df8-11eb-8a82-ec7b013081eb.png)
(at this stage, the interview is complete, but the pairing is still configuring the device. A user could look at "Interview Complete" and think pairing has finished)

**After**:
![image](https://user-images.githubusercontent.com/974569/103486831-afb47700-4df8-11eb-8a2e-e54cde937442.png)
![image](https://user-images.githubusercontent.com/974569/103486832-b216d100-4df8-11eb-8c0c-cdaa5d5bfb92.png)
![image](https://user-images.githubusercontent.com/974569/103486836-b511c180-4df8-11eb-9529-9db605477f54.png)



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
