### PR TITLE
Always rename entity ID on device name change + clearer user question

### DIFF
--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -685,7 +685,7 @@ export class HaConfigDevicePage extends LitElement {
         }
         const entities = this._entities(this.deviceId, this.entities);
 
-        const renameEntityid =
+        const renameEntityId =
           this.showAdvanced &&
           (await showConfirmationDialog(this, {
             title: this.hass.localize(
@@ -708,14 +708,9 @@ export class HaConfigDevicePage extends LitElement {
             newName = name.replace(oldDeviceName, newDeviceName);
           }
 
-          if (renameEntityid) {
-            const oldSearch = slugify(oldDeviceName);
-            if (entity.entity_id.includes(oldSearch)) {
-              newEntityId = entity.entity_id.replace(
-                oldSearch,
-                slugify(newDeviceName)
-              );
-            }
+          if (renameEntityId) {
+            newEntityId =
+              entity.entity_id.split(".", 1)[0] + "." + slugify(newDeviceName);
           }
 
           if (!newName && !newEntityId) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1894,7 +1894,7 @@
           },
           "scripts": "Scripts",
           "scenes": "Scenes",
-          "confirm_rename_entity_ids": "Do you also want to rename the entity IDs of your entities?",
+          "confirm_rename_entity_ids": "Should the entity IDs for this device be renamed to match the new device name?",
           "confirm_rename_entity_ids_warning": "This will not change any configuration (like automations, scripts, scenes, dashboards) that is currently using these entities! You will have to update them yourself to use the new entity IDs!",
           "confirm_disable_config_entry": "There are no more devices for the config entry {entry_name}, do you want to instead disable the config entry?",
           "disabled": "Disabled",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

This discussion https://github.com/home-assistant/frontend/discussions/8645 made me think about the wording a bit.

I think the proposed question makes it clearer what HA is about to do. Plus I removed the weird check if the existing entity ID contains the old name of the device, since that does not have to be the case and we would otherwise just silently do nothing, but is not transparent to the user.

**Example:**
Entity is initially named "TV" -> User changes to "TV Livng" but does not allow the renaming to happen (for whatever reason, maybe even misclick) -> User corrects typo to "TV Living" and presses "Rename":
* In the old coding, no renaming takes place since the entity ID is still domain.tv but the coding looks for domain.tv_livng. 
* With the new coding, we will always follow the device name if the user presses "Rename" so we would end up with entity ID domain.tv_living.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
