### PR TITLE
add 'allow-download' to iframe sandbox for chrome

### DIFF
--- a/src/panels/iframe/ha-panel-iframe.js
+++ b/src/panels/iframe/ha-panel-iframe.js
@@ -24,7 +24,7 @@ class HaPanelIframe extends PolymerElement {
 
       <iframe
         src="[[panel.config.url]]"
-        sandbox="allow-forms allow-popups allow-pointer-lock allow-same-origin allow-scripts allow-modals"
+        sandbox="allow-forms allow-popups allow-pointer-lock allow-same-origin allow-scripts allow-modals allow-download"
         allowfullscreen="true"
         webkitallowfullscreen="true"
         mozallowfullscreen="true"


### PR DESCRIPTION
add 'allow-download' to iframe sandbox for chrome so that items can be downloaded from within an iframe

This is a simple fix for #8309, but I'm worried that it introduces a security issue so needs some thought, see https://www.chromestatus.com/feature/5706745674465280#:~:text=Sandboxed%20iframe%20can%20initiate%20or,attributes%20list%20to%20opt%20in.

## Breaking change

This shouldn't break anything, but it does have potential security issues.

## Proposed change

Add 'allow-download' to the iframe sandbox.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

None :-)

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #8309

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
