### PR TITLE
Initial custom configuration for ZHA

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -1,4 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
+import { HaFormSchema } from "../components/ha-form/ha-form";
 import { HomeAssistant } from "../types";
 
 export interface ZHAEntityReference extends HassEntity {
@@ -73,6 +74,11 @@ export interface ZHAGroup {
   name: string;
   group_id: number;
   members: ZHADeviceEndpoint[];
+}
+
+export interface ZHAConfiguration {
+  data: Record<string, Record<string, unknown>>;
+  schemas: Record<string, HaFormSchema[]>;
 }
 
 export interface ZHAGroupMember {
@@ -282,7 +288,9 @@ export const addGroup = (
     members: membersToAdd,
   });
 
-export const fetchZHAConfiguration = (hass: HomeAssistant): Promise<any> =>
+export const fetchZHAConfiguration = (
+  hass: HomeAssistant
+): Promise<ZHAConfiguration> =>
   hass.callWS({
     type: "zha/configuration",
   });

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -282,6 +282,20 @@ export const addGroup = (
     members: membersToAdd,
   });
 
+export const fetchZHAConfiguration = (hass: HomeAssistant): Promise<any> =>
+  hass.callWS({
+    type: "zha/configuration",
+  });
+
+export const updateZHAConfiguration = (
+  hass: HomeAssistant,
+  data: any
+): Promise<any> =>
+  hass.callWS({
+    type: "zha/configuration/update",
+    data: data,
+  });
+
 export const INITIALIZED = "INITIALIZED";
 export const INTERVIEW_COMPLETE = "INTERVIEW_COMPLETE";
 export const CONFIGURED = "CONFIGURED";

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -114,15 +114,15 @@ class ZHAConfigDashboard extends LitElement {
               </div>`
             : ""}
         </ha-card>
-        <ha-card
-          header=${this.hass.localize(
-            "ui.panel.config.zha.configuration_page.configuration_options_title"
-          )}
-        >
-          <div class="card-content">
-            ${this._configuration
-              ? Object.entries(this._configuration.schemas).map(
-                  ([section, schema]) => html`<ha-form
+        ${this._configuration
+          ? Object.entries(this._configuration.schemas).map(
+              ([section, schema]) => html` <ha-card
+                header=${this.hass.localize(
+                  `ui.panel.config.zha.configuration_page.${section}.title`
+                )}
+              >
+                <div class="card-content">
+                  <ha-form
                     .schema=${schema}
                     .data=${this._configuration
                       ? this._configuration.data[section]
@@ -132,10 +132,12 @@ class ZHAConfigDashboard extends LitElement {
                       this.hass.localize,
                       section
                     )}
-                  ></ha-form>`
-                )
-              : ""}
-          </div>
+                  ></ha-form>
+                </div>
+              </ha-card>`
+            )
+          : ""}
+        <ha-card>
           <div class="card-actions">
             <mwc-button @click=${this._updateConfiguration}
               >${this.hass.localize(
@@ -144,6 +146,7 @@ class ZHAConfigDashboard extends LitElement {
             >
           </div>
         </ha-card>
+
         <a href="/config/zha/add" slot="fab">
           <ha-fab
             .label=${this.hass.localize("ui.panel.config.zha.add_device")}

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -163,14 +163,8 @@ class ZHAConfigDashboard extends LitElement {
     for (const section of Object.keys(this._configuration!.schemas)) {
       data[section] = {};
       const sectionData = this._configuration!.data[section];
-      const sectionSchema = this._configuration!.schemas[section];
-      for (const field of sectionSchema) {
-        if (
-          field.name in sectionData &&
-          sectionData[field.name] !== field.default
-        ) {
-          data[section][field.name] = sectionData[field.name];
-        }
+      for (const field of Object.keys(sectionData)) {
+        data[section][field] = sectionData[field];
       }
       if (!Object.keys(data[section]).length) {
         delete data[section];

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -60,21 +60,11 @@ class ZHAConfigDashboard extends LitElement {
 
   @property() private _configuration?: ZHAConfiguration;
 
-  private _firstUpdatedCalled = false;
-
-  public connectedCallback(): void {
-    super.connectedCallback();
-    if (this.hass && this._firstUpdatedCalled) {
-      this._fetchConfiguration();
-    }
-  }
-
   protected firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
     if (this.hass) {
       this._fetchConfiguration();
     }
-    this._firstUpdatedCalled = true;
   }
 
   protected render(): TemplateResult {
@@ -184,7 +174,7 @@ class ZHAConfigDashboard extends LitElement {
           data[section][field.name] = sectionData[field.name];
         }
       }
-      if (data[section] === {}) {
+      if (!Object.keys(data[section]).length) {
         delete data[section];
       }
     }

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -45,6 +45,8 @@ export const zhaTabs: PageNavigation[] = [
   },
 ];
 
+const ZHA_OPTIONS = "zha_options";
+
 @customElement("zha-config-dashboard")
 class ZHAConfigDashboard extends LitElement {
   @property({ type: Object }) public hass!: HomeAssistant;
@@ -85,7 +87,11 @@ class ZHAConfigDashboard extends LitElement {
         .tabs=${zhaTabs}
         back-path="/config/integrations"
       >
-        <ha-card header="Shortcuts">
+        <ha-card
+          header=${this.hass.localize(
+            "ui.panel.config.zha.configuration_page.shortcuts_title"
+          )}
+        >
           ${this.configEntryId
             ? html`<div class="card-actions">
                 <a
@@ -109,19 +115,29 @@ class ZHAConfigDashboard extends LitElement {
               </div>`
             : ""}
         </ha-card>
-        <ha-card header="Configuration Options">
+        <ha-card
+          header=${this.hass.localize(
+            "ui.panel.config.zha.configuration_page.configuration_options_title"
+          )}
+        >
           <div class="card-content">
             ${this._configuration
               ? html`<ha-form
-                  .schema=${this._configuration.schemas.options}
-                  .data=${this._configuration.data.options}
+                  .schema=${this._configuration.schemas.zha_options}
+                  .data=${this._configuration.data.zha_options}
                   @value-changed=${this._optionsDataChanged}
+                  .computeLabel=${this._computeLabelCallback(
+                    this.hass.localize,
+                    ZHA_OPTIONS
+                  )}
                 ></ha-form>`
               : ""}
           </div>
           <div class="card-actions">
             <mwc-button @click=${this._updateConfiguration}
-              >Update Configuration</mwc-button
+              >${this.hass.localize(
+                "ui.panel.config.zha.configuration_page.update_button"
+              )}</mwc-button
             >
           </div>
         </ha-card>
@@ -143,11 +159,11 @@ class ZHAConfigDashboard extends LitElement {
   }
 
   private _optionsDataChanged(ev: CustomEvent) {
-    this._configuration.data.options = ev.detail.value;
+    this._configuration.data.zha_options = ev.detail.value;
   }
 
   private async _updateConfiguration(): Promise<any> {
-    const sections = ["options"];
+    const sections = ["zha_options"];
     const data = {};
     for (const section of sections) {
       data[section] = {};
@@ -166,6 +182,14 @@ class ZHAConfigDashboard extends LitElement {
       }
     }
     await updateZHAConfiguration(this.hass!, data);
+  }
+
+  private _computeLabelCallback(localize, section) {
+    // Returns a callback for ha-form to calculate labels per schema object
+    return (schema) =>
+      localize(
+        `ui.panel.config.zha.configuration_page.${section}.${schema.name}`
+      ) || schema.name;
   }
 
   static get styles(): CSSResultArray {

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -153,7 +153,7 @@ class ZHAConfigDashboard extends LitElement {
     this._configuration = await fetchZHAConfiguration(this.hass!);
   }
 
-  private _dataChanged(ev: CustomEvent) {
+  private _dataChanged(ev) {
     this._configuration!.data[ev.currentTarget!.section] = ev.detail.value;
   }
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -114,9 +114,7 @@ class ZHAConfigDashboard extends LitElement {
                 <div class="card-content">
                   <ha-form
                     .schema=${schema}
-                    .data=${this._configuration
-                      ? this._configuration.data[section]
-                      : {}}
+                    .data=${this._configuration!.data[section]}
                     @value-changed=${this._dataChangedCallback(section)}
                     .computeLabel=${this._computeLabelCallback(
                       this.hass.localize,
@@ -129,11 +127,11 @@ class ZHAConfigDashboard extends LitElement {
           : ""}
         <ha-card>
           <div class="card-actions">
-            <mwc-button @click=${this._updateConfiguration}
-              >${this.hass.localize(
+            <mwc-button @click=${this._updateConfiguration}>
+              ${this.hass.localize(
                 "ui.panel.config.zha.configuration_page.update_button"
-              )}</mwc-button
-            >
+              )}
+            </mwc-button>
           </div>
         </ha-card>
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -115,7 +115,8 @@ class ZHAConfigDashboard extends LitElement {
                   <ha-form
                     .schema=${schema}
                     .data=${this._configuration!.data[section]}
-                    @value-changed=${this._dataChangedCallback(section)}
+                    @value-changed=${this._dataChanged}
+                    .section=${section}
                     .computeLabel=${this._computeLabelCallback(
                       this.hass.localize,
                       section
@@ -152,28 +153,15 @@ class ZHAConfigDashboard extends LitElement {
     this._configuration = await fetchZHAConfiguration(this.hass!);
   }
 
-  private _dataChangedCallback(section: string) {
-    return (ev: CustomEvent) => {
-      this._configuration!.data[section] = ev.detail.value;
-    };
+  private _dataChanged(ev: CustomEvent) {
+    this._configuration!.data[ev.currentTarget!.section] = ev.detail.value;
   }
 
   private async _updateConfiguration(): Promise<any> {
-    const data = {};
-    for (const section of Object.keys(this._configuration!.schemas)) {
-      data[section] = {};
-      const sectionData = this._configuration!.data[section];
-      for (const field of Object.keys(sectionData)) {
-        data[section][field] = sectionData[field];
-      }
-      if (!Object.keys(data[section]).length) {
-        delete data[section];
-      }
-    }
-    await updateZHAConfiguration(this.hass!, data);
+    await updateZHAConfiguration(this.hass!, this._configuration!.data);
   }
 
-  private _computeLabelCallback(localize, section) {
+  private _computeLabelCallback(localize, section: string) {
     // Returns a callback for ha-form to calculate labels per schema object
     return (schema) =>
       localize(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2380,6 +2380,15 @@
             "manufacturer_code_override": "Manufacturer Code Override",
             "value": "Value"
           },
+          "configuration_page": {
+            "shortcuts_title": "Shortcuts",
+            "configuration_options_title": "Configuration Options",
+            "update_button": "Update Configuration",
+            "zha_options": {
+              "enable_identify_on_join": "Enable identify effect when devices join the network",
+              "default_light_transition": "Default light transition time (seconds)"
+            }
+          },
           "add_device_page": {
             "spinner": "Searching for ZHA Zigbee devices...",
             "pairing_mode": "Make sure your devices are in pairing mode. Check the instructions of your device on how to do this.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2382,9 +2382,9 @@
           },
           "configuration_page": {
             "shortcuts_title": "Shortcuts",
-            "configuration_options_title": "Configuration Options",
             "update_button": "Update Configuration",
             "zha_options": {
+              "title": "Global Options",
               "enable_identify_on_join": "Enable identify effect when devices join the network",
               "default_light_transition": "Default light transition time (seconds)"
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR adds support for custom configuration in ZHA. Initial support is added for setting a default transition time and for enabling / disabling the identity effect when devices are paired. Eventually this will be used for advanced network configuration as well.

~~**REQUIRES** https://github.com/home-assistant/core/pull/48423~~ Merged

![image](https://user-images.githubusercontent.com/1335687/112736879-6faeed00-8f2c-11eb-9554-9bc510dba9e6.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
