### PR TITLE
Change <html> background color to improve over-scrolling

### DIFF
--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -46,7 +46,7 @@
         background-color: #THEMEC;
       }
       html {
-        background-color: var(--primary-background-color);
+        background-color: var(--app-header-background-color);
       }
       @media (prefers-color-scheme: dark) {
         html {


### PR DESCRIPTION
## Proposed change

Over-scrolling is very annoying. Currently, when over-scrolling, a giant white bar will appear at the top of the page (this is because the app header will move down). The goal with these changes to modify the default html background color (which is never seen unless over-scrolling) and make it match the header. This makes it so when you over-scroll you can barely tell, because the app header's background color and html background color blend together.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
