### PR TITLE
Ensure consistent card look on device config page

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -131,7 +131,11 @@ export class HaDeviceEntitiesCard extends LitElement {
 
   private _renderEntry(entry: EntityRegistryStateEntry): TemplateResult {
     return html`
-      <paper-icon-item .entry=${entry} @click=${this._openEditEntry}>
+      <paper-icon-item
+        class="disabled-entry"
+        .entry=${entry}
+        @click=${this._openEditEntry}
+      >
         <ha-svg-icon
           slot="item-icon"
           .path=${domainIcon(computeDomain(entry.entity_id))}
@@ -188,6 +192,9 @@ export class HaDeviceEntitiesCard extends LitElement {
       .disabled-entry {
         color: var(--secondary-text-color);
       }
+      #entities {
+        margin-top: -24px; /* match the spacing between card title and content of the device info card above it */
+      }
       #entities > * {
         margin: 8px 16px 8px 8px;
       }
@@ -196,8 +203,9 @@ export class HaDeviceEntitiesCard extends LitElement {
       }
       paper-icon-item {
         min-height: 40px;
-        padding: 0 8px;
+        padding: 0 16px;
         cursor: pointer;
+        --paper-item-icon-width: 48px;
       }
       .name {
         font-size: 14px;

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -420,7 +420,7 @@ export class HaConfigDevicePage extends LitElement {
                               : "";
                           })
                         : html`
-                            <paper-item class="no-link">
+                            <div class="card-content">
                               ${this.hass.localize(
                                 "ui.panel.config.devices.add_prompt",
                                 "name",
@@ -428,7 +428,7 @@ export class HaConfigDevicePage extends LitElement {
                                   "ui.panel.config.devices.automation.automations"
                                 )
                               )}
-                            </paper-item>
+                            </div>
                           `}
                     </ha-card>
                   `
@@ -502,7 +502,7 @@ export class HaConfigDevicePage extends LitElement {
                                   : "";
                               })
                             : html`
-                                <paper-item class="no-link">
+                                <div class="card-content">
                                   ${this.hass.localize(
                                     "ui.panel.config.devices.add_prompt",
                                     "name",
@@ -510,7 +510,7 @@ export class HaConfigDevicePage extends LitElement {
                                       "ui.panel.config.devices.scene.scenes"
                                     )
                                   )}
-                                </paper-item>
+                                </div>
                               `
                         }
                       </ha-card>
@@ -558,7 +558,7 @@ export class HaConfigDevicePage extends LitElement {
                                 : "";
                             })
                           : html`
-                              <paper-item class="no-link">
+                              <div class="card-content">
                                 ${this.hass.localize(
                                   "ui.panel.config.devices.add_prompt",
                                   "name",
@@ -566,7 +566,7 @@ export class HaConfigDevicePage extends LitElement {
                                     "ui.panel.config.devices.script.scripts"
                                   )
                                 )}
-                              </paper-item>
+                              </div>
                             `}
                       </ha-card>
                     `
@@ -953,17 +953,9 @@ export class HaConfigDevicePage extends LitElement {
           font-size: var(--paper-font-body1_-_font-size);
         }
 
-        paper-item.no-link {
-          cursor: default;
-        }
-
         a {
           text-decoration: none;
           color: var(--primary-color);
-        }
-
-        ha-card {
-          padding-bottom: 8px;
         }
 
         ha-card a {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The cards on the device config page were inconsistent:

1. The space between the card title was different for each of the three types: Device info, device state/config/diagnostics and the automation/scene/script cards => now aligned. The only difference remains that once e.g. automations exist, they are a bit pushed down from the title visually since the paper-items (rows) have some padding.
2. The placeholder texts when no automations/scenes/scrips exist, are now regular text elements (in `card-content`) rather than paper-items. If everyone agrees, the same should be done for area config as well.
3. The disabled entities were rendered incorrectly: wrong color and incorrect spacing of text and icon. 

**Before:**
![image](https://user-images.githubusercontent.com/114137/138601268-34e44edb-278b-42f5-aaee-eb07a1e259bc.png)

**Before:**
![image](https://user-images.githubusercontent.com/114137/138601429-c69032c4-a8a8-42de-a494-d91f2863214c.png)


**After:**
![image](https://user-images.githubusercontent.com/114137/138601289-4d8f58fd-2407-49ef-8657-5cf5476fbcb4.png)

**After (with automations created):**
![image](https://user-images.githubusercontent.com/114137/138601334-dd33dff9-06ba-4a3d-a054-a9364566947e.png)

**After (show disabled entities):**
![image](https://user-images.githubusercontent.com/114137/138601436-96e47d3f-ee9f-4a7f-83d1-132852ac9d87.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
