### PR TITLE
More precise name handling for auto-generated dashboards

### DIFF
--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -217,7 +217,7 @@ const hasUpperCase = (str: string): boolean => {
 const adjustName = (name: string): string => {
   // If first word already has an upper case letter (e.g. from brand name)
   // leave as-is, otherwise capitalize the first word.
-  return hasUpperCase(name.split(" ")[0])
+  return hasUpperCase(name.substr(0, name.indexOf(" ")))
     ? name
     : name[0].toUpperCase() + name.slice(1);
 };

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -219,7 +219,7 @@ const adjustName = (name: string): string => {
   // leave as-is, otherwise capitalize the first word.
   return hasUpperCase(name.split(" ")[0])
     ? name
-    : name.charAt(0).toUpperCase() + name.slice(1);
+    : name[0].toUpperCase() + name.slice(1);
 };
 
 const computeDefaultViewStates = (

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -191,7 +191,7 @@ export const computeCards = (
         (name = computeStateName(stateObj)).startsWith(titlePrefix)
           ? {
               entity: entityId,
-              name: name.substr(titlePrefix.length),
+              name: adjustName(name.substr(titlePrefix.length)),
             }
           : entityId;
 
@@ -208,6 +208,18 @@ export const computeCards = (
   }
 
   return cards;
+};
+
+const hasUpperCase = (str: string): boolean => {
+  return str.toLowerCase() !== str;
+};
+
+const adjustName = (name: string): string => {
+  // If first word already has an upper case letter (e.g. from brand name)
+  // leave as-is, otherwise capitalize the first word.
+  return hasUpperCase(name.split(" ")[0])
+    ? name
+    : name.charAt(0).toUpperCase() + name.slice(1);
 };
 
 const computeDefaultViewStates = (

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -173,9 +173,6 @@ class HuiGenericEntityRow extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .info::first-letter {
-        text-transform: uppercase;
-      }
       .flex ::slotted(*) {
         margin-left: 8px;
         min-width: 0;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The original solution https://github.com/home-assistant/frontend/pull/7962 was too crude. This approach is now only adjusting the name for the auto-generated dashboards, which was the use-case that the original PR attempted to handle initially.

New logic (again only for auto-generated dashboards):
1. If first word (after the automatic card title removal took effect) contains at least one upper case letter, leave as is (since probably a brand name or fixed term).
2. Otherwise capitalize the word.

Examples for various entity names, assuming the card title is "Bedroom":
Bedroom Light => Light
Bedroom light => Light
Bedroom specialBrand light => specialBrand light

Alternative would be to completely go back to the old logic, but leaves the issue of bad looking auto-generated dashboards, which is not good either.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8275
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
