### PR TITLE
Only render badge value if there is no icon and no image

### DIFF
--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -73,13 +73,17 @@ export class HaStateLabelBadge extends LitElement {
 
     const value = this._computeValue(domain, entityState);
     const icon = this.icon ? this.icon : this._computeIcon(domain, entityState);
-    const image = this.icon
+    const image = icon
       ? ""
       : this.image
       ? this.image
       : entityState.attributes.entity_picture_local ||
         entityState.attributes.entity_picture;
 
+    // Rendering priority inside badge:
+    // 1. Icon
+    // 2. Image
+    // 3. Value string as fallback
     return html`
       <ha-label-badge
         class=${classMap({
@@ -96,7 +100,7 @@ export class HaStateLabelBadge extends LitElement {
         .description=${this.name ?? computeStateName(entityState)}
       >
         ${!image && icon ? html`<ha-icon .icon=${icon}></ha-icon>` : ""}
-        ${value && (this.icon || !this.image)
+        ${value && !icon && !image
           ? html`<span class=${value && value.length > 4 ? "big" : ""}
               >${value}</span
             >`

--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -70,12 +70,16 @@ export class HaStateLabelBadge extends LitElement {
     }
 
     // Rendering priority inside badge:
-    // 1. Image (either directly from badge config or otherwise entity)
-    // 2. Icon (either directly from badge config or determined from entity state)
-    // 3. Value string as fallback
+    // 1. Icon directly defined in badge config
+    // 2. Image directly defined in badge config
+    // 3. Image taken from entity picture
+    // 4. Icon determined via entity state
+    // 5. Value string as fallback
     const domain = computeStateDomain(entityState);
     const icon = this.icon ? this.icon : this._computeIcon(domain, entityState);
-    const image = this.image
+    const image = this.icon
+      ? ""
+      : this.image
       ? this.image
       : entityState.attributes.entity_picture_local ||
         entityState.attributes.entity_picture;

--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -69,21 +69,19 @@ export class HaStateLabelBadge extends LitElement {
       `;
     }
 
+    // Rendering priority inside badge:
+    // 1. Image (either directly from badge config or otherwise entity)
+    // 2. Icon (either directly from badge config or determined from entity state)
+    // 3. Value string as fallback
     const domain = computeStateDomain(entityState);
-
-    const value = this._computeValue(domain, entityState);
     const icon = this.icon ? this.icon : this._computeIcon(domain, entityState);
-    const image = icon
-      ? ""
-      : this.image
+    const image = this.image
       ? this.image
       : entityState.attributes.entity_picture_local ||
         entityState.attributes.entity_picture;
+    const value =
+      !image && !icon ? this._computeValue(domain, entityState) : undefined;
 
-    // Rendering priority inside badge:
-    // 1. Icon
-    // 2. Image
-    // 3. Value string as fallback
     return html`
       <ha-label-badge
         class=${classMap({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The previous condition to check if the value string should be rendered looked at the class members, not at the actually determined values in the `render()` function.

Also the value string render condition resulted in both icon and value being rendered inside the badge. No the value is only shown if no image or icon is determined.

```
    badges:
      - entity: climate.test_thermo
      - entity: light.office_ceiling
      - entity: input_number.num_test
      - entity: alarm_control_panel.home_alarm
      - entity: binary_sensor.movement_backyard
      - entity: camera.demo_camera
      - entity: camera.demo_camera
        icon: mdi:police-badge-outline
      - entity: camera.demo_camera
        image: /local/spacegaier.jpg
      - entity: sensor.tablet_a7_akkufullstand
      - entity: sensor.tablet_a7_akkufullstand
        icon: mdi:police-badge-outline
      - entity: person.test_user
      - entity: person.ada
```

**Before**: Both badges that have an image are also showing the value plus the third last badge that has an icon defined shows icon and value.
![image](https://user-images.githubusercontent.com/114137/137644817-27b6b279-4a4a-4b55-9abd-6c85ca5e1150.png)

**After**:
![image](https://user-images.githubusercontent.com/114137/137644796-319720ed-b929-493f-aa97-fa5b9db3cc8a.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10236
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
