### PR TITLE
Check for `null` action nodes before rendering

### DIFF
--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -115,10 +115,6 @@ export class HatScriptGraph extends LitElement {
   };
 
   private render_action_node(node: Action, path: string, graphStart = false) {
-    if (node === null) {
-      return html``;
-    }
-
     const type =
       Object.keys(this.typeRenderers).find((key) => key in node) || "other";
     this.renderedNodes[path] = { config: node, path };
@@ -177,21 +173,25 @@ export class HatScriptGraph extends LitElement {
                     ?track=${track_this}
                     ?active=${this.selected === branch_path}
                   ></hat-graph-node>
-                  ${ensureArray(branch.sequence).map((action, j) =>
-                    this.render_action_node(
-                      action,
-                      `${branch_path}/sequence/${j}`
-                    )
-                  )}
+                  ${branch.sequence !== null
+                    ? ensureArray(branch.sequence).map((action, j) =>
+                        this.render_action_node(
+                          action,
+                          `${branch_path}/sequence/${j}`
+                        )
+                      )
+                    : ""}
                 </div>
               `;
             })
           : ""}
         <div ?track=${track_default}>
           <hat-graph-spacer ?track=${track_default}></hat-graph-spacer>
-          ${ensureArray(config.default)?.map((action, i) =>
-            this.render_action_node(action, `${path}/default/${i}`)
-          )}
+          ${config.default !== null
+            ? ensureArray(config.default)?.map((action, i) =>
+                this.render_action_node(action, `${path}/default/${i}`)
+              )
+            : ""}
         </div>
       </hat-graph-branch>
     `;

--- a/src/components/trace/hat-script-graph.ts
+++ b/src/components/trace/hat-script-graph.ts
@@ -115,6 +115,10 @@ export class HatScriptGraph extends LitElement {
   };
 
   private render_action_node(node: Action, path: string, graphStart = false) {
+    if (node === null) {
+      return html``;
+    }
+
     const type =
       Object.keys(this.typeRenderers).find((key) => key in node) || "other";
     this.renderedNodes[path] = { config: node, path };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Handle `null` for `sequence` and `default`. In fact the fix is generic for all actions, but those are two I tested with. The backend allows those automation, so the frontend trace should handle them.

The path rendering looks a little bit off in the left path since there is no node in the right one, hence the left path has some slightly weird pathing angles, but I think this is unrelated to this PR.

![image](https://user-images.githubusercontent.com/114137/132945279-fe6b5dcb-0a8b-4d3c-9119-e2183f354598.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9901
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
