### PR TITLE
Prevent YAML mode if no entity is set in card editor

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-humidifier-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-humidifier-card-editor.ts
@@ -20,7 +20,7 @@ import { configElementStyle } from "./config-elements-style";
 
 const cardConfigStruct = object({
   type: string(),
-  entity: string(),
+  entity: optional(string()),
   name: optional(string()),
   theme: optional(string()),
 });

--- a/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
@@ -28,7 +28,7 @@ import { configElementStyle } from "./config-elements-style";
 
 const cardConfigStruct = object({
   type: string(),
-  entity: string(),
+  entity: optional(string()),
   image: optional(string()),
   name: optional(string()),
   camera_image: optional(string()),

--- a/src/panels/lovelace/editor/config-elements/hui-plant-status-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-plant-status-card-editor.ts
@@ -21,7 +21,7 @@ import { configElementStyle } from "./config-elements-style";
 
 const cardConfigStruct = object({
   type: string(),
-  entity: string(),
+  entity: optional(string()),
   name: optional(string()),
   theme: optional(string()),
 });

--- a/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-thermostat-card-editor.ts
@@ -20,7 +20,7 @@ import { configElementStyle } from "./config-elements-style";
 
 const cardConfigStruct = object({
   type: string(),
-  entity: string(),
+  entity: optional(string()),
   name: optional(string()),
   theme: optional(string()),
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

A few card editors had the `entity` parameter that from a logical perspective is mandatory also defined as a technical requirement. That meant if you e.g. entered the editor of a `thermostat` card and cleared the entity input field, the editor would be forced into YAML mode, since `entity` was now undefined.

This PR now marks them as technically optional (as was already the case for most other editors). The cards themselves are already checking if no matching entity is provided and will render the appropriate error message directly to the card to inform the user anyway.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
