### PR TITLE
Fix default strategy when energy is not configured

### DIFF
--- a/src/panels/lovelace/strategies/original-states-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states-strategy.ts
@@ -39,12 +39,7 @@ export class OriginalStatesStrategy {
       subscribeEntityRegistry(hass.connection, () => undefined);
     }
 
-    let energyPromise: Promise<EnergyPreferences> | undefined;
-
-    if (isComponentLoaded(hass, "energy")) {
-      energyPromise = getEnergyPreferences(hass);
-    }
-
+    let energyPrefs: EnergyPreferences | undefined;
     const [areaEntries, deviceEntries, entityEntries, localize] =
       await Promise.all([
         subscribeOne(hass.connection, subscribeAreaRegistry),
@@ -53,7 +48,13 @@ export class OriginalStatesStrategy {
         hass.loadBackendTranslation("title"),
       ]);
 
-    const energyPrefs = energyPromise ? await energyPromise : undefined;
+    if (isComponentLoaded(hass, "energy")) {
+      try {
+        energyPrefs = await getEnergyPreferences(hass);
+      } catch (_) {
+        // Nothing to do here
+      }
+    }
 
     // User can override default view. If they didn't, we will add one
     // that contains all entities.

--- a/src/panels/lovelace/strategies/original-states-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states-strategy.ts
@@ -39,7 +39,12 @@ export class OriginalStatesStrategy {
       subscribeEntityRegistry(hass.connection, () => undefined);
     }
 
-    let energyPrefs: EnergyPreferences | undefined;
+    let energyPromise: Promise<EnergyPreferences> | undefined;
+
+    if (isComponentLoaded(hass, "energy")) {
+      energyPromise = getEnergyPreferences(hass);
+    }
+
     const [areaEntries, deviceEntries, entityEntries, localize] =
       await Promise.all([
         subscribeOne(hass.connection, subscribeAreaRegistry),
@@ -48,9 +53,11 @@ export class OriginalStatesStrategy {
         hass.loadBackendTranslation("title"),
       ]);
 
-    if (isComponentLoaded(hass, "energy")) {
+    let energyPrefs: EnergyPreferences | undefined;
+
+    if (energyPromise) {
       try {
-        energyPrefs = await getEnergyPreferences(hass);
+        energyPrefs = await energyPromise;
       } catch (_) {
         // Nothing to do here
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9821
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
