### PR TITLE
Update zwave_js log subscription to handle core changes

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -193,6 +193,18 @@ export const getIdentifiersFromDevice = (
   };
 };
 
+export type ZWaveJSLogUpdate = ZWaveJSLogMessageUpdate | ZWaveJSLogConfigUpdate;
+
+interface ZWaveJSLogMessageUpdate {
+  type: "log_message";
+  log_message: ZWaveJSLogMessage;
+}
+
+interface ZWaveJSLogConfigUpdate {
+  type: "log_config";
+  log_config: ZWaveJSLogConfig;
+}
+
 export interface ZWaveJSLogMessage {
   timestamp: string;
   level: string;
@@ -203,10 +215,10 @@ export interface ZWaveJSLogMessage {
 export const subscribeZWaveJSLogs = (
   hass: HomeAssistant,
   entry_id: string,
-  callback: (message: ZWaveJSLogMessage) => void
+  callback: (update: ZWaveJSLogUpdate) => void
 ) =>
-  hass.connection.subscribeMessage<ZWaveJSLogMessage>(callback, {
-    type: "zwave_js/subscribe_logs",
+  hass.connection.subscribeMessage<ZWaveJSLogUpdate>(callback, {
+    type: "zwave_js/subscribe_log_updates",
     entry_id,
   });
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -31,16 +31,20 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
 
   public hassSubscribe(): Array<UnsubscribeFunc | Promise<UnsubscribeFunc>> {
     return [
-      subscribeZWaveJSLogs(this.hass, this.configEntryId, (log) => {
+      subscribeZWaveJSLogs(this.hass, this.configEntryId, (update) => {
         if (!this.hasUpdated) {
           return;
         }
-        if (Array.isArray(log.message)) {
-          for (const line of log.message) {
-            this._textarea!.value += `${line}\n`;
+        if (update.type === "log_message") {
+          if (Array.isArray(update.log_message.message)) {
+            for (const line of update.log_message.message) {
+              this._textarea!.value += `${line}\n`;
+            }
+          } else {
+            this._textarea!.value += `${update.log_message.message}\n`;
           }
         } else {
-          this._textarea!.value += `${log.message}\n`;
+          this._logConfig = update.log_config;
         }
       }).then((unsub) => {
         this._textarea!.value += `${this.hass.localize(
@@ -123,7 +127,6 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
       return;
     }
     setZWaveJSLogLevel(this.hass!, this.configEntryId, selected);
-    this._logConfig.level = selected;
     this._textarea!.value += `${this.hass.localize(
       "ui.panel.config.zwave_js.logs.log_level_changed",
       { level: selected.charAt(0).toUpperCase() + selected.slice(1) }


### PR DESCRIPTION
## Proposed change
Follow up to https://github.com/home-assistant/frontend/pull/9238 . One of the questions that came up for me is how do we keep the log config state maintained in the frontend up to date. In this core PR https://github.com/home-assistant/core/pull/51096 we have adjusted the subscription WS command to include updates to the log config. As part of that, I changed the endpoint name and the signature of the payload that is returned. This PR handles those changes and should be merged in concert with the other ticket

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
