### PR TITLE
Allow `hui-timestamp-display` in markdown

### DIFF
--- a/src/common/datetime/format_date.ts
+++ b/src/common/datetime/format_date.ts
@@ -9,3 +9,12 @@ export const formatDate = toLocaleDateStringSupportsOptions
         day: "numeric",
       })
   : (dateObj: Date) => format(dateObj, "longDate");
+
+export const formatDateWeekday = toLocaleDateStringSupportsOptions
+  ? (dateObj: Date, locales: string) =>
+      dateObj.toLocaleDateString(locales, {
+        weekday: "long",
+        month: "short",
+        day: "numeric",
+      })
+  : (dateObj: Date) => format(dateObj, "dddd, D MMM");

--- a/src/common/datetime/format_time.ts
+++ b/src/common/datetime/format_time.ts
@@ -17,3 +17,12 @@ export const formatTimeWithSeconds = toLocaleTimeStringSupportsOptions
         second: "2-digit",
       })
   : (dateObj: Date) => format(dateObj, "mediumTime");
+
+export const formatTimeWeekday = toLocaleTimeStringSupportsOptions
+  ? (dateObj: Date, locales: string) =>
+      dateObj.toLocaleTimeString(locales, {
+        weekday: "long",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+  : (dateObj: Date) => format(dateObj, "dddd, HH:mm");

--- a/src/components/ha-markdown-element.ts
+++ b/src/components/ha-markdown-element.ts
@@ -1,9 +1,13 @@
 import { customElement, property, UpdatingElement } from "lit-element";
 import { fireEvent } from "../common/dom/fire_event";
 import { renderMarkdown } from "../resources/render-markdown";
+import type { HomeAssistant } from "../types";
+import { HuiTimestampDisplay } from "../panels/lovelace/components/hui-timestamp-display";
 
 @customElement("ha-markdown-element")
 class HaMarkdownElement extends UpdatingElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
   @property() public content?;
 
   @property({ type: Boolean }) public allowSvg = false;
@@ -55,6 +59,8 @@ class HaMarkdownElement extends UpdatingElement {
         // Fire a resize event when images loaded to notify content resized
       } else if (node instanceof HTMLImageElement) {
         node.addEventListener("load", this._resize);
+      } else if (node instanceof HuiTimestampDisplay) {
+        node.hass = this.hass;
       }
     }
   }

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -7,7 +7,6 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
-import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
 import "./ha-markdown-element";
 

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -35,58 +35,55 @@ class HaMarkdown extends LitElement {
     </ha-markdown-element>`;
   }
 
-  static get styles(): CSSResult[] {
-    return [
-      haStyle,
-      css`
-        :host {
-          display: block;
-        }
-        ha-markdown-element {
-          -ms-user-select: text;
-          -webkit-user-select: text;
-          -moz-user-select: text;
-        }
-        ha-markdown-element > *:first-child {
-          margin-top: 0;
-        }
-        ha-markdown-element > *:last-child {
-          margin-bottom: 0;
-        }
-        ha-markdown-element a {
-          color: var(--primary-color);
-        }
-        ha-markdown-element img {
-          max-width: 100%;
-        }
-        ha-markdown-element code,
-        pre {
-          background-color: var(--markdown-code-background-color, none);
-          border-radius: 3px;
-        }
-        ha-markdown-element svg {
-          background-color: var(--markdown-svg-background-color, none);
-          color: var(--markdown-svg-color, none);
-        }
-        ha-markdown-element code {
-          font-size: 85%;
-          padding: 0.2em 0.4em;
-        }
-        ha-markdown-element pre code {
-          padding: 0;
-        }
-        ha-markdown-element pre {
-          padding: 16px;
-          overflow: auto;
-          line-height: 1.45;
-          font-family: var(--code-font-family, monospace);
-        }
-        ha-markdown-element h2 {
-          font-size: 1.5em;
-          font-weight: bold;
-        }
-      `,
-    ];
+  static get styles(): CSSResult {
+    return css`
+      :host {
+        display: block;
+      }
+      ha-markdown-element {
+        -ms-user-select: text;
+        -webkit-user-select: text;
+        -moz-user-select: text;
+      }
+      ha-markdown-element > *:first-child {
+        margin-top: 0;
+      }
+      ha-markdown-element > *:last-child {
+        margin-bottom: 0;
+      }
+      ha-markdown-element a {
+        color: var(--primary-color);
+      }
+      ha-markdown-element img {
+        max-width: 100%;
+      }
+      ha-markdown-element code,
+      pre {
+        background-color: var(--markdown-code-background-color, none);
+        border-radius: 3px;
+      }
+      ha-markdown-element svg {
+        background-color: var(--markdown-svg-background-color, none);
+        color: var(--markdown-svg-color, none);
+      }
+      ha-markdown-element code {
+        font-size: 85%;
+        padding: 0.2em 0.4em;
+      }
+      ha-markdown-element pre code {
+        padding: 0;
+      }
+      ha-markdown-element pre {
+        padding: 16px;
+        overflow: auto;
+        line-height: 1.45;
+        font-family: var(--code-font-family, monospace);
+      }
+      ha-markdown-element h2 {
+        font-size: 1.5em;
+        font-weight: bold;
+      }
+    `;
   }
 }
 

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -7,7 +7,7 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
-
+import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
 import "./ha-markdown-element";
 
@@ -35,55 +35,58 @@ class HaMarkdown extends LitElement {
     </ha-markdown-element>`;
   }
 
-  static get styles(): CSSResult {
-    return css`
-      :host {
-        display: block;
-      }
-      ha-markdown-element {
-        -ms-user-select: text;
-        -webkit-user-select: text;
-        -moz-user-select: text;
-      }
-      ha-markdown-element > *:first-child {
-        margin-top: 0;
-      }
-      ha-markdown-element > *:last-child {
-        margin-bottom: 0;
-      }
-      ha-markdown-element a {
-        color: var(--primary-color);
-      }
-      ha-markdown-element img {
-        max-width: 100%;
-      }
-      ha-markdown-element code,
-      pre {
-        background-color: var(--markdown-code-background-color, none);
-        border-radius: 3px;
-      }
-      ha-markdown-element svg {
-        background-color: var(--markdown-svg-background-color, none);
-        color: var(--markdown-svg-color, none);
-      }
-      ha-markdown-element code {
-        font-size: 85%;
-        padding: 0.2em 0.4em;
-      }
-      ha-markdown-element pre code {
-        padding: 0;
-      }
-      ha-markdown-element pre {
-        padding: 16px;
-        overflow: auto;
-        line-height: 1.45;
-        font-family: var(--code-font-family, monospace);
-      }
-      ha-markdown-element h2 {
-        font-size: 1.5em;
-        font-weight: bold;
-      }
-    `;
+  static get styles(): CSSResult[] {
+    return [
+      haStyle,
+      css`
+        :host {
+          display: block;
+        }
+        ha-markdown-element {
+          -ms-user-select: text;
+          -webkit-user-select: text;
+          -moz-user-select: text;
+        }
+        ha-markdown-element > *:first-child {
+          margin-top: 0;
+        }
+        ha-markdown-element > *:last-child {
+          margin-bottom: 0;
+        }
+        ha-markdown-element a {
+          color: var(--primary-color);
+        }
+        ha-markdown-element img {
+          max-width: 100%;
+        }
+        ha-markdown-element code,
+        pre {
+          background-color: var(--markdown-code-background-color, none);
+          border-radius: 3px;
+        }
+        ha-markdown-element svg {
+          background-color: var(--markdown-svg-background-color, none);
+          color: var(--markdown-svg-color, none);
+        }
+        ha-markdown-element code {
+          font-size: 85%;
+          padding: 0.2em 0.4em;
+        }
+        ha-markdown-element pre code {
+          padding: 0;
+        }
+        ha-markdown-element pre {
+          padding: 16px;
+          overflow: auto;
+          line-height: 1.45;
+          font-family: var(--code-font-family, monospace);
+        }
+        ha-markdown-element h2 {
+          font-size: 1.5em;
+          font-weight: bold;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -26,8 +26,13 @@ class HaMarkdown extends LitElement {
       return html``;
     }
 
-    return html`<ha-markdown-element .hass=${this.hass} .content=${this.content} .allowSvg=${this.allowSvg} .breaks=${this.breaks}>
-</ha-markdown-element>`;
+    return html` <ha-markdown-element
+      .hass=${this.hass}
+      .content=${this.content}
+      .allowSvg=${this.allowSvg}
+      .breaks=${this.breaks}
+    >
+    </ha-markdown-element>`;
   }
 
   static get styles(): CSSResult {

--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -7,10 +7,14 @@ import {
   property,
   TemplateResult,
 } from "lit-element";
+
+import type { HomeAssistant } from "../types";
 import "./ha-markdown-element";
 
 @customElement("ha-markdown")
 class HaMarkdown extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
   @property() public content?;
 
   @property({ type: Boolean }) public allowSvg = false;
@@ -22,11 +26,8 @@ class HaMarkdown extends LitElement {
       return html``;
     }
 
-    return html`<ha-markdown-element
-      .content=${this.content}
-      .allowSvg=${this.allowSvg}
-      .breaks=${this.breaks}
-    ></ha-markdown-element>`;
+    return html`<ha-markdown-element .hass=${this.hass} .content=${this.content} .allowSvg=${this.allowSvg} .breaks=${this.breaks}>
+</ha-markdown-element>`;
   }
 
   static get styles(): CSSResult {

--- a/src/panels/lovelace/cards/hui-markdown-card.ts
+++ b/src/panels/lovelace/cards/hui-markdown-card.ts
@@ -82,6 +82,7 @@ export class HuiMarkdownCard extends LitElement implements LovelaceCard {
     return html`
       <ha-card .header="${this._config.title}">
         <ha-markdown
+          .hass=${this.hass}
           breaks
           class=${classMap({
             "no-header": !this._config.title,

--- a/src/panels/lovelace/components/hui-timestamp-display.ts
+++ b/src/panels/lovelace/components/hui-timestamp-display.ts
@@ -7,6 +7,7 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit-element";
+import checkValidDate from "../../../common/datetime/check_valid_date";
 import { formatDate } from "../../../common/datetime/format_date";
 import { formatDateTime } from "../../../common/datetime/format_date_time";
 import { formatTime } from "../../../common/datetime/format_time";
@@ -54,7 +55,7 @@ export class HuiTimestampDisplay extends LitElement {
 
     const tsDate = new Date(this.ts);
 
-    if (isNaN(tsDate.getTime())) {
+    if (checkValidDate(tsDate)) {
       return html`${this.hass.localize(
         "ui.panel.lovelace.components.timestamp-display.invalid"
       )}`;

--- a/src/panels/lovelace/components/hui-timestamp-display.ts
+++ b/src/panels/lovelace/components/hui-timestamp-display.ts
@@ -53,7 +53,7 @@ export class HuiTimestampDisplay extends LitElement {
       return html``;
     }
 
-    const tsDate = new Date(this.ts);
+    const tsDate = this.ts instanceof Date ? this.ts : new Date(this.ts);
 
     if (checkValidDate(tsDate)) {
       return html`${this.hass.localize(
@@ -108,11 +108,12 @@ export class HuiTimestampDisplay extends LitElement {
 
   private _updateRelative(): void {
     if (this.ts && this.hass!.localize) {
+      const tsDate = this.ts instanceof Date ? this.ts : new Date(this.ts);
       this._relative =
         this._format === "relative"
-          ? relativeTime(new Date(this.ts), this.hass!.localize)
+          ? relativeTime(tsDate, this.hass!.localize)
           : (this._relative = relativeTime(new Date(), this.hass!.localize, {
-              compareTime: new Date(this.ts),
+              compareTime: tsDate,
               includeTense: false,
             }));
     }

--- a/src/panels/lovelace/components/hui-timestamp-display.ts
+++ b/src/panels/lovelace/components/hui-timestamp-display.ts
@@ -8,17 +8,25 @@ import {
   TemplateResult,
 } from "lit-element";
 import checkValidDate from "../../../common/datetime/check_valid_date";
-import { formatDate } from "../../../common/datetime/format_date";
+import {
+  formatDate,
+  formatDateWeekday,
+} from "../../../common/datetime/format_date";
 import { formatDateTime } from "../../../common/datetime/format_date_time";
-import { formatTime } from "../../../common/datetime/format_time";
+import {
+  formatTime,
+  formatTimeWeekday,
+} from "../../../common/datetime/format_time";
 import relativeTime from "../../../common/datetime/relative_time";
 import { HomeAssistant } from "../../../types";
 import { TimestampRenderingFormats } from "./types";
 
 const FORMATS: { [key: string]: (ts: Date, lang: string) => string } = {
   date: formatDate,
+  date_weekday: formatDateWeekday,
   datetime: formatDateTime,
   time: formatTime,
+  time_weekday: formatTimeWeekday,
 };
 const INTERVAL_FORMAT = ["relative", "total"];
 
@@ -55,7 +63,7 @@ export class HuiTimestampDisplay extends LitElement {
 
     const tsDate = this.ts instanceof Date ? this.ts : new Date(this.ts);
 
-    if (checkValidDate(tsDate)) {
+    if (!checkValidDate(tsDate)) {
       return html`${this.hass.localize(
         "ui.panel.lovelace.components.timestamp-display.invalid"
       )}`;

--- a/src/panels/lovelace/components/hui-timestamp-display.ts
+++ b/src/panels/lovelace/components/hui-timestamp-display.ts
@@ -22,10 +22,10 @@ const FORMATS: { [key: string]: (ts: Date, lang: string) => string } = {
 const INTERVAL_FORMAT = ["relative", "total"];
 
 @customElement("hui-timestamp-display")
-class HuiTimestampDisplay extends LitElement {
+export class HuiTimestampDisplay extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @property() public ts?: Date;
+  @property() public ts?: string | Date;
 
   @property() public format?: TimestampRenderingFormats;
 
@@ -52,7 +52,9 @@ class HuiTimestampDisplay extends LitElement {
       return html``;
     }
 
-    if (isNaN(this.ts.getTime())) {
+    const tsDate = new Date(this.ts);
+
+    if (isNaN(tsDate.getTime())) {
       return html`${this.hass.localize(
         "ui.panel.lovelace.components.timestamp-display.invalid"
       )}`;
@@ -64,7 +66,7 @@ class HuiTimestampDisplay extends LitElement {
       return html` ${this._relative} `;
     }
     if (format in FORMATS) {
-      return html` ${FORMATS[format](this.ts, this.hass.language)} `;
+      return html`${FORMATS[format](tsDate, this.hass.language)}`;
     }
     return html`${this.hass.localize(
       "ui.panel.lovelace.components.timestamp-display.invalid_format"
@@ -107,9 +109,9 @@ class HuiTimestampDisplay extends LitElement {
     if (this.ts && this.hass!.localize) {
       this._relative =
         this._format === "relative"
-          ? relativeTime(this.ts, this.hass!.localize)
+          ? relativeTime(new Date(this.ts), this.hass!.localize)
           : (this._relative = relativeTime(new Date(), this.hass!.localize, {
-              compareTime: this.ts,
+              compareTime: new Date(this.ts),
               includeTense: false,
             }));
     }

--- a/src/panels/lovelace/components/types.ts
+++ b/src/panels/lovelace/components/types.ts
@@ -11,5 +11,7 @@ export type TimestampRenderingFormats =
   | "relative"
   | "total"
   | "date"
+  | "date_weekday"
   | "time"
+  | "time_weekday"
   | "datetime";

--- a/src/resources/markdown_worker.ts
+++ b/src/resources/markdown_worker.ts
@@ -22,6 +22,7 @@ const renderMarkdown = (
   if (!whiteListNormal) {
     whiteListNormal = {
       ...(getDefaultWhiteList() as WhiteList),
+      style: [],
       "ha-icon": ["icon"],
       "ha-svg-icon": ["path"],
       "hui-timestamp-display": ["ts", "format"],

--- a/src/resources/markdown_worker.ts
+++ b/src/resources/markdown_worker.ts
@@ -24,6 +24,7 @@ const renderMarkdown = (
       ...(getDefaultWhiteList() as WhiteList),
       "ha-icon": ["icon"],
       "ha-svg-icon": ["path"],
+      "hui-timestamp-display": ["ts", "format"],
     };
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

**Use case:**

I have a markdown card that displays upcoming weather alerts. I show the weather condition plus of course the time period for when they are going to apply. Currently I have this template in the markdown card:

`{{ time_start | timestamp_custom("%a %H:%M") }}`. That however, means that the date formatting (e.g. the weekdays) are set in the locale of the backend, ignoring the user language of the frontend. So in my case I have a German dashboard with a German alert text (German weather alert integration) but an English weekday.

![image](https://user-images.githubusercontent.com/114137/105609756-aab96680-5dab-11eb-9fdd-d980e73f9a9f.png)

**Solution:**

This PR now adds the `<hui-timestamp-display>` to the allowed list of HA tags in the markdown. I also included `<style>` which is also supported by the marked JS library we use since we have `gfm` enabled.

![image](https://user-images.githubusercontent.com/114137/105611891-78623600-5db8-11eb-8666-483843d27295.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
