### PR TITLE
Add icon support to gauge

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -63,7 +63,7 @@ export const computeStateDisplay = (
 
   if (domain === "humidifier") {
     if (compareState === "on" && stateObj.attributes.humidity) {
-      return `${stateObj.attributes.humidity}%`;
+      return `${stateObj.attributes.humidity} %`;
     }
   }
 

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -240,8 +240,8 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
 
       .row {
         display: flex;
-        padding: 8px 16px 0;
         justify-content: space-around;
+        padding-top: 4px;
       }
 
       .name {

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -139,11 +139,7 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
           })}
         ></ha-gauge>
         <div class="row">
-          <div class="icon">
-            <ha-icon
-              .icon=${this._config.icon || stateIcon(stateObj)}
-            ></ha-icon>
-          </div>
+          <ha-icon .icon=${this._config.icon || stateIcon(stateObj)}></ha-icon>
           <div class="name">
             ${this._config.name || computeStateName(stateObj)}
           </div>
@@ -241,7 +237,8 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
       .row {
         display: flex;
         justify-content: space-around;
-        padding-top: 4px;
+        margin-top: 4px;
+        align-items: center;
       }
 
       .name {
@@ -251,12 +248,10 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
         width: 100%;
         font-size: 16px;
         font-weight: 500;
-        margin-top: 8px;
       }
 
-      .icon {
+      ha-icon {
         color: var(--state-icon-color, #44739e);
-        margin-top: 4px;
         margin-right: 4px;
       }
     `;

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -247,9 +247,10 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
       .name {
         text-align: center;
         line-height: initial;
-        color: var(--primary-text-color);
+        color: var(--secondary-text-color);
         width: 100%;
-        font-size: 15px;
+        font-size: 16px;
+        font-weight: 500;
         margin-top: 8px;
       }
 

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -14,6 +14,7 @@ import { styleMap } from "lit-html/directives/style-map";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeStateName } from "../../../common/entity/compute_state_name";
+import { stateIcon } from "../../../common/entity/state_icon";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import "../../../components/ha-card";
 import "../../../components/ha-gauge";
@@ -137,8 +138,15 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
             "--gauge-color": this._computeSeverity(state),
           })}
         ></ha-gauge>
-        <div class="name">
-          ${this._config.name || computeStateName(stateObj)}
+        <div class="row">
+          <div class="icon">
+            <ha-icon
+              .icon=${this._config.icon || stateIcon(stateObj)}
+            ></ha-icon>
+          </div>
+          <div class="name">
+            ${this._config.name || computeStateName(stateObj)}
+          </div>
         </div>
       </ha-card>
     `;
@@ -230,6 +238,12 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
         max-width: 250px;
       }
 
+      .row {
+        display: flex;
+        padding: 8px 16px 0;
+        justify-content: space-around;
+      }
+
       .name {
         text-align: center;
         line-height: initial;
@@ -237,6 +251,12 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
         width: 100%;
         font-size: 15px;
         margin-top: 8px;
+      }
+
+      .icon {
+        color: var(--state-icon-color, #44739e);
+        margin-top: 4px;
+        margin-right: 4px;
       }
     `;
   }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -114,6 +114,7 @@ export interface GaugeCardConfig extends LovelaceCardConfig {
   max?: number;
   severity?: SeverityConfig;
   theme?: string;
+  icon?: string;
 }
 
 export interface ConfigEntity extends EntityConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -12,8 +12,10 @@ import {
 import { assert, number, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { computeRTLDirection } from "../../../../common/util/compute_rtl";
+import { stateIcon } from "../../../../common/entity/state_icon";
 import "../../../../components/ha-formfield";
 import "../../../../components/ha-switch";
+import "../../../../components/ha-icon-input";
 import { HomeAssistant } from "../../../../types";
 import { GaugeCardConfig, SeverityConfig } from "../../cards/types";
 import "../../components/hui-entity-editor";
@@ -31,6 +33,7 @@ const cardConfigStruct = object({
   max: optional(number()),
   severity: optional(object()),
   theme: optional(string()),
+  icon: optional(string()),
 });
 
 const includeDomains = ["sensor"];
@@ -75,6 +78,10 @@ export class HuiGaugeCardEditor extends LitElement
     return this._config!.severity || undefined;
   }
 
+  get _icon(): string {
+    return this._config!.icon || "";
+  }
+
   protected render(): TemplateResult {
     if (!this.hass || !this._config) {
       return html``;
@@ -105,16 +112,30 @@ export class HuiGaugeCardEditor extends LitElement
           .configValue=${"name"}
           @value-changed="${this._valueChanged}"
         ></paper-input>
-        <paper-input
-          .label="${this.hass.localize(
-            "ui.panel.lovelace.editor.card.generic.unit"
-          )} (${this.hass.localize(
-            "ui.panel.lovelace.editor.card.config.optional"
-          )})"
-          .value="${this._unit}"
-          .configValue=${"unit"}
-          @value-changed="${this._valueChanged}"
-        ></paper-input>
+        <div class="side-by-side">
+          <paper-input
+            .label="${this.hass.localize(
+              "ui.panel.lovelace.editor.card.generic.unit"
+            )} (${this.hass.localize(
+              "ui.panel.lovelace.editor.card.config.optional"
+            )})"
+            .value="${this._unit}"
+            .configValue=${"unit"}
+            @value-changed="${this._valueChanged}"
+          ></paper-input>
+          <ha-icon-input
+            .label="${this.hass.localize(
+              "ui.panel.lovelace.editor.card.generic.icon"
+            )} (${this.hass.localize(
+              "ui.panel.lovelace.editor.card.config.optional"
+            )})"
+            .value=${this._icon}
+            .placeholder=${this._icon ||
+            stateIcon(this.hass.states[this._entity])}
+            .configValue=${"icon"}
+            @value-changed=${this._valueChanged}
+          ></ha-icon-input>
+        </div>
         <hui-theme-select-editor
           .hass=${this.hass}
           .value="${this._theme}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

Previously there was no icon shown (inconsistent compared to other cards). Now, the icons will appear unless we add a toggle for that.

## Proposed change

Icon now shown in front of label.
![image](https://user-images.githubusercontent.com/114137/103497519-0befb900-4e42-11eb-879a-46150709f074.png)


Editor support:
![image](https://user-images.githubusercontent.com/114137/103497532-17db7b00-4e42-11eb-9560-ec7bf48b8301.png)

Also for a more consistent look with the entity and sensor cards (plus feels lighter / more modern), the label now uses the secondary color.
![image](https://user-images.githubusercontent.com/114137/103497576-42c5cf00-4e42-11eb-8d7b-ada422c8393c.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16323

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
