### PR TITLE
Handle text overflow for tabs

### DIFF
--- a/src/components/ha-tab.ts
+++ b/src/components/ha-tab.ts
@@ -98,6 +98,7 @@ export class HaTab extends LitElement {
         box-sizing: border-box;
         align-items: center;
         justify-content: center;
+        width: 100%;
         height: var(--header-height);
         cursor: pointer;
         position: relative;
@@ -106,6 +107,9 @@ export class HaTab extends LitElement {
 
       .name {
         white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
       }
 
       :host([active]) {
@@ -121,6 +125,10 @@ export class HaTab extends LitElement {
         display: flex;
         justify-content: center;
         overflow: hidden;
+      }
+
+      :host([narrow]) div {
+        padding: 0 4px;
       }
     `;
   }

--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -236,6 +236,12 @@ class HassTabsSubpage extends LitElement {
       #tabbar {
         display: flex;
         font-size: 14px;
+        overflow: hidden;
+      }
+
+      #tabbar > a {
+        overflow: hidden;
+        max-width: 45%;
       }
 
       #tabbar.bottom-bar {


### PR DESCRIPTION
## Proposed change

This change handles text overflow in the tabs interface, both at wide and narrow screen widths by adding the necessary CSS to make `text-overflow: ellipsis` work here. Also, at narrow widths the tabs previously retained 32px of padding from the larger tab design at the top of the screen which did not make sense for the tabs at the bottom of the screen (and flexbox made the padding irrelevant anyway). This change reduces that padding at narrow widths.

This PR addresses https://github.com/home-assistant/frontend/issues/10068 with ellipsis.

**Question for maintainers**: we could also make the `line-height` smaller and allow text wrapping and possibly `-webkit-line-clamp` to allow at least two lines of text in each tab.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Visit one of the pages that displays tabs and adjust the screen size to view this in action. It may be more obvious to use a non-english language that has longer text labels for certain tabs. The issue linked above has a screenshot of the current state when the text is too long for the tab size. It is simply cropped/hidden instead of intentionally handled via CSS rules.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/issues/10068
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
