### PR TITLE
Unified alarm panel icons everywhere

### DIFF
--- a/src/common/entity/alarm_panel_icon.ts
+++ b/src/common/entity/alarm_panel_icon.ts
@@ -1,0 +1,22 @@
+/** Return an icon representing a alarm panel state. */
+
+export const alarmPanelIcon = (state?: string) => {
+  switch (state) {
+    case "armed_away":
+    case "armed_vacation":
+      return "hass:shield-lock";
+    case "armed_home":
+      return "hass:shield-home";
+    case "armed_night":
+      return "hass:shield-moon";
+    case "armed_custom_bypass":
+      return "hass:security";
+    case "pending":
+      return "hass:shield-outline";
+    case "triggered":
+      return "hass:bell-ring";
+    case "disarmed":
+    default:
+      return "hass:shield-check";
+  }
+};

--- a/src/common/entity/alarm_panel_icon.ts
+++ b/src/common/entity/alarm_panel_icon.ts
@@ -17,6 +17,7 @@ export const alarmPanelIcon = (state?: string) => {
     case "triggered":
       return "hass:bell-ring";
     case "disarmed":
+      return "hass:shield-off";
     default:
       return "hass:shield-check";
   }

--- a/src/common/entity/alarm_panel_icon.ts
+++ b/src/common/entity/alarm_panel_icon.ts
@@ -3,8 +3,9 @@
 export const alarmPanelIcon = (state?: string) => {
   switch (state) {
     case "armed_away":
-    case "armed_vacation":
       return "hass:shield-lock";
+    case "armed_vacation":
+      return "hass:shield-airplane";
     case "armed_home":
       return "hass:shield-home";
     case "armed_night":

--- a/src/common/entity/alarm_panel_icon.ts
+++ b/src/common/entity/alarm_panel_icon.ts
@@ -19,6 +19,6 @@ export const alarmPanelIcon = (state?: string) => {
     case "disarmed":
       return "hass:shield-off";
     default:
-      return "hass:shield-check";
+      return "hass:shield";
   }
 };

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -5,6 +5,7 @@ import { HassEntity } from "home-assistant-js-websocket";
  * Optionally pass in a state to influence the domain icon.
  */
 import { DEFAULT_DOMAIN_ICON, FIXED_DOMAIN_ICONS } from "../const";
+import { alarmPanelIcon } from "./alarm_panel_icon";
 import { binarySensorIcon } from "./binary_sensor_icon";
 import { coverIcon } from "./cover_icon";
 import { sensorIcon } from "./sensor_icon";
@@ -18,18 +19,7 @@ export const domainIcon = (
 
   switch (domain) {
     case "alarm_control_panel":
-      switch (compareState) {
-        case "armed_home":
-          return "hass:bell-plus";
-        case "armed_night":
-          return "hass:bell-sleep";
-        case "disarmed":
-          return "hass:bell-outline";
-        case "triggered":
-          return "hass:bell-ring";
-        default:
-          return "hass:bell";
-      }
+      return alarmPanelIcon(compareState);
 
     case "binary_sensor":
       return binarySensorIcon(compareState, stateObj);

--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -13,7 +13,6 @@ import secondsToDuration from "../../common/datetime/seconds_to_duration";
 import { computeStateDisplay } from "../../common/entity/compute_state_display";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { computeStateName } from "../../common/entity/compute_state_name";
-import { domainIcon } from "../../common/entity/domain_icon";
 import { stateIcon } from "../../common/entity/state_icon";
 import { timerTimeRemaining } from "../../data/timer";
 import { formatNumber } from "../../common/string/format_number";
@@ -141,26 +140,6 @@ export class HaStateLabelBadge extends LitElement {
     }
     switch (domain) {
       case "alarm_control_panel":
-        if (entityState.state === "pending") {
-          return "hass:clock-fast";
-        }
-        if (entityState.state === "armed_away") {
-          return "hass:nature";
-        }
-        if (entityState.state === "armed_home") {
-          return "hass:home-variant";
-        }
-        if (entityState.state === "armed_night") {
-          return "hass:weather-night";
-        }
-        if (entityState.state === "armed_custom_bypass") {
-          return "hass:shield-home";
-        }
-        if (entityState.state === "triggered") {
-          return "hass:alert-circle";
-        }
-        // state == 'disarmed'
-        return domainIcon(domain, entityState);
       case "binary_sensor":
       case "device_tracker":
       case "updater":

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -12,6 +12,7 @@ import { customElement, property, state, query } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { alarmPanelIcon } from "../../../common/entity/alarm_panel_icon";
 import "../../../components/ha-card";
 import "../../../components/ha-label-badge";
 import {
@@ -23,17 +24,6 @@ import { findEntities } from "../common/find-entities";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import type { LovelaceCard } from "../types";
 import { AlarmPanelCardConfig } from "./types";
-
-const ICONS = {
-  armed_away: "hass:shield-lock",
-  armed_custom_bypass: "hass:security",
-  armed_home: "hass:shield-home",
-  armed_night: "hass:shield-moon",
-  armed_vacation: "hass:shield-lock",
-  disarmed: "hass:shield-check",
-  pending: "hass:shield-outline",
-  triggered: "hass:bell-ring",
-};
 
 const BUTTONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "clear"];
 
@@ -162,7 +152,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       >
         <ha-label-badge
           class="${classMap({ [stateObj.state]: true })}"
-          .icon="${ICONS[stateObj.state] || "hass:shield-outline"}"
+          .icon="${alarmPanelIcon(stateObj.state)}"
           .label="${this._stateIconLabel(stateObj.state)}"
           @click=${this._handleMoreInfo}
         ></ha-label-badge>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Unified alarm panel icons everywhere

There should be same in alarm panel card and also in badges.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
