### PR TITLE
Add view in visualization button to the device page for ZHA devices

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -89,6 +89,11 @@ export const reconfigureNode = (
     ieee: ieeeAddress,
   });
 
+export const refreshTopology = (hass: HomeAssistant): Promise<void> =>
+  hass.callWS({
+    type: "zha/topology/update",
+  });
+
 export const fetchAttributesForCluster = (
   hass: HomeAssistant,
   ieeeAddress: string,

--- a/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-actions-zha.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-actions-zha.ts
@@ -86,6 +86,11 @@ export class HaDeviceActionsZha extends LitElement {
             </mwc-button>
           `
         : ""}
+      <mwc-button @click=${this._onViewInVisualizationClick}>
+        ${this.hass!.localize(
+          "ui.dialogs.zha_device_info.buttons.view_in_visualization"
+        )}
+      </mwc-button>
     `;
   }
 
@@ -102,6 +107,13 @@ export class HaDeviceActionsZha extends LitElement {
 
   private _onAddDevicesClick() {
     navigate(this, "/config/zha/add/" + this._zhaDevice!.ieee);
+  }
+
+  private _onViewInVisualizationClick() {
+    navigate(
+      this,
+      "/config/zha/visualization/" + this._zhaDevice!.device_reg_id
+    );
   }
 
   private async _handleZigbeeInfoClicked() {

--- a/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-actions-zha.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-actions-zha.ts
@@ -79,6 +79,11 @@ export class HaDeviceActionsZha extends LitElement {
                 "ui.dialogs.zha_device_info.buttons.clusters"
               )}
             </mwc-button>
+            <mwc-button @click=${this._onViewInVisualizationClick}>
+              ${this.hass!.localize(
+                "ui.dialogs.zha_device_info.buttons.view_in_visualization"
+              )}
+            </mwc-button>
             <mwc-button class="warning" @click=${this._removeDevice}>
               ${this.hass!.localize(
                 "ui.dialogs.zha_device_info.buttons.remove"
@@ -86,11 +91,6 @@ export class HaDeviceActionsZha extends LitElement {
             </mwc-button>
           `
         : ""}
-      <mwc-button @click=${this._onViewInVisualizationClick}>
-        ${this.hass!.localize(
-          "ui.dialogs.zha_device_info.buttons.view_in_visualization"
-        )}
-      </mwc-button>
     `;
   }
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard-router.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard-router.ts
@@ -59,6 +59,8 @@ class ZHAConfigDashboardRouter extends HassRouterPage {
       el.groupId = this.routeTail.path.substr(1);
     } else if (this._currentPage === "device") {
       el.ieee = this.routeTail.path.substr(1);
+    } else if (this._currentPage === "visualization") {
+      el.zoomedDeviceId = this.routeTail.path.substr(1);
     }
 
     const searchParams = new URLSearchParams(window.location.search);

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -12,6 +12,8 @@ import {
 import { Edge, EdgeOptions, Network, Node } from "vis-network";
 import { navigate } from "../../../../../common/navigate";
 import "../../../../../common/search/search-input";
+import "../../../../../components/ha-button-menu";
+import "../../../../../components/buttons/ha-call-api-button";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/ha-button-menu";
 import "../../../../../components/ha-svg-icon";
@@ -25,7 +27,7 @@ import { formatAsPaddedHex } from "./functions";
 export class ZHANetworkVisualizationPage extends LitElement {
   @property({ type: Object }) public hass!: HomeAssistant;
 
-  @property({ type: Boolean }) public narrow!: boolean;
+  @property({ type: Boolean, reflect: true }) public narrow = false;
 
   @query("#visualization", true)
   private _visualization?: HTMLElement;
@@ -128,6 +130,11 @@ export class ZHANetworkVisualizationPage extends LitElement {
             .includeDomains="['zha']"
             @value-changed=${this._zoomToDevice}
           ></ha-device-picker>
+          <ha-call-api-button .hass=${this.hass} path="zha/topology/update">
+            ${this.hass!.localize(
+              "ui.panel.config.zha.visualization.refresh_topology"
+            )}
+          </ha-call-api-button>
         </div>
         <div id="visualization"></div>
       </hass-subpage>
@@ -299,29 +306,58 @@ export class ZHANetworkVisualizationPage extends LitElement {
           line-height: var(--paper-font-display1_-_line-height);
           opacity: var(--dark-primary-opacity);
         }
+
         .table-header {
           border-bottom: 1px solid --divider-color;
           padding: 0 16px;
           display: flex;
           align-items: center;
+          flex-direction: row;
           height: var(--header-height);
         }
+
+        :host([narrow]) .table-header {
+          flex-direction: column;
+          align-items: stretch;
+          height: var(--header-height) * 3;
+        }
+
         .search-toolbar {
           display: flex;
           align-items: center;
           color: var(--secondary-text-color);
           padding: 0 16px;
         }
+
         search-input {
           position: relative;
           top: 2px;
           flex: 1;
         }
+
+        :host(:not([narrow])) search-input {
+          margin: 5px;
+        }
+
         search-input.header {
           left: -8px;
         }
+
         ha-device-picker {
           flex: 1;
+        }
+
+        :host(:not([narrow])) ha-device-picker {
+          margin: 5px;
+        }
+
+        ha-call-api-button {
+          font-weight: 500;
+          color: var(--primary-color);
+        }
+
+        :host(:not([narrow])) ha-call-api-button {
+          margin: 5px;
         }
       `,
     ];

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -25,11 +25,9 @@ import "../../../../../components/ha-button-menu";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/ha-button-menu";
 import "../../../../../components/ha-svg-icon";
-import { fetchDevices, ZHADevice } from "../../../../../data/zha";
-import "../../../../../layouts/hass-subpage";
 import { PolymerChangedEvent } from "../../../../../polymer-types";
-import type { HomeAssistant } from "../../../../../types";
 import { formatAsPaddedHex } from "./functions";
+import { DeviceRegistryEntry } from "../../../../../data/device_registry";
 
 @customElement("zha-network-visualization-page")
 export class ZHANetworkVisualizationPage extends LitElement {
@@ -141,7 +139,7 @@ export class ZHANetworkVisualizationPage extends LitElement {
             .label=${this.hass.localize(
               "ui.panel.config.zha.visualization.zoom_label"
             )}
-            .includeDomains="['zha']"
+            .deviceFilter=${(device) => this._filterDevices(device)}
             @value-changed=${this._onZoomToDevice}
           ></ha-device-picker>
           <mwc-button @click=${this._refreshTopology}
@@ -312,6 +310,20 @@ export class ZHANetworkVisualizationPage extends LitElement {
 
   private async _refreshTopology(): Promise<void> {
     await refreshTopology(this.hass);
+  }
+
+  private _filterDevices(device: DeviceRegistryEntry): boolean {
+    if (!this.hass) {
+      return false;
+    }
+    for (const parts of device.identifiers) {
+      for (const part of parts) {
+        if (part === "zha") {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -9,11 +9,19 @@ import {
   PropertyValues,
   query,
 } from "lit-element";
-import { Edge, EdgeOptions, Network, Node } from "vis-network";
+
+import "@material/mwc-button";
 import { navigate } from "../../../../../common/navigate";
+import {
+  fetchDevices,
+  refreshTopology,
+  ZHADevice,
+} from "../../../../../data/zha";
+import "../../../../../layouts/hass-subpage";
+import type { HomeAssistant } from "../../../../../types";
+import { Network, Edge, Node, EdgeOptions } from "vis-network";
 import "../../../../../common/search/search-input";
 import "../../../../../components/ha-button-menu";
-import "../../../../../components/buttons/ha-call-api-button";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/ha-button-menu";
 import "../../../../../components/ha-svg-icon";
@@ -130,11 +138,11 @@ export class ZHANetworkVisualizationPage extends LitElement {
             .includeDomains="['zha']"
             @value-changed=${this._zoomToDevice}
           ></ha-device-picker>
-          <ha-call-api-button .hass=${this.hass} path="zha/topology/update">
-            ${this.hass!.localize(
+          <mwc-button @click=${this._refreshTopology}
+            >${this.hass!.localize(
               "ui.panel.config.zha.visualization.refresh_topology"
-            )}
-          </ha-call-api-button>
+            )}</mwc-button
+          >
         </div>
         <div id="visualization"></div>
       </hass-subpage>
@@ -292,6 +300,10 @@ export class ZHANetworkVisualizationPage extends LitElement {
     });
   }
 
+  private async _refreshTopology(): Promise<void> {
+    await refreshTopology(this.hass);
+  }
+
   static get styles(): CSSResult[] {
     return [
       css`
@@ -351,12 +363,12 @@ export class ZHANetworkVisualizationPage extends LitElement {
           margin: 5px;
         }
 
-        ha-call-api-button {
+        mwc-button {
           font-weight: 500;
           color: var(--primary-color);
         }
 
-        :host(:not([narrow])) ha-call-api-button {
+        :host(:not([narrow])) mwc-button {
           margin: 5px;
         }
       `,

--- a/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-network-visualization-page.ts
@@ -21,7 +21,6 @@ import "../../../../../layouts/hass-subpage";
 import type { HomeAssistant } from "../../../../../types";
 import { Network, Edge, Node, EdgeOptions } from "vis-network";
 import "../../../../../common/search/search-input";
-import "../../../../../components/ha-button-menu";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/ha-button-menu";
 import "../../../../../components/ha-svg-icon";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -743,7 +743,8 @@
           "remove": "Remove Device",
           "clusters": "Manage Clusters",
           "reconfigure": "Reconfigure Device",
-          "zigbee_information": "Zigbee device signature"
+          "zigbee_information": "Zigbee device signature",
+          "view_in_visualization": "View in Visualization"
         },
         "services": {
           "reconfigure": "Reconfigure ZHA device (heal device). Use this if you are having issues with the device. If the device in question is a battery powered device please ensure it is awake and accepting commands when you use this service.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2363,7 +2363,8 @@
             "header": "Network Visualization",
             "caption": "Visualization",
             "highlight_label": "Highlight Devices",
-            "zoom_label": "Zoom To Device"
+            "zoom_label": "Zoom To Device",
+            "refresh_topology": "Refresh Topology"
           },
           "group_binding": {
             "header": "Group Binding",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

This PR adds a button to the device page that allows you to jump directly to a zoomed in view of the device in the ZHA network visualization. It also adds a button to the visualization that allows you to request an update of the topology data from the network. 

~~**Needs a rebase after #7913 gets merged.**~~

**Depends on:** https://github.com/home-assistant/core/pull/44840

<img width="338" alt="Screen Shot 2021-01-05 at 7 31 00 AM" src="https://user-images.githubusercontent.com/1335687/103646954-8266e680-4f28-11eb-902f-2cb88146a4fc.png">

![view_in_viz](https://user-images.githubusercontent.com/1335687/103647121-c5c15500-4f28-11eb-8a25-c24d4b415b68.gif)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
