### PR TITLE
Apply flat polyfill globally

### DIFF
--- a/src/entrypoints/authorize.ts
+++ b/src/entrypoints/authorize.ts
@@ -4,6 +4,7 @@ import "../auth/ha-authorize";
 import "../resources/ha-style";
 import "../resources/roboto";
 import "../resources/safari-14-attachshadow-patch";
+import "../resources/array.flat.polyfill";
 
 /* polyfill for paper-dropdown */
 setTimeout(

--- a/src/entrypoints/onboarding.ts
+++ b/src/entrypoints/onboarding.ts
@@ -4,6 +4,7 @@ import "../onboarding/ha-onboarding";
 import "../resources/ha-style";
 import "../resources/roboto";
 import "../resources/safari-14-attachshadow-patch";
+import "../resources/array.flat.polyfill";
 
 declare global {
   interface Window {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Globally enable the `Array.prototype.flat` polyfill.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

On my older Android tablet (before I updated Chrome and Web View), I was seeing this error when trying to log in with the companion app:

```
"Uncaught (in promise) TypeError: e.flat is not a function", source: http://192.168.88.200/frontend_latest/authorize.328ad78a.js
```

This led me to #9404, where it appeared that the `Array.prototype.flat` polyfill had only been added to the `core` entrypoint. It looks like this polyfill might actually be needed globally (or at least also for the authorize entrypoint).

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x]  There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
