### PR TITLE
Add disabled by column to entity datatable

### DIFF
--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -164,7 +164,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
   );
 
   private _columns = memoize(
-    (narrow, _language): DataTableColumnContainer => ({
+    (narrow, _language, showDisabled): DataTableColumnContainer => ({
       icon: {
         title: "",
         type: "icon",
@@ -220,6 +220,19 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         hidden: narrow,
         filterable: true,
         width: "15%",
+      },
+      disabled_by: {
+        title: this.hass.localize(
+          "ui.panel.config.entities.picker.headers.disabled_by"
+        ),
+        sortable: true,
+        hidden: narrow || !showDisabled,
+        filterable: true,
+        width: "15%",
+        template: (disabled_by) =>
+          this.hass.localize(
+            `ui.panel.config.devices.disabled_by.${disabled_by}`
+          ) || disabled_by,
       },
       status: {
         title: this.hass.localize(
@@ -466,7 +479,11 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
           : "/config"}
         .route=${this.route}
         .tabs=${configSections.integrations}
-        .columns=${this._columns(this.narrow, this.hass.language)}
+        .columns=${this._columns(
+          this.narrow,
+          this.hass.language,
+          this._showDisabled
+        )}
         .data=${filteredEntities}
         .activeFilters=${activeFilters}
         .numHidden=${this._numHiddenEntities}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2129,6 +2129,7 @@
               "entity_id": "Entity ID",
               "integration": "Integration",
               "area": "Area",
+              "disabled_by": "Disabled by",
               "status": "Status"
             },
             "selected": "{number} selected",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add a "Disabled by" column to the entities datatable.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
