### PR TITLE
Add "paste list" option to shopping list card

### DIFF
--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -122,6 +122,7 @@ class HuiShoppingListCard
               )}
             >
             </ha-svg-icon>
+
             ${html`<paper-textarea
                 no-label-float
                 class="addBox"
@@ -371,10 +372,10 @@ class HuiShoppingListCard
       }
 
       .add-item-icon {
-        margin-right: 18px;
+        margin: 11px 18px 0 -2px;
         width: 22px;
         height: 22px;
-        margin-left: -2px;
+        align-self: flex-start;
       }
 
       .card-content {
@@ -382,8 +383,9 @@ class HuiShoppingListCard
       }
 
       .addButton {
-        padding: 12px 0 12px 20px;
+        padding: 10px 0 10px 20px;
         cursor: pointer;
+        align-self: flex-end;
       }
 
       .reorderButton {

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -379,7 +379,7 @@ class HuiShoppingListCard
     for (const item of input) {
       const trimmed = item.trim();
       if (trimmed !== "") {
-        this._addPastedItem(item);
+        this._addPastedItem(trimmed);
       }
     }
   }

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -393,21 +393,27 @@ class HuiShoppingListCard
         align-items: center;
       }
 
+      .card-content {
+        margin-top: 0;
+      }
+
       .input-mode .item {
         cursor: pointer;
         color: var(--secondary-text-color);
+      }
+
+      .input-mode .item.active,
+      .input-mode .item:hover {
+        color: var(--primary-text-color);
+        font-weight: 500;
       }
 
       .input-mode .item:first-of-type {
         margin: 0 28px 0 0;
       }
 
-      .input-mode .item.active {
-        color: var(--primary-text-color);
-      }
-
       .input-mode {
-        margin-bottom: 12px;
+        margin-bottom: 24px;
       }
 
       .input-mode ha-svg-icon {

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -1,8 +1,9 @@
-import { mdiDrag, mdiNotificationClearAll, mdiSort } from "@mdi/js";
+import { mdiDrag, mdiDotsVertical } from "@mdi/js";
 import "@polymer/paper-checkbox/paper-checkbox";
 import { PaperInputElement } from "@polymer/paper-input/paper-input";
 import "@polymer/paper-input/paper-textarea";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
+import { ActionDetail } from "@material/mwc-list";
 import {
   css,
   CSSResultGroup,
@@ -18,6 +19,7 @@ import { repeat } from "lit/directives/repeat";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
+import "../../../components/ha-button-menu";
 import {
   addItem,
   clearItems,
@@ -130,16 +132,25 @@ class HuiShoppingListCard
               @paste=${this._handlePaste}
               @keydown=${this._handleKeyPress}
             ></paper-textarea>`}
-
-            <ha-svg-icon
-              class="reorderButton"
-              .path=${mdiSort}
-              .title=${this.hass!.localize(
-                "ui.panel.lovelace.cards.shopping-list.reorder_items"
-              )}
-              @click=${this._toggleReorder}
-            >
-            </ha-svg-icon>
+            <ha-button-menu corner="BOTTOM_START" @action=${this._handleAction}>
+              <mwc-icon-button slot="trigger">
+                <ha-svg-icon .path=${mdiDotsVertical}></ha-svg-icon>
+              </mwc-icon-button>
+              <mwc-list-item>
+                ${this.hass!.localize(
+                  "ui.panel.lovelace.cards.shopping-list.clear_items"
+                )}
+              </mwc-list-item>
+              <mwc-list-item
+                >${this._reordering
+                  ? this.hass!.localize(
+                      "ui.panel.lovelace.cards.shopping-list.hide_reordering_tool"
+                    )
+                  : this.hass!.localize(
+                      "ui.panel.lovelace.cards.shopping-list.show_reordering_tool"
+                    )}
+              </mwc-list-item>
+            </ha-button-menu>
           </div>
           ${this._reordering
             ? html`
@@ -156,24 +167,6 @@ class HuiShoppingListCard
             : this._renderItems(this._uncheckedItems!)}
           ${this._checkedItems!.length > 0
             ? html`
-                <div class="divider"></div>
-                <div class="checked">
-                  <span>
-                    ${this.hass!.localize(
-                      "ui.panel.lovelace.cards.shopping-list.checked_items"
-                    )}
-                  </span>
-                  <ha-svg-icon
-                    class="clearall"
-                    tabindex="0"
-                    .path=${mdiNotificationClearAll}
-                    .title=${this.hass!.localize(
-                      "ui.panel.lovelace.cards.shopping-list.clear_items"
-                    )}
-                    @click=${this._clearItems}
-                  >
-                  </ha-svg-icon>
-                </div>
                 ${repeat(
                   this._checkedItems!,
                   (item) => item.id,
@@ -256,6 +249,17 @@ class HuiShoppingListCard
     }
     this._checkedItems = checkedItems;
     this._uncheckedItems = uncheckedItems;
+  }
+
+  private _handleAction(ev: CustomEvent<ActionDetail>) {
+    switch (ev.detail.index) {
+      case 0:
+        this._clearItems();
+        break;
+      case 1:
+        this._toggleReorder();
+        break;
+    }
   }
 
   private _completeItem(ev): void {

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -135,8 +135,13 @@ class HuiShoppingListCard
               <ha-svg-icon
                 class="list-icon"
                 .path=${mdiFormatListBulleted}
+                .title=${this.hass!.localize(
+                  "ui.panel.lovelace.cards.shopping-list.add_single_item"
+                )}
               ></ha-svg-icon
-              >Input single item
+              >${this.hass!.localize(
+                "ui.panel.lovelace.cards.shopping-list.add_single_item"
+              )}
             </div>
             <div
               class=${classMap({
@@ -148,22 +153,33 @@ class HuiShoppingListCard
               <ha-svg-icon
                 class="paste-icon"
                 .path=${mdiClipboardListOutline}
+                .title=${this.hass!.localize(
+                  "ui.panel.lovelace.cards.shopping-list.paste_list"
+                )}
               ></ha-svg-icon
-              >Paste list
+              >${this.hass!.localize(
+                "ui.panel.lovelace.cards.shopping-list.paste_list"
+              )}
             </div>
           </div>
           <div class="addRow">
+            <ha-svg-icon
+              class="addButton"
+              .path=${mdiPlus}
+              .title=${this._singleInput
+                ? this.hass!.localize(
+                    "ui.panel.lovelace.cards.shopping-list.add_item"
+                  )
+                : this.hass!.localize(
+                    "ui.panel.lovelace.cards.shopping-list.add_items"
+                  )}
+              @click=${this._singleInput
+                ? this._addItem
+                : this._handleMultipleItemsInput}
+            >
+            </ha-svg-icon>
             ${this._singleInput
               ? html`
-                  <ha-svg-icon
-                    class="addButton"
-                    .path=${mdiPlus}
-                    .title=${this.hass!.localize(
-                      "ui.panel.lovelace.cards.shopping-list.add_item"
-                    )}
-                    @click=${this._addItem}
-                  >
-                  </ha-svg-icon>
                   <paper-input
                     no-label-float
                     class="addBox"
@@ -173,21 +189,14 @@ class HuiShoppingListCard
                     @keydown=${this._addKeyPress}
                   ></paper-input>
                 `
-              : html`<ha-svg-icon
-                    class="addButton"
-                    .path=${mdiPlus}
-                    .title=${this.hass!.localize(
-                      "ui.panel.lovelace.cards.shopping-list.add_item"
-                    )}
-                    @click=${this._handleMultipleItemsInput}
-                  >
-                  </ha-svg-icon>
-                  <paper-textarea
-                    no-label-float
-                    class="addBox"
-                    placeholder="Paste a list of items (one per row)"
-                    @paste=${this._handlePaste}
-                  ></paper-textarea>`}
+              : html`<paper-textarea
+                  no-label-float
+                  class="addBox"
+                  placeholder=${this.hass!.localize(
+                    "ui.panel.lovelace.cards.shopping-list.textarea_placeholder"
+                  )}
+                  @paste=${this._handlePaste}
+                ></paper-textarea>`}
 
             <ha-svg-icon
               class="reorderButton"

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -440,7 +440,7 @@ class HuiShoppingListCard
       }
 
       .reorderButton {
-        padding-left: 16px;
+        padding: 12px;
         cursor: pointer;
       }
 

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -177,6 +177,7 @@ class HuiShoppingListCard
                   no-label-float
                   class="addBox"
                   placeholder="Paste a list of items (one per row)"
+                  @paste=${this._handlePaste}
                 ></paper-textarea>`}
 
             <ha-svg-icon
@@ -343,9 +344,29 @@ class HuiShoppingListCard
     }
   }
 
+  private _addPastedItem(item): void {
+    const newItem = this._newItem;
+    if (item.length > 0) {
+      addItem(this.hass!, item!).catch(() => this._fetchData());
+    }
+
+    newItem.value = "";
+
+    newItem.focus();
+  }
+
   private _addKeyPress(ev): void {
     if (ev.keyCode === 13) {
       this._addItem(null);
+    }
+  }
+
+  private _handlePaste(ev): void {
+    const splittedOnLinebreaks = ev.clipboardData.getData("text").split("\n");
+    for (const item of splittedOnLinebreaks) {
+      if (item.trim() !== "") {
+        this._addPastedItem(item);
+      }
     }
   }
 

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -267,21 +267,20 @@ class HuiShoppingListCard
   }
 
   private _addItem(item: string): void {
-    const newItem = this._newItem;
     if (item.length > 0) {
       addItem(this.hass!, item).catch(() => this._fetchData());
     }
-
-    newItem.value = "";
   }
 
   private _setUpList(input: string[]): void {
+    const newItem = this._newItem;
     for (const item of input) {
       const trimmed = item.trim();
       if (trimmed !== "") {
         this._addItem(trimmed);
       }
     }
+    newItem.value = "";
   }
 
   private _splitOnLineBreaks(input: string) {
@@ -300,7 +299,9 @@ class HuiShoppingListCard
 
   private _handlePaste(ev: {
     clipboardData: { getData: (arg0: string) => string };
+    preventDefault: () => void;
   }): void {
+    ev.preventDefault();
     this._splitOnLineBreaks(ev.clipboardData.getData("text"));
   }
 

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -8,6 +8,7 @@ import {
 } from "@mdi/js";
 import "@polymer/paper-checkbox/paper-checkbox";
 import { PaperInputElement } from "@polymer/paper-input/paper-input";
+import "@polymer/paper-input/paper-textarea";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import {
   css,
@@ -64,6 +65,8 @@ class HuiShoppingListCard
   @state() private _reordering = false;
 
   @state() private _renderEmptySortable = false;
+
+  @state() private _singleInput = true;
 
   private _sortable?;
 
@@ -122,14 +125,26 @@ class HuiShoppingListCard
       >
         <div class="card-content">
           <div class="input-mode">
-            <div class="item active">
+            <div
+              class=${classMap({
+                item: true,
+                active: this._singleInput,
+              })}
+              @click=${!this._singleInput ? this._toggleInput : null}
+            >
               <ha-svg-icon
                 class="list-icon"
                 .path=${mdiFormatListBulleted}
               ></ha-svg-icon
               >Input single item
             </div>
-            <div class="item">
+            <div
+              class=${classMap({
+                item: true,
+                active: !this._singleInput,
+              })}
+              @click=${this._singleInput ? this._toggleInput : null}
+            >
               <ha-svg-icon
                 class="paste-icon"
                 .path=${mdiClipboardListOutline}
@@ -147,14 +162,23 @@ class HuiShoppingListCard
               @click=${this._addItem}
             >
             </ha-svg-icon>
-            <paper-input
-              no-label-float
-              class="addBox"
-              placeholder=${this.hass!.localize(
-                "ui.panel.lovelace.cards.shopping-list.add_item"
-              )}
-              @keydown=${this._addKeyPress}
-            ></paper-input>
+            ${this._singleInput
+              ? html`
+                  <paper-input
+                    no-label-float
+                    class="addBox"
+                    placeholder=${this.hass!.localize(
+                      "ui.panel.lovelace.cards.shopping-list.add_item"
+                    )}
+                    @keydown=${this._addKeyPress}
+                  ></paper-input>
+                `
+              : html`<paper-textarea
+                  no-label-float
+                  class="addBox"
+                  placeholder="Paste a list of items (one per row)"
+                ></paper-textarea>`}
+
             <ha-svg-icon
               class="reorderButton"
               .path=${mdiSort}
@@ -342,6 +366,10 @@ class HuiShoppingListCard
     }
   }
 
+  private _toggleInput() {
+    this._singleInput = !this._singleInput;
+  }
+
   private _createSortable() {
     const sortableEl = this._sortableEl;
     this._sortable = new Sortable(sortableEl, {
@@ -400,12 +428,12 @@ class HuiShoppingListCard
       .input-mode .item {
         cursor: pointer;
         color: var(--secondary-text-color);
+        font-weight: 500;
       }
 
       .input-mode .item.active,
       .input-mode .item:hover {
         color: var(--primary-text-color);
-        font-weight: 500;
       }
 
       .input-mode .item.active:hover {
@@ -441,7 +469,8 @@ class HuiShoppingListCard
         --paper-checkbox-label-spacing: 0px;
       }
 
-      paper-input {
+      paper-input,
+      paper-textarea {
         flex-grow: 1;
       }
 

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -1,4 +1,11 @@
-import { mdiDrag, mdiNotificationClearAll, mdiPlus, mdiSort } from "@mdi/js";
+import {
+  mdiDrag,
+  mdiNotificationClearAll,
+  mdiPlus,
+  mdiSort,
+  mdiClipboardListOutline,
+  mdiFormatListBulleted,
+} from "@mdi/js";
 import "@polymer/paper-checkbox/paper-checkbox";
 import { PaperInputElement } from "@polymer/paper-input/paper-input";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
@@ -113,88 +120,108 @@ class HuiShoppingListCard
           "has-header": "title" in this._config,
         })}
       >
-        <div class="addRow">
-          <ha-svg-icon
-            class="addButton"
-            .path=${mdiPlus}
-            .title=${this.hass!.localize(
-              "ui.panel.lovelace.cards.shopping-list.add_item"
-            )}
-            @click=${this._addItem}
-          >
-          </ha-svg-icon>
-          <paper-input
-            no-label-float
-            class="addBox"
-            placeholder=${this.hass!.localize(
-              "ui.panel.lovelace.cards.shopping-list.add_item"
-            )}
-            @keydown=${this._addKeyPress}
-          ></paper-input>
-          <ha-svg-icon
-            class="reorderButton"
-            .path=${mdiSort}
-            .title=${this.hass!.localize(
-              "ui.panel.lovelace.cards.shopping-list.reorder_items"
-            )}
-            @click=${this._toggleReorder}
-          >
-          </ha-svg-icon>
-        </div>
-        ${this._reordering
-          ? html`
-              <div id="sortable">
-                ${guard([this._uncheckedItems, this._renderEmptySortable], () =>
-                  this._renderEmptySortable
-                    ? ""
-                    : this._renderItems(this._uncheckedItems!)
-                )}
-              </div>
-            `
-          : this._renderItems(this._uncheckedItems!)}
-        ${this._checkedItems!.length > 0
-          ? html`
-              <div class="divider"></div>
-              <div class="checked">
-                <span>
-                  ${this.hass!.localize(
-                    "ui.panel.lovelace.cards.shopping-list.checked_items"
-                  )}
-                </span>
-                <ha-svg-icon
-                  class="clearall"
-                  tabindex="0"
-                  .path=${mdiNotificationClearAll}
-                  .title=${this.hass!.localize(
-                    "ui.panel.lovelace.cards.shopping-list.clear_items"
-                  )}
-                  @click=${this._clearItems}
-                >
-                </ha-svg-icon>
-              </div>
-              ${repeat(
-                this._checkedItems!,
-                (item) => item.id,
-                (item) =>
-                  html`
-                    <div class="editRow">
-                      <paper-checkbox
-                        tabindex="0"
-                        ?checked=${item.complete}
-                        .itemId=${item.id}
-                        @click=${this._completeItem}
-                      ></paper-checkbox>
-                      <paper-input
-                        no-label-float
-                        .value=${item.name}
-                        .itemId=${item.id}
-                        @change=${this._saveEdit}
-                      ></paper-input>
-                    </div>
-                  `
+        <div class="card-content">
+          <div class="input-mode">
+            <div class="item active">
+              <ha-svg-icon
+                class="list-icon"
+                .path=${mdiFormatListBulleted}
+              ></ha-svg-icon
+              >Input single item
+            </div>
+            <div class="item">
+              <ha-svg-icon
+                class="paste-icon"
+                .path=${mdiClipboardListOutline}
+              ></ha-svg-icon
+              >Paste list
+            </div>
+          </div>
+          <div class="addRow">
+            <ha-svg-icon
+              class="addButton"
+              .path=${mdiPlus}
+              .title=${this.hass!.localize(
+                "ui.panel.lovelace.cards.shopping-list.add_item"
               )}
-            `
-          : ""}
+              @click=${this._addItem}
+            >
+            </ha-svg-icon>
+            <paper-input
+              no-label-float
+              class="addBox"
+              placeholder=${this.hass!.localize(
+                "ui.panel.lovelace.cards.shopping-list.add_item"
+              )}
+              @keydown=${this._addKeyPress}
+            ></paper-input>
+            <ha-svg-icon
+              class="reorderButton"
+              .path=${mdiSort}
+              .title=${this.hass!.localize(
+                "ui.panel.lovelace.cards.shopping-list.reorder_items"
+              )}
+              @click=${this._toggleReorder}
+            >
+            </ha-svg-icon>
+          </div>
+          ${this._reordering
+            ? html`
+                <div id="sortable">
+                  ${guard(
+                    [this._uncheckedItems, this._renderEmptySortable],
+                    () =>
+                      this._renderEmptySortable
+                        ? ""
+                        : this._renderItems(this._uncheckedItems!)
+                  )}
+                </div>
+              `
+            : this._renderItems(this._uncheckedItems!)}
+          ${this._checkedItems!.length > 0
+            ? html`
+                <div class="divider"></div>
+                <div class="checked">
+                  <span>
+                    ${this.hass!.localize(
+                      "ui.panel.lovelace.cards.shopping-list.checked_items"
+                    )}
+                  </span>
+                  <ha-svg-icon
+                    class="clearall"
+                    tabindex="0"
+                    .path=${mdiNotificationClearAll}
+                    .title=${this.hass!.localize(
+                      "ui.panel.lovelace.cards.shopping-list.clear_items"
+                    )}
+                    @click=${this._clearItems}
+                  >
+                  </ha-svg-icon>
+                </div>
+                ${repeat(
+                  this._checkedItems!,
+                  (item) => item.id,
+                  (item) =>
+                    html`
+                      <div class="editRow">
+                        <paper-checkbox
+                          tabindex="0"
+                          ?checked=${item.complete}
+                          .itemId=${item.id}
+                          @click=${this._completeItem}
+                        ></paper-checkbox>
+                        <paper-input
+                          no-label-float
+                          .value=${item.name}
+                          .itemId=${item.id}
+                          @change=${this._saveEdit}
+                        ></paper-input>
+                      </div>
+                    `
+                )}
+              `
+            : ""}
+        </div>
       </ha-card>
     `;
   }
@@ -349,7 +376,6 @@ class HuiShoppingListCard
   static get styles(): CSSResultGroup {
     return css`
       ha-card {
-        padding: 16px;
         height: 100%;
         box-sizing: border-box;
       }
@@ -360,15 +386,33 @@ class HuiShoppingListCard
 
       .editRow,
       .addRow,
-      .checked {
+      .checked,
+      .input-mode,
+      .input-mode .item {
         display: flex;
-        flex-direction: row;
         align-items: center;
       }
 
-      .addRow ha-icon {
+      .input-mode .item {
+        cursor: pointer;
         color: var(--secondary-text-color);
-        --mdc-icon-size: 26px;
+      }
+
+      .input-mode .item:first-of-type {
+        margin: 0 28px 0 0;
+      }
+
+      .input-mode .item.active {
+        color: var(--primary-text-color);
+      }
+
+      .input-mode {
+        margin-bottom: 12px;
+      }
+
+      .input-mode ha-svg-icon {
+        --mdc-icon-size: 18px;
+        padding-right: 4px;
       }
 
       .addButton {
@@ -399,12 +443,6 @@ class HuiShoppingListCard
       .checked span {
         color: var(--primary-text-color);
         font-weight: 500;
-      }
-
-      .divider {
-        height: 1px;
-        background-color: var(--divider-color);
-        margin: 10px 0;
       }
 
       .clearall {

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -408,6 +408,10 @@ class HuiShoppingListCard
         font-weight: 500;
       }
 
+      .input-mode .item.active:hover {
+        cursor: auto;
+      }
+
       .input-mode .item:first-of-type {
         margin: 0 28px 0 0;
       }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2903,6 +2903,10 @@
             "checked_items": "Checked items",
             "clear_items": "Clear checked items",
             "add_item": "Add item",
+            "add_items": "Add items",
+            "add_single_item": "Add single item",
+            "paste_list": "Paste list",
+            "textarea_placeholder": "Paste a list of items (one per row)",
             "reorder_items": "Reorder items",
             "drag_and_drop": "Drag and drop"
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2904,6 +2904,8 @@
             "clear_items": "Clear checked items",
             "add_item": "Add item",
             "reorder_items": "Reorder items",
+            "show_reordering_tool": "Show reordering tool",
+            "hide_reordering_tool": "Hide reordering tool",
             "drag_and_drop": "Drag and drop"
           },
           "picture-elements": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2903,10 +2903,6 @@
             "checked_items": "Checked items",
             "clear_items": "Clear checked items",
             "add_item": "Add item",
-            "add_items": "Add items",
-            "add_single_item": "Add single item",
-            "paste_list": "Paste list",
-            "textarea_placeholder": "Paste a list of items (one per row)",
             "reorder_items": "Reorder items",
             "drag_and_drop": "Drag and drop"
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2900,12 +2900,9 @@
             "never_triggered": "Never triggered"
           },
           "shopping-list": {
-            "checked_items": "Checked items",
+            "clear_item": "Clear checked item",
             "clear_items": "Clear checked items",
             "add_item": "Add item",
-            "reorder_items": "Reorder items",
-            "show_reordering_tool": "Show reordering tool",
-            "hide_reordering_tool": "Hide reordering tool",
             "drag_and_drop": "Drag and drop"
           },
           "picture-elements": {


### PR DESCRIPTION
## Proposed change

I found the following proposal of a new feature for the shopping list integration/card, making it possible to paste a list of items, instead of adding them one by one:

[https://github.com/home-assistant/frontend/issues/6224](https://github.com/home-assistant/frontend/issues/6224)

This PR implements this by letting the user switch between "single input mode" or "multi line input mode" in a textarea. Each new line (identified by line breaks) will be considered a new item.

Small demo of current state of the proposed change, showing: 

- A paste of the list 
- A manual input of multiple items at once 
- The functionality to trim unneeded spaces around the item and exclusion of empty items.

![screen-capture](https://user-images.githubusercontent.com/3705116/132247897-b25000d2-f40d-4e76-9045-d2a498b18bb8.gif)


## Type of change

The user can now decide if he/she wants to input each item one by one, or paste a whole list (maybe someone sent it by SMS, not an uncommon scenario in our family at least) at once. The user can also write a multiline list in the textarea introduced in this PR. Once he/she hits the add button, each row on in the text box are converted into list items. 

I have also introduced trim() on each string, to make sure no empty spaces or such are added to the list by mistake.

Some new strings has been introduced that I guess need to be translated. Not sure exactly what the process are on these?

Apart from this, I removed some legacy stylings that were no longer having an effect on the svg icons, which seems to have changed since this component was built. I also tried to align it slightly better in terms of margin/padding so that it looks and behaves more like the other cards generated from scratch in the dev environment container.

I didn't find the location of the tests, so I wasn't able to add any. But will of course update the PR once you give me directions on how to find the tests :)

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ X ] Code quality improvements to existing code or addition of tests

## Example configuration

No configuration needed more than activating the shoppingList integration and trying out the shopping list card and of course the pasting list option in particular.

## Additional information

- This PR implements the following feature request:
[https://github.com/home-assistant/frontend/issues/6224](https://github.com/home-assistant/frontend/issues/6224)

## Checklist

- [ X ] The code change is tested and works locally.
- [ X ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

I didn't find the location of the tests, so I wasn't able to add any. But will of course update the PR once you give me directions on how to find the tests :)
