### PR TITLE
Allow theming of header edit background color

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -815,7 +815,7 @@ class HUIRoot extends LitElement {
 
         .edit-mode app-header,
         .edit-mode app-toolbar {
-          background-color: var(--dark-color, #455a64);
+          background-color: var(--app-header-edit-background-color, var(--dark-color, #455a64));
           color: var(--text-dark-color);
         }
         .edit-mode div[main-title] {

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -784,8 +784,6 @@ class HUIRoot extends LitElement {
       haStyle,
       css`
         :host {
-          --dark-color: #455a64;
-          --text-dark-color: #fff;
           -ms-user-select: none;
           -webkit-user-select: none;
           -moz-user-select: none;

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -814,7 +814,7 @@ class HUIRoot extends LitElement {
         .edit-mode app-header,
         .edit-mode app-toolbar {
           background-color: var(--app-header-edit-background-color, #455a64);
-          color: var(--app-header-text-color, #fff);
+          color: var(--app-header-edit-text-color, #fff);
         }
         .edit-mode div[main-title] {
           pointer-events: auto;

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -815,8 +815,8 @@ class HUIRoot extends LitElement {
 
         .edit-mode app-header,
         .edit-mode app-toolbar {
-          background-color: var(--app-header-edit-background-color, var(--dark-color, #455a64));
-          color: var(--text-dark-color);
+          background-color: var(--app-header-edit-background-color, #455a64);
+          color: var(--app-header-text-color, #fff);
         }
         .edit-mode div[main-title] {
           pointer-events: auto;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This lets themes apply their own background coloring to the header during edit mode, using the variable `--app-header-edit-background-color`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
frontend:
  themes:
    test:
      app-header-edit-background-color: red
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: Historical #7480
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
