### PR TITLE
Colorize trace paths for choose without explicit default case

### DIFF
--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -143,11 +143,12 @@ class HatScriptGraph extends LitElement {
     graphStart = false
   ) {
     const trace = this.trace.trace[path] as ChooseActionTraceStep[] | undefined;
-    const trace_path = trace?.[0].result
-      ? trace[0].result.choice === "default"
-        ? [Array.isArray(config.choose) ? config.choose.length : 0]
-        : [trace[0].result.choice]
-      : [];
+    const trace_path =
+      trace !== undefined
+        ? trace[0].result === undefined || trace[0].result.choice === "default"
+          ? [Array.isArray(config.choose) ? config.choose.length : 0]
+          : [trace[0].result.choice]
+        : [];
     return html`
       <hat-graph
         tabindex=${trace === undefined ? "-1" : "0"}
@@ -204,7 +205,9 @@ class HatScriptGraph extends LitElement {
           <hat-graph-spacer
             class=${classMap({
               track:
-                trace !== undefined && trace[0].result?.choice === "default",
+                trace !== undefined &&
+                (trace[0].result === undefined ||
+                  trace[0].result?.choice === "default"),
             })}
           ></hat-graph-spacer>
           ${ensureArray(config.default)?.map((action, i) =>

--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -207,7 +207,7 @@ class HatScriptGraph extends LitElement {
               track:
                 trace !== undefined &&
                 (trace[0].result === undefined ||
-                  trace[0].result?.choice === "default"),
+                  trace[0].result.choice === "default"),
             })}
           ></hat-graph-spacer>
           ${ensureArray(config.default)?.map((action, i) =>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Traces of `choose` would not mark the default path as followed if the `default:` option is undefined:

![image](https://user-images.githubusercontent.com/1299821/124833102-f3419680-df7d-11eb-85b2-8caf0c8ac2e4.png)



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
