### PR TITLE
Show config entry state on card

### DIFF
--- a/gallery/src/demos/demo-integration-card.ts
+++ b/gallery/src/demos/demo-integration-card.ts
@@ -14,8 +14,13 @@ import { IntegrationManifest } from "../../../src/data/integration";
 
 import { provideHass } from "../../../src/fake_data/provide_hass";
 import { HomeAssistant } from "../../../src/types";
-import "../../../src/panels/config/integrations/ha-config-integrations";
-import type { ConfigEntryExtended } from "../../../src/panels/config/integrations/ha-config-integrations";
+import "../../../src/panels/config/integrations/ha-integration-card";
+import "../../../src/panels/config/integrations/ha-ignored-config-entry-card";
+import "../../../src/panels/config/integrations/ha-config-flow-card";
+import type {
+  ConfigEntryExtended,
+  DataEntryFlowProgressExtended,
+} from "../../../src/panels/config/integrations/ha-config-integrations";
 import { DeviceRegistryEntry } from "../../../src/data/device_registry";
 import { EntityRegistryEntry } from "../../../src/data/entity_registry";
 import { classMap } from "lit-html/directives/class-map";
@@ -78,8 +83,44 @@ const disabledEntry = createConfigEntry("Disabled", {
   state: "not_loaded",
   disabled_by: "user",
 });
+const disabledFailedUnloadEntry = createConfigEntry(
+  "Disabled - Failed Unload",
+  {
+    state: "failed_unload",
+    disabled_by: "user",
+  }
+);
 
-const infos: Array<{
+const configFlows: DataEntryFlowProgressExtended[] = [
+  {
+    flow_id: "adbb401329d8439ebb78ef29837826a8",
+    handler: "roku",
+    context: {
+      source: "ssdp",
+      unique_id: "YF008D862864",
+      title_placeholders: {
+        name: "Living room Roku",
+      },
+    },
+    step_id: "discovery_confirm",
+    localized_title: "Roku: Living room Roku",
+  },
+  {
+    flow_id: "adbb401329d8439ebb78ef29837826a8",
+    handler: "hue",
+    context: {
+      source: "reauth",
+      unique_id: "YF008D862864",
+      title_placeholders: {
+        name: "Living room Roku",
+      },
+    },
+    step_id: "discovery_confirm",
+    localized_title: "Philips Hue",
+  },
+];
+
+const configEntries: Array<{
   items: ConfigEntryExtended[];
   is_custom?: boolean;
   disabled?: boolean;
@@ -95,7 +136,6 @@ const infos: Array<{
   { items: [setupRetryEntry] },
   { items: [failedUnloadEntry] },
   { items: [notLoadedEntry] },
-  { items: [disabledEntry] },
   {
     items: [
       loadedEntry,
@@ -111,15 +151,11 @@ const infos: Array<{
       optionsFlowEntry,
     ],
   },
+  { disabled: true, items: [disabledEntry] },
+  { disabled: true, items: [disabledFailedUnloadEntry] },
   {
     disabled: true,
-    items: [
-      disabledEntry,
-      loadedEntry,
-      configPanelEntry,
-      optionsFlowEntry,
-      notLoadedEntry,
-    ],
+    items: [disabledEntry, disabledFailedUnloadEntry],
   },
   {
     items: [loadedEntry, configPanelEntry],
@@ -184,7 +220,22 @@ export class DemoIntegrationCard extends LitElement {
         </ha-formfield>
       </div>
 
-      ${infos.map(
+      <ha-ignored-config-entry-card
+        .hass=${this.hass}
+        .entry=${createConfigEntry("Ignored Entry")}
+        .manifest=${createManifest(this.isCustomIntegration, this.isCloud)}
+      ></ha-ignored-config-entry-card>
+
+      ${configFlows.map(
+        (flow) => html`
+          <ha-config-flow-card
+            .hass=${this.hass}
+            .flow=${flow}
+            .manifest=${createManifest(this.isCustomIntegration, this.isCloud)}
+          ></ha-config-flow-card>
+        `
+      )}
+      ${configEntries.map(
         (info) => html`
           <ha-integration-card
             class=${classMap({
@@ -227,6 +278,10 @@ export class DemoIntegrationCard extends LitElement {
         grid-gap: 16px 16px;
         padding: 8px 16px 16px;
         margin-bottom: 64px;
+      }
+
+      :host > * {
+        max-width: 500px;
       }
 
       ha-formfield {

--- a/gallery/src/demos/demo-integration-card.ts
+++ b/gallery/src/demos/demo-integration-card.ts
@@ -18,6 +18,7 @@ import "../../../src/panels/config/integrations/ha-config-integrations";
 import type { ConfigEntryExtended } from "../../../src/panels/config/integrations/ha-config-integrations";
 import { DeviceRegistryEntry } from "../../../src/data/device_registry";
 import { EntityRegistryEntry } from "../../../src/data/entity_registry";
+import { classMap } from "lit-html/directives/class-map";
 
 const createConfigEntry = (
   title: string,
@@ -48,28 +49,32 @@ const createManifest = (
   iot_class: isCloud ? "cloud_polling" : "local_polling",
 });
 
-const loadedEntry = createConfigEntry("loaded");
-const configPanelEntry = createConfigEntry("config panel", {
+const loadedEntry = createConfigEntry("Loaded");
+const nameAsDomainEntry = createConfigEntry("ESPHome");
+const longNameEntry = createConfigEntry(
+  "Entry with a super long name that is going to the next line"
+);
+const configPanelEntry = createConfigEntry("Config Panel", {
   domain: "mqtt",
   localized_domain_name: "MQTT",
 });
-const optionsFlowEntry = createConfigEntry("options flow", {
+const optionsFlowEntry = createConfigEntry("Options Flow", {
   supports_options: true,
 });
-const setupErrorEntry = createConfigEntry("setup-error", {
+const setupErrorEntry = createConfigEntry("Setup Error", {
   state: "setup_error",
 });
-const migrationErrorEntry = createConfigEntry("migration-error", {
+const migrationErrorEntry = createConfigEntry("Migration Error", {
   state: "migration_error",
 });
-const setupRetryEntry = createConfigEntry("setup_retry", {
+const setupRetryEntry = createConfigEntry("Setup Retry", {
   state: "setup_retry",
 });
-const failedUnloadEntry = createConfigEntry("failed_unload", {
+const failedUnloadEntry = createConfigEntry("Failed Unload", {
   state: "failed_unload",
 });
-const notLoadedEntry = createConfigEntry("not_loaded", { state: "not_loaded" });
-const disabledEntry = createConfigEntry("disabled", {
+const notLoadedEntry = createConfigEntry("Not Loaded", { state: "not_loaded" });
+const disabledEntry = createConfigEntry("Disabled", {
   state: "not_loaded",
   disabled_by: "user",
 });
@@ -77,10 +82,14 @@ const disabledEntry = createConfigEntry("disabled", {
 const infos: Array<{
   items: ConfigEntryExtended[];
   is_custom?: boolean;
+  disabled?: boolean;
+  highlight?: string;
 }> = [
   { items: [loadedEntry] },
   { items: [configPanelEntry] },
   { items: [optionsFlowEntry] },
+  { items: [nameAsDomainEntry] },
+  { items: [longNameEntry] },
   { items: [setupErrorEntry] },
   { items: [migrationErrorEntry] },
   { items: [setupRetryEntry] },
@@ -90,15 +99,31 @@ const infos: Array<{
   {
     items: [
       loadedEntry,
+      longNameEntry,
       setupErrorEntry,
       migrationErrorEntry,
       setupRetryEntry,
       failedUnloadEntry,
       notLoadedEntry,
       disabledEntry,
+      nameAsDomainEntry,
       configPanelEntry,
       optionsFlowEntry,
     ],
+  },
+  {
+    disabled: true,
+    items: [
+      disabledEntry,
+      loadedEntry,
+      configPanelEntry,
+      optionsFlowEntry,
+      notLoadedEntry,
+    ],
+  },
+  {
+    items: [loadedEntry, configPanelEntry],
+    highlight: "Loaded",
   },
 ];
 
@@ -162,12 +187,17 @@ export class DemoIntegrationCard extends LitElement {
       ${infos.map(
         (info) => html`
           <ha-integration-card
+            class=${classMap({
+              highlight: info.highlight !== undefined,
+            })}
             .hass=${this.hass}
             domain="esphome"
             .items=${info.items}
             .manifest=${createManifest(this.isCustomIntegration, this.isCloud)}
             .entityRegistryEntries=${createEntityRegistryEntries(info.items[0])}
             .deviceRegistryEntries=${createDeviceRegistryEntries(info.items[0])}
+            ?disabled=${info.disabled}
+            .selectedConfigEntryId=${info.highlight}
           ></ha-integration-card>
         `
       )}

--- a/gallery/src/demos/demo-integration-card.ts
+++ b/gallery/src/demos/demo-integration-card.ts
@@ -49,7 +49,10 @@ const createManifest = (
 });
 
 const loadedEntry = createConfigEntry("loaded");
-const configPanelEntry = createConfigEntry("config panel", { domain: "mqtt" });
+const configPanelEntry = createConfigEntry("config panel", {
+  domain: "mqtt",
+  localized_domain_name: "MQTT",
+});
 const optionsFlowEntry = createConfigEntry("options flow", {
   supports_options: true,
 });

--- a/gallery/src/demos/demo-integration-card.ts
+++ b/gallery/src/demos/demo-integration-card.ts
@@ -1,0 +1,211 @@
+import {
+  customElement,
+  html,
+  css,
+  internalProperty,
+  LitElement,
+  TemplateResult,
+  property,
+} from "lit-element";
+import "../../../src/components/ha-formfield";
+import "../../../src/components/ha-switch";
+
+import { IntegrationManifest } from "../../../src/data/integration";
+
+import { provideHass } from "../../../src/fake_data/provide_hass";
+import { HomeAssistant } from "../../../src/types";
+import "../../../src/panels/config/integrations/ha-config-integrations";
+import type { ConfigEntryExtended } from "../../../src/panels/config/integrations/ha-config-integrations";
+import { DeviceRegistryEntry } from "../../../src/data/device_registry";
+import { EntityRegistryEntry } from "../../../src/data/entity_registry";
+
+const createConfigEntry = (
+  title: string,
+  override: Partial<ConfigEntryExtended> = {}
+): ConfigEntryExtended => ({
+  entry_id: title,
+  domain: "esphome",
+  localized_domain_name: "ESPHome",
+  title,
+  source: "zeroconf",
+  state: "loaded",
+  connection_class: "local_push",
+  supports_options: false,
+  supports_unload: true,
+  disabled_by: null,
+  ...override,
+});
+
+const createManifest = (
+  isCustom: boolean,
+  isCloud: boolean
+): IntegrationManifest => ({
+  name: "ESPHome",
+  domain: "esphome",
+  is_built_in: !isCustom,
+  config_flow: false,
+  documentation: "https://www.home-assistant.io/integrations/esphome/",
+  iot_class: isCloud ? "cloud_polling" : "local_polling",
+});
+
+const loadedEntry = createConfigEntry("loaded");
+const configPanelEntry = createConfigEntry("config panel", { domain: "mqtt" });
+const optionsFlowEntry = createConfigEntry("options flow", {
+  supports_options: true,
+});
+const setupErrorEntry = createConfigEntry("setup-error", {
+  state: "setup_error",
+});
+const migrationErrorEntry = createConfigEntry("migration-error", {
+  state: "migration_error",
+});
+const setupRetryEntry = createConfigEntry("setup_retry", {
+  state: "setup_retry",
+});
+const failedUnloadEntry = createConfigEntry("failed_unload", {
+  state: "failed_unload",
+});
+const notLoadedEntry = createConfigEntry("not_loaded", { state: "not_loaded" });
+const disabledEntry = createConfigEntry("disabled", {
+  state: "not_loaded",
+  disabled_by: "user",
+});
+
+const infos: Array<{
+  items: ConfigEntryExtended[];
+  is_custom?: boolean;
+}> = [
+  { items: [loadedEntry] },
+  { items: [configPanelEntry] },
+  { items: [optionsFlowEntry] },
+  { items: [setupErrorEntry] },
+  { items: [migrationErrorEntry] },
+  { items: [setupRetryEntry] },
+  { items: [failedUnloadEntry] },
+  { items: [notLoadedEntry] },
+  { items: [disabledEntry] },
+  {
+    items: [
+      loadedEntry,
+      setupErrorEntry,
+      migrationErrorEntry,
+      setupRetryEntry,
+      failedUnloadEntry,
+      notLoadedEntry,
+      disabledEntry,
+      configPanelEntry,
+      optionsFlowEntry,
+    ],
+  },
+];
+
+const createEntityRegistryEntries = (
+  item: ConfigEntryExtended
+): EntityRegistryEntry[] => [
+  {
+    config_entry_id: item.entry_id,
+    device_id: "mock-device-id",
+    area_id: null,
+    disabled_by: null,
+    entity_id: "binary_sensor.updater",
+    name: null,
+    icon: null,
+    platform: "updater",
+  },
+];
+
+const createDeviceRegistryEntries = (
+  item: ConfigEntryExtended
+): DeviceRegistryEntry[] => [
+  {
+    entry_type: null,
+    config_entries: [item.entry_id],
+    connections: [],
+    manufacturer: "ESPHome",
+    model: "Mock Device",
+    name: "Tag Reader",
+    sw_version: null,
+    id: "mock-device-id",
+    identifiers: [],
+    via_device_id: null,
+    area_id: null,
+    name_by_user: null,
+    disabled_by: null,
+  },
+];
+
+@customElement("demo-integration-card")
+export class DemoIntegrationCard extends LitElement {
+  @property({ attribute: false }) hass?: HomeAssistant;
+
+  @internalProperty() isCustomIntegration = false;
+
+  @internalProperty() isCloud = false;
+
+  protected render(): TemplateResult {
+    if (!this.hass) {
+      return html``;
+    }
+    return html`
+      <div class="filters">
+        <ha-formfield label="Custom Integration">
+          <ha-switch @change=${this._toggleCustomIntegration}></ha-switch>
+        </ha-formfield>
+        <ha-formfield label="Relies on cloud">
+          <ha-switch @change=${this._toggleCloud}></ha-switch>
+        </ha-formfield>
+      </div>
+
+      ${infos.map(
+        (info) => html`
+          <ha-integration-card
+            .hass=${this.hass}
+            domain="esphome"
+            .items=${info.items}
+            .manifest=${createManifest(this.isCustomIntegration, this.isCloud)}
+            .entityRegistryEntries=${createEntityRegistryEntries(info.items[0])}
+            .deviceRegistryEntries=${createDeviceRegistryEntries(info.items[0])}
+          ></ha-integration-card>
+        `
+      )}
+    `;
+  }
+
+  protected firstUpdated(changedProps) {
+    super.firstUpdated(changedProps);
+    const hass = provideHass(this);
+    hass.updateTranslations(null, "en");
+    hass.updateTranslations("config", "en");
+  }
+
+  private _toggleCustomIntegration() {
+    this.isCustomIntegration = !this.isCustomIntegration;
+  }
+
+  private _toggleCloud() {
+    this.isCloud = !this.isCloud;
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        grid-gap: 16px 16px;
+        padding: 8px 16px 16px;
+        margin-bottom: 64px;
+      }
+
+      ha-formfield {
+        margin: 8px 0;
+        display: block;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-integration-card": DemoIntegrationCard;
+  }
+}

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -5,7 +5,13 @@ export interface ConfigEntry {
   domain: string;
   title: string;
   source: string;
-  state: string;
+  state:
+    | "loaded"
+    | "setup_error"
+    | "migration_error"
+    | "setup_retry"
+    | "not_loaded"
+    | "failed_unload";
   connection_class: string;
   supports_options: boolean;
   supports_unload: boolean;

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -15,7 +15,7 @@ export interface ConfigEntry {
   connection_class: string;
   supports_options: boolean;
   supports_unload: boolean;
-  disabled_by: string | null;
+  disabled_by: "user" | null;
 }
 
 export interface ConfigEntryMutableParams {

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -9,13 +9,13 @@ export interface DeviceRegistryEntry {
   config_entries: string[];
   connections: Array<[string, string]>;
   identifiers: Array<[string, string]>;
-  manufacturer: string;
-  model?: string;
-  name?: string;
-  sw_version?: string;
-  via_device_id?: string;
-  area_id?: string;
-  name_by_user?: string;
+  manufacturer: string | null;
+  model: string | null;
+  name: string | null;
+  sw_version: string | null;
+  via_device_id: string | null;
+  area_id: string | null;
+  name_by_user: string | null;
   entry_type: "service" | null;
   disabled_by: string | null;
 }

--- a/src/data/entity_registry.ts
+++ b/src/data/entity_registry.ts
@@ -5,12 +5,12 @@ import { HomeAssistant } from "../types";
 
 export interface EntityRegistryEntry {
   entity_id: string;
-  name: string;
-  icon?: string;
+  name: string | null;
+  icon: string | null;
   platform: string;
-  config_entry_id?: string;
-  device_id?: string;
-  area_id?: string;
+  config_entry_id: string | null;
+  device_id: string | null;
+  area_id: string | null;
   disabled_by: string | null;
 }
 

--- a/src/data/integration.ts
+++ b/src/data/integration.ts
@@ -15,7 +15,13 @@ export interface IntegrationManifest {
   ssdp?: Array<{ manufacturer?: string; modelName?: string; st?: string }>;
   zeroconf?: string[];
   homekit?: { models: string[] };
-  quality_scale?: string;
+  quality_scale?: "gold" | "internal" | "platinum" | "silver";
+  iot_class:
+    | "assumed_state"
+    | "cloud_polling"
+    | "cloud_push"
+    | "local_polling"
+    | "local_push";
 }
 
 export const integrationIssuesUrl = (

--- a/src/panels/config/devices/device-registry-detail/dialog-device-registry-detail.ts
+++ b/src/panels/config/devices/device-registry-detail/dialog-device-registry-detail.ts
@@ -33,7 +33,7 @@ class DialogDeviceRegistryDetail extends LitElement {
 
   @internalProperty() private _params?: DeviceRegistryDetailDialogParams;
 
-  @internalProperty() private _areaId?: string;
+  @internalProperty() private _areaId?: string | null;
 
   @internalProperty() private _disabledBy!: string | null;
 

--- a/src/panels/config/entities/entity-registry-basic-editor.ts
+++ b/src/panels/config/entities/entity-registry-basic-editor.ts
@@ -38,7 +38,7 @@ export class HaEntityRegistryBasicEditor extends SubscribeMixin(LitElement) {
 
   @internalProperty() private _entityId!: string;
 
-  @internalProperty() private _areaId?: string;
+  @internalProperty() private _areaId?: string | null;
 
   @internalProperty() private _disabledBy!: string | null;
 

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -663,6 +663,10 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
           entity_id: entityId,
           platform: computeDomain(entityId),
           disabled_by: null,
+          area_id: null,
+          config_entry_id: null,
+          device_id: null,
+          icon: null,
           readonly: true,
           selectable: false,
         });

--- a/src/panels/config/integrations/ha-config-flow-card.ts
+++ b/src/panels/config/integrations/ha-config-flow-card.ts
@@ -1,0 +1,130 @@
+import {
+  customElement,
+  LitElement,
+  property,
+  css,
+  html,
+  TemplateResult,
+} from "lit-element";
+import { classMap } from "lit-html/directives/class-map";
+import { fireEvent } from "../../../common/dom/fire_event";
+import {
+  ATTENTION_SOURCES,
+  DISCOVERY_SOURCES,
+  ignoreConfigFlow,
+  localizeConfigFlowTitle,
+} from "../../../data/config_flow";
+import type { IntegrationManifest } from "../../../data/integration";
+import { showConfigFlowDialog } from "../../../dialogs/config-flow/show-dialog-config-flow";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
+import type { HomeAssistant } from "../../../types";
+import type { DataEntryFlowProgressExtended } from "./ha-config-integrations";
+import "./ha-integration-action-card";
+
+@customElement("ha-config-flow-card")
+export class HaConfigFlowCard extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public flow!: DataEntryFlowProgressExtended;
+
+  @property() public manifest?: IntegrationManifest;
+
+  protected render(): TemplateResult {
+    const attention = ATTENTION_SOURCES.includes(this.flow.context.source);
+    return html`
+      <ha-integration-action-card
+        class=${classMap({
+          discovered: !attention,
+          attention: attention,
+        })}
+        .hass=${this.hass}
+        .manifest=${this.manifest}
+        .banner=${this.hass.localize(
+          `ui.panel.config.integrations.${
+            attention ? "attention" : "discovered"
+          }`
+        )}
+        .domain=${this.flow.handler}
+        .label=${this.flow.localized_title}
+      >
+        <mwc-button
+          unelevated
+          @click=${this._continueFlow}
+          .label=${this.hass.localize(
+            `ui.panel.config.integrations.${
+              attention ? "reconfigure" : "configure"
+            }`
+          )}
+        ></mwc-button>
+        ${DISCOVERY_SOURCES.includes(this.flow.context.source) &&
+        this.flow.context.unique_id
+          ? html`
+              <mwc-button
+                @click=${this._ignoreFlow}
+                .label=${this.hass.localize(
+                  "ui.panel.config.integrations.ignore.ignore"
+                )}
+              ></mwc-button>
+            `
+          : ""}
+      </ha-integration-action-card>
+    `;
+  }
+
+  private _continueFlow() {
+    showConfigFlowDialog(this, {
+      continueFlowId: this.flow.flow_id,
+      dialogClosedCallback: () => {
+        this._handleFlowUpdated();
+      },
+    });
+  }
+
+  private async _ignoreFlow() {
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.hass!.localize(
+        "ui.panel.config.integrations.ignore.confirm_ignore_title",
+        "name",
+        localizeConfigFlowTitle(this.hass.localize, this.flow)
+      ),
+      text: this.hass!.localize(
+        "ui.panel.config.integrations.ignore.confirm_ignore"
+      ),
+      confirmText: this.hass!.localize(
+        "ui.panel.config.integrations.ignore.ignore"
+      ),
+    });
+    if (!confirmed) {
+      return;
+    }
+    await ignoreConfigFlow(
+      this.hass,
+      this.flow.flow_id,
+      localizeConfigFlowTitle(this.hass.localize, this.flow)
+    );
+    this._handleFlowUpdated();
+  }
+
+  private _handleFlowUpdated() {
+    fireEvent(this, "change", undefined, {
+      bubbles: false,
+    });
+  }
+
+  static styles = css`
+    .attention {
+      --state-color: var(--error-color);
+      --text-on-state-color: var(--text-primary-color);
+    }
+    .discovered {
+      --state-color: var(--primary-color);
+      --text-on-state-color: var(--text-primary-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-config-flow-card": HaConfigFlowCard;
+  }
+}

--- a/src/panels/config/integrations/ha-config-integrations-common.ts
+++ b/src/panels/config/integrations/ha-config-integrations-common.ts
@@ -1,0 +1,75 @@
+import { mdiPackageVariant, mdiCloud } from "@mdi/js";
+import "@polymer/paper-tooltip/paper-tooltip";
+import { css, html } from "lit-element";
+import { IntegrationManifest } from "../../../data/integration";
+import { HomeAssistant } from "../../../types";
+
+export const haConfigIntegrationsStyles = css`
+  .banner {
+    background-color: var(--state-color);
+    color: var(--text-on-state-color);
+    text-align: center;
+    padding: 8px;
+  }
+  .icons {
+    position: absolute;
+    top: 0px;
+    right: 16px;
+    color: var(--text-on-state-color, var(--secondary-text-color));
+    background-color: var(--state-color, #e0e0e0);
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 1px 4px 2px;
+  }
+  .icons ha-svg-icon {
+    width: 20px;
+    height: 20px;
+  }
+  paper-tooltip {
+    white-space: nowrap;
+  }
+`;
+
+export const haConfigIntegrationRenderIcons = (
+  hass: HomeAssistant,
+  manifest?: IntegrationManifest
+) => {
+  const icons: [string, string][] = [];
+
+  if (manifest) {
+    if (!manifest.is_built_in) {
+      icons.push([
+        mdiPackageVariant,
+        hass.localize(
+          "ui.panel.config.integrations.config_entry.provided_by_custom_component"
+        ),
+      ]);
+    }
+
+    if (manifest.iot_class && manifest.iot_class.startsWith("cloud_")) {
+      icons.push([
+        mdiCloud,
+        hass.localize(
+          "ui.panel.config.integrations.config_entry.depends_on_cloud"
+        ),
+      ]);
+    }
+  }
+
+  return icons.length === 0
+    ? ""
+    : html`
+        <div class="icons">
+          ${icons.map(
+            ([icon, description]) => html`
+              <span>
+                <ha-svg-icon .path=${icon}></ha-svg-icon>
+                <paper-tooltip animation-delay="0"
+                  >${description}</paper-tooltip
+                >
+              </span>
+            `
+          )}
+        </div>
+      `;
+};

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -54,7 +54,6 @@ import type { HaIntegrationCard } from "./ha-integration-card";
 
 import "../../../common/search/search-input";
 import "../../../components/ha-button-menu";
-import "../../../components/ha-card";
 import "../../../components/ha-fab";
 import "../../../components/ha-checkbox";
 import "../../../components/ha-svg-icon";
@@ -416,27 +415,28 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
                     .deviceRegistryEntries=${this._deviceRegistryEntries}
                   ></ha-integration-card>`
               )
-            : !this._configEntries.length
+            : // If we're showing 0 cards, show empty state text
+            (!this._showIgnored || ignoredConfigEntries.length === 0) &&
+              (!this._showDisabled || disabledConfigEntries.size === 0) &&
+              groupedConfigEntries.size === 0
             ? html`
-                <ha-card outlined>
-                  <div class="card-content">
-                    <h1>
-                      ${this.hass.localize("ui.panel.config.integrations.none")}
-                    </h1>
-                    <p>
-                      ${this.hass.localize(
-                        "ui.panel.config.integrations.no_integrations"
-                      )}
-                    </p>
-                    <mwc-button
-                      @click=${this._createFlow}
-                      unelevated
-                      .label=${this.hass.localize(
-                        "ui.panel.config.integrations.add_integration"
-                      )}
-                    ></mwc-button>
-                  </div>
-                </ha-card>
+                <div class="empty-message">
+                  <h1>
+                    ${this.hass.localize("ui.panel.config.integrations.none")}
+                  </h1>
+                  <p>
+                    ${this.hass.localize(
+                      "ui.panel.config.integrations.no_integrations"
+                    )}
+                  </p>
+                  <mwc-button
+                    @click=${this._createFlow}
+                    unelevated
+                    .label=${this.hass.localize(
+                      "ui.panel.config.integrations.add_integration"
+                    )}
+                  ></mwc-button>
+                </div>
               `
             : ""}
           ${this._filter &&
@@ -444,7 +444,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
           !groupedConfigEntries.size &&
           this._configEntries.length
             ? html`
-                <div class="none-found">
+                <div class="empty-message">
                   <h1>
                     ${this.hass.localize(
                       "ui.panel.config.integrations.none_found"
@@ -617,44 +617,15 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         .container > * {
           max-width: 500px;
         }
-        ha-card {
-          display: flex;
-          flex-direction: column;
-          justify-content: space-between;
-        }
-        .ignored {
-          --ha-card-border-color: var(--light-theme-disabled-color);
-        }
-        .ignored img {
-          filter: grayscale(1);
-        }
-        .ignored .header {
-          background: var(--light-theme-disabled-color);
-          color: var(--text-primary-color);
-          padding: 8px;
-          text-align: center;
-        }
-        .card-content {
-          display: flex;
-          height: 100%;
-          margin-top: 0;
-          padding: 16px;
-          text-align: center;
-          flex-direction: column;
-          justify-content: space-between;
-        }
-        .image {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: 60px;
-          margin-bottom: 16px;
-          vertical-align: middle;
-        }
-        .none-found {
+
+        .empty-message {
           margin: auto;
           text-align: center;
         }
+        .empty-message h1 {
+          margin-bottom: 0;
+        }
+
         search-input.header {
           display: block;
           position: relative;
@@ -674,27 +645,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
           position: relative;
           top: 2px;
         }
-        img {
-          max-height: 100%;
-          max-width: 90%;
-        }
-        .none-found {
-          margin: auto;
-          text-align: center;
-        }
-        h1 {
-          margin-bottom: 0;
-        }
-        h2 {
-          margin-top: 0;
-          word-wrap: break-word;
-          display: -webkit-box;
-          -webkit-box-orient: vertical;
-          -webkit-line-clamp: 3;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: normal;
-        }
+
         .active-filters {
           color: var(--primary-text-color);
           position: relative;

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -598,6 +598,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
   private _handleFlowUpdated() {
     this._loadConfigEntries();
     getConfigFlowInProgressCollection(this.hass.connection).refresh();
+    this._fetchManifests();
   }
 
   private _createFlow() {
@@ -607,7 +608,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
       },
       showAdvanced: this.showAdvanced,
     });
-    // For config entries. Also loading config flow ones for add integration
+    // For config entries. Also loading config flow ones for added integration
     this.hass.loadBackendTranslation("title", undefined, true);
   }
 

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -119,9 +119,8 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
   @internalProperty()
   private _deviceRegistryEntries: DeviceRegistryEntry[] = [];
 
-  @internalProperty() private _manifests!: {
-    [domain: string]: IntegrationManifest;
-  };
+  @internalProperty()
+  private _manifests: Record<string, IntegrationManifest> = {};
 
   @internalProperty() private _showIgnored = false;
 

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -2,9 +2,8 @@ import "@material/mwc-icon-button";
 import { ActionDetail } from "@material/mwc-list";
 import "@material/mwc-list/mwc-list-item";
 import { mdiFilterVariant, mdiPlus } from "@mdi/js";
-import "@polymer/app-route/app-route";
 import Fuse from "fuse.js";
-import { UnsubscribeFunc } from "home-assistant-js-websocket";
+import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import {
   css,
   CSSResult,
@@ -16,31 +15,15 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit-element";
-import { classMap } from "lit-html/directives/class-map";
 import { ifDefined } from "lit-html/directives/if-defined";
 import memoizeOne from "memoize-one";
-import { HASSDomEvent } from "../../../common/dom/fire_event";
 import { navigate } from "../../../common/navigate";
-import "../../../common/search/search-input";
 import { caseInsensitiveCompare } from "../../../common/string/compare";
-import { LocalizeFunc } from "../../../common/translations/localize";
 import { extractSearchParam } from "../../../common/url/search-params";
 import { nextRender } from "../../../common/util/render-status";
-import "../../../components/ha-button-menu";
-import "../../../components/ha-card";
-import "../../../components/ha-fab";
-import "../../../components/ha-checkbox";
-import "../../../components/ha-svg-icon";
+import { ConfigEntry, getConfigEntries } from "../../../data/config_entries";
 import {
-  ConfigEntry,
-  deleteConfigEntry,
-  getConfigEntries,
-} from "../../../data/config_entries";
-import {
-  ATTENTION_SOURCES,
-  DISCOVERY_SOURCES,
   getConfigFlowInProgressCollection,
-  ignoreConfigFlow,
   localizeConfigFlowTitle,
   subscribeConfigFlowInProgress,
 } from "../../../data/config_flow";
@@ -60,21 +43,44 @@ import {
 } from "../../../data/integration";
 import { showConfigFlowDialog } from "../../../dialogs/config-flow/show-dialog-config-flow";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
-import "../../../layouts/hass-loading-screen";
-import "../../../layouts/hass-tabs-subpage";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
-import { HomeAssistant, Route } from "../../../types";
-import { brandsUrl } from "../../../util/brands-url";
 import { configSections } from "../ha-panel-config";
-import "./ha-integration-card";
-import type {
-  ConfigEntryRemovedEvent,
-  ConfigEntryUpdatedEvent,
-  HaIntegrationCard,
-} from "./ha-integration-card";
 
-interface DataEntryFlowProgressExtended extends DataEntryFlowProgress {
+import type { HomeAssistant, Route } from "../../../types";
+import type { HASSDomEvent } from "../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../common/translations/localize";
+import type { HaIntegrationCard } from "./ha-integration-card";
+
+import "../../../common/search/search-input";
+import "../../../components/ha-button-menu";
+import "../../../components/ha-card";
+import "../../../components/ha-fab";
+import "../../../components/ha-checkbox";
+import "../../../components/ha-svg-icon";
+import "../../../layouts/hass-loading-screen";
+import "../../../layouts/hass-tabs-subpage";
+import "./ha-integration-card";
+import "./ha-config-flow-card";
+import "./ha-ignored-config-entry-card";
+
+export interface ConfigEntryUpdatedEvent {
+  entry: ConfigEntry;
+}
+
+export interface ConfigEntryRemovedEvent {
+  entryId: string;
+}
+
+declare global {
+  // for fire event
+  interface HASSDomEvents {
+    "entry-updated": ConfigEntryUpdatedEvent;
+    "entry-removed": ConfigEntryRemovedEvent;
+  }
+}
+
+export interface DataEntryFlowProgressExtended extends DataEntryFlowProgress {
   localized_title?: string;
 }
 
@@ -216,12 +222,6 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
       configEntriesInProgress: DataEntryFlowProgressExtended[],
       filter?: string
     ): DataEntryFlowProgressExtended[] => {
-      configEntriesInProgress = configEntriesInProgress.map(
-        (flow: DataEntryFlowProgressExtended) => ({
-          ...flow,
-          title: localizeConfigFlowTitle(this.hass.localize, flow),
-        })
-      );
       if (!filter) {
         return configEntriesInProgress;
       }
@@ -348,11 +348,12 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
                         "number",
                         disabledConfigEntries.size
                       )}
-                      <mwc-button @click=${this._toggleShowDisabled}>
-                        ${this.hass.localize(
+                      <mwc-button
+                        @click=${this._toggleShowDisabled}
+                        .label=${this.hass.localize(
                           "ui.panel.config.integrations.disable.show"
                         )}
-                      </mwc-button>
+                      ></mwc-button>
                     </div>`
                   : ""}
                 ${filterMenu}
@@ -361,112 +362,30 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
 
         <div
           class="container"
-          @entry-removed=${this._handleRemoved}
-          @entry-updated=${this._handleUpdated}
+          @entry-removed=${this._handleEntryRemoved}
+          @entry-updated=${this._handleEntryUpdated}
         >
           ${this._showIgnored
             ? ignoredConfigEntries.map(
-                (item: ConfigEntryExtended) => html`
-                  <ha-card outlined class="ignored">
-                    <div class="header">
-                      ${this.hass.localize(
-                        "ui.panel.config.integrations.ignore.ignored"
-                      )}
-                    </div>
-                    <div class="card-content">
-                      <div class="image">
-                        <img
-                          src=${brandsUrl(item.domain, "logo")}
-                          referrerpolicy="no-referrer"
-                          @error=${this._onImageError}
-                          @load=${this._onImageLoad}
-                        />
-                      </div>
-                      <h2>
-                        ${// In 2020.2 we added support for item.title. All ignored entries before
-                        // that have title "Ignored" so we fallback to localized domain name.
-                        item.title === "Ignored"
-                          ? item.localized_domain_name
-                          : item.title}
-                      </h2>
-                      <mwc-button
-                        @click=${this._removeIgnoredIntegration}
-                        .entry=${item}
-                        aria-label=${this.hass.localize(
-                          "ui.panel.config.integrations.ignore.stop_ignore"
-                        )}
-                        >${this.hass.localize(
-                          "ui.panel.config.integrations.ignore.stop_ignore"
-                        )}</mwc-button
-                      >
-                    </div>
-                  </ha-card>
+                (entry: ConfigEntryExtended) => html`
+                  <ha-ignored-config-entry-card
+                    .hass=${this.hass}
+                    .manifest=${this._manifests[entry.domain]}
+                    .entry=${entry}
+                    @change=${this._handleFlowUpdated}
+                  ></ha-ignored-config-entry-card>
                 `
               )
             : ""}
           ${configEntriesInProgress.length
             ? configEntriesInProgress.map(
-                (flow: DataEntryFlowProgressExtended) => {
-                  const attention = ATTENTION_SOURCES.includes(
-                    flow.context.source
-                  );
-                  return html`
-                    <ha-card
-                      outlined
-                      class=${classMap({
-                        discovered: !attention,
-                        attention: attention,
-                      })}
-                    >
-                      <div class="header">
-                        ${this.hass.localize(
-                          `ui.panel.config.integrations.${
-                            attention ? "attention" : "discovered"
-                          }`
-                        )}
-                      </div>
-                      <div class="card-content">
-                        <div class="image">
-                          <img
-                            src=${brandsUrl(flow.handler, "logo")}
-                            referrerpolicy="no-referrer"
-                            @error=${this._onImageError}
-                            @load=${this._onImageLoad}
-                          />
-                        </div>
-                        <h2>
-                          ${flow.localized_title}
-                        </h2>
-                        <div>
-                          <mwc-button
-                            unelevated
-                            @click=${this._continueFlow}
-                            .flowId=${flow.flow_id}
-                          >
-                            ${this.hass.localize(
-                              `ui.panel.config.integrations.${
-                                attention ? "reconfigure" : "configure"
-                              }`
-                            )}
-                          </mwc-button>
-                          ${DISCOVERY_SOURCES.includes(flow.context.source) &&
-                          flow.context.unique_id
-                            ? html`
-                                <mwc-button
-                                  @click=${this._ignoreFlow}
-                                  .flow=${flow}
-                                >
-                                  ${this.hass.localize(
-                                    "ui.panel.config.integrations.ignore.ignore"
-                                  )}
-                                </mwc-button>
-                              `
-                            : ""}
-                        </div>
-                      </div>
-                    </ha-card>
-                  `;
-                }
+                (flow: DataEntryFlowProgressExtended) => html`
+                  <ha-config-flow-card
+                    .hass=${this.hass}
+                    .flow=${flow}
+                    @change=${this._handleFlowUpdated}
+                  ></ha-config-flow-card>
+                `
               )
             : ""}
           ${this._showDisabled
@@ -509,11 +428,13 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
                         "ui.panel.config.integrations.no_integrations"
                       )}
                     </p>
-                    <mwc-button @click=${this._createFlow} unelevated
-                      >${this.hass.localize(
+                    <mwc-button
+                      @click=${this._createFlow}
+                      unelevated
+                      .label=${this.hass.localize(
                         "ui.panel.config.integrations.add_integration"
-                      )}</mwc-button
-                    >
+                      )}
+                    ></mwc-button>
                   </div>
                 </ha-card>
               `
@@ -580,13 +501,13 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
     this._manifests = manifests;
   }
 
-  private _handleRemoved(ev: HASSDomEvent<ConfigEntryRemovedEvent>) {
+  private _handleEntryRemoved(ev: HASSDomEvent<ConfigEntryRemovedEvent>) {
     this._configEntries = this._configEntries!.filter(
       (entry) => entry.entry_id !== ev.detail.entryId
     );
   }
 
-  private _handleUpdated(ev: HASSDomEvent<ConfigEntryUpdatedEvent>) {
+  private _handleEntryUpdated(ev: HASSDomEvent<ConfigEntryUpdatedEvent>) {
     const newEntry = ev.detail.entry;
     this._configEntries = this._configEntries!.map((entry) =>
       entry.entry_id === newEntry.entry_id
@@ -612,46 +533,10 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
     this.hass.loadBackendTranslation("title", undefined, true);
   }
 
-  private _continueFlow(ev: Event) {
-    showConfigFlowDialog(this, {
-      continueFlowId: (ev.target! as any).flowId,
-      dialogClosedCallback: () => {
-        this._handleFlowUpdated();
-      },
-    });
-  }
-
-  private async _ignoreFlow(ev: Event) {
-    const flow = (ev.target! as any).flow;
-    const confirmed = await showConfirmationDialog(this, {
-      title: this.hass!.localize(
-        "ui.panel.config.integrations.ignore.confirm_ignore_title",
-        "name",
-        localizeConfigFlowTitle(this.hass.localize, flow)
-      ),
-      text: this.hass!.localize(
-        "ui.panel.config.integrations.ignore.confirm_ignore"
-      ),
-      confirmText: this.hass!.localize(
-        "ui.panel.config.integrations.ignore.ignore"
-      ),
-    });
-    if (!confirmed) {
-      return;
-    }
-    await ignoreConfigFlow(
-      this.hass,
-      flow.flow_id,
-      localizeConfigFlowTitle(this.hass.localize, flow)
-    );
-    this._loadConfigEntries();
-    getConfigFlowInProgressCollection(this.hass.connection).refresh();
-  }
-
   private _handleMenuAction(ev: CustomEvent<ActionDetail>) {
     switch (ev.detail.index) {
       case 0:
-        this._toggleShowIgnored();
+        this._showIgnored = !this._showIgnored;
         break;
       case 1:
         this._toggleShowDisabled();
@@ -659,52 +544,12 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
     }
   }
 
-  private _toggleShowIgnored() {
-    this._showIgnored = !this._showIgnored;
-  }
-
   private _toggleShowDisabled() {
     this._showDisabled = !this._showDisabled;
   }
 
-  private async _removeIgnoredIntegration(ev: Event) {
-    const entry = (ev.target! as any).entry;
-    showConfirmationDialog(this, {
-      title: this.hass!.localize(
-        "ui.panel.config.integrations.ignore.confirm_delete_ignore_title",
-        "name",
-        this.hass.localize(`component.${entry.domain}.title`)
-      ),
-      text: this.hass!.localize(
-        "ui.panel.config.integrations.ignore.confirm_delete_ignore"
-      ),
-      confirmText: this.hass!.localize(
-        "ui.panel.config.integrations.ignore.stop_ignore"
-      ),
-      confirm: async () => {
-        const result = await deleteConfigEntry(this.hass, entry.entry_id);
-        if (result.require_restart) {
-          alert(
-            this.hass.localize(
-              "ui.panel.config.integrations.config_entry.restart_confirm"
-            )
-          );
-        }
-        this._loadConfigEntries();
-      },
-    });
-  }
-
   private _handleSearchChange(ev: CustomEvent) {
     this._filter = ev.detail.value;
-  }
-
-  private _onImageLoad(ev) {
-    ev.target.style.visibility = "initial";
-  }
-
-  private _onImageError(ev) {
-    ev.target.style.visibility = "hidden";
   }
 
   private async _highlightEntry() {
@@ -769,32 +614,13 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
           padding: 8px 16px 16px;
           margin-bottom: 64px;
         }
-        ha-card {
+        .container > * {
           max-width: 500px;
+        }
+        ha-card {
           display: flex;
           flex-direction: column;
           justify-content: space-between;
-        }
-        .attention {
-          --ha-card-border-color: var(--error-color);
-        }
-        .attention .header {
-          background: var(--error-color);
-          color: var(--text-primary-color);
-          padding: 8px;
-          text-align: center;
-        }
-        .attention mwc-button {
-          --mdc-theme-primary: var(--error-color);
-        }
-        .discovered {
-          --ha-card-border-color: var(--primary-color);
-        }
-        .discovered .header {
-          background: var(--primary-color);
-          color: var(--text-primary-color);
-          padding: 8px;
-          text-align: center;
         }
         .ignored {
           --ha-card-border-color: var(--light-theme-disabled-color);

--- a/src/panels/config/integrations/ha-ignored-config-entry-card.ts
+++ b/src/panels/config/integrations/ha-ignored-config-entry-card.ts
@@ -1,0 +1,96 @@
+import {
+  customElement,
+  LitElement,
+  property,
+  css,
+  html,
+  TemplateResult,
+} from "lit-element";
+import { fireEvent } from "../../../common/dom/fire_event";
+import { deleteConfigEntry } from "../../../data/config_entries";
+import type { IntegrationManifest } from "../../../data/integration";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
+import type { HomeAssistant } from "../../../types";
+import type { ConfigEntryExtended } from "./ha-config-integrations";
+import "./ha-integration-action-card";
+
+@customElement("ha-ignored-config-entry-card")
+export class HaIgnoredConfigEntryCard extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public entry!: ConfigEntryExtended;
+
+  @property() public manifest?: IntegrationManifest;
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-integration-action-card
+        .hass=${this.hass}
+        .manifest=${this.manifest}
+        .banner=${this.hass.localize(
+          "ui.panel.config.integrations.ignore.ignored"
+        )}
+        .domain=${this.entry.domain}
+        .label=${this.entry.title === "Ignored"
+          ? // In 2020.2 we added support for entry.title. All ignored entries before
+            // that have title "Ignored" so we fallback to localized domain name.
+            this.entry.localized_domain_name
+          : this.entry.title}
+      >
+        <mwc-button
+          unelevated
+          @click=${this._removeIgnoredIntegration}
+          .label=${this.hass.localize(
+            "ui.panel.config.integrations.ignore.stop_ignore"
+          )}
+        ></mwc-button>
+      </ha-integration-action-card>
+    `;
+  }
+
+  private async _removeIgnoredIntegration() {
+    showConfirmationDialog(this, {
+      title: this.hass!.localize(
+        "ui.panel.config.integrations.ignore.confirm_delete_ignore_title",
+        "name",
+        this.hass.localize(`component.${this.entry.domain}.title`)
+      ),
+      text: this.hass!.localize(
+        "ui.panel.config.integrations.ignore.confirm_delete_ignore"
+      ),
+      confirmText: this.hass!.localize(
+        "ui.panel.config.integrations.ignore.stop_ignore"
+      ),
+      confirm: async () => {
+        const result = await deleteConfigEntry(this.hass, this.entry.entry_id);
+        if (result.require_restart) {
+          alert(
+            this.hass.localize(
+              "ui.panel.config.integrations.config_entry.restart_confirm"
+            )
+          );
+        }
+        fireEvent(this, "change", undefined, {
+          bubbles: false,
+        });
+      },
+    });
+  }
+
+  static styles = css`
+    :host {
+      --state-color: var(--divider-color, #e0e0e0);
+      --text-on-state-color: var(--primary-text-color);
+    }
+
+    mwc-button {
+      --mdc-theme-primary: var(--primary-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-ignored-config-entry-card": HaIgnoredConfigEntryCard;
+  }
+}

--- a/src/panels/config/integrations/ha-ignored-config-entry-card.ts
+++ b/src/panels/config/integrations/ha-ignored-config-entry-card.ts
@@ -80,7 +80,6 @@ export class HaIgnoredConfigEntryCard extends LitElement {
   static styles = css`
     :host {
       --state-color: var(--divider-color, #e0e0e0);
-      --text-on-state-color: var(--primary-text-color);
     }
 
     mwc-button {

--- a/src/panels/config/integrations/ha-integration-action-card.ts
+++ b/src/panels/config/integrations/ha-integration-action-card.ts
@@ -99,7 +99,7 @@ export class HaIntegrationActionCard extends LitElement {
           display: flex;
           justify-content: space-between;
           align-items: center;
-          padding: 8px 16px 0 8px;
+          padding: 8px 6px 0;
           height: 48px;
         }
       `,

--- a/src/panels/config/integrations/ha-integration-action-card.ts
+++ b/src/panels/config/integrations/ha-integration-action-card.ts
@@ -1,0 +1,114 @@
+import {
+  customElement,
+  LitElement,
+  property,
+  CSSResult,
+  css,
+} from "lit-element";
+import { TemplateResult, html } from "lit-html";
+import { IntegrationManifest } from "../../../data/integration";
+import { HomeAssistant } from "../../../types";
+import { brandsUrl } from "../../../util/brands-url";
+import {
+  haConfigIntegrationRenderIcons,
+  haConfigIntegrationsStyles,
+} from "./ha-config-integrations-common";
+
+@customElement("ha-integration-action-card")
+export class HaIntegrationActionCard extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public banner!: string;
+
+  @property() public domain!: string;
+
+  @property() public label!: string;
+
+  @property() public manifest?: IntegrationManifest;
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-card outlined>
+        <div class="banner">
+          ${this.banner}
+        </div>
+        <div class="content">
+          ${haConfigIntegrationRenderIcons(this.hass, this.manifest)}
+          <div class="image">
+            <img
+              src=${brandsUrl(this.domain, "logo")}
+              referrerpolicy="no-referrer"
+              @error=${this._onImageError}
+              @load=${this._onImageLoad}
+            />
+          </div>
+          <h2>${this.label}</h2>
+        </div>
+        <div class="actions"><slot></slot></div>
+      </ha-card>
+    `;
+  }
+
+  private _onImageLoad(ev) {
+    ev.target.style.visibility = "initial";
+  }
+
+  private _onImageError(ev) {
+    ev.target.style.visibility = "hidden";
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haConfigIntegrationsStyles,
+      css`
+        ha-card {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          --ha-card-border-color: var(--state-color);
+          --mdc-theme-primary: var(--state-color);
+        }
+        .content {
+          position: relative;
+          flex: 1;
+        }
+        .image {
+          height: 60px;
+          margin-top: 16px;
+          display: flex;
+          align-items: center;
+          justify-content: space-around;
+        }
+        img {
+          max-width: 90%;
+          max-height: 100%;
+        }
+        h2 {
+          text-align: center;
+          margin: 16px 8px 0;
+        }
+        .attention {
+          --state-color: var(--error-color);
+          --text-on-state-color: var(--text-primary-color);
+        }
+        .discovered {
+          --state-color: var(--primary-color);
+          --text-on-state-color: var(--text-primary-color);
+        }
+        .actions {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: 8px 16px 0 8px;
+          height: 48px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-integration-action-card": HaIntegrationActionCard;
+  }
+}

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -37,6 +37,7 @@ import { haStyle } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
 import { brandsUrl } from "../../../util/brands-url";
 import { ConfigEntryExtended } from "./ha-config-integrations";
+import { nothing } from "lit-html";
 
 export interface ConfigEntryUpdatedEvent {
   entry: ConfigEntry;
@@ -89,7 +90,7 @@ export class HaIntegrationCard extends LitElement {
 
   @property() public items!: ConfigEntryExtended[];
 
-  @property() public manifest!: IntegrationManifest;
+  @property() public manifest?: IntegrationManifest;
 
   @property() public entityRegistryEntries!: EntityRegistryEntry[];
 
@@ -315,22 +316,25 @@ export class HaIntegrationCard extends LitElement {
                 `
               : ""}
           </div>
-          <ha-button-menu corner="BOTTOM_START">
-            <mwc-icon-button
-              .title=${this.hass.localize("ui.common.menu")}
-              .label=${this.hass.localize("ui.common.overflow_menu")}
-              slot="trigger"
-            >
-              <ha-svg-icon .path=${mdiDotsVertical}></ha-svg-icon>
-            </mwc-icon-button>
-            <mwc-list-item @request-selected="${this._handleSystemOptions}">
-              ${this.hass.localize(
-                "ui.panel.config.integrations.config_entry.system_options"
-              )}
-            </mwc-list-item>
-            ${!this.manifest
-              ? ""
-              : html`
+          ${!this.manifest
+            ? nothing
+            : html`
+                <ha-button-menu corner="BOTTOM_START">
+                  <mwc-icon-button
+                    .title=${this.hass.localize("ui.common.menu")}
+                    .label=${this.hass.localize("ui.common.overflow_menu")}
+                    slot="trigger"
+                  >
+                    <ha-svg-icon .path=${mdiDotsVertical}></ha-svg-icon>
+                  </mwc-icon-button>
+                  <mwc-list-item
+                    @request-selected="${this._handleSystemOptions}"
+                  >
+                    ${this.hass.localize(
+                      "ui.panel.config.integrations.config_entry.system_options"
+                    )}
+                  </mwc-list-item>
+
                   <a
                     href=${this.manifest.documentation}
                     rel="noreferrer"
@@ -345,40 +349,44 @@ export class HaIntegrationCard extends LitElement {
                       ></ha-svg-icon>
                     </mwc-list-item>
                   </a>
-                `}
-            ${!item.disabled_by &&
-            item.state === "loaded" &&
-            item.supports_unload &&
-            item.source !== "system"
-              ? html`<mwc-list-item @request-selected="${this._handleReload}">
-                  ${this.hass.localize(
-                    "ui.panel.config.integrations.config_entry.reload"
-                  )}
-                </mwc-list-item>`
-              : ""}
-            ${item.disabled_by === "user"
-              ? html`<mwc-list-item @request-selected="${this._handleEnable}">
-                  ${this.hass.localize("ui.common.enable")}
-                </mwc-list-item>`
-              : item.source !== "system"
-              ? html`<mwc-list-item
-                  class="warning"
-                  @request-selected="${this._handleDisable}"
-                >
-                  ${this.hass.localize("ui.common.disable")}
-                </mwc-list-item>`
-              : ""}
-            ${item.source !== "system"
-              ? html`<mwc-list-item
-                  class="warning"
-                  @request-selected="${this._handleDelete}"
-                >
-                  ${this.hass.localize(
-                    "ui.panel.config.integrations.config_entry.delete"
-                  )}
-                </mwc-list-item>`
-              : ""}
-          </ha-button-menu>
+                  ${!item.disabled_by &&
+                  item.state === "loaded" &&
+                  item.supports_unload &&
+                  item.source !== "system"
+                    ? html`<mwc-list-item
+                        @request-selected="${this._handleReload}"
+                      >
+                        ${this.hass.localize(
+                          "ui.panel.config.integrations.config_entry.reload"
+                        )}
+                      </mwc-list-item>`
+                    : ""}
+                  ${item.disabled_by === "user"
+                    ? html`<mwc-list-item
+                        @request-selected="${this._handleEnable}"
+                      >
+                        ${this.hass.localize("ui.common.enable")}
+                      </mwc-list-item>`
+                    : item.source !== "system"
+                    ? html`<mwc-list-item
+                        class="warning"
+                        @request-selected="${this._handleDisable}"
+                      >
+                        ${this.hass.localize("ui.common.disable")}
+                      </mwc-list-item>`
+                    : ""}
+                  ${item.source !== "system"
+                    ? html`<mwc-list-item
+                        class="warning"
+                        @request-selected="${this._handleDelete}"
+                      >
+                        ${this.hass.localize(
+                          "ui.panel.config.integrations.config_entry.delete"
+                        )}
+                      </mwc-list-item>`
+                    : ""}
+                </ha-button-menu>
+              `}
         </div>
       </ha-card>
     `;

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -215,15 +215,11 @@ export class HaIntegrationCard extends LitElement {
               <div class="header">
                 ${this.hass.localize(...header)}${!headerLinkLogs
                   ? ""
-                  : `. ${this.hass.localize(
-                      "ui.panel.config.integrations.config_entry.check_the_logs",
-                      "logs_link",
-                      html`<a href="/config/logs"
-                        >${this.hass.localize(
-                          "ui.panel.config.integrations.config_entry.logs"
-                        )}</a
-                      >`
-                    )}`}
+                  : html`<a href="/config/logs"
+                      >${this.hass.localize(
+                        "ui.panel.config.integrations.config_entry.check_the_logs"
+                      )}</a
+                    >`}
               </div>
             `
           : ""}

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -247,7 +247,7 @@ export class HaIntegrationCard extends LitElement {
         ),
       ]);
     }
-    if (item.connection_class.substring(0, 6) === "cloud_") {
+    if (item.connection_class.startsWith("cloud_")) {
       icons.push([
         mdiCloud,
         this.hass.localize(

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -237,33 +237,23 @@ export class HaIntegrationCard extends LitElement {
       ];
     }
 
-    const icons: TemplateResult[] = [];
+    const icons: [string, string][] = [];
 
     if (this.manifest && !this.manifest.is_built_in) {
-      icons.push(html`
-        <span>
-          <ha-svg-icon .path=${mdiPackageVariant}></ha-svg-icon>
-          <paper-tooltip animation-delay="0"
-            >${this.hass.localize(
-              "ui.panel.config.integrations.config_entry.provided_by_custom_component"
-            )}</paper-tooltip
-          >
-        </span>
-      `);
+      icons.push([
+        mdiPackageVariant,
+        this.hass.localize(
+          "ui.panel.config.integrations.config_entry.provided_by_custom_component"
+        ),
+      ]);
     }
     if (item.connection_class.substring(0, 6) === "cloud_") {
-      icons.push(
-        html`
-          <span>
-            <ha-svg-icon .path=${mdiCloud}></ha-svg-icon>
-            <paper-tooltip animation-delay="0"
-              >${this.hass.localize(
-                "ui.panel.config.integrations.config_entry.depends_on_cloud"
-              )}</paper-tooltip
-            >
-          </span>
-        `
-      );
+      icons.push([
+        mdiCloud,
+        this.hass.localize(
+          "ui.panel.config.integrations.config_entry.depends_on_cloud"
+        ),
+      ]);
     }
 
     return html`
@@ -287,7 +277,22 @@ export class HaIntegrationCard extends LitElement {
           ? html`<div class="header">${this.hass.localize(...header)}</div>`
           : ""}
         <div class="card-content">
-          ${icons.length === 0 ? "" : html`<div class="icons">${icons}</div>`}
+          ${icons.length === 0
+            ? ""
+            : html`
+                <div class="icons">
+                  ${icons.map(
+                    ([icon, description]) => html`
+                      <span>
+                        <ha-svg-icon .path=${icon}></ha-svg-icon>
+                        <paper-tooltip animation-delay="0"
+                          >${description}</paper-tooltip
+                        >
+                      </span>
+                    `
+                  )}
+                </div>
+              `}
           <div class="image">
             <img
               src=${brandsUrl(item.domain, "logo")}

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -199,7 +199,7 @@ export class HaIntegrationCard extends LitElement {
     const entities = this._getEntities(item);
 
     let stateText: [string, ...unknown[]] | undefined;
-    let stateTextLinkLogs = false;
+    let stateTextExtra: TemplateResult | string | undefined;
 
     if (item.disabled_by) {
       stateText = [
@@ -209,13 +209,26 @@ export class HaIntegrationCard extends LitElement {
           `ui.panel.config.integrations.config_entry.disable.disabled_by.${item.disabled_by}`
         ) || item.disabled_by,
       ];
+      if (item.state === "failed_unload") {
+        stateTextExtra = html`.
+        ${this.hass.localize(
+          "ui.panel.config.integrations.config_entry.disable_restart_confirm"
+        )}.`;
+      }
     } else if (item.state === "not_loaded") {
       stateText = ["ui.panel.config.integrations.config_entry.not_loaded"];
     } else if (ERROR_STATES.includes(item.state)) {
       stateText = [
         `ui.panel.config.integrations.config_entry.state.${item.state}`,
       ];
-      stateTextLinkLogs = true;
+      stateTextExtra = html`
+        <br />
+        <a href="/config/logs"
+          >${this.hass.localize(
+            "ui.panel.config.integrations.config_entry.check_the_logs"
+          )}</a
+        >
+      `;
     }
 
     return html`
@@ -223,16 +236,7 @@ export class HaIntegrationCard extends LitElement {
         ${stateText
           ? html`
               <div class="message">
-                ${this.hass.localize(...stateText)}${!stateTextLinkLogs
-                  ? ""
-                  : html`
-                      <br />
-                      <a href="/config/logs"
-                        >${this.hass.localize(
-                          "ui.panel.config.integrations.config_entry.check_the_logs"
-                        )}</a
-                      >
-                    `}
+                ${this.hass.localize(...stateText)}${stateTextExtra}
               </div>
             `
           : ""}

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -133,7 +133,10 @@ export class HaIntegrationCard extends LitElement {
         ]);
       }
 
-      if (this.manifest.iot_class.startsWith("cloud_")) {
+      if (
+        this.manifest.iot_class &&
+        this.manifest.iot_class.startsWith("cloud_")
+      ) {
         icons.push([
           mdiCloud,
           this.hass.localize(

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -1,6 +1,12 @@
 import type { RequestSelectedDetail } from "@material/mwc-list/mwc-list-item";
 import "@polymer/paper-tooltip/paper-tooltip";
-import { mdiAlertCircle, mdiDotsVertical, mdiOpenInNew } from "@mdi/js";
+import {
+  mdiAlertCircle,
+  mdiCloud,
+  mdiDotsVertical,
+  mdiOpenInNew,
+  mdiPackageVariant,
+} from "@mdi/js";
 import {
   css,
   CSSResult,
@@ -37,7 +43,6 @@ import { haStyle } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
 import { brandsUrl } from "../../../util/brands-url";
 import { ConfigEntryExtended } from "./ha-config-integrations";
-import { nothing } from "lit-html";
 
 export interface ConfigEntryUpdatedEvent {
   entry: ConfigEntry;
@@ -128,7 +133,7 @@ export class HaIntegrationCard extends LitElement {
                 "ui.panel.config.integrations.config_entry.disable.disabled"
               )}
             </div>`
-          : nothing}
+          : ""}
         <div class="group-header">
           <img
             src=${brandsUrl(this.domain, "icon")}
@@ -168,7 +173,7 @@ export class HaIntegrationCard extends LitElement {
                         )}
                       </paper-tooltip>
                     </span>`
-                  : nothing}
+                  : ""}
                 <ha-icon-next></ha-icon-next>
               </paper-item>`
           )}
@@ -181,6 +186,35 @@ export class HaIntegrationCard extends LitElement {
     const devices = this._getDevices(item);
     const services = this._getServices(item);
     const entities = this._getEntities(item);
+
+    const icons: TemplateResult[] = [];
+
+    if (this.manifest && !this.manifest.is_built_in) {
+      icons.push(html`
+        <span>
+          <ha-svg-icon .path=${mdiPackageVariant}></ha-svg-icon>
+          <paper-tooltip animation-delay="0"
+            >${this.hass.localize(
+              "ui.panel.config.integrations.config_entry.provided_by_custom_component"
+            )}</paper-tooltip
+          >
+        </span>
+      `);
+    }
+    if (item.connection_class.substring(0, 6) === "cloud_") {
+      icons.push(
+        html`
+          <span>
+            <ha-svg-icon .path=${mdiCloud}></ha-svg-icon>
+            <paper-tooltip animation-delay="0"
+              >${this.hass.localize(
+                "ui.panel.config.integrations.config_entry.depends_on_cloud"
+              )}</paper-tooltip
+            >
+          </span>
+        `
+      );
+    }
 
     return html`
       <ha-card
@@ -198,7 +232,7 @@ export class HaIntegrationCard extends LitElement {
               icon="hass:chevron-left"
               @click=${this._back}
             ></ha-icon-button>`
-          : nothing}
+          : ""}
         ${item.disabled_by
           ? html`<div class="header">
               ${this.hass.localize(
@@ -221,8 +255,9 @@ export class HaIntegrationCard extends LitElement {
                 >`
               )}
             </div>`
-          : nothing}
+          : ""}
         <div class="card-content">
+          ${icons.length === 0 ? "" : html`<div class="icons">${icons}</div>`}
           <div class="image">
             <img
               src=${brandsUrl(item.domain, "logo")}
@@ -235,7 +270,7 @@ export class HaIntegrationCard extends LitElement {
             ${item.localized_domain_name}
           </h2>
           <h3>
-            ${item.localized_domain_name === item.title ? nothing : item.title}
+            ${item.localized_domain_name === item.title ? "" : item.title}
           </h3>
           ${devices.length || services.length || entities.length
             ? html`
@@ -249,9 +284,9 @@ export class HaIntegrationCard extends LitElement {
                             "count",
                             devices.length
                           )}</a
-                        >${services.length ? "," : nothing}
+                        >${services.length ? "," : ""}
                       `
-                    : nothing}
+                    : ""}
                   ${services.length
                     ? html`
                         <a
@@ -263,10 +298,10 @@ export class HaIntegrationCard extends LitElement {
                           )}</a
                         >
                       `
-                    : nothing}
+                    : ""}
                   ${(devices.length || services.length) && entities.length
                     ? this.hass.localize("ui.common.and")
-                    : nothing}
+                    : ""}
                   ${entities.length
                     ? html`
                         <a
@@ -278,10 +313,10 @@ export class HaIntegrationCard extends LitElement {
                           )}</a
                         >
                       `
-                    : nothing}
+                    : ""}
                 </div>
               `
-            : nothing}
+            : ""}
         </div>
         <div class="card-actions">
           <div>
@@ -289,7 +324,7 @@ export class HaIntegrationCard extends LitElement {
               ? html`<mwc-button unelevated @click=${this._handleEnable}>
                   ${this.hass.localize("ui.common.enable")}
                 </mwc-button>`
-              : nothing}
+              : ""}
             <mwc-button @click=${this._editEntryName}>
               ${this.hass.localize(
                 "ui.panel.config.integrations.config_entry.rename"
@@ -314,10 +349,10 @@ export class HaIntegrationCard extends LitElement {
                     )}
                   </mwc-button>
                 `
-              : nothing}
+              : ""}
           </div>
           ${!this.manifest
-            ? nothing
+            ? ""
             : html`
                 <ha-button-menu corner="BOTTOM_START">
                   <mwc-icon-button
@@ -360,7 +395,7 @@ export class HaIntegrationCard extends LitElement {
                           "ui.panel.config.integrations.config_entry.reload"
                         )}
                       </mwc-list-item>`
-                    : nothing}
+                    : ""}
                   ${item.disabled_by === "user"
                     ? html`<mwc-list-item
                         @request-selected="${this._handleEnable}"
@@ -374,7 +409,7 @@ export class HaIntegrationCard extends LitElement {
                       >
                         ${this.hass.localize("ui.common.disable")}
                       </mwc-list-item>`
-                    : nothing}
+                    : ""}
                   ${item.source !== "system"
                     ? html`<mwc-list-item
                         class="warning"
@@ -384,7 +419,7 @@ export class HaIntegrationCard extends LitElement {
                           "ui.panel.config.integrations.config_entry.delete"
                         )}
                       </mwc-list-item>`
-                    : nothing}
+                    : ""}
                 </ha-button-menu>
               `}
         </div>
@@ -635,6 +670,16 @@ export class HaIntegrationCard extends LitElement {
         .card-content {
           padding: 16px;
           text-align: center;
+          position: relative;
+        }
+        .icons {
+          position: absolute;
+          top: 2px;
+          right: 2px;
+          color: var(--secondary-text-color);
+        }
+        .icons ha-svg-icon {
+          width: 20px;
         }
         ha-card.integration .card-content {
           padding-bottom: 3px;
@@ -714,6 +759,9 @@ export class HaIntegrationCard extends LitElement {
           position: absolute;
           background: rgba(var(--rgb-card-background-color), 0.6);
           border-radius: 50%;
+        }
+        paper-tooltip {
+          white-space: nowrap;
         }
       `,
     ];

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -215,11 +215,12 @@ export class HaIntegrationCard extends LitElement {
               <div class="header">
                 ${this.hass.localize(...header)}${!headerLinkLogs
                   ? ""
-                  : html`<a href="/config/logs"
-                      >${this.hass.localize(
-                        "ui.panel.config.integrations.config_entry.check_the_logs"
-                      )}</a
-                    >`}
+                  : html`.
+                      <a href="/config/logs"
+                        >${this.hass.localize(
+                          "ui.panel.config.integrations.config_entry.check_the_logs"
+                        )}</a
+                      >`}
               </div>
             `
           : ""}
@@ -291,8 +292,7 @@ export class HaIntegrationCard extends LitElement {
               ? html`<mwc-button unelevated @click=${this._handleEnable}>
                   ${this.hass.localize("ui.common.enable")}
                 </mwc-button>`
-              : ""}
-            ${item.domain in integrationsWithPanel
+              : item.domain in integrationsWithPanel
               ? html`<a
                   href=${`${
                     integrationsWithPanel[item.domain].path

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -128,7 +128,7 @@ export class HaIntegrationCard extends LitElement {
                 "ui.panel.config.integrations.config_entry.disable.disabled"
               )}
             </div>`
-          : ""}
+          : nothing}
         <div class="group-header">
           <img
             src=${brandsUrl(this.domain, "icon")}
@@ -168,7 +168,7 @@ export class HaIntegrationCard extends LitElement {
                         )}
                       </paper-tooltip>
                     </span>`
-                  : ""}
+                  : nothing}
                 <ha-icon-next></ha-icon-next>
               </paper-item>`
           )}
@@ -198,7 +198,7 @@ export class HaIntegrationCard extends LitElement {
               icon="hass:chevron-left"
               @click=${this._back}
             ></ha-icon-button>`
-          : ""}
+          : nothing}
         ${item.disabled_by
           ? html`<div class="header">
               ${this.hass.localize(
@@ -221,7 +221,7 @@ export class HaIntegrationCard extends LitElement {
                 >`
               )}
             </div>`
-          : ""}
+          : nothing}
         <div class="card-content">
           <div class="image">
             <img
@@ -235,7 +235,7 @@ export class HaIntegrationCard extends LitElement {
             ${item.localized_domain_name}
           </h2>
           <h3>
-            ${item.localized_domain_name === item.title ? "" : item.title}
+            ${item.localized_domain_name === item.title ? nothing : item.title}
           </h3>
           ${devices.length || services.length || entities.length
             ? html`
@@ -249,9 +249,9 @@ export class HaIntegrationCard extends LitElement {
                             "count",
                             devices.length
                           )}</a
-                        >${services.length ? "," : ""}
+                        >${services.length ? "," : nothing}
                       `
-                    : ""}
+                    : nothing}
                   ${services.length
                     ? html`
                         <a
@@ -263,10 +263,10 @@ export class HaIntegrationCard extends LitElement {
                           )}</a
                         >
                       `
-                    : ""}
+                    : nothing}
                   ${(devices.length || services.length) && entities.length
                     ? this.hass.localize("ui.common.and")
-                    : ""}
+                    : nothing}
                   ${entities.length
                     ? html`
                         <a
@@ -278,10 +278,10 @@ export class HaIntegrationCard extends LitElement {
                           )}</a
                         >
                       `
-                    : ""}
+                    : nothing}
                 </div>
               `
-            : ""}
+            : nothing}
         </div>
         <div class="card-actions">
           <div>
@@ -289,7 +289,7 @@ export class HaIntegrationCard extends LitElement {
               ? html`<mwc-button unelevated @click=${this._handleEnable}>
                   ${this.hass.localize("ui.common.enable")}
                 </mwc-button>`
-              : ""}
+              : nothing}
             <mwc-button @click=${this._editEntryName}>
               ${this.hass.localize(
                 "ui.panel.config.integrations.config_entry.rename"
@@ -314,7 +314,7 @@ export class HaIntegrationCard extends LitElement {
                     )}
                   </mwc-button>
                 `
-              : ""}
+              : nothing}
           </div>
           ${!this.manifest
             ? nothing
@@ -360,7 +360,7 @@ export class HaIntegrationCard extends LitElement {
                           "ui.panel.config.integrations.config_entry.reload"
                         )}
                       </mwc-list-item>`
-                    : ""}
+                    : nothing}
                   ${item.disabled_by === "user"
                     ? html`<mwc-list-item
                         @request-selected="${this._handleEnable}"
@@ -374,7 +374,7 @@ export class HaIntegrationCard extends LitElement {
                       >
                         ${this.hass.localize("ui.common.disable")}
                       </mwc-list-item>`
-                    : ""}
+                    : nothing}
                   ${item.source !== "system"
                     ? html`<mwc-list-item
                         class="warning"
@@ -384,7 +384,7 @@ export class HaIntegrationCard extends LitElement {
                           "ui.panel.config.integrations.config_entry.delete"
                         )}
                       </mwc-list-item>`
-                    : ""}
+                    : nothing}
                 </ha-button-menu>
               `}
         </div>

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -645,6 +645,7 @@ export class HaIntegrationCard extends LitElement {
           justify-content: space-between;
           align-items: center;
           padding-right: 5px;
+          height: 48px;
         }
         .group-header {
           display: flex;

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -177,7 +177,7 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
     });
   }
 
-  private _computeEntityName(entity: EntityRegistryEntry): string {
+  private _computeEntityName(entity: EntityRegistryEntry): string | null {
     if (this.hass.states[entity.entity_id]) {
       return computeStateName(this.hass.states[entity.entity_id]);
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2172,7 +2172,9 @@
                 "device": "device"
               },
               "disable_confirm": "Are you sure you want to disable this config entry? Its devices and entities will be disabled."
-            }
+            },
+            "provided_by_custom_component": "Provided by a custom component",
+            "depends_on_cloud": "Depends on the cloud"
           },
           "config_flow": {
             "aborted": "Aborted",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2142,7 +2142,7 @@
             "entities": "{count} {count, plural,\n  one {entity}\n  other {entities}\n}",
             "services": "{count} {count, plural,\n  one {service}\n  other {services}\n}",
             "rename": "Rename",
-            "options": "Options",
+            "configure": "Configure",
             "system_options": "System options",
             "documentation": "Documentation",
             "delete": "Delete",
@@ -2162,6 +2162,7 @@
             "area": "In {area}",
             "no_area": "No Area",
             "not_loaded": "Not loaded",
+            "check_the_logs": "Check the {logs_link}",
             "logs": "logs",
             "disable": {
               "disabled": "Disabled",
@@ -2175,9 +2176,14 @@
             },
             "provided_by_custom_component": "Provided by a custom component",
             "depends_on_cloud": "Depends on the cloud",
-            "is_setup_retry": "Retrying to set up, check the {logs_link}",
-            "is_setup_error": "Failed to set up, check the {logs_link}",
-            "is_failed_unload": "Failed to unload, check the {logs_link}"
+            "state": {
+              "loaded": "Not loaded",
+              "setup_error": "Failed to set up",
+              "migration_error": "Migration error",
+              "setup_retry": "Retrying to set up",
+              "not_loaded": "Not loaded",
+              "failed_unload": "Failed to unload"
+            }
           },
           "config_flow": {
             "aborted": "Aborted",
@@ -2248,11 +2254,7 @@
             "create": "Create"
           }
         },
-        "hassio": {
-          "button": "Configure"
-        },
         "mqtt": {
-          "button": "Configure",
           "title": "MQTT",
           "description_publish": "Publish a packet",
           "topic": "topic",
@@ -2266,7 +2268,6 @@
           "message_received": "Message {id} received on {topic} at {time}:"
         },
         "ozw": {
-          "button": "Configure",
           "common": {
             "zwave": "Z-Wave",
             "node_id": "Node ID",
@@ -2381,7 +2382,6 @@
           }
         },
         "zha": {
-          "button": "Configure",
           "common": {
             "clusters": "Clusters",
             "manufacturer_code_override": "Manufacturer Code Override",
@@ -2469,7 +2469,6 @@
           }
         },
         "zwave": {
-          "button": "Configure",
           "description": "Manage your Z-Wave network",
           "learn_more": "Learn more about Z-Wave",
           "common": {
@@ -2560,7 +2559,6 @@
           }
         },
         "zwave_js": {
-          "button": "Configure",
           "navigation": {
             "network": "Network"
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2161,7 +2161,7 @@
             "entity_unavailable": "Entity unavailable",
             "area": "In {area}",
             "no_area": "No Area",
-            "not_loaded": "Not loaded, check the {logs_link}",
+            "not_loaded": "Not loaded",
             "logs": "logs",
             "disable": {
               "disabled": "Disabled",
@@ -2174,7 +2174,10 @@
               "disable_confirm": "Are you sure you want to disable this config entry? Its devices and entities will be disabled."
             },
             "provided_by_custom_component": "Provided by a custom component",
-            "depends_on_cloud": "Depends on the cloud"
+            "depends_on_cloud": "Depends on the cloud",
+            "is_setup_retry": "Retrying to set up, check the {logs_link}",
+            "is_setup_error": "Failed to set up, check the {logs_link}",
+            "is_failed_unload": "Failed to unload, check the {logs_link}"
           },
           "config_flow": {
             "aborted": "Aborted",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2162,7 +2162,7 @@
             "area": "In {area}",
             "no_area": "No Area",
             "not_loaded": "Not loaded",
-            "check_the_logs": "Check the {logs_link}",
+            "check_the_logs": "Check the logs",
             "logs": "logs",
             "disable": {
               "disabled": "Disabled",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2163,7 +2163,6 @@
             "no_area": "No Area",
             "not_loaded": "Not loaded",
             "check_the_logs": "Check the logs",
-            "logs": "logs",
             "disable": {
               "disabled": "Disabled",
               "disabled_cause": "Disabled by {cause}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The typing of manifests was incorrect, causing occasional exceptions when loading the integrations page. This makes the integration cards handle no manifest. We will only load the whole menu when manifest is loaded, this makes initial render also faster.

Also adds icons to the integration card when it's a custom component or relies on the cloud.

_Two days later_

I've redesigned the whole integration card together with Bram.


https://user-images.githubusercontent.com/1444314/114950530-21dd2480-9e08-11eb-9ab7-11f6e4769d48.mp4


<details><summary>Old screenshots</summary>

![Screenshot 2021-04-13 at 15 59 56](https://user-images.githubusercontent.com/1444314/114631459-77cb9400-9c71-11eb-96e2-52ba5b264d29.png)

### Not loaded
![Screenshot 2021-04-13 at 16 38 14](https://user-images.githubusercontent.com/1444314/114634327-21f9ea80-9c77-11eb-8e39-a9e61df6f810.png)

### Retry setup
![Screenshot 2021-04-13 at 16 38 28](https://user-images.githubusercontent.com/1444314/114634345-2920f880-9c77-11eb-9469-cc7ba43eb1df.png)

### Failed to setup
![Screenshot 2021-04-13 at 16 38 50](https://user-images.githubusercontent.com/1444314/114634354-2f16d980-9c77-11eb-99e3-5b56a152ad47.png)

### Failed to unload
![Screenshot 2021-04-13 at 16 39 16](https://user-images.githubusercontent.com/1444314/114634363-363de780-9c77-11eb-9dd9-309043149ddb.png)

### Not loaded
![Screenshot 2021-04-13 at 16 39 29](https://user-images.githubusercontent.com/1444314/114634368-3b9b3200-9c77-11eb-8204-9ae23b37a06f.png)

### Disabled

![Screenshot 2021-04-13 at 16 39 53](https://user-images.githubusercontent.com/1444314/114634381-42c24000-9c77-11eb-881c-ad7475cbb464.png)

</details>

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
