### PR TITLE
Add volatile_organic_compounds device class

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -79,6 +79,7 @@ export const FIXED_DEVICE_CLASS_ICONS = {
   signal_strength: "hass:wifi",
   sulphur_dioxide: "mdi:molecule",
   timestamp: "hass:clock",
+  volatile_organic_compounds: "mdi:molecule",
   voltage: "hass:sine-wave",
 };
 

--- a/src/util/hass-attributes-util.ts
+++ b/src/util/hass-attributes-util.ts
@@ -73,6 +73,7 @@ const hassAttributeUtil = {
       "sulphur_dioxide",
       "temperature",
       "timestamp",
+      "volatile_organic_compounds",
       "voltage",
     ],
     switch: ["switch", "outlet"],


### PR DESCRIPTION
## Proposed change

Add volatile_organic_compounds device class  to frontend (part of https://github.com/home-assistant/core/pull/55050).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/architecture/discussions/608
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19053

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
