### PR TITLE
Fixed Logbook Card/Panel/Dialog Incorrect Entires for `input_datetime` Entities

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -29,37 +29,63 @@ export const computeStateDisplay = (
   const domain = computeStateDomain(stateObj);
 
   if (domain === "input_datetime") {
-    let date: Date;
-    if (!stateObj.attributes.has_time) {
+    if (state) {
+      // If trying to display an explicit state, need to parse the explict state to `Date` then format.
+      try {
+        if (!stateObj.attributes.has_time) {
+          // Only has date.
+          const dateTimeObj = new Date(state);
+          return formatDate(dateTimeObj, locale);
+        }
+        if (!stateObj.attributes.has_date) {
+          // Only has time.
+          const now = new Date();
+          const dateTiemString = now.toDateString() + " " + state;
+          const dateTimeObj = new Date(dateTiemString);
+          return formatTime(dateTimeObj, locale);
+        } 
+          // Has both date and time
+          return formatDateTime(new Date(state), locale);
+        
+      } catch {
+        // If `Date` constructor throws error, meaning the explict state isn't a valid date/time string,
+        // just return it.
+        return state;
+      }
+    } else {
+      // If not trying to display an explicit state, just format `stateObj.state`.
+      let date: Date;
+      if (!stateObj.attributes.has_time) {
+        date = new Date(
+          stateObj.attributes.year,
+          stateObj.attributes.month - 1,
+          stateObj.attributes.day
+        );
+        return formatDate(date, locale);
+      }
+      if (!stateObj.attributes.has_date) {
+        const now = new Date();
+        date = new Date(
+          // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548
+          // don't use artificial 1970 year.
+          now.getFullYear(),
+          now.getMonth(),
+          now.getDay(),
+          stateObj.attributes.hour,
+          stateObj.attributes.minute
+        );
+        return formatTime(date, locale);
+      }
+
       date = new Date(
         stateObj.attributes.year,
         stateObj.attributes.month - 1,
-        stateObj.attributes.day
-      );
-      return formatDate(date, locale);
-    }
-    if (!stateObj.attributes.has_date) {
-      const now = new Date();
-      date = new Date(
-        // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548
-        // don't use artificial 1970 year.
-        now.getFullYear(),
-        now.getMonth(),
-        now.getDay(),
+        stateObj.attributes.day,
         stateObj.attributes.hour,
         stateObj.attributes.minute
       );
-      return formatTime(date, locale);
+      return formatDateTime(date, locale);
     }
-
-    date = new Date(
-      stateObj.attributes.year,
-      stateObj.attributes.month - 1,
-      stateObj.attributes.day,
-      stateObj.attributes.hour,
-      stateObj.attributes.minute
-    );
-    return formatDateTime(date, locale);
   }
 
   if (domain === "humidifier") {

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -81,16 +81,8 @@ export const computeStateDisplay = (
         return formatDate(date, locale);
       }
       if (!stateObj.attributes.has_date) {
-        const now = new Date();
-        date = new Date(
-          // Due to bugs.chromium.org/p/chromium/issues/detail?id=797548
-          // don't use artificial 1970 year.
-          now.getFullYear(),
-          now.getMonth(),
-          now.getDay(),
-          stateObj.attributes.hour,
-          stateObj.attributes.minute
-        );
+        date = new Date();
+        date.setHours(stateObj.attributes.hour, stateObj.attributes.minute);
         return formatTime(date, locale);
       }
 

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -33,39 +33,26 @@ export const computeStateDisplay = (
       // If trying to display an explicit state, need to parse the explict state to `Date` then format.
       // Attributes aren't available, we have to use `state`.
       try {
-        // We are going to convert the state string into a ISO8601 string,
-        // which is always in UTC and causing the tiemzone info to be lost,
-        // therefore we need to compensate the local timezone offset.
-        const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
         const components = state.split(" ");
         if (components.length === 2) {
           // Date and time.
-          const iso8601String = components.join("T") + "Z";
+          const iso8601String = components.join("T");
           const dateObj = new Date(iso8601String);
-          const adjustedDateObj = new Date(dateObj.getTime() + timezoneOffset);
-          return formatDateTime(adjustedDateObj, locale);
+          return formatDateTime(dateObj, locale);
         }
         if (components.length === 1) {
           if (state.includes("-")) {
             // Date only.
-            // Date only state is already a valid ISO8601 string.
-            const dateObj = new Date(state);
-            const adjustedDateObj = new Date(
-              dateObj.getTime() + timezoneOffset
-            );
-            return formatDate(adjustedDateObj, locale);
+            const iso8601String = `${state}"T00:00"`;
+            const dateObj = new Date(iso8601String);
+            return formatDate(dateObj, locale);
           }
           if (state.includes(":")) {
             // Time only.
-            // Inserting today's Date string.
             const now = new Date();
-            const dateISO8601String =
-              now.toISOString().substring(0, 10) + "T" + state + "Z";
-            const dateObj = new Date(dateISO8601String);
-            const adjustedDateObj = new Date(
-              dateObj.getTime() + timezoneOffset
-            );
-            return formatTime(adjustedDateObj, locale);
+            const iso8601String = `${now.toISOString().split("T")[0]}T${state}`;
+            const dateObj = new Date(iso8601String);
+            return formatTime(dateObj, locale);
           }
         }
         return state;

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -28,13 +28,20 @@ export const computeStateDisplay = (
 
   const domain = computeStateDomain(stateObj);
 
+  // Below logic for `input_datetime` works only if the frontend's (browser's) timezone is the same as core's.
+  // If frontend's timezone is different from core's, `input_datetime`s' state display computation will be incorrect.
+  // Needs further fixes for frontend to get core's timezone offset, in order to make computation correct all the time.
   if (domain === "input_datetime") {
     if (state) {
       // If trying to display an explicit state, need to parse the explict state to `Date` then format.
+      // Attributes aren't available, we have to use `state`.
       try {
         if (!stateObj.attributes.has_time) {
           // Only has date.
           const dateObj = new Date(state);
+          // When only date is passed to `Date` constructor, it uses UTC regardless frontend's timezone,
+          // so we need to compensate that timezone offset.
+          // Other usages of `Date` constructor uses frontend's timezone w/o problem, no compensation needed.
           const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
           const adjustedDateObj = new Date(dateObj.getTime() + timezoneOffset);
           return formatDate(adjustedDateObj, locale);

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -34,19 +34,21 @@ export const computeStateDisplay = (
       try {
         if (!stateObj.attributes.has_time) {
           // Only has date.
-          const dateTimeObj = new Date(state);
-          return formatDate(dateTimeObj, locale);
+          const dateObj = new Date(state);
+          const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
+          const adjustedDateObj = new Date(dateObj.getTime() + timezoneOffset);
+          return formatDate(adjustedDateObj, locale);
         }
         if (!stateObj.attributes.has_date) {
           // Only has time.
           const now = new Date();
           const dateTiemString = now.toDateString() + " " + state;
-          const dateTimeObj = new Date(dateTiemString);
-          return formatTime(dateTimeObj, locale);
-        } 
-          // Has both date and time
-          return formatDateTime(new Date(state), locale);
-        
+          const dateObj = new Date(dateTiemString);
+          return formatTime(dateObj, locale);
+        }
+        // Has both date and time
+        const dateObj = new Date(state);
+        return formatDateTime(dateObj, locale);
       } catch {
         // If `Date` constructor throws error, meaning the explict state isn't a valid date/time string,
         // just return it.

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -33,6 +33,9 @@ export const computeStateDisplay = (
       // If trying to display an explicit state, need to parse the explict state to `Date` then format.
       // Attributes aren't available, we have to use `state`.
       try {
+        // We are going to convert the state string into a ISO8601 string,
+        // which is always in UTC and causing the tiemzone info to be lost,
+        // therefore we need to compensate the local timezone offset.
         const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
         const components = state.split(" ");
         if (components.length === 2) {
@@ -45,6 +48,7 @@ export const computeStateDisplay = (
         if (components.length === 1) {
           if (state.includes("-")) {
             // Date only.
+            // Date only state is already a valid ISO8601 string.
             const dateObj = new Date(state);
             const adjustedDateObj = new Date(
               dateObj.getTime() + timezoneOffset
@@ -53,6 +57,7 @@ export const computeStateDisplay = (
           }
           if (state.includes(":")) {
             // Time only.
+            // Inserting today's Date string.
             const now = new Date();
             const dateISO8601String =
               now.toISOString().substring(0, 10) + "T" + state + "Z";
@@ -65,8 +70,8 @@ export const computeStateDisplay = (
         }
         return state;
       } catch {
-        // If `Date` constructor throws error, meaning the explict state isn't a valid date/time string,
-        // just return it.
+        // Formatting methods may throw error if date parsing doesn't go well,
+        // just return the state string in that case.
         return state;
       }
     } else {

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -46,7 +46,10 @@ export const computeStateDisplay = (
           if (state.includes(":")) {
             // Time only.
             const now = new Date();
-            return formatTime(new Date(`${now.toISOString().split("T")[0]}T${state}`), locale);
+            return formatTime(
+              new Date(`${now.toISOString().split("T")[0]}T${state}`),
+              locale
+            );
           }
         }
         return state;

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -43,7 +43,7 @@ export const computeStateDisplay = (
         if (components.length === 1) {
           if (state.includes("-")) {
             // Date only.
-            const iso8601String = `${state}"T00:00"`;
+            const iso8601String = `${state}T00:00`;
             const dateObj = new Date(iso8601String);
             return formatDate(dateObj, locale);
           }

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -39,9 +39,9 @@ export const computeStateDisplay = (
         if (!stateObj.attributes.has_time) {
           // Only has date.
           const dateObj = new Date(state);
-          // When only date is passed to `Date` constructor, it uses UTC regardless frontend's timezone,
-          // so we need to compensate that timezone offset.
-          // Other usages of `Date` constructor uses frontend's timezone w/o problem, no compensation needed.
+          // When only date is passed to `Date` constructor, it uses UTC regardless of frontend's timezone,
+          // so we need to add the frontend's timezone offset.
+          // Other usages of `Date` constructor have both date and time in the string, frontend's timezone is used w/o problem.
           const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
           const adjustedDateObj = new Date(dateObj.getTime() + timezoneOffset);
           return formatDate(adjustedDateObj, locale);
@@ -53,7 +53,7 @@ export const computeStateDisplay = (
           const dateObj = new Date(dateTiemString);
           return formatTime(dateObj, locale);
         }
-        // Has both date and time
+        // Has both date and time.
         const dateObj = new Date(state);
         return formatDateTime(dateObj, locale);
       } catch {
@@ -62,7 +62,7 @@ export const computeStateDisplay = (
         return state;
       }
     } else {
-      // If not trying to display an explicit state, just format `stateObj.state`.
+      // If not trying to display an explicit state, create `Date` object from `stateObj`'s attributes then format.
       let date: Date;
       if (!stateObj.attributes.has_time) {
         date = new Date(

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -28,9 +28,6 @@ export const computeStateDisplay = (
 
   const domain = computeStateDomain(stateObj);
 
-  // Below logic for `input_datetime` works only if the frontend's (browser's) timezone is the same as core's.
-  // If frontend's timezone is different from core's, `input_datetime`s' state display computation will be incorrect.
-  // Needs further fixes for frontend to get core's timezone offset, in order to make computation correct all the time.
   if (domain === "input_datetime") {
     if (state) {
       // If trying to display an explicit state, need to parse the explict state to `Date` then format.

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -33,26 +33,37 @@ export const computeStateDisplay = (
       // If trying to display an explicit state, need to parse the explict state to `Date` then format.
       // Attributes aren't available, we have to use `state`.
       try {
-        if (!stateObj.attributes.has_time) {
-          // Only has date.
-          const dateObj = new Date(state);
-          // When only date is passed to `Date` constructor, it uses UTC regardless of frontend's timezone,
-          // so we need to add the frontend's timezone offset.
-          // Other usages of `Date` constructor have both date and time in the string, frontend's timezone is used w/o problem.
-          const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
+        const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
+        const components = state.split(" ");
+        if (components.length === 2) {
+          // Date and time.
+          const iso8601String = components.join("T") + "Z";
+          const dateObj = new Date(iso8601String);
           const adjustedDateObj = new Date(dateObj.getTime() + timezoneOffset);
-          return formatDate(adjustedDateObj, locale);
+          return formatDateTime(adjustedDateObj, locale);
         }
-        if (!stateObj.attributes.has_date) {
-          // Only has time.
-          const now = new Date();
-          const dateTiemString = now.toDateString() + " " + state;
-          const dateObj = new Date(dateTiemString);
-          return formatTime(dateObj, locale);
+        if (components.length === 1) {
+          if (state.includes("-")) {
+            // Date only.
+            const dateObj = new Date(state);
+            const adjustedDateObj = new Date(
+              dateObj.getTime() + timezoneOffset
+            );
+            return formatDate(adjustedDateObj, locale);
+          }
+          if (state.includes(":")) {
+            // Time only.
+            const now = new Date();
+            const dateISO8601String =
+              now.toISOString().substring(0, 10) + "T" + state + "Z";
+            const dateObj = new Date(dateISO8601String);
+            const adjustedDateObj = new Date(
+              dateObj.getTime() + timezoneOffset
+            );
+            return formatTime(adjustedDateObj, locale);
+          }
         }
-        // Has both date and time.
-        const dateObj = new Date(state);
-        return formatDateTime(dateObj, locale);
+        return state;
       } catch {
         // If `Date` constructor throws error, meaning the explict state isn't a valid date/time string,
         // just return it.

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -36,23 +36,17 @@ export const computeStateDisplay = (
         const components = state.split(" ");
         if (components.length === 2) {
           // Date and time.
-          const iso8601String = components.join("T");
-          const dateObj = new Date(iso8601String);
-          return formatDateTime(dateObj, locale);
+          return formatDateTime(new Date(components.join("T")), locale);
         }
         if (components.length === 1) {
           if (state.includes("-")) {
             // Date only.
-            const iso8601String = `${state}T00:00`;
-            const dateObj = new Date(iso8601String);
-            return formatDate(dateObj, locale);
+            return formatDate(new Date(`${state}T00:00`), locale);
           }
           if (state.includes(":")) {
             // Time only.
             const now = new Date();
-            const iso8601String = `${now.toISOString().split("T")[0]}T${state}`;
-            const dateObj = new Date(iso8601String);
-            return formatTime(dateObj, locale);
+            return formatTime(new Date(`${now.toISOString().split("T")[0]}T${state}`), locale);
           }
         }
         return state;

--- a/test-mocha/common/entity/compute_state_display.ts
+++ b/test-mocha/common/entity/compute_state_display.ts
@@ -236,6 +236,98 @@ describe("computeStateDisplay", () => {
     });
   });
 
+  describe("Localizes input_datetime state parameter with full date time", () => {
+    const stateObj: any = {
+      entity_id: "input_datetime.test",
+      state: "123",
+      attributes: {
+        has_date: true,
+        has_time: true,
+        year: 2021,
+        month: 6,
+        day: 13,
+        hour: 15,
+        minute: 26,
+        second: 36,
+      },
+    };
+    it("Uses am/pm time format", () => {
+      assert.strictEqual(
+        computeStateDisplay(
+          localize,
+          stateObj,
+          localeData,
+          "2021-07-04 15:40:03"
+        ),
+        "July 4, 2021, 3:40 PM"
+      );
+    });
+    it("Uses 24h time format", () => {
+      localeData.time_format = TimeFormat.twenty_four;
+      assert.strictEqual(
+        computeStateDisplay(
+          localize,
+          stateObj,
+          localeData,
+          "2021-07-04 15:40:03"
+        ),
+        "July 4, 2021, 15:40"
+      );
+    });
+  });
+
+  it("Localizes input_datetime state parameter with date", () => {
+    const stateObj: any = {
+      entity_id: "input_datetime.test",
+      state: "123",
+      attributes: {
+        has_date: true,
+        has_time: false,
+        year: 2021,
+        month: 6,
+        day: 13,
+        hour: 15,
+        minute: 26,
+        second: 36,
+      },
+    };
+    assert.strictEqual(
+      computeStateDisplay(localize, stateObj, localeData, "2021-07-04"),
+      "July 4, 2021"
+    );
+  });
+
+  describe("Localizes input_datetime state parameter with time", () => {
+    const stateObj: any = {
+      entity_id: "input_datetime.test",
+      state: "123",
+      attributes: {
+        has_date: false,
+        has_time: true,
+        year: 2021,
+        month: 6,
+        day: 13,
+        hour: 15,
+        minute: 26,
+        second: 36,
+      },
+    };
+    it("Uses am/pm time format", () => {
+      localeData.time_format = TimeFormat.am_pm;
+      assert.strictEqual(
+        computeStateDisplay(localize, stateObj, localeData, "17:05:07"),
+        "5:05 PM"
+      );
+    });
+    it("Uses 24h time format", () => {
+      localeData.time_format = TimeFormat.twenty_four;
+      assert.strictEqual(
+        computeStateDisplay(localize, stateObj, localeData, "17:05:07"),
+        "17:05"
+      );
+    });
+  });
+
   it("Localizes unavailable", () => {
     const altLocalize = (message, ...args) => {
       if (message === "state.sensor.unavailable") {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The issue (in the video, although I changed the input_datetime to different dates, logbook dialog's every entry shows the same date):

https://user-images.githubusercontent.com/7324708/121449645-d8b8d500-c95f-11eb-8ba2-fd00be464471.mp4

The issue under the hood is:
Back in #6978 we added a parameter `state` to `computeStateDisplay` in order to compute the display of an explicit state (instead of the entity's current state). But the `input_datetime` handling wasn't changed properly.
The `input_datetime` handling should try to format the passed in explicit `state` if it exists. 
This PR added the handling for passed in explicit input_datetime `state`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

N/A

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9405
- This PR is related to issue or discussion: #6978
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
