### PR TITLE
Make slider default for number selector

### DIFF
--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -29,12 +29,12 @@ export class HaNumberSelector extends LitElement {
 
   protected render() {
     return html`${this.label}
-      ${this.selector.number.mode === "slider"
+      ${this.selector.number.mode !== "box"
         ? html`<ha-slider
             .min=${this.selector.number.min}
             .max=${this.selector.number.max}
             .value=${this._value}
-            .step=${this.selector.number.step}
+            .step=${this.selector.number.step ?? 1}
             .disabled=${this.disabled}
             pin
             ignore-bar-touch
@@ -44,16 +44,14 @@ export class HaNumberSelector extends LitElement {
         : ""}
       <paper-input
         pattern="[0-9]+([\\.][0-9]+)?"
-        .label=${this.selector.number.mode === "slider"
-          ? undefined
-          : this.label}
+        .label=${this.selector.number.mode !== "box" ? undefined : this.label}
         .placeholder=${this.placeholder}
-        .noLabelFloat=${this.selector.number.mode === "slider"}
+        .noLabelFloat=${this.selector.number.mode !== "box"}
         class=${classMap({ single: this.selector.number.mode === "box" })}
         .min=${this.selector.number.min}
         .max=${this.selector.number.max}
         .value=${this.value}
-        .step=${this.selector.number.step}
+        .step=${this.selector.number.step ?? 1}
         .disabled=${this.disabled}
         type="number"
         auto-validate

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -72,8 +72,8 @@ export interface NumberSelector {
   number: {
     min: number;
     max: number;
-    step: number;
-    mode: "box" | "slider";
+    step?: number;
+    mode?: "box" | "slider";
     unit_of_measurement?: string;
   };
 }


### PR DESCRIPTION

## Proposed change

Make slider default for number selector according to the schema:
<https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/selector.py#L106>

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
