### PR TITLE
Allow themeing of media control card

### DIFF
--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -332,7 +332,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
   protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
 
-    if (!this._config || !this.hass || !changedProps.has("hass")) {
+    if (!this._config || !this.hass) {
       return;
     }
 

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -332,7 +332,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
   protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
 
-    if (!this._config || !this.hass || !changedProps.has("_config")) {
+    if (!this._config || !this.hass || (!changedProps.has("_config") && !changedProps.has("hass"))) {
       return;
     }
 

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -332,7 +332,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
   protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
 
-    if (!this._config || !this.hass) {
+    if (!this._config || !this.hass || !changedProps.has("_config")) {
       return;
     }
 

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -37,6 +37,7 @@ export interface EmptyStateCardConfig extends LovelaceCardConfig {
 export interface EntityCardConfig extends LovelaceCardConfig {
   attribute?: string;
   unit?: string;
+  theme?: string;
 }
 
 export interface EntitiesCardEntityConfig extends EntityConfig {
@@ -174,6 +175,7 @@ export interface LogbookCardConfig extends LovelaceCardConfig {
   entities: string[];
   title?: string;
   hours_to_show?: number;
+  theme?: string;
 }
 
 export interface MapCardConfig extends LovelaceCardConfig {
@@ -198,6 +200,7 @@ export interface MarkdownCardConfig extends LovelaceCardConfig {
 
 export interface MediaControlCardConfig extends LovelaceCardConfig {
   entity: string;
+  theme?: string;
 }
 
 export interface HistoryGraphCardConfig extends LovelaceCardConfig {
@@ -311,4 +314,5 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
   name?: string;
   show_forecast?: boolean;
   secondary_info_attribute?: string;
+  theme?: string;
 }

--- a/src/panels/lovelace/editor/config-elements/hui-media-control-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-media-control-card-editor.ts
@@ -11,12 +11,14 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/entity/ha-entity-picker";
 import { HomeAssistant } from "../../../../types";
 import { MediaControlCardConfig } from "../../cards/types";
+import "../../components/hui-theme-select-editor";
 import { LovelaceCardEditor } from "../../types";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 
 const cardConfigStruct = object({
   type: string(),
   entity: optional(string()),
+  theme: optional(string()),
 });
 
 const includeDomains = ["media_player"];
@@ -35,6 +37,10 @@ export class HuiMediaControlCardEditor extends LitElement
 
   get _entity(): string {
     return this._config!.entity || "";
+  }
+
+  get _theme(): string {
+    return this._config!.theme || "";
   }
 
   protected render(): TemplateResult {
@@ -57,6 +63,12 @@ export class HuiMediaControlCardEditor extends LitElement
           @change="${this._valueChanged}"
           allow-custom-entity
         ></ha-entity-picker>
+        <hui-theme-select-editor
+          .hass=${this.hass}
+          .value=${this._theme}
+          .configValue=${"theme"}
+          @value-changed=${this._valueChanged}
+        ></hui-theme-select-editor>
       </div>
     `;
   }

--- a/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
@@ -74,6 +74,12 @@ export class HuiPictureCardEditor extends LitElement
           .configValue="${"image"}"
           @value-changed="${this._valueChanged}"
         ></paper-input>
+        <hui-theme-select-editor
+          .hass=${this.hass}
+          .value="${this._theme}"
+          .configValue="${"theme"}"
+          @value-changed="${this._valueChanged}"
+        ></hui-theme-select-editor>
         <div class="side-by-side">
           <hui-action-editor
             .label="${this.hass.localize(
@@ -99,12 +105,6 @@ export class HuiPictureCardEditor extends LitElement
             .configValue="${"hold_action"}"
             @value-changed="${this._valueChanged}"
           ></hui-action-editor>
-          <hui-theme-select-editor
-            .hass=${this.hass}
-            .value="${this._theme}"
-            .configValue="${"theme"}"
-            @value-changed="${this._valueChanged}"
-          ></hui-theme-select-editor>
         </div>
       </div>
     `;

--- a/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
@@ -215,6 +215,12 @@ export class HuiPictureEntityCardEditor extends LitElement
             ></ha-formfield>
           </div>
         </div>
+        <hui-theme-select-editor
+          .hass=${this.hass}
+          .value="${this._theme}"
+          .configValue="${"theme"}"
+          @value-changed="${this._valueChanged}"
+        ></hui-theme-select-editor>
         <div class="side-by-side">
           <hui-action-editor
             .label="${this.hass.localize(
@@ -240,12 +246,6 @@ export class HuiPictureEntityCardEditor extends LitElement
             .configValue="${"hold_action"}"
             @value-changed="${this._valueChanged}"
           ></hui-action-editor>
-          <hui-theme-select-editor
-            .hass=${this.hass}
-            .value="${this._theme}"
-            .configValue="${"theme"}"
-            @value-changed="${this._valueChanged}"
-          ></hui-theme-select-editor>
         </div>
       </div>
     `;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

1. Allow themeing for media control card. Was already technically possible, but had no editor support plus did not work for previewing (too restrictive checks in `updated()`).
2. Explicitly state in the card config interfaces where themes work (previously some relied on the generic `[key: string]: any;` in `LovelaceCardConfig`.
3. Moved theme picker for picture card and picture entity card out of the side-by-side since there were already two other fields in the row for the actions and those need more space to e.g. provide a URL or navigation target. Was quite crowded.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16282

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
