### PR TITLE
Switch update and openChangelog button

### DIFF
--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -177,7 +177,7 @@ class HassioAddonInfo extends LitElement {
                         ${this.supervisor.localize("addon.dashboard.changelog")}
                       </mwc-button>
                     `
-                  : ""}
+                  : html`<span></span>`}
                 <mwc-button @click=${this._updateClicked}>
                   ${this.supervisor.localize("common.update")}
                 </mwc-button>

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -171,9 +171,6 @@ class HassioAddonInfo extends LitElement {
                   : ""}
               </div>
               <div class="card-actions">
-                <mwc-button @click=${this._updateClicked}>
-                  ${this.supervisor.localize("common.update")}
-                </mwc-button>
                 ${this.addon.changelog
                   ? html`
                       <mwc-button @click=${this._openChangelog}>
@@ -181,6 +178,9 @@ class HassioAddonInfo extends LitElement {
                       </mwc-button>
                     `
                   : ""}
+                <mwc-button @click=${this._updateClicked}>
+                  ${this.supervisor.localize("common.update")}
+                </mwc-button>
               </div>
             </ha-card>
           `


### PR DESCRIPTION
## Proposed change

In hassio addon info page, update and open change log button are inverted from other place in HA.

Update button are always on the right except for addons

Update core 

![image](https://user-images.githubusercontent.com/6990995/117972706-bcf3ec00-b32b-11eb-92fc-56025e0e9211.png)

Addons

![image](https://user-images.githubusercontent.com/6990995/117972810-df860500-b32b-11eb-8374-001aafb852a7.png)

The change switch place of buttons to be aligned of what is done elsewhere

## Type of change


- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
