### PR TITLE
number slider: change column width check from 350px to 300px

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -149,7 +149,7 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
       return;
     }
 
-    element.hidden = this.parentElement.clientWidth <= 350;
+    element.hidden = this.parentElement.clientWidth <= 300;
   }
 
   private get _inputElement(): { value: string } {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Change check on column width from 350px -> 300px to hide certain elements.

The problem with 350 is, that it is most of the time to big and the state most of the time hidden, because the responsive column change is on 300. So just before reaching 350/directly after 300 you will get another column with again below 350.

See Screenshots here https://github.com/home-assistant/frontend/pull/8050#issuecomment-761591651 and here https://github.com/home-assistant/frontend/pull/8050#issuecomment-771445933

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/8050

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

