### PR TITLE
Pass the width and height when requesting camera images

### DIFF
--- a/src/common/util/time-cache-function-promise.ts
+++ b/src/common/util/time-cache-function-promise.ts
@@ -7,14 +7,10 @@ interface ResultCache<T> {
 export const timeCachePromiseFunc = async <T>(
   cacheKey: string,
   cacheTime: number,
-  func: (
-    hass: HomeAssistant,
-    entityId: string,
-    ...args: unknown[]
-  ) => Promise<T>,
+  func: (hass: HomeAssistant, entityId: string, ...args: any[]) => Promise<T>,
   hass: HomeAssistant,
   entityId: string,
-  ...args: unknown[]
+  ...args: any[]
 ): Promise<T> => {
   let cache: ResultCache<T> | undefined = (hass as any)[cacheKey];
 

--- a/src/common/util/time-cache-function-promise.ts
+++ b/src/common/util/time-cache-function-promise.ts
@@ -7,10 +7,14 @@ interface ResultCache<T> {
 export const timeCachePromiseFunc = async <T>(
   cacheKey: string,
   cacheTime: number,
-  func: (hass: HomeAssistant, entityId: string, ...args: any[]) => Promise<T>,
+  func: (
+    hass: HomeAssistant,
+    entityId: string,
+    ...args: unknown[]
+  ) => Promise<T>,
   hass: HomeAssistant,
   entityId: string,
-  ...args: any[]
+  ...args: unknown[]
 ): Promise<T> => {
   let cache: ResultCache<T> | undefined = (hass as any)[cacheKey];
 

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -39,8 +39,7 @@ export const computeMJPEGStreamUrl = (entity: CameraEntity) =>
 export const fetchThumbnailUrlWithCache = (
   hass: HomeAssistant,
   entityId: string,
-  width: number,
-  height: number
+  ...args: any[]
 ) =>
   timeCachePromiseFunc(
     "_cameraTmbUrl",
@@ -48,18 +47,16 @@ export const fetchThumbnailUrlWithCache = (
     fetchThumbnailUrl,
     hass,
     entityId,
-    width,
-    height
+    args
   );
 
 export const fetchThumbnailUrl = async (
   hass: HomeAssistant,
   entityId: string,
-  width: number,
-  height: number
+  ...args: any[]
 ) => {
   const path = await getSignedPath(hass, `/api/camera_proxy/${entityId}`);
-  return hass.hassUrl(`${path.path}&width=${width}&height=${height}`);
+  return hass.hassUrl(`${path.path}&width=${args[0][0]}&height=${args[0][1]}`);
 };
 
 export const fetchStreamUrl = async (

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -38,22 +38,28 @@ export const computeMJPEGStreamUrl = (entity: CameraEntity) =>
 
 export const fetchThumbnailUrlWithCache = (
   hass: HomeAssistant,
-  entityId: string
+  entityId: string,
+  width: number,
+  height: number
 ) =>
   timeCachePromiseFunc(
     "_cameraTmbUrl",
     9000,
     fetchThumbnailUrl,
     hass,
-    entityId
+    entityId,
+    width,
+    height
   );
 
 export const fetchThumbnailUrl = async (
   hass: HomeAssistant,
-  entityId: string
+  entityId: string,
+  width: number,
+  height: number
 ) => {
   const path = await getSignedPath(hass, `/api/camera_proxy/${entityId}`);
-  return hass.hassUrl(path.path);
+  return hass.hassUrl(`${path.path}&width=${width}&height=${height}`);
 };
 
 export const fetchStreamUrl = async (

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -56,7 +56,7 @@ export const fetchThumbnailUrl = async (
   ...args: any[]
 ) => {
   const path = await getSignedPath(hass, `/api/camera_proxy/${entityId}`);
-  return hass.hassUrl(`${path.path}&width=${args[0][0]}&height=${args[0][1]}`);
+  return hass.hassUrl(`${path.path}&width=${width}&height=${height}`);
 };
 
 export const fetchStreamUrl = async (

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -47,7 +47,7 @@ export const fetchThumbnailUrlWithCache = (
     fetchThumbnailUrl,
     hass,
     entityId,
-    args
+    ...args
   );
 
 export const fetchThumbnailUrl = async (

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -39,7 +39,8 @@ export const computeMJPEGStreamUrl = (entity: CameraEntity) =>
 export const fetchThumbnailUrlWithCache = (
   hass: HomeAssistant,
   entityId: string,
-  ...args: any[]
+  width: number,
+  height: number
 ) =>
   timeCachePromiseFunc(
     "_cameraTmbUrl",

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -54,7 +54,8 @@ export const fetchThumbnailUrlWithCache = (
 export const fetchThumbnailUrl = async (
   hass: HomeAssistant,
   entityId: string,
-  ...args: any[]
+  width: number,
+  height: number
 ) => {
   const path = await getSignedPath(hass, `/api/camera_proxy/${entityId}`);
   return hass.hassUrl(`${path.path}&width=${width}&height=${height}`);

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -39,7 +39,8 @@ export const computeMJPEGStreamUrl = (entity: CameraEntity) =>
 export const fetchThumbnailUrlWithCache = (
   hass: HomeAssistant,
   entityId: string,
-  ...args: any[]
+  width: number,
+  height: number
 ) =>
   timeCachePromiseFunc(
     "_cameraTmbUrl",
@@ -47,16 +48,18 @@ export const fetchThumbnailUrlWithCache = (
     fetchThumbnailUrl,
     hass,
     entityId,
-    args
+    width,
+    height
   );
 
 export const fetchThumbnailUrl = async (
   hass: HomeAssistant,
   entityId: string,
-  ...args: any[]
+  width: number,
+  height: number
 ) => {
   const path = await getSignedPath(hass, `/api/camera_proxy/${entityId}`);
-  return hass.hassUrl(`${path.path}&width=${args[0][0]}&height=${args[0][1]}`);
+  return hass.hassUrl(`${path.path}&width=${width}&height=${height}`);
 };
 
 export const fetchStreamUrl = async (

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -48,7 +48,8 @@ export const fetchThumbnailUrlWithCache = (
     fetchThumbnailUrl,
     hass,
     entityId,
-    ...args
+    width,
+    height
   );
 
 export const fetchThumbnailUrl = async (

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -228,15 +228,19 @@ export class HuiImage extends LitElement {
       return;
     }
 
+    // One the first render we will known know the width
+    const element_width = this._image.offsetWidth
+      ? this._image.offsetWidth
+      : 640;
     // Because the aspect ratio might result in a smaller image,
     // we ask for 200% of what we need to make sure the image is
     // still clear. In practice, for 4k sources, this is still
     // an order of magnitude smaller.
-    const width = Math.ceil(this._image.offsetWidth * 2);
+    const width = Math.ceil(element_width * 2);
     // If the image has not rendered yet we may have a zero height
     const height = this._image.offsetHeight
       ? this._image.offsetHeight * 2
-      : Math.ceil(this._image.offsetWidth * 2 * (9 / 16));
+      : Math.ceil(element_width * 2 * (9 / 16));
 
     this._cameraImageSrc = await fetchThumbnailUrlWithCache(
       this.hass,

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -19,6 +19,10 @@ import { HomeAssistant } from "../../../types";
 const UPDATE_INTERVAL = 10000;
 const DEFAULT_FILTER = "grayscale(100%)";
 
+const MAX_IMAGE_WIDTH = 640;
+const ASPECT_RATIO_DEFAULT = 9 / 16;
+const SCALING_FACTOR = 2;
+
 export interface StateSpecificConfig {
   [state: string]: string;
 }
@@ -228,19 +232,19 @@ export class HuiImage extends LitElement {
       return;
     }
 
-    // One the first render we will known know the width
+    // One the first render we will not know the width
     const element_width = this._image.offsetWidth
       ? this._image.offsetWidth
-      : 640;
+      : MAX_IMAGE_WIDTH;
     // Because the aspect ratio might result in a smaller image,
     // we ask for 200% of what we need to make sure the image is
     // still clear. In practice, for 4k sources, this is still
     // an order of magnitude smaller.
-    const width = Math.ceil(element_width * 2);
+    const width = Math.ceil(element_width * SCALING_FACTOR);
     // If the image has not rendered yet we may have a zero height
     const height = this._image.offsetHeight
-      ? this._image.offsetHeight * 2
-      : Math.ceil(element_width * 2 * (9 / 16));
+      ? this._image.offsetHeight * SCALING_FACTOR
+      : Math.ceil(element_width * SCALING_FACTOR * ASPECT_RATIO_DEFAULT);
 
     this._cameraImageSrc = await fetchThumbnailUrlWithCache(
       this.hass,

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -228,9 +228,15 @@ export class HuiImage extends LitElement {
       return;
     }
 
+    // Because the aspect ratio might result in a smaller image,
+    // we ask for 200% of what we need to make sure the image is
+    // still clear. In practice, for 4k sources, this is still
+    // an order of magnitude smaller.
     this._cameraImageSrc = await fetchThumbnailUrlWithCache(
       this.hass,
-      this.cameraImage
+      this.cameraImage,
+      this._image.offsetWidth * 2,
+      this._image.offsetHeight * 2
     );
   }
 

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -228,17 +228,20 @@ export class HuiImage extends LitElement {
       return;
     }
 
-    const height = this._image.offsetHeight
-      ? this._image.offsetHeight * 2
-      : Math.ceil((this._image.offsetWidth * 2 * 3) / 4);
     // Because the aspect ratio might result in a smaller image,
     // we ask for 200% of what we need to make sure the image is
     // still clear. In practice, for 4k sources, this is still
     // an order of magnitude smaller.
+    const width = Math.ceil(this._image.offsetWidth * 2);
+    // If the image has not rendered yet we may have a zero height
+    const height = this._image.offsetHeight
+      ? this._image.offsetHeight * 2
+      : Math.ceil(this._image.offsetWidth * 2 * (9 / 16));
+
     this._cameraImageSrc = await fetchThumbnailUrlWithCache(
       this.hass,
       this.cameraImage,
-      this._image.offsetWidth * 2,
+      width,
       height
     );
   }

--- a/src/panels/lovelace/components/hui-image.ts
+++ b/src/panels/lovelace/components/hui-image.ts
@@ -228,6 +228,9 @@ export class HuiImage extends LitElement {
       return;
     }
 
+    const height = this._image.offsetHeight
+      ? this._image.offsetHeight * 2
+      : Math.ceil((this._image.offsetWidth * 2 * 3) / 4);
     // Because the aspect ratio might result in a smaller image,
     // we ask for 200% of what we need to make sure the image is
     // still clear. In practice, for 4k sources, this is still
@@ -236,7 +239,7 @@ export class HuiImage extends LitElement {
       this.hass,
       this.cameraImage,
       this._image.offsetWidth * 2,
-      this._image.offsetHeight * 2
+      height
     );
   }
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Pass the width and height when requesting camera images

Requires https://github.com/home-assistant/core/pull/53835

Testing:

- [x] Tested with Chrome with network throttling to fast 3g.  Cameras are now usable
- [x] Tested with mobile device with poor service.  Cameras are now usable

Additional improvement would be to not update cameras that are not inside the viewport, but that is outside the scope of this PR because even with this change there are timeouts on slow 3g (https://github.com/home-assistant/frontend/pull/9690).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
