### PR TITLE
Make scenes toggleable

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -136,6 +136,7 @@ export const DOMAINS_TOGGLE = new Set([
   "group",
   "automation",
   "humidifier",
+  "scene",
 ]);
 
 /** Temperature units. */

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -121,7 +121,7 @@ export const DOMAINS_HIDE_MORE_INFO = [
 export const DOMAINS_MORE_INFO_NO_HISTORY = ["camera", "configurator", "scene"];
 
 /** States that we consider "off". */
-export const STATES_OFF = ["closed", "locked", "off"];
+export const STATES_OFF = ["closed", "locked", "off", "scening"];
 
 /** Binary States */
 export const BINARY_STATE_ON = "on";


### PR DESCRIPTION
## Proposed change
This PR adds the state "scening" to the list of entity states that are considered an "off" state. Like that, scenes (that are always in the "scening" state), will always be turned on when they are toggled. This simplifies the configuration of button cards, entity buttons, and header/footer buttons that are supposed to turn on scenes: The user only has to select the entity id when configuring the button in the UI editor, there is no need anymore to change the tap action to call-service and configure service data in the code view.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Before this PR:
```yaml
type: button
tap_action:
  action: call-service
  service: scene.turn_on
  service_data:
    entity_id: scene.fancy_scene_that_shall_be_turned_on
```
After this PR:
```yaml
type: button
entity: scene.fancy_scene_that_shall_be_turned_on
```

## Additional information

- This PR fixes or closes issue: closes #5610
- This PR is related to issue or discussion: [#8147](https://github.com/home-assistant/frontend/discussions/8147), [forum discussion](https://community.home-assistant.io/t/turn-on-scene-with-button-in-lovelace-card-header-footer/267355)
- Link to documentation pull request:

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
