### PR TITLE
Use number format setting for attribute rows

### DIFF
--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -72,8 +72,9 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
                 .ts=${date}
                 .format=${this._config.format}
               ></hui-timestamp-display>`
-            : // will return the original attribute value if NaN
-              formatNumber(attribute, this.hass.locale) ?? "-"}
+            : typeof attribute === "number"
+            ? formatNumber(attribute, this.hass.locale)
+            : attribute ?? "-"}
           ${this._config.suffix}
         </div>
       </hui-generic-entity-row>

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -72,8 +72,8 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
                 .ts=${date}
                 .format=${this._config.format}
               ></hui-timestamp-display>`
-            : formatNumber(attribute, this.hass.locale) ?? "-"}
-          // will return the original attribute value if NaN
+            : // will return the original attribute value if NaN
+              formatNumber(attribute, this.hass.locale) ?? "-"}
           ${this._config.suffix}
         </div>
       </hui-generic-entity-row>

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -10,6 +10,7 @@ import {
   TemplateResult,
 } from "lit-element";
 import checkValidDate from "../../../common/datetime/check_valid_date";
+import { formatNumber } from "../../../common/string/format_number";
 import { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
@@ -71,7 +72,8 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
                 .ts=${date}
                 .format=${this._config.format}
               ></hui-timestamp-display>`
-            : attribute ?? "-"}
+            : formatNumber(attribute, this.hass.locale) ?? "-"}
+          // will return the original attribute value if NaN
           ${this._config.suffix}
         </div>
       </hui-generic-entity-row>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Rendered attributes in an `Entities` card did not adhere to the new number format setting.

The red values all share the same source, but the first one is an attribute row and the other two are a template sensor based on that attribute (frontend correctly handled those states already).
![image](https://user-images.githubusercontent.com/114137/113910858-96490f80-97d9-11eb-8a8f-61f689f8f9b4.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
