### PR TITLE
Make "button row" name optional to be consistent with "button card" and "buttons row"

### DIFF
--- a/src/panels/lovelace/special-rows/hui-button-row.ts
+++ b/src/panels/lovelace/special-rows/hui-button-row.ts
@@ -10,6 +10,7 @@ import {
 } from "lit-element";
 import { DOMAINS_TOGGLE } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/ha-icon";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
@@ -29,10 +30,6 @@ export class HuiButtonRow extends LitElement implements LovelaceRow {
       throw new Error("Invalid configuration");
     }
 
-    if (!config.name) {
-      throw new Error("No name specified");
-    }
-
     this._config = {
       tap_action: {
         action:
@@ -50,10 +47,17 @@ export class HuiButtonRow extends LitElement implements LovelaceRow {
       return html``;
     }
 
+    const stateObj =
+      this._config.entity && this.hass
+        ? this.hass.states[this._config.entity]
+        : undefined;
+
     return html`
       <ha-icon .icon=${this._config.icon || "hass:remote"}></ha-icon>
       <div class="flex">
-        <div>${this._config.name}</div>
+        <div>
+          ${this._config.name || (stateObj ? computeStateName(stateObj) : "")}
+        </div>
         <mwc-button
           @action=${this._handleAction}
           .actionHandler=${actionHandler({

--- a/src/panels/lovelace/special-rows/hui-button-row.ts
+++ b/src/panels/lovelace/special-rows/hui-button-row.ts
@@ -11,6 +11,7 @@ import {
 import { DOMAINS_TOGGLE } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeStateName } from "../../../common/entity/compute_state_name";
+import { stateIcon } from "../../../common/entity/state_icon";
 import "../../../components/ha-icon";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
@@ -28,6 +29,10 @@ export class HuiButtonRow extends LitElement implements LovelaceRow {
   public setConfig(config: ButtonRowConfig): void {
     if (!config) {
       throw new Error("Invalid configuration");
+    }
+
+    if (!config.name && !config.entity) {
+      throw new Error("No name and no entity specified");
     }
 
     this._config = {
@@ -53,7 +58,11 @@ export class HuiButtonRow extends LitElement implements LovelaceRow {
         : undefined;
 
     return html`
-      <ha-icon .icon=${this._config.icon || "hass:remote"}></ha-icon>
+      <ha-icon
+        .icon=${this._config.icon ||
+        (stateObj ? stateIcon(stateObj) : "hass:remote")}
+      >
+      </ha-icon>
       <div class="flex">
         <div>
           ${this._config.name || (stateObj ? computeStateName(stateObj) : "")}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

Not breaking, since officially no one should have been setting an entity yet for this row. If they were and did not specify an override icon until now, then the "hass:remote" icon that they had so far will be replaced by the entity icon.

## Proposed change

Making the behavior of `button` row and `button` card consistent: `name` is now optional and we use the entity friendly name if we have one. We also use the icon from it, if no override icon is provided.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16261

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
