### PR TITLE
Add button to call lock.open to lock state card

### DIFF
--- a/src/data/lock.ts
+++ b/src/data/lock.ts
@@ -1,0 +1,1 @@
+export const SUPPORT_OPEN = 1;

--- a/src/state-summary/state-card-lock.js
+++ b/src/state-summary/state-card-lock.js
@@ -5,6 +5,8 @@ import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 import "../components/entity/state-info";
 import LocalizeMixin from "../mixins/localize-mixin";
+import { supportsFeature } from "../common/entity/supports-feature";
+import { SUPPORT_OPEN } from "../data/lock";
 
 /*
  * @appliesMixin LocalizeMixin

--- a/src/state-summary/state-card-lock.js
+++ b/src/state-summary/state-card-lock.js
@@ -25,6 +25,12 @@ class StateCardLock extends LocalizeMixin(PolymerElement) {
         ${this.stateInfoTemplate}
         <mwc-button
           on-click="_callService"
+          data-service="open"
+          hidden$="[[!canOpen]]"
+          >[[localize('ui.card.lock.open')]]</mwc-button
+        >        
+        <mwc-button
+          on-click="_callService"
           data-service="unlock"
           hidden$="[[!isLocked]]"
           >[[localize('ui.card.lock.unlock')]]</mwc-button
@@ -61,12 +67,14 @@ class StateCardLock extends LocalizeMixin(PolymerElement) {
         value: false,
       },
       isLocked: Boolean,
+      canOpen: Boolean,
     };
   }
 
   _stateObjChanged(newVal) {
     if (newVal) {
       this.isLocked = newVal.state === "locked";
+      this.canOpen = supportsFeature(newVal, SUPPORT_OPEN);
     }
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -178,7 +178,8 @@
       "lock": {
         "code": "[%key:ui::card::alarm_control_panel::code%]",
         "lock": "Lock",
-        "unlock": "Unlock"
+        "unlock": "Unlock",
+        "open": "Open"
       },
       "media_player": {
         "source": "Source",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This adds a new 'Open' button to the state card for the lock entity that calls the `lock.open` service.
The button is placed next to the 'Lock' and 'Unlock' buttons and is hidden if the lock does not support this feature.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: none
- This PR is related to issue or discussion: none
- Link to documentation pull request: none

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
