### PR TITLE
Fix resetting theme, only fallback to light when theme doesnt support…

### DIFF
--- a/src/common/dom/apply_themes_on_element.ts
+++ b/src/common/dom/apply_themes_on_element.ts
@@ -39,7 +39,7 @@ export const applyThemesOnElement = (
   if (themeSettings) {
     if (themeSettings.dark) {
       cacheKey = `${cacheKey}__dark`;
-      themeRules = darkStyles;
+      themeRules = { ...darkStyles };
     }
 
     if (selectedTheme === "default") {

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -67,14 +67,15 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       if (!this.hass) {
         return;
       }
-      const themeName =
-        this.hass.selectedThemeSettings?.theme ||
-        (darkPreferred && this.hass.themes.default_dark_theme
-          ? this.hass.themes.default_dark_theme!
-          : this.hass.themes.default_theme);
 
       let themeSettings: Partial<HomeAssistant["selectedThemeSettings"]> = this
         .hass!.selectedThemeSettings;
+
+      const themeName =
+        themeSettings?.theme ||
+        (darkPreferred && this.hass.themes.default_dark_theme
+          ? this.hass.themes.default_dark_theme!
+          : this.hass.themes.default_theme);
 
       let darkMode =
         themeSettings?.dark === undefined ? darkPreferred : themeSettings?.dark;
@@ -84,18 +85,8 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
           ? this.hass.themes.themes[themeSettings.theme]
           : undefined;
 
-      if (selectedTheme) {
-        // Override dark mode selection depending on what the theme actually provides.
-        // Leave the selection as-is if the theme supports the requested mode.
-        if (darkMode && !selectedTheme.modes?.dark) {
-          darkMode = false;
-        } else if (
-          !darkMode &&
-          !selectedTheme.modes?.light &&
-          selectedTheme.modes?.dark
-        ) {
-          darkMode = true;
-        }
+      if (selectedTheme && darkMode && !selectedTheme.modes) {
+        darkMode = false;
       }
 
       themeSettings = { ...this.hass.selectedThemeSettings, dark: darkMode };


### PR DESCRIPTION
… modes

## Proposed change

Fixes resetting the theme (we edited the `darkStyles` object 🙈 )

Removes fallback to dark theme when theme doesn't have the `light` mode.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
