### PR TITLE
Show color temperature in the UI

### DIFF
--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -15,6 +15,7 @@ import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { stateIcon } from "../../common/entity/state_icon";
 import { iconColorCSS } from "../../common/style/icon_color_css";
 import type { HomeAssistant } from "../../types";
+import { computeLightColor } from "../../data/light";
 import "../ha-icon";
 
 export class StateBadge extends LitElement {
@@ -99,8 +100,11 @@ export class StateBadge extends LitElement {
         hostStyle.backgroundImage = `url(${imageUrl})`;
         this._showIcon = false;
       } else if (stateObj.state === "on") {
-        if (this.stateColor !== false && stateObj.attributes.rgb_color) {
-          iconStyle.color = `rgb(${stateObj.attributes.rgb_color.join(",")})`;
+        if (stateObj) {
+          const color = computeLightColor(stateObj);
+          if (color) {
+            iconStyle.color = color;
+          }
         }
         if (stateObj.attributes.brightness && this.stateColor !== false) {
           const brightness = stateObj.attributes.brightness;

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -30,7 +30,7 @@ import { stateIcon } from "../../../common/entity/state_icon";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import { iconColorCSS } from "../../../common/style/icon_color_css";
 import "../../../components/ha-card";
-import { LightEntity } from "../../../data/light";
+import { LightEntity, computeLightColor } from "../../../data/light";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
@@ -177,7 +177,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
                 (stateObj ? stateIcon(stateObj) : "")}
                 style=${styleMap({
                   filter: stateObj ? this._computeBrightness(stateObj) : "",
-                  color: stateObj ? this._computeColor(stateObj) : "",
+                  color: stateObj ? computeLightColor(stateObj) : "",
                   height: this._config.icon_height
                     ? this._config.icon_height
                     : "",
@@ -300,13 +300,6 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
     }
     const brightness = stateObj.attributes.brightness;
     return `brightness(${(brightness + 245) / 5}%)`;
-  }
-
-  private _computeColor(stateObj: HassEntity | LightEntity): string {
-    if (this._config?.state_color && stateObj.attributes.rgb_color) {
-      return `rgb(${stateObj.attributes.rgb_color.join(",")})`;
-    }
-    return "";
   }
 
   private _handleAction(ev: ActionHandlerEvent) {

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -19,7 +19,11 @@ import { stateIcon } from "../../../common/entity/state_icon";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
 import { UNAVAILABLE, UNAVAILABLE_STATES } from "../../../data/entity";
-import { LightEntity, lightSupportsDimming } from "../../../data/light";
+import {
+  LightEntity,
+  lightSupportsDimming,
+  computeLightColor,
+} from "../../../data/light";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
@@ -133,7 +137,7 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
                 .disabled=${UNAVAILABLE_STATES.includes(stateObj.state)}
                 style=${styleMap({
                   filter: this._computeBrightness(stateObj),
-                  color: this._computeColor(stateObj),
+                  color: computeLightColor(stateObj),
                 })}
                 @action=${this._handleAction}
                 .actionHandler=${actionHandler({
@@ -231,15 +235,6 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
     }
     const brightness = stateObj.attributes.brightness;
     return `brightness(${(brightness + 245) / 5}%)`;
-  }
-
-  private _computeColor(stateObj: LightEntity): string {
-    if (stateObj.state === "off") {
-      return "";
-    }
-    return stateObj.attributes.rgb_color
-      ? `rgb(${stateObj.attributes.rgb_color.join(",")})`
-      : "";
   }
 
   private _handleAction(ev: ActionHandlerEvent) {


### PR DESCRIPTION

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When debugging yeelights, it was difficult to do testing because
the UI didn't reflect the color temperature.

Ported the color temp to rgb code from homeassistant.util.color

<img width="297" alt="Screen Shot 2021-08-19 at 2 55 53 PM" src="https://user-images.githubusercontent.com/663432/130135926-2026f098-6d7d-4c87-89d8-001de4c015d5.png">
<img width="286" alt="Screen Shot 2021-08-19 at 2 55 50 PM" src="https://user-images.githubusercontent.com/663432/130135927-dae2068d-4fe5-47e8-8920-c3546a9ed4e3.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
