### PR TITLE
Increase font size for alarm keypad number buttons

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -197,7 +197,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
           ? html``
           : html`
               <div id="keypad">
-                ${BUTTONS.map((value, index) => {
+                ${BUTTONS.map((value) => {
                   return value === ""
                     ? html` <mwc-button disabled></mwc-button> `
                     : html`
@@ -206,7 +206,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                           @click="${this._handlePadClick}"
                           outlined
                           class=${classMap({
-                            numberkey: index !== BUTTONS.length - 1, // exclude last key = "clear"
+                            numberkey: value !== "clear",
                           })}
                         >
                           ${value === "clear"

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -368,7 +368,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       }
 
       mwc-button.numberkey {
-        --mdc-typography-button-font-size: 22px;
+        --mdc-typography-button-font-size: var(--keypad-font-size, 0.875rem);
       }
     `;
   }

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -197,7 +197,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
           ? html``
           : html`
               <div id="keypad">
-                ${BUTTONS.map((value) => {
+                ${BUTTONS.map((value, index) => {
                   return value === ""
                     ? html` <mwc-button disabled></mwc-button> `
                     : html`
@@ -205,6 +205,9 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
                           .value="${value}"
                           @click="${this._handlePadClick}"
                           outlined
+                          class=${classMap({
+                            numberkey: index !== BUTTONS.length - 1, // exclude last key = "clear"
+                          })}
                         >
                           ${value === "clear"
                             ? this.hass!.localize(
@@ -344,7 +347,6 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       }
 
       #keypad mwc-button {
-        text-size: 20px;
         padding: 8px;
         width: 30%;
         box-sizing: border-box;
@@ -363,6 +365,10 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
 
       mwc-button#disarm {
         color: var(--error-color);
+      }
+
+      mwc-button.numberkey {
+        --mdc-typography-button-font-size: 22px;
       }
     `;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Allow the option to style the font size for alarm keypad number buttons for better readability. The non-number buttons are left unchanged.

Example when styled to 22px:
![grafik](https://user-images.githubusercontent.com/114137/104095267-3accbb80-5296-11eb-8186-616ff2e919d6.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/discussions/8005
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
