### PR TITLE
Prevent not needed `<hr>` in more-info-light

### DIFF
--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -126,7 +126,6 @@ class MoreInfoLight extends LitElement {
                       @change=${this._ctSliderChanged}
                       pin
                     ></ha-labeled-slider>
-                    <hr></hr>
                   `
                 : ""}
               ${supportsColor && (!supportsTemp || this._mode === "color")
@@ -147,72 +146,66 @@ class MoreInfoLight extends LitElement {
                         class="segmentationButton"
                       ></ha-icon-button>
                     </div>
-                    
-                    ${
-                      supportsRgbw || supportsRgbww
-                        ? html`<ha-labeled-slider
+
+                    ${supportsRgbw || supportsRgbww
+                      ? html`<ha-labeled-slider
+                          .caption=${this.hass.localize(
+                            "ui.card.light.color_brightness"
+                          )}
+                          icon="hass:brightness-7"
+                          max="100"
+                          .value=${this._colorBrightnessSliderValue ?? 100}
+                          @change=${this._colorBrightnessSliderChanged}
+                          pin
+                        ></ha-labeled-slider>`
+                      : ""}
+                    ${supportsRgbw
+                      ? html`
+                          <ha-labeled-slider
                             .caption=${this.hass.localize(
-                              "ui.card.light.color_brightness"
+                              "ui.card.light.white_value"
                             )}
-                            icon="hass:brightness-7"
+                            icon="hass:file-word-box"
                             max="100"
-                            .value=${this._colorBrightnessSliderValue ?? 100}
-                            @change=${this._colorBrightnessSliderChanged}
+                            .name=${"wv"}
+                            .value=${this._wvSliderValue}
+                            @change=${this._wvSliderChanged}
                             pin
-                          ></ha-labeled-slider>`
-                        : ""
-                    }
-                    ${
-                      supportsRgbw
-                        ? html`
-                            <ha-labeled-slider
-                              .caption=${this.hass.localize(
-                                "ui.card.light.white_value"
-                              )}
-                              icon="hass:file-word-box"
-                              max="100"
-                              .name=${"wv"}
-                              .value=${this._wvSliderValue}
-                              @change=${this._wvSliderChanged}
-                              pin
-                            ></ha-labeled-slider>
-                          `
-                        : ""
-                    }
-                    ${
-                      supportsRgbww
-                        ? html`
-                            <ha-labeled-slider
-                              .caption=${this.hass.localize(
-                                "ui.card.light.cold_white_value"
-                              )}
-                              icon="hass:file-word-box-outline"
-                              max="100"
-                              .name=${"cw"}
-                              .value=${this._cwSliderValue}
-                              @change=${this._wvSliderChanged}
-                              pin
-                            ></ha-labeled-slider>
-                            <ha-labeled-slider
-                              .caption=${this.hass.localize(
-                                "ui.card.light.warm_white_value"
-                              )}
-                              icon="hass:file-word-box"
-                              max="100"
-                              .name=${"ww"}
-                              .value=${this._wwSliderValue}
-                              @change=${this._wvSliderChanged}
-                              pin
-                            ></ha-labeled-slider>
-                          `
-                        : ""
-                    }
-                    <hr></hr>
+                          ></ha-labeled-slider>
+                        `
+                      : ""}
+                    ${supportsRgbww
+                      ? html`
+                          <ha-labeled-slider
+                            .caption=${this.hass.localize(
+                              "ui.card.light.cold_white_value"
+                            )}
+                            icon="hass:file-word-box-outline"
+                            max="100"
+                            .name=${"cw"}
+                            .value=${this._cwSliderValue}
+                            @change=${this._wvSliderChanged}
+                            pin
+                          ></ha-labeled-slider>
+                          <ha-labeled-slider
+                            .caption=${this.hass.localize(
+                              "ui.card.light.warm_white_value"
+                            )}
+                            icon="hass:file-word-box"
+                            max="100"
+                            .name=${"ww"}
+                            .value=${this._wwSliderValue}
+                            @change=${this._wvSliderChanged}
+                            pin
+                          ></ha-labeled-slider>
+                        `
+                      : ""}
                   `
                 : ""}
               ${supportsFeature(this.stateObj, SUPPORT_EFFECT) &&
               this.stateObj!.attributes.effect_list?.length
                 ? html`
+                    <hr></hr>
                     <ha-paper-dropdown-menu
                       .label=${this.hass.localize("ui.card.light.effect")}
                     >


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

If you have a light that supports brightness and color temperature, the more-info dialog added a `<hr>` below the color temperature slider, although there is no further UI section below it.
![image](https://user-images.githubusercontent.com/114137/116923469-f4d9a000-ac56-11eb-8192-fdd5aa949c78.png)


With this PR the `<hr>` only gets added if there is actually something below the color temperature such as an effect selection, by given the "authority" to add that `<hr>` to the effect rendering section (the color temperature | color selection area already had the "authority" to add its own `<hr>`).

Confirmed in gallery that everything looks good.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
