### PR TITLE
Set standard name for Cancel button, to align translations

### DIFF
--- a/src/panels/lovelace/editor/hui-dialog-save-config.ts
+++ b/src/panels/lovelace/editor/hui-dialog-save-config.ts
@@ -127,7 +127,7 @@ export class HuiSaveConfig extends LitElement implements HassDialog {
           ? html`
               <mwc-button slot="primaryAction" @click=${this.closeDialog}
                 >${this.hass!.localize(
-                  "ui.panel.lovelace.editor.save_config.cancel"
+                  "ui.common.cancel"
                 )}
               </mwc-button>
               <mwc-button

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2821,7 +2821,6 @@
             "yaml_control": "To take control in YAML mode, create a YAML file with the name you specified in your config for this dashboard, or the default 'ui-lovelace.yaml'.",
             "yaml_config": "To help you start here is the current config of this dashboard:",
             "empty_config": "Start with an empty dashboard",
-            "cancel": "Never mind",
             "close": "Close",
             "save": "Take control"
           },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

From a brief discussion in "Lokalise->Polymer frontend" for `ui::panel::lovelace::editor::save_config::cancel`

![Screenshot_20210414_092008](https://user-images.githubusercontent.com/1636266/114669828-a34a8f00-9d02-11eb-8453-024801ffa3bc.png)

The original english text for the buttons is **"Never mind"** and "Take control".

Desired action for "Never mind" is to Cancel and close the prompt, however:
- Spanish translation was "No importa", in context "Sure, I don't mind" (!!)
- Default french translation was cheesy: "Oublie ce que j'ai dit, c'est pas grave" / "Forget what I just said, it is not important" :smile: 

From Dannie Rothman at Lokalise:

> I Agree, Danish, Swedish and Norwegian also ends up as something like "Forget it" or "Not really" - i changed the Danish version to something matching "Cancel" 

Proposed PR change is "Never mind" becoming "Cancel" to make it more intuitive and standard UI, aligned across languages.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
