### PR TITLE
Fix external auth reconnection loop if connection lost after refresh token expiration

### DIFF
--- a/src/external_app/external_auth.ts
+++ b/src/external_app/external_auth.ts
@@ -87,9 +87,7 @@ export class ExternalAuth extends Auth {
     this._tokenCallbackPromise = new Promise<RefreshTokenResponse>(
       (resolve, reject) => {
         window[CALLBACK_SET_TOKEN] = (success, data) =>
-          success
-            ? resolve(data)
-            : reject(new Error("Refresh token unsuccessful; "));
+          success ? resolve(data) : reject(data);
       }
     );
 

--- a/src/external_app/external_auth.ts
+++ b/src/external_app/external_auth.ts
@@ -72,8 +72,8 @@ export class ExternalAuth extends Auth {
         await this._tokenCallbackPromise;
         return;
       } catch (e) {
-        //_tokenCallbackPromise is in a rejected state
-        // Clear the tokenCallbackPromise and go on refreshing access token
+        // _tokenCallbackPromise is in a rejected state
+        // Clear the _tokenCallbackPromise and go on refreshing access token
         this._tokenCallbackPromise = undefined;
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR fixes the bug described in the issue #7732. This bug was introduced with PR #7236.

The external auth module (which is used by the companion apps (iOS/Android)) doesn't survive a lost connection if the refresh token is expired. The process is fully described in the issue #7732

The problem occurs frequently more on devices which doesn't close/suspend the app if not used and therefore doesn't force close the connection by closing/suspending the app.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
For better debugging, I lowered the refresh token expiration from 30 minutes to 1 minute in HA here:
https://github.com/home-assistant/core/blob/ac3a6aaa8cdb005b3c900f9d9671e5a859351060/homeassistant/auth/const.py#L4

To reproduce this problem you need to disable "Close connection automatically" in the profile settings (only if you didn't lower the refresh token expiration time < 5 minutes) and use the Home Assistant Companion App (Then the external auth module is used)

1. Open the app and let it open and wait for the refresh token timeout (30 minutes or if lowered the ACCESS_TOKE_EXPIRATION then X Minutes)
2. Right after the refresh token is expired, stop HA
3. Now wait till the App tries to reconnect and show the "Connection unsuccessful" popup with the "Wait/Retry/Settings" buttons.
3a. Alternatively you can try to trigger a fetch from HA with auth (which needs a new refresh token), by opening e.g. the history tab.
4. Now start HA again.

Now we are in a reconnection loop and the frontend cannot connect anymore.
You will see in the Home Assistant log continuously following messages (Be sure to enable the websocket debug logs in HA)
```yaml
logger:
  default: info
  logs:
    homeassistant.components.websocket_api: debug
```
```
2020-11-16 17:31:00 DEBUG (MainThread) [homeassistant.components.websocket_api.http.connection.140600942755264] Connected from ipaddress
2020-11-16 17:31:00 DEBUG (MainThread) [homeassistant.components.websocket_api.http.connection.140600942755264] Sending {'type': 'auth_required', 'ha_version': '0.117.6'}
2020-11-16 17:31:00 DEBUG (MainThread) [homeassistant.components.websocket_api.http.connection.140600942755264] Disconnected
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7732 
- This PR is related to issue or discussion: #7236 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
