### PR TITLE
Add WebRTC stream player

### DIFF
--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -80,7 +80,7 @@ class HaCameraStream extends LitElement {
     ) {
       if (typeof RTCPeerConnection === "undefined") {
         return html`<ha-alert alert-type="error"
-          >${this.hass.localize(
+          >${this.hass!.localize(
             "ui.components.media-browser.video_not_supported"
           )}</ha-alert
         >`;

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -75,16 +75,23 @@ class HaCameraStream extends LitElement {
       return html``;
     }
     if (
-      supportsFeature(this.stateObj!, CAMERA_SUPPORT_STREAM) &&
-      this.stateObj!.attributes.stream_type === STREAM_TYPE_WEB_RTC
+      supportsFeature(this.stateObj, CAMERA_SUPPORT_STREAM) &&
+      this.stateObj.attributes.stream_type === STREAM_TYPE_WEB_RTC
     ) {
+      if (typeof RTCPeerConnection === "undefined") {
+        return html`<ha-alert alert-type="error"
+          >${this.hass.localize(
+            "ui.components.media-browser.video_not_supported"
+          )}</ha-alert
+        >`;
+      }
       return html` <ha-web-rtc-player
         autoplay
         playsinline
         .muted=${this.muted}
         .controls=${this.controls}
         .hass=${this.hass}
-        .entityid=${this.stateObj!.entity_id}
+        .entityid=${this.stateObj.entity_id}
       ></ha-web-rtc-player>`;
     }
     return html`
@@ -92,7 +99,7 @@ class HaCameraStream extends LitElement {
         ? html`
             <img
               .src=${__DEMO__
-                ? this.stateObj!.attributes.entity_picture!
+                ? this.stateObj.attributes.entity_picture!
                 : this._connected
                 ? computeMJPEGStreamUrl(this.stateObj)
                 : ""}

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -95,7 +95,7 @@ class HaCameraStream extends LitElement {
             .hass=${this.hass}
             .url=${this._url}
           ></ha-hls-player>`
-        : "";
+        : html``;
     }
     if (this.stateObj.attributes.stream_type === STREAM_TYPE_WEB_RTC) {
       return html` <ha-web-rtc-player
@@ -123,7 +123,7 @@ class HaCameraStream extends LitElement {
       return true;
     }
     if (
-      this.stateObj.attributes.stream_type === STREAM_TYPE_WEB_RTC &&
+      this.stateObj!.attributes.stream_type === STREAM_TYPE_WEB_RTC &&
       typeof RTCPeerConnection === "undefined"
     ) {
       // Stream requires WebRTC but browser does not support, so fallback to

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -7,7 +7,6 @@ import {
   TemplateResult,
 } from "lit";
 import { customElement, property, state, query } from "lit/decorators";
-import { fireEvent } from "../common/dom/fire_event";
 import { handleWebRtcOffer, WebRtcAnswer } from "../data/camera";
 import type { HomeAssistant } from "../types";
 import "./ha-alert";
@@ -51,7 +50,6 @@ class HaWebRtcPlayer extends LitElement {
         .muted=${this.muted}
         ?playsinline=${this.playsInline}
         ?controls=${this.controls}
-        @loadeddata=${this._elementResized}
       ></video>
     `;
   }
@@ -110,10 +108,6 @@ class HaWebRtcPlayer extends LitElement {
       sdp: webRtcAnswer.answer,
     });
     await peerConnection.setRemoteDescription(remoteDesc);
-  }
-
-  private _elementResized() {
-    fireEvent(this, "iron-resize");
   }
 
   private _cleanUp() {

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -1,0 +1,157 @@
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  PropertyValues,
+  TemplateResult,
+} from "lit";
+import { customElement, property, state, query } from "lit/decorators";
+import { fireEvent } from "../common/dom/fire_event";
+import { handleWebRtcOffer, WebRtcAnswer } from "../data/camera";
+import type { HomeAssistant } from "../types";
+
+@customElement("ha-web-rtc-player")
+class HaWebRtcPlayer extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public entityid!: string;
+
+  @property({ type: Boolean, attribute: "controls" })
+  public controls = false;
+
+  @property({ type: Boolean, attribute: "muted" })
+  public muted = false;
+
+  @property({ type: Boolean, attribute: "autoplay" })
+  public autoPlay = false;
+
+  @property({ type: Boolean, attribute: "playsinline" })
+  public playsInline = false;
+
+  @state() private _error?: string;
+
+  // don't cache this, as we remove it on disconnects
+  @query("#remote-stream") private _videoEl!: HTMLVideoElement;
+
+  protected render(): TemplateResult {
+    if (this._error) {
+      return html`<hass-error-screen
+        .error=${this._error}
+      ></hass-error-screen>`;
+    }
+    return html`
+      <video
+        id="remote-stream"
+        ?autoplay=${this.autoPlay}
+        .muted=${this.muted}
+        ?playsinline=${this.playsInline}
+        ?controls=${this.controls}
+        @loadeddata=${this._elementResized}
+      ></video>
+    `;
+  }
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this._cleanUp();
+  }
+
+  protected updated(changedProperties: PropertyValues<this>) {
+    if (!changedProperties.has("entityid")) {
+      return;
+    }
+    if (!this._videoEl) {
+      return;
+    }
+    this._startWebRtc();
+  }
+
+  private async _startWebRtc(): Promise<void> {
+    if (typeof RTCPeerConnection === "undefined") {
+      return;
+    }
+
+    // A WebRTC connection is established by first sending an offer through
+    // a signal path from the integration. An answer is returned, then all
+    // other stream is handled purely client side.
+    const peerConnection = new RTCPeerConnection();
+
+    // Some cameras (such as nest) require a data channel to establish a stream
+    // however, not used by any integrations.
+    peerConnection.createDataChannel("dataSendChannel");
+
+    // Get connection information about the remote stream throught the camera
+    // integration.
+    const offerOptions = {
+      offerToReceiveAudio: 1,
+      offerToReceiveVideo: 1,
+    };
+    const offer = await peerConnection.createOffer(offerOptions);
+    await peerConnection.setLocalDescription(offer);
+
+    let webRtcAnswer: WebRtcAnswer;
+    try {
+      webRtcAnswer = await handleWebRtcOffer(
+        this.hass!,
+        this.entityid!,
+        offer.sdp
+      );
+    } catch (err) {
+      this._error = "Failed to start WebRTC stream: " + err.message;
+      return;
+    }
+
+    // Render remote stream once media tracks are discovered.
+    const remoteStream = new MediaStream();
+    peerConnection.addEventListener("track", (event) => {
+      remoteStream.addTrack(event.track);
+      this._videoEl.srcObject = remoteStream;
+    });
+
+    // TODO: When there is an error negotiating a stream, can we display that?
+    // TODO: Can we detect a stream authentication failure and automatically reconnect?
+    // peerConnection.oniceconnectionstatechange = (event) => {
+    //    console.log("connection", peerConnection.iceConnectionState);
+    // };
+
+    // Initiate the stream with the remote device
+    const remoteDesc = new RTCSessionDescription({
+      type: "answer",
+      sdp: webRtcAnswer.answer,
+    });
+    await peerConnection.setRemoteDescription(remoteDesc);
+  }
+
+  private _elementResized() {
+    fireEvent(this, "iron-resize");
+  }
+
+  private _cleanUp() {
+    if (this._videoEl) {
+      const videoEl = this._videoEl;
+      videoEl.removeAttribute("src");
+      videoEl.load();
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    // TODO: Need to handle the case where the video is vertical so that it
+    // resizees to fit within the height of the screen.
+    return css`
+      video {
+        display: block;
+      }
+
+      video {
+        width: 100%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-web-rtc-player": HaWebRtcPlayer;
+  }
+}

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -88,8 +88,8 @@ class HaWebRtcPlayer extends LitElement {
     let webRtcAnswer: WebRtcAnswer;
     try {
       webRtcAnswer = await handleWebRtcOffer(
-        this.hass!,
-        this.entityid!,
+        this.hass,
+        this.entityid,
         offer.sdp!
       );
     } catch (err: any) {

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -70,6 +70,7 @@ class HaWebRtcPlayer extends LitElement {
   }
 
   private async _startWebRtc(): Promise<void> {
+    this._error = undefined;
     const peerConnection = new RTCPeerConnection();
     // Some cameras (such as nest) require a data channel to establish a stream
     // however, not used by any integrations.

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -72,17 +72,13 @@ class HaWebRtcPlayer extends LitElement {
   }
 
   private async _startWebRtc(): Promise<void> {
-    if (typeof RTCPeerConnection === "undefined") {
-      return;
-    }
-
     const peerConnection = new RTCPeerConnection();
     // Some cameras (such as nest) require a data channel to establish a stream
     // however, not used by any integrations.
     peerConnection.createDataChannel("dataSendChannel");
     const offerOptions: RTCOfferOptions = {
-      offerToReceiveAudio: 1,
-      offerToReceiveVideo: 1,
+      offerToReceiveAudio: true,
+      offerToReceiveVideo: true,
     };
     const offer: RTCSessionDescriptionInit = await peerConnection.createOffer(
       offerOptions
@@ -132,10 +128,6 @@ class HaWebRtcPlayer extends LitElement {
     return css`
       video {
         display: block;
-      }
-
-      video {
-        width: 100%;
       }
     `;
   }

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -90,7 +90,7 @@ class HaWebRtcPlayer extends LitElement {
       webRtcAnswer = await handleWebRtcOffer(
         this.hass!,
         this.entityid!,
-        offer.sdp
+        offer.sdp!
       );
     } catch (err: any) {
       this._error = "Failed to start WebRTC stream: " + err.message;

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -80,11 +80,13 @@ class HaWebRtcPlayer extends LitElement {
     // Some cameras (such as nest) require a data channel to establish a stream
     // however, not used by any integrations.
     peerConnection.createDataChannel("dataSendChannel");
-    const offerOptions = {
+    const offerOptions: RTCOfferOptions = {
       offerToReceiveAudio: 1,
       offerToReceiveVideo: 1,
     };
-    const offer = await peerConnection.createOffer(offerOptions);
+    const offer: RTCSessionDescriptionInit = await peerConnection.createOffer(
+      offerOptions
+    );
     await peerConnection.setLocalDescription(offer);
 
     let webRtcAnswer: WebRtcAnswer;
@@ -94,7 +96,7 @@ class HaWebRtcPlayer extends LitElement {
         this.entityid!,
         offer.sdp
       );
-    } catch (err) {
+    } catch (err: any) {
       this._error = "Failed to start WebRTC stream: " + err.message;
       return;
     }

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -86,19 +86,15 @@ export const fetchStreamUrl = async (
   return stream;
 };
 
-export const handleWebRtcOffer = async (
+export const handleWebRtcOffer = (
   hass: HomeAssistant,
   entityId: string,
   offer: string
-) => {
-  const data = {
+) => hass.callWS<WebRtcAnswer>({
     type: "camera/web_rtc_offer",
     entity_id: entityId,
     offer: offer,
-  };
-  const answer = await hass.callWS<WebRtcAnswer>(data);
-  return answer;
-};
+  });
 
 export const fetchCameraPrefs = (hass: HomeAssistant, entityId: string) =>
   hass.callWS<CameraPreferences>({

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -9,11 +9,15 @@ import { getSignedPath } from "./auth";
 export const CAMERA_SUPPORT_ON_OFF = 1;
 export const CAMERA_SUPPORT_STREAM = 2;
 
+export const STREAM_TYPE_HLS = "hls";
+export const STREAM_TYPE_WEB_RTC = "web_rtc";
+
 interface CameraEntityAttributes extends HassEntityAttributeBase {
   model_name: string;
   access_token: string;
   brand: string;
   motion_detection: boolean;
+  stream_type: string;
 }
 
 export interface CameraEntity extends HassEntityBase {
@@ -31,6 +35,10 @@ export interface CameraThumbnail {
 
 export interface Stream {
   url: string;
+}
+
+export interface WebRtcAnswer {
+  answer: string;
 }
 
 export const computeMJPEGStreamUrl = (entity: CameraEntity) =>
@@ -76,6 +84,20 @@ export const fetchStreamUrl = async (
   const stream = await hass.callWS<Stream>(data);
   stream.url = hass.hassUrl(stream.url);
   return stream;
+};
+
+export const handleWebRtcOffer = async (
+  hass: HomeAssistant,
+  entityId: string,
+  offer: string
+) => {
+  const data = {
+    type: "camera/web_rtc_offer",
+    entity_id: entityId,
+    offer: offer,
+  };
+  const answer = await hass.callWS<WebRtcAnswer>(data);
+  return answer;
 };
 
 export const fetchCameraPrefs = (hass: HomeAssistant, entityId: string) =>

--- a/src/data/camera.ts
+++ b/src/data/camera.ts
@@ -90,7 +90,8 @@ export const handleWebRtcOffer = (
   hass: HomeAssistant,
   entityId: string,
   offer: string
-) => hass.callWS<WebRtcAnswer>({
+) =>
+  hass.callWS<WebRtcAnswer>({
     type: "camera/web_rtc_offer",
     entity_id: entityId,
     offer: offer,

--- a/src/dialogs/more-info/controls/more-info-camera.ts
+++ b/src/dialogs/more-info/controls/more-info-camera.ts
@@ -17,6 +17,7 @@ import {
   CameraPreferences,
   CAMERA_SUPPORT_STREAM,
   fetchCameraPrefs,
+  STREAM_TYPE_HLS,
   updateCameraPrefs,
 } from "../../../data/camera";
 import type { HomeAssistant } from "../../../types";
@@ -82,7 +83,10 @@ class MoreInfoCamera extends LitElement {
     if (
       curEntityId &&
       isComponentLoaded(this.hass!, "stream") &&
-      supportsFeature(this.stateObj!, CAMERA_SUPPORT_STREAM)
+      supportsFeature(this.stateObj!, CAMERA_SUPPORT_STREAM) &&
+      // The stream component for HLS streams supports a server-side pre-load
+      // option that client initiated WebRTC streams do not
+      this.stateObj!.attributes.stream_type === STREAM_TYPE_HLS
     ) {
       // Fetch in background while we set up the video.
       this._fetchCameraPrefs();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add support for playing WebRTC Streams, initially motivated by Nest Battery Camera / Doorbell.  
This is an implementation of https://github.com/home-assistant/architecture/discussions/640

This introduces a new element `ha-web-rtc-player` that is used by the `ha-camera-stream` element for cameras of `stream_type` for `STREAM_TYPE_WEB_RTC`. 

The stream is initiated by creating a `RTCPeerConnection` which creates an `offer`. This is passed down to core, where the integration is asked to pass the `offer` to the remote device via a signaling path, and the response is an `answer` which contains information for how the javascript client can connect to the remote device.  See https://webrtc.org/getting-started/peer-connections for additional detail on establishing a connection.  In the specific case of a nest camera, this translates to a [GenerateWebRtcStream](https://developers.google.com/nest/device-access/traits/device/camera-live-stream#generatewebrtcstream) RPC against the API.

Once a connection is established, the remote tracks are added to the local `MediaStream` for playback.  See https://webrtc.org/getting-started/remote-streams for more detail.  Nest cameras require a data channel, however, it does not appear to actually communicate any information at the moment.

Overall tasks I have planned:
- [X] Initial working end-to-end, tested on Chrome Desktop with a Nest Doorbell Camera
- [ ] Handle resizing of the window for vertical video for Doorbell cameras
- [ ] Testing on multiple browsers and devices
- [ ] Testing of various NAT scenarios
- [ ] Error handling for initial connection failures
- [ ] Handling for errors once stream is established (e.g. nest stream expiration)

Support for `nest` WebRTC is tracked in https://github.com/home-assistant/core/issues/55302

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/55302
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
