### PR TITLE
Make device classes in logbook translatable

### DIFF
--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -2,6 +2,7 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { BINARY_STATE_OFF, BINARY_STATE_ON } from "../common/const";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateDisplay } from "../common/entity/compute_state_display";
+import { LocalizeFunc } from "../common/translations/localize";
 import { HomeAssistant } from "../types";
 import { UNAVAILABLE_STATES } from "./entity";
 
@@ -35,9 +36,11 @@ export const getLogbookDataForContext = async (
   hass: HomeAssistant,
   startDate: string,
   contextId?: string
-): Promise<LogbookEntry[]> =>
-  addLogbookMessage(
+): Promise<LogbookEntry[]> => {
+  const localize = await hass.loadBackendTranslation("device_class");
+  return addLogbookMessage(
     hass,
+    localize,
     await getLogbookDataFromServer(
       hass,
       startDate,
@@ -47,6 +50,7 @@ export const getLogbookDataForContext = async (
       contextId
     )
   );
+};
 
 export const getLogbookData = async (
   hass: HomeAssistant,
@@ -54,9 +58,11 @@ export const getLogbookData = async (
   endDate: string,
   entityId?: string,
   entity_matches_only?: boolean
-): Promise<LogbookEntry[]> =>
-  addLogbookMessage(
+): Promise<LogbookEntry[]> => {
+  const localize = await hass.loadBackendTranslation("device_class");
+  return addLogbookMessage(
     hass,
+    localize,
     await getLogbookDataCache(
       hass,
       startDate,
@@ -65,9 +71,11 @@ export const getLogbookData = async (
       entity_matches_only
     )
   );
+};
 
 export const addLogbookMessage = (
   hass: HomeAssistant,
+  localize: LocalizeFunc,
   logbookData: LogbookEntry[]
 ): LogbookEntry[] => {
   for (const entry of logbookData) {
@@ -75,6 +83,7 @@ export const addLogbookMessage = (
     if (entry.state && stateObj) {
       entry.message = getLogbookMessage(
         hass,
+        localize,
         entry.state,
         stateObj,
         computeDomain(entry.entity_id!)
@@ -157,6 +166,7 @@ export const clearLogbookCache = (startDate: string, endDate: string) => {
 
 export const getLogbookMessage = (
   hass: HomeAssistant,
+  localize: LocalizeFunc,
   state: string,
   stateObj: HassEntity,
   domain: string
@@ -165,21 +175,17 @@ export const getLogbookMessage = (
     case "device_tracker":
     case "person":
       if (state === "not_home") {
-        return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_away`);
+        return localize(`${LOGBOOK_LOCALIZE_PATH}.was_away`);
       }
       if (state === "home") {
-        return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_at_home`);
+        return localize(`${LOGBOOK_LOCALIZE_PATH}.was_at_home`);
       }
-      return hass.localize(
-        `${LOGBOOK_LOCALIZE_PATH}.was_at_state`,
-        "state",
-        state
-      );
+      return localize(`${LOGBOOK_LOCALIZE_PATH}.was_at_state`, "state", state);
 
     case "sun":
       return state === "above_horizon"
-        ? hass.localize(`${LOGBOOK_LOCALIZE_PATH}.rose`)
-        : hass.localize(`${LOGBOOK_LOCALIZE_PATH}.set`);
+        ? localize(`${LOGBOOK_LOCALIZE_PATH}.rose`)
+        : localize(`${LOGBOOK_LOCALIZE_PATH}.set`);
 
     case "binary_sensor": {
       const isOn = state === BINARY_STATE_ON;
@@ -189,19 +195,19 @@ export const getLogbookMessage = (
       switch (device_class) {
         case "battery":
           if (isOn) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_low`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_low`);
           }
           if (isOff) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_normal`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_normal`);
           }
           break;
 
         case "connectivity":
           if (isOn) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_connected`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_connected`);
           }
           if (isOff) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_disconnected`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_disconnected`);
           }
           break;
 
@@ -210,46 +216,46 @@ export const getLogbookMessage = (
         case "opening":
         case "window":
           if (isOn) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_opened`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_opened`);
           }
           if (isOff) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_closed`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_closed`);
           }
           break;
 
         case "lock":
           if (isOn) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_unlocked`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_unlocked`);
           }
           if (isOff) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_locked`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_locked`);
           }
           break;
 
         case "plug":
           if (isOn) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_plugged_in`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_plugged_in`);
           }
           if (isOff) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_unplugged`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_unplugged`);
           }
           break;
 
         case "presence":
           if (isOn) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_at_home`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_at_home`);
           }
           if (isOff) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_away`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_away`);
           }
           break;
 
         case "safety":
           if (isOn) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_unsafe`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_unsafe`);
           }
           if (isOff) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_safe`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.was_safe`);
           }
           break;
 
@@ -265,27 +271,27 @@ export const getLogbookMessage = (
         case "sound":
         case "vibration":
           if (isOn) {
-            return hass.localize(
+            return localize(
               `${LOGBOOK_LOCALIZE_PATH}.detected_device_class`,
               "device_class",
-              hass.localize(`device_class.${device_class}`)
+              localize(`component.binary_sensor.device_class.${device_class}`)
             );
           }
           if (isOff) {
-            return hass.localize(
+            return localize(
               `${LOGBOOK_LOCALIZE_PATH}.cleared_device_class`,
               "device_class",
-              hass.localize(`device_class.${device_class}`)
+              localize(`component.binary_sensor.device_class.${device_class}`)
             );
           }
           break;
 
         case "tamper":
           if (isOn) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.detected_tampering`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.detected_tampering`);
           }
           if (isOff) {
-            return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.cleared_tampering`);
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.cleared_tampering`);
           }
           break;
       }
@@ -296,43 +302,43 @@ export const getLogbookMessage = (
     case "cover":
       switch (state) {
         case "open":
-          return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_opened`);
+          return localize(`${LOGBOOK_LOCALIZE_PATH}.was_opened`);
         case "opening":
-          return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.is_opening`);
+          return localize(`${LOGBOOK_LOCALIZE_PATH}.is_opening`);
         case "closing":
-          return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.is_closing`);
+          return localize(`${LOGBOOK_LOCALIZE_PATH}.is_closing`);
         case "closed":
-          return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_closed`);
+          return localize(`${LOGBOOK_LOCALIZE_PATH}.was_closed`);
       }
       break;
 
     case "lock":
       if (state === "unlocked") {
-        return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_unlocked`);
+        return localize(`${LOGBOOK_LOCALIZE_PATH}.was_unlocked`);
       }
       if (state === "locked") {
-        return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.was_locked`);
+        return localize(`${LOGBOOK_LOCALIZE_PATH}.was_locked`);
       }
       break;
   }
 
   if (state === BINARY_STATE_ON) {
-    return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.turned_on`);
+    return localize(`${LOGBOOK_LOCALIZE_PATH}.turned_on`);
   }
 
   if (state === BINARY_STATE_OFF) {
-    return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.turned_off`);
+    return localize(`${LOGBOOK_LOCALIZE_PATH}.turned_off`);
   }
 
   if (UNAVAILABLE_STATES.includes(state)) {
-    return hass.localize(`${LOGBOOK_LOCALIZE_PATH}.became_unavailable`);
+    return localize(`${LOGBOOK_LOCALIZE_PATH}.became_unavailable`);
   }
 
   return hass.localize(
     `${LOGBOOK_LOCALIZE_PATH}.changed_to_state`,
     "state",
     stateObj
-      ? computeStateDisplay(hass.localize, stateObj, hass.locale, state)
+      ? computeStateDisplay(localize, stateObj, hass.locale, state)
       : state
   );
 };

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -271,18 +271,18 @@ export const getLogbookMessage = (
         case "sound":
         case "vibration":
           if (isOn) {
-            return localize(
-              `${LOGBOOK_LOCALIZE_PATH}.detected_device_class`,
-              "device_class",
-              localize(`component.binary_sensor.device_class.${device_class}`)
-            );
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.detected_device_class`, {
+              device_class: localize(
+                `component.binary_sensor.device_class.${device_class}`
+              ),
+            });
           }
           if (isOff) {
-            return localize(
-              `${LOGBOOK_LOCALIZE_PATH}.cleared_device_class`,
-              "device_class",
-              localize(`component.binary_sensor.device_class.${device_class}`)
-            );
+            return localize(`${LOGBOOK_LOCALIZE_PATH}.cleared_device_class`, {
+              device_class: localize(
+                `component.binary_sensor.device_class.${device_class}`
+              ),
+            });
           }
           break;
 

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -268,14 +268,14 @@ export const getLogbookMessage = (
             return hass.localize(
               `${LOGBOOK_LOCALIZE_PATH}.detected_device_class`,
               "device_class",
-              device_class
+              hass.localize(`device_class.${device_class}`)
             );
           }
           if (isOff) {
             return hass.localize(
               `${LOGBOOK_LOCALIZE_PATH}.cleared_device_class`,
               "device_class",
-              device_class
+              hass.localize(`device_class.${device_class}`)
             );
           }
           break;

--- a/src/data/translation.ts
+++ b/src/data/translation.ts
@@ -37,7 +37,8 @@ export type TranslationCategory =
   | "options"
   | "device_automation"
   | "mfa_setup"
-  | "system_health";
+  | "system_health"
+  | "device_class";
 
 export const fetchTranslationPreferences = (hass: HomeAssistant) =>
   fetchFrontendUserData(hass.connection, "language");

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -104,6 +104,19 @@
       "device": "Device"
     }
   },
+  "device_class": {
+    "cold": "cold",
+    "gas": "gas",
+    "heat": "heat",
+    "moisture": "moisture",
+    "motion": "motion",
+    "occupancy": "occupancy",
+    "power": "power",
+    "problem": "problem",
+    "smoke": "smoke",
+    "sound": "sound",
+    "vibration": "vibration"
+  },
   "ui": {
     "auth_store": {
       "ask": "Do you want to stay logged in?",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -104,19 +104,6 @@
       "device": "Device"
     }
   },
-  "device_class": {
-    "cold": "cold",
-    "gas": "gas",
-    "heat": "heat",
-    "moisture": "moisture",
-    "motion": "motion",
-    "occupancy": "occupancy",
-    "power": "power",
-    "problem": "problem",
-    "smoke": "smoke",
-    "sound": "sound",
-    "vibration": "vibration"
-  },
   "ui": {
     "auth_store": {
       "ask": "Do you want to stay logged in?",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Requires https://github.com/home-assistant/core/pull/58471.

Currently the logbook shows the technical device class instead of a proper translation for certain binary sensors.

Translations will be provided by the backend.

<s>For now I added a new global translation key section "device_class", but only actually added there the ones that the logbook needs (the ones that represent states such as "cold", "heat", ... as opposed to objects such as "lock", "door", ...), since for many others there are dedicated translations in the logbook component (such as "was opened" for doors).

With that in mind we could also just have those few live in the logbook component translations, but I thought that we might need those translations (potentially also for more/all device classes) in the frontend in the future, hence the "global" segment.</s>

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
