### PR TITLE
Fix the issue that logbook card doesn't translate `context.user_id` to name if it's a user's id.

### DIFF
--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -141,10 +141,10 @@ export class MoreInfoLogbook extends LitElement {
     const userIdToName = {};
 
     // Start loading users
-    const userProm = this.hass!.user!.is_admin && fetchUsers(this.hass!);
+    const userProm = this.hass.user?.is_admin && fetchUsers(this.hass);
 
     // Process persons
-    Object.values(this.hass!.states).forEach((entity) => {
+    Object.values(this.hass.states).forEach((entity) => {
       if (
         entity.attributes.user_id &&
         computeStateDomain(entity) === "person"

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -5,7 +5,6 @@ import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { throttle } from "../../common/util/throttle";
 import "../../components/ha-circular-progress";
 import "../../components/state-history-charts";
-import { fetchPersons } from "../../data/person";
 import { fetchUsers } from "../../data/user";
 import { getLogbookData, LogbookEntry } from "../../data/logbook";
 import { loadTraceContexts, TraceContexts } from "../../data/trace";

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { throttle } from "../../common/util/throttle";
 import "../../components/ha-circular-progress";
 import "../../components/state-history-charts";
@@ -142,23 +143,19 @@ export class MoreInfoLogbook extends LitElement {
   private async _fetchUserNames(hass: HomeAssistant) {
     const userIdToName = {};
 
-    // Start loading all the data
-    const personProm = fetchPersons(hass);
+    // Start loading users
     const userProm = hass.user!.is_admin && fetchUsers(hass);
 
     // Process persons
-    const persons = await personProm;
-
-    for (const person of persons.storage) {
-      if (person.user_id) {
-        userIdToName[person.user_id] = person.name;
+    Object.values(hass.states).forEach((entity) => {
+      if (
+        entity.attributes.user_id &&
+        computeStateDomain(entity) === "person"
+      ) {
+        this._userIdToName[entity.attributes.user_id] =
+          entity.attributes.friendly_name;
       }
-    }
-    for (const person of persons.config) {
-      if (person.user_id) {
-        userIdToName[person.user_id] = person.name;
-      }
-    }
+    });
 
     // Process users
     if (userProm) {

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -28,7 +28,7 @@ export class MoreInfoLogbook extends LitElement {
 
   private _lastLogbookDate?: Date;
 
-  private _fetchUserDone?: Promise<unknown>;
+  private _fetchUserPromise?: Promise<void>;
 
   private _throttleGetLogbookEntries = throttle(() => {
     this._getLogBookData();
@@ -75,7 +75,7 @@ export class MoreInfoLogbook extends LitElement {
 
   protected firstUpdated(): void {
     if (this.hass) {
-      this._fetchUserDone = this._fetchUserNames(this.hass);
+      this._fetchUserPromise = this._fetchUserNames(this.hass);
     }
     this.addEventListener("click", (ev) => {
       if ((ev.composedPath()[0] as HTMLElement).tagName === "A") {
@@ -131,7 +131,7 @@ export class MoreInfoLogbook extends LitElement {
         true
       ),
       loadTraceContexts(this.hass),
-      this._fetchUserDone,
+      this._fetchUserPromise,
     ]);
     this._logbookEntries = this._logbookEntries
       ? [...newEntries, ...this._logbookEntries]

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -73,9 +73,7 @@ export class MoreInfoLogbook extends LitElement {
   }
 
   protected firstUpdated(): void {
-    if (this.hass) {
-      this._fetchUserPromise = this._fetchUserNames(this.hass);
-    }
+    this._fetchUserPromise = this._fetchUserNames();
     this.addEventListener("click", (ev) => {
       if ((ev.composedPath()[0] as HTMLElement).tagName === "A") {
         setTimeout(() => closeDialog("ha-more-info-dialog"), 500);
@@ -139,14 +137,14 @@ export class MoreInfoLogbook extends LitElement {
     this._traceContexts = traceContexts;
   }
 
-  private async _fetchUserNames(hass: HomeAssistant) {
+  private async _fetchUserNames() {
     const userIdToName = {};
 
     // Start loading users
-    const userProm = hass.user!.is_admin && fetchUsers(hass);
+    const userProm = this.hass!.user!.is_admin && fetchUsers(this.hass!);
 
     // Process persons
-    Object.values(hass.states).forEach((entity) => {
+    Object.values(this.hass!.states).forEach((entity) => {
       if (
         entity.attributes.user_id &&
         computeStateDomain(entity) === "person"

--- a/src/panels/logbook/ha-panel-logbook.ts
+++ b/src/panels/logbook/ha-panel-logbook.ts
@@ -45,7 +45,7 @@ export class HaPanelLogbook extends LitElement {
 
   @state() private _ranges?: DateRangePickerRanges;
 
-  private _fetchUserDone?: Promise<unknown>;
+  private _fetchUserPromise?: Promise<void>;
 
   @state() private _userIdToName = {};
 
@@ -137,7 +137,7 @@ export class HaPanelLogbook extends LitElement {
     super.firstUpdated(changedProps);
     this.hass.loadBackendTranslation("title");
 
-    this._fetchUserDone = this._fetchUserNames();
+    this._fetchUserPromise = this._fetchUserNames();
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -259,7 +259,7 @@ export class HaPanelLogbook extends LitElement {
         this._entityId
       ),
       isComponentLoaded(this.hass, "trace") ? loadTraceContexts(this.hass) : {},
-      this._fetchUserDone,
+      this._fetchUserPromise,
     ]);
 
     this._entries = entries;

--- a/src/panels/logbook/ha-panel-logbook.ts
+++ b/src/panels/logbook/ha-panel-logbook.ts
@@ -199,7 +199,7 @@ export class HaPanelLogbook extends LitElement {
     const userIdToName = {};
 
     // Start loading users
-    const userProm = this.hass.user!.is_admin && fetchUsers(this.hass);
+    const userProm = this.hass.user?.is_admin && fetchUsers(this.hass);
 
     // Process persons
     Object.values(this.hass.states).forEach((entity) => {

--- a/src/panels/logbook/ha-panel-logbook.ts
+++ b/src/panels/logbook/ha-panel-logbook.ts
@@ -17,7 +17,6 @@ import {
   getLogbookData,
   LogbookEntry,
 } from "../../data/logbook";
-import { fetchPersons } from "../../data/person";
 import { loadTraceContexts, TraceContexts } from "../../data/trace";
 import { fetchUsers } from "../../data/user";
 import "../../layouts/ha-app-layout";

--- a/src/panels/logbook/ha-panel-logbook.ts
+++ b/src/panels/logbook/ha-panel-logbook.ts
@@ -4,6 +4,7 @@ import "@polymer/app-layout/app-toolbar/app-toolbar";
 import { css, html, LitElement, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { computeRTL } from "../../common/util/compute_rtl";
 import "../../components/entity/ha-entity-picker";
 import "../../components/ha-circular-progress";
@@ -198,23 +199,19 @@ export class HaPanelLogbook extends LitElement {
   private async _fetchUserNames() {
     const userIdToName = {};
 
-    // Start loading all the data
-    const personProm = fetchPersons(this.hass);
+    // Start loading users
     const userProm = this.hass.user!.is_admin && fetchUsers(this.hass);
 
     // Process persons
-    const persons = await personProm;
-
-    for (const person of persons.storage) {
-      if (person.user_id) {
-        userIdToName[person.user_id] = person.name;
+    Object.values(this.hass.states).forEach((entity) => {
+      if (
+        entity.attributes.user_id &&
+        computeStateDomain(entity) === "person"
+      ) {
+        this._userIdToName[entity.attributes.user_id] =
+          entity.attributes.friendly_name;
       }
-    }
-    for (const person of persons.config) {
-      if (person.user_id) {
-        userIdToName[person.user_id] = person.name;
-      }
-    }
+    });
 
     // Process users
     if (userProm) {

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -117,9 +117,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
   }
 
   protected firstUpdated(): void {
-    if (this.hass) {
-      this._fetchUserPromise = this._fetchUserNames(this.hass);
-    }
+    this._fetchUserPromise = this._fetchUserNames();
   }
 
   protected updated(changedProperties: PropertyValues) {
@@ -256,14 +254,14 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
     this._lastLogbookDate = now;
   }
 
-  private async _fetchUserNames(hass: HomeAssistant) {
+  private async _fetchUserNames() {
     const userIdToName = {};
 
     // Start loading users
-    const userProm = hass.user!.is_admin && fetchUsers(hass);
+    const userProm = this.hass!.user!.is_admin && fetchUsers(this.hass!);
 
     // Process persons
-    Object.values(hass.states).forEach((entity) => {
+    Object.values(this.hass!.states).forEach((entity) => {
       if (
         entity.attributes.user_id &&
         computeStateDomain(entity) === "person"

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -52,7 +52,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
     };
   }
 
-  @property({ attribute: false }) public hass?: HomeAssistant;
+  @property({ attribute: false }) public hass!: HomeAssistant;
 
   @state() private _config?: LogbookCardConfig;
 

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -258,7 +258,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
     const userIdToName = {};
 
     // Start loading users
-    const userProm = this.hass!.user!.is_admin && fetchUsers(this.hass!);
+    const userProm = this.hass.user?.is_admin && fetchUsers(this.hass);
 
     // Process persons
     Object.values(this.hass!.states).forEach((entity) => {

--- a/src/panels/lovelace/cards/hui-logbook-card.ts
+++ b/src/panels/lovelace/cards/hui-logbook-card.ts
@@ -64,7 +64,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
 
   private _lastLogbookDate?: Date;
 
-  private _fetchUserDone?: Promise<unknown>;
+  private _fetchUserPromise?: Promise<void>;
 
   private _throttleGetLogbookEntries = throttle(() => {
     this._getLogBookData();
@@ -118,7 +118,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
 
   protected firstUpdated(): void {
     if (this.hass) {
-      this._fetchUserDone = this._fetchUserNames(this.hass);
+      this._fetchUserPromise = this._fetchUserNames(this.hass);
     }
   }
 
@@ -242,7 +242,7 @@ export class HuiLogbookCard extends LitElement implements LovelaceCard {
         this._configEntities!.map((entity) => entity.entity).toString(),
         true
       ),
-      this._fetchUserDone,
+      this._fetchUserPromise,
     ]);
 
     const logbookEntries = this._logbookEntries


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Logbook card translates `context.user_id` into names. So that it shows: 'light.bedroom turned off by Shane'.

But it only works if the user is associated with a `person` entity (e.g. the user was created when a person was created and was given a password).
If the user isn't associated with a `person` entity (e.g. the user was created in the users page, not from a 'person'), logbook card won't translate `context.user_id` into a name.

The issue is that logbook card only fetches persons info, doesn't fetch users info.

**This PR copied [how logbook panel fetches persons and users](https://github.com/home-assistant/frontend/blob/dev/src/panels/logbook/ha-panel-logbook.ts#L202-L203) into logbook card, and replaced how logbook card used to fetch persons.**

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

N/A

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
