### PR TITLE
Fix various picker clearing bug scenarios in automation editor

### DIFF
--- a/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
@@ -51,7 +51,7 @@ export class HaDeviceAction extends LitElement {
   );
 
   protected render() {
-    const deviceId = this._deviceId || this.action.device_id;
+    const deviceId = this._deviceId;
 
     return html`
       <ha-device-picker
@@ -98,7 +98,6 @@ export class HaDeviceAction extends LitElement {
   protected updated(changedPros) {
     const prevAction = changedPros.get("action");
     if (prevAction && !deviceAutomationsEqual(prevAction, this.action)) {
-      this._deviceId = undefined;
       this._getCapabilities();
     }
   }

--- a/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
@@ -51,7 +51,7 @@ export class HaDeviceCondition extends LitElement {
   );
 
   protected render() {
-    const deviceId = this._deviceId || this.condition.device_id;
+    const deviceId = this._deviceId;
 
     return html`
       <ha-device-picker

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -51,7 +51,7 @@ export class HaDeviceTrigger extends LitElement {
   );
 
   protected render() {
-    const deviceId = this._deviceId || this.trigger.device_id;
+    const deviceId = this._deviceId;
 
     return html`
       <ha-device-picker


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

There were a few scenarios where clearing a picker in the automation editor lead to issues:

1. **Action Device**: If the device picker was cleared, the selected action (plus the extra-fields below) remained. Now they are cleared and hidden.
2. **Action Service 1**: If you select a service and then a matching entity in the picker below, but then change the service to one from a completely different domain, the selected entity remained although now it most likely no longer makes sense. With this PR the entity picker now gets cleared in that case to prevent invalid data combinations.
3. **Action Service 2**: The coding enforces a validity check on the config structure, which means an empty `entity_id` is not allowed and leads to an error which results in the editor jumping into YAML mode. This occurred if you had selected an entity for your service call, but then cleared the entity picker. This PR now ensures that the `entity_id` property gets removed from the config, so that the config assert does not consider the config invalid any longer.
4. **Condition Device**: Analog point 1.
5. **Trigger Device**: Analog point 1.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
