### PR TITLE
Fix Z-Wave JS Node Config Panel handling null values

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -301,11 +301,11 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
       return;
     }
 
-    this._updateConfigParameter(ev.target, parseInt(ev.target.selected));
+    this._updateConfigParameter(ev.target, Number(ev.target.selected));
   }
 
   private debouncedUpdate = debounce((target) => {
-    const value = parseInt(target.value);
+    const value = Number(target.value);
     this._config![target.key].value = value;
 
     this._updateConfigParameter(target, value);
@@ -315,7 +315,9 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
     if (ev.target === undefined || this._config![ev.target.key] === undefined) {
       return;
     }
-    if (this._config![ev.target.key].value === parseInt(ev.target.value)) {
+    if (
+      Number(this._config![ev.target.key].value) === Number(ev.target.value)
+    ) {
       return;
     }
     this.debouncedUpdate(ev.target);

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -304,8 +304,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
     this._updateConfigParameter(ev.target, Number(ev.target.selected));
   }
 
-  private debouncedUpdate = debounce((target) => {
-    const value = Number(target.value);
+  private debouncedUpdate = debounce((target, value) => {
     this._config![target.key].value = value;
 
     this._updateConfigParameter(target, value);
@@ -315,12 +314,11 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
     if (ev.target === undefined || this._config![ev.target.key] === undefined) {
       return;
     }
-    if (
-      Number(this._config![ev.target.key].value) === Number(ev.target.value)
-    ) {
+    const value = Number(ev.target.value);
+    if (Number(this._config![ev.target.key].value) === value) {
       return;
     }
-    this.debouncedUpdate(ev.target);
+    this.debouncedUpdate(ev.target, value);
   }
 
   private _updateConfigParameter(target, value) {


### PR DESCRIPTION
## Proposed change

This change cleans up some value comparisons to fix a bug where receiving a value of `null` for a `ranged` config type would cause the panel to try to update the config item to null on page load

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
