### PR TITLE
ZHA UI enhancements

### DIFF
--- a/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-actions-zha.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-actions-zha.ts
@@ -21,6 +21,7 @@ import { haStyle } from "../../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../../types";
 import { showZHAClusterDialog } from "../../../../integrations/integration-panels/zha/show-dialog-zha-cluster";
 import { showZHADeviceZigbeeInfoDialog } from "../../../../integrations/integration-panels/zha/show-dialog-zha-device-zigbee-info";
+import { showZHADeviceChildrenDialog } from "../../../../integrations/integration-panels/zha/show-dialog-zha-device-children";
 
 @customElement("ha-device-actions-zha")
 export class HaDeviceActionsZha extends LitElement {
@@ -64,6 +65,11 @@ export class HaDeviceActionsZha extends LitElement {
         ? html`
             <mwc-button @click=${this._onAddDevicesClick}>
               ${this.hass!.localize("ui.dialogs.zha_device_info.buttons.add")}
+            </mwc-button>
+            <mwc-button @click=${this._handleDeviceChildrenClicked}>
+              ${this.hass!.localize(
+                "ui.dialogs.zha_device_info.buttons.device_children"
+              )}
             </mwc-button>
           `
         : ""}
@@ -118,6 +124,10 @@ export class HaDeviceActionsZha extends LitElement {
 
   private async _handleZigbeeInfoClicked() {
     showZHADeviceZigbeeInfoDialog(this, { device: this._zhaDevice! });
+  }
+
+  private async _handleDeviceChildrenClicked() {
+    showZHADeviceChildrenDialog(this, { device: this._zhaDevice! });
   }
 
   private async _removeDevice() {

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
@@ -76,7 +76,7 @@ class DialogZHADeviceChildren extends LitElement {
     },
   };
 
-  public async showDialog(
+  public showDialog(
     params: ZHADeviceChildrenDialogParams
   ): Promise<void> {
     this._device = params.device;

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
@@ -19,6 +19,7 @@ import type {
   DataTableColumnContainer,
   DataTableRowData,
 } from "../../../../../components/data-table/ha-data-table";
+import "../../../../../components/ha-circular-progress";
 import { fetchDevices, ZHADevice } from "../../../../../data/zha";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 
@@ -89,7 +90,7 @@ class DialogZHADeviceChildren extends LitElement {
   }
 
   protected render(): TemplateResult {
-    if (!this._devices) {
+    if (!this._device) {
       return html``;
     }
     return html`
@@ -101,14 +102,25 @@ class DialogZHADeviceChildren extends LitElement {
           this.hass,
           this.hass.localize(`ui.dialogs.zha_device_info.device_children`)
         )}
-        ><ha-data-table
-          .columns=${this._columns}
-          .data=${this._deviceChildren(this._device, this._devices)}
-          auto-height
-          .dir=${computeRTLDirection(this.hass)}
-          .searchLabel=${this.hass.localize("ui.components.data-table.search")}
-          .noDataText=${this.hass.localize("ui.components.data-table.no-data")}
-        ></ha-data-table>
+      >
+        ${!this._devices
+          ? html`<ha-circular-progress
+              alt="Loading"
+              size="large"
+              active
+            ></ha-circular-progress>`
+          : html`<ha-data-table
+              .columns=${this._columns}
+              .data=${this._deviceChildren(this._device, this._devices)}
+              auto-height
+              .dir=${computeRTLDirection(this.hass)}
+              .searchLabel=${this.hass.localize(
+                "ui.components.data-table.search"
+              )}
+              .noDataText=${this.hass.localize(
+                "ui.components.data-table.no-data"
+              )}
+            ></ha-data-table>`}
       </ha-dialog>
     `;
   }

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
@@ -97,7 +97,7 @@ class DialogZHADeviceChildren extends LitElement {
       <ha-dialog
         hideActions
         open
-        @closed="${this.closeDialog}"
+        @closed=${this.closeDialog}
         .heading=${createCloseHeading(
           this.hass,
           this.hass.localize(`ui.dialogs.zha_device_info.device_children`)

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
@@ -78,7 +78,7 @@ class DialogZHADeviceChildren extends LitElement {
 
   public showDialog(
     params: ZHADeviceChildrenDialogParams
-  ): Promise<void> {
+  ): void {
     this._device = params.device;
     this._fetchData();
   }

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
@@ -19,7 +19,6 @@ import type {
   DataTableColumnContainer,
   DataTableRowData,
 } from "../../../../../components/data-table/ha-data-table";
-import "../../../../../components/ha-circular-progress";
 import { fetchDevices, ZHADevice } from "../../../../../data/zha";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 
@@ -36,8 +35,6 @@ class DialogZHADeviceChildren extends LitElement {
   @internalProperty() private _device: ZHADevice | undefined;
 
   @internalProperty() private _devices: Map<string, ZHADevice> | undefined;
-
-  @internalProperty() private _opened = false;
 
   private _deviceChildren = memoizeOne(
     (
@@ -83,45 +80,35 @@ class DialogZHADeviceChildren extends LitElement {
   ): Promise<void> {
     this._device = params.device;
     this._fetchData();
-    this._opened = true;
   }
 
   public closeDialog(): void {
     this._device = undefined;
     this._devices = undefined;
-    this._opened = false;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   protected render(): TemplateResult {
+    if (!this._devices) {
+      return html``;
+    }
     return html`
       <ha-dialog
-        .open=${this._opened}
         hideActions
-        @closing="${this.closeDialog}"
+        open
+        @closed="${this.closeDialog}"
         .heading=${createCloseHeading(
           this.hass,
           this.hass.localize(`ui.dialogs.zha_device_info.device_children`)
         )}
-      >
-        ${!this._devices
-          ? html`<ha-circular-progress
-              alt="Loading"
-              size="large"
-              active
-            ></ha-circular-progress>`
-          : html` <ha-data-table
-              .columns=${this._columns}
-              .data=${this._deviceChildren(this._device, this._devices)}
-              auto-height
-              .dir=${computeRTLDirection(this.hass)}
-              .searchLabel=${this.hass.localize(
-                "ui.components.data-table.search"
-              )}
-              .noDataText=${this.hass.localize(
-                "ui.components.data-table.no-data"
-              )}
-            ></ha-data-table>`}
+        ><ha-data-table
+          .columns=${this._columns}
+          .data=${this._deviceChildren(this._device, this._devices)}
+          auto-height
+          .dir=${computeRTLDirection(this.hass)}
+          .searchLabel=${this.hass.localize("ui.components.data-table.search")}
+          .noDataText=${this.hass.localize("ui.components.data-table.no-data")}
+        ></ha-data-table>
       </ha-dialog>
     `;
   }

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-children.ts
@@ -1,0 +1,130 @@
+import {
+  CSSResult,
+  customElement,
+  html,
+  internalProperty,
+  LitElement,
+  property,
+  TemplateResult,
+} from "lit-element";
+import memoizeOne from "memoize-one";
+import { computeRTLDirection } from "../../../../../common/util/compute_rtl";
+import "../../../../../components/ha-code-editor";
+import { createCloseHeading } from "../../../../../components/ha-dialog";
+import { haStyleDialog } from "../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../types";
+import { ZHADeviceChildrenDialogParams } from "./show-dialog-zha-device-children";
+import "../../../../../components/data-table/ha-data-table";
+import type {
+  DataTableColumnContainer,
+  DataTableRowData,
+} from "../../../../../components/data-table/ha-data-table";
+import { fetchDevices, ZHADevice } from "../../../../../data/zha";
+
+export interface DeviceRowData extends DataTableRowData {
+  id: string;
+  name: string;
+  lqi: number;
+}
+
+@customElement("dialog-zha-device-children")
+class DialogZHADeviceChildren extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @internalProperty() private _device: any;
+
+  @internalProperty() private _devices: Map<string, ZHADevice> = new Map();
+
+  private _deviceChildren = memoizeOne(
+    (device: ZHADevice, devices: Map<string, ZHADevice>) => {
+      const outputDevices: DeviceRowData[] = [];
+
+      device.neighbors.forEach((child) => {
+        const zhaDevice: ZHADevice | undefined = devices.get(child.ieee);
+        if (zhaDevice) {
+          outputDevices.push({
+            name: zhaDevice.user_given_name || zhaDevice.name,
+            id: zhaDevice.device_reg_id,
+            lqi: child.lqi,
+          });
+        }
+      });
+
+      return outputDevices;
+    }
+  );
+
+  private _columns: DataTableColumnContainer = {
+    name: {
+      title: "Name",
+      sortable: true,
+      filterable: true,
+      direction: "asc",
+      grows: true,
+    },
+    lqi: {
+      title: "LQI",
+      sortable: true,
+      filterable: true,
+      direction: "asc",
+      width: "75px",
+    },
+  };
+
+  public async showDialog(
+    params: ZHADeviceChildrenDialogParams
+  ): Promise<void> {
+    this._device = params.device;
+    await this._fetchData();
+  }
+
+  protected render(): TemplateResult {
+    if (!this._device) {
+      return html``;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        hideActions
+        @closing="${this._close}"
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass.localize(`ui.dialogs.zha_device_info.device_children`)
+        )}
+      >
+        <ha-data-table
+          .columns=${this._columns}
+          .data=${this._deviceChildren(this._device, this._devices)}
+          auto-height
+          .dir=${computeRTLDirection(this.hass)}
+          .searchLabel=${this.hass.localize("ui.components.data-table.search")}
+          .noDataText=${this.hass.localize("ui.components.data-table.no-data")}
+        ></ha-data-table>
+      </ha-dialog>
+    `;
+  }
+
+  private async _fetchData(): Promise<void> {
+    if (this._device && this.hass) {
+      const devices = await fetchDevices(this.hass!);
+      this._devices = new Map(
+        devices.map((device: ZHADevice) => [device.ieee, device])
+      );
+    }
+  }
+
+  private _close(): void {
+    this._device = undefined;
+  }
+
+  static get styles(): CSSResult {
+    return haStyleDialog;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-zha-device-children": DialogZHADeviceChildren;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/zha/show-dialog-zha-device-children.ts
+++ b/src/panels/config/integrations/integration-panels/zha/show-dialog-zha-device-children.ts
@@ -1,0 +1,20 @@
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import { ZHADevice } from "../../../../../data/zha";
+
+export interface ZHADeviceChildrenDialogParams {
+  device: ZHADevice;
+}
+
+export const loadZHADeviceChildrenDialog = () =>
+  import("./dialog-zha-device-children");
+
+export const showZHADeviceChildrenDialog = (
+  element: HTMLElement,
+  zhaDeviceChildrenParams: ZHADeviceChildrenDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-zha-device-children",
+    dialogImport: loadZHADeviceChildrenDialog,
+    dialogParams: zhaDeviceChildrenParams,
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -743,12 +743,14 @@
         "manuf": "by {manufacturer}",
         "no_area": "No Area",
         "device_signature": "Zigbee device signature",
+        "device_children": "Zigbee device children",
         "buttons": {
           "add": "Add Devices via this device",
           "remove": "Remove Device",
           "clusters": "Manage Clusters",
           "reconfigure": "Reconfigure Device",
           "zigbee_information": "Zigbee device signature",
+          "device_children": "View Children",
           "view_in_visualization": "View in Visualization"
         },
         "services": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2373,6 +2373,7 @@
             "caption": "Visualization",
             "highlight_label": "Highlight Devices",
             "zoom_label": "Zoom To Device",
+            "auto_zoom": "Auto Zoom",
             "refresh_topology": "Refresh Topology"
           },
           "group_binding": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR adds auto zoom in the ZHA network visualization page and it also adds a dialog on the device page that allows you to see the children for router and coordinator type devices. 

![auto-zoom](https://user-images.githubusercontent.com/1335687/110221986-3f2fe200-7e9d-11eb-9442-33ec24cad90b.gif)

<img width="659" alt="Screen Shot 2021-03-06 at 4 59 19 PM" src="https://user-images.githubusercontent.com/1335687/110221998-4fe05800-7e9d-11eb-9cb8-0c515d023e33.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
