### PR TITLE
Ensure logbook context is actually read and rendered

### DIFF
--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -120,7 +120,7 @@ export class MoreInfoLogbook extends LitElement {
       lastDate.toISOString(),
       now.toISOString(),
       this.entityId,
-      true
+      false
     );
     this._logbookEntries = this._logbookEntries
       ? [...newEntries, ...this._logbookEntries]

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -165,15 +165,15 @@ class HaLogbook extends LitElement {
                   : item.context_event_type === "call_service"
                   ? // Service Call
                     ` ${this.hass.localize("ui.components.logbook.by_service")}
-                  ${item.context_domain}.${item.context_service}`
+                    ${item.context_domain}.${item.context_service}`
                   : item.context_entity_id === item.entity_id
                   ? // HomeKit or something that self references
                     ` ${this.hass.localize("ui.components.logbook.by")}
-                  ${
-                    item.context_name
-                      ? item.context_name
-                      : item.context_event_type
-                  }`
+                    ${
+                      item.context_name
+                        ? item.context_name
+                        : item.context_event_type
+                    }`
                   : // Another entity such as an automation or script
                     html` ${this.hass.localize("ui.components.logbook.by")}
                       <a

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -236,7 +236,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
       lastDate.toISOString(),
       now.toISOString(),
       this._configEntities!.map((entity) => entity.entity).toString(),
-      true
+      false
     );
 
     const logbookEntries = this._logbookEntries


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

In the "logbook card" on the "more info logbook" we are blocking the retrieval of the context, which means that e.g. if a light is turned on by an automation we miss the info which automation was responsible. In the regular logbook we retrieve the info.

I don't think that this is a performance risk, since in both changed instances we are only retrieving logbook data for a single or a user defined (= low) number of entities.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
