### PR TITLE
Re-add success/failure indicator on call service button in dev tools

### DIFF
--- a/src/components/buttons/ha-progress-button.ts
+++ b/src/components/buttons/ha-progress-button.ts
@@ -5,7 +5,7 @@ import { customElement, property, query } from "lit/decorators";
 import "../ha-circular-progress";
 
 @customElement("ha-progress-button")
-class HaProgressButton extends LitElement {
+export class HaProgressButton extends LitElement {
   @property({ type: Boolean }) public disabled = false;
 
   @property({ type: Boolean }) public progress = false;

--- a/src/panels/developer-tools/service/developer-tools-service.ts
+++ b/src/panels/developer-tools/service/developer-tools-service.ts
@@ -135,11 +135,15 @@ class HaPanelDevService extends LitElement {
                 >`
               : ""}
           </div>
-          <mwc-button .disabled=${!isValid} raised @click=${this._callService}>
+          <ha-progress-button
+            .disabled=${!isValid}
+            raised
+            @click=${this._callService}
+          >
             ${this.hass.localize(
               "ui.panel.developer-tools.tabs.services.call_service"
             )}
-          </mwc-button>
+          </ha-progress-button>
         </div>
       </div>
 
@@ -295,12 +299,14 @@ class HaPanelDevService extends LitElement {
     }
   );
 
-  private async _callService() {
+  private async _callService(ev) {
+    const button = ev.currentTarget;
     if (!this._serviceData?.service) {
       return;
     }
     try {
       await callExecuteScript(this.hass, [this._serviceData]);
+      button.actionSuccess();
     } catch (err) {
       const [domain, service] = this._serviceData.service.split(".", 2);
       if (
@@ -310,6 +316,7 @@ class HaPanelDevService extends LitElement {
         return;
       }
       forwardHaptic("failure");
+      button.actionError();
       showToast(this, {
         message:
           this.hass.localize(

--- a/src/panels/developer-tools/service/developer-tools-service.ts
+++ b/src/panels/developer-tools/service/developer-tools-service.ts
@@ -9,7 +9,8 @@ import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeObjectId } from "../../../common/entity/compute_object_id";
 import { hasTemplate } from "../../../common/string/has-template";
 import { extractSearchParam } from "../../../common/url/search-params";
-import "../../../components/buttons/ha-progress-button";
+import { HaProgressButton } from "../../../components/buttons/ha-progress-button";
+
 import "../../../components/entity/ha-entity-picker";
 import "../../../components/ha-card";
 import "../../../components/ha-expansion-panel";
@@ -300,7 +301,7 @@ class HaPanelDevService extends LitElement {
   );
 
   private async _callService(ev) {
-    const button = ev.currentTarget;
+    const button = ev.currentTarget as HaProgressButton;
     if (!this._serviceData?.service) {
       return;
     }

--- a/src/panels/developer-tools/service/developer-tools-service.ts
+++ b/src/panels/developer-tools/service/developer-tools-service.ts
@@ -306,7 +306,6 @@ class HaPanelDevService extends LitElement {
     }
     try {
       await callExecuteScript(this.hass, [this._serviceData]);
-      button.actionSuccess();
     } catch (err) {
       const [domain, service] = this._serviceData.service.split(".", 2);
       if (
@@ -325,7 +324,9 @@ class HaPanelDevService extends LitElement {
             this._serviceData.service
           ) + ` ${err.message}`,
       });
+      return;
     }
+    button.actionSuccess();
   }
 
   private _toggleYaml() {


### PR DESCRIPTION
## Proposed change
It seems that the feedback that we used to get through the call service button in developer tools to indicate a successful or failed call was removed as part of #8410 . This PR adds it back in - if it was intentional I am not clear on why since it seems to work with no loss in functionality elsewhere

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/8562

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
