### PR TITLE
Use integration manifest for service documentation URL

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -77,9 +77,8 @@ export class HaServiceControl extends LitElement {
       this.hass.services
     );
 
-    // Fetch the manifest if we have a service and either:
-    // a) no manifest yet
-    // b) the service domain changed
+    // Fetch the manifest if we have a service selected and the service domain changed.
+    // If no service is selected, clear the manifest.
     if (this.value?.service) {
       if (
         oldValue?.service

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -77,8 +77,20 @@ export class HaServiceControl extends LitElement {
       this.hass.services
     );
 
+    // Fetch the manifest if we have a service and either:
+    // a) no manifest yet
+    // b) the service domain changed
     if (this.value?.service) {
-      this._fetchManifest(computeDomain(this.value?.service));
+      if (
+        oldValue?.service
+          ? computeDomain(this.value?.service) !==
+            computeDomain(oldValue?.service)
+          : true
+      ) {
+        this._fetchManifest(computeDomain(this.value?.service));
+      }
+    } else {
+      this._manifest = undefined;
     }
 
     if (
@@ -311,7 +323,6 @@ export class HaServiceControl extends LitElement {
     if (ev.detail.value === this._value?.service) {
       return;
     }
-    this._manifest = undefined;
     fireEvent(this, "value-changed", {
       value: { service: ev.detail.value || "" },
     });

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -81,10 +81,8 @@ export class HaServiceControl extends LitElement {
     // If no service is selected, clear the manifest.
     if (this.value?.service) {
       if (
-        oldValue?.service
-          ? computeDomain(this.value?.service) !==
-            computeDomain(oldValue?.service)
-          : true
+        !oldValue?.service ||
+        computeDomain(this.value.service) !== computeDomain(oldValue.service)
       ) {
         this._fetchManifest(computeDomain(this.value?.service));
       }
@@ -405,6 +403,7 @@ export class HaServiceControl extends LitElement {
   }
 
   private async _fetchManifest(integration: string) {
+    this._manifest = undefined;
     try {
       this._manifest = await fetchIntegrationManifest(this.hass, integration);
     } catch (err) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Use the integration manifest for the service documentation, so that it also works for custom integrations.

If the user just switches to a different service from the same domain, no re-fetching happens. Only when a different domain is used, a new fetch request is triggered.

@bramkragten Do you think we need to add static caching to only retrieve the manifest once per integration (even if in between the user selects a different domain)? I would expect that usually a user is not wildly switching around the integrations when creating e.g. automations, so there should not be that many WS calls anyway.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9919
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
