### PR TITLE
Z-Wave JS Heal Node -> Heal Device

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2775,7 +2775,7 @@
             "node_ready": "Node Ready",
             "device_config": "Configure Device",
             "reinterview_device": "Re-interview Device",
-            "heal_node": "Heal Node",
+            "heal_node": "Heal Device",
             "remove_failed": "Remove Failed Device"
           },
           "node_config": {


### PR DESCRIPTION
Adjust heal_node translation from "Heal Node" to "Heal Device" to match the naming scheme of the other buttons under device info.