### PR TITLE
Add "customize" button to entity registry settings panel

### DIFF
--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -13,6 +13,7 @@ import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { domainIcon } from "../../../common/entity/domain_icon";
+import { navigate } from "../../../common/navigate";
 import "../../../components/ha-area-picker";
 import "../../../components/ha-expansion-panel";
 import "../../../components/ha-icon-input";
@@ -235,14 +236,23 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
           : ""}
       </div>
       <div class="buttons">
-        <mwc-button
-          class="warning"
-          @click=${this._confirmDeleteEntry}
-          .disabled=${this._submitting ||
-          !(stateObj && stateObj.attributes.restored)}
-        >
-          ${this.hass.localize("ui.dialogs.entity_registry.editor.delete")}
-        </mwc-button>
+        <div>
+          <mwc-button
+            class="warning"
+            @click=${this._confirmDeleteEntry}
+            .disabled=${this._submitting ||
+            !(stateObj && stateObj.attributes.restored)}
+          >
+            ${this.hass.localize("ui.dialogs.entity_registry.editor.delete")}
+          </mwc-button>
+          ${this.hass.userData?.showAdvanced
+            ? html`<mwc-button @click=${this._goToCustomize}>
+                ${this.hass.localize(
+                  "ui.dialogs.entity_registry.editor.customize"
+                )}
+              </mwc-button>`
+            : ""}
+        </div>
         <mwc-button
           @click=${this._updateEntry}
           .disabled=${invalidDomainUpdate || this._submitting}
@@ -354,6 +364,11 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
 
   private _disabledByChanged(ev: Event): void {
     this._disabledBy = (ev.target as HaSwitch).checked ? null : "user";
+  }
+
+  private _goToCustomize(): void {
+    navigate(`/config/customize/edit/${this.entry.entity_id}`);
+    fireEvent(this as HTMLElement, "close-dialog");
   }
 
   static get styles(): CSSResultGroup {

--- a/translations/frontend/en.json
+++ b/translations/frontend/en.json
@@ -992,7 +992,8 @@
                     "note": "Note: This might not work yet with all integrations.",
                     "open_device_settings": "Open device settings",
                     "unavailable": "This entity is not currently available.",
-                    "update": "Update"
+                    "update": "Update",
+                    "customize": "Customize"
                 },
                 "faq": "documentation",
                 "info_customize": "You can overwrite some attributes in the {customize_link} section.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

For users with "advanced mode" enabled, this change adds a Customize button to the entity registry settings panel next to the existing "delete" button. It provides an easy entrypoint to customize an entity beyond what's possible in the settings panel. With new features like long-term statistics, it's becoming more common to need to edit things like device class and state class. This makes that functionality more discoverable for entities with unique IDs (as we already have such a link in the panel for entities without unique IDs).

Please note that this is my first contribution to the `frontend` repo, so I was not positive on the right way to add this new localized string. Please let me know if there are more changes to make to do this right.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
