### PR TITLE
Add input elements to login page for password managers

### DIFF
--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -21,7 +21,7 @@ import { litLocalizeLiteMixin } from "../mixins/lit-localize-lite-mixin";
 type State = "loading" | "error" | "step";
 
 class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
-  @property() public authProvider?: AuthProvider;
+  @property({ attribute: false }) public authProvider?: AuthProvider;
 
   @property() public clientId?: string;
 
@@ -43,7 +43,7 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
       <ha-password-manager-polyfill
         .step=${this._step}
         .stepData=${this._stepData}
-        @submit=${this._handleSubmit}
+        @form-submitted=${this._handleSubmit}
         @value-changed=${this._stepDataChanged}
       ></ha-password-manager-polyfill>
     `;
@@ -240,11 +240,17 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
     await this.updateComplete;
     // 100ms to give all the form elements time to initialize.
     setTimeout(() => {
-      const form = this.shadowRoot!.querySelector("ha-form");
+      const form = this.renderRoot.querySelector("ha-form");
       if (form) {
         (form as any).focus();
       }
     }, 100);
+
+    setTimeout(() => {
+      this.renderRoot.querySelector(
+        "ha-password-manager-polyfill"
+      )!.boundingRect = this.getBoundingClientRect();
+    }, 500);
   }
 
   private _stepDataChanged(ev: CustomEvent) {
@@ -338,3 +344,9 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
   }
 }
 customElements.define("ha-auth-flow", HaAuthFlow);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-auth-flow": HaAuthFlow;
+  }
+}

--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -7,7 +7,7 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit";
-import { PasswordManagerPolyfill } from "./ha-password-manager-polyfill";
+import "./ha-password-manager-polyfill";
 import { property, state } from "lit/decorators";
 import "../components/ha-form/ha-form";
 import "../components/ha-markdown";
@@ -37,22 +37,16 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
 
   @state() private _errorMessage?: string;
 
-  @state() private _pmPolyfill: PasswordManagerPolyfill;
-
-  constructor() {
-    super();
-    this._pmPolyfill = new PasswordManagerPolyfill(
-      (newData) => {
-        this._stepData = newData;
-      },
-      (ev) => {
-        this._handleSubmit(ev);
-      }
-    );
-  }
-
   protected render() {
-    return html` <form>${this._renderForm()}</form> `;
+    return html`
+      <form>${this._renderForm()}</form>
+      <ha-password-manager-polyfill
+        .step=${this._step}
+        .stepData=${this._stepData}
+        @submit=${this._handleSubmit}
+        @value-changed=${this._stepDataChanged}
+      ></ha-password-manager-polyfill>
+    `;
   }
 
   protected firstUpdated(changedProps: PropertyValues) {
@@ -243,9 +237,6 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
       this._stepData = stepData;
     }
 
-    this._pmPolyfill.setStep(this._step);
-    this._pmPolyfill.update(this._stepData);
-
     await this.updateComplete;
     // 100ms to give all the form elements time to initialize.
     setTimeout(() => {
@@ -258,7 +249,6 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
 
   private _stepDataChanged(ev: CustomEvent) {
     this._stepData = ev.detail.value;
-    this._pmPolyfill.update(this._stepData);
   }
 
   private _computeStepDescription(step: DataEntryFlowStepForm) {

--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -7,6 +7,7 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit";
+import { PasswordManagerPolyfill } from "./ha-password-manager-polyfill";
 import { property, state } from "lit/decorators";
 import "../components/ha-form/ha-form";
 import "../components/ha-markdown";
@@ -35,6 +36,20 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
   @state() private _step?: DataEntryFlowStep;
 
   @state() private _errorMessage?: string;
+
+  @state() private _pmPolyfill: PasswordManagerPolyfill;
+
+  constructor() {
+    super();
+    this._pmPolyfill = new PasswordManagerPolyfill(
+      (newData) => {
+        this._stepData = newData;
+      },
+      (ev) => {
+        this._handleSubmit(ev);
+      }
+    );
+  }
 
   protected render() {
     return html` <form>${this._renderForm()}</form> `;
@@ -228,6 +243,9 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
       this._stepData = stepData;
     }
 
+    this._pmPolyfill.setStep(this._step);
+    this._pmPolyfill.update(this._stepData);
+
     await this.updateComplete;
     // 100ms to give all the form elements time to initialize.
     setTimeout(() => {
@@ -240,6 +258,7 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
 
   private _stepDataChanged(ev: CustomEvent) {
     this._stepData = ev.detail.value;
+    this._pmPolyfill.update(this._stepData);
   }
 
   private _computeStepDescription(step: DataEntryFlowStepForm) {

--- a/src/auth/ha-password-manager-polyfill.ts
+++ b/src/auth/ha-password-manager-polyfill.ts
@@ -102,8 +102,9 @@ export class HaPasswordManagerPolyfill extends LitElement {
 
   private _valueChanged(ev: Event) {
     const target = ev.target! as HTMLInputElement;
+    this.stepData = { ...this.stepData, [target.id]: target.value };
     fireEvent(this, "value-changed", {
-      value: { ...this.stepData, [target.id]: target.value },
+      value: this.stepData,
     });
   }
 }

--- a/src/auth/ha-password-manager-polyfill.ts
+++ b/src/auth/ha-password-manager-polyfill.ts
@@ -1,0 +1,63 @@
+// All children of ha-authorize with Shadow DOM roots
+const SHADOW_ELEMENTS =
+  "ha-auth-flow, ha-form, ha-form-string, paper-input, paper-input-container, iron-input, mwc-button";
+
+function findThroughShadowDOM(root, querySelector) {
+  // Finds children of root, even across shadow DOM boundaries.
+  const results = [...root.querySelectorAll(querySelector)];
+  root.querySelectorAll(SHADOW_ELEMENTS).forEach((el) => {
+    results.push(...findThroughShadowDOM(el.shadowRoot, querySelector));
+  });
+  return results;
+}
+
+const passwordManagerPolyfill = document.createElement("form");
+passwordManagerPolyfill.setAttribute("aria-hidden", "true");
+passwordManagerPolyfill.id = "password-manager-polyfill";
+passwordManagerPolyfill.innerHTML = `
+<input id="username" />
+<input id="password" type="password" />
+<input type="submit"/>
+<style>
+  #password-manager-polyfill {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+  }
+</style>
+`;
+document.body.appendChild(passwordManagerPolyfill);
+
+passwordManagerPolyfill.addEventListener("submit", (ev) => {
+  ev.preventDefault();
+  // Click the next button after a delay allowing the inputs to update.
+  // The delay also allows the user to see the fields were filled before they disappear.
+  setTimeout(() => {
+    const authorizeRoot = document.querySelector("ha-authorize")!.shadowRoot;
+    findThroughShadowDOM(authorizeRoot, "button")[0].click();
+  }, 300);
+});
+
+passwordManagerPolyfill.addEventListener("input", (ev) => {
+  const authorizeRoot = document.querySelector("ha-authorize")!.shadowRoot;
+  const inputs = findThroughShadowDOM(authorizeRoot, "input");
+  if (inputs.length !== 2) {
+    throw new Error("Username and Password fields not found on page");
+  }
+  const target = ev.target! as HTMLInputElement;
+  // The event notifies the parent element the password field has changed.
+  const event = new Event("input", { bubbles: true });
+  // Update the fields after some delay so that the username field has time to
+  // update before the password is set. This way, when password is set, both fields are passed together.
+  setTimeout(() => {
+    if (target.id === "username") {
+      inputs[0].value = target.value;
+      inputs[0].dispatchEvent(event);
+    }
+    if (target.id === "password") {
+      inputs[1].value = target.value;
+      inputs[1].dispatchEvent(event);
+    }
+  }, 1);
+});

--- a/src/auth/ha-password-manager-polyfill.ts
+++ b/src/auth/ha-password-manager-polyfill.ts
@@ -20,6 +20,8 @@ export class PasswordManagerPolyfill {
     this._polyfill = document.createElement("form");
     this._polyfill.setAttribute("aria-hidden", "true");
     this._polyfill.className = "password-manager-polyfill";
+    // The left+top and input styles position the polyfill fields directly over the existing ones
+    // This makes sure password managers place their UI elements in the correct spot
     this._polyfill.innerHTML = `
       <input id="username" />
       <input id="password" type="password" />
@@ -27,9 +29,15 @@ export class PasswordManagerPolyfill {
       <style>
         .password-manager-polyfill {
           position: absolute;
+          top: 170px;
+          left: 50%;
           width: 0;
           height: 0;
           overflow: hidden;
+        }
+        .password-manager-polyfill input {
+          width: 210px;
+          height: 60px;
         }
       </style>
     `;

--- a/src/auth/ha-password-manager-polyfill.ts
+++ b/src/auth/ha-password-manager-polyfill.ts
@@ -1,9 +1,14 @@
-import "@polymer/iron-input";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import { HaFormSchema } from "../components/ha-form/ha-form";
 import { DataEntryFlowStep } from "../data/data_entry_flow";
+
+declare global {
+  interface HASSDomEvents {
+    submit: undefined;
+  }
+}
 
 const ENABLED_HANDLERS = [
   "homeassistant",
@@ -64,15 +69,16 @@ export class HaPasswordManagerPolyfill extends LitElement {
 
   private render_input(schema: HaFormSchema): TemplateResult {
     const inputType = schema.name.includes("password") ? "password" : "text";
-    // Iron-input needed for reliable updating of the input value
     if (schema.type === "string") {
-      return html`<iron-input bind-value=${this.stepData[schema.name]}>
+      return html`
         <input
+          tabindex="-1"
           id=${schema.name}
           type=${inputType}
+          .value=${this.stepData[schema.name] || ""}
           @input=${this._valueChanged}
         />
-      </iron-input>`;
+      `;
     }
     return html``;
   }

--- a/src/entrypoints/authorize.ts
+++ b/src/entrypoints/authorize.ts
@@ -3,6 +3,7 @@ import "../resources/compatibility";
 import "@polymer/polymer/lib/elements/dom-if";
 import "@polymer/polymer/lib/elements/dom-repeat";
 import "../auth/ha-authorize";
+import "../auth/ha-password-manager-polyfill";
 import "../resources/ha-style";
 import "../resources/roboto";
 import "../resources/safari-14-attachshadow-patch";

--- a/src/entrypoints/authorize.ts
+++ b/src/entrypoints/authorize.ts
@@ -3,7 +3,6 @@ import "../resources/compatibility";
 import "@polymer/polymer/lib/elements/dom-if";
 import "@polymer/polymer/lib/elements/dom-repeat";
 import "../auth/ha-authorize";
-import "../auth/ha-password-manager-polyfill";
 import "../resources/ha-style";
 import "../resources/roboto";
 import "../resources/safari-14-attachshadow-patch";


### PR DESCRIPTION
I gave up fighting the quirks that appeared in #9235 so I'm trying plan B: create input fields outside the shadow dom that password managers can see, and keep these new fields in sync with the existing ones.

## Proposed change

The new `ha-password-manager-polyfill` script adds this HTML to the page:

```html
<form id="password-manager-polyfill" aria-hidden="true">
  <input id="username" />
  <input id="password" type="password" />
  <input type="submit"/>
  <style>
    #password-manager-polyfill {
      position: absolute;
      width: 0;
      height: 0;
      overflow: hidden;
    }
  </style>
</form>
```
With the embedded `<style>` element, the form is rendered so that password mangers still think it exists, but is invisible to humans.

Input events are captured on the form, and the username and password fields on the page are updated to reflect whatever new content was inserted.
The form submit is also intercepted, and the "next" button is clicked when the form is submitted by the password manager.

**:warning: future problem warning :warning:**

When [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=746593), browsers, and password managers fix this bug on their end, having two password fields might confuse password managers. I can't test because nobody has seemed to have fixed it yet, but I'd like to make this change future-proof.

I don't think this would cause issues, because if the password manager decides to fill out the existing HA fields and not the invisible ones, all the better. But I'm open to advice here.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: #3133 (This PR doesn't address the accessibility problems)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally *(in Firefox with gopass-bridge; I haven't had the chance to test any other combination of browser/password manager yet)*.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
  ^ I should probably do this after most changes are approved