### PR TITLE
Align entities card section header styling

### DIFF
--- a/src/panels/lovelace/special-rows/hui-section-row.ts
+++ b/src/panels/lovelace/special-rows/hui-section-row.ts
@@ -41,10 +41,11 @@ class HuiSectionRow extends LitElement implements LovelaceRow {
   static get styles(): CSSResult {
     return css`
       .label {
-        color: var(--primary-color);
+        color: var(--secondary-text-color);
         margin-left: 8px;
-        margin-bottom: 16px;
+        margin-bottom: 8px;
         margin-top: 16px;
+        font-weight: 500;
       }
       .divider {
         height: 1px;

--- a/src/panels/lovelace/special-rows/hui-section-row.ts
+++ b/src/panels/lovelace/special-rows/hui-section-row.ts
@@ -41,7 +41,7 @@ class HuiSectionRow extends LitElement implements LovelaceRow {
   static get styles(): CSSResult {
     return css`
       .label {
-        color: var(--secondary-text-color);
+        color: var(--primary-text-color);
         margin-left: 8px;
         margin-bottom: 8px;
         margin-top: 16px;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Currently the section header is using the primary color that we normally reserve for links, buttons, other interactive elements. This is quite misleading.

![grafik](https://user-images.githubusercontent.com/114137/104017825-1bac2c00-51b9-11eb-87d1-f7a49dd68333.png)

I tried several alternatives. In all I reduced the margin at the bottom to the next element a bit since it was quite far away.

1. Primary text color:
![grafik](https://user-images.githubusercontent.com/114137/104017942-4ac29d80-51b9-11eb-83b6-f04044ecb30d.png)

2. Primary text color + font weight:
![grafik](https://user-images.githubusercontent.com/114137/104017976-5d3cd700-51b9-11eb-8bc2-af390a627e23.png)

3. Secondary text color + font weight:
![grafik](https://user-images.githubusercontent.com/114137/104018598-5b274800-51ba-11eb-81e9-1d4814176ddb.png)

4. Use exact style from entity / gauge card (when https://github.com/home-assistant/frontend/pull/8081 merged) = secondary text color + font weight + font size 16px
![grafik](https://user-images.githubusercontent.com/114137/104018022-75acf180-51b9-11eb-8fe4-baf520bc4cda.png)

=> I personally like the "sleek" look in number 3 esp. when combined with other cards such as entity or gauge. It feels lighter and provides better separation between regular rows and the section header.
The font size increase in number 4 makes it more consistent with the other cards, but is not really required, since the text color already provides enough visual separation.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
