### PR TITLE
Allow not_set value for timestamp device class

### DIFF
--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -1,2 +1,6 @@
+import { UNAVAILABLE_STATES } from "./entity";
+
 export const SENSOR_DEVICE_CLASS_BATTERY = "battery";
 export const SENSOR_DEVICE_CLASS_TIMESTAMP = "timestamp";
+export const NOT_SET = "not_set";
+export const VALID_TIMESTAMP_STATES = UNAVAILABLE_STATES + [NOT_SET];

--- a/src/data/sensor.ts
+++ b/src/data/sensor.ts
@@ -3,4 +3,4 @@ import { UNAVAILABLE_STATES } from "./entity";
 export const SENSOR_DEVICE_CLASS_BATTERY = "battery";
 export const SENSOR_DEVICE_CLASS_TIMESTAMP = "timestamp";
 export const NOT_SET = "not_set";
-export const VALID_TIMESTAMP_STATES = UNAVAILABLE_STATES + [NOT_SET];
+export const VALID_TIMESTAMP_STATES = UNAVAILABLE_STATES.concat([NOT_SET]);

--- a/src/panels/lovelace/cards/hui-glance-card.ts
+++ b/src/panels/lovelace/cards/hui-glance-card.ts
@@ -17,13 +17,15 @@ import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/entity/state-badge";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
-import { UNAVAILABLE_STATES } from "../../../data/entity";
 import {
   ActionHandlerEvent,
   CallServiceActionConfig,
   MoreInfoActionConfig,
 } from "../../../data/lovelace";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
+import {
+  SENSOR_DEVICE_CLASS_TIMESTAMP,
+  VALID_TIMESTAMP_STATES,
+} from "../../../data/sensor";
 import { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { findEntities } from "../common/find-entities";
@@ -319,7 +321,7 @@ export class HuiGlanceCard extends LitElement implements LovelaceCard {
                 ${computeDomain(entityConf.entity) === "sensor" &&
                 stateObj.attributes.device_class ===
                   SENSOR_DEVICE_CLASS_TIMESTAMP &&
-                !UNAVAILABLE_STATES.includes(stateObj.state)
+                !VALID_TIMESTAMP_STATES.includes(stateObj.state)
                   ? html`
                       <hui-timestamp-display
                         .hass=${this.hass}

--- a/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-sensor-entity-row.ts
@@ -8,9 +8,11 @@ import {
 } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { computeStateDisplay } from "../../../common/entity/compute_state_display";
-import { UNAVAILABLE_STATES } from "../../../data/entity";
 import { ActionHandlerEvent } from "../../../data/lovelace";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
+import {
+  SENSOR_DEVICE_CLASS_TIMESTAMP,
+  VALID_TIMESTAMP_STATES,
+} from "../../../data/sensor";
 import { HomeAssistant } from "../../../types";
 import { EntitiesCardEntityConfig } from "../cards/types";
 import { actionHandler } from "../common/directives/action-handler-directive";
@@ -71,7 +73,7 @@ class HuiSensorEntityRow extends LitElement implements LovelaceRow {
         >
           ${stateObj.attributes.device_class ===
             SENSOR_DEVICE_CLASS_TIMESTAMP &&
-          !UNAVAILABLE_STATES.includes(stateObj.state)
+          !VALID_TIMESTAMP_STATES.includes(stateObj.state)
             ? html`
                 <hui-timestamp-display
                   .hass=${this.hass}

--- a/src/state-summary/state-card-display.ts
+++ b/src/state-summary/state-card-display.ts
@@ -7,8 +7,10 @@ import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateDisplay } from "../common/entity/compute_state_display";
 import { computeRTL } from "../common/util/compute_rtl";
 import "../components/entity/state-info";
-import { UNAVAILABLE_STATES } from "../data/entity";
-import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../data/sensor";
+import {
+  SENSOR_DEVICE_CLASS_TIMESTAMP,
+  VALID_TIMESTAMP_STATES,
+} from "../data/sensor";
 import "../panels/lovelace/components/hui-timestamp-display";
 import { haStyle } from "../resources/styles";
 import type { HomeAssistant } from "../types";
@@ -42,7 +44,7 @@ export class StateCardDisplay extends LitElement {
           ${computeDomain(this.stateObj.entity_id) === "sensor" &&
           this.stateObj.attributes.device_class ===
             SENSOR_DEVICE_CLASS_TIMESTAMP &&
-          !UNAVAILABLE_STATES.includes(this.stateObj.state)
+          !VALID_TIMESTAMP_STATES.includes(this.stateObj.state)
             ? html` <hui-timestamp-display
                 .hass=${this.hass}
                 .ts=${new Date(this.stateObj.state)}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently sensor with device class timestamp only supports `unavailable` and `unknown` states apart from actual timestamp.
These states are quite special and usually used for error states. `unavailable` for example renders as a red sign in entity manager:
<img width="160" alt="Screenshot 2021-09-10 at 13 29 33" src="https://user-images.githubusercontent.com/3767331/132853438-56e1c46c-7c02-4415-9020-5c542410ddc8.png">

Some timestamp entities like alarms or timers may be not set and `unknown` state also doesn't represent that state correctly.

Right now `not_set` state will be rendered as `Invalid timestamp`, this PR addresses that.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
