### PR TITLE
Adjust dev-tools wording: "Active listeners"

### DIFF
--- a/src/panels/developer-tools/event/developer-tools-event.js
+++ b/src/panels/developer-tools/event/developer-tools-event.js
@@ -105,7 +105,7 @@ class HaPanelDevEvent extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
         <div>
           <div class="header">
-            [[localize( 'ui.panel.developer-tools.tabs.events.available_events'
+            [[localize( 'ui.panel.developer-tools.tabs.events.current_listeners'
             )]]
           </div>
           <events-list

--- a/src/panels/developer-tools/event/developer-tools-event.js
+++ b/src/panels/developer-tools/event/developer-tools-event.js
@@ -105,7 +105,7 @@ class HaPanelDevEvent extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
         <div>
           <div class="header">
-            [[localize( 'ui.panel.developer-tools.tabs.events.current_listeners'
+            [[localize( 'ui.panel.developer-tools.tabs.events.active_listeners'
             )]]
           </div>
           <events-list

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3664,7 +3664,7 @@
             "data": "Event Data (YAML, optional)",
             "fire_event": "Fire Event",
             "event_fired": "Event {name} fired",
-            "current_listeners": "Current listeners",
+            "active_listeners": "Active listeners",
             "count_listeners": " ({count}  listeners)",
             "listen_to_events": "Listen to events",
             "listening_to": "Listening to",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3664,7 +3664,7 @@
             "data": "Event Data (YAML, optional)",
             "fire_event": "Fire Event",
             "event_fired": "Event {name} fired",
-            "available_events": "Available Events",
+            "current_listeners": "Current listeners",
             "count_listeners": " ({count}  listeners)",
             "listen_to_events": "Listen to events",
             "listening_to": "Listening to",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Current heading is misleading, since it is not a (complete) list of possible events, but instead a list of the events that currently have active listeners.

![grafik](https://user-images.githubusercontent.com/114137/132553320-1bb0af36-e57b-4bdd-b639-be18da70f6f1.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9336
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
