### PR TITLE
Don't use badges in generated Lovelace + group entities by area

### DIFF
--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -43,7 +43,6 @@ import {
   PictureEntityCardConfig,
   ThermostatCardConfig,
 } from "../cards/types";
-import { processEditorEntities } from "../editor/process-editor-entities";
 import { LovelaceRowConfig } from "../entity-rows/types";
 
 const DEFAULT_VIEW_ENTITY_ID = "group.default_view";
@@ -247,13 +246,11 @@ const generateViewConfig = (
     const state = splitted.ungrouped[entityId];
     const domain = computeStateDomain(state);
 
-    const coll = ungroupedEntitites;
-
-    if (!(domain in coll)) {
-      coll[domain] = [];
+    if (!(domain in ungroupedEntitites)) {
+      ungroupedEntitites[domain] = [];
     }
 
-    coll[domain].push(state.entity_id);
+    ungroupedEntitites[domain].push(state.entity_id);
   });
 
   let cards: LovelaceCardConfig[] = [];


### PR DESCRIPTION

## Breaking change

Lovelace dashboard for generated users will change!

## Proposed change

This removes the use of badges in generated Lovelace dashboards.

It also now respects the area of the entity to group entities by area.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
