### PR TITLE
Correctly handle seconds in top "delay" key

### DIFF
--- a/src/panels/config/automation/action/types/ha-automation-action-delay.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-delay.ts
@@ -26,9 +26,9 @@ export class HaDelayAction extends LitElement implements ActionElement {
         const parts = this.action.delay?.toString().split(":") || [];
         data = {
           hours: Number(parts[0]) || 0,
-          minutes: Number(parts[1]),
-          seconds: Number(parts[2]),
-          milliseconds: Number(parts[3]),
+          minutes: Number(parts[1]) || 0,
+          seconds: Number(parts[2]) || 0,
+          milliseconds: Number(parts[3]) || 0,
         };
       } else {
         data = { seconds: this.action.delay };

--- a/src/panels/config/automation/action/types/ha-automation-action-delay.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-delay.ts
@@ -22,13 +22,17 @@ export class HaDelayAction extends LitElement implements ActionElement {
     let data: HaFormTimeData = {};
 
     if (typeof this.action.delay !== "object") {
-      const parts = this.action.delay?.toString().split(":") || [];
-      data = {
-        hours: Number(parts[0]),
-        minutes: Number(parts[1]),
-        seconds: Number(parts[2]),
-        milliseconds: Number(parts[3]),
-      };
+      if (isNaN(this.action.delay)) {
+        const parts = this.action.delay?.toString().split(":") || [];
+        data = {
+          hours: Number(parts[0]),
+          minutes: Number(parts[1]),
+          seconds: Number(parts[2]),
+          milliseconds: Number(parts[3]),
+        };
+      } else {
+        data = { seconds: this.action.delay };
+      }
     } else {
       const { days, minutes, seconds, milliseconds } = this.action.delay;
       let { hours } = this.action.delay || 0;
@@ -46,7 +50,8 @@ export class HaDelayAction extends LitElement implements ActionElement {
         .data=${data}
         enableMillisecond
         @value-changed=${this._valueChanged}
-      ></ha-time-input>
+      >
+      </ha-time-input>
     `;
   }
 

--- a/src/panels/config/automation/action/types/ha-automation-action-delay.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-delay.ts
@@ -25,7 +25,7 @@ export class HaDelayAction extends LitElement implements ActionElement {
       if (isNaN(this.action.delay)) {
         const parts = this.action.delay?.toString().split(":") || [];
         data = {
-          hours: Number(parts[0]),
+          hours: Number(parts[0]) || 0,
           minutes: Number(parts[1]),
           seconds: Number(parts[2]),
           milliseconds: Number(parts[3]),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The format `delay: <seconds>` was incorrectly interpreted also as a string time value and attempted to be split at ":". This meant the seconds were interpreted as hours.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8376
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
