### PR TITLE
Add auto slider/box mode to number entity

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
@@ -84,7 +84,7 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
         ${stateObj.attributes.mode === "slider" ||
         (stateObj.attributes.mode === "auto" &&
           (Number(stateObj.attributes.max) - Number(stateObj.attributes.min)) /
-            Number(stateObj.attributes.step) <
+            Number(stateObj.attributes.step) <=
             256)
           ? html`
               <div class="flex">

--- a/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-number-entity-row.ts
@@ -81,7 +81,11 @@ class HuiNumberEntityRow extends LitElement implements LovelaceRow {
 
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
-        ${stateObj.attributes.mode === "slider"
+        ${stateObj.attributes.mode === "slider" ||
+        (stateObj.attributes.mode === "auto" &&
+          (Number(stateObj.attributes.max) - Number(stateObj.attributes.min)) /
+            Number(stateObj.attributes.step) <
+            256)
           ? html`
               <div class="flex">
                 <ha-slider

--- a/src/state-summary/state-card-number.js
+++ b/src/state-summary/state-card-number.js
@@ -6,6 +6,7 @@ import { html } from "@polymer/polymer/lib/utils/html-tag";
 /* eslint-plugin-disable lit */
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 import "../components/entity/state-info";
+import "../components/ha-slider";
 
 class StateCardNumber extends mixinBehaviors(
   [IronResizableBehavior],
@@ -15,12 +16,21 @@ class StateCardNumber extends mixinBehaviors(
     return html`
       <style include="iron-flex iron-flex-alignment"></style>
       <style>
+        ha-slider {
+          margin-left: auto;
+        }
         .state {
           @apply --paper-font-body1;
           color: var(--primary-text-color);
 
           text-align: right;
           line-height: 40px;
+        }
+        .sliderstate {
+          min-width: 45px;
+        }
+        ha-slider[hidden] {
+          display: none !important;
         }
         paper-input {
           text-align: right;
@@ -30,6 +40,19 @@ class StateCardNumber extends mixinBehaviors(
 
       <div class="horizontal justified layout" id="number_card">
         ${this.stateInfoTemplate}
+        <ha-slider
+          min="[[min]]"
+          max="[[max]]"
+          value="{{value}}"
+          step="[[step]]"
+          hidden="[[hiddenslider]]"
+          pin
+          on-change="selectedValueChanged"
+          on-click="stopPropagation"
+          id="slider"
+          ignore-bar-touch=""
+        >
+        </ha-slider>
         <paper-input
           no-label-float=""
           auto-validate=""
@@ -41,9 +64,19 @@ class StateCardNumber extends mixinBehaviors(
           type="number"
           on-change="selectedValueChanged"
           on-click="stopPropagation"
+          hidden="[[hiddenbox]]"
         >
         </paper-input>
-        <div class="state">[[stateObj.attributes.unit_of_measurement]]</div>
+        <div class="state" hidden="[[hiddenbox]]">
+          [[stateObj.attributes.unit_of_measurement]]
+        </div>
+        <div
+          id="sliderstate"
+          class="state sliderstate"
+          hidden="[[hiddenslider]]"
+        >
+          [[value]] [[stateObj.attributes.unit_of_measurement]]
+        </div>
       </div>
     `;
   }
@@ -58,9 +91,31 @@ class StateCardNumber extends mixinBehaviors(
     `;
   }
 
+  ready() {
+    super.ready();
+    if (typeof ResizeObserver === "function") {
+      const ro = new ResizeObserver((entries) => {
+        entries.forEach(() => {
+          this.hiddenState();
+        });
+      });
+      ro.observe(this.$.number_card);
+    } else {
+      this.addEventListener("iron-resize", this.hiddenState);
+    }
+  }
+
   static get properties() {
     return {
       hass: Object,
+      hiddenbox: {
+        type: Boolean,
+        value: true,
+      },
+      hiddenslider: {
+        type: Boolean,
+        value: true,
+      },
       inDialog: {
         type: Boolean,
         value: false,
@@ -83,17 +138,44 @@ class StateCardNumber extends mixinBehaviors(
       },
       step: Number,
       value: Number,
+      mode: String,
     };
   }
 
+  hiddenState() {
+    if (this.mode !== "slider") return;
+    const sliderwidth = this.$.slider.offsetWidth;
+    if (sliderwidth < 100) {
+      this.$.sliderstate.hidden = true;
+    } else if (sliderwidth >= 145) {
+      this.$.sliderstate.hidden = false;
+    }
+  }
+
   stateObjectChanged(newVal) {
+    const prevMode = this.mode;
+    const min = Number(newVal.attributes.min);
+    const max = Number(newVal.attributes.max);
+    const step = Number(newVal.attributes.step);
+    const range = (max - min) / step;
+
     this.setProperties({
-      min: Number(newVal.attributes.min),
-      max: Number(newVal.attributes.max),
-      step: Number(newVal.attributes.step),
+      min: min,
+      max: max,
+      step: step,
       value: Number(newVal.state),
+      mode: String(newVal.attributes.mode),
       maxlength: String(newVal.attributes.max).length,
+      hiddenbox:
+        newVal.attributes.mode === "slider" ||
+        (newVal.attributes.mode === "auto" && range <= 256),
+      hiddenslider:
+        newVal.attributes.mode === "box" ||
+        (newVal.attributes.mode === "auto" && range > 256),
     });
+    if (this.mode === "slider" && prevMode !== "slider") {
+      this.hiddenState();
+    }
   }
 
   selectedValueChanged() {

--- a/src/state-summary/state-card-number.js
+++ b/src/state-summary/state-card-number.js
@@ -101,7 +101,7 @@ class StateCardNumber extends mixinBehaviors(
       });
       ro.observe(this.$.number_card);
     } else {
-      this.addEventListener("iron-resize", this.hiddenState);
+      this.addEventListener("iron-resize", () => this.hiddenState());
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change


This extends the `number` entity with an optional mode, it provides a hint to the UI on how to represent this number entity in either a slider or box, similar to how we do it with `input_number`.

The difference is the `auto` mode, which is the default. This should cover almost all cases out there and will be instantly applied to all existing `number` entities.

When in `auto` mode: If the range of possible positions on the `number` is 256 positions or smaller, it will become a `slider`, else a `box` is automatically picked.

The demo platform has been extended, the 2 existing entities (volume, PWM) have a fixed mode, while the large and small range entities have the default `auto` mode.

Backend PR: <https://github.com/home-assistant/core/pull/57737>


![image](https://user-images.githubusercontent.com/195327/137409198-914ea66d-e3f1-4e22-85d1-a2332f048255.png)


![image](https://user-images.githubusercontent.com/195327/137409222-67e11ccc-090b-4bad-8d75-5219ef9a1fde.png)

![image](https://user-images.githubusercontent.com/195327/137409242-2da351ad-06fd-4608-890f-1cc874a2d38b.png)


Related to: <https://github.com/home-assistant/core/pull/56862>

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
