### PR TITLE
Show setting for auto connect seperately if currently connected

### DIFF
--- a/src/panels/config/cloud/account/cloud-remote-pref.ts
+++ b/src/panels/config/cloud/account/cloud-remote-pref.ts
@@ -24,7 +24,7 @@ import { showCloudCertificateDialog } from "../dialog-cloud-certificate/show-dia
 
 @customElement("cloud-remote-pref")
 export class CloudRemotePref extends LitElement {
-  @property({ attribute: false }) public hass?: HomeAssistant;
+  @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property() public cloudStatus?: CloudStatusLoggedIn;
 
@@ -32,6 +32,8 @@ export class CloudRemotePref extends LitElement {
     if (!this.cloudStatus) {
       return html``;
     }
+
+    const { remote_enabled } = this.cloudStatus.prefs;
 
     const {
       remote_connected,
@@ -42,12 +44,12 @@ export class CloudRemotePref extends LitElement {
     if (!remote_certificate) {
       return html`
         <ha-card
-          header=${this.hass!.localize(
+          header=${this.hass.localize(
             "ui.panel.config.cloud.account.remote.title"
           )}
         >
           <div class="preparing">
-            ${this.hass!.localize(
+            ${this.hass.localize(
               "ui.panel.config.cloud.account.remote.access_is_being_prepared"
             )}
           </div>
@@ -57,25 +59,26 @@ export class CloudRemotePref extends LitElement {
 
     return html`
       <ha-card
-        header=${this.hass!.localize(
+        header=${this.hass.localize(
           "ui.panel.config.cloud.account.remote.title"
         )}
       >
-        <div class="switch">
-          <ha-switch
-            .checked="${remote_connected}"
-            @change="${this._toggleChanged}"
-          ></ha-switch>
+        <div class="connection-status">
+          ${this.hass.localize(
+            `ui.panel.config.cloud.account.remote.${
+              remote_connected ? "connected" : "not_connected"
+            }`
+          )}
         </div>
         <div class="card-content">
-          ${this.hass!.localize("ui.panel.config.cloud.account.remote.info")}
-          ${remote_connected
-            ? this.hass!.localize(
-                "ui.panel.config.cloud.account.remote.instance_is_available"
-              )
-            : this.hass!.localize(
-                "ui.panel.config.cloud.account.remote.instance_will_be_available"
-              )}
+          ${this.hass.localize("ui.panel.config.cloud.account.remote.info")}
+          ${this.hass.localize(
+            `ui.panel.config.cloud.account.remote.${
+              remote_connected
+                ? "instance_is_available"
+                : "instance_will_be_available"
+            }`
+          )}
           <a
             href="https://${remote_domain}"
             target="_blank"
@@ -84,6 +87,25 @@ export class CloudRemotePref extends LitElement {
           >
             https://${remote_domain}</a
           >.
+
+          <div class="remote-enabled">
+            <h3>
+              ${this.hass.localize(
+                "ui.panel.config.cloud.account.remote.remote_enabled.caption"
+              )}
+            </h3>
+            <div class="remote-enabled-switch">
+              <ha-switch
+                .checked="${remote_enabled}"
+                @change="${this._toggleChanged}"
+              ></ha-switch>
+            </div>
+          </div>
+          <p>
+            ${this.hass.localize(
+              "ui.panel.config.cloud.account.remote.remote_enabled.description"
+            )}
+          </p>
         </div>
         <div class="card-actions">
           <a
@@ -92,7 +114,7 @@ export class CloudRemotePref extends LitElement {
             rel="noreferrer"
           >
             <mwc-button
-              >${this.hass!.localize(
+              >${this.hass.localize(
                 "ui.panel.config.cloud.account.remote.link_learn_how_it_works"
               )}</mwc-button
             >
@@ -101,7 +123,7 @@ export class CloudRemotePref extends LitElement {
             ? html`
                 <div class="spacer"></div>
                 <mwc-button @click=${this._openCertInfo}>
-                  ${this.hass!.localize(
+                  ${this.hass.localize(
                     "ui.panel.config.cloud.account.remote.certificate_info"
                   )}
                 </mwc-button>
@@ -123,9 +145,9 @@ export class CloudRemotePref extends LitElement {
 
     try {
       if (toggle.checked) {
-        await connectCloudRemote(this.hass!);
+        await connectCloudRemote(this.hass);
       } else {
-        await disconnectCloudRemote(this.hass!);
+        await disconnectCloudRemote(this.hass);
       }
       fireEvent(this, "ha-refresh-cloud-status");
     } catch (err) {
@@ -145,7 +167,7 @@ export class CloudRemotePref extends LitElement {
       .break-word {
         overflow-wrap: break-word;
       }
-      .switch {
+      .connection-status {
         position: absolute;
         right: 24px;
         top: 24px;
@@ -162,6 +184,25 @@ export class CloudRemotePref extends LitElement {
       }
       .spacer {
         flex-grow: 1;
+      }
+      .remote-enabled {
+        display: flex;
+        margin-top: 1.5em;
+      }
+      .remote-enabled + p {
+        margin-top: 0.5em;
+      }
+      h3 {
+        margin: 0 0 8px 0;
+      }
+      .remote-enabled h3 {
+        flex-grow: 1;
+        margin: 0;
+      }
+      .remote-enabled-switch {
+        margin-top: 0.25em;
+        margin-right: 7px;
+        margin-left: 0.5em;
       }
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1794,10 +1794,16 @@
             },
             "remote": {
               "title": "Remote Control",
-              "access_is_being_prepared": "Remote access is being prepared. We will notify you when it's ready.",
+              "connected": "Connected",
+              "not_connected": "Not Connected",
+              "access_is_being_prepared": "Remote control is being prepared. We will notify you when it's ready.",
               "info": "Home Assistant Cloud provides a secure remote connection to your instance while away from home.",
               "instance_is_available": "Your instance is available at",
               "instance_will_be_available": "Your instance will be available at",
+              "remote_enabled": {
+                "caption": "Automatically connect",
+                "description": "Enable this option to make sure that Home Assistant instance is always remotely accessible."
+              },
               "link_learn_how_it_works": "Learn how it works",
               "certificate_info": "Certificate Info"
             },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1802,7 +1802,7 @@
               "instance_will_be_available": "Your instance will be available at",
               "remote_enabled": {
                 "caption": "Automatically connect",
-                "description": "Enable this option to make sure that Home Assistant instance is always remotely accessible."
+                "description": "Enable this option to make sure that your Home Assistant instance is always remotely accessible."
               },
               "link_learn_how_it_works": "Learn how it works",
               "certificate_info": "Certificate Info"


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The cloud remote control card exists of 2 pieces of data: are we connected + should we automatically establish a connection.

This info was shown as a single switch. This meant that users that enabled remote connection via a service or the Nabu Casa portal didn't realize that they didn't have remote connect enabled.

This splits the connection status out of the toggle and shows it independently.

![Screenshot 2021-05-01 at 22 01 15](https://user-images.githubusercontent.com/1444314/116802598-cb8b0980-aac8-11eb-9caa-eb8d5b4598e3.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
