### PR TITLE
Config flow: Show next when not last step

### DIFF
--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -82,9 +82,13 @@ class StepFlowForm extends LitElement {
                 <mwc-button
                   @click=${this._submitStep}
                   .disabled=${!allRequiredInfoFilledIn}
-                  >${this.hass.localize(
-                    "ui.panel.config.integrations.config_flow.submit"
-                  )}
+                  >${this.step.last_step === false
+                    ? this.hass.localize(
+                        "ui.panel.config.integrations.config_flow.next"
+                      )
+                    : this.hass.localize(
+                        "ui.panel.config.integrations.config_flow.submit"
+                      )}
                 </mwc-button>
 
                 ${!allRequiredInfoFilledIn

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -82,13 +82,11 @@ class StepFlowForm extends LitElement {
                 <mwc-button
                   @click=${this._submitStep}
                   .disabled=${!allRequiredInfoFilledIn}
-                  >${this.step.last_step === false
-                    ? this.hass.localize(
-                        "ui.panel.config.integrations.config_flow.next"
-                      )
-                    : this.hass.localize(
-                        "ui.panel.config.integrations.config_flow.submit"
-                      )}
+                  >${this.hass.localize(
+                    `ui.panel.config.integrations.config_flow.${
+                      this.step.last_step === false ? "next" : "submit"
+                    }`
+                  )}
                 </mwc-button>
 
                 ${!allRequiredInfoFilledIn

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2191,6 +2191,7 @@
             "dismiss": "Dismiss dialog",
             "finish": "Finish",
             "submit": "Submit",
+            "next": "Next",
             "not_all_required_fields": "Not all required fields are filled in.",
             "error_saving_area": "Error saving area: {error}",
             "created_config": "Created configuration for {name}.",


### PR DESCRIPTION

## Proposed change

Show next in the button instead of submit, to make clear that there are more steps.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
