### PR TITLE
Handle config entry not loaded on Z-Wave JS config panel

### DIFF
--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -27,6 +27,12 @@ export type ConfigEntryMutableParams = Partial<
   >
 >;
 
+export const ERROR_STATES: ConfigEntry["state"][] = [
+  "migration_error",
+  "setup_error",
+  "setup_retry",
+];
+
 export const getConfigEntries = (hass: HomeAssistant) =>
   hass.callApi<ConfigEntry[]>("GET", "config/config_entries/entry");
 

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -22,6 +22,7 @@ import {
   enableConfigEntry,
   reloadConfigEntry,
   updateConfigEntry,
+  ERROR_STATES,
 } from "../../../data/config_entries";
 import type { DeviceRegistryEntry } from "../../../data/device_registry";
 import type { EntityRegistryEntry } from "../../../data/entity_registry";
@@ -37,12 +38,6 @@ import { haStyle, haStyleScrollbar } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import type { ConfigEntryExtended } from "./ha-config-integrations";
 import "./ha-integration-header";
-
-const ERROR_STATES: ConfigEntry["state"][] = [
-  "migration_error",
-  "setup_error",
-  "setup_retry",
-];
 
 const integrationsWithPanel = {
   hassio: "/hassio/dashboard",

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -20,6 +20,7 @@ import {
 import {
   ConfigEntry,
   getConfigEntries,
+  ERROR_STATES,
 } from "../../../../../data/config_entries";
 import {
   showAlertDialog,
@@ -33,10 +34,8 @@ import "../../../ha-config-section";
 import { showZWaveJSAddNodeDialog } from "./show-dialog-zwave_js-add-node";
 import { showZWaveJSRemoveNodeDialog } from "./show-dialog-zwave_js-remove-node";
 import { configTabs } from "./zwave_js-config-router";
-import { getConfigEntries } from "../../../../../data/config_entries";
 import { showOptionsFlowDialog } from "../../../../../dialogs/config-flow/show-dialog-options-flow";
 
-const ERROR_STATES = ["migration_error", "setup_error", "setup_retry"];
 @customElement("zwave_js-config-dashboard")
 class ZWaveJSConfigDashboard extends LitElement {
   @property({ type: Object }) public hass!: HomeAssistant;
@@ -239,10 +238,12 @@ class ZWaveJSConfigDashboard extends LitElement {
     if (item.disabled_by) {
       stateText = [
         "ui.panel.config.integrations.config_entry.disable.disabled_cause",
-        "cause",
-        this.hass.localize(
-          `ui.panel.config.integrations.config_entry.disable.disabled_by.${item.disabled_by}`
-        ) || item.disabled_by,
+        {
+          cause:
+            this.hass.localize(
+              `ui.panel.config.integrations.config_entry.disable.disabled_by.${item.disabled_by}`
+            ) || item.disabled_by,
+        },
       ];
       if (item.state === "failed_unload") {
         stateTextExtra = html`.


### PR DESCRIPTION
## Proposed change
Updates the Z-Wave JS config panel dashboard to handle instances where the config entry is not loaded or is in error state.

Previously it would show a partial non-functional dashboard with a handful of errors in the browser console:
![image](https://user-images.githubusercontent.com/7545841/122659717-9904a100-d148-11eb-94f5-e17f5e8d1658.png)

Now it will show an error screen:
![image](https://user-images.githubusercontent.com/7545841/122659696-783c4b80-d148-11eb-9754-9d835ec7123d.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
