### PR TITLE
Fix race in translations loading

### DIFF
--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -126,7 +126,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       this._applyTranslations(this.hass!);
     }
 
-    protected panelUrlChanged(newPanelUrl) {
+    protected panelUrlChanged(newPanelUrl: string) {
       super.panelUrlChanged(newPanelUrl);
       // this may be triggered before hassConnected
       this._loadFragmentTranslations(
@@ -339,13 +339,16 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
           ...data,
         },
       };
-      const changes: Partial<HomeAssistant> = {
-        resources,
-        localize: await computeLocalize(this, language, resources),
-      };
+
+      // Update resources immediately, so when a new update comes in we don't miss values
+      this._updateHass({ resources });
+
+      const localize = await computeLocalize(this, language, resources);
 
       if (language === (this.hass ?? this._pendingHass).language) {
-        this._updateHass(changes);
+        this._updateHass({
+          localize,
+        });
       }
     }
 


### PR DESCRIPTION

## Proposed change

We would wait with updating resources until the translations polyfills would be loaded, this could cause that a new resource update would not have the previous update as that was still waiting for the load of localize.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
