### PR TITLE
Fix Z-Wave JS add node wizard and add interview status

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -164,9 +164,7 @@ class DialogZWaveJSAddNode extends LitElement {
                 </div>
               </div>
               <mwc-button slot="primaryAction" @click=${this.closeDialog}>
-                ${this.hass.localize(
-                  "ui.panel.config.zwave_js.add_node.cancel_inclusion"
-                )}
+                ${this.hass.localize("ui.panel.config.zwave_js.common.close")}
               </mwc-button>
             `
           : ``}

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -291,6 +291,7 @@ class DialogZWaveJSAddNode extends LitElement {
         if (!this._nodeAdded) {
           this._status = "";
           this._unsubscribe();
+          this._stoppedTimeout = undefined;
         }
       }, 3000);
     }
@@ -344,6 +345,11 @@ class DialogZWaveJSAddNode extends LitElement {
     this._status = "";
     this._nodeAdded = false;
     this._device = undefined;
+    this._stages = undefined;
+    if (this._stoppedTimeout) {
+      clearTimeout(this._stoppedTimeout);
+      this._stoppedTimeout = undefined;
+    }
     this._use_secure_inclusion = false;
 
     fireEvent(this, "dialog-closed", { dialog: this.localName });

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-add-node.ts
@@ -34,7 +34,13 @@ class DialogZWaveJSAddNode extends LitElement {
 
   @state() private _status = "";
 
+  @state() private _nodeAdded = false;
+
   @state() private _device?: ZWaveJSAddNodeDevice;
+
+  @state() private _stages?: string[];
+
+  private _stoppedTimeout?: any;
 
   private _addNodeTimeoutHandle?: number;
 
@@ -128,6 +134,42 @@ class DialogZWaveJSAddNode extends LitElement {
               </mwc-button>
             `
           : ``}
+        ${this._status === "interviewing"
+          ? html`
+              <div class="flex-container">
+                <ha-circular-progress active></ha-circular-progress>
+                <div class="status">
+                  <p>
+                    <b
+                      >${this.hass.localize(
+                        "ui.panel.config.zwave_js.add_node.interview_started"
+                      )}</b
+                    >
+                  </p>
+                  ${this._stages
+                    ? html` <div class="stages">
+                        ${this._stages.map(
+                          (stage) => html`
+                            <span class="stage">
+                              <ha-svg-icon
+                                .path=${mdiCheckCircle}
+                                class="success"
+                              ></ha-svg-icon>
+                              ${stage}
+                            </span>
+                          `
+                        )}
+                      </div>`
+                    : ""}
+                </div>
+              </div>
+              <mwc-button slot="primaryAction" @click=${this.closeDialog}>
+                ${this.hass.localize(
+                  "ui.panel.config.zwave_js.add_node.cancel_inclusion"
+                )}
+              </mwc-button>
+            `
+          : ``}
         ${this._status === "failed"
           ? html`
               <div class="flex-container">
@@ -141,6 +183,21 @@ class DialogZWaveJSAddNode extends LitElement {
                       "ui.panel.config.zwave_js.add_node.inclusion_failed"
                     )}
                   </p>
+                  ${this._stages
+                    ? html` <div class="stages">
+                        ${this._stages.map(
+                          (stage) => html`
+                            <span class="stage">
+                              <ha-svg-icon
+                                .path=${mdiCheckCircle}
+                                class="success"
+                              ></ha-svg-icon>
+                              ${stage}
+                            </span>
+                          `
+                        )}
+                      </div>`
+                    : ""}
                 </div>
               </div>
               <mwc-button slot="primaryAction" @click=${this.closeDialog}>
@@ -168,6 +225,21 @@ class DialogZWaveJSAddNode extends LitElement {
                       )}
                     </mwc-button>
                   </a>
+                  ${this._stages
+                    ? html` <div class="stages">
+                        ${this._stages.map(
+                          (stage) => html`
+                            <span class="stage">
+                              <ha-svg-icon
+                                .path=${mdiCheckCircle}
+                                class="success"
+                              ></ha-svg-icon>
+                              ${stage}
+                            </span>
+                          `
+                        )}
+                      </div>`
+                    : ""}
                 </div>
               </div>
               <mwc-button slot="primaryAction" @click=${this.closeDialog}>
@@ -211,15 +283,39 @@ class DialogZWaveJSAddNode extends LitElement {
       this._status = "failed";
     }
     if (message.event === "inclusion stopped") {
-      if (this._status !== "finished") {
-        this._status = "";
-      }
-      this._unsubscribe();
+      // we get the inclusion stopped event before the node added event
+      // during a successful inclusion. so we set a timer to wait 3 seconds
+      // to give the node added event time to come in before assuming it
+      // timed out or was cancelled and unsubscribing.
+      this._stoppedTimeout = setTimeout(() => {
+        if (!this._nodeAdded) {
+          this._status = "";
+          this._unsubscribe();
+        }
+      }, 3000);
     }
     if (message.event === "device registered") {
       this._device = message.device;
+    }
+    if (message.event === "node added") {
+      this._nodeAdded = true;
+      if (this._stoppedTimeout) {
+        clearTimeout(this._stoppedTimeout);
+      }
+      this._status = "interviewing";
+    }
+
+    if (message.event === "interview completed") {
       this._status = "finished";
       this._unsubscribe();
+    }
+
+    if (message.event === "interview stage completed") {
+      if (this._stages === undefined) {
+        this._stages = [message.stage];
+      } else {
+        this._stages = [...this._stages, message.stage];
+      }
     }
   }
 
@@ -246,6 +342,7 @@ class DialogZWaveJSAddNode extends LitElement {
     this._unsubscribe();
     this.entry_id = undefined;
     this._status = "";
+    this._nodeAdded = false;
     this._device = undefined;
     this._use_secure_inclusion = false;
 
@@ -261,11 +358,24 @@ class DialogZWaveJSAddNode extends LitElement {
         }
 
         .success {
-          color: green;
+          color: var(--success-color);
         }
 
         .failed {
-          color: red;
+          color: var(--warning-color);
+        }
+
+        .stages {
+          margin-top: 16px;
+        }
+
+        .flex-container .stage ha-svg-icon {
+          width: 16px;
+          height: 16px;
+          margin-right: 0px;
+        }
+        .stage {
+          padding: 8px;
         }
 
         blockquote {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2631,8 +2631,10 @@
             "controller_in_inclusion_mode": "Your Z-Wave controller is now in inclusion mode.",
             "follow_device_instructions": "Follow the directions that came with your device to trigger pairing on the device.",
             "inclusion_failed": "The node could not be added. Please check the logs for more information.",
-            "inclusion_finished": "The node has been added. It may take a few minutes for all entities to show up as we finish setting up the node in the background.",
-            "view_device": "View Device"
+            "inclusion_finished": "The node has been added.",
+            "view_device": "View Device",
+            "interview_started": "The device is being interviewed. This may take some time.",
+            "interview_failed": "The device interview failed. Additional information may be available in the logs."
           },
           "remove_node": {
             "title": "Remove a Z-Wave Node",


### PR DESCRIPTION
# Proposed change

Fixes the Z-Wave JS add node wizard and adds interview status.

Recent changes in Z-Wave JS cause us to receive the "interview stopped" event before we receive the "device registered" event, so the success message would never display.

This reworks the logic a bit and adds support for showing completed interview steps, similar to the Re-interview node dialog.

Requires https://github.com/home-assistant/core/pull/50384


https://user-images.githubusercontent.com/7545841/117598312-8e042d00-b115-11eb-93af-c0da796ffca8.mp4



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
