### PR TITLE
Translate new setup time info header + add blank before unit

### DIFF
--- a/src/panels/config/info/integrations-card.ts
+++ b/src/panels/config/info/integrations-card.ts
@@ -65,7 +65,7 @@ class IntegrationsCard extends LitElement {
                     <th></th>
                     <th></th>`
                 : ""}
-              <th>Setup time</th>
+              <th>${this.hass.localize("ui.panel.config.info.setup_time")}</th>
             </tr>
           </thead>
           <tbody>
@@ -113,7 +113,7 @@ class IntegrationsCard extends LitElement {
                       ${this.narrow
                         ? html`<div class="mobile-row">
                             <div>${docLink} ${issueLink}</div>
-                            ${setupSeconds ? html`${setupSeconds}s` : ""}
+                            ${setupSeconds ? html`${setupSeconds} s` : ""}
                           </div>`
                         : ""}
                     </td>
@@ -123,7 +123,7 @@ class IntegrationsCard extends LitElement {
                           <td>${docLink}</td>
                           <td>${issueLink}</td>
                           <td class="setup">
-                            ${setupSeconds ? html`${setupSeconds}s` : ""}
+                            ${setupSeconds ? html`${setupSeconds} s` : ""}
                           </td>
                         `}
                   </tr>
@@ -169,6 +169,7 @@ class IntegrationsCard extends LitElement {
       }
       td.setup {
         text-align: right;
+        white-space: nowrap;
       }
       th {
         text-align: right;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1039,6 +1039,7 @@
           "integrations": "Integrations",
           "documentation": "Documentation",
           "issues": "Issues",
+          "setup_time": "Setup time",
           "system_health": {
             "manage": "Manage",
             "more_info": "more info"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

1. Made new column header translatable
2. Added a space before the unit to be consistent with rest of UI

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
