### PR TITLE
Show entity_picture in logbook

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -138,6 +138,9 @@ export const DOMAINS_TOGGLE = new Set([
   "humidifier",
 ]);
 
+/** Domains that have a dynamic entity image / picture. */
+export const DOMAINS_WITH_DYNAMIC_PICTURE = new Set(["camera", "media_player"]);
+
 /** Temperature units. */
 export const UNIT_C = "°C";
 export const UNIT_F = "°F";

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -11,6 +11,7 @@ import {
 } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 import { scroll } from "lit-virtualizer";
+import { DOMAINS_WITH_DYNAMIC_PICTURE } from "../../common/const";
 import { formatDate } from "../../common/datetime/format_date";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
@@ -18,9 +19,9 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { domainIcon } from "../../common/entity/domain_icon";
 import { computeRTL, emitRTLDirection } from "../../common/util/compute_rtl";
+import "../../components/entity/state-badge";
 import "../../components/ha-circular-progress";
 import "../../components/ha-relative-time";
-import "../../components/entity/state-badge";
 import { LogbookEntry } from "../../data/logbook";
 import { haStyle, haStyleScrollbar } from "../../resources/styles";
 import { HomeAssistant } from "../../types";
@@ -116,6 +117,7 @@ class HaLogbook extends LitElement {
       : undefined;
     const item_username =
       item.context_user_id && this.userIdToName[item.context_user_id];
+    const domain = item.entity_id ? computeDomain(item.entity_id) : item.domain;
 
     return html`
       <div class="entry-container">
@@ -134,20 +136,17 @@ class HaLogbook extends LitElement {
         <div class="entry ${classMap({ "no-entity": !item.entity_id })}">
           <div class="icon-message">
             ${!this.noIcon
-              ? html`
+              ? // We do not want to use dynamic entity pictures (e.g., from media player) for the log book rendering,
+                // as they would present a false state in the log (played media right now vs actual historic data).
+                html`
                   <state-badge
                     .hass=${this.hass}
                     .overrideIcon=${item.icon ??
-                    domainIcon(
-                      item.entity_id
-                        ? computeDomain(item.entity_id)
-                        : item.domain,
-                      stateObj,
-                      item.state
-                    )}
-                    .overrideImage=${stateObj?.attributes
-                      .entity_picture_local ||
-                    stateObj?.attributes.entity_picture}
+                    domainIcon(domain, stateObj, item.state)}
+                    .overrideImage=${DOMAINS_WITH_DYNAMIC_PICTURE.has(domain)
+                      ? ""
+                      : stateObj?.attributes.entity_picture_local ||
+                        stateObj?.attributes.entity_picture}
                   ></state-badge>
                 `
               : ""}

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -19,8 +19,8 @@ import { computeDomain } from "../../common/entity/compute_domain";
 import { domainIcon } from "../../common/entity/domain_icon";
 import { computeRTL, emitRTLDirection } from "../../common/util/compute_rtl";
 import "../../components/ha-circular-progress";
-import "../../components/ha-icon";
 import "../../components/ha-relative-time";
+import "../../components/entity/state-badge";
 import { LogbookEntry } from "../../data/logbook";
 import { haStyle, haStyleScrollbar } from "../../resources/styles";
 import { HomeAssistant } from "../../types";
@@ -111,7 +111,9 @@ class HaLogbook extends LitElement {
     }
 
     const previous = this.entries[index - 1];
-    const state = item.entity_id ? this.hass.states[item.entity_id] : undefined;
+    const stateObj = item.entity_id
+      ? this.hass.states[item.entity_id]
+      : undefined;
     const item_username =
       item.context_user_id && this.userIdToName[item.context_user_id];
 
@@ -133,16 +135,20 @@ class HaLogbook extends LitElement {
           <div class="icon-message">
             ${!this.noIcon
               ? html`
-                  <ha-icon
-                    .icon=${item.icon ??
+                  <state-badge
+                    .hass=${this.hass}
+                    .overrideIcon=${item.icon ??
                     domainIcon(
                       item.entity_id
                         ? computeDomain(item.entity_id)
                         : item.domain,
-                      state,
+                      stateObj,
                       item.state
                     )}
-                  ></ha-icon>
+                    .overrideImage=${stateObj?.attributes
+                      .entity_picture_local ||
+                    stateObj?.attributes.entity_picture}
+                  ></state-badge>
                 `
               : ""}
             <div class="message-relative_time">
@@ -295,7 +301,7 @@ class HaLogbook extends LitElement {
           color: var(--secondary-text-color);
         }
 
-        ha-icon {
+        state-badge {
           margin-right: 16px;
           flex-shrink: 0;
           color: var(--state-icon-color);
@@ -330,7 +336,7 @@ class HaLogbook extends LitElement {
           padding: 8px;
         }
 
-        .narrow .icon-message ha-icon {
+        .narrow .icon-message state-badge {
           margin-left: 0;
         }
       `,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Switched out the `<ha-icon>` against a `<state-badge>`. For it work I adjusted the state-badge a bit so it can work without a `stateObj` since some logbook entries do not have an actual object (e.g. HA stop and start).

![grafik](https://user-images.githubusercontent.com/114137/104091336-0567a400-527d-11eb-9b8e-8c49324ccf23.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/7734
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
