### PR TITLE
Fix map card editor + ensure dark-mode toggle actually works

### DIFF
--- a/src/panels/lovelace/components/hui-input-list-editor.ts
+++ b/src/panels/lovelace/components/hui-input-list-editor.ts
@@ -30,7 +30,7 @@ export class HuiInputListEditor extends LitElement {
       ${this.value.map((listEntry, index) => {
         return html`
           <paper-input
-            label="${this.inputLabel}"
+            .label=${this.inputLabel}
             .value=${listEntry}
             .configValue=${"entry"}
             .index=${index}
@@ -48,7 +48,7 @@ export class HuiInputListEditor extends LitElement {
         `;
       })}
       <paper-input
-        label="${this.inputLabel}"
+        .label=${this.inputLabel}
         @change=${this._addEntry}
       ></paper-input>
     `;

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -96,35 +96,35 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     return html`
       <div class="card-config">
         <paper-input
-          .label=${this.hass.localize(
+          .label="${this.hass.localize(
             "ui.panel.lovelace.editor.card.generic.title"
           )}
           (${this.hass.localize(
             "ui.panel.lovelace.editor.card.config.optional"
-          )})
+          )})"
           .value=${this._title}
           .configValue=${"title"}
           @value-changed=${this._valueChanged}
         ></paper-input>
         <div class="side-by-side">
           <paper-input
-            .label=${this.hass.localize(
+            .label="${this.hass.localize(
               "ui.panel.lovelace.editor.card.generic.aspect_ratio"
             )}
             (${this.hass.localize(
               "ui.panel.lovelace.editor.card.config.optional"
-            )})
+            )})"
             .value=${this._aspect_ratio}
             .configValue=${"aspect_ratio"}
             @value-changed=${this._valueChanged}
           ></paper-input>
           <paper-input
-            .label=${this.hass.localize(
+            .label="${this.hass.localize(
               "ui.panel.lovelace.editor.card.map.default_zoom"
             )}
             (${this.hass.localize(
               "ui.panel.lovelace.editor.card.config.optional"
-            )})
+            )})"
             type="number"
             .value="${this._default_zoom}"
             .configValue=${"default_zoom"}
@@ -145,14 +145,14 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
             ></ha-switch
           ></ha-formfield>
           <paper-input
-            .label=${this.hass.localize(
+            .label="${this.hass.localize(
               "ui.panel.lovelace.editor.card.map.hours_to_show"
             )}
             (${this.hass.localize(
               "ui.panel.lovelace.editor.card.config.optional"
-            )})
+            )})"
             type="number"
-            .value="${this._hours_to_show}"
+            .value=${this._hours_to_show}
             .configValue=${"hours_to_show"}
             @value-changed=${this._valueChanged}
           ></paper-input>
@@ -199,7 +199,8 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
       return;
     }
     const target = ev.target! as EditorTarget;
-    let value = ev.detail.value;
+
+    let value = target.checked !== undefined ? target.checked : ev.detail.value;
 
     if (target.configValue && this[`_${target.configValue}`] === value) {
       return;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Follow-up to PR https://github.com/home-assistant/frontend/pull/8115.

1. Fix incorrectly removed quotation marks for multi translation element labels
2. Ensure that the dark-mode toggle can actually work.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
