### PR TITLE
Ensure we always show backend error in automation and script editor

### DIFF
--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -502,9 +502,9 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
         }
       },
       (errors) => {
-        this._errors = errors.body.message;
+        this._errors = errors.body.message || errors.body;
         showToast(this, {
-          message: errors.body.message,
+          message: errors.body.message || errors.body,
         });
         throw errors;
       }

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -502,7 +502,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
         }
       },
       (errors) => {
-        this._errors = errors.body.message || errors.body;
+        this._errors = errors.body.message || errors.error || errors.body;
         showToast(this, {
           message: errors.body.message || errors.body,
         });

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -504,7 +504,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
       (errors) => {
         this._errors = errors.body.message || errors.error || errors.body;
         showToast(this, {
-          message: errors.body.message || errors.body,
+          message: errors.body.message || errors.error || errors.body,
         });
         throw errors;
       }

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -660,9 +660,9 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
         }
       },
       (errors) => {
-        this._errors = errors.body.message || errors.body;
+        this._errors = errors.body.message || errors.error || errors.body;
         showToast(this, {
-          message: errors.body.message || errors.body,
+          message: errors.body.message || errors.error || errors.body,
         });
         throw errors;
       }

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -660,9 +660,9 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
         }
       },
       (errors) => {
-        this._errors = errors.body.message;
+        this._errors = errors.body.message || errors.body;
         showToast(this, {
-          message: errors.body.message,
+          message: errors.body.message || errors.body,
         });
         throw errors;
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

I have an automation currently that I cannot save due to some backend failöure (separate issue). However, in that case the frontend only shows an empty toast as the backend is not actually providing a proper error message.

This PR ensures that we at least show the more generic error to inform the user.

Debug screenshot of generic backend response:
![image](https://user-images.githubusercontent.com/114137/104251518-32c87380-5470-11eb-9979-5aeee2f77b1a.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
