### PR TITLE
Add manual limit selection to graph header/footer

### DIFF
--- a/src/panels/lovelace/cards/hui-sensor-card.ts
+++ b/src/panels/lovelace/cards/hui-sensor-card.ts
@@ -55,6 +55,7 @@ class HuiSensorCard extends HuiEntityCard {
         entity: config.entity,
         detail: detail || 1,
         hours_to_show: hours_to_show || 24,
+        limits: config.limits!,
       };
 
       entityCardConfig.footer = footerConfig;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -286,6 +286,10 @@ export interface SensorCardConfig extends LovelaceCardConfig {
   detail?: number;
   theme?: string;
   hours_to_show?: number;
+  limits?: {
+    min: number;
+    max: number;
+  };
 }
 
 export interface ShoppingListCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -287,8 +287,8 @@ export interface SensorCardConfig extends LovelaceCardConfig {
   theme?: string;
   hours_to_show?: number;
   limits?: {
-    min: number;
-    max: number;
+    min?: number;
+    max?: number;
   };
 }
 

--- a/src/panels/lovelace/common/graph/coordinates.ts
+++ b/src/panels/lovelace/common/graph/coordinates.ts
@@ -58,7 +58,7 @@ export const coordinates = (
   hours: number,
   width: number,
   detail: number,
-  limits?: { min: number; max: number }
+  limits?: { min?: number; max?: number }
 ): number[][] | undefined => {
   history.forEach((item) => {
     item.state = Number(item.state);

--- a/src/panels/lovelace/common/graph/coordinates.ts
+++ b/src/panels/lovelace/common/graph/coordinates.ts
@@ -57,15 +57,20 @@ export const coordinates = (
   history: any,
   hours: number,
   width: number,
-  detail: number
+  detail: number,
+  limits?: { min: number; max: number }
 ): number[][] | undefined => {
   history.forEach((item) => {
     item.state = Number(item.state);
   });
   history = history.filter((item) => !Number.isNaN(item.state));
 
-  const min = Math.min(...history.map((item) => item.state));
-  const max = Math.max(...history.map((item) => item.state));
+  const min = limits
+    ? limits.min
+    : Math.min(...history.map((item) => item.state));
+  const max = limits
+    ? limits.max
+    : Math.max(...history.map((item) => item.state));
   const now = new Date().getTime();
 
   const reduce = (res, item, point) => {

--- a/src/panels/lovelace/common/graph/coordinates.ts
+++ b/src/panels/lovelace/common/graph/coordinates.ts
@@ -65,10 +65,10 @@ export const coordinates = (
   });
   history = history.filter((item) => !Number.isNaN(item.state));
 
-  const min = limits
+  const min = limits?.min !== undefined
     ? limits.min
     : Math.min(...history.map((item) => item.state));
-  const max = limits
+  const max = limits?.max !== undefined
     ? limits.max
     : Math.max(...history.map((item) => item.state));
   const now = new Date().getTime();

--- a/src/panels/lovelace/common/graph/coordinates.ts
+++ b/src/panels/lovelace/common/graph/coordinates.ts
@@ -65,12 +65,14 @@ export const coordinates = (
   });
   history = history.filter((item) => !Number.isNaN(item.state));
 
-  const min = limits?.min !== undefined
-    ? limits.min
-    : Math.min(...history.map((item) => item.state));
-  const max = limits?.max !== undefined
-    ? limits.max
-    : Math.max(...history.map((item) => item.state));
+  const min =
+    limits?.min !== undefined
+      ? limits.min
+      : Math.min(...history.map((item) => item.state));
+  const max =
+    limits?.max !== undefined
+      ? limits.max
+      : Math.max(...history.map((item) => item.state));
   const now = new Date().getTime();
 
   const reduce = (res, item, point) => {

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -11,6 +11,7 @@ import {
   TemplateResult,
 } from "lit-element";
 import "../../../components/ha-circular-progress";
+import { showMediaBrowserDialog } from "../../../components/media-player/show-media-browser-dialog";
 import { fetchRecent } from "../../../data/history";
 import { HomeAssistant } from "../../../types";
 import { findEntities } from "../common/find-entities";
@@ -24,8 +25,7 @@ const MINUTE = 60000;
 const HOUR = MINUTE * 60;
 
 @customElement("hui-graph-header-footer")
-export class HuiGraphHeaderFooter
-  extends LitElement
+export class HuiGraphHeaderFooter extends LitElement
   implements LovelaceHeaderFooter {
   public static async getConfigElement(): Promise<LovelaceHeaderFooterEditor> {
     await import("../editor/config-elements/hui-graph-footer-editor");
@@ -190,12 +190,21 @@ export class HuiGraphHeaderFooter
       this._stateHistory!.push(...stateHistory[0]);
     }
 
+    const limits =
+      this._config!.limits === undefined &&
+      this._stateHistory?.some(
+        (entity) => entity.attributes?.unit_of_measurement === "%"
+      )
+        ? { min: 0, max: 100 }
+        : this._config!.limits;
+
     this._coordinates =
       coordinates(
         this._stateHistory,
         this._config!.hours_to_show!,
         500,
-        this._config!.detail!
+        this._config!.detail!,
+        limits
       ) || [];
 
     this._date = endTime;

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -11,7 +11,6 @@ import {
   TemplateResult,
 } from "lit-element";
 import "../../../components/ha-circular-progress";
-import { showMediaBrowserDialog } from "../../../components/media-player/show-media-browser-dialog";
 import { fetchRecent } from "../../../data/history";
 import { HomeAssistant } from "../../../types";
 import { findEntities } from "../common/find-entities";

--- a/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
+++ b/src/panels/lovelace/header-footer/hui-graph-header-footer.ts
@@ -24,7 +24,8 @@ const MINUTE = 60000;
 const HOUR = MINUTE * 60;
 
 @customElement("hui-graph-header-footer")
-export class HuiGraphHeaderFooter extends LitElement
+export class HuiGraphHeaderFooter
+  extends LitElement
   implements LovelaceHeaderFooter {
   public static async getConfigElement(): Promise<LovelaceHeaderFooterEditor> {
     await import("../editor/config-elements/hui-graph-footer-editor");

--- a/src/panels/lovelace/header-footer/types.ts
+++ b/src/panels/lovelace/header-footer/types.ts
@@ -15,6 +15,10 @@ export interface GraphHeaderFooterConfig extends LovelaceHeaderFooterConfig {
   entity: string;
   detail?: number;
   hours_to_show?: number;
+  limits?: {
+    min: number;
+    max: number;
+  };
 }
 
 export interface PictureHeaderFooterConfig extends LovelaceHeaderFooterConfig {

--- a/src/panels/lovelace/header-footer/types.ts
+++ b/src/panels/lovelace/header-footer/types.ts
@@ -16,8 +16,8 @@ export interface GraphHeaderFooterConfig extends LovelaceHeaderFooterConfig {
   detail?: number;
   hours_to_show?: number;
   limits?: {
-    min: number;
-    max: number;
+    min?: number;
+    max?: number;
   };
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add a manual y-limit selection to graph header/footer and sensor cards.

```yaml
type: sensor
entity: sensor.temperature2
graph: line
detail: 2
hours_to_show: 1
limits:
  min: 0
  max: 30
name: 'Manual limits [0,30]'
```

Default limits still automatically fit the data unless any `unit_of_measurement` is `%`. Then the default are 0-100.

No GUI editor.

![image](https://user-images.githubusercontent.com/1299821/117413793-aeb26400-af16-11eb-8a1b-b459ede84709.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
Edit 2021-07-18:

A bit of background and discussion can be found on discord, starting here and continuing a few dozen messages: https://discord.com/channels/330944238910963714/351047592588869643/837837258743873577

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
