### PR TITLE
Add opt-in toggle for zwave-js telemetry to config panel

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -56,6 +56,11 @@ export interface ZWaveJSSetConfigParamData {
   value: string | number;
 }
 
+export interface ZWaveJSDataCollectionStatus {
+  enabled: boolean;
+  opted_in: boolean;
+}
+
 export enum NodeStatus {
   Unknown,
   Asleep,
@@ -73,6 +78,26 @@ export const fetchNetworkStatus = (
   hass.callWS({
     type: "zwave_js/network_status",
     entry_id,
+  });
+
+export const fetchDataCollectionStatus = (
+  hass: HomeAssistant,
+  entry_id: string
+): Promise<ZWaveJSDataCollectionStatus> =>
+  hass.callWS({
+    type: "zwave_js/data_collection_status",
+    entry_id,
+  });
+
+export const setDataCollectionPreference = (
+  hass: HomeAssistant,
+  entry_id: string,
+  opted_in: boolean
+): Promise<any> =>
+  hass.callWS({
+    type: "zwave_js/update_data_collection_preference",
+    entry_id,
+    opted_in,
   });
 
 export const fetchNodeStatus = (

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -191,10 +191,11 @@ class ZWaveJSConfigDashboard extends LitElement {
                   <div class="card-content">
                     <p>
                       Enable the reporting of anonymized telemetry and
-                      statistics to the <em>Z-Wave JS organization</em>.
-                      Information about the data that is collected and how it is
-                      used, including an example of the data collected, can be
-                      found in the
+                      statistics to the <em>Z-Wave JS organization</em>. This
+                      data will be used to focus development efforts and improve
+                      the user experience. Information about the data that is
+                      collected and how it is used, including an example of the
+                      data collected, can be found in the
                       <a
                         target="_blank"
                         href="https://zwave-js.github.io/node-zwave-js/#/data-collection/data-collection?id=usage-statistics"

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -17,9 +17,11 @@ import "../../../../../components/ha-svg-icon";
 import "../../../../../components/ha-icon-next";
 import { getSignedPath } from "../../../../../data/auth";
 import {
+  fetchDataCollectionStatus,
   fetchNetworkStatus,
   fetchNodeStatus,
   NodeStatus,
+  setDataCollectionPreference,
   ZWaveJSNetwork,
   ZWaveJSNode,
 } from "../../../../../data/zwave_js";
@@ -54,6 +56,8 @@ class ZWaveJSConfigDashboard extends LitElement {
   @internalProperty() private _status = "unknown";
 
   @internalProperty() private _icon = mdiCircle;
+
+  @internalProperty() private _dataCollectionOptIn?: boolean;
 
   protected firstUpdated() {
     if (this.hass) {
@@ -167,6 +171,38 @@ class ZWaveJSConfigDashboard extends LitElement {
                     </mwc-button>
                   </div>
                 </ha-card>
+                <ha-card>
+                  <div class="card-header">
+                    <h1>Third-Party Data Reporting</h1>
+                    ${this._dataCollectionOptIn !== undefined
+                      ? html`
+                          <ha-switch
+                            .checked=${this._dataCollectionOptIn === true}
+                            @change=${this._dataCollectionToggled}
+                          ></ha-switch>
+                        `
+                      : html`
+                          <ha-circular-progress
+                            size="small"
+                            active
+                          ></ha-circular-progress>
+                        `}
+                  </div>
+                  <div class="card-content">
+                    <p>
+                      Enable the reporting of anonymized telemetry and
+                      statistics to the <em>Z-Wave JS organization</em>.
+                      Information about the data that is collected and how it is
+                      used, including an example of the data collected, can be
+                      found in the
+                      <a
+                        target="_blank"
+                        href="https://zwave-js.github.io/node-zwave-js/#/data-collection/data-collection?id=usage-statistics"
+                        >Z-Wave JS data collection documentation</a
+                      >.
+                    </p>
+                  </div>
+                </ha-card>
               `
             : ``}
           <button class="link dump" @click=${this._dumpDebugClicked}>
@@ -188,6 +224,14 @@ class ZWaveJSConfigDashboard extends LitElement {
     if (this._status === "connected") {
       this._icon = mdiCheckCircle;
     }
+    const dataCollectionStatus = await fetchDataCollectionStatus(
+      this.hass!,
+      this.configEntryId
+    );
+    this._dataCollectionOptIn =
+      dataCollectionStatus.opted_in === true ||
+      dataCollectionStatus.enabled === true;
+
     this._fetchNodeStatus();
   }
 
@@ -211,6 +255,14 @@ class ZWaveJSConfigDashboard extends LitElement {
     showZWaveJSRemoveNodeDialog(this, {
       entry_id: this.configEntryId!,
     });
+  }
+
+  private _dataCollectionToggled(ev) {
+    setDataCollectionPreference(
+      this.hass!,
+      this.configEntryId!,
+      ev.target.checked
+    );
   }
 
   private async _dumpDebugClicked() {
@@ -321,8 +373,19 @@ class ZWaveJSConfigDashboard extends LitElement {
           font-size: 1rem;
         }
 
+        .card-header {
+          display: flex;
+        }
+        .card-header h1 {
+          flex: 1;
+        }
+        .card-header ha-switch {
+          width: 48px;
+          margin-top: 16px;
+        }
+
         ha-card {
-          margin: 0 auto;
+          margin: 0px auto 24px;
           max-width: 600px;
         }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -219,15 +219,18 @@ class ZWaveJSConfigDashboard extends LitElement {
     if (!this.configEntryId) {
       return;
     }
-    this._network = await fetchNetworkStatus(this.hass!, this.configEntryId);
+    const [network, dataCollectionStatus] = await Promise.all([
+      fetchNetworkStatus(this.hass!, this.configEntryId),
+      fetchDataCollectionStatus(this.hass!, this.configEntryId),
+    ]);
+
+    this._network = network;
+
     this._status = this._network.client.state;
     if (this._status === "connected") {
       this._icon = mdiCheckCircle;
     }
-    const dataCollectionStatus = await fetchDataCollectionStatus(
-      this.hass!,
-      this.configEntryId
-    );
+
     this._dataCollectionOptIn =
       dataCollectionStatus.opted_in === true ||
       dataCollectionStatus.enabled === true;


### PR DESCRIPTION
## Proposed change

Add a card with toggle switch for opting into the Z-Wave JS data collection/telemetry. Open to suggestions on better wording for the card. There was some talk on Discord in #devs_zwave about not making it translatable, so I haven't done translations, but happy to change that if desired.

Backend PR has been merged.

![image](https://user-images.githubusercontent.com/7545841/115488231-28183a00-a228-11eb-8582-12994155d287.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
