### PR TITLE
Add button to download logs from zwave_js logs page

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -130,7 +130,7 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
 
   private _downloadLogs() {
     const aEl = document.createElement("a");
-    aEl.download = `zwave_js logs ${this.startDateTime.toISOString()} to ${new Date().toISOString()}.log`;
+    aEl.download = `zwave_js ${this.startDateTime.toISOString()} to ${new Date().toISOString()}.log`;
     aEl.href = `data:text/plain;charset=utf-8,${encodeURI(
       this._textarea!.value
     )}`;

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -93,17 +93,14 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
                   `
                 : ""}
             </div>
-            <div>
               <mwc-icon-button
                 label="Download Logs"
                 @click=${this._downloadLogs}
               >
                 <ha-svg-icon
-                  .title="Download Logs"
                   .path=${mdiDownload}
                 ></ha-svg-icon>
               </mwc-icon-button>
-            </div>
           </ha-card>
           <textarea readonly></textarea>
         </div>

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -93,14 +93,14 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
                   `
                 : ""}
             </div>
-              <mwc-icon-button
-                label="Download Logs"
-                @click=${this._downloadLogs}
-              >
-                <ha-svg-icon
-                  .path=${mdiDownload}
-                ></ha-svg-icon>
-              </mwc-icon-button>
+            <mwc-icon-button
+              label=${this.hass.localize(
+                "ui.panel.config.zwave_js.logs.download_logs"
+              )}
+              @click=${this._downloadLogs}
+            >
+              <ha-svg-icon .path=${mdiDownload}></ha-svg-icon>
+            </mwc-icon-button>
           </ha-card>
           <textarea readonly></textarea>
         </div>

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -26,8 +26,6 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
 
   @property() public configEntryId!: string;
 
-  @property() public startDateTime = new Date();
-
   @state() private _logConfig?: ZWaveJSLogConfig;
 
   @query("textarea", true) private _textarea?: HTMLTextAreaElement;
@@ -130,7 +128,7 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
 
   private _downloadLogs() {
     const aEl = document.createElement("a");
-    aEl.download = `zwave_js ${this.startDateTime.toISOString()} to ${new Date().toISOString()}.log`;
+    aEl.download = `zwave_js.log`;
     aEl.href = `data:text/plain;charset=utf-8,${encodeURI(
       this._textarea!.value
     )}`;

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -14,6 +14,7 @@ import "../../../../../layouts/hass-tabs-subpage";
 import { SubscribeMixin } from "../../../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../../../resources/styles";
 import { HomeAssistant, Route } from "../../../../../types";
+import { fileDownload } from "../../../../../util/file_download";
 import { configTabs } from "./zwave_js-config-router";
 
 @customElement("zwave_js-logs")
@@ -124,12 +125,11 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
   }
 
   private _downloadLogs() {
-    const aEl = document.createElement("a");
-    aEl.download = `zwave_js.log`;
-    aEl.href = `data:text/plain;charset=utf-8,${encodeURI(
-      this._textarea!.value
-    )}`;
-    aEl.click();
+    fileDownload(
+      this,
+      `data:text/plain;charset=utf-8,${encodeURI(this._textarea!.value)}`,
+      `zwave_js.log`
+    );
   }
 
   private _dropdownSelected(ev) {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -1,5 +1,6 @@
 import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-listbox/paper-listbox";
+import { mdiDownload } from "@mdi/js";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, CSSResultArray, html, LitElement } from "lit";
 import { customElement, property, state, query } from "lit/decorators";
@@ -24,6 +25,8 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
   @property({ type: Boolean }) public narrow!: boolean;
 
   @property() public configEntryId!: string;
+
+  @property() public startDateTime = new Date();
 
   @state() private _logConfig?: ZWaveJSLogConfig;
 
@@ -92,6 +95,17 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
                   `
                 : ""}
             </div>
+            <div>
+              <mwc-icon-button
+                label="Download Logs"
+                @click=${this._downloadLogs}
+              >
+                <ha-svg-icon
+                  .title="Download Logs"
+                  .path=${mdiDownload}
+                ></ha-svg-icon>
+              </mwc-icon-button>
+            </div>
           </ha-card>
           <textarea readonly></textarea>
         </div>
@@ -112,6 +126,15 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
       this.hass!,
       this.configEntryId
     );
+  }
+
+  private _downloadLogs() {
+    const aEl = document.createElement("a");
+    aEl.download = `zwave_js logs ${this.startDateTime.toISOString()} to ${new Date().toISOString()}.log`;
+    aEl.href = `data:text/plain;charset=utf-8,${encodeURI(
+      this._textarea!.value
+    )}`;
+    aEl.click();
   }
 
   private _dropdownSelected(ev) {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -95,7 +95,7 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
                 : ""}
             </div>
             <mwc-icon-button
-              label=${this.hass.localize(
+              .label=${this.hass.localize(
                 "ui.panel.config.zwave_js.logs.download_logs"
               )}
               @click=${this._downloadLogs}

--- a/translations/frontend/en.json
+++ b/translations/frontend/en.json
@@ -2990,7 +2990,8 @@
                         "log_level": "Log Level",
                         "log_level_changed": "Log Level changed to: {level}",
                         "subscribed_to_logs": "Subscribed to Z-Wave JS Log Messages...",
-                        "title": "Z-Wave JS Logs"
+                        "title": "Z-Wave JS Logs",
+                        "download_logs": "Download Logs"
                     },
                     "navigation": {
                         "logs": "Logs",


### PR DESCRIPTION
## Proposed change
Adds a new download button to the zwave_js log page that lets a user download the logs shown in the frontend (used automation trace downloads as a reference). I know nothing about CSS and HTML so the placement of this icon may not be great, open to suggestions

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
