### PR TITLE
Ensure 0 does not get formatted to empty string

### DIFF
--- a/src/common/string/format_number.ts
+++ b/src/common/string/format_number.ts
@@ -58,7 +58,7 @@ export const formatNumber = (
       ).format(Number(num));
     }
   }
-  return num ? num.toString() : "";
+  return num.toString();
 };
 
 /**

--- a/test-mocha/common/string/format_number.ts
+++ b/test-mocha/common/string/format_number.ts
@@ -15,13 +15,13 @@ describe("formatNumber", () => {
     );
   });
 
-  it("Test format 'none' (keep comma despite language 'en')", () => {
+  it("Test format 'none' (keep dot despite language 'de')", () => {
     assert.strictEqual(
-      formatNumber("1,23", {
-        language: "en",
+      formatNumber(1.23, {
+        language: "de",
         number_format: NumberFormat.none,
       }),
-      "1,23"
+      "1.23"
     );
   });
 

--- a/test-mocha/common/string/format_number.ts
+++ b/test-mocha/common/string/format_number.ts
@@ -15,6 +15,56 @@ describe("formatNumber", () => {
     );
   });
 
+  it("Test format 'none' (keep comma despite language 'en')", () => {
+    assert.strictEqual(
+      formatNumber("1,23", {
+        language: "en",
+        number_format: NumberFormat.none,
+      }),
+      "1,23"
+    );
+  });
+
+  it("Ensure zero is kept for format 'language'", () => {
+    assert.strictEqual(
+      formatNumber(0, {
+        language: "en",
+        number_format: NumberFormat.language,
+      }),
+      "0"
+    );
+  });
+
+  it("Ensure zero is kept for format 'none'", () => {
+    assert.strictEqual(
+      formatNumber(0, {
+        language: "en",
+        number_format: NumberFormat.none,
+      }),
+      "0"
+    );
+  });
+
+  it("Test empty string input for format 'none'", () => {
+    assert.strictEqual(
+      formatNumber("", {
+        language: "en",
+        number_format: NumberFormat.none,
+      }),
+      ""
+    );
+  });
+
+  it("Test empty string input for format 'language'", () => {
+    assert.strictEqual(
+      formatNumber("", {
+        language: "en",
+        number_format: NumberFormat.language,
+      }),
+      "0"
+    );
+  });
+
   it("Formats number with options", () => {
     assert.strictEqual(
       formatNumber(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Currently a zero gets formatted to an empty string for number format "none". That should not happen as none means input = output value during formatting.

`num` is already ensured to be `string` or `number` in the function so no need to check for falsy during the  `return` statement (I think?).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #8969
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
