### PR TITLE
Include config entry title in delete confirmation prompt

### DIFF
--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -549,7 +549,8 @@ export class HaIntegrationCard extends LitElement {
 
     const confirmed = await showConfirmationDialog(this, {
       text: this.hass.localize(
-        "ui.panel.config.integrations.config_entry.delete_confirm"
+        "ui.panel.config.integrations.config_entry.delete_confirm",
+        { title: configEntry.title }
       ),
     });
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2317,7 +2317,7 @@
             "system_options": "System options",
             "documentation": "Documentation",
             "delete": "Delete",
-            "delete_confirm": "Are you sure you want to delete this integration?",
+            "delete_confirm": "Are you sure you want to delete the {title} integration?",
             "reload": "Reload",
             "restart_confirm": "Restart Home Assistant to finish removing this integration",
             "reload_confirm": "The integration was reloaded",


### PR DESCRIPTION
## Proposed change

Include the title of the config entry in the delete integration confirmation prompt.
![image](https://user-images.githubusercontent.com/7545841/130369705-cbea4369-1d87-49ac-8e79-7df9e386216d.png)

Should help clear up confusion in instances like this issue: https://github.com/home-assistant/core/issues/54991

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
