### PR TITLE
Draw a `<hr>` above the attributes in more-info

### DIFF
--- a/src/components/ha-attributes.ts
+++ b/src/components/ha-attributes.ts
@@ -27,13 +27,19 @@ class HaAttributes extends LitElement {
       return html``;
     }
 
+    const attributes = this.computeDisplayAttributes(
+      Object.keys(hassAttributeUtil.LOGIC_STATE_ATTRIBUTES).concat(
+        this.extraFilters ? this.extraFilters.split(",") : []
+      )
+    );
+    if (attributes.length === 0) {
+      return html``;
+    }
+
     return html`
+      <hr />
       <div>
-        ${this.computeDisplayAttributes(
-          Object.keys(hassAttributeUtil.LOGIC_STATE_ATTRIBUTES).concat(
-            this.extraFilters ? this.extraFilters.split(",") : []
-          )
-        ).map(
+        ${attributes.map(
           (attribute) => html`
             <div class="data-entry">
               <div class="key">${formatAttributeName(attribute)}</div>
@@ -79,6 +85,11 @@ class HaAttributes extends LitElement {
           margin: 0px;
           overflow-wrap: break-word;
           white-space: pre-line;
+        }
+        hr {
+          border-color: var(--divider-color);
+          border-bottom: none;
+          margin: 8px 0;
         }
       `,
     ];

--- a/src/components/ha-attributes.ts
+++ b/src/components/ha-attributes.ts
@@ -89,7 +89,7 @@ class HaAttributes extends LitElement {
         hr {
           border-color: var(--divider-color);
           border-bottom: none;
-          margin: 8px 0;
+          margin: 16px 0;
         }
       `,
     ];

--- a/src/dialogs/more-info/controls/more-info-automation.ts
+++ b/src/dialogs/more-info/controls/more-info-automation.ts
@@ -26,6 +26,7 @@ class MoreInfoAutomation extends LitElement {
     }
 
     return html`
+      <hr />
       <div class="flex">
         <div>${this.hass.localize("ui.card.automation.last_triggered")}:</div>
         <ha-relative-time
@@ -60,6 +61,11 @@ class MoreInfoAutomation extends LitElement {
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
+      }
+      hr {
+        border-color: var(--divider-color);
+        border-bottom: none;
+        margin: 8px 0;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-automation.ts
+++ b/src/dialogs/more-info/controls/more-info-automation.ts
@@ -65,7 +65,7 @@ class MoreInfoAutomation extends LitElement {
       hr {
         border-color: var(--divider-color);
         border-bottom: none;
-        margin: 8px 0;
+        margin: 16px 0;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -585,7 +585,7 @@ class MoreInfoLight extends LitElement {
       hr {
         border-color: var(--divider-color);
         border-bottom: none;
-        margin: 8px 0;
+        margin: 16px 0;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -102,7 +102,7 @@ class MoreInfoLight extends LitElement {
           : ""}
         ${this.stateObj.state === "on"
           ? html`
-              ${supportsTemp || supportsColor ? html`<hr></hr>` : ""}
+              ${supportsTemp || supportsColor ? html`<hr />` : ""}
               ${supportsTemp && supportsColor
                 ? html`<ha-button-toggle-group
                     fullWidth
@@ -205,7 +205,7 @@ class MoreInfoLight extends LitElement {
               ${supportsFeature(this.stateObj, SUPPORT_EFFECT) &&
               this.stateObj!.attributes.effect_list?.length
                 ? html`
-                    <hr></hr>
+                    <hr />
                     <ha-paper-dropdown-menu
                       .label=${this.hass.localize("ui.card.light.effect")}
                     >

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -560,7 +560,7 @@ class MoreInfoLight extends LitElement {
       }
 
       ha-button-toggle-group {
-        margin: 8px 0px;
+        margin-bottom: 8px;
       }
 
       ha-color-picker {

--- a/src/dialogs/more-info/controls/more-info-script.ts
+++ b/src/dialogs/more-info/controls/more-info-script.ts
@@ -23,6 +23,7 @@ class MoreInfoScript extends LitElement {
     }
 
     return html`
+      <hr />
       <div class="flex">
         <div>
           ${this.hass.localize(
@@ -46,6 +47,11 @@ class MoreInfoScript extends LitElement {
       .flex {
         display: flex;
         justify-content: space-between;
+      }
+      hr {
+        border-color: var(--divider-color);
+        border-bottom: none;
+        margin: 8px 0;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-script.ts
+++ b/src/dialogs/more-info/controls/more-info-script.ts
@@ -51,7 +51,7 @@ class MoreInfoScript extends LitElement {
       hr {
         border-color: var(--divider-color);
         border-bottom: none;
-        margin: 8px 0;
+        margin: 16px 0;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-sun.ts
+++ b/src/dialogs/more-info/controls/more-info-sun.ts
@@ -29,6 +29,7 @@ class MoreInfoSun extends LitElement {
     const order = risingDate > settingDate ? ["set", "ris"] : ["ris", "set"];
 
     return html`
+      <hr />
       ${order.map(
         (item) => html`
           <div class="row">
@@ -81,6 +82,11 @@ class MoreInfoSun extends LitElement {
       }
       ha-relative-time::first-letter {
         text-transform: lowercase;
+      }
+      hr {
+        border-color: var(--divider-color);
+        border-bottom: none;
+        margin: 8px 0;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-sun.ts
+++ b/src/dialogs/more-info/controls/more-info-sun.ts
@@ -86,7 +86,7 @@ class MoreInfoSun extends LitElement {
       hr {
         border-color: var(--divider-color);
         border-bottom: none;
-        margin: 8px 0;
+        margin: 16px 0;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-water_heater.js
+++ b/src/dialogs/more-info/controls/more-info-water_heater.js
@@ -50,7 +50,6 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
         .single-row {
           padding: 8px 0;
         }
-        }
       </style>
 
       <div class$="[[computeClassNames(stateObj)]]">


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Follow up to https://github.com/home-assistant/frontend/pull/9080#issuecomment-831896574.

`<ha-attributes>` now adds a `<hr>` if there are attributes to show. To have a consistent look,  I added the same line to those more-info dialogs that do not use `<ha-attributes>` but show a few fixed attributes, such as e.g. sun with the sun set, sun rise and elevation info.

![image](https://user-images.githubusercontent.com/114137/117028531-18a3f100-acfe-11eb-8706-a408c22a8679.png)

![image](https://user-images.githubusercontent.com/114137/117028537-1a6db480-acfe-11eb-916d-86d4190451a7.png)

![image](https://user-images.githubusercontent.com/114137/117028554-1e99d200-acfe-11eb-955a-fd332f3e44da.png)

![image](https://user-images.githubusercontent.com/114137/117028757-4be68000-acfe-11eb-8e41-b49470e507b7.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
