### PR TITLE
Provide stub config for entity-filter

### DIFF
--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -15,6 +15,15 @@ import {
 import { computeCardSize } from "../common/compute-card-size";
 
 class EntityFilterCard extends UpdatingElement implements LovelaceCard {
+  public static getStubConfig(): EntityFilterCardConfig {
+    return {
+      type: "entity-filter",
+      entities: [{ entity: "sun.sun" }],
+      state_filter: ["above_horizon"],
+      card: { type: "entities", title: "Sun up" },
+    };
+  }
+
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @property() public isPanel = false;

--- a/src/panels/lovelace/cards/hui-entity-filter-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-filter-card.ts
@@ -1,26 +1,42 @@
+import {
+  internalProperty,
+  property,
+  PropertyValues,
+  UpdatingElement,
+} from "lit-element";
 import { LovelaceCardConfig } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
+import { computeCardSize } from "../common/compute-card-size";
 import { evaluateFilter } from "../common/evaluate-filter";
+import { findEntities } from "../common/find-entites";
 import { processConfigEntities } from "../common/process-config-entities";
 import { createCardElement } from "../create-element/create-card-element";
 import { EntityFilterEntityConfig } from "../entity-rows/types";
 import { LovelaceCard } from "../types";
 import { EntityFilterCardConfig } from "./types";
-import {
-  property,
-  internalProperty,
-  PropertyValues,
-  UpdatingElement,
-} from "lit-element";
-import { computeCardSize } from "../common/compute-card-size";
 
 class EntityFilterCard extends UpdatingElement implements LovelaceCard {
-  public static getStubConfig(): EntityFilterCardConfig {
+  public static getStubConfig(
+    hass: HomeAssistant,
+    entities: string[],
+    entitiesFallback: string[]
+  ): EntityFilterCardConfig {
+    const maxEntities = 3;
+    const foundEntities = findEntities(
+      hass,
+      maxEntities,
+      entities,
+      entitiesFallback,
+      ["light", "switch", "sensor"]
+    );
+
     return {
       type: "entity-filter",
-      entities: [{ entity: "sun.sun" }],
-      state_filter: ["above_horizon"],
-      card: { type: "entities", title: "Sun up" },
+      entities: foundEntities,
+      state_filter: [
+        foundEntities[0] ? hass.states[foundEntities[0]].state : "",
+      ],
+      card: { type: "entities" },
     };
   }
 

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -91,7 +91,7 @@ export interface EntityFilterCardConfig extends LovelaceCardConfig {
   type: "entity-filter";
   entities: Array<EntityFilterEntityConfig | string>;
   state_filter: Array<{ key: string } | string>;
-  card: Partial<LovelaceCardConfig>;
+  card?: Partial<LovelaceCardConfig>;
   show_empty?: boolean;
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2708,7 +2708,7 @@
               "image": "Image Path",
               "maximum": "Maximum",
               "manual": "Manual",
-              "manual_description": "Need to add a custom card or just want to manually write the yaml?",
+              "manual_description": "Need to add a custom card or just want to manually write the YAML?",
               "minimum": "Minimum",
               "name": "Name",
               "refresh_interval": "Refresh Interval",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Void in case https://github.com/home-assistant/frontend/pull/7637 gets merged soon.

Currently, if you add an entity-filter you are greeted by the YAML editor in an error state, because mandatory config keys are missing. With this PR we now provide something meaningful as a starting point.

![grafik](https://user-images.githubusercontent.com/114137/104098130-bb8eb600-529c-11eb-8ea2-f900a53556c2.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
