### PR TITLE
Prevent darkMode overwrite by frontend_default_dark_theme

### DIFF
--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -97,10 +97,6 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         themeSettings
       );
 
-      // Now determine value that should be stored in the local storage settings
-      darkMode =
-        darkMode || !!(darkPreferred && this.hass.themes.default_dark_theme);
-
       if (darkMode !== this.hass.themes.darkMode) {
         this._updateHass({
           themes: { ...this.hass.themes!, darkMode },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The active `this.hass.themeSettings.darkMode` selection got incorrectly overwritten in the following edge case:

You have defined backend themes via `frontend_default_theme` and `frontend_default_dark_theme` and the OS is set to "dark preferred". The logic inside `_applyTheme()` first determines the correct active dark mode (and applies the matching theme variant), but then a few lines later it got overwritten to dark because `darkPreferred` and `this.hass.themes.default_dark_theme` were true while `darkMode` can correctly be set to false, but "looses" in the boolean "||" operation.

That meant that if you have selected the "light" radio box in the theme selection (while "Backend-selected" is the theme name), the overall theme was the light one (since it got applied a few lines after the initial correct darkMode determination), but inside `this.hass.themeSettings.darkMode` we had the wrong value.

This problem was noticeable if in that configuration you go the HA general settings and you see that despite the light theme being used, the map  of the location editor was in dark mode (since unless the caller provides a fixed `darkMode` value, `<ha-map>` uses the `this.hass.themes.darkMode`).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
