### PR TITLE
Convert multi-state to array before saving

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -179,7 +179,7 @@ export interface StateCondition extends BaseCondition {
   condition: "state";
   entity_id: string;
   attribute?: string;
-  state: string | number;
+  state: string | number | string[];
   for?: string | number | ForDict;
 }
 

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -81,7 +81,7 @@ export class HaStateCondition extends LitElement implements ConditionElement {
     value: string | number
   ): string | number | string[] {
     if (typeof value === "string") {
-      const splitValue = value?.split(",");
+      const splitValue = value.split(",");
       return splitValue?.length > 1 ? splitValue : value;
     }
     return value;

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -80,8 +80,11 @@ export class HaStateCondition extends LitElement implements ConditionElement {
   private coerceToCorrectValueType(
     value: string | number
   ): string | number | string[] {
-    const splitValue = typeof value === "string" ? value?.split(",") : null;
-    return splitValue?.length ? splitValue : value;
+    if (typeof value === "string") {
+      const splitValue = value?.split(",");
+      return splitValue?.length > 1 ? splitValue : value;
+    }
+    return value;
   }
 
   private coerceToCommaSeparatedString(

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -23,20 +23,24 @@ export class HaStateCondition extends LitElement implements ConditionElement {
   }
 
   protected render() {
-    const { entity_id, attribute, state } = this.condition;
+    const { attribute } = this.condition;
+    const stateString = this.coerceToCommaSeparatedString(this.condition.state);
+    const entityIdString = this.coerceToCommaSeparatedString(
+      this.condition.entity_id
+    );
     const forTime = createDurationData(this.condition.for);
 
     return html`
       <ha-entity-picker
-        .value=${entity_id}
+        .value=${entityIdString}
         .name=${"entity_id"}
-        @value-changed=${this._valueChanged}
+        @value-changed=${this._arrayValueChanged}
         .hass=${this.hass}
         allow-custom-entity
       ></ha-entity-picker>
       <ha-entity-attribute-picker
         .hass=${this.hass}
-        .entityId=${entity_id}
+        .entityId=${entityIdString}
         .value=${attribute}
         .name=${"attribute"}
         .label=${this.hass.localize(
@@ -50,8 +54,8 @@ export class HaStateCondition extends LitElement implements ConditionElement {
           "ui.panel.config.automation.editor.conditions.type.state.state"
         )}
         .name=${"state"}
-        .value=${state}
-        @value-changed=${this._valueChanged}
+        .value=${stateString}
+        @value-changed=${this._arrayValueChanged}
       ></paper-input>
       <ha-duration-input
         .label=${this.hass.localize(
@@ -66,6 +70,24 @@ export class HaStateCondition extends LitElement implements ConditionElement {
 
   private _valueChanged(ev: CustomEvent): void {
     handleChangeEvent(this, ev);
+  }
+
+  private _arrayValueChanged(ev: CustomEvent): void {
+    ev.detail.value = this.coerceToCorrectValueType(ev.detail.value);
+    handleChangeEvent(this, ev);
+  }
+
+  private coerceToCorrectValueType(
+    value: string | number
+  ): string | number | string[] {
+    const splitValue = typeof value === "string" ? value?.split(",") : null;
+    return splitValue?.length ? splitValue : value;
+  }
+
+  private coerceToCommaSeparatedString(
+    value: string | string[] | number
+  ): string | number {
+    return Array.isArray(value) ? value.join(",") : value;
   }
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
When editing automations state conditions in the UI, if multiple states or multiple entities are specified (comma-separated), send them to the backend as an array.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
If multiple entityIds or states are present on an automation state condition, first convert them to a comma-separated string to display in the UI form. Then, when reading the form value back into the `Condition` object, convert the string into an array.
- This PR fixes or closes issue: fixes #6664
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

## Demo
![multiple-states](https://user-images.githubusercontent.com/11449043/138574110-1380dc3f-e0f5-4d5c-91c8-8fea2ff29a76.gif)
