### PR TITLE
Prevent `computeDomain()` call if no entity ID selected

### DIFF
--- a/src/common/entity/compute_domain.ts
+++ b/src/common/entity/compute_domain.ts
@@ -1,2 +1,2 @@
 export const computeDomain = (entityId: string): string =>
-  entityId.substr(0, entityId.indexOf("."));
+  entityId ? entityId.substr(0, entityId.indexOf(".")) : "";

--- a/src/common/entity/compute_domain.ts
+++ b/src/common/entity/compute_domain.ts
@@ -1,2 +1,2 @@
 export const computeDomain = (entityId: string): string =>
-  entityId ? entityId.substr(0, entityId.indexOf(".")) : "";
+  entityId.substr(0, entityId.indexOf("."));

--- a/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
@@ -63,7 +63,9 @@ export class HuiGenericEntityRowEditor
       return html``;
     }
 
-    const domain = computeDomain(this._config.entity);
+    const domain = this._config.entity
+      ? computeDomain(this._config.entity)
+      : "";
 
     return html`
       <div class="card-config">

--- a/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
@@ -63,7 +63,7 @@ export class HuiGenericEntityRowEditor
       return html``;
     }
 
-    const domain = this._entity ? computeDomain(this._entity) : "";
+    const domain = computeDomain(this._entity);
 
     return html`
       <div class="card-config">

--- a/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-generic-entity-row-editor.ts
@@ -63,9 +63,7 @@ export class HuiGenericEntityRowEditor
       return html``;
     }
 
-    const domain = this._config.entity
-      ? computeDomain(this._config.entity)
-      : "";
+    const domain = this._entity ? computeDomain(this._entity) : "";
 
     return html`
       <div class="card-config">


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

1. Setup an Entities card
2. Enter the visual sub editor for a single row (via the "pencil" icon on the main Entities card editor)
3. Press the "X" icon in the entity selection field
4. JS exception occurs

This PR prevent the call to `computeDomain()` in that case.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
