### PR TITLE
Use const everywhere for "group.default_view"

### DIFF
--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -3,6 +3,8 @@ import {
   HassEntity,
   STATE_NOT_RUNNING,
 } from "home-assistant-js-websocket";
+import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import { DEFAULT_VIEW_ENTITY_ID } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeObjectId } from "../../../common/entity/compute_object_id";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
@@ -13,7 +15,6 @@ import { splitByGroups } from "../../../common/entity/split_by_groups";
 import { compare } from "../../../common/string/compare";
 import { LocalizeFunc } from "../../../common/translations/localize";
 import { subscribeOne } from "../../../common/util/subscribe-one";
-import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import {
   AreaRegistryEntry,
   subscribeAreaRegistry,
@@ -45,7 +46,6 @@ import {
 } from "../cards/types";
 import { LovelaceRowConfig } from "../entity-rows/types";
 
-const DEFAULT_VIEW_ENTITY_ID = "group.default_view";
 const HIDE_DOMAIN = new Set([
   "automation",
   "configurator",
@@ -181,7 +181,8 @@ export const computeCards = (
         titlePrefix &&
         stateObj &&
         // eslint-disable-next-line no-cond-assign
-        (name = computeStateName(stateObj)) !== titlePrefix && name.startsWith(titlePrefix)
+        (name = computeStateName(stateObj)) !== titlePrefix &&
+        name.startsWith(titlePrefix)
           ? {
               entity: entityId,
               name: adjustName(name.substr(titlePrefix.length)),

--- a/test-mocha/common/entity/extract_views.spec.ts
+++ b/test-mocha/common/entity/extract_views.spec.ts
@@ -1,7 +1,6 @@
 import * as assert from "assert";
-
+import { DEFAULT_VIEW_ENTITY_ID } from "../../../src/common/const";
 import { extractViews } from "../../../src/common/entity/extract_views";
-
 import { createEntities, createView } from "./test_util";
 
 describe("extractViews", () => {
@@ -14,7 +13,7 @@ describe("extractViews", () => {
     entities[view2.entity_id] = view2;
 
     const view3 = createView({
-      entity_id: "group.default_view",
+      entity_id: DEFAULT_VIEW_ENTITY_ID,
       attributes: { order: 8 },
     });
     entities[view3.entity_id] = view3;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Small cleanup.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
