### PR TITLE
Fix card deletion dialog buttons out of view

### DIFF
--- a/src/components/dialog/ha-paper-dialog.ts
+++ b/src/components/dialog/ha-paper-dialog.ts
@@ -15,7 +15,7 @@ const haTabFixBehaviorImpl = {
   },
 };
 
-// paper-dialog that uses the haTabFixBehaviorImpl behvaior
+// paper-dialog that uses the haTabFixBehaviorImpl behavior
 // export class HaPaperDialog extends paperDialogClass {}
 // @ts-ignore
 export class HaPaperDialog

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -26,6 +26,12 @@ export class HuiDialogDeleteCard extends LitElement {
     }
   }
 
+  public closeDialog(): void {
+    this._params = undefined;
+    this._cardConfig = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
   protected render(): TemplateResult {
     if (!this._params) {
       return html``;
@@ -34,7 +40,7 @@ export class HuiDialogDeleteCard extends LitElement {
     return html`
       <ha-dialog
         open
-        @closed=${this.close}
+        @closed=${this.closeDialog}
         .heading=${this.hass.localize("ui.panel.lovelace.cards.confirm_delete")}
       >
         <div>
@@ -49,7 +55,7 @@ export class HuiDialogDeleteCard extends LitElement {
               `
             : ""}
         </div>
-        <mwc-button slot="secondaryAction" @click="${this.close}">
+        <mwc-button slot="secondaryAction" @click="${this.closeDialog}">
           ${this.hass!.localize("ui.common.cancel")}
         </mwc-button>
         <mwc-button
@@ -80,18 +86,12 @@ export class HuiDialogDeleteCard extends LitElement {
     ];
   }
 
-  public close(): void {
-    this._params = undefined;
-    this._cardConfig = undefined;
-    fireEvent(this, "dialog-closed", { dialog: this.localName });
-  }
-
   private _delete(): void {
     if (!this._params?.deleteCard) {
       return;
     }
     this._params.deleteCard();
-    this.close();
+    this.closeDialog();
   }
 }
 

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -76,6 +76,9 @@ export class HuiDialogDeleteCard extends LitElement {
           display: block;
           width: 100%;
         }
+        ha-paper-dialog {
+          top: 0;
+        }
       `,
     ];
   }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -34,7 +34,7 @@ export class HuiDialogDeleteCard extends LitElement {
     return html`
       <ha-dialog
         open
-        @closed=${this._close}
+        @closed=${this.close}
         .heading=${this.hass.localize("ui.panel.lovelace.cards.confirm_delete")}
       >
         <div>
@@ -49,7 +49,7 @@ export class HuiDialogDeleteCard extends LitElement {
               `
             : ""}
         </div>
-        <mwc-button slot="secondaryAction" @click="${this._close}">
+        <mwc-button slot="secondaryAction" @click="${this.close}">
           ${this.hass!.localize("ui.common.cancel")}
         </mwc-button>
         <mwc-button
@@ -91,7 +91,7 @@ export class HuiDialogDeleteCard extends LitElement {
       return;
     }
     this._params.deleteCard();
-    this._close();
+    this.close();
   }
 }
 

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-delete-card.ts
@@ -80,7 +80,7 @@ export class HuiDialogDeleteCard extends LitElement {
     ];
   }
 
-  private _close(): void {
+  public close(): void {
     this._params = undefined;
     this._cardConfig = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

For bigger elements such as a `picture-element` card the deletion buttons are out of view. A window resize solves it (dialog gets centered on screen again), but the existing "iron-resize" does not seem to work. If the resize event fire is put in a `setTimeout()` it works for the first time the deletion dialog gets opened, but not any subsequent times (proofing that a delayed "iron-resize" once the deletion card preview has rendered works fine).

This is my rather hacky attempt at solving that. A more elegant solution would of course be preferred.

Note: Despite `top: 0;` the dialog is not smushed to the window top since it carries a `24px` margin anyway.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #7933
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
