### PR TITLE
Use svg icons for default panels

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -1,11 +1,21 @@
 import "@material/mwc-button/mwc-button";
 import {
   mdiBell,
+  mdiCalendar,
+  mdiCart,
   mdiCellphoneCog,
+  mdiChartBox,
   mdiClose,
+  mdiCog,
+  mdiFormatListBulletedType,
+  mdiHammer,
+  mdiHomeAssistant,
+  mdiLightningBolt,
   mdiMenu,
   mdiMenuOpen,
+  mdiPlayBoxMultiple,
   mdiPlus,
+  mdiTooltipAccount,
   mdiViewDashboard,
 } from "@mdi/js";
 import "@polymer/paper-item/paper-icon-item";
@@ -60,6 +70,20 @@ const SORT_VALUE_URL_PATHS = {
   "developer-tools": 9,
   hassio: 10,
   config: 11,
+};
+
+const PANEL_ICONS = {
+  lovelace: mdiViewDashboard,
+  energy: mdiLightningBolt,
+  map: mdiTooltipAccount,
+  logbook: mdiFormatListBulletedType,
+  history: mdiChartBox,
+  "developer-tools": mdiHammer,
+  hassio: mdiHomeAssistant,
+  config: mdiCog,
+  calendar: mdiCalendar,
+  "media-browser": mdiPlayBoxMultiple,
+  "shopping-list": mdiCart,
 };
 
 const panelSorter = (
@@ -348,6 +372,60 @@ class HaSidebar extends LitElement {
     `;
   }
 
+  private _renderPanels(panels: PanelInfo[]) {
+    return panels.map((panel) =>
+      this._renderPanel(
+        panel.url_path,
+        panel.url_path === this.hass.defaultPanel
+          ? panel.title || this.hass.localize("panel.states")
+          : this.hass.localize(`panel.${panel.title}`) || panel.title,
+        panel.icon,
+        panel.url_path === this.hass.defaultPanel && !panel.icon
+          ? PANEL_ICONS.lovelace
+          : panel.url_path in PANEL_ICONS
+          ? PANEL_ICONS[panel.url_path]
+          : undefined
+      )
+    );
+  }
+
+  private _renderPanel(
+    urlPath: string,
+    title: string | null,
+    icon?: string | null,
+    iconPath?: string | null
+  ) {
+    return html`
+      <a
+        aria-role="option"
+        href=${`/${urlPath}`}
+        data-panel=${urlPath}
+        tabindex="-1"
+        @mouseenter=${this._itemMouseEnter}
+        @mouseleave=${this._itemMouseLeave}
+      >
+        <paper-icon-item>
+          ${iconPath
+            ? html`<ha-svg-icon
+                slot="item-icon"
+                .path=${iconPath}
+              ></ha-svg-icon>`
+            : html`<ha-icon slot="item-icon" .icon=${icon}></ha-icon>`}
+          <span class="item-text">${title}</span>
+        </paper-icon-item>
+        ${this.editMode
+          ? html`<ha-icon-button
+              .label=${this.hass.localize("ui.sidebar.hide_panel")}
+              .path=${mdiClose}
+              class="hide-panel"
+              .panel=${urlPath}
+              @click=${this._hidePanel}
+            ></ha-icon-button>`
+          : ""}
+      </a>
+    `;
+  }
+
   private _renderPanelsEdit(beforeSpacer: PanelInfo[]) {
     // prettier-ignore
     return html`<div id="sortable">
@@ -360,7 +438,7 @@ class HaSidebar extends LitElement {
   }
 
   private _renderHiddenPanels() {
-    return html` ${this._hiddenPanels.length
+    return html`${this._hiddenPanels.length
       ? html`${this._hiddenPanels.map((url) => {
           const panel = this.hass.panels[url];
           if (!panel) {
@@ -371,12 +449,17 @@ class HaSidebar extends LitElement {
             class="hidden-panel"
             .panel=${url}
           >
-            <ha-icon
-              slot="item-icon"
-              .icon=${panel.url_path === this.hass.defaultPanel
-                ? "mdi:view-dashboard"
-                : panel.icon}
-            ></ha-icon>
+            ${panel.url_path === this.hass.defaultPanel && !panel.icon
+              ? html`<ha-svg-icon
+                  slot="item-icon"
+                  .path=${PANEL_ICONS.lovelace}
+                ></ha-svg-icon>`
+              : panel.url_path in PANEL_ICONS
+              ? html`<ha-svg-icon
+                  slot="item-icon"
+                  .path=${PANEL_ICONS[panel.url_path]}
+                ></ha-svg-icon>`
+              : html`<ha-icon slot="item-icon" .icon=${panel.icon}></ha-icon>`}
             <span class="item-text"
               >${panel.url_path === this.hass.defaultPanel
                 ? this.hass.localize("panel.states")
@@ -412,7 +495,7 @@ class HaSidebar extends LitElement {
       }
     }
 
-    return html` <div
+    return html`<div
       class="notifications-container"
       @mouseenter=${this._itemMouseEnter}
       @mouseleave=${this._itemMouseLeave}
@@ -680,58 +763,6 @@ class HaSidebar extends LitElement {
       return;
     }
     fireEvent(this, "hass-toggle-menu");
-  }
-
-  private _renderPanels(panels: PanelInfo[]) {
-    return panels.map((panel) =>
-      this._renderPanel(
-        panel.url_path,
-        panel.url_path === this.hass.defaultPanel
-          ? panel.title || this.hass.localize("panel.states")
-          : this.hass.localize(`panel.${panel.title}`) || panel.title,
-        panel.icon,
-        panel.url_path === this.hass.defaultPanel && !panel.icon
-          ? mdiViewDashboard
-          : undefined
-      )
-    );
-  }
-
-  private _renderPanel(
-    urlPath: string,
-    title: string | null,
-    icon?: string | null,
-    iconPath?: string | null
-  ) {
-    return html`
-      <a
-        aria-role="option"
-        href=${`/${urlPath}`}
-        data-panel=${urlPath}
-        tabindex="-1"
-        @mouseenter=${this._itemMouseEnter}
-        @mouseleave=${this._itemMouseLeave}
-      >
-        <paper-icon-item>
-          ${iconPath
-            ? html`<ha-svg-icon
-                slot="item-icon"
-                .path=${iconPath}
-              ></ha-svg-icon>`
-            : html`<ha-icon slot="item-icon" .icon=${icon}></ha-icon>`}
-          <span class="item-text">${title}</span>
-        </paper-icon-item>
-        ${this.editMode
-          ? html`<ha-icon-button
-              .label=${this.hass.localize("ui.sidebar.hide_panel")}
-              .path=${mdiClose}
-              class="hide-panel"
-              .panel=${urlPath}
-              @click=${this._hidePanel}
-            ></ha-icon-button>`
-          : ""}
-      </a>
-    `;
   }
 
   static get styles(): CSSResultGroup {

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -73,15 +73,15 @@ const SORT_VALUE_URL_PATHS = {
 };
 
 const PANEL_ICONS = {
-  lovelace: mdiViewDashboard,
-  energy: mdiLightningBolt,
-  map: mdiTooltipAccount,
-  logbook: mdiFormatListBulletedType,
-  history: mdiChartBox,
-  "developer-tools": mdiHammer,
-  hassio: mdiHomeAssistant,
-  config: mdiCog,
   calendar: mdiCalendar,
+  config: mdiCog,
+  "developer-tools": mdiHammer,
+  energy: mdiLightningBolt,
+  hassio: mdiHomeAssistant,
+  history: mdiChartBox,
+  logbook: mdiFormatListBulletedType,
+  lovelace: mdiViewDashboard,
+  map: mdiTooltipAccount,
   "media-browser": mdiPlayBoxMultiple,
   "shopping-list": mdiCart,
 };


### PR DESCRIPTION
## Proposed change

The default panels will no longer use `ha-icon` but use inlines svg icons.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
