### PR TITLE
Restore previous codemirror tab behavior

### DIFF
--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -1,6 +1,5 @@
 import type { StreamLanguage } from "@codemirror/stream-parser";
 import type { EditorView, KeyBinding, ViewUpdate } from "@codemirror/view";
-import { indentMore, indentLess } from "@codemirror/commands";
 import {
   customElement,
   internalProperty,
@@ -134,11 +133,11 @@ export class HaCodeEditor extends UpdatingElement {
             ...loaded.defaultKeymap,
             {
               key: "Tab",
-              run: indentMore,
+              run: loaded.indentMore,
             },
             {
               key: "Shift-Tab",
-              run: indentLess,
+              run: loaded.indentLess,
             },
             saveKeyBinding,
           ]),

--- a/src/components/ha-code-editor.ts
+++ b/src/components/ha-code-editor.ts
@@ -1,5 +1,6 @@
 import type { StreamLanguage } from "@codemirror/stream-parser";
 import type { EditorView, KeyBinding, ViewUpdate } from "@codemirror/view";
+import { indentMore, indentLess } from "@codemirror/commands";
 import {
   customElement,
   internalProperty,
@@ -131,7 +132,14 @@ export class HaCodeEditor extends UpdatingElement {
           loaded.lineNumbers(),
           loaded.keymap.of([
             ...loaded.defaultKeymap,
-            loaded.defaultTabBinding,
+            {
+              key: "Tab",
+              run: indentMore,
+            },
+            {
+              key: "Shift-Tab",
+              run: indentLess,
+            },
             saveKeyBinding,
           ]),
           loaded.tagExtension(modeTag, this._mode),

--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -7,8 +7,9 @@ import { yaml } from "@codemirror/legacy-modes/mode/yaml";
 export { keymap } from "@codemirror/view";
 export { CMEditorView as EditorView };
 export { EditorState, Prec, tagExtension } from "@codemirror/state";
-export { defaultKeymap, defaultTabBinding } from "@codemirror/commands";
+export { defaultKeymap } from "@codemirror/commands";
 export { lineNumbers } from "@codemirror/gutter";
+export { indentMore, indentLess } from "@codemirror/commands";
 
 export const langs = {
   jinja2: StreamLanguage.define(jinja2),

--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -7,9 +7,8 @@ import { yaml } from "@codemirror/legacy-modes/mode/yaml";
 export { keymap } from "@codemirror/view";
 export { CMEditorView as EditorView };
 export { EditorState, Prec, tagExtension } from "@codemirror/state";
-export { defaultKeymap } from "@codemirror/commands";
+export { defaultKeymap, indentLess, indentMore } from "@codemirror/commands";
 export { lineNumbers } from "@codemirror/gutter";
-export { indentMore, indentLess } from "@codemirror/commands";
 
 export const langs = {
   jinja2: StreamLanguage.define(jinja2),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Restores the previous behavior of Tab = 2 spaces. However, it needs to be noted that CM6 by design does not have that as default behavior, apparently due to some accessibility concerns. For the current beta, I think we need to ignore that since otherwise YAML saving is broken, which weighs heavier.

Also CM6 includes an escape hatch: Esc + Tab leaves the editor, see: https://codemirror.net/6/examples/tab/

Perhaps we can document that somewhere?

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8460
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
