### PR TITLE
Fix excessive rerendering of history charts

### DIFF
--- a/src/components/state-history-charts.ts
+++ b/src/components/state-history-charts.ts
@@ -13,7 +13,7 @@ import "./state-history-chart-line";
 import "./state-history-chart-timeline";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import type { HomeAssistant } from "../types";
-import { hasConfigOrEntityChanged } from "../common/has-changed";
+import { hasConfigOrEntityChanged } from "../panels/lovelace/common/has-changed";
 import { HistoryResult } from "../data/history";
 
 @customElement("state-history-charts")

--- a/src/components/state-history-charts.ts
+++ b/src/components/state-history-charts.ts
@@ -6,12 +6,14 @@ import {
   html,
   LitElement,
   property,
+  PropertyValues,
   TemplateResult,
 } from "lit-element";
 import "./state-history-chart-line";
 import "./state-history-chart-timeline";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import type { HomeAssistant } from "../types";
+import { hasConfigOrEntityChanged } from "../common/has-changed";
 import { HistoryResult } from "../data/history";
 
 @customElement("state-history-charts")
@@ -81,6 +83,13 @@ class StateHistoryCharts extends LitElement {
         `
       )}
     `;
+  }
+
+  protected shouldUpdate(changedProps: PropertyValues): boolean {
+    return (
+      hasConfigOrEntityChanged(this, changedProps) ||
+      changedProperties.has("historyData")
+    );
   }
 
   private _isHistoryEmpty(): boolean {

--- a/src/components/state-history-charts.ts
+++ b/src/components/state-history-charts.ts
@@ -88,7 +88,7 @@ class StateHistoryCharts extends LitElement {
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     return (
       hasConfigOrEntityChanged(this, changedProps) ||
-      changedProperties.has("historyData")
+      changedProps.has("historyData")
     );
   }
 

--- a/src/components/state-history-charts.ts
+++ b/src/components/state-history-charts.ts
@@ -85,10 +85,7 @@ class StateHistoryCharts extends LitElement {
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
-    return (
-      changedProps.has("isLoadingData") ||
-      changedProps.has("historyData")
-    );
+    return !(changedProps.size === 1 && changedProps.has("hass"));
   }
 
   private _isHistoryEmpty(): boolean {

--- a/src/components/state-history-charts.ts
+++ b/src/components/state-history-charts.ts
@@ -87,7 +87,7 @@ class StateHistoryCharts extends LitElement {
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     return (
-      hasConfigOrEntityChanged(this, changedProps) ||
+      changedProps.has("isLoadingData") ||
       changedProps.has("historyData")
     );
   }

--- a/src/components/state-history-charts.ts
+++ b/src/components/state-history-charts.ts
@@ -13,7 +13,6 @@ import "./state-history-chart-line";
 import "./state-history-chart-timeline";
 import { isComponentLoaded } from "../common/config/is_component_loaded";
 import type { HomeAssistant } from "../types";
-import { hasConfigOrEntityChanged } from "../panels/lovelace/common/has-changed";
 import { HistoryResult } from "../data/history";
 
 @customElement("state-history-charts")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Closes https://github.com/home-assistant/frontend/issues/8274

When @spacegaier reimplemented the history chart as LitElement, that unfortunately broke their tooltips because the chart would rerender on every change of the hass object. In my case that was every 500 ms and I'm not able to read that fast.

This PR implements shouldUpdate so the chart only rerenders when there was either a change to its own entity or the underlying history data.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
