### PR TITLE
Add "subscribed to log" message on Z-Wave JS log subscription

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -50,6 +50,11 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
         } else {
           this._textarea!.value += `${log.message}\n`;
         }
+      }).then((unsub) => {
+        this._textarea!.value += `${this.hass.localize(
+          "ui.panel.config.zwave_js.logs.subscribed_to_logs"
+        )}\n`;
+        return unsub;
       }),
     ];
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2648,7 +2648,8 @@
           },
           "logs": {
             "title": "Z-Wave JS Logs",
-            "log_level": "Log Level"
+            "log_level": "Log Level",
+            "subscribed_to_logs": "Subscribed to Z-Wave JS Log Messages..."
           }
         }
       },


### PR DESCRIPTION
## Proposed change

When opening the Z-Wave JS Log pane it wasn't clear that it automatically subscribed to logs, as it could be a while before the first log message is received. This prints a message at the top of the log textarea on subscription to let the user know.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
