### PR TITLE
Fix various `slugify()` issues + add tests

### DIFF
--- a/src/common/string/slugify.ts
+++ b/src/common/string/slugify.ts
@@ -12,8 +12,8 @@ export const slugify = (value: string, delimiter = "_") => {
     .replace(p, (c) => b.charAt(a.indexOf(c))) // Replace special characters
     .replace(/&/g, `${delimiter}and${delimiter}`) // Replace & with 'and'
     .replace(/[^\w-]+/g, "") // Remove all non-word characters
-    .replace(/-/, delimiter) // Replace - with delimiter
-    .replace(new RegExp(`/${delimiter}${delimiter}+/`, "g"), delimiter) // Replace multiple delimiters with single delimiter
-    .replace(new RegExp(`/^${delimiter}+/`), "") // Trim delimiter from start of text
-    .replace(new RegExp(`/-+$/`), ""); // Trim delimiter from end of text
+    .replace(/-/g, delimiter) // Replace - with delimiter
+    .replace(new RegExp(`(${delimiter})\\1+`, "g"), "$1") // Replace multiple delimiters with single delimiter
+    .replace(new RegExp(`^${delimiter}+`), "") // Trim delimiter from start of text
+    .replace(new RegExp(`${delimiter}+$`), ""); // Trim delimiter from end of text
 };

--- a/test/common/string/slugify.ts
+++ b/test/common/string/slugify.ts
@@ -1,0 +1,27 @@
+import { assert } from "chai";
+import { slugify } from "../../../src/common/string/slugify";
+
+describe("slugify", () => {
+  // With default delimiter
+  assert.strictEqual(slugify("abc"), "abc");
+  assert.strictEqual(slugify("ABC"), "abc");
+  assert.strictEqual(slugify("abc DEF"), "abc_def");
+  assert.strictEqual(slugify("abc-DEF"), "abc_def");
+  assert.strictEqual(slugify("abc_DEF"), "abc_def");
+  assert.strictEqual(slugify("abc å DEF"), "abc_a_def");
+  assert.strictEqual(slugify("abc:DEF"), "abc_def");
+  assert.strictEqual(slugify("abc&DEF"), "abc_and_def");
+  assert.strictEqual(slugify("abc^^DEF"), "abcdef");
+  assert.strictEqual(slugify("abc   DEF"), "abc_def");
+  assert.strictEqual(slugify("_abc DEF"), "abc_def");
+  assert.strictEqual(slugify("abc DEF_"), "abc_def");
+  assert.strictEqual(slugify("abc-DEF ghi"), "abc_def_ghi");
+  assert.strictEqual(slugify("abc-DEF-ghi"), "abc_def_ghi");
+  assert.strictEqual(slugify("abc - DEF - ghi"), "abc_def_ghi");
+  assert.strictEqual(slugify("abc---DEF---ghi"), "abc_def_ghi");
+  assert.strictEqual(slugify("___abc___DEF___ghi___"), "abc_def_ghi");
+
+  // With custom delimiter
+  assert.strictEqual(slugify("abc def", "-"), "abc-def");
+  assert.strictEqual(slugify("abc-def", "-"), "abc-def");
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Existing logic had various issues:
1. Only the first `-` was getting replaced => global flag added
2. The existing logic to prevent duplicate delimiters in the output was hard-coded to two consecutive instances => now replaced by a generic solution
3. The logic to trim any delimiter from the start of end was invalid and had no effect => fixed

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10378
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
