### PR TITLE
Tweak UI handle-errors text message a bit

### DIFF
--- a/src/panels/lovelace/common/structs/handle-errors.ts
+++ b/src/panels/lovelace/common/structs/handle-errors.ts
@@ -12,11 +12,13 @@ export const handleStructError = (err: Error): string[] => {
       );
     } else {
       errors.push(
-        `The value of "${failure.path.join(
+        `The provided value for "${failure.path.join(
           "."
-        )}" is not supported by the UI editor, we support "${
+        )}" is not supported by the UI editor. We support (${
           failure.type
-        }" but received "${JSON.stringify(failure.value)}".`
+        }) but received ${
+          failure.value ? "(" + JSON.stringify(failure.value) + ")" : "no value"
+        }.`
       );
     }
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Those 4 double quotes always irked me, as well as the apostrophe followed by a double quote.

![image](https://user-images.githubusercontent.com/114137/105562978-c6296080-5d1c-11eb-9d57-68a6c8ef6138.png)

I changed three things:
1. The expected type and the actual value are now put into round brackets. Makes it easier to read.
2. If no value is provided, then the text now says so.
3. Small wording changes for clarity and readability.

A few examples how it looks now:
![image](https://user-images.githubusercontent.com/114137/105563053-0a1c6580-5d1d-11eb-86d0-cf74e4575fcd.png)

![image](https://user-images.githubusercontent.com/114137/105563056-0dafec80-5d1d-11eb-9acd-e51015f7dbd1.png)

![image](https://user-images.githubusercontent.com/114137/105563061-11437380-5d1d-11eb-8fe1-2c45784c2deb.png)

![image](https://user-images.githubusercontent.com/114137/105563063-13a5cd80-5d1d-11eb-8d2a-144df7209c8b.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
