### PR TITLE
Try to fix download of zwave_js logs

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-logs.ts
@@ -131,7 +131,9 @@ class ZWaveJSLogs extends SubscribeMixin(LitElement) {
   private _downloadLogs() {
     fileDownload(
       this,
-      `data:text/plain;charset=utf-8,${encodeURI(this._textarea!.value)}`,
+      `data:text/plain;charset=utf-8,${encodeURIComponent(
+        this._textarea!.value
+      )}`,
       `zwave_js.log`
     );
   }


### PR DESCRIPTION
## Type of change
It seems that the logs get truncated from the download when a `#` is in the data. This is an attempt to fix that

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
