### PR TITLE
Filter adapters with information from the Supervisor

### DIFF
--- a/src/panels/config/core/ha-config-network.ts
+++ b/src/panels/config/core/ha-config-network.ts
@@ -74,19 +74,19 @@ class ConfigNetwork extends LitElement {
   private async _load() {
     this._error = undefined;
     try {
-      const coreNetowrk = await getNetworkConfig(this.hass);
+      const coreNetwork = await getNetworkConfig(this.hass);
       if (isComponentLoaded(this.hass, "hassio")) {
         const supervisorNetwork = await fetchNetworkInfo(this.hass);
         const interfaces = new Set(
           supervisorNetwork.interfaces.map((int) => int.interface)
         );
         if (interfaces.size) {
-          coreNetowrk.adapters = coreNetowrk.adapters.filter((adapter) =>
+          coreNetwork.adapters = coreNetwork.adapters.filter((adapter) =>
             interfaces.has(adapter.name)
           );
         }
       }
-      this._networkConfig = coreNetowrk;
+      this._networkConfig = coreNetwork;
     } catch (err) {
       this._error = err.message || err;
     }

--- a/src/panels/config/core/ha-config-network.ts
+++ b/src/panels/config/core/ha-config-network.ts
@@ -77,11 +77,12 @@ class ConfigNetwork extends LitElement {
       const coreNetowrk = await getNetworkConfig(this.hass);
       if (isComponentLoaded(this.hass, "hassio")) {
         const supervisorNetwork = await fetchNetworkInfo(this.hass);
-        if (supervisorNetwork.interfaces.length) {
+        const interfaces = new Set(
+          supervisorNetwork.interfaces.map((int) => int.interface)
+        );
+        if (interfaces.size) {
           coreNetowrk.adapters = coreNetowrk.adapters.filter((adapter) =>
-            supervisorNetwork.interfaces.some(
-              (int) => int.interface === adapter.name
-            )
+            interfaces.has(adapter.name)
           );
         }
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Filter the adapters shown with information from the Supervisor if the `hassio` integration is loaded

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
