### PR TITLE
Add support for `no-state` and `entity-no-longer-available` statistic…

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -77,11 +77,23 @@ export interface StatisticsMetaData {
 }
 
 export type StatisticsValidationResult =
+  | StatisticsValidationResultNoState
   | StatisticsValidationResultEntityNotRecorded
+  | StatisticsValidationResultEntityNoLongerRecorded
   | StatisticsValidationResultUnsupportedStateClass
   | StatisticsValidationResultUnitsChanged
   | StatisticsValidationResultUnsupportedUnitMetadata
   | StatisticsValidationResultUnsupportedUnitState;
+
+export interface StatisticsValidationResultNoState {
+  type: "no_state";
+  data: { statistic_id: string };
+}
+
+export interface StatisticsValidationResultEntityNoLongerRecorded {
+  type: "entity_no_longer_recorded";
+  data: { statistic_id: string };
+}
 
 export interface StatisticsValidationResultEntityNotRecorded {
   type: "entity_not_recorded";

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -8,18 +8,24 @@ import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/data-table/ha-data-table";
 import type { DataTableColumnContainer } from "../../../components/data-table/ha-data-table";
 import {
+  clearStatistics,
   getStatisticIds,
   StatisticsMetaData,
   StatisticsValidationResult,
   validateStatistics,
 } from "../../../data/history";
-import { showAlertDialog } from "../../../dialogs/generic/show-dialog-box";
+import {
+  showAlertDialog,
+  showConfirmationDialog,
+} from "../../../dialogs/generic/show-dialog-box";
 import { haStyle } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
 import { showFixStatisticsUnitsChangedDialog } from "./show-dialog-statistics-fix-units-changed";
 import { showFixStatisticsUnsupportedUnitMetadataDialog } from "./show-dialog-statistics-fix-unsupported-unit-meta";
 
 const FIX_ISSUES_ORDER = {
+  no_state: 0,
+  entity_no_longer_recorded: 1,
   entity_not_recorded: 1,
   unsupported_unit_state: 2,
   unsupported_state_class: 3,
@@ -103,7 +109,7 @@ class HaPanelDevStatistics extends LitElement {
       <ha-data-table
         .columns=${this._columns(this.hass.localize)}
         .data=${this._data}
-        noDataText="No issues found!"
+        noDataText="No statistics"
         id="statistic_id"
         clickable
         @row-click=${this._rowClicked}
@@ -155,6 +161,20 @@ class HaPanelDevStatistics extends LitElement {
     );
     const issue = issues[0];
     switch (issue.type) {
+      case "no_state":
+        showConfirmationDialog(this, {
+          title: "Entity has no state",
+          text: html`This entity has no state at the moment, if this is an
+            orphaned entity, you may want to remove the long term statistics of
+            it from your database.<br /><br />Do you want to permantly remove
+            the long term statistics of ${issue.data.statistic_id} from your
+            database?`,
+          confirm: async () => {
+            await clearStatistics(this.hass, [issue.data.statistic_id]);
+            this._validateStatistics();
+          },
+        });
+        break;
       case "entity_not_recorded":
         showAlertDialog(this, {
           title: "Entity not recorded",
@@ -162,6 +182,24 @@ class HaPanelDevStatistics extends LitElement {
             we can not track long term statistics for it. <br /><br />You
             probably excluded this entity, or have just included some
             entities.<br /><br />See the
+            <a
+              href="https://www.home-assistant.io/integrations/recorder/#configure-filter"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              recorder documentation</a
+            >
+            for more information.`,
+        });
+        break;
+      case "entity_no_longer_recorded":
+        showAlertDialog(this, {
+          title: "Entity no longer recorded",
+          text: html`We have generated statistics for this entity in the past,
+            but state changes of this entity are no longer recorded, therefore,
+            we can not track long term statistics for it anymore.
+            <br /><br />You probably excluded this entity, or have just included
+            some entities.<br /><br />See the
             <a
               href="https://www.home-assistant.io/integrations/recorder/#configure-filter"
               target="_blank"

--- a/src/panels/developer-tools/statistics/developer-tools-statistics.ts
+++ b/src/panels/developer-tools/statistics/developer-tools-statistics.ts
@@ -166,7 +166,7 @@ class HaPanelDevStatistics extends LitElement {
           title: "Entity has no state",
           text: html`This entity has no state at the moment, if this is an
             orphaned entity, you may want to remove the long term statistics of
-            it from your database.<br /><br />Do you want to permantly remove
+            it from your database.<br /><br />Do you want to permanently remove
             the long term statistics of ${issue.data.statistic_id} from your
             database?`,
           confirm: async () => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3879,7 +3879,9 @@
               "unsupported_unit_state": "The unit (''{state_unit}'') of this entity doesn't match a unit of device class ''{device_class}''.",
               "unsupported_unit_metadata": "The unit (''{metadata_unit}'') of the recorded statistics doesn't match the supported unit ''{supported_unit}'' of device class ''{device_class}''.",
               "unsupported_state_class": "The state class ''{state_class}'' of this entity is not supported.",
-              "entity_not_recorded": "This entity is excluded from being recorded."
+              "entity_not_recorded": "This entity is excluded from being recorded.",
+              "entity_no_longer_recorded": "This entity is no longer being recorded.",
+              "no_state": "There is no state available for this entity."
             },
             "fix_issue": {
               "fix": "Fix issue",


### PR DESCRIPTION
…s validation


## Proposed change

https://github.com/home-assistant/core/pull/57324
https://github.com/home-assistant/core/pull/58092

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
