### PR TITLE
Add a way to use a value of an attribute in conditional card

### DIFF
--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -10,7 +10,7 @@ export interface Condition {
 
 export function checkConditionsMet(
   conditions: Condition[],
-  hass: HomeAssistant,
+  hass: HomeAssistant
 ): boolean {
   return conditions.every((c) => {
     const entity = hass!.states[c.entity];

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -3,17 +3,21 @@ import { HomeAssistant } from "../../../types";
 
 export interface Condition {
   entity: string;
+  attribute?: string;
   state?: string;
   state_not?: string;
 }
 
 export function checkConditionsMet(
   conditions: Condition[],
-  hass: HomeAssistant
+  hass: HomeAssistant,
 ): boolean {
   return conditions.every((c) => {
-    const state = hass.states[c.entity]
-      ? hass!.states[c.entity].state
+    const entity = hass!.states[c.entity];
+    const state = entity
+      ? c.attribute
+        ? entity.attributes[c.attribute] || UNAVAILABLE
+        : entity.state
       : UNAVAILABLE;
 
     return c.state ? state === c.state : state !== c.state_not;

--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -29,7 +29,6 @@ import { configElementStyle } from "./config-elements-style";
 
 const conditionStruct = object({
   entity: string(),
-  attribute: optional(string()),
   state: optional(string()),
   state_not: optional(string()),
 });
@@ -149,21 +148,6 @@ export class HuiConditionalCardEditor
                         allow-custom-entity
                       ></ha-entity-picker>
                     </div>
-                    <div class="attribute">
-                      <ha-entity-attribute-picker
-                        .hass=${this.hass}
-                        .entityId=${cond.entity}
-                        .index=${idx}
-                        .label="${this.hass!.localize(
-                          "ui.panel.lovelace.editor.card.generic.attribute"
-                        )} (${this.hass!.localize(
-                          "ui.panel.lovelace.editor.card.config.optional"
-                        )})"
-                        .value=${cond.attribute}
-                        .configValue=${"attribute"}
-                        @value-changed=${this._changeCondition}
-                      ></ha-entity-attribute-picker>
-                    </div>
                     <div class="state">
                       <paper-dropdown-menu>
                         <paper-listbox
@@ -190,11 +174,7 @@ export class HuiConditionalCardEditor
                           "ui.panel.lovelace.editor.card.generic.state"
                         )} (${this.hass!.localize(
                           "ui.panel.lovelace.editor.card.conditional.current_state"
-                        )}: ${cond.attribute
-                          ? this.hass?.states[cond.entity].attributes[
-                              cond.attribute
-                            ]
-                          : this.hass?.states[cond.entity].state})"
+                        )}: ${this.hass?.states[cond.entity].state})"
                         .value=${cond.state_not !== undefined
                           ? cond.state_not
                           : cond.state}
@@ -299,12 +279,6 @@ export class HuiConditionalCardEditor
       const condition = { ...conditions[target.index] };
       if (target.configValue === "entity") {
         condition.entity = target.value;
-      } else if (target.configValue === "attribute") {
-        if (target.value === "" || target.value === undefined) {
-          delete condition.attribute;
-        } else {
-          condition.attribute = target.value;
-        }
       } else if (target.configValue === "state") {
         if (condition.state_not !== undefined) {
           condition.state_not = target.value;

--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -29,6 +29,7 @@ import { configElementStyle } from "./config-elements-style";
 
 const conditionStruct = object({
   entity: string(),
+  attribute: optional(string()),
   state: optional(string()),
   state_not: optional(string()),
 });
@@ -148,6 +149,21 @@ export class HuiConditionalCardEditor
                         allow-custom-entity
                       ></ha-entity-picker>
                     </div>
+                    <div class="attribute">
+                      <ha-entity-attribute-picker
+                        .hass=${this.hass}
+                        .entityId=${cond.entity}
+                        .index=${idx}
+                        .label="${this.hass!.localize(
+                              "ui.panel.lovelace.editor.card.generic.attribute"
+                            )} (${this.hass!.localize(
+                              "ui.panel.lovelace.editor.card.config.optional"
+                            )})"
+                        .value=${cond.attribute}
+                        .configValue=${"attribute"}
+                        @value-changed=${this._changeCondition}
+                      ></ha-entity-attribute-picker>
+                    </div>
                     <div class="state">
                       <paper-dropdown-menu>
                         <paper-listbox
@@ -174,7 +190,9 @@ export class HuiConditionalCardEditor
                           "ui.panel.lovelace.editor.card.generic.state"
                         )} (${this.hass!.localize(
                           "ui.panel.lovelace.editor.card.conditional.current_state"
-                        )}: ${this.hass?.states[cond.entity].state})"
+                        )}: ${cond.attribute 
+                          ? this.hass?.states[cond.entity].attributes[cond.attribute] 
+                          : this.hass?.states[cond.entity].state})"
                         .value=${cond.state_not !== undefined
                           ? cond.state_not
                           : cond.state}
@@ -279,6 +297,12 @@ export class HuiConditionalCardEditor
       const condition = { ...conditions[target.index] };
       if (target.configValue === "entity") {
         condition.entity = target.value;
+      } else if(target.configValue === "attribute") {
+        if (target.value === "" || target.value === undefined) {
+          delete condition.attribute;
+        } else {
+          condition.attribute = target.value;
+        }
       } else if (target.configValue === "state") {
         if (condition.state_not !== undefined) {
           condition.state_not = target.value;

--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -155,10 +155,10 @@ export class HuiConditionalCardEditor
                         .entityId=${cond.entity}
                         .index=${idx}
                         .label="${this.hass!.localize(
-                              "ui.panel.lovelace.editor.card.generic.attribute"
-                            )} (${this.hass!.localize(
-                              "ui.panel.lovelace.editor.card.config.optional"
-                            )})"
+                          "ui.panel.lovelace.editor.card.generic.attribute"
+                        )} (${this.hass!.localize(
+                          "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
                         .value=${cond.attribute}
                         .configValue=${"attribute"}
                         @value-changed=${this._changeCondition}
@@ -190,8 +190,10 @@ export class HuiConditionalCardEditor
                           "ui.panel.lovelace.editor.card.generic.state"
                         )} (${this.hass!.localize(
                           "ui.panel.lovelace.editor.card.conditional.current_state"
-                        )}: ${cond.attribute 
-                          ? this.hass?.states[cond.entity].attributes[cond.attribute] 
+                        )}: ${cond.attribute
+                          ? this.hass?.states[cond.entity].attributes[
+                              cond.attribute
+                            ]
                           : this.hass?.states[cond.entity].state})"
                         .value=${cond.state_not !== undefined
                           ? cond.state_not
@@ -297,7 +299,7 @@ export class HuiConditionalCardEditor
       const condition = { ...conditions[target.index] };
       if (target.configValue === "entity") {
         condition.entity = target.value;
-      } else if(target.configValue === "attribute") {
+      } else if (target.configValue === "attribute") {
         if (target.value === "" || target.value === undefined) {
           delete condition.attribute;
         } else {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Added a new optional field: `attribute` to card's configuration. When an attribute is provided, a value of given attribute is used instead of entity's state to calculate card's visibility.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
Lovelace:
```yaml
type: conditional
conditions:
  - entity: binary_sensor.example_sensor
    state: value_1
    attribute: example_attribute
card:
  type: entities
  entities:
    - entity: sun.sun
```
Configuration.yaml:
```yaml
input_boolean:
  helper:
    name: Helper
template:
  - binary_sensor:
      - name: Example sensor
        state: "{{ is_state('input_boolean.helper', 'on') }}"
        attributes:
          example_attribute: >
            {% if is_state('input_boolean.helper', 'on') %}
              value_1
            {% else %}
              value_2
            {% endif %}
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- ~~This PR fixes or closes issue: fixes #~~
- ~~This PR is related to issue or discussion:~~
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21151

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
