### PR TITLE
Fix store auth disappearing

### DIFF
--- a/src/dialogs/ha-store-auth-card.ts
+++ b/src/dialogs/ha-store-auth-card.ts
@@ -50,6 +50,9 @@ class HaStoreAuth extends LitElement {
         bottom: 16px;
         right: 16px;
         transition: bottom 0.25s;
+        --ha-card-box-shadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.2),
+          0px 6px 10px 0px rgba(0, 0, 0, 0.14),
+          0px 1px 18px 0px rgba(0, 0, 0, 0.12);
       }
 
       .card-actions {

--- a/src/state/auth-mixin.ts
+++ b/src/state/auth-mixin.ts
@@ -33,7 +33,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
           .then(() => {
             const el = document.createElement("ha-store-auth-card");
             this.provideHass(el);
-            this.shadowRoot!.appendChild(el);
+            document.body.appendChild(el);
           });
       }
     }

--- a/src/util/register-service-worker.ts
+++ b/src/util/register-service-worker.ts
@@ -39,13 +39,12 @@ export const registerServiceWorker = async (
       }
 
       // Notify users a new frontend is available.
-      // When
       showToast(rootEl, {
         message: "A new version of the frontend is available.",
         action: {
           // We tell the service worker to call skipWaiting, which activates
           // the new service worker. Above we listen for `controllerchange`
-          // so we reload the page once a new servic worker activates.
+          // so we reload the page once a new service worker activates.
           action: () => installingWorker.postMessage({ type: "skipWaiting" }),
           text: "reload",
         },


### PR DESCRIPTION


## Proposed change

Fixes #9311

When `home-assistant` would re-render, it would remove the manually added `ha-store-auth-card` element as it was not known by Lit.

We now add it to the body instead of to `home-assistant`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
