### PR TITLE
Ensure Sortable is recreated when card editors are reopened

### DIFF
--- a/src/panels/lovelace/components/hui-entity-editor.ts
+++ b/src/panels/lovelace/components/hui-entity-editor.ts
@@ -92,7 +92,7 @@ export class HuiEntityEditor extends LitElement {
     try {
       Sortable.mount(OnSpill);
       Sortable.mount(new AutoScroll());
-    } catch (error) {
+    } catch (_err) {
       // Sortable throws an error if it tries to re-mount an already mounted plugin.
       // We ignore those errors because firstUpdated will be called multiple times if the
       // editor is closed and re-opened.

--- a/src/panels/lovelace/components/hui-entity-editor.ts
+++ b/src/panels/lovelace/components/hui-entity-editor.ts
@@ -39,8 +39,6 @@ export class HuiEntityEditor extends LitElement {
   public connectedCallback() {
     super.connectedCallback();
     this._attached = true;
-    // Request update so that the Sortable can be re-initialized after the entities are rendered.
-    this.requestUpdate();
   }
 
   public disconnectedCallback() {

--- a/src/panels/lovelace/components/hui-entity-editor.ts
+++ b/src/panels/lovelace/components/hui-entity-editor.ts
@@ -39,6 +39,8 @@ export class HuiEntityEditor extends LitElement {
   public connectedCallback() {
     super.connectedCallback();
     this._attached = true;
+    // Request update so that the Sortable can be re-initialized after the entities are rendered.
+    this.requestUpdate();
   }
 
   public disconnectedCallback() {
@@ -87,8 +89,14 @@ export class HuiEntityEditor extends LitElement {
   }
 
   protected firstUpdated(): void {
-    Sortable.mount(OnSpill);
-    Sortable.mount(new AutoScroll());
+    try {
+      Sortable.mount(OnSpill);
+      Sortable.mount(new AutoScroll());
+    } catch (error) {
+      // Sortable throws an error if it tries to re-mount an already mounted plugin.
+      // We ignore those errors because firstUpdated will be called multiple times if the
+      // editor is closed and re-opened.
+    }
   }
 
   protected updated(changedProps: PropertyValues): void {

--- a/src/panels/lovelace/components/hui-entity-editor.ts
+++ b/src/panels/lovelace/components/hui-entity-editor.ts
@@ -10,10 +10,6 @@ import {
 import { customElement, property, state } from "lit/decorators";
 import { guard } from "lit/directives/guard";
 import type { SortableEvent } from "sortablejs";
-import Sortable, {
-  AutoScroll,
-  OnSpill,
-} from "sortablejs/modular/sortable.core.esm";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/ha-entity-picker";
 import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
@@ -21,6 +17,8 @@ import "../../../components/ha-icon-button";
 import { sortableStyles } from "../../../resources/ha-sortable-style";
 import { HomeAssistant } from "../../../types";
 import { EntityConfig } from "../entity-rows/types";
+
+let Sortable;
 
 @customElement("hui-entity-editor")
 export class HuiEntityEditor extends LitElement {
@@ -34,7 +32,7 @@ export class HuiEntityEditor extends LitElement {
 
   @state() private _renderEmptySortable = false;
 
-  private _sortable?: Sortable;
+  private _sortable?;
 
   public connectedCallback() {
     super.connectedCallback();
@@ -86,17 +84,6 @@ export class HuiEntityEditor extends LitElement {
     `;
   }
 
-  protected firstUpdated(): void {
-    try {
-      Sortable.mount(OnSpill);
-      Sortable.mount(new AutoScroll());
-    } catch (_err) {
-      // Sortable throws an error if it tries to re-mount an already mounted plugin.
-      // We ignore those errors because firstUpdated will be called multiple times if the
-      // editor is closed and re-opened.
-    }
-  }
-
   protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
 
@@ -134,7 +121,17 @@ export class HuiEntityEditor extends LitElement {
     this._renderEmptySortable = false;
   }
 
-  private _createSortable() {
+  private async _createSortable() {
+    if (!Sortable) {
+      const sortableImport = await import(
+        "sortablejs/modular/sortable.core.esm"
+      );
+
+      Sortable = sortableImport.Sortable;
+      Sortable.mount(sortableImport.OnSpill);
+      Sortable.mount(sortableImport.AutoScroll());
+    }
+
     this._sortable = new Sortable(this.shadowRoot!.querySelector(".entities"), {
       animation: 150,
       fallbackClass: "sortable-fallback",

--- a/src/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -48,8 +48,6 @@ export class HuiEntitiesCardRowEditor extends LitElement {
   public connectedCallback() {
     super.connectedCallback();
     this._attached = true;
-    // Request update so that the Sortable can be re-initialized after the entities are rendered.
-    this.requestUpdate();
   }
 
   public disconnectedCallback() {

--- a/src/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -10,10 +10,6 @@ import {
 import { customElement, property, state } from "lit/decorators";
 import { guard } from "lit/directives/guard";
 import type { SortableEvent } from "sortablejs";
-import Sortable, {
-  AutoScroll,
-  OnSpill,
-} from "sortablejs/modular/sortable.core.esm";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/ha-entity-picker";
 import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
@@ -22,6 +18,8 @@ import "../../../components/ha-svg-icon";
 import { sortableStyles } from "../../../resources/ha-sortable-style";
 import { HomeAssistant } from "../../../types";
 import { EntityConfig, LovelaceRowConfig } from "../entity-rows/types";
+
+let Sortable;
 
 declare global {
   interface HASSDomEvents {
@@ -43,7 +41,7 @@ export class HuiEntitiesCardRowEditor extends LitElement {
 
   @state() private _renderEmptySortable = false;
 
-  private _sortable?: Sortable;
+  private _sortable?;
 
   public connectedCallback() {
     super.connectedCallback();
@@ -134,17 +132,6 @@ export class HuiEntitiesCardRowEditor extends LitElement {
     `;
   }
 
-  protected firstUpdated(): void {
-    try {
-      Sortable.mount(OnSpill);
-      Sortable.mount(new AutoScroll());
-    } catch (error) {
-      // Sortable throws an error if it tries to re-mount an already mounted plugin.
-      // We ignore those errors because firstUpdated will be called multiple times if the
-      // editor is closed and re-opened.
-    }
-  }
-
   protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
 
@@ -182,7 +169,17 @@ export class HuiEntitiesCardRowEditor extends LitElement {
     this._renderEmptySortable = false;
   }
 
-  private _createSortable() {
+  private async _createSortable() {
+    if (!Sortable) {
+      const sortableImport = await import(
+        "sortablejs/modular/sortable.core.esm"
+      );
+
+      Sortable = sortableImport.Sortable;
+      Sortable.mount(sortableImport.OnSpill);
+      Sortable.mount(sortableImport.AutoScroll());
+    }
+
     this._sortable = new Sortable(this.shadowRoot!.querySelector(".entities"), {
       animation: 150,
       fallbackClass: "sortable-fallback",

--- a/src/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -48,6 +48,8 @@ export class HuiEntitiesCardRowEditor extends LitElement {
   public connectedCallback() {
     super.connectedCallback();
     this._attached = true;
+    // Request update so that the Sortable can be re-initialized after the entities are rendered.
+    this.requestUpdate();
   }
 
   public disconnectedCallback() {
@@ -135,8 +137,14 @@ export class HuiEntitiesCardRowEditor extends LitElement {
   }
 
   protected firstUpdated(): void {
-    Sortable.mount(OnSpill);
-    Sortable.mount(new AutoScroll());
+    try {
+      Sortable.mount(OnSpill);
+      Sortable.mount(new AutoScroll());
+    } catch (error) {
+      // Sortable throws an error if it tries to re-mount an already mounted plugin.
+      // We ignore those errors because firstUpdated will be called multiple times if the
+      // editor is closed and re-opened.
+    }
   }
 
   protected updated(changedProps: PropertyValues): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Allow sorting in lovelace card editors when they are closed and reopened.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
* Wrap `Sortable.mount` in a try catch because it throws an error when re-registering plugins when the card is re-opened 

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10359
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

## Demo
![sort](https://user-images.githubusercontent.com/11449043/138571193-267f43b0-771f-4ed4-95b6-607dc6f53532.gif)