### PR TITLE
Fix missing alarm state in translation: vacation

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -74,6 +74,7 @@
       "armed_home": "[%key:state_badge::alarm_control_panel::armed%]",
       "armed_away": "[%key:state_badge::alarm_control_panel::armed%]",
       "armed_night": "[%key:state_badge::alarm_control_panel::armed%]",
+      "armed_vacation": "[%key:state_badge::alarm_control_panel::armed%]",
       "armed_custom_bypass": "[%key:state_badge::alarm_control_panel::armed%]",
       "pending": "Pend",
       "arming": "Arming",
@@ -117,6 +118,7 @@
         "arm_home": "Arm home",
         "arm_away": "Arm away",
         "arm_night": "Arm night",
+        "arm_vacation": "Arm vacation"
         "arm_custom_bypass": "Custom bypass"
       },
       "automation": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -118,7 +118,7 @@
         "arm_home": "Arm home",
         "arm_away": "Arm away",
         "arm_night": "Arm night",
-        "arm_vacation": "Arm vacation"
+        "arm_vacation": "Arm vacation",
         "arm_custom_bypass": "Custom bypass"
       },
       "automation": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Vacation mode is missing in translation so button in frontend is empty:
<img width="353" alt="Capture d’écran 2021-08-27 à 12 28 37" src="https://user-images.githubusercontent.com/12999535/131115276-34bc3e18-b661-433f-9271-0fb944d8d6e5.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
