### PR TITLE
Fix history and logbook for input_datetime

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -40,7 +40,9 @@ export const computeStateDisplay = (
       return formatTime(date, language);
     }
 
-    date = new Date(compareState);
+    // For datetime, we have to ensure that we have an ISO date with the
+    // "T" separator to prevent issues on iOS and macOS.
+    date = new Date(compareState.replace(" ", "T"));
     return formatDateTime(date, language);
   }
 

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -30,34 +30,17 @@ export const computeStateDisplay = (
   if (domain === "input_datetime") {
     let date: Date;
     if (!stateObj.attributes.has_time) {
-      date = new Date(
-        stateObj.attributes.year,
-        stateObj.attributes.month - 1,
-        stateObj.attributes.day
-      );
+      date = new Date(compareState);
       return formatDate(date, language);
     }
     if (!stateObj.attributes.has_date) {
-      const now = new Date();
-      date = new Date(
-        // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548
-        // don't use artificial 1970 year.
-        now.getFullYear(),
-        now.getMonth(),
-        now.getDay(),
-        stateObj.attributes.hour,
-        stateObj.attributes.minute
-      );
+      const parts = compareState.split(":").map(Number);
+      date = new Date();
+      date.setHours(parts[0], parts[1], parts[2]);
       return formatTime(date, language);
     }
 
-    date = new Date(
-      stateObj.attributes.year,
-      stateObj.attributes.month - 1,
-      stateObj.attributes.day,
-      stateObj.attributes.hour,
-      stateObj.attributes.minute
-    );
+    date = new Date(compareState);
     return formatDateTime(date, language);
   }
 

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -30,7 +30,11 @@ export const computeStateDisplay = (
   if (domain === "input_datetime") {
     let date: Date;
     if (!stateObj.attributes.has_time) {
-      date = new Date(compareState);
+      const parts = compareState.split("-").map(Number);
+      date = new Date();
+      date.setFullYear(parts[0]);
+      date.setMonth(parts[1]);
+      date.setDate(parts[2]);
       return formatDate(date, language);
     }
     if (!stateObj.attributes.has_date) {
@@ -40,7 +44,7 @@ export const computeStateDisplay = (
       return formatTime(date, language);
     }
 
-    // For datetime, we have to ensure that we have an ISO date with the
+    // For datetime, we have to ensure that we have an ISO string with the
     // "T" separator to prevent issues on iOS and macOS.
     date = new Date(compareState.replace(" ", "T"));
     return formatDateTime(date, language);

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -33,7 +33,7 @@ export const computeStateDisplay = (
       const parts = compareState.split("-").map(Number);
       date = new Date();
       date.setFullYear(parts[0]);
-      date.setMonth(parts[1]);
+      date.setMonth(parts[1] - 1);
       date.setDate(parts[2]);
       return formatDate(date, language);
     }

--- a/src/data/cached-history.ts
+++ b/src/data/cached-history.ts
@@ -121,6 +121,10 @@ export const getRecentWithCache = (
 
   const curCacheProm = cache.prom;
 
+  // For accurate history display of an input_datetime we require the attributes
+  // => we need a complete response => minimalResponse = false
+  const minimalResponse = entityId.split(".")[0] !== "input_datetime";
+
   const genProm = async () => {
     let fetchedHistory: HassEntity[][];
 
@@ -132,7 +136,9 @@ export const getRecentWithCache = (
           entityId,
           toFetchStartTime,
           endTime,
-          appendingToCache
+          appendingToCache,
+          undefined,
+          minimalResponse
         ),
       ]);
       fetchedHistory = results[1];

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -54,7 +54,7 @@ export interface HistoryResult {
 
 export const fetchRecent = (
   hass,
-  entityId,
+  entityId: string,
   startTime,
   endTime,
   skipInitialState = false,
@@ -86,13 +86,14 @@ export const fetchDate = (
   hass: HomeAssistant,
   startTime: Date,
   endTime: Date,
-  entityId
+  entityId: string,
+  minimalResponse = true
 ): Promise<HassEntity[][]> => {
   return hass.callApi(
     "GET",
-    `history/period/${startTime.toISOString()}?end_time=${endTime.toISOString()}&minimal_response${
-      entityId ? `&filter_entity_id=${entityId}` : ``
-    }`
+    `history/period/${startTime.toISOString()}?end_time=${endTime.toISOString()}${
+      minimalResponse ? "&minimal_response" : ""
+    }${entityId ? `&filter_entity_id=${entityId}` : ``}`
   );
 };
 

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -172,11 +172,17 @@ class HaPanelHistory extends LitElement {
 
   private async _getHistory() {
     this._isLoading = true;
+
+    // For accurate history display of an input_datetime we require the attributes
+    // => we need a complete response => minimalResponse = false
+    const minimalResponse = this._entityId.split(".")[0] !== "input_datetime";
+
     const dateHistory = await fetchDate(
       this.hass,
       this._startDate,
       this._endDate,
-      this._entityId
+      this._entityId,
+      minimalResponse
     );
     this._stateHistory = computeHistory(
       this.hass,

--- a/test-mocha/common/entity/compute_state_display.ts
+++ b/test-mocha/common/entity/compute_state_display.ts
@@ -139,7 +139,7 @@ describe("computeStateDisplay", () => {
   it("Localizes input_datetime with full date time", () => {
     const stateObj: any = {
       entity_id: "input_datetime.test",
-      state: "123",
+      state: "2017-11-18 11:12:13",
       attributes: {
         has_date: true,
         has_time: true,
@@ -160,7 +160,7 @@ describe("computeStateDisplay", () => {
   it("Localizes input_datetime with date", () => {
     const stateObj: any = {
       entity_id: "input_datetime.test",
-      state: "123",
+      state: "2017-11-18",
       attributes: {
         has_date: true,
         has_time: false,
@@ -181,7 +181,7 @@ describe("computeStateDisplay", () => {
   it("Localizes input_datetime with time", () => {
     const stateObj: any = {
       entity_id: "input_datetime.test",
-      state: "123",
+      state: "11:12:13",
       attributes: {
         has_date: false,
         has_time: true,


### PR DESCRIPTION
Probably obsolete once core PR https://github.com/home-assistant/core/pull/45208 has been merged.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The underlying reason for the problem that both history and logbook for `input_datetime` were incorrect, stems from the following:

Function `computeStateDisplay()` assumed that for `input_datetime` the `attributes` of the state would always be available, both to determine the state type ("date", "time" or "datetime" via the `hass_time` and `hass_date` flags) as well as for the actual values. For separate reasons that however was never true:

History: The backend data retrieval always used "minimal_response" which meant only the first and last returned state contained the attributes.
Logbook: The backend webservice never provided the state attributes at all.

The solution I came up with consists of the following parts:
1. For the history webservice call check if we are requesting data for an `input_datetime`. If yes, never set the `minimal_response` parameter.
2. Adjust `computeStateDisplay()` so that for the actual state display, we no longer use the attributes, but the state itself. We still use the attributes to determine the type ("date", "time" or "datetime"). Two scenarios come into play here:
2.1 Execution for history: Thanks to point 1, we will always have the attributes of the history state entries now => so even if in the middle of the historic data the type changed, the display will be correct since each state carries the type info ("date", "time" or "datetime").
2.2. Execution for logbook: Since we will never have the historic state attributes here, we have to rely on the type provided by the current state attributes. That means that if in the past the entity was of type "date" and now has been switched to "time", some logbook entries will show incorrect data, since we always have to assume "time" now.

If we are fine with the restriction from the logbook logic (and I cannot imagine a scenario where an `input_datetime` is changing its type), then we could even revert the changes in regards to "minimal_response" for the history to reduce the data load.

Note: The initial history panel display will request historic data for all entities => no entity filter => cannot check for `input_datetime` => behavior the same as int he logbook (we have to assume the type based on the current attributes).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/7309
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
