### PR TITLE
Multiple entities on history panel

### DIFF
--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -79,6 +79,8 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
+  @property({ type: Boolean }) public horizontal = false;
+
   @state() private _areas?: { [areaId: string]: AreaRegistryEntry };
 
   @state() private _devices?: {
@@ -117,45 +119,55 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     if (!this._areas || !this._devices || !this._entities) {
       return html``;
     }
-    return html`<div class="mdc-chip-set items">
-        ${this.value?.area_id
-          ? ensureArray(this.value.area_id).map((area_id) => {
-              const area = this._areas![area_id];
-              return this._renderChip(
-                "area_id",
-                area_id,
-                area?.name || area_id,
-                undefined,
-                mdiSofa
-              );
-            })
-          : ""}
-        ${this.value?.device_id
-          ? ensureArray(this.value.device_id).map((device_id) => {
-              const device = this._devices![device_id];
-              return this._renderChip(
-                "device_id",
-                device_id,
-                device ? computeDeviceName(device, this.hass) : device_id,
-                undefined,
-                mdiDevices
-              );
-            })
-          : ""}
-        ${this.value?.entity_id
-          ? ensureArray(this.value.entity_id).map((entity_id) => {
-              const entity = this.hass.states[entity_id];
-              return this._renderChip(
-                "entity_id",
-                entity_id,
-                entity ? computeStateName(entity) : entity_id,
-                entity
-              );
-            })
-          : ""}
-      </div>
+    return html`<div class=${this.horizontal ? "horizontal-container" : ""}>
+      ${this.horizontal ? this._renderChips() : this._renderItems()}
       ${this._renderPicker()}
-      <div class="mdc-chip-set">
+      ${this.horizontal ? this._renderItems() : this._renderChips()}
+    </div>`;
+  }
+
+  private _renderItems() {
+    return html`<div class="mdc-chip-set items">
+      ${this.value?.area_id
+        ? ensureArray(this.value.area_id).map((area_id) => {
+            const area = this._areas![area_id];
+            return this._renderChip(
+              "area_id",
+              area_id,
+              area?.name || area_id,
+              undefined,
+              mdiSofa
+            );
+          })
+        : ""}
+      ${this.value?.device_id
+        ? ensureArray(this.value.device_id).map((device_id) => {
+            const device = this._devices![device_id];
+            return this._renderChip(
+              "device_id",
+              device_id,
+              device ? computeDeviceName(device, this.hass) : device_id,
+              undefined,
+              mdiDevices
+            );
+          })
+        : ""}
+      ${this.value?.entity_id
+        ? ensureArray(this.value.entity_id).map((entity_id) => {
+            const entity = this.hass.states[entity_id];
+            return this._renderChip(
+              "entity_id",
+              entity_id,
+              entity ? computeStateName(entity) : entity_id,
+              entity
+            );
+          })
+        : ""}
+    </div>`;
+  }
+
+  private _renderChips() {
+    return html`<div class="mdc-chip-set">
         <div
           class="mdc-chip area_id add"
           .type=${"area_id"}
@@ -217,7 +229,6 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
           </span>
         </div>
       </div>
-
       ${this.helper
         ? html`<ha-input-helper-text>${this.helper}</ha-input-helper-text>`
         : ""} `;
@@ -321,6 +332,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
           .entityFilter=${this.entityRegFilter}
           .includeDeviceClasses=${this.includeDeviceClasses}
           .includeDomains=${this.includeDomains}
+          class=${this.horizontal ? "hidden-picker" : ""}
           @value-changed=${this._targetPicked}
         ></ha-area-picker>`;
       case "device_id":
@@ -335,6 +347,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
           .entityFilter=${this.entityRegFilter}
           .includeDeviceClasses=${this.includeDeviceClasses}
           .includeDomains=${this.includeDomains}
+          class=${this.horizontal ? "hidden-picker" : ""}
           @value-changed=${this._targetPicked}
         ></ha-device-picker>`;
       case "entity_id":
@@ -348,6 +361,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
           .entityFilter=${this.entityFilter}
           .includeDeviceClasses=${this.includeDeviceClasses}
           .includeDomains=${this.includeDomains}
+          class=${this.horizontal ? "hidden-picker" : ""}
           @value-changed=${this._targetPicked}
           allow-custom-entity
         ></ha-entity-picker>`;
@@ -539,6 +553,16 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
   static get styles(): CSSResultGroup {
     return css`
       ${unsafeCSS(chipStyles)}
+      .hidden-picker {
+        height: 0px;
+        display: inline-block;
+        overflow: hidden;
+        position: absolute;
+      }
+      .horizontal-container {
+        display: flex;
+        flex-wrap: wrap;
+      }
       .mdc-chip {
         color: var(--primary-text-color);
       }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -12,6 +12,7 @@ import {
 } from "date-fns/esm";
 import { css, html, LitElement, PropertyValues } from "lit";
 import { property, state } from "lit/decorators";
+import { UnsubscribeFunc } from "home-assistant-js-websocket/dist/types";
 import { navigate } from "../../common/navigate";
 import {
   createSearchParam,
@@ -19,7 +20,7 @@ import {
 } from "../../common/url/search-params";
 import { computeRTL } from "../../common/util/compute_rtl";
 import "../../components/chart/state-history-charts";
-import "../../components/entity/ha-entity-picker";
+import "../../components/ha-target-picker";
 import "../../components/ha-circular-progress";
 import "../../components/ha-date-range-picker";
 import type { DateRangePickerRanges } from "../../components/ha-date-range-picker";
@@ -29,8 +30,20 @@ import { computeHistory, fetchDateWS } from "../../data/history";
 import "../../layouts/ha-app-layout";
 import { haStyle } from "../../resources/styles";
 import { HomeAssistant } from "../../types";
+import {
+  EntityRegistryEntry,
+  subscribeEntityRegistry,
+} from "../../data/entity_registry";
+import { SubscribeMixin } from "../../mixins/subscribe-mixin";
+import { computeStateName } from "../../common/entity/compute_state_name";
+import { computeDomain } from "../../common/entity/compute_domain";
 
-class HaPanelHistory extends LitElement {
+export interface StateEntity extends EntityRegistryEntry {
+  readonly?: boolean;
+  selectable?: boolean;
+}
+
+class HaPanelHistory extends SubscribeMixin(LitElement) {
   @property() hass!: HomeAssistant;
 
   @property({ reflect: true, type: Boolean }) narrow!: boolean;
@@ -39,7 +52,7 @@ class HaPanelHistory extends LitElement {
 
   @property() _endDate: Date;
 
-  @property() _entityId = "";
+  @property() _targetPickerValue?;
 
   @property() _isLoading = false;
 
@@ -48,6 +61,10 @@ class HaPanelHistory extends LitElement {
   @property({ reflect: true, type: Boolean }) rtl = false;
 
   @state() private _ranges?: DateRangePickerRanges;
+
+  @state() private _entities?: EntityRegistryEntry[];
+
+  @state() private _stateEntities?: StateEntity[];
 
   public constructor() {
     super();
@@ -59,6 +76,14 @@ class HaPanelHistory extends LitElement {
     const end = new Date();
     end.setHours(end.getHours() + 1, 0, 0, 0);
     this._endDate = end;
+  }
+
+  public hassSubscribe(): UnsubscribeFunc[] {
+    return [
+      subscribeEntityRegistry(this.hass.connection!, (entities) => {
+        this._entities = entities;
+      }),
+    ];
   }
 
   protected render() {
@@ -80,25 +105,40 @@ class HaPanelHistory extends LitElement {
           </app-toolbar>
         </app-header>
 
-        <div class="filters">
-          <ha-date-range-picker
-            .hass=${this.hass}
-            ?disabled=${this._isLoading}
-            .startDate=${this._startDate}
-            .endDate=${this._endDate}
-            .ranges=${this._ranges}
-            @change=${this._dateRangeChanged}
-          ></ha-date-range-picker>
-
-          <ha-entity-picker
-            .hass=${this.hass}
-            .value=${this._entityId}
-            .label=${this.hass.localize(
-              "ui.components.entity.entity-picker.entity"
-            )}
-            .disabled=${this._isLoading}
-            @change=${this._entityPicked}
-          ></ha-entity-picker>
+        <div class="flex content">
+          <div class="filters flex layout horizontal narrow-wrap">
+            <ha-date-range-picker
+              .hass=${this.hass}
+              ?disabled=${this._isLoading}
+              .startDate=${this._startDate}
+              .endDate=${this._endDate}
+              .ranges=${this._ranges}
+              @change=${this._dateRangeChanged}
+            ></ha-date-range-picker>
+            <ha-target-picker
+              .hass=${this.hass}
+              .value=${this._targetPickerValue}
+              .disabled=${this._isLoading}
+              .horizontal=${true}
+              @value-changed=${this._entitiesChanged}
+            ></ha-target-picker>
+          </div>
+          ${this._isLoading
+            ? html`<div class="progress-wrapper">
+                <ha-circular-progress
+                  active
+                  alt=${this.hass.localize("ui.common.loading")}
+                ></ha-circular-progress>
+              </div>`
+            : html`
+                <state-history-charts
+                  .hass=${this.hass}
+                  .historyData=${this._stateHistory}
+                  .endTime=${this._endDate}
+                  no-single
+                >
+                </state-history-charts>
+              `}
         </div>
         ${this._isLoading
           ? html`<div class="progress-wrapper">
@@ -142,7 +182,13 @@ class HaPanelHistory extends LitElement {
         [addDays(weekStart, -7), addDays(weekEnd, -7)],
     };
 
-    this._entityId = extractSearchParam("entity_id") ?? "";
+    const entityIds = extractSearchParam("entity_id");
+    if (entityIds) {
+      const splitEntityIds = entityIds.split(",");
+      this._targetPickerValue = {
+        entity_id: splitEntityIds,
+      };
+    }
 
     const startDate = extractSearchParam("start_date");
     if (startDate) {
@@ -158,15 +204,42 @@ class HaPanelHistory extends LitElement {
     if (
       changedProps.has("_startDate") ||
       changedProps.has("_endDate") ||
-      changedProps.has("_entityId")
+      changedProps.has("_targetPickerValue") ||
+      changedProps.has("_entities")
     ) {
       this._getHistory();
     }
 
-    if (changedProps.has("hass")) {
+    if (changedProps.has("hass") || changedProps.has("_entities")) {
       const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
       if (!oldHass || oldHass.language !== this.hass.language) {
         this.rtl = computeRTL(this.hass);
+      }
+      if (this._entities) {
+        const stateEntities: StateEntity[] = [];
+        const regEntityIds = new Set(
+          this._entities.map((entity) => entity.entity_id)
+        );
+        for (const entityId of Object.keys(this.hass.states)) {
+          if (regEntityIds.has(entityId)) {
+            continue;
+          }
+          stateEntities.push({
+            name: computeStateName(this.hass.states[entityId]),
+            entity_id: entityId,
+            platform: computeDomain(entityId),
+            disabled_by: null,
+            hidden_by: null,
+            area_id: null,
+            config_entry_id: null,
+            device_id: null,
+            icon: null,
+            readonly: true,
+            selectable: false,
+            entity_category: null,
+          });
+        }
+        this._stateEntities = stateEntities;
       }
     }
   }
@@ -177,18 +250,105 @@ class HaPanelHistory extends LitElement {
 
   private async _getHistory() {
     this._isLoading = true;
-    const dateHistory = await fetchDateWS(
-      this.hass,
-      this._startDate,
-      this._endDate,
-      this._entityId
-    );
+    const entityIds = this._getEntityIds();
+    const dateHistory =
+      entityIds.length === 0
+        ? {}
+        : await fetchDateWS(
+            this.hass,
+            this._startDate,
+            this._endDate,
+            entityIds
+          );
     this._stateHistory = computeHistory(
       this.hass,
       dateHistory,
       this.hass.localize
     );
     this._isLoading = false;
+  }
+
+  private _getEntityIds(): string[] {
+    if (
+      this._targetPickerValue === undefined ||
+      this._entities === undefined ||
+      this._stateEntities === undefined
+    ) {
+      return [];
+    }
+    const entityIds = this._entities
+      .filter((entity) => {
+        const { area_id, device_id, entity_id } = this._targetPickerValue;
+        if (area_id !== undefined) {
+          if (typeof area_id === "string" && area_id === entity.area_id) {
+            return true;
+          }
+          if (Array.isArray(area_id) && area_id.includes(entity.area_id)) {
+            return true;
+          }
+        }
+        if (device_id !== undefined) {
+          if (typeof device_id === "string" && device_id === entity.device_id) {
+            return true;
+          }
+          if (
+            Array.isArray(device_id) &&
+            device_id.includes(entity.device_id)
+          ) {
+            return true;
+          }
+        }
+        if (entity_id !== undefined) {
+          if (typeof entity_id === "string" && entity_id === entity.entity_id) {
+            return true;
+          }
+          if (
+            Array.isArray(entity_id) &&
+            entity_id.includes(entity.entity_id)
+          ) {
+            return true;
+          }
+        }
+        return false;
+      })
+      .map((entity) => entity.entity_id);
+    const stateEntityIds = this._stateEntities
+      .filter((entity) => {
+        const { area_id, device_id, entity_id } = this._targetPickerValue;
+        if (area_id !== undefined) {
+          if (typeof area_id === "string" && area_id === entity.area_id) {
+            return true;
+          }
+          if (Array.isArray(area_id) && area_id.includes(entity.area_id)) {
+            return true;
+          }
+        }
+        if (device_id !== undefined) {
+          if (typeof device_id === "string" && device_id === entity.device_id) {
+            return true;
+          }
+          if (
+            Array.isArray(device_id) &&
+            device_id.includes(entity.device_id)
+          ) {
+            return true;
+          }
+        }
+        if (entity_id !== undefined) {
+          if (typeof entity_id === "string" && entity_id === entity.entity_id) {
+            return true;
+          }
+          if (
+            Array.isArray(entity_id) &&
+            entity_id.includes(entity.entity_id)
+          ) {
+            return true;
+          }
+        }
+        return false;
+      })
+      .map((entity) => entity.entity_id);
+    return [...entityIds, ...stateEntityIds];
   }
 
   private _dateRangeChanged(ev) {
@@ -203,8 +363,8 @@ class HaPanelHistory extends LitElement {
     this._updatePath();
   }
 
-  private _entityPicked(ev) {
-    this._entityId = ev.target.value;
+  private _entitiesChanged(ev) {
+    this._targetPickerValue = ev.detail.value;
 
     this._updatePath();
   }
@@ -212,8 +372,8 @@ class HaPanelHistory extends LitElement {
   private _updatePath() {
     const params: Record<string, string> = {};
 
-    if (this._entityId) {
-      params.entity_id = this._entityId;
+    if (this._targetPickerValue) {
+      params.entity_id = this._getEntityIds().join(",");
     }
 
     if (this._startDate) {
@@ -253,6 +413,18 @@ class HaPanelHistory extends LitElement {
 
         :host([virtualize]) {
           height: 100%;
+        }
+
+        :host([narrow]) .narrow-wrap {
+          flex-wrap: wrap;
+        }
+
+        .horizontal {
+          align-items: center;
+        }
+
+        :host(:not([narrow])) .selector-padding {
+          padding-left: 32px;
         }
 
         .progress-wrapper {

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -38,11 +38,6 @@ import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import { computeStateName } from "../../common/entity/compute_state_name";
 import { computeDomain } from "../../common/entity/compute_domain";
 
-export interface StateEntity extends EntityRegistryEntry {
-  readonly?: boolean;
-  selectable?: boolean;
-}
-
 class HaPanelHistory extends SubscribeMixin(LitElement) {
   @property() hass!: HomeAssistant;
 
@@ -64,7 +59,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
 
   @state() private _entities?: EntityRegistryEntry[];
 
-  @state() private _stateEntities?: StateEntity[];
+  @state() private _stateEntities?: EntityRegistryEntry[];
 
   public constructor() {
     super();
@@ -216,7 +211,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
         this.rtl = computeRTL(this.hass);
       }
       if (this._entities) {
-        const stateEntities: StateEntity[] = [];
+        const stateEntities: EntityRegistryEntry[] = [];
         const regEntityIds = new Set(
           this._entities.map((entity) => entity.entity_id)
         );
@@ -234,8 +229,6 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
             config_entry_id: null,
             device_id: null,
             icon: null,
-            readonly: true,
-            selectable: false,
             entity_category: null,
           });
         }
@@ -268,6 +261,35 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
     this._isLoading = false;
   }
 
+  private _filterEntity(entity: EntityRegistryEntry): boolean {
+    const { area_id, device_id, entity_id } = this._targetPickerValue;
+    if (area_id !== undefined) {
+      if (typeof area_id === "string" && area_id === entity.area_id) {
+        return true;
+      }
+      if (Array.isArray(area_id) && area_id.includes(entity.area_id)) {
+        return true;
+      }
+    }
+    if (device_id !== undefined) {
+      if (typeof device_id === "string" && device_id === entity.device_id) {
+        return true;
+      }
+      if (Array.isArray(device_id) && device_id.includes(entity.device_id)) {
+        return true;
+      }
+    }
+    if (entity_id !== undefined) {
+      if (typeof entity_id === "string" && entity_id === entity.entity_id) {
+        return true;
+      }
+      if (Array.isArray(entity_id) && entity_id.includes(entity.entity_id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private _getEntityIds(): string[] {
     if (
       this._targetPickerValue === undefined ||
@@ -277,76 +299,10 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
       return [];
     }
     const entityIds = this._entities
-      .filter((entity) => {
-        const { area_id, device_id, entity_id } = this._targetPickerValue;
-        if (area_id !== undefined) {
-          if (typeof area_id === "string" && area_id === entity.area_id) {
-            return true;
-          }
-          if (Array.isArray(area_id) && area_id.includes(entity.area_id)) {
-            return true;
-          }
-        }
-        if (device_id !== undefined) {
-          if (typeof device_id === "string" && device_id === entity.device_id) {
-            return true;
-          }
-          if (
-            Array.isArray(device_id) &&
-            device_id.includes(entity.device_id)
-          ) {
-            return true;
-          }
-        }
-        if (entity_id !== undefined) {
-          if (typeof entity_id === "string" && entity_id === entity.entity_id) {
-            return true;
-          }
-          if (
-            Array.isArray(entity_id) &&
-            entity_id.includes(entity.entity_id)
-          ) {
-            return true;
-          }
-        }
-        return false;
-      })
+      .filter((entity) => this._filterEntity(entity))
       .map((entity) => entity.entity_id);
     const stateEntityIds = this._stateEntities
-      .filter((entity) => {
-        const { area_id, device_id, entity_id } = this._targetPickerValue;
-        if (area_id !== undefined) {
-          if (typeof area_id === "string" && area_id === entity.area_id) {
-            return true;
-          }
-          if (Array.isArray(area_id) && area_id.includes(entity.area_id)) {
-            return true;
-          }
-        }
-        if (device_id !== undefined) {
-          if (typeof device_id === "string" && device_id === entity.device_id) {
-            return true;
-          }
-          if (
-            Array.isArray(device_id) &&
-            device_id.includes(entity.device_id)
-          ) {
-            return true;
-          }
-        }
-        if (entity_id !== undefined) {
-          if (typeof entity_id === "string" && entity_id === entity.entity_id) {
-            return true;
-          }
-          if (
-            Array.isArray(entity_id) &&
-            entity_id.includes(entity.entity_id)
-          ) {
-            return true;
-          }
-        }
-        return false;
-      })
+      .filter((entity) => this._filterEntity(entity))
       .map((entity) => entity.entity_id);
     return [...entityIds, ...stateEntityIds];
   }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -114,7 +114,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
               .hass=${this.hass}
               .value=${this._targetPickerValue}
               .disabled=${this._isLoading}
-              .horizontal=${true}
+              horizontal
               @value-changed=${this._entitiesChanged}
             ></ha-target-picker>
           </div>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Allow multiple entities to be selected on the history panel. I have found that for some use cases I want to see all entities together on a timeline and couldn't find any way to do it. On investigation of the history API I discovered that it is already possible to query the state of multiple entities using a comma-separated list. I switched out the entity-picker with an entities-picker and enhanced entities-picker to be displayed horizontally so that it looks somewhat neat.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change
User interface only modification to allow the user to select multiple entities on the history page instead of just one.

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- I didn't create an issue or anything to initially gather thoughts so let me know if I need to do something like that!

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
