### PR TITLE
Show parameter number on ZWaveJS device config panel

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -176,7 +176,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
               ? html`
                   ${Object.entries(this._config).map(
                     ([id, item]) => html` <ha-settings-row
-                      class="content config-item"
+                      class="config-item"
                       .configId=${id}
                       .narrow=${this.narrow}
                     >
@@ -474,6 +474,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
         ha-settings-row {
           --paper-time-input-justify-content: flex-end;
           border-top: 1px solid var(--divider-color);
+          padding: 4px 16px;
         }
 
         .prefix {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -482,7 +482,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
           text-transform: uppercase;
           font-size: 0.8em;
           padding-right: 24px;
-          line-height: 1.3em;
+          line-height: 1.5em;
         }
 
         .prefix span {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -194,6 +194,11 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
   private _generateConfigBox(id, item): TemplateResult {
     const result = this._results[id];
     const labelAndDescription = html`
+      <span slot="prefix" class="prefix">
+        ${this.hass.localize("ui.panel.config.zwave_js.node_config.parameter")}
+        <br />
+        <span>${item.property}</span>
+      </span>
       <span slot="heading">${item.metadata.label}</span>
       <span slot="description">
         ${item.metadata.description}
@@ -469,6 +474,19 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
         ha-settings-row {
           --paper-time-input-justify-content: flex-end;
           border-top: 1px solid var(--divider-color);
+        }
+
+        .prefix {
+          color: var(--secondary-text-color);
+          text-align: center;
+          text-transform: uppercase;
+          font-size: 0.8em;
+          padding-right: 24px;
+          line-height: 1.3em;
+        }
+
+        .prefix span {
+          font-size: 1.3em;
         }
 
         :host(:not([narrow])) ha-settings-row paper-input {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2621,7 +2621,8 @@
             "error_device_not_found": "Device not found",
             "set_param_accepted": "The parameter has been updated.",
             "set_param_queued": "The parameter change has been queued, and will be updated when the device wakes up.",
-            "set_param_error": "An error occurred."
+            "set_param_error": "An error occurred.",
+            "parameter": "Parameter"
           },
           "node_status": {
             "unknown": "Unknown",


### PR DESCRIPTION
## Proposed change

Most Z-Wave device manuals refer to configuration options by their parameter number, but we didn't show this number in the config panel.

![image](https://user-images.githubusercontent.com/7545841/124318309-73af6400-db46-11eb-8c4c-8d0da9b73cad.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
