### PR TITLE
Visual alignment of automation and script more info dialogs

### DIFF
--- a/src/dialogs/more-info/controls/more-info-automation.ts
+++ b/src/dialogs/more-info/controls/more-info-automation.ts
@@ -57,7 +57,9 @@ class MoreInfoAutomation extends LitElement {
       }
       .actions {
         margin: 8px 0;
-        text-align: right;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-script.ts
+++ b/src/dialogs/more-info/controls/more-info-script.ts
@@ -1,5 +1,7 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import {
+  css,
+  CSSResult,
   customElement,
   html,
   LitElement,
@@ -21,10 +23,12 @@ class MoreInfoScript extends LitElement {
     }
 
     return html`
-      <div>
-        ${this.hass.localize(
-          "ui.dialogs.more_info_control.script.last_triggered"
-        )}:
+      <div class="flex">
+        <div>
+          ${this.hass.localize(
+            "ui.dialogs.more_info_control.script.last_triggered"
+          )}:
+        </div>
         ${this.stateObj.attributes.last_triggered
           ? html`
               <ha-relative-time
@@ -34,6 +38,15 @@ class MoreInfoScript extends LitElement {
             `
           : this.hass.localize("ui.components.relative_time.never")}
       </div>
+    `;
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      .flex {
+        display: flex;
+        justify-content: space-between;
+      }
     `;
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Remove two inconsistencies:

1. Script more info: "Last triggered" info was not separated into label on the left, value on the right. Fixed now.
2. Automation more info: "Execute" button was on the right rather than in the middle as we do with all other more info dialogs that contain actions (counter, timer, etc.).

![image](https://user-images.githubusercontent.com/114137/105769399-0deafa80-5f5e-11eb-9c6d-cb472f152ca2.png)

![image](https://user-images.githubusercontent.com/114137/105769435-19d6bc80-5f5e-11eb-8101-3536a3d1bff5.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
