### PR TITLE
Format blueprint descriptions with markdown

### DIFF
--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../data/blueprint";
 import "../../../components/ha-blueprint-picker";
 import "../../../components/ha-circular-progress";
+import "../../../components/ha-markdown";
 import "../../../components/ha-selector/ha-selector";
 import "../../../components/ha-settings-row";
 
@@ -148,9 +149,11 @@ export class HaBlueprintAutomationEditor extends LitElement {
                   There is an error in this Blueprint: ${blueprint.error}
                 </p>`
               : html`${blueprint?.metadata.description
-                  ? html`<p class="card-content pre-line">
-                      ${blueprint.metadata.description}
-                    </p>`
+                  ? html`<ha-markdown
+                      class="card-content"
+                      breaks
+                      .content=${blueprint.metadata.description}
+                    ></ha-markdown>`
                   : ""}
                 ${blueprint?.metadata?.input &&
                 Object.keys(blueprint.metadata.input).length
@@ -266,9 +269,6 @@ export class HaBlueprintAutomationEditor extends LitElement {
       css`
         .padding {
           padding: 16px;
-        }
-        .pre-line {
-          white-space: pre-line;
         }
         .blueprint-picker-container {
           padding: 16px;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Blueprints can get pretty complex. Being able do describe them well would help.

![image](https://user-images.githubusercontent.com/1299821/103947251-1b1f8100-5138-11eb-988f-ae184b3b34c8.png)

Can this be abused? Yes.  
Does that make it a bad idea? No.


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
blueprint:
  name: Time of Day - Manager
  description: |
    ## Keeps track of Time of Day.

    This requires you to set up an `input_select` [helper entity](/config/helpers) which has the following options:

    * morning
    * day
    * evening
    * night

    Whenever the time of day changes, the event `TOD_UPDATE` is fired. You can use this event as a trigger for your automations, and either look at the `tod` parameter of the event data or the current state of the `input_select` to determine the current Time of Day.

  domain: automation
  input:
...

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
