### PR TITLE
Change supportsStop to supportsStopTilt

### DIFF
--- a/src/components/ha-cover-tilt-controls.ts
+++ b/src/components/ha-cover-tilt-controls.ts
@@ -50,7 +50,7 @@ class HaCoverTiltControls extends LitElement {
       ></ha-icon-button>
       <ha-icon-button
         class=${classMap({
-          invisible: !this._entityObj.supportsStop,
+          invisible: !this._entityObj.supportsStopTilt,
         })}
         label=${this.hass.localize("ui.dialogs.more_info_control.stop_cover")}
         icon="hass:stop"


### PR DESCRIPTION
## Proposed change

Since a recent update, the controls for a cover with only tilt features are partially broken. The `stop` button is not present anymore since a recent update. This is due to the fact that front-end checks for `supportsStop` instead of `supportsStopTilt`. This is the wrong feature from `supported_features`, since it is not related to the tilt controls.

**Before:**
<img width="320" alt="Screen Shot 2021-01-13 at 18 23 59" src="https://user-images.githubusercontent.com/1424596/104491088-0af12100-55d2-11eb-9d1f-1b07656aba91.png">

**After:**
<img width="480" alt="Screen Shot 2021-01-13 at 18 38 48" src="https://user-images.githubusercontent.com/1424596/104491085-09275d80-55d2-11eb-854b-f0451093ef1d.png">

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

- This PR fixes or closes issue: fixes #7186, fixes #7750
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
