### PR TITLE
Add QR code to long lived access tokens dialog

### DIFF
--- a/src/panels/profile/ha-long-lived-access-token-dialog.ts
+++ b/src/panels/profile/ha-long-lived-access-token-dialog.ts
@@ -58,14 +58,14 @@ export class HaLongLivedAccessTokenDialog extends LitElement {
           <paper-input
             dialogInitialFocus
             .value=${this._params.token}
-            .type=${"text"}
+            type="text"
           ></paper-input>
           <div id="qr">
             ${this._qrCode
               ? this._qrCode
               : html`
-                  <mwc-button @click=${this._generateQR}
-                    >Generate QR code
+                  <mwc-button @click=${this._generateQR}>
+                    Generate QR code
                   </mwc-button>
                 `}
           </div>

--- a/src/panels/profile/ha-long-lived-access-token-dialog.ts
+++ b/src/panels/profile/ha-long-lived-access-token-dialog.ts
@@ -50,14 +50,12 @@ export class HaLongLivedAccessTokenDialog extends LitElement {
         @closed=${this.closeDialog}
       >
         <div>
-          <p class="no-bottom-padding">
-            ${this.hass.localize(
-              "ui.panel.profile.long_lived_access_tokens.prompt_copy_token"
-            )}
-          </p>
           <paper-input
             dialogInitialFocus
             .value=${this._params.token}
+            .label=${this.hass.localize(
+              "ui.panel.profile.long_lived_access_tokens.prompt_copy_token"
+            )}
             type="text"
           ></paper-input>
           <div id="qr">
@@ -102,26 +100,6 @@ export class HaLongLivedAccessTokenDialog extends LitElement {
     return [
       haStyleDialog,
       css`
-        :host([inert]) {
-          pointer-events: initial !important;
-          cursor: initial !important;
-        }
-        a {
-          color: var(--primary-color);
-        }
-        p {
-          margin: 0;
-          padding-top: 6px;
-          padding-bottom: 24px;
-          color: var(--primary-text-color);
-        }
-        .no-bottom-padding {
-          padding-bottom: 0;
-        }
-        ha-dialog {
-          /* Place above other dialogs */
-          --dialog-z-index: 104;
-        }
         #qr {
           text-align: center;
         }

--- a/src/panels/profile/ha-long-lived-access-token-dialog.ts
+++ b/src/panels/profile/ha-long-lived-access-token-dialog.ts
@@ -1,0 +1,137 @@
+import {
+  css,
+  CSSResult,
+  customElement,
+  html,
+  internalProperty,
+  LitElement,
+  property,
+  TemplateResult,
+} from "lit-element";
+import "@material/mwc-button";
+import "@polymer/paper-input/paper-input";
+import { fireEvent } from "../../common/dom/fire_event";
+import { createCloseHeading } from "../../components/ha-dialog";
+import { haStyleDialog } from "../../resources/styles";
+import type { HomeAssistant } from "../../types";
+import { LongLivedAccessTokenDialogParams } from "./show-long-lived-access-token-dialog";
+
+const QR_LOGO_URL = "/static/icons/favicon-192x192.png";
+
+@customElement("ha-long-lived-access-token-dialog")
+export class HaLongLivedAccessTokenDialog extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false })
+  private _params?: LongLivedAccessTokenDialogParams;
+
+  @internalProperty() private _qrCode?: TemplateResult;
+
+  public showDialog(params: LongLivedAccessTokenDialogParams): void {
+    this._params = params;
+  }
+
+  public closeDialog() {
+    this._params = undefined;
+    this._qrCode = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render(): TemplateResult {
+    if (!this._params || !this._params.token) {
+      return html``;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        hideActions
+        .heading=${createCloseHeading(this.hass, this._params.name)}
+        @closed=${this.closeDialog}
+      >
+        <div>
+          <p class="no-bottom-padding">
+            ${this.hass.localize(
+              "ui.panel.profile.long_lived_access_tokens.prompt_copy_token"
+            )}
+          </p>
+          <paper-input
+            dialogInitialFocus
+            .value=${this._params.token}
+            .type=${"text"}
+          ></paper-input>
+          <div id="qr">
+            ${this._qrCode
+              ? this._qrCode
+              : html`
+                  <mwc-button @click=${this._generateQR}
+                    >Generate QR code
+                  </mwc-button>
+                `}
+          </div>
+        </div>
+      </ha-dialog>
+    `;
+  }
+
+  private async _generateQR() {
+    const qrcode = await import("qrcode");
+    const canvas = await qrcode.toCanvas(this._params?.token, {
+      width: 180,
+      errorCorrectionLevel: "Q",
+    });
+    const context = canvas.getContext("2d");
+
+    const imageObj = new Image();
+    imageObj.src = QR_LOGO_URL;
+    await new Promise((resolve) => {
+      imageObj.onload = resolve;
+    });
+    context.drawImage(
+      imageObj,
+      canvas.width / 3,
+      canvas.height / 3,
+      canvas.width / 3,
+      canvas.height / 3
+    );
+
+    this._qrCode = html`<img src=${canvas.toDataURL()}></img>`;
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        :host([inert]) {
+          pointer-events: initial !important;
+          cursor: initial !important;
+        }
+        a {
+          color: var(--primary-color);
+        }
+        p {
+          margin: 0;
+          padding-top: 6px;
+          padding-bottom: 24px;
+          color: var(--primary-text-color);
+        }
+        .no-bottom-padding {
+          padding-bottom: 0;
+        }
+        ha-dialog {
+          /* Place above other dialogs */
+          --dialog-z-index: 104;
+        }
+        #qr {
+          text-align: center;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-long-lived-access-token-dialog": HaLongLivedAccessTokenDialog;
+  }
+}

--- a/src/panels/profile/ha-long-lived-access-tokens-card.ts
+++ b/src/panels/profile/ha-long-lived-access-tokens-card.ts
@@ -25,6 +25,7 @@ import {
 import { haStyle } from "../../resources/styles";
 import "../../styles/polymer-ha-style";
 import { HomeAssistant } from "../../types";
+import { showLongLivedAccessTokenDialog } from "./show-long-lived-access-token-dialog";
 
 @customElement("ha-long-lived-access-tokens-card")
 class HaLongLivedTokens extends LitElement {
@@ -125,13 +126,7 @@ class HaLongLivedTokens extends LitElement {
         client_name: name,
       });
 
-      showPromptDialog(this, {
-        title: name,
-        text: this.hass.localize(
-          "ui.panel.profile.long_lived_access_tokens.prompt_copy_token"
-        ),
-        defaultValue: token,
-      });
+      showLongLivedAccessTokenDialog(this, { token, name });
 
       fireEvent(this, "hass-refresh-tokens");
     } catch (err) {

--- a/src/panels/profile/show-long-lived-access-token-dialog.ts
+++ b/src/panels/profile/show-long-lived-access-token-dialog.ts
@@ -1,0 +1,17 @@
+import { fireEvent } from "../../common/dom/fire_event";
+
+export interface LongLivedAccessTokenDialogParams {
+  token: string;
+  name: string;
+}
+
+export const showLongLivedAccessTokenDialog = (
+  element: HTMLElement,
+  longLivedAccessTokenDialogParams: LongLivedAccessTokenDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "ha-long-lived-access-token-dialog",
+    dialogImport: () => import("./ha-long-lived-access-token-dialog"),
+    dialogParams: longLivedAccessTokenDialogParams,
+  });
+};


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This change adds a QR code when generating an long lived access token. This can then be used by, for example, a mobile app to load the token without having to rely on the user to copy/paste this manually.

![image](https://user-images.githubusercontent.com/1644496/115297446-522e1580-a1b0-11eb-979e-24714baf8983.png)
![image](https://user-images.githubusercontent.com/1644496/115297476-5823f680-a1b0-11eb-84e6-99d2b6a953d8.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: https://community.home-assistant.io/t/show-long-lived-access-tokens-as-qr-code/288016

Code largely copied from `dialog-tag-detail.ts`, it may be worthwhile to refactor code to use a common helper function.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
