### PR TITLE
Avoid gaps in grid card with conditional

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "appPort": "8124:8123",
+  "forwardPorts": [8123],
   "context": "..",
   "postCreateCommand": "script/bootstrap",
   "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "forwardPorts": [8123],
+  "appPort": "8124:8123",
   "context": "..",
   "postCreateCommand": "script/bootstrap",
   "extensions": [

--- a/src/panels/lovelace/cards/hui-grid-card.ts
+++ b/src/panels/lovelace/cards/hui-grid-card.ts
@@ -79,7 +79,7 @@ class HuiGridCard extends HuiStackCard<GridCardConfig> {
         :host([square]) #root {
           grid-auto-rows: 1fr;
         }
-        :host([square]) #root::after {
+        :host([square]) #root::before {
           content: "";
           width: 0;
           padding-bottom: 100%;

--- a/src/panels/lovelace/cards/hui-grid-card.ts
+++ b/src/panels/lovelace/cards/hui-grid-card.ts
@@ -92,6 +92,10 @@ class HuiGridCard extends HuiStackCard<GridCardConfig> {
           grid-column: 1 / 1;
         }
         :host([square]) #root > *:not([hidden]) ~ *:not([hidden]) {
+           /* 
+	       * Remove grid-row and grid-column from every element that comes after
+	       * the first not-hidden element
+	       */
           grid-row: unset;
           grid-column: unset;
         }

--- a/src/panels/lovelace/cards/hui-grid-card.ts
+++ b/src/panels/lovelace/cards/hui-grid-card.ts
@@ -87,9 +87,13 @@ class HuiGridCard extends HuiStackCard<GridCardConfig> {
           grid-column: 1 / 1;
         }
 
-        :host([square]) #root > *:first-child {
+        :host([square]) #root > *:not([invisible]) {
           grid-row: 1 / 1;
           grid-column: 1 / 1;
+        }
+        :host([square]) #root > *:not([invisible]) ~ *:not([invisible]) {
+          grid-row: unset;
+          grid-column: unset;
         }
       `,
     ];

--- a/src/panels/lovelace/cards/hui-grid-card.ts
+++ b/src/panels/lovelace/cards/hui-grid-card.ts
@@ -79,7 +79,7 @@ class HuiGridCard extends HuiStackCard<GridCardConfig> {
         :host([square]) #root {
           grid-auto-rows: 1fr;
         }
-        :host([square]) #root::before {
+        :host([square]) #root::after {
           content: "";
           width: 0;
           padding-bottom: 100%;
@@ -87,11 +87,11 @@ class HuiGridCard extends HuiStackCard<GridCardConfig> {
           grid-column: 1 / 1;
         }
 
-        :host([square]) #root > *:not([invisible]) {
+        :host([square]) #root > *:not([hidden]) {
           grid-row: 1 / 1;
           grid-column: 1 / 1;
         }
-        :host([square]) #root > *:not([invisible]) ~ *:not([invisible]) {
+        :host([square]) #root > *:not([hidden]) ~ *:not([hidden]) {
           grid-row: unset;
           grid-column: unset;
         }

--- a/src/panels/lovelace/cards/hui-grid-card.ts
+++ b/src/panels/lovelace/cards/hui-grid-card.ts
@@ -92,7 +92,7 @@ class HuiGridCard extends HuiStackCard<GridCardConfig> {
           grid-column: 1 / 1;
         }
         :host([square]) #root > *:not([hidden]) ~ *:not([hidden]) {
-           /* 
+          /*
 	       * Remove grid-row and grid-column from every element that comes after
 	       * the first not-hidden element
 	       */

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -17,6 +17,8 @@ export class HuiConditionalBase extends ReactiveElement {
 
   @property() protected _config?: ConditionalCardConfig | ConditionalRowConfig;
 
+  @property({ type: Boolean, reflect: true }) public invisible = false;
+
   protected _element?: LovelaceCard | LovelaceRow;
 
   protected createRenderRoot() {
@@ -55,6 +57,7 @@ export class HuiConditionalBase extends ReactiveElement {
 
     const visible =
       this.editMode || checkConditionsMet(this._config.conditions, this.hass);
+    this.invisible = !visible;
 
     this.style.setProperty("display", visible ? "" : "none");
 

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -17,7 +17,7 @@ export class HuiConditionalBase extends ReactiveElement {
 
   @property() protected _config?: ConditionalCardConfig | ConditionalRowConfig;
 
-  @property({ type: Boolean, reflect: true }) public invisible = false;
+  @property({ type: Boolean, reflect: true }) public hidden = false;
 
   protected _element?: LovelaceCard | LovelaceRow;
 
@@ -57,7 +57,7 @@ export class HuiConditionalBase extends ReactiveElement {
 
     const visible =
       this.editMode || checkConditionsMet(this._config.conditions, this.hass);
-    this.invisible = !visible;
+    this.hidden = !visible;
 
     this.style.setProperty("display", visible ? "" : "none");
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The first card in a grid is forced into col 1 row 1 if the cards are square. That means there will be a gap if that card is currently hidden (by e.g. a conditional).

This fixes that by giving conditionals an attribute, and then checking for that as a special case in the grid card.

This uses a CSS trick to apply the row/col contraint to all cards, and then unset it to all but the first visible one. See https://stackoverflow.com/questions/3615518/css-selector-to-select-first-element-of-a-given-class/3615559#3615559


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9433
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
