### PR TITLE
Add download dump button to zwave_js panel

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -19,13 +19,21 @@ export interface ZWaveJSClient {
 
 export interface ZWaveJSController {
   home_id: string;
-  node_count: number;
+  nodes: number[];
 }
 
 export interface ZWaveJSNode {
   node_id: number;
   ready: boolean;
   status: number;
+}
+
+export enum NodeStatus {
+  Unknown,
+  Asleep,
+  Awake,
+  Dead,
+  Alive,
 }
 
 export const nodeStatus = ["unknown", "asleep", "awake", "dead", "alive"];

--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -57,7 +57,7 @@ class DialogBox extends LitElement {
         open
         ?scrimClickAction=${confirmPrompt}
         ?escapeKeyAction=${confirmPrompt}
-        @closed=${this._dialogClosed}
+        @closing=${this._dialogClosed}
         defaultAction="ignore"
         .heading=${this._params.title
           ? this._params.title

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -1,5 +1,6 @@
 import "@material/mwc-button/mwc-button";
-import { mdiCheckCircle, mdiCircle } from "@mdi/js";
+import "@material/mwc-icon-button/mwc-icon-button";
+import { mdiCheckCircle, mdiCircle, mdiRefresh } from "@mdi/js";
 import {
   css,
   CSSResultArray,
@@ -12,6 +13,7 @@ import {
 } from "lit-element";
 import { classMap } from "lit-html/directives/class-map";
 import "../../../../../components/ha-card";
+import "../../../../../components/ha-svg-icon";
 import "../../../../../components/ha-icon-next";
 import { getSignedPath } from "../../../../../data/auth";
 import {
@@ -67,6 +69,9 @@ class ZWaveJSConfigDashboard extends LitElement {
         .route=${this.route}
         .tabs=${configTabs}
       >
+        <mwc-icon-button slot="toolbar-icon" @click=${this._fetchData}>
+          <ha-svg-icon .path=${mdiRefresh}></ha-svg-icon>
+        </mwc-icon-button>
         <ha-config-section .narrow=${this.narrow} .isWide=${this.isWide}>
           <div slot="header">
             ${this.hass.localize("ui.panel.config.zwave_js.dashboard.header")}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -257,7 +257,10 @@ class ZWaveJSConfigDashboard extends LitElement {
         `/api/zwave_js/dump/${this.configEntryId}`
       );
     } catch (err) {
-      alert(`Error: ${err}`);
+      showAlertDialog(this, {
+        title: "Error",
+        text: err.error || err.body || err,
+      });
       return;
     }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2401,7 +2401,13 @@
             "driver_version": "Driver Version",
             "server_version": "Server Version",
             "home_id": "Home ID",
-            "node_count": "Node Count"
+            "nodes_ready": "Nodes ready",
+            "dump_debug": "Download a dump of your network to help diagnose issues",
+            "dump_dead_nodes_title": "Some of your nodes are dead",
+            "dump_dead_nodes_text": "Some of your nodes didn't respond and are assumed dead. These will not be fully exported.",
+            "dump_not_ready_title": "Not all nodes are ready yet",
+            "dump_not_ready_text": "If you create an export while not all nodes are ready, you could miss needed data. Give your network some time to query all nodes. Do you want to continue with the dump?",
+            "dump_not_ready_confirm": "download"
           },
           "device_info": {
             "zwave_info": "Z-Wave Info",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2407,7 +2407,7 @@
             "dump_dead_nodes_text": "Some of your nodes didn't respond and are assumed dead. These will not be fully exported.",
             "dump_not_ready_title": "Not all nodes are ready yet",
             "dump_not_ready_text": "If you create an export while not all nodes are ready, you could miss needed data. Give your network some time to query all nodes. Do you want to continue with the dump?",
-            "dump_not_ready_confirm": "download"
+            "dump_not_ready_confirm": "Download"
           },
           "device_info": {
             "zwave_info": "Z-Wave Info",


### PR DESCRIPTION
Needs https://github.com/home-assistant/core/pull/45452

## Proposed change

Adds button to download a dump of your zwave js network/nodes

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
