### PR TITLE
Add translations for ZHA alarm control panel configuration

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2394,6 +2394,12 @@
               "title": "Global Options",
               "enable_identify_on_join": "Enable identify effect when devices join the network",
               "default_light_transition": "Default light transition time (seconds)"
+            },
+            "zha_alarm_options": {
+              "title": "Alarm Control Panel Options",
+              "alarm_master_code": "Master code for the alarm control panel(s)",
+              "alarm_failed_tries": "The number of consecutive failed code entries to trigger an alarm",
+              "alarm_arm_requires_code": "Code required for arming actions"
             }
           },
           "add_device_page": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR adds translations for ZHA alarm control panel configs. In the next release I may move the config translations to the back end to keep them all together so that only the backend PR will need to be opened instead of needing a backend and frontend PR each time the options are expanded. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
