### PR TITLE
Adjust calendar translations to fix loading issue in calendar card

### DIFF
--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -114,7 +114,7 @@ export class HAFullCalendar extends LitElement {
                         class="today"
                         @click=${this._handleToday}
                         >${this.hass.localize(
-                          "ui.panel.calendar.today"
+                          "ui.components.calendar.today"
                         )}</mwc-button
                       >
                       <ha-icon-button
@@ -169,7 +169,7 @@ export class HAFullCalendar extends LitElement {
                         class="today"
                         @click=${this._handleToday}
                         >${this.hass.localize(
-                          "ui.panel.calendar.today"
+                          "ui.components.calendar.today"
                         )}</mwc-button
                       >
                       <ha-button-toggle-group

--- a/src/panels/calendar/ha-panel-calendar.ts
+++ b/src/panels/calendar/ha-panel-calendar.ts
@@ -74,7 +74,7 @@ class PanelCalendar extends LitElement {
         <div class="content">
           <div class="calendar-list">
             <div class="calendar-list-header">
-              ${this.hass.localize("ui.panel.calendar.my_calendars")}
+              ${this.hass.localize("ui.components.calendar.my_calendars")}
             </div>
             ${this._calendars.map(
               (selCal) =>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -479,6 +479,10 @@
           "url": "URL",
           "video": "Video"
         }
+      },
+      "calendar": {
+        "my_calendars": "My Calendars",
+        "today": "Today"
       }
     },
     "dialogs": {
@@ -779,10 +783,6 @@
       "done": "Done"
     },
     "panel": {
-      "calendar": {
-        "my_calendars": "My Calendars",
-        "today": "Today"
-      },
       "config": {
         "header": "Configure Home Assistant",
         "introduction": "In this view it is possible to configure your components and Home Assistant. Not everything is possible to configure from the UI yet, but we're working on it.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Since the translations where in the "panel" key section, they were only loaded if you went to the panel first. Now they are moved to "components" so that cards also get them.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8067
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
