### PR TITLE
Ensure explicit `false` values from customize form get stored

### DIFF
--- a/src/panels/config/customize/ha-config-customize.ts
+++ b/src/panels/config/customize/ha-config-customize.ts
@@ -25,7 +25,7 @@ class HaConfigCustomize extends LitElement {
   protected render(): TemplateResult {
     return html`
       <hass-tabs-subpage
-      .hass=${this.hass}
+        .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
         back-path="/config"

--- a/src/panels/config/customize/ha-form-customize.js
+++ b/src/panels/config/customize/ha-form-customize.js
@@ -180,10 +180,15 @@ export class HaFormCustomize extends LocalizeMixin(PolymerElement) {
       this.newAttributes
     );
     attrs.forEach((attr) => {
-      if (attr.closed || attr.secondary || !attr.attribute || !attr.value)
+      if (
+        attr.closed ||
+        attr.secondary ||
+        !attr.attribute ||
+        attr.value == null
+      )
         return;
       const value = attr.type === "json" ? JSON.parse(attr.value) : attr.value;
-      if (!value) return;
+      if (value == null) return;
       data[attr.attribute] = value;
     });
 

--- a/src/panels/config/customize/ha-form-customize.js
+++ b/src/panels/config/customize/ha-form-customize.js
@@ -184,11 +184,12 @@ export class HaFormCustomize extends LocalizeMixin(PolymerElement) {
         attr.closed ||
         attr.secondary ||
         !attr.attribute ||
-        attr.value == null
+        attr.value === null ||
+        attr.value === undefined
       )
         return;
       const value = attr.type === "json" ? JSON.parse(attr.value) : attr.value;
-      if (value == null) return;
+      if (value === null || value === undefined) return;
       data[attr.attribute] = value;
     });
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

`false` values for explicitly added customize attributes should be stored, but currently the `!value` checks filters them out. Now we only rule them out if they are `null` or `undefined`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10377
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
