### PR TITLE
Handle edit mode for panel mode cards better

### DIFF
--- a/src/panels/lovelace/cards/hui-iframe-card.ts
+++ b/src/panels/lovelace/cards/hui-iframe-card.ts
@@ -31,9 +31,6 @@ export class HuiIframeCard extends LitElement implements LovelaceCard {
   @property({ type: Boolean, reflect: true })
   public isPanel = false;
 
-  @property({ type: Boolean, reflect: true })
-  public editMode = false;
-
   @property() protected _config?: IframeCardConfig;
 
   public getCardSize(): number {
@@ -92,10 +89,6 @@ export class HuiIframeCard extends LitElement implements LovelaceCard {
       :host([ispanel]) ha-card {
         width: 100%;
         height: 100%;
-      }
-
-      :host([ispanel][editMode]) ha-card {
-        height: calc(100% - 51px);
       }
 
       ha-card {

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -72,9 +72,6 @@ class HuiMapCard extends LitElement implements LovelaceCard {
   @property({ type: Boolean, reflect: true })
   public isPanel = false;
 
-  @property({ type: Boolean, reflect: true })
-  public editMode = false;
-
   @property()
   private _history?: HassEntity[][];
 
@@ -658,10 +655,6 @@ class HuiMapCard extends LitElement implements LovelaceCard {
 
   static get styles(): CSSResult {
     return css`
-      :host([ispanel][editMode]) ha-card {
-        height: calc(100% - 51px);
-      }
-
       ha-card {
         overflow: hidden;
         width: 100%;

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -8,7 +8,6 @@ import {
   CSSResult,
   customElement,
   html,
-  internalProperty,
   LitElement,
   property,
   PropertyValues,

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -8,8 +8,10 @@ import {
   CSSResult,
   customElement,
   html,
+  internalProperty,
   LitElement,
   property,
+  PropertyValues,
   queryAssignedNodes,
   TemplateResult,
 } from "lit-element";
@@ -39,9 +41,19 @@ export class HuiCardOptions extends LitElement {
     return this._assignedNodes ? computeCardSize(this._assignedNodes[0]) : 1;
   }
 
+  protected updated(changedProps: PropertyValues) {
+    if (!changedProps.has("path") || !this.path) {
+      return;
+    }
+    this.classList.toggle(
+      "panel",
+      this.lovelace!.config.views[this.path![0]].panel
+    );
+  }
+
   protected render(): TemplateResult {
     return html`
-      <slot></slot>
+      <div class="card"><slot></slot></div>
       <ha-card>
         <div class="card-actions">
           <mwc-button @click=${this._editCard}
@@ -108,8 +120,12 @@ export class HuiCardOptions extends LitElement {
         outline: 2px solid var(--primary-color);
       }
 
-      ::slotted(*) {
+      :host:not(.panel) ::slotted(*) {
         display: block;
+      }
+
+      :host(.panel) .card {
+        height: calc(100% - 59px);
       }
 
       ha-card {


### PR DESCRIPTION


## Proposed change

Some panel cards where not show in edit mode because of styling in `hui-card-options` I fixed that and made the edit mode fixes from map and iframe card generic in `hui-card-options`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
