### PR TITLE
Add an absolute height to cast receiver to fix height inheritance

### DIFF
--- a/cast/src/receiver/layout/hc-lovelace.ts
+++ b/cast/src/receiver/layout/hc-lovelace.ts
@@ -94,7 +94,7 @@ class HcLovelace extends LitElement {
     return css`
       :host {
         min-height: 100vh;
-        height: 1px;
+        height: 0;
         display: flex;
         flex-direction: column;
         box-sizing: border-box;

--- a/cast/src/receiver/layout/hc-lovelace.ts
+++ b/cast/src/receiver/layout/hc-lovelace.ts
@@ -94,6 +94,7 @@ class HcLovelace extends LitElement {
     return css`
       :host {
         min-height: 100vh;
+        height: 1px;
         display: flex;
         flex-direction: column;
         box-sizing: border-box;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Set a `1px` height on the `hc-lovelace` element used when casting views to a home hub. Without this property set, child elements can't set relative heights. See [this blog post](https://www.456bereastreet.com/archive/201306/height_in_percent_when_parent_has_min-height_and_no_height/) for context on what I think the problem is. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
For the UI:
```yaml
title: Home
views:
  - title: test_page
    path: test_page
    panel: true
    badges: []
    cards:
      - type: iframe
        url: 'http://10.0.0.91:8123/local/tileboard/index.html'
```
This is easy to replicate when running the default version of tileboard, but it would likely happen with any other relatively sized thing.

## Additional information

I ran into this issue when trying to cast an iframe ([tileboard](https://github.com/resoai/TileBoard)) to my Google Home Hub. Nothing showed up on the screen. After setting up the [dev cast environment](https://github.com/home-assistant/frontend/tree/dev/cast) and attaching a web inspector to it, I discovered that it was squashing the entire page contents to `0px`. I tried a few things to fix it, including setting the iframe to `100vh`, but this seemed like the most correct way to fix it. 

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I'm not sure what the best way to test this is (if any), but locally I've tested casting the default lovelace UI page and tileboard and both work.

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
