### PR TITLE
Improve WebRTC stream error handling and cleanup

### DIFF
--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -97,7 +97,7 @@ class HaWebRtcPlayer extends LitElement {
         offer.sdp!
       );
     } catch (err: any) {
-      this._error = "Unable to initiate WebRTC stream: " + err.message;
+      this._error = "Failed to start WebRTC stream: " + err.message;
       peerConnection.close();
       return;
     }
@@ -117,7 +117,7 @@ class HaWebRtcPlayer extends LitElement {
     try {
       await peerConnection.setRemoteDescription(remoteDesc);
     } catch (err: any) {
-      this._error = "Unable to connect to WebRTC stream: " + err.message;
+      this._error = "Failed to connect WebRTC stream: " + err.message;
       peerConnection.close();
       return;
     }

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -103,11 +103,12 @@ class HaWebRtcPlayer extends LitElement {
     }
 
     // Setup callbacks to render remote stream once media tracks are discovered.
-    this._remoteStream = new MediaStream();
+    const remoteStream = new MediaStream();
     peerConnection.addEventListener("track", (event) => {
-      this._remoteStream.addTrack(event.track);
-      this._videoEl.srcObject = this._remoteStream;
+      remoteStream.addTrack(event.track);
+      this._videoEl.srcObject = remoteStream;
     });
+    this._remoteStream = remoteStream;
 
     // Initiate the stream with the remote device
     const remoteDesc = new RTCSessionDescription({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add error handler for setRemoteDescription, and keep track of peer connection and remote stream and run cleanup when closing the stream dialog.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
