### PR TITLE
Allow timestamp attribute formatting + central timestamp formats

### DIFF
--- a/src/common/datetime/check_valid_date.ts
+++ b/src/common/datetime/check_valid_date.ts
@@ -1,0 +1,7 @@
+export default function checkValidDate(date?: Date): boolean {
+  if (!date) {
+    return false;
+  }
+
+  return date instanceof Date && !isNaN(date.valueOf());
+}

--- a/src/common/datetime/check_valid_datetime_string.ts
+++ b/src/common/datetime/check_valid_datetime_string.ts
@@ -1,4 +1,0 @@
-export default function checkValidDatetimeString(datetime: string): boolean {
-  const date = new Date(datetime);
-  return date instanceof Date && !isNaN(date.valueOf());
-}

--- a/src/common/datetime/check_valid_datetime_string.ts
+++ b/src/common/datetime/check_valid_datetime_string.ts
@@ -1,0 +1,4 @@
+export default function checkValidDatetimeString(datetime: string): boolean {
+  const date = new Date(datetime);
+  return date instanceof Date && !isNaN(date.valueOf());
+}

--- a/src/panels/lovelace/components/hui-timestamp-display.ts
+++ b/src/panels/lovelace/components/hui-timestamp-display.ts
@@ -12,6 +12,7 @@ import { formatDateTime } from "../../../common/datetime/format_date_time";
 import { formatTime } from "../../../common/datetime/format_time";
 import relativeTime from "../../../common/datetime/relative_time";
 import { HomeAssistant } from "../../../types";
+import { TimestampRenderingFormats } from "./types";
 
 const FORMATS: { [key: string]: (ts: Date, lang: string) => string } = {
   date: formatDate,
@@ -26,12 +27,7 @@ class HuiTimestampDisplay extends LitElement {
 
   @property() public ts?: Date;
 
-  @property() public format?:
-    | "relative"
-    | "total"
-    | "date"
-    | "datetime"
-    | "time";
+  @property() public format?: TimestampRenderingFormats;
 
   @internalProperty() private _relative?: string;
 

--- a/src/panels/lovelace/components/types.ts
+++ b/src/panels/lovelace/components/types.ts
@@ -6,3 +6,10 @@ export interface ConditionalBaseConfig extends LovelaceCardConfig {
   card: LovelaceCardConfig | LovelaceElementConfig;
   conditions: Condition[];
 }
+
+export type TimestampRenderingFormats =
+  | "relative"
+  | "total"
+  | "date"
+  | "time"
+  | "datetime";

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -22,10 +22,11 @@ import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
 import "../components/hui-timestamp-display";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
+import { TimestampRenderingFormats } from "../components/types";
 import { LovelaceRow } from "./types";
 
 interface SensorEntityConfig extends EntitiesCardEntityConfig {
-  format?: "relative" | "total" | "date" | "time" | "datetime";
+  format?: TimestampRenderingFormats;
 }
 
 @customElement("hui-sensor-entity-row")

--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -1,6 +1,7 @@
 import { ActionConfig } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
 import { Condition } from "../common/validate-condition";
+import { TimestampRenderingFormats } from "../components/types";
 
 export interface EntityConfig {
   entity: string;
@@ -84,8 +85,10 @@ export interface ConditionalRowConfig extends EntityConfig {
   row: EntityConfig;
   conditions: Condition[];
 }
+
 export interface AttributeRowConfig extends EntityConfig {
   attribute: string;
   prefix?: string;
   suffix?: string;
+  format?: TimestampRenderingFormats;
 }

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -46,7 +46,6 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
     }
 
     const stateObj = this.hass.states[this._config.entity];
-    const attribute = stateObj.attributes[this._config.attribute];
 
     if (!stateObj) {
       return html`
@@ -56,6 +55,7 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
       `;
     }
 
+    const attribute = stateObj.attributes[this._config.attribute];
     let date: Date | undefined;
     if (this._config.format) {
       date = new Date(attribute);

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -12,6 +12,7 @@ import {
 import { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
+import "../components/hui-timestamp-display";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { AttributeRowConfig, LovelaceRow } from "../entity-rows/types";
 
@@ -57,7 +58,15 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <div>
-          ${this._config.prefix} ${attribute ?? "-"} ${this._config.suffix}
+          ${this._config.prefix}
+          ${this._config.format
+            ? html` <hui-timestamp-display
+                .hass=${this.hass}
+                .ts=${new Date(attribute)}
+                .format=${this._config.format}
+              ></hui-timestamp-display>`
+            : attribute ?? "-"}
+          ${this._config.suffix}
         </div>
       </hui-generic-entity-row>
     `;

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -9,6 +9,7 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit-element";
+import checkValidDatetimeString from "../../../common/datetime/check_valid_datetime_string";
 import { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
@@ -59,7 +60,7 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <div>
           ${this._config.prefix}
-          ${this._config.format
+          ${this._config.format && checkValidDatetimeString(attribute)
             ? html` <hui-timestamp-display
                 .hass=${this.hass}
                 .ts=${new Date(attribute)}

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -9,7 +9,7 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit-element";
-import checkValidDatetimeString from "../../../common/datetime/check_valid_datetime_string";
+import checkValidDate from "../../../common/datetime/check_valid_date";
 import { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
@@ -56,14 +56,19 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
       `;
     }
 
+    let date: Date | undefined;
+    if (this._config.format) {
+      date = new Date(attribute);
+    }
+
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <div>
           ${this._config.prefix}
-          ${this._config.format && checkValidDatetimeString(attribute)
+          ${this._config.format && checkValidDate(date)
             ? html` <hui-timestamp-display
                 .hass=${this.hass}
-                .ts=${new Date(attribute)}
+                .ts=${date}
                 .format=${this._config.format}
               ></hui-timestamp-display>`
             : attribute ?? "-"}

--- a/test-mocha/common/datetime/check_valid_date.ts
+++ b/test-mocha/common/datetime/check_valid_date.ts
@@ -1,0 +1,19 @@
+import { assert } from "chai";
+
+import checkValidDate from "../../../src/common/datetime/check_valid_date";
+
+describe("checkValidDate", () => {
+  it("works", () => {
+    assert.strictEqual(checkValidDate(new Date()), true);
+    assert.strictEqual(
+      checkValidDate(new Date("2021-01-19T11:36:57+00:00")),
+      true
+    );
+    assert.strictEqual(
+      checkValidDate(new Date("2021-01-19X11:36:57+00:00")),
+      false
+    );
+    assert.strictEqual(checkValidDate(new Date("2021-01-19")), true);
+    assert.strictEqual(checkValidDate(undefined), false);
+  });
+});

--- a/test-mocha/common/datetime/relative_time.ts
+++ b/test-mocha/common/datetime/relative_time.ts
@@ -1,0 +1,217 @@
+import { assert } from "chai";
+
+import relativeTime from "../../../src/common/datetime/relative_time";
+
+describe("relativeTime", () => {
+  // Mock localize function for testing
+  const localize = (message, ...args) =>
+    message + (args.length ? ": " + args.join(",") : "");
+
+  it("now", () => {
+    const now = new Date();
+    assert.strictEqual(
+      relativeTime(now, localize, { compareTime: now }),
+      "ui.components.relative_time.just_now"
+    );
+  });
+
+  it("past_second", () => {
+    const inputdt = new Date("2021-02-03T11:22:00+00:00");
+    const compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.past_duration.second: count,33"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.second: count,33"
+    );
+  });
+
+  it("past_minute", () => {
+    const inputdt = new Date("2021-02-03T11:20:33+00:00");
+    const compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.past_duration.minute: count,2"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.minute: count,2"
+    );
+  });
+
+  it("past_hour", () => {
+    const inputdt = new Date("2021-02-03T09:22:33+00:00");
+    const compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.past_duration.hour: count,2"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.hour: count,2"
+    );
+  });
+
+  it("past_day", () => {
+    let inputdt = new Date("2021-02-01T11:22:33+00:00");
+    let compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.past_duration.day: count,2"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.day: count,2"
+    );
+
+    // Test switch from days to weeks
+    inputdt = new Date("2021-01-28T11:22:33+00:00");
+    compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.day: count,6"
+    );
+    inputdt = new Date("2021-01-27T11:22:33+00:00");
+    compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.notStrictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.day: count,7"
+    );
+  });
+
+  it("past_week", () => {
+    const inputdt = new Date("2021-01-03T11:22:33+00:00");
+    const compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.past_duration.week: count,4"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.week: count,4"
+    );
+  });
+
+  it("future_second", () => {
+    const inputdt = new Date("2021-02-03T11:22:55+00:00");
+    const compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.future_duration.second: count,22"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.second: count,22"
+    );
+  });
+
+  it("future_minute", () => {
+    const inputdt = new Date("2021-02-03T11:24:33+00:00");
+    const compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.future_duration.minute: count,2"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.minute: count,2"
+    );
+  });
+
+  it("future_hour", () => {
+    const inputdt = new Date("2021-02-03T13:22:33+00:00");
+    const compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.future_duration.hour: count,2"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.hour: count,2"
+    );
+  });
+
+  it("future_day", () => {
+    let inputdt = new Date("2021-02-05T11:22:33+00:00");
+    let compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.future_duration.day: count,2"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.day: count,2"
+    );
+
+    // Test switch from days to weeks
+    inputdt = new Date("2021-02-09T11:22:33+00:00");
+    compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.day: count,6"
+    );
+    inputdt = new Date("2021-02-10T11:22:33+00:00");
+    compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.notStrictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.day: count,7"
+    );
+  });
+
+  it("future_week", () => {
+    const inputdt = new Date("2021-03-03T11:22:33+00:00");
+    const compare = new Date("2021-02-03T11:22:33+00:00");
+    assert.strictEqual(
+      relativeTime(inputdt, localize, { compareTime: compare }),
+      "ui.components.relative_time.future_duration.week: count,4"
+    );
+    assert.strictEqual(
+      relativeTime(inputdt, localize, {
+        compareTime: compare,
+        includeTense: false,
+      }),
+      "ui.components.relative_time.duration.week: count,4"
+    );
+  });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

1. Centralize the definition of allowed timestamp formats rather than duplicating in many places.
2. Allow setting of `format` for attributes in `entities` card to be consistent with entity state rendering.

If the attribute is not a valid timestamp value, then the `hui-timestamp-display` will show "Invalid timestamp".

Before:
![image](https://user-images.githubusercontent.com/114137/104595485-f9ac2100-5672-11eb-8cff-a4537aa15071.png)


After:
![image](https://user-images.githubusercontent.com/114137/104595407-de411600-5672-11eb-8b63-8d143b4f8a8e.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: entities
entities:
  - type: attribute
    entity: sun.sun
    attribute: next_rising
    format: datetime
    secondary_info: last-changed
    name: Next sun rising
  - entity: sun.sun
    secondary_info: last-changed
state_color: true
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
