### PR TITLE
Add ResizeObserver to EntityRow

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -1,5 +1,4 @@
 import "@polymer/paper-input/paper-input";
-import { debounce } from "chart.js/helpers";
 import {
   css,
   CSSResultGroup,
@@ -11,6 +10,7 @@ import {
 import { customElement, property, state } from "lit/decorators";
 import { computeStateDisplay } from "../../../common/entity/compute_state_display";
 import { computeRTLDirection } from "../../../common/util/compute_rtl";
+import { debounce } from "../../../common/util/debounce";
 import "../../../components/ha-slider";
 import { UNAVAILABLE_STATES } from "../../../data/entity";
 import { setValue } from "../../../data/input_text";

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -49,7 +49,7 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
   }
 
   public disconnectedCallback(): void {
-    this._resizeObserver?.unobserve(this);
+    this._resizeObserver?.disconnect();
   }
 
   protected firstUpdated(): void {
@@ -177,7 +177,9 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
         debounce(() => this._measureCard(), 250, false)
       );
     }
-    this._resizeObserver.observe(this);
+    if (this.parentElement) {
+      this._resizeObserver.observe(this.parentElement);
+    }
   }
 
   private get _inputElement(): { value: string } {

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -145,14 +145,6 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
 
   private async _initialLoad(): Promise<void> {
     this._loaded = true;
-    await this.updateComplete;
-    const element = this.shadowRoot!.querySelector(".state") as HTMLElement;
-
-    if (!element || !this.parentElement) {
-      return;
-    }
-
-    element.hidden = this.parentElement.clientWidth <= 300;
   }
 
   private get _inputElement(): { value: string } {

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -145,6 +145,15 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
 
   private async _initialLoad(): Promise<void> {
     this._loaded = true;
+    await this.updateComplete;
+    const element = this.shadowRoot!.querySelector(".state") as HTMLElement;
+
+    if (!element || !this.parentElement) {
+      return;
+    }
+
+    // TODO: This should update when resizeObserver detects a change.
+    element.hidden = this.parentElement.clientWidth <= 300;
   }
 
   private get _inputElement(): { value: string } {

--- a/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-number-entity-row.ts
@@ -130,6 +130,9 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
 
   static get styles(): CSSResultGroup {
     return css`
+      :host {
+        display: block;
+      }
       .flex {
         display: flex;
         align-items: center;
@@ -164,10 +167,10 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
       return;
     }
     const element = this.shadowRoot!.querySelector(".state") as HTMLElement;
-    if (!element || !this.parentElement) {
+    if (!element) {
       return;
     }
-    element.hidden = this.parentElement.clientWidth <= 300;
+    element.hidden = this.clientWidth <= 300;
   }
 
   private async _attachObserver(): Promise<void> {
@@ -177,8 +180,8 @@ class HuiInputNumberEntityRow extends LitElement implements LovelaceRow {
         debounce(() => this._measureCard(), 250, false)
       );
     }
-    if (this.parentElement) {
-      this._resizeObserver.observe(this.parentElement);
+    if (this.isConnected) {
+      this._resizeObserver.observe(this);
     }
   }
 


### PR DESCRIPTION
## Proposed change

Add observer to entity-rows so elements hidden due to space constraints
do not stay hidden when the window is resized (enlarged).

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #2905
- This PR is related to the discussion at: https://community.home-assistant.io/t/input-number-slider-not-showing-number/118241/12 (numbers on sliders being hidden depending on browser width)

## Checklist

- [ ] The code change is tested and works locally.
- [X ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
