### PR TITLE
Allow falsey values for attribute value in a picture-elements card element.

### DIFF
--- a/src/panels/lovelace/elements/hui-state-label-element.ts
+++ b/src/panels/lovelace/elements/hui-state-label-element.ts
@@ -57,7 +57,7 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
 
     if (
       this._config.attribute &&
-      !stateObj.attributes[this._config.attribute]
+      stateObj.attributes[this._config.attribute] === undefined
     ) {
       return html`
         <hui-warning-element

--- a/src/panels/lovelace/elements/hui-state-label-element.ts
+++ b/src/panels/lovelace/elements/hui-state-label-element.ts
@@ -57,7 +57,7 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
 
     if (
       this._config.attribute &&
-      stateObj.attributes[this._config.attribute] === undefined
+      !this._config.attribute in stateObj.attributes
     ) {
       return html`
         <hui-warning-element

--- a/src/panels/lovelace/elements/hui-state-label-element.ts
+++ b/src/panels/lovelace/elements/hui-state-label-element.ts
@@ -57,7 +57,7 @@ class HuiStateLabelElement extends LitElement implements LovelaceElement {
 
     if (
       this._config.attribute &&
-      !this._config.attribute in stateObj.attributes
+      !(this._config.attribute in stateObj.attributes)
     ) {
       return html`
         <hui-warning-element


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Allow attribute values that are falsey (`0`, `false`, `''`) for picture elements when using the `attribute` key.  e.g.

```yaml
cards:
  -   type: picture-elements
      image: "/local/tp-04.png"
      elements:
      - type: state-label
        entity:  air_quality.master_bedroom
        attribute: particulate_matter_2_5
        suffix: ' PM2.5'
        style:
          # ...
```

In this example the value of `0` is completely valid, but the card will show a warning instead of the value of `0`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
cards:
  -   type: picture-elements
      image: "/local/tp-04.png"
      elements:
      - type: state-label
        entity:  air_quality.master_bedroom
        attribute: particulate_matter_2_5
        suffix: ' PM2.5'
        style:
          # ...
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
