### PR TITLE
Add additional weblink attributes

### DIFF
--- a/src/panels/lovelace/entity-rows/types.ts
+++ b/src/panels/lovelace/entity-rows/types.ts
@@ -29,6 +29,8 @@ export interface WeblinkConfig {
   name?: string;
   icon?: string;
   url: string;
+  new_tab?: boolean;
+  download?: boolean;
 }
 export interface TextConfig {
   type: "text";

--- a/src/panels/lovelace/special-rows/hui-weblink-row.ts
+++ b/src/panels/lovelace/special-rows/hui-weblink-row.ts
@@ -7,6 +7,7 @@ import {
   LitElement,
   TemplateResult,
 } from "lit-element";
+import { ifDefined } from "lit-html/directives/if-defined";
 import "../../../components/ha-icon";
 import { HomeAssistant } from "../../../types";
 import { LovelaceRow, WeblinkConfig } from "../entity-rows/types";
@@ -37,8 +38,9 @@ class HuiWeblinkRow extends LitElement implements LovelaceRow {
     return html`
       <a
         href=${this._config.url}
-        target=${this._config.url.indexOf("://") !== -1 ? "_blank" : ""}
+        target=${ifDefined(this._computeTargetValue())}
         rel="noreferrer"
+        ?download=${this._config.download}
       >
         <ha-icon .icon="${this._config.icon}"></ha-icon>
         <div>${this._config.name}</div>
@@ -65,6 +67,15 @@ class HuiWeblinkRow extends LitElement implements LovelaceRow {
         margin-left: 16px;
       }
     `;
+  }
+
+  protected _computeTargetValue(): string | undefined {
+    return this._config &&
+      (this._config.url.indexOf("://") !== -1 ||
+        this._config.new_tab === true ||
+        this._config.download === true)
+      ? "_blank"
+      : undefined;
   }
 }
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add `new_tab` and `download` attributes to `Entities` card -> `Weblink`.

The `http` component ([Docs](https://www.home-assistant.io/integrations/http/#hosting-files)) allows the user to host local files, eg. csv. When used together with `weblink`, the frontend assumes that it's save to open them in the current window, since it's a local address. However, this doesn't work in most browsers (tested with Chome and Safari) and most importantly breaks the mobile apps.

This PR adds the ability to overwrite if a link should be opened in a new tab using the `new_tab` attribute.
Additionally I've added `download` to add the html `download` property to the link element.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
- type: weblink
  url: /local/data.csv
  new_tab: true
- type: weblink
  url: /local/data2.csv
  download: true
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16367

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
