### PR TITLE
Show feedback for setting Z-Wave JS config parameters

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -36,8 +36,6 @@ export interface ZWaveJSNodeConfigParam {
   value: any;
   configuration_value_type: string;
   metadata: ZWaveJSNodeConfigParamMetadata;
-  result?: string;
-  error?: string;
 }
 
 export interface ZWaveJSNodeConfigParamMetadata {

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -31,6 +31,7 @@ export interface ZWaveJSNode {
 export interface ZWaveJSNodeConfigParams {
   [key: string]: ZWaveJSNodeConfigParam;
 }
+
 export interface ZWaveJSNodeConfigParam {
   property: number;
   value: any;

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -61,15 +61,15 @@ export interface ZWaveJSSetConfigParamData {
   value: string | number;
 }
 
-export interface ZWaveJSDataCollectionStatus {
-  enabled: boolean;
-  opted_in: boolean;
-}
-
 export interface ZWaveJSSetConfigParamResult {
   value_id?: string;
   status?: string;
   error?: string;
+}
+
+export interface ZWaveJSDataCollectionStatus {
+  enabled: boolean;
+  opted_in: boolean;
 }
 
 export enum NodeStatus {

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -29,11 +29,15 @@ export interface ZWaveJSNode {
 }
 
 export interface ZWaveJSNodeConfigParams {
+  [key: string]: ZWaveJSNodeConfigParam;
+}
+export interface ZWaveJSNodeConfigParam {
   property: number;
   value: any;
   configuration_value_type: string;
   metadata: ZWaveJSNodeConfigParamMetadata;
   result?: string;
+  error?: string;
 }
 
 export interface ZWaveJSNodeConfigParamMetadata {
@@ -122,7 +126,7 @@ export const fetchNodeConfigParameters = (
   hass: HomeAssistant,
   entry_id: string,
   node_id: number
-): Promise<ZWaveJSNodeConfigParams[]> =>
+): Promise<ZWaveJSNodeConfigParams> =>
   hass.callWS({
     type: "zwave_js/get_config_parameters",
     entry_id,

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -61,15 +61,15 @@ export interface ZWaveJSSetConfigParamData {
   value: string | number;
 }
 
-<<<<<<< HEAD
 export interface ZWaveJSDataCollectionStatus {
   enabled: boolean;
   opted_in: boolean;
-=======
+}
+
 export interface ZWaveJSSetConfigParamResult {
   value_id: string;
   status: string;
->>>>>>> add basic feedback for set config param
+  error?: string;
 }
 
 export enum NodeStatus {

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -33,6 +33,7 @@ export interface ZWaveJSNodeConfigParams {
   value: any;
   configuration_value_type: string;
   metadata: ZWaveJSNodeConfigParamMetadata;
+  result?: string;
 }
 
 export interface ZWaveJSNodeConfigParamMetadata {
@@ -56,9 +57,15 @@ export interface ZWaveJSSetConfigParamData {
   value: string | number;
 }
 
+<<<<<<< HEAD
 export interface ZWaveJSDataCollectionStatus {
   enabled: boolean;
   opted_in: boolean;
+=======
+export interface ZWaveJSSetConfigParamResult {
+  value_id: string;
+  status: string;
+>>>>>>> add basic feedback for set config param
 }
 
 export enum NodeStatus {
@@ -129,7 +136,7 @@ export const setNodeConfigParameter = (
   property: number,
   value: number,
   property_key?: number
-): Promise<unknown> => {
+): Promise<ZWaveJSSetConfigParamResult> => {
   const data: ZWaveJSSetConfigParamData = {
     type: "zwave_js/set_config_parameter",
     entry_id,

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -67,8 +67,8 @@ export interface ZWaveJSDataCollectionStatus {
 }
 
 export interface ZWaveJSSetConfigParamResult {
-  value_id: string;
-  status: string;
+  value_id?: string;
+  status?: string;
   error?: string;
 }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -428,15 +428,15 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
       haStyle,
       css`
         .accepted {
-          color: green;
+          color: var(--success-color);
         }
 
         .queued {
-          color: #fca503;
+          color: var(--warning-color);
         }
 
         .error {
-          color: red;
+          color: var(--error-color);
         }
 
         .secondary {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -212,7 +212,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
               )}
             </em>`
           : ""}
-        ${result && result.status
+        ${result?.status
           ? html` <p
               class="result ${classMap({
                 [result.status]: true,

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -212,7 +212,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
               )}
             </em>`
           : ""}
-        ${result
+        ${result && result.status
           ? html` <p
               class="result ${classMap({
                 [result.status]: true,

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -388,7 +388,8 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
 
   private setResult(key: string, value: string | undefined) {
     if (value === undefined) {
-      this._results = { ...this._results, [key]: undefined };
+      delete this._results[key];
+      this.requestUpdate();
     } else {
       this._results = { ...this._results, [key]: { status: value } };
     }

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -47,6 +47,12 @@ import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import memoizeOne from "memoize-one";
 import { classMap } from "lit-html/directives/class-map";
 
+const icons = {
+  accepted: mdiCheckCircle,
+  queued: mdiProgressClock,
+  error: mdiCloseCircle,
+};
+
 const getDevice = memoizeOne(
   (
     deviceId: string,
@@ -87,7 +93,10 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
 
   @internalProperty() private _config?: ZWaveJSNodeConfigParams;
 
-  @internalProperty() private _results: ZWaveJSSetConfigParamResult[] = [];
+  @internalProperty() private _results: Record<
+    string,
+    ZWaveJSSetConfigParamResult
+  > = {};
 
   @internalProperty() private _error?: string;
 
@@ -188,11 +197,6 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
   }
 
   private _generateConfigBox(id, item): TemplateResult {
-    const icons = {
-      accepted: mdiCheckCircle,
-      queued: mdiProgressClock,
-      error: mdiCloseCircle,
-    };
     const result = this._results[id];
     const labelAndDescription = html`
       <span slot="heading">${item.metadata.label}</span>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2606,7 +2606,9 @@
             "zwave_js_device_database": "Z-Wave JS Device Database",
             "battery_device_notice": "Battery devices must be awake to update their config. Please refer to your device manual for instructions on how to wake the device.",
             "parameter_is_read_only": "This parameter is read-only.",
-            "error_device_not_found": "Device not found"
+            "error_device_not_found": "Device not found",
+            "set_param_accepted": "The parameter has been updated",
+            "set_param_queued": "The parameter change has been queued, and will be updated when the device wakes up."
           },
           "node_status": {
             "unknown": "Unknown",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2607,8 +2607,9 @@
             "battery_device_notice": "Battery devices must be awake to update their config. Please refer to your device manual for instructions on how to wake the device.",
             "parameter_is_read_only": "This parameter is read-only.",
             "error_device_not_found": "Device not found",
-            "set_param_accepted": "The parameter has been updated",
-            "set_param_queued": "The parameter change has been queued, and will be updated when the device wakes up."
+            "set_param_accepted": "The parameter has been updated.",
+            "set_param_queued": "The parameter change has been queued, and will be updated when the device wakes up.",
+            "set_param_error": "An error occurred."
           },
           "node_status": {
             "unknown": "Unknown",


### PR DESCRIPTION
## Proposed change
Show feedback on the Z-Wave JS device config page when parameters are updated:

![image](https://user-images.githubusercontent.com/7545841/115474499-93074800-a20b-11eb-8183-a97afbafd14d.png)

![image](https://user-images.githubusercontent.com/7545841/115474531-a0243700-a20b-11eb-9fef-486159d2b19b.png)

![image](https://user-images.githubusercontent.com/7545841/115474546-aca88f80-a20b-11eb-9491-cb03a26f1a04.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
