### PR TITLE
Fix zwave_js config panel manual entry inputs

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -197,7 +197,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
 
     // Numeric entries with a min value of 0 and max of 1 are considered boolean
     if (
-      (item.configuration_value_type === "range" &&
+      (item.configuration_value_type === "manual_entry" &&
         item.metadata.min === 0 &&
         item.metadata.max === 1) ||
       this._isEnumeratedBool(item)
@@ -217,7 +217,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
       `;
     }
 
-    if (item.configuration_value_type === "range") {
+    if (item.configuration_value_type === "manual_entry") {
       return html`${labelAndDescription}
         <paper-input
           type="number"


### PR DESCRIPTION
## Proposed change

An update to the zwave_js_server changed numeric entry inputs to be a `configuration_value_type` of `manual_entry` instead of `range` - this updates the frontend to match again.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
