### PR TITLE
Show pressure units in weather details card

### DIFF
--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -108,7 +108,7 @@ class MoreInfoWeather extends LitElement {
                   this.stateObj.attributes.pressure,
                   this.hass.locale
                 )}
-                ${getWeatherUnit(this.hass, "air_pressure")}
+                ${getWeatherUnit(this.hass, "pressure")}
               </div>
             </div>
           `


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The units for Air Pressure when viewing the details of a weather card do not show. This tiny change fixes that :)

Before:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/18223213/120098199-5e7b8b80-c0e9-11eb-88c2-de77c1deade0.png">

After:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/18223213/120098176-43a91700-c0e9-11eb-8506-39b33a691d2c.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

The relevant code in `more-info-weather.ts` references retrieving units for the `air_pressure` quantity:

https://github.com/home-assistant/frontend/blob/03bbf6a5820a9f50c9a2aa24605007b0211c0f9c/src/dialogs/more-info/controls/more-info-weather.ts#L107-L111

So I added a case switch for `air_pressure` in the `getWeatherUnit` function. An alternative would be to simply change `air_pressure` to `pressure` in `more-info-weather.ts`, but I figure this way is more resilient to future mistakes.

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/29947
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally (on `ecobee` integration specifically).
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
