### PR TITLE
Convert suggest-card dialog to `ha-dialog`

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-create-card.ts
@@ -55,6 +55,7 @@ export class HuiCreateDialogCard
   public closeDialog(): boolean {
     this._params = undefined;
     this._currTabIndex = 0;
+    this._selectedEntities = [];
     fireEvent(this, "dialog-closed", { dialog: this.localName });
     return true;
   }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
@@ -1,7 +1,8 @@
 import "@polymer/paper-dialog-scrollable/paper-dialog-scrollable";
 import deepFreeze from "deep-freeze";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state, query } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/dialog/ha-paper-dialog";
 import "../../../../components/ha-yaml-editor";
 import type { HaYamlEditor } from "../../../../components/ha-yaml-editor";
@@ -52,11 +53,15 @@ export class HuiDialogSuggestCard extends LitElement {
       return html``;
     }
     return html`
-      <ha-paper-dialog with-backdrop opened>
-        <h2>
-          ${this.hass!.localize("ui.panel.lovelace.editor.suggest_card.header")}
-        </h2>
-        <paper-dialog-scrollable>
+      <ha-dialog
+        open
+        scrimClickAction
+        @closed=${this._close}
+        .heading=${this.hass!.localize(
+          "ui.panel.lovelace.editor.suggest_card.header"
+        )}
+      >
+        <div>
           ${this._cardConfig
             ? html`
                 <div class="element-preview">
@@ -80,37 +85,39 @@ export class HuiDialogSuggestCard extends LitElement {
                 </div>
               `
             : ""}
-        </paper-dialog-scrollable>
-        <div class="paper-dialog-buttons">
-          <mwc-button @click="${this._close}">
-            ${this._params.yaml
-              ? this.hass!.localize("ui.common.close")
-              : this.hass!.localize("ui.common.cancel")}
-          </mwc-button>
-          ${!this._params.yaml
-            ? html`
-                <mwc-button @click="${this._pickCard}"
-                  >${this.hass!.localize(
-                    "ui.panel.lovelace.editor.suggest_card.create_own"
-                  )}</mwc-button
-                >
-                <mwc-button ?disabled="${this._saving}" @click="${this._save}">
-                  ${this._saving
-                    ? html`
-                        <ha-circular-progress
-                          active
-                          title="Saving"
-                          size="small"
-                        ></ha-circular-progress>
-                      `
-                    : this.hass!.localize(
-                        "ui.panel.lovelace.editor.suggest_card.add"
-                      )}
-                </mwc-button>
-              `
-            : ""}
         </div>
-      </ha-paper-dialog>
+        <mwc-button slot="secondaryAction" @click="${this._close}">
+          ${this._params.yaml
+            ? this.hass!.localize("ui.common.close")
+            : this.hass!.localize("ui.common.cancel")}
+        </mwc-button>
+        ${!this._params.yaml
+          ? html`
+              <mwc-button slot="primaryAction" @click="${this._pickCard}"
+                >${this.hass!.localize(
+                  "ui.panel.lovelace.editor.suggest_card.create_own"
+                )}</mwc-button
+              >
+              <mwc-button
+                slot="primaryAction"
+                ?disabled="${this._saving}"
+                @click="${this._save}"
+              >
+                ${this._saving
+                  ? html`
+                      <ha-circular-progress
+                        active
+                        title="Saving"
+                        size="small"
+                      ></ha-circular-progress>
+                    `
+                  : this.hass!.localize(
+                      "ui.panel.lovelace.editor.suggest_card.add"
+                    )}
+              </mwc-button>
+            `
+          : ""}
+      </ha-dialog>
     `;
   }
 
@@ -120,17 +127,17 @@ export class HuiDialogSuggestCard extends LitElement {
       css`
         @media all and (max-width: 450px), all and (max-height: 500px) {
           /* overrule the ha-style-dialog max-height on small screens */
-          ha-paper-dialog {
+          ha-dialog {
             max-height: 100%;
             height: 100%;
           }
         }
         @media all and (min-width: 850px) {
-          ha-paper-dialog {
+          ha-dialog {
             width: 845px;
           }
         }
-        ha-paper-dialog {
+        ha-dialog {
           max-width: 845px;
           --dialog-z-index: 5;
         }
@@ -157,6 +164,7 @@ export class HuiDialogSuggestCard extends LitElement {
   private _close(): void {
     this._params = undefined;
     this._cardConfig = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
   private _pickCard(): void {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
@@ -161,7 +161,7 @@ export class HuiDialogSuggestCard extends LitElement {
     ];
   }
 
-  private _close(): void {
+  public close(): void {
     this._params = undefined;
     this._cardConfig = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
@@ -56,7 +56,7 @@ export class HuiDialogSuggestCard extends LitElement {
       <ha-dialog
         open
         scrimClickAction
-        @closed=${this._close}
+        @closed=${this.close}
         .heading=${this.hass!.localize(
           "ui.panel.lovelace.editor.suggest_card.header"
         )}
@@ -86,7 +86,7 @@ export class HuiDialogSuggestCard extends LitElement {
               `
             : ""}
         </div>
-        <mwc-button slot="secondaryAction" @click="${this._close}">
+        <mwc-button slot="secondaryAction" @click="${this.close}">
           ${this._params.yaml
             ? this.hass!.localize("ui.common.close")
             : this.hass!.localize("ui.common.cancel")}
@@ -182,7 +182,7 @@ export class HuiDialogSuggestCard extends LitElement {
       path: this._params!.path,
       entities: this._params!.entities,
     });
-    this._close();
+    this.close();
   }
 
   private async _save(): Promise<void> {
@@ -204,7 +204,7 @@ export class HuiDialogSuggestCard extends LitElement {
     );
     this._saving = false;
     showSaveSuccessToast(this, this.hass);
-    this._close();
+    this.close();
   }
 }
 

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
@@ -106,7 +106,7 @@ export class HuiDialogSuggestCard extends LitElement {
               >
               <mwc-button
                 slot="primaryAction"
-                ?disabled="${this._saving}"
+                .disabled="${this._saving}"
                 @click="${this._save}"
               >
                 ${this._saving

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-suggest-card.ts
@@ -48,6 +48,12 @@ export class HuiDialogSuggestCard extends LitElement {
     }
   }
 
+  public closeDialog(): void {
+    this._params = undefined;
+    this._cardConfig = undefined;
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
   protected render(): TemplateResult {
     if (!this._params) {
       return html``;
@@ -56,7 +62,7 @@ export class HuiDialogSuggestCard extends LitElement {
       <ha-dialog
         open
         scrimClickAction
-        @closed=${this.close}
+        @closed=${this.closeDialog}
         .heading=${this.hass!.localize(
           "ui.panel.lovelace.editor.suggest_card.header"
         )}
@@ -86,7 +92,7 @@ export class HuiDialogSuggestCard extends LitElement {
               `
             : ""}
         </div>
-        <mwc-button slot="secondaryAction" @click="${this.close}">
+        <mwc-button slot="secondaryAction" @click="${this.closeDialog}">
           ${this._params.yaml
             ? this.hass!.localize("ui.common.close")
             : this.hass!.localize("ui.common.cancel")}
@@ -161,12 +167,6 @@ export class HuiDialogSuggestCard extends LitElement {
     ];
   }
 
-  public close(): void {
-    this._params = undefined;
-    this._cardConfig = undefined;
-    fireEvent(this, "dialog-closed", { dialog: this.localName });
-  }
-
   private _pickCard(): void {
     if (
       !this._params?.lovelaceConfig ||
@@ -182,7 +182,7 @@ export class HuiDialogSuggestCard extends LitElement {
       path: this._params!.path,
       entities: this._params!.entities,
     });
-    this.close();
+    this.closeDialog();
   }
 
   private async _save(): Promise<void> {
@@ -204,7 +204,7 @@ export class HuiDialogSuggestCard extends LitElement {
     );
     this._saving = false;
     showSaveSuccessToast(this, this.hass);
-    this.close();
+    this.closeDialog();
   }
 }
 

--- a/src/panels/lovelace/editor/card-editor/hui-entity-picker-table.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-entity-picker-table.ts
@@ -68,9 +68,7 @@ export class HuiEntityPickerTable extends LitElement {
           <div @click=${this._handleEntityClicked} style="cursor: pointer;">
             ${name}
             ${narrow
-              ? html`
-                  <div class="secondary">${entity.stateObj.entity_id}</div>
-                `
+              ? html` <div class="secondary">${entity.entity_id}</div> `
               : ""}
           </div>
         `,

--- a/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
+++ b/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
@@ -89,9 +89,9 @@ export class HuiUnusedEntities extends LitElement {
               icon: "",
               entity_id: entity,
               stateObj,
-              name: computeStateName(stateObj),
+              name: stateObj ? computeStateName(stateObj) : "Unavailable",
               domain: computeDomain(entity),
-              last_changed: stateObj!.last_changed,
+              last_changed: stateObj?.last_changed,
             };
           }) as DataTableRowData[]}
           @selected-changed=${this._handleSelectedChanged}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Move to `ha-dialog` to prevent the resizing & positioning issues.

Also clear the selected entities upon dialog closure to prevent weird behavior after entity based card suggestion flow was cancelled (wrong buttons state + no more change to select entities).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9452 fixes #9453
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
