### PR TITLE
Fix energy onboarding `add_solar_production` button (#10275)

### DIFF
--- a/src/panels/energy/cards/energy-setup-wizard-card.ts
+++ b/src/panels/energy/cards/energy-setup-wizard-card.ts
@@ -1,7 +1,12 @@
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
-import { EnergyPreferences, saveEnergyPreferences } from "../../../data/energy";
+import {
+  EnergyInfo,
+  EnergyPreferences,
+  getEnergyInfo,
+  saveEnergyPreferences,
+} from "../../../data/energy";
 import { LovelaceCardConfig } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
 import { LovelaceCard, Lovelace } from "../../lovelace/types";
@@ -19,6 +24,8 @@ export class EnergySetupWizard extends LitElement implements LovelaceCard {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public lovelace?: Lovelace;
+
+  @state() private _info?: EnergyInfo;
 
   @state() private _step = 0;
 
@@ -39,6 +46,7 @@ export class EnergySetupWizard extends LitElement implements LovelaceCard {
 
   protected firstUpdated() {
     this.hass.loadFragmentTranslation("config");
+    this._fetchconfig();
   }
 
   protected render(): TemplateResult {
@@ -54,6 +62,7 @@ export class EnergySetupWizard extends LitElement implements LovelaceCard {
         ? html`<ha-energy-solar-settings
             .hass=${this.hass}
             .preferences=${this._preferences}
+            .info=${this._info}
             @value-changed=${this._prefsChanged}
           ></ha-energy-solar-settings>`
         : this._step === 2
@@ -88,6 +97,10 @@ export class EnergySetupWizard extends LitElement implements LovelaceCard {
             </mwc-button>`}
       </div>
     `;
+  }
+
+  private async _fetchconfig() {
+    this._info = await getEnergyInfo(this.hass);
   }
 
   private _prefsChanged(ev: CustomEvent) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixes energy onboarding by adding the `add solar production` button back into the wizard process.

Every other single step in the energy wizard has a button to add consumption/return/storage. So I'm not sure why this was originally excluded.

![image](https://user-images.githubusercontent.com/3487107/137555255-b8f3051e-5add-4052-852a-3a0a206347a7.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10275
- ~This PR is related to issue or discussion:~
- ~Link to documentation pull request:~

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
