### PR TITLE
Take cover "opening" and "closing" into account

### DIFF
--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -216,7 +216,6 @@ export const getLogbookMessage = (
         case "cold":
         case "gas":
         case "heat":
-        case "colightld":
         case "moisture":
         case "motion":
         case "occupancy":
@@ -246,9 +245,17 @@ export const getLogbookMessage = (
     }
 
     case "cover":
-      return state === "open"
-        ? hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_opened`)
-        : hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_closed`);
+      switch (state) {
+        case "open":
+          return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_opened`);
+        case "opening":
+          return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.is_opening`);
+        case "closing":
+          return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.is_closing`);
+        case "closed":
+          return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_closed`);
+      }
+      break;
 
     case "lock":
       if (state === "unlocked") {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -311,6 +311,8 @@
           "was_disconnected": "was disconnected",
           "was_opened": "was opened",
           "was_closed": "was closed",
+          "is_opening": "is opening",
+          "is_closing": "is closing",
           "was_unlocked": "was unlocked",
           "was_locked": "was locked",
           "was_plugged_in": "was plugged in",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Frontend logbook only considered `open`and `closed` in the logbook, but not the intermediate states `opening` and `closing`.

![image](https://user-images.githubusercontent.com/114137/109433610-8dfaf900-7a11-11eb-9391-af72a1110a25.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8489
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
