### PR TITLE
Set sensible default tap_action (same logic as button row)

### DIFF
--- a/src/panels/lovelace/special-rows/hui-buttons-row.ts
+++ b/src/panels/lovelace/special-rows/hui-buttons-row.ts
@@ -6,6 +6,8 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
+import { DOMAINS_TOGGLE } from "../../../common/const";
+import { computeDomain } from "../../../common/entity/compute_domain";
 import { HomeAssistant } from "../../../types";
 import { processConfigEntities } from "../common/process-config-entities";
 import "../components/hui-buttons-base";
@@ -28,7 +30,13 @@ export class HuiButtonsRow extends LitElement implements LovelaceRow {
   public setConfig(config: ButtonsRowConfig): void {
     this._configEntities = processConfigEntities(config.entities).map(
       (entityConfig) => ({
-        tap_action: { action: "toggle" },
+        tap_action: {
+          action:
+            entityConfig.entity &&
+            DOMAINS_TOGGLE.has(computeDomain(entityConfig.entity))
+              ? "toggle"
+              : "more-info",
+        },
         hold_action: { action: "more-info" },
         ...entityConfig,
       })


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The `button` row already had logic to determine a sensible default tap action. Now copied over to `buttons` row to prevent impossible toggles.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
