### PR TITLE
Use dynamic struct validation for entities card rows

### DIFF
--- a/src/common/structs/is-custom-type.ts
+++ b/src/common/structs/is-custom-type.ts
@@ -1,6 +1,6 @@
 import { refine, string } from "superstruct";
 
-const isCustomType = (value: string) => value.startsWith("custom:");
+export const isCustomType = (value: string) => value.startsWith("custom:");
 
 export const customType = () =>
   refine(string(), "custom element type", isCustomType);

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -149,21 +149,13 @@ const customEntitiesRowConfigStruct = type({
   type: customType(),
 });
 
-// Required for dynamic validation below
-type baseEntitiesRowConfigStruct = {
-  type: string;
-};
-
 const entitiesRowConfigStruct = dynamic<any>((value) => {
-  if (
-    typeof value === "object" &&
-    Object.prototype.hasOwnProperty.call(value, "type")
-  ) {
-    if (isCustomType((value as baseEntitiesRowConfigStruct).type)) {
+  if (value && typeof value === "object" && "type" in value) {
+    if (isCustomType((value as LovelaceRowConfig).type!)) {
       return customEntitiesRowConfigStruct;
     }
 
-    switch ((value as baseEntitiesRowConfigStruct).type) {
+    switch ((value as LovelaceRowConfig).type!) {
       case "attribute": {
         return attributeEntitiesRowConfigStruct;
       }

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -149,17 +149,21 @@ const customEntitiesRowConfigStruct = type({
   type: customType(),
 });
 
-const entitiesRowConfigStruct = dynamic((value) => {
+// Required for dynamic validation below
+type baseEntitiesRowConfigStruct = {
+  type: string;
+};
+
+const entitiesRowConfigStruct = dynamic<any>((value) => {
   if (
     typeof value === "object" &&
-    value !== null &&
     Object.prototype.hasOwnProperty.call(value, "type")
   ) {
-    if (isCustomType(value.type)) {
+    if (isCustomType((value as baseEntitiesRowConfigStruct).type)) {
       return customEntitiesRowConfigStruct;
     }
 
-    switch (value.type) {
+    switch ((value as baseEntitiesRowConfigStruct).type) {
       case "attribute": {
         return attributeEntitiesRowConfigStruct;
       }
@@ -193,6 +197,7 @@ const entitiesRowConfigStruct = dynamic((value) => {
     }
   }
 
+  // No "type" property => has to be the default entity row config struct
   return entitiesConfigStruct;
 });
 

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -8,8 +8,9 @@ import {
   any,
   array,
   assert,
-  boolean,
   assign,
+  boolean,
+  dynamic,
   literal,
   number,
   object,
@@ -19,7 +20,10 @@ import {
   union,
 } from "superstruct";
 import { fireEvent, HASSDomEvent } from "../../../../common/dom/fire_event";
-import { customType } from "../../../../common/structs/is-custom-type";
+import {
+  customType,
+  isCustomType,
+} from "../../../../common/structs/is-custom-type";
 import { entityId } from "../../../../common/structs/is-entity-id";
 import { computeRTLDirection } from "../../../../common/util/compute_rtl";
 import "../../../../components/entity/state-badge";
@@ -38,6 +42,7 @@ import "../hui-entities-card-row-editor";
 import "../hui-sub-element-editor";
 import { processEditorEntities } from "../process-editor-entities";
 import { actionConfigStruct } from "../structs/action-struct";
+import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 import { entitiesConfigStruct } from "../structs/entities-struct";
 import {
   EditorTarget,
@@ -45,7 +50,6 @@ import {
   SubElementEditorConfig,
 } from "../types";
 import { configElementStyle } from "./config-elements-style";
-import { baseLovelaceCardConfig } from "../structs/base-card-struct";
 
 const buttonEntitiesRowConfigStruct = object({
   type: literal("button"),
@@ -141,24 +145,56 @@ const textEntitiesRowConfigStruct = object({
   icon: optional(string()),
 });
 
-const customRowConfigStruct = type({
+const customEntitiesRowConfigStruct = type({
   type: customType(),
 });
 
-const entitiesRowConfigStruct = union([
-  entitiesConfigStruct,
-  buttonEntitiesRowConfigStruct,
-  castEntitiesRowConfigStruct,
-  conditionalEntitiesRowConfigStruct,
-  dividerEntitiesRowConfigStruct,
-  sectionEntitiesRowConfigStruct,
-  webLinkEntitiesRowConfigStruct,
-  buttonsEntitiesRowConfigStruct,
-  attributeEntitiesRowConfigStruct,
-  callServiceEntitiesRowConfigStruct,
-  textEntitiesRowConfigStruct,
-  customRowConfigStruct,
-]);
+const entitiesRowConfigStruct = dynamic((value) => {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    Object.prototype.hasOwnProperty.call(value, "type")
+  ) {
+    if (isCustomType(value.type)) {
+      return customEntitiesRowConfigStruct;
+    }
+
+    switch (value.type) {
+      case "attribute": {
+        return attributeEntitiesRowConfigStruct;
+      }
+      case "button": {
+        return buttonEntitiesRowConfigStruct;
+      }
+      case "buttons": {
+        return buttonsEntitiesRowConfigStruct;
+      }
+      case "call-service": {
+        return callServiceEntitiesRowConfigStruct;
+      }
+      case "cast": {
+        return castEntitiesRowConfigStruct;
+      }
+      case "conditional": {
+        return conditionalEntitiesRowConfigStruct;
+      }
+      case "divider": {
+        return dividerEntitiesRowConfigStruct;
+      }
+      case "section": {
+        return sectionEntitiesRowConfigStruct;
+      }
+      case "text": {
+        return textEntitiesRowConfigStruct;
+      }
+      case "weblink": {
+        return webLinkEntitiesRowConfigStruct;
+      }
+    }
+  }
+
+  return entitiesConfigStruct;
+});
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Currently in the entities card editor, we show a lot of false-positive warnings and errors which really confuses the users.

The reason is that as all the existing row configs were in a union and the validation logic checked them all and basically listed all combinations of potential issues. Now by using [`dynamic`](https://docs.superstructjs.org/api-reference/utilities#dynamic) from `superstruct` we only check the config that matches the `type` of the row.

=> We now only show relevant errors to the user.

**Before:**

There are two errors here: The mandatory `attribute` key is missing plus the not yet supported `icon` key is there. But as the YAML input is not matching any row config, we see a huge list of false-positive errors.

![image](https://user-images.githubusercontent.com/114137/132139563-b99ed407-6319-46ca-881c-b45c8f201db9.png)

![image](https://user-images.githubusercontent.com/114137/132139565-8a0ac2f5-5647-43c4-afbe-0bd955dff011.png)


**After:**
![image](https://user-images.githubusercontent.com/114137/132139512-4aa748fb-341b-4a35-8b80-2978abdcc4b7.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #9586
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
