### PR TITLE
Add feedback dialog for ZHA device reconfiguration

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -82,12 +82,17 @@ export interface ZHAGroupMember {
 
 export const reconfigureNode = (
   hass: HomeAssistant,
-  ieeeAddress: string
-): Promise<void> =>
-  hass.callWS({
-    type: "zha/devices/reconfigure",
-    ieee: ieeeAddress,
-  });
+  ieeeAddress: string,
+  callbackFunction: any
+) => {
+  return hass.connection.subscribeMessage(
+    (message) => callbackFunction(message),
+    {
+      type: "zha/devices/reconfigure",
+      ieee: ieeeAddress,
+    }
+  );
+};
 
 export const refreshTopology = (hass: HomeAssistant): Promise<void> =>
   hass.callWS({

--- a/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-actions-zha.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-actions-zha.ts
@@ -11,16 +11,13 @@ import {
 } from "lit-element";
 import { navigate } from "../../../../../../common/navigate";
 import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
-import {
-  fetchZHADevice,
-  reconfigureNode,
-  ZHADevice,
-} from "../../../../../../data/zha";
+import { fetchZHADevice, ZHADevice } from "../../../../../../data/zha";
 import { showConfirmationDialog } from "../../../../../../dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../../types";
 import { showZHAClusterDialog } from "../../../../integrations/integration-panels/zha/show-dialog-zha-cluster";
 import { showZHADeviceZigbeeInfoDialog } from "../../../../integrations/integration-panels/zha/show-dialog-zha-device-zigbee-info";
+import { showZHAReconfigureDeviceDialog } from "../../../../integrations/integration-panels/zha/show-dialog-zha-reconfigure-device";
 import { showZHADeviceChildrenDialog } from "../../../../integrations/integration-panels/zha/show-dialog-zha-device-children";
 
 @customElement("ha-device-actions-zha")
@@ -108,7 +105,7 @@ export class HaDeviceActionsZha extends LitElement {
     if (!this.hass) {
       return;
     }
-    reconfigureNode(this.hass, this._zhaDevice!.ieee);
+    showZHAReconfigureDeviceDialog(this, { device: this._zhaDevice! });
   }
 
   private _onAddDevicesClick() {

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-reconfigure-device.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-reconfigure-device.ts
@@ -117,7 +117,7 @@ class DialogZHAReconfigureDevice extends LitElement {
     this._subscribed = reconfigureNode(
       this.hass,
       params.device.ieee,
-      this._handleMessage
+      this._handleMessage.bind(this)
     );
     this._reconfigureDeviceTimeoutHandle = setTimeout(
       () => this._unsubscribe(),

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-reconfigure-device.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-reconfigure-device.ts
@@ -1,0 +1,151 @@
+import {
+  css,
+  CSSResult,
+  customElement,
+  html,
+  internalProperty,
+  LitElement,
+  property,
+  TemplateResult,
+} from "lit-element";
+import { createCloseHeading } from "../../../../../components/ha-dialog";
+import { haStyleDialog } from "../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../types";
+import { ZHAReconfigureDeviceDialogParams } from "./show-dialog-zha-reconfigure-device";
+import { IronAutogrowTextareaElement } from "@polymer/iron-autogrow-textarea";
+import "@polymer/paper-input/paper-textarea";
+import "../../../../../components/ha-circular-progress";
+import { LOG_OUTPUT } from "../../../../../data/zha";
+
+@customElement("dialog-zha-reconfigure-device")
+class DialogZHAReconfigureDevice extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @internalProperty() private _active = false;
+
+  @internalProperty() private _formattedEvents = "";
+
+  @internalProperty()
+  private _params: ZHAReconfigureDeviceDialogParams | undefined = undefined;
+
+  private _subscribed?: Promise<() => Promise<void>>;
+
+  private _reconfigureDeviceTimeoutHandle: any = undefined;
+
+  public async showDialog(
+    params: ZHAReconfigureDeviceDialogParams
+  ): Promise<void> {
+    this._params = params;
+    this._subscribe(params);
+  }
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-dialog
+        open
+        hideActions
+        @closing="${this._close}"
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass.localize(`ui.dialogs.zha_reconfigure_device.heading`)
+        )}
+      >
+        <div class="searching">
+          ${this._active
+            ? html`
+                <h1>
+                  ${this._params?.device.user_given_name ||
+                  this._params?.device.name}
+                </h1>
+                <ha-circular-progress
+                  active
+                  alt="Searching"
+                ></ha-circular-progress>
+              `
+            : ""}
+        </div>
+        <paper-textarea
+          readonly
+          max-rows="10"
+          class="log"
+          value="${this._formattedEvents}"
+        >
+        </paper-textarea>
+      </ha-dialog>
+    `;
+  }
+
+  private _handleMessage(message: any): void {
+    if (message.type === LOG_OUTPUT) {
+      this._formattedEvents += message.log_entry.message + "\n";
+      if (this.shadowRoot) {
+        const paperTextArea = this.shadowRoot.querySelector("paper-textarea");
+        if (paperTextArea) {
+          const textArea = (paperTextArea.inputElement as IronAutogrowTextareaElement)
+            .textarea;
+          textArea.scrollTop = textArea.scrollHeight;
+        }
+      }
+    }
+  }
+
+  private _close(): void {
+    this._unsubscribe();
+    this._formattedEvents = "";
+    this._params = undefined;
+  }
+
+  private _unsubscribe(): void {
+    this._active = false;
+    if (this._reconfigureDeviceTimeoutHandle) {
+      clearTimeout(this._reconfigureDeviceTimeoutHandle);
+    }
+    if (this._subscribed) {
+      this._subscribed.then((unsub) => unsub());
+      this._subscribed = undefined;
+    }
+  }
+
+  private _subscribe(params: ZHAReconfigureDeviceDialogParams): void {
+    if (!this.hass) {
+      return;
+    }
+    this._active = true;
+    const data: any = { type: "zha/devices/reconfigure" };
+    data.ieee = params.device.ieee;
+    this._subscribed = this.hass.connection.subscribeMessage(
+      (message) => this._handleMessage(message),
+      data
+    );
+    this._reconfigureDeviceTimeoutHandle = setTimeout(
+      () => this._unsubscribe(),
+      60000
+    );
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        ha-circular-progress {
+          padding: 20px;
+        }
+        .searching {
+          margin-top: 20px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+        .log {
+          padding: 16px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-zha-reconfigure-device": DialogZHAReconfigureDevice;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/zha/show-dialog-zha-reconfigure-device.ts
+++ b/src/panels/config/integrations/integration-panels/zha/show-dialog-zha-reconfigure-device.ts
@@ -1,0 +1,20 @@
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import { ZHADevice } from "../../../../../data/zha";
+
+export interface ZHAReconfigureDeviceDialogParams {
+  device: ZHADevice;
+}
+
+export const loadZHAReconfigureDeviceDialog = () =>
+  import("./dialog-zha-reconfigure-device");
+
+export const showZHAReconfigureDeviceDialog = (
+  element: HTMLElement,
+  zhaReconfigureDeviceParams: ZHAReconfigureDeviceDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-zha-reconfigure-device",
+    dialogImport: loadZHAReconfigureDeviceDialog,
+    dialogParams: zhaReconfigureDeviceParams,
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -747,6 +747,9 @@
         "enable_new_entities_description": "If disabled, newly discovered entities for {integration} will not be automatically added to Home Assistant.",
         "update": "Update"
       },
+      "zha_reconfigure_device": {
+        "heading": "Reconfiguring device"
+      },
       "zha_device_info": {
         "manuf": "by {manufacturer}",
         "no_area": "No Area",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR adds support for visual feedback for ZHA device reconfiguration.

**REQUIRES** https://github.com/home-assistant/core/pull/48447

https://user-images.githubusercontent.com/1335687/112768568-96335d80-8fea-11eb-97fe-fe506c773c0c.mov

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
