### PR TITLE
Make states that are numbers line graphs by default

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -200,6 +200,15 @@ const processLineChartEntities = (
   };
 };
 
+const isNumberValued = (states: HassEntity[]): boolean => {
+  for (const state of states) {
+    if (isNaN(parseFloat(state.state))) {
+      return false;
+    }
+  }
+  return true;
+};
+
 export const computeHistory = (
   hass: HomeAssistant,
   stateHistory: HassEntity[][],
@@ -231,6 +240,8 @@ export const computeHistory = (
       unit = hass.config.unit_system.temperature;
     } else if (computeStateDomain(stateInfo[0]) === "humidifier") {
       unit = "%";
+    } else if (isNumberValued(stateInfo)) {
+      unit = " ";
     }
 
     if (!unit) {

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -4,6 +4,7 @@ import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { computeStateName } from "../common/entity/compute_state_name";
 import { LocalizeFunc } from "../common/translations/localize";
 import { HomeAssistant } from "../types";
+import { UNAVAILABLE_STATES } from "./entity";
 
 const DOMAINS_USE_LAST_UPDATED = ["climate", "humidifier", "water_heater"];
 const LINE_ATTRIBUTES_TO_KEEP = [
@@ -201,10 +202,18 @@ const processLineChartEntities = (
 };
 
 const isNumberValued = (states: HassEntity[]): boolean => {
-  for (const state of states) {
-    if (isNaN(parseFloat(state.state))) {
-      return false;
-    }
+  if (states.every((state) => UNAVAILABLE_STATES.includes(state.state))) {
+    return false;
+  }
+
+  if (
+    states.some(
+      (state) =>
+        isNaN(parseFloat(state.state)) &&
+        !UNAVAILABLE_STATES.includes(state.state)
+    )
+  ) {
+    return false;
   }
   return true;
 };

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -201,7 +201,7 @@ const processLineChartEntities = (
   };
 };
 
-const isNumberValued = (states: HassEntity[]): boolean => {
+const isNumerical = (states: HassEntity[]): boolean => {
   if (states.every((state) => UNAVAILABLE_STATES.includes(state.state))) {
     return false;
   }
@@ -249,7 +249,7 @@ export const computeHistory = (
       unit = hass.config.unit_system.temperature;
     } else if (computeStateDomain(stateInfo[0]) === "humidifier") {
       unit = "%";
-    } else if (isNumberValued(stateInfo)) {
+    } else if (isNumerical(stateInfo)) {
       unit = " ";
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Sensor values with no `unit_of_measurement` are now displayed as that weird bar thing in the various history graphs.
This change makes it default to a normal line graph if *every* state in the history can be parsed as a number.

While there will be weird edge cases, I think this is a more sane default.

Before (DemoMailbox, PWM 1, volume):
![image](https://user-images.githubusercontent.com/1299821/107084470-61c7d000-67f7-11eb-972e-8e92c72a73ad.png)


After:
![image](https://user-images.githubusercontent.com/1299821/107084411-4e1c6980-67f7-11eb-8ccf-9814a6d64989.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [X] Something in between those two... maybe?


## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6453
- This PR is related to issue or discussion: home-assistant/architecture#503
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
