### PR TITLE
Correct grid neutrality card tooltip, make consistent with new colors

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-grid-neutrality-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-grid-neutrality-gauge-card.ts
@@ -103,7 +103,7 @@ class HuiEnergyGridGaugeCard
               <paper-tooltip animation-delay="0" for="info" position="left">
                 <span>
                   ${this.hass.localize(
-                    "ui.panel.lovelace.cards.energy.grid_neutrality_gauge.net_energy_usage"
+                    "ui.panel.lovelace.cards.energy.grid_neutrality_gauge.energy_dependency"
                   )}
                   <br /><br />
                   ${this.hass.localize(

--- a/src/panels/lovelace/cards/energy/hui-energy-grid-neutrality-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-grid-neutrality-gauge-card.ts
@@ -103,11 +103,11 @@ class HuiEnergyGridGaugeCard
               <paper-tooltip animation-delay="0" for="info" position="left">
                 <span>
                   ${this.hass.localize(
-                    "ui.panel.lovelace.cards.energy.grid_neutrality_gauge.energy_dependency"
+                    "ui.panel.lovelace.cards.energy.grid_neutrality_gauge.net_energy_usage"
                   )}
                   <br /><br />
                   ${this.hass.localize(
-                    "ui.panel.lovelace.cards.energy.grid_neutrality_gauge.red_green_color_explain"
+                    "ui.panel.lovelace.cards.energy.grid_neutrality_gauge.color_explain"
                   )}
                 </span>
               </paper-tooltip>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3027,8 +3027,8 @@
               "self_consumed_solar_could_not_calc": "Self-consumed solar energy couldn't be calculated"
             },
             "grid_neutrality_gauge": {
-              "energy_dependency": "This card represents your energy dependency.",
-              "red_green_color_explain": "If it's green, it means you produced more energy than that you consumed from the grid. If it's in the red, it means that you relied on the grid for part of your home's energy consumption.",
+              "net_energy_usage": "This card indicates your net energy usage.",
+              "color_explain": "If the needle is in the purple, you returned more energy to the grid than you consumed from it. If it's in the blue, you consumed more energy from the grid than you returned.",
               "net_returned_grid": "Net returned to the grid",
               "net_consumed_grid": "Net consumed from the grid",
               "grid_neutrality_not_calculated": "Grid neutrality could not be calculated"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3027,7 +3027,7 @@
               "self_consumed_solar_could_not_calc": "Self-consumed solar energy couldn't be calculated"
             },
             "grid_neutrality_gauge": {
-              "net_energy_usage": "This card indicates your net energy usage.",
+              "energy_dependency": "This card indicates your net energy usage.",
               "color_explain": "If the needle is in the purple, you returned more energy to the grid than you consumed from it. If it's in the blue, you consumed more energy from the grid than you returned.",
               "net_returned_grid": "Net returned to the grid",
               "net_consumed_grid": "Net consumed from the grid",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

- Correct and revise the tooltip per #9976 and making it consistent with the new colors implemented by #10054 

### Before
```
This card represents your energy dependency.

If it's green, it means you produced more energy than that you
consumed from the grid. If it's in the red, it means that you
relied on the grid for part of your home's energy consumption.
```
### After
```
This card indicates your net energy usage.

If the needle is in the purple, you returned more energy to the
grid than you consumed from it. If it's in the blue, you consumed
more energy from the grid than you returned. 
```


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9976 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
