### PR TITLE
Add UI for Z-Wave JS Device Reinterview

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -1,3 +1,4 @@
+import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { HomeAssistant } from "../types";
 import { DeviceRegistryEntry } from "./device_registry";
 
@@ -149,6 +150,22 @@ export const setNodeConfigParameter = (
     property_key,
   };
   return hass.callWS(data);
+};
+
+export const reinterviewNode = (
+  hass: HomeAssistant,
+  entry_id: string,
+  node_id: number,
+  callbackFunction: any
+): Promise<UnsubscribeFunc> => {
+  return hass.connection.subscribeMessage(
+    (message: any) => callbackFunction(message),
+    {
+      type: "zwave_js/refresh_node_info",
+      entry_id: entry_id,
+      node_id: node_id,
+    }
+  );
 };
 
 export const getIdentifiersFromDevice = function (

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -72,6 +72,11 @@ export interface ZWaveJSDataCollectionStatus {
   opted_in: boolean;
 }
 
+export interface ZWaveJSRefreshNodeStatusMessage {
+  event: string;
+  stage?: string;
+}
+
 export enum NodeStatus {
   Unknown,
   Asleep,
@@ -156,7 +161,7 @@ export const reinterviewNode = (
   hass: HomeAssistant,
   entry_id: string,
   node_id: number,
-  callbackFunction: any
+  callbackFunction: (message: ZWaveJSRefreshNodeStatusMessage) => void
 ): Promise<UnsubscribeFunc> => {
   return hass.connection.subscribeMessage(
     (message: any) => callbackFunction(message),

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-actions-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-actions-zwave_js.ts
@@ -11,9 +11,13 @@ import {
   TemplateResult,
 } from "lit-element";
 import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
+import {
+  getIdentifiersFromDevice,
+  ZWaveJSNodeIdentifiers,
+} from "../../../../../../data/zwave_js";
 import { haStyle } from "../../../../../../resources/styles";
-
 import { HomeAssistant } from "../../../../../../types";
+import { showZWaveJSReinterviewNodeDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-reinterview-node";
 
 @customElement("ha-device-actions-zwave_js")
 export class HaDeviceActionsZWaveJS extends LitElement {
@@ -23,9 +27,19 @@ export class HaDeviceActionsZWaveJS extends LitElement {
 
   @internalProperty() private _entryId?: string;
 
+  @internalProperty() private _nodeId?: number;
+
   protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has("device")) {
       this._entryId = this.device.config_entries[0];
+
+      const identifiers:
+        | ZWaveJSNodeIdentifiers
+        | undefined = getIdentifiersFromDevice(this.device);
+      if (!identifiers) {
+        return;
+      }
+      this._nodeId = identifiers.node_id;
     }
   }
 
@@ -40,7 +54,20 @@ export class HaDeviceActionsZWaveJS extends LitElement {
           )}
         </mwc-button>
       </a>
+      <mwc-button @click=${this._reinterviewClicked}
+        >Re-interview Device</mwc-button
+      >
     `;
+  }
+
+  private async _reinterviewClicked() {
+    if (!this._nodeId || !this._entryId) {
+      return;
+    }
+    showZWaveJSReinterviewNodeDialog(this, {
+      entry_id: this._entryId,
+      node_id: this._nodeId,
+    });
   }
 
   static get styles(): CSSResult[] {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -31,13 +31,14 @@ class DialogZWaveJSReinterviewNode extends LitElement {
 
   @internalProperty() private _stage?: string;
 
-  @internalProperty() private _stages: string[] = [];
+  @internalProperty() private _stages?: string[];
 
   private _subscribed?: Promise<UnsubscribeFunc>;
 
   public async showDialog(
     params: ZWaveJSReinterviewNodeDialogParams
   ): Promise<void> {
+    this._stages = undefined;
     this.entry_id = params.entry_id;
     this.node_id = params.node_id;
   }
@@ -152,7 +153,7 @@ class DialogZWaveJSReinterviewNode extends LitElement {
               </mwc-button>
             `
           : ``}
-        ${this._stages.length > 0
+        ${this._stages
           ? html`
               <div class="stages">
                 ${this._stages.map(
@@ -190,7 +191,11 @@ class DialogZWaveJSReinterviewNode extends LitElement {
       this._status = "started";
     }
     if (message.event === "interview stage completed") {
-      this._stages = [...this._stages, message.stage];
+      if (this._stages === undefined) {
+        this._stages = [message.stage];
+      } else {
+        this._stages = [...this._stages, message.stage];
+      }
     }
     if (message.event === "interview failed") {
       this._unsubscribe();
@@ -214,7 +219,7 @@ class DialogZWaveJSReinterviewNode extends LitElement {
     this.entry_id = undefined;
     this.node_id = undefined;
     this._status = undefined;
-    this._stages = [];
+    this._stages = undefined;
 
     this._unsubscribe();
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -87,6 +87,11 @@ class DialogZWaveJSReinterviewNode extends LitElement {
                       )}
                     </b>
                   </p>
+                  <p>
+                    ${this.hass.localize(
+                      "ui.panel.config.zwave_js.reinterview_node.run_in_background"
+                    )}
+                  </p>
                   ${this._stage
                     ? html`
                         <p>

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -17,6 +17,7 @@ import { HomeAssistant } from "../../../../../types";
 import { ZWaveJSReinterviewNodeDialogParams } from "./show-dialog-zwave_js-reinterview-node";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
+import { reinterviewNode } from "../../../../../data/zwave_js";
 
 @customElement("dialog-zwave_js-reinterview-node")
 class DialogZWaveJSReinterviewNode extends LitElement {
@@ -152,13 +153,11 @@ class DialogZWaveJSReinterviewNode extends LitElement {
     if (!this.hass) {
       return;
     }
-    this._subscribed = this.hass.connection.subscribeMessage(
-      (message) => this._handleMessage(message),
-      {
-        type: "zwave_js/refresh_node_info",
-        entry_id: this.entry_id,
-        node_id: this.node_id,
-      }
+    this._subscribed = reinterviewNode(
+      this.hass,
+      this.entry_id!,
+      this.node_id!,
+      this._handleMessage.bind(this)
     );
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -1,0 +1,245 @@
+import "@material/mwc-button/mwc-button";
+import { mdiCheckCircle, mdiCloseCircle } from "@mdi/js";
+import {
+  CSSResult,
+  customElement,
+  html,
+  LitElement,
+  property,
+  internalProperty,
+  TemplateResult,
+  css,
+} from "lit-element";
+import "../../../../../components/ha-circular-progress";
+import { createCloseHeading } from "../../../../../components/ha-dialog";
+import { haStyleDialog } from "../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../types";
+import { ZWaveJSReinterviewNodeDialogParams } from "./show-dialog-zwave_js-reinterview-node";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import { reinterviewNode } from "../../../../../data/zwave_js";
+
+@customElement("dialog-zwave_js-reinterview-node")
+class DialogZWaveJSReinterviewNode extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @internalProperty() private entry_id?: string;
+
+  @internalProperty() private node_id?: number;
+
+  @internalProperty() private _status = "";
+
+  private _subscribed?: Promise<() => Promise<void>>;
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._unsubscribe();
+  }
+
+  public async showDialog(
+    params: ZWaveJSReinterviewNodeDialogParams
+  ): Promise<void> {
+    this.entry_id = params.entry_id;
+    this.node_id = params.node_id;
+  }
+
+  protected render(): TemplateResult {
+    if (!this.entry_id) {
+      return html``;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        @closed="${this.closeDialog}"
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass.localize("ui.panel.config.zwave_js.reinterview_node.title")
+        )}
+      >
+        ${this._status === ""
+          ? html`
+              <p>
+                ${this.hass.localize(
+                  "ui.panel.config.zwave_js.reinterview_node.introduction"
+                )}
+              </p>
+              <p>
+                <em>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.reinterview_node.battery_device_warning"
+                  )}
+                </em>
+              </p>
+              <mwc-button slot="primaryAction" @click=${this._startReinterview}>
+                ${this.hass.localize(
+                  "ui.panel.config.zwave_js.reinterview_node.start_reinterview"
+                )}
+              </mwc-button>
+            `
+          : ``}
+        ${this._status === "started"
+          ? html`
+              <div class="flex-container">
+                <ha-circular-progress active></ha-circular-progress>
+                <div class="status">
+                  <p>
+                    <b>
+                      ${this.hass.localize(
+                        "ui.panel.config.zwave_js.reinterview_node.in_progress"
+                      )}
+                    </b>
+                  </p>
+                  <p>
+                    ${this.hass.localize(
+                      "ui.panel.config.zwave_js.reinterview_node.in_progress_close_note"
+                    )}
+                  </p>
+                </div>
+              </div>
+              <mwc-button slot="primaryAction" @click=${this.closeDialog}>
+                ${this.hass.localize("ui.panel.config.zwave_js.common.close")}
+              </mwc-button>
+            `
+          : ``}
+        ${this._status === "failed"
+          ? html`
+              <div class="flex-container">
+                <ha-svg-icon
+                  .path=${mdiCheckCircle}
+                  class="success"
+                ></ha-svg-icon>
+                <div class="status">
+                  <p>
+                    ${this.hass.localize(
+                      "ui.panel.config.zwave_js.reinterview_node.interview_failed"
+                    )}
+                  </p>
+                </div>
+              </div>
+              <mwc-button slot="primaryAction" @click=${this.closeDialog}>
+                ${this.hass.localize("ui.panel.config.zwave_js.common.close")}
+              </mwc-button>
+            `
+          : ``}
+        ${this._status === "finished"
+          ? html`
+              <div class="flex-container">
+                <ha-svg-icon
+                  .path=${mdiCheckCircle}
+                  class="success"
+                ></ha-svg-icon>
+                <div class="status">
+                  <p>
+                    ${this.hass.localize(
+                      "ui.panel.config.zwave_js.reinterview_node.interview_complete"
+                    )}
+                  </p>
+                </div>
+              </div>
+              <mwc-button slot="primaryAction" @click=${this.closeDialog}>
+                ${this.hass.localize("ui.panel.config.zwave_js.common.close")}
+              </mwc-button>
+            `
+          : ``}
+      </ha-dialog>
+    `;
+  }
+
+  private _startReinterview(): void {
+    if (!this.hass) {
+      return;
+    }
+    this._subscribed = this.hass.connection.subscribeMessage(
+      (message) => this._handleMessage(message),
+      {
+        type: "zwave_js/refresh_node_info",
+        entry_id: this.entry_id,
+        node_id: this.node_id,
+      }
+    );
+  }
+
+  private _handleMessage(message: any): void {
+    if (message.event === "interview started") {
+      this._status = "started";
+    }
+    if (message.event === "interview failed") {
+      this._unsubscribe();
+      this._status = "failed";
+    }
+    if (message.event === "interview completed") {
+      this._unsubscribe();
+      this._status = "finished";
+    }
+  }
+
+  private _unsubscribe(): void {
+    if (this._subscribed) {
+      this._subscribed.then((unsub) => unsub());
+      this._subscribed = undefined;
+    }
+  }
+
+  public closeDialog(): void {
+    this.entry_id = undefined;
+    this.node_id = undefined;
+    this._status = "";
+
+    this._unsubscribe();
+
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  static get styles(): CSSResult[] {
+    return [
+      haStyleDialog,
+      css`
+        .secure_inclusion_field {
+          margin-top: 48px;
+        }
+
+        .success {
+          color: green;
+        }
+
+        .failed {
+          color: red;
+        }
+
+        blockquote {
+          display: block;
+          background-color: #ddd;
+          padding: 8px;
+          margin: 8px 0;
+          font-size: 0.9em;
+        }
+
+        blockquote em {
+          font-size: 0.9em;
+          margin-top: 6px;
+        }
+
+        .flex-container {
+          display: flex;
+          align-items: center;
+        }
+
+        ha-svg-icon {
+          width: 68px;
+          height: 48px;
+        }
+
+        .flex-container ha-circular-progress,
+        .flex-container ha-svg-icon {
+          margin-right: 20px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-zwave_js-reinterview-node": DialogZWaveJSReinterviewNode;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -29,8 +29,6 @@ class DialogZWaveJSReinterviewNode extends LitElement {
 
   @internalProperty() private _status?: string;
 
-  @internalProperty() private _stage?: string;
-
   @internalProperty() private _stages?: string[];
 
   private _subscribed?: Promise<UnsubscribeFunc>;
@@ -95,17 +93,6 @@ class DialogZWaveJSReinterviewNode extends LitElement {
                       "ui.panel.config.zwave_js.reinterview_node.run_in_background"
                     )}
                   </p>
-                  ${this._stage
-                    ? html`
-                        <p>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.reinterview_node.interview_stage",
-                            "stage",
-                            this._stage
-                          )}
-                        </p>
-                      `
-                    : ""}
                 </div>
               </div>
               <mwc-button slot="primaryAction" @click=${this.closeDialog}>
@@ -212,7 +199,6 @@ class DialogZWaveJSReinterviewNode extends LitElement {
       this._subscribed.then((unsub) => unsub());
       this._subscribed = undefined;
     }
-    this._stage = undefined;
   }
 
   public closeDialog(): void {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -205,29 +205,12 @@ class DialogZWaveJSReinterviewNode extends LitElement {
     return [
       haStyleDialog,
       css`
-        .secure_inclusion_field {
-          margin-top: 48px;
-        }
-
         .success {
-          color: green;
+          color: var(--success-color);
         }
 
         .failed {
-          color: red;
-        }
-
-        blockquote {
-          display: block;
-          background-color: #ddd;
-          padding: 8px;
-          margin: 8px 0;
-          font-size: 0.9em;
-        }
-
-        blockquote em {
-          font-size: 0.9em;
-          margin-top: 6px;
+          color: var(--warning-color);
         }
 
         .flex-container {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -31,6 +31,8 @@ class DialogZWaveJSReinterviewNode extends LitElement {
 
   @internalProperty() private _stage?: string;
 
+  @internalProperty() private _stages: string[] = [];
+
   private _subscribed?: Promise<UnsubscribeFunc>;
 
   public async showDialog(
@@ -150,6 +152,23 @@ class DialogZWaveJSReinterviewNode extends LitElement {
               </mwc-button>
             `
           : ``}
+        ${this._stages.length > 0
+          ? html`
+              <div class="stages">
+                ${this._stages.map(
+                  (stage) => html`
+                    <span class="stage">
+                      <ha-svg-icon
+                        .path=${mdiCheckCircle}
+                        class="success"
+                      ></ha-svg-icon>
+                      ${stage}
+                    </span>
+                  `
+                )}
+              </div>
+            `
+          : ""}
       </ha-dialog>
     `;
   }
@@ -171,7 +190,7 @@ class DialogZWaveJSReinterviewNode extends LitElement {
       this._status = "started";
     }
     if (message.event === "interview stage completed") {
-      this._stage = message.stage;
+      this._stages = [...this._stages, message.stage];
     }
     if (message.event === "interview failed") {
       this._unsubscribe();
@@ -195,6 +214,7 @@ class DialogZWaveJSReinterviewNode extends LitElement {
     this.entry_id = undefined;
     this.node_id = undefined;
     this._status = undefined;
+    this._stages = [];
 
     this._unsubscribe();
 
@@ -216,6 +236,18 @@ class DialogZWaveJSReinterviewNode extends LitElement {
         .flex-container {
           display: flex;
           align-items: center;
+        }
+
+        .stages {
+          margin-top: 16px;
+        }
+
+        .stage ha-svg-icon {
+          width: 16px;
+          height: 16px;
+        }
+        .stage {
+          padding: 8px;
         }
 
         ha-svg-icon {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -16,6 +16,7 @@ import { haStyleDialog } from "../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../types";
 import { ZWaveJSReinterviewNodeDialogParams } from "./show-dialog-zwave_js-reinterview-node";
 import { fireEvent } from "../../../../../common/dom/fire_event";
+import { UnsubscribeFunc } from "home-assistant-js-websocket";
 
 @customElement("dialog-zwave_js-reinterview-node")
 class DialogZWaveJSReinterviewNode extends LitElement {
@@ -25,11 +26,11 @@ class DialogZWaveJSReinterviewNode extends LitElement {
 
   @internalProperty() private node_id?: number;
 
-  @internalProperty() private _status = "";
+  @internalProperty() private _status?: string;
 
   @internalProperty() private _stage?: string;
 
-  private _subscribed?: Promise<() => Promise<void>>;
+  private _subscribed?: Promise<UnsubscribeFunc>;
 
   public disconnectedCallback(): void {
     super.disconnectedCallback();
@@ -51,13 +52,13 @@ class DialogZWaveJSReinterviewNode extends LitElement {
     return html`
       <ha-dialog
         open
-        @closed="${this.closeDialog}"
+        @closed=${this.closeDialog}
         .heading=${createCloseHeading(
           this.hass,
           this.hass.localize("ui.panel.config.zwave_js.reinterview_node.title")
         )}
       >
-        ${this._status === ""
+        ${!this._status
           ? html`
               <p>
                 ${this.hass.localize(

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-reinterview-node.ts
@@ -32,11 +32,6 @@ class DialogZWaveJSReinterviewNode extends LitElement {
 
   private _subscribed?: Promise<UnsubscribeFunc>;
 
-  public disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._unsubscribe();
-  }
-
   public async showDialog(
     params: ZWaveJSReinterviewNodeDialogParams
   ): Promise<void> {
@@ -195,7 +190,7 @@ class DialogZWaveJSReinterviewNode extends LitElement {
   public closeDialog(): void {
     this.entry_id = undefined;
     this.node_id = undefined;
-    this._status = "";
+    this._status = undefined;
 
     this._unsubscribe();
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-reinterview-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-reinterview-node.ts
@@ -1,0 +1,20 @@
+import { fireEvent } from "../../../../../common/dom/fire_event";
+
+export interface ZWaveJSReinterviewNodeDialogParams {
+  entry_id: string;
+  node_id: number;
+}
+
+export const loadReinterviewNodeDialog = () =>
+  import("./dialog-zwave_js-reinterview-node");
+
+export const showZWaveJSReinterviewNodeDialog = (
+  element: HTMLElement,
+  reinterviewNodeDialogParams: ZWaveJSReinterviewNodeDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-zwave_js-reinterview-node",
+    dialogImport: loadReinterviewNodeDialog,
+    dialogParams: reinterviewNodeDialogParams,
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2653,9 +2653,9 @@
             "battery_device_warning": "You will need to wake battery powered devices before starting the re-interview. Refer to your device's manual for instructions on how to wake the device.",
             "start_reinterview": "Start Re-interview",
             "in_progress": "The device is being interviewed. This may take some time.",
-            "in_progress_close_note": "You can close this dialog and the interview will complete in the background.",
             "interview_failed": "The device interview failed. Additional information may be available in the logs.",
-            "interview_complete": "Device interview complete."
+            "interview_complete": "Device interview complete.",
+            "interview_stage": "Interview stage: {stage}"
           }
         }
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2655,8 +2655,7 @@
             "start_reinterview": "Start Re-interview",
             "in_progress": "The device is being interviewed. This may take some time.",
             "interview_failed": "The device interview failed. Additional information may be available in the logs.",
-            "interview_complete": "Device interview complete.",
-            "interview_stage": "Interview stage: {stage}"
+            "interview_complete": "Device interview complete."
           }
         }
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2646,6 +2646,16 @@
             "follow_device_instructions": "Follow the directions that came with your device to trigger exclusion on the device.",
             "exclusion_failed": "The node could not be removed. Please check the logs for more information.",
             "exclusion_finished": "Node {id} has been removed from your Z-Wave network."
+          },
+          "reinterview_node": {
+            "title": "Re-interview a Z-Wave Device",
+            "introduction": "Re-interview a device on your Z-Wave network. Use this feature if your device has missing or incorrect functionality.",
+            "battery_device_warning": "You will need to wake battery powered devices before starting the re-interview. Refer to your device's manual for instructions on how to wake the device.",
+            "start_reinterview": "Start Re-interview",
+            "in_progress": "The device is being interviewed. This may take some time.",
+            "in_progress_close_note": "You can close this dialog and the interview will complete in the background.",
+            "interview_failed": "The device interview failed. Additional information may be available in the logs.",
+            "interview_complete": "Device interview complete."
           }
         }
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2651,6 +2651,7 @@
             "title": "Re-interview a Z-Wave Device",
             "introduction": "Re-interview a device on your Z-Wave network. Use this feature if your device has missing or incorrect functionality.",
             "battery_device_warning": "You will need to wake battery powered devices before starting the re-interview. Refer to your device's manual for instructions on how to wake the device.",
+            "run_in_background": "You can close this dialog and the interview will continue in the background.",
             "start_reinterview": "Start Re-interview",
             "in_progress": "The device is being interviewed. This may take some time.",
             "interview_failed": "The device interview failed. Additional information may be available in the logs.",


### PR DESCRIPTION
## Proposed change

Add a UI for re-interviewing a Z-Wave JS device.

Depends on https://github.com/home-assistant/core/pull/49024

![ReinterviewNode](https://user-images.githubusercontent.com/7545841/115480866-69edb400-a219-11eb-93f0-0258273b8b0e.gif)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
