### PR TITLE
Only display current temp when not None

### DIFF
--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -149,10 +149,9 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
                     this.hass!.language
                   )}
             <tspan dx="-3" dy="-6.5" style="font-size: 4px;">
-              ${this.hass.config.unit_system.temperature}`
+              ${this.hass.config.unit_system.temperature}</tspan>`
                 : ""
             }
-            </tspan>
           </text>
         </svg>
       `;

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -149,7 +149,8 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
                     this.hass!.language
                   )}
             <tspan dx="-3" dy="-6.5" style="font-size: 4px;">
-              ${this.hass.config.unit_system.temperature}</tspan>`
+              ${this.hass.config.unit_system.temperature}
+            </tspan>`
                 : ""
             }
           </text>

--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -132,27 +132,30 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
             ></round-slider>
           `;
 
-    const currentTemperature = !isNaN(stateObj.attributes.current_temperature)
-      ? svg`
-          <svg viewBox="0 0 40 20">
-            <text
-              x="50%"
-              dx="1"
-              y="60%"
-              text-anchor="middle"
-              style="font-size: 13px;"
-            >
-              ${formatNumber(
-                stateObj.attributes.current_temperature,
-                this.hass!.language
-              )}
-              <tspan dx="-3" dy="-6.5" style="font-size: 4px;">
-                ${this.hass.config.unit_system.temperature}
-              </tspan>
-            </text>
-          </svg>
-        `
-      : "";
+    const currentTemperature = svg`
+        <svg viewBox="0 0 40 20">
+          <text
+            x="50%"
+            dx="1"
+            y="60%"
+            text-anchor="middle"
+            style="font-size: 13px;"
+          >
+            ${
+              stateObj.attributes.current_temperature !== null &&
+              !isNaN(stateObj.attributes.current_temperature)
+                ? svg`${formatNumber(
+                    stateObj.attributes.current_temperature,
+                    this.hass!.language
+                  )}
+            <tspan dx="-3" dy="-6.5" style="font-size: 4px;">
+              ${this.hass.config.unit_system.temperature}`
+                : ""
+            }
+            </tspan>
+          </text>
+        </svg>
+      `;
 
     const setValues = svg`
       <svg id="set-values">


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Only display the current temperature including unit of measurement when actually provided by the backend.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #8311
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
