### PR TITLE
Prevent possible parent action-row from switching to yamlMode

### DIFF
--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -252,6 +252,9 @@ export default class HaAutomationActionRow extends LitElement {
   }
 
   private _handleUiModeNotAvailable(ev: CustomEvent) {
+    // Prevent possible parent action-row from switching to yamlMode
+    ev.cancelBubble = true;
+
     this._warnings = handleStructError(this.hass, ev.detail).warnings;
     if (!this._yamlMode) {
       this._yamlMode = true;

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -253,7 +253,7 @@ export default class HaAutomationActionRow extends LitElement {
 
   private _handleUiModeNotAvailable(ev: CustomEvent) {
     // Prevent possible parent action-row from switching to yamlMode
-    ev.cancelBubble = true;
+    ev.stopPropagation();
 
     this._warnings = handleStructError(this.hass, ev.detail).warnings;
     if (!this._yamlMode) {

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -53,6 +53,9 @@ export default class HaAutomationAction extends LitElement {
   }
 
   private _move(ev: CustomEvent) {
+    // Prevent possible parent action-row from also moving
+    ev.cancelBubble = true;
+
     const index = (ev.target as any).index;
     const newIndex = ev.detail.direction === "up" ? index - 1 : index + 1;
     const actions = this.actions.concat();

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -54,7 +54,7 @@ export default class HaAutomationAction extends LitElement {
 
   private _move(ev: CustomEvent) {
     // Prevent possible parent action-row from also moving
-    ev.cancelBubble = true;
+    ev.stopPropagation();
 
     const index = (ev.target as any).index;
     const newIndex = ev.detail.direction === "up" ? index - 1 : index + 1;


### PR DESCRIPTION
Now that we have the choose action, it's possible to have nested action-rows. If an action contains a template, we should only switch that action-row to yamlMode instead of all action-rows.

This will also enable the ui-interactions such as reordering and deletion of individual yaml actions inside a choose action.

By canceling the bubbling on the first encouter we prevent the event from bubbling upwards to parent action-rows.

Implements: #9584

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
alias: New Automation
description: ''
mode: single
trigger: []
condition: []
action:
  - choose:
      - conditions: []
        sequence:
          - delay: '{{ 00:00:00:00 }}'
          - choose:
              - conditions: []
                sequence:
                  - delay: '{{ 12:34:56 }}'
            default: []
    default: []
  - service: notify.notify
    data:
      message: '{{}}'

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #9584
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
