### PR TITLE
Add log level changed message when user changes Z-Wave JS log level

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -118,14 +118,15 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
     if (ev.target === undefined || this._logConfig === undefined) {
       return;
     }
-    if (this._logConfig.level === ev.target.selected) {
+    const selected = ev.target.selected;
+    if (this._logConfig.level === selected) {
       return;
     }
-    setZWaveJSLogLevel(this.hass!, this.configEntryId, ev.target.selected);
+    setZWaveJSLogLevel(this.hass!, this.configEntryId, selected);
     this._textarea!.value += `${this.hass.localize(
       "ui.panel.config.zwave_js.logs.log_level_changed",
       "level",
-      ev.target.selected
+      selected.charAt(0).toUpperCase() + selected.slice(1)
     )}\n`;
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -126,8 +126,8 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
     this._logConfig.level = selected;
     this._textarea!.value += `${this.hass.localize(
       "ui.panel.config.zwave_js.logs.log_level_changed",
-      "level",
-      selected.charAt(0).toUpperCase() + selected.slice(1)
+      {level:
+      selected.charAt(0).toUpperCase() + selected.slice(1)}
     )}\n`;
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -122,6 +122,11 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
       return;
     }
     setZWaveJSLogLevel(this.hass!, this.configEntryId, ev.target.selected);
+    this._textarea!.value += `${this.hass.localize(
+      "ui.panel.config.zwave_js.logs.log_level_changed",
+      "level",
+      ev.target.selected
+    )}\n`;
   }
 
   static get styles(): CSSResultArray {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -123,6 +123,7 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
       return;
     }
     setZWaveJSLogLevel(this.hass!, this.configEntryId, selected);
+    this._logConfig.level = selected;
     this._textarea!.value += `${this.hass.localize(
       "ui.panel.config.zwave_js.logs.log_level_changed",
       "level",

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -126,8 +126,7 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
     this._logConfig.level = selected;
     this._textarea!.value += `${this.hass.localize(
       "ui.panel.config.zwave_js.logs.log_level_changed",
-      {level:
-      selected.charAt(0).toUpperCase() + selected.slice(1)}
+      { level: selected.charAt(0).toUpperCase() + selected.slice(1) }
     )}\n`;
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2662,7 +2662,7 @@
             "title": "Z-Wave JS Logs",
             "log_level": "Log Level",
             "subscribed_to_logs": "Subscribed to Z-Wave JS Log Messages...",
-            "log_level_changed": "Log level changed to: {level}"
+            "log_level_changed": "Log Level changed to: {level}"
           }
         }
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2661,7 +2661,8 @@
           "logs": {
             "title": "Z-Wave JS Logs",
             "log_level": "Log Level",
-            "subscribed_to_logs": "Subscribed to Z-Wave JS Log Messages..."
+            "subscribed_to_logs": "Subscribed to Z-Wave JS Log Messages...",
+            "log_level_changed": "Log level changed to {level} (this change will not persist between zwave-js-server restarts)"
           }
         }
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2662,7 +2662,7 @@
             "title": "Z-Wave JS Logs",
             "log_level": "Log Level",
             "subscribed_to_logs": "Subscribed to Z-Wave JS Log Messages...",
-            "log_level_changed": "Log level changed to {level} (this change will not persist between zwave-js-server restarts)"
+            "log_level_changed": "Log level changed to: {level}"
           }
         }
       },


### PR DESCRIPTION
## Proposed change
This is similar to https://github.com/home-assistant/frontend/pull/9062 in that when the user changes the log level on the logging UI page, there's no feedback to confirm that the log level actually changed. When you go from a more noisy to a less noisy log level in particular, it almost seems like something was broken.

I fixed a a bug that this exposed where you can't go back to the original log level that was set when you first loaded this page without a hard refresh. This is because we never updated the stored logConfig so setting it back to the original would
return early.

CC @cgarwood 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/9062
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
