### PR TITLE
Use ha-chip for alarm control panel card

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -8,13 +8,13 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit";
-import { customElement, property, state, query } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { alarmPanelIcon } from "../../../common/entity/alarm_panel_icon";
 import "../../../components/ha-card";
-import "../../../components/ha-label-badge";
+import "../../../components/ha-chip";
 import {
   callAlarmAction,
   FORMAT_NUMBER,
@@ -150,13 +150,15 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
         stateObj.attributes.friendly_name ||
         this._stateDisplay(stateObj.state)}
       >
-        <ha-label-badge
+        <ha-chip
+          hasIcon
           class=${classMap({ [stateObj.state]: true })}
-          .label=${this._stateIconLabel(stateObj.state)}
           @click=${this._handleMoreInfo}
         >
-          <ha-svg-icon .path=${alarmPanelIcon(stateObj.state)}></ha-svg-icon>
-        </ha-label-badge>
+          <ha-svg-icon slot="icon" .path=${alarmPanelIcon(stateObj.state)}>
+          </ha-svg-icon>
+          ${this._stateDisplay(stateObj.state)}
+        </ha-chip>
         <div id="armActions" class="actions">
           ${(stateObj.state === "disarmed"
             ? this._config.states!
@@ -215,15 +217,6 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
     `;
   }
 
-  private _stateIconLabel(entityState: string): string {
-    const stateLabel = entityState.split("_").pop();
-    return stateLabel === "disarmed" ||
-      stateLabel === "triggered" ||
-      !stateLabel
-      ? ""
-      : this._stateDisplay(entityState);
-  }
-
   private _actionDisplay(entityState: string): string {
     return this.hass!.localize(`ui.card.alarm_control_panel.${entityState}`);
   }
@@ -273,14 +266,12 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
         --alarm-state-color: var(--alarm-color-armed);
       }
 
-      ha-label-badge {
-        --ha-label-badge-color: var(--alarm-state-color);
-        --label-badge-text-color: var(--alarm-state-color);
-        --label-badge-background-color: var(--card-background-color);
+      ha-chip {
+        --ha-chip-text-color: var(--alarm-state-color);
         color: var(--alarm-state-color);
         position: absolute;
         right: 12px;
-        top: 8px;
+        top: 12px;
         cursor: pointer;
       }
 

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -145,20 +145,21 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
     }
 
     return html`
-      <ha-card
-        .header=${this._config.name ||
-        stateObj.attributes.friendly_name ||
-        this._stateDisplay(stateObj.state)}
-      >
-        <ha-chip
-          hasIcon
-          class=${classMap({ [stateObj.state]: true })}
-          @click=${this._handleMoreInfo}
-        >
-          <ha-svg-icon slot="icon" .path=${alarmPanelIcon(stateObj.state)}>
-          </ha-svg-icon>
-          ${this._stateDisplay(stateObj.state)}
-        </ha-chip>
+      <ha-card>
+        <h1 class="card-header">
+          ${this._config.name ||
+          stateObj.attributes.friendly_name ||
+          this._stateDisplay(stateObj.state)}
+          <ha-chip
+            hasIcon
+            class=${classMap({ [stateObj.state]: true })}
+            @click=${this._handleMoreInfo}
+          >
+            <ha-svg-icon slot="icon" .path=${alarmPanelIcon(stateObj.state)}>
+            </ha-svg-icon>
+            ${this._stateDisplay(stateObj.state)}
+          </ha-chip>
+        </h1>
         <div id="armActions" class="actions">
           ${(stateObj.state === "disarmed"
             ? this._config.states!
@@ -267,12 +268,13 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       }
 
       ha-chip {
-        --ha-chip-text-color: var(--alarm-state-color);
-        color: var(--alarm-state-color);
-        position: absolute;
-        right: 12px;
-        top: 12px;
-        cursor: pointer;
+        --ha-chip-background-color: var(--alarm-state-color);
+        --ha-chip-text-color: var(--text-primary-color);
+      }
+
+      .card-header {
+        display: flex;
+        justify-content: space-between;
       }
 
       .disarmed {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -19,6 +19,7 @@ import {
   callAlarmAction,
   FORMAT_NUMBER,
 } from "../../../data/alarm_control_panel";
+import { UNAVAILABLE } from "../../../data/entity";
 import type { HomeAssistant } from "../../../types";
 import { findEntities } from "../common/find-entities";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
@@ -225,10 +226,11 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
   }
 
   private _stateDisplay(entityState: string): string {
-    return (
-      this.hass!.localize(
-        `component.alarm_control_panel.state._.${entityState}`
-      ) || this.hass!.localize("state.default.unavailable")
+    if (entityState === UNAVAILABLE) {
+      return this.hass!.localize("state.default.unavailable");
+    }
+    return this.hass!.localize(
+      `component.alarm_control_panel.state._.${entityState}`
     );
   }
 

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -226,12 +226,11 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
   }
 
   private _stateDisplay(entityState: string): string {
-    if (entityState === UNAVAILABLE) {
-      return this.hass!.localize("state.default.unavailable");
-    }
-    return this.hass!.localize(
-      `component.alarm_control_panel.state._.${entityState}`
-    ) || entityState;
+    return entityState === UNAVAILABLE
+      ? this.hass!.localize("state.default.unavailable")
+      : this.hass!.localize(
+          `component.alarm_control_panel.state._.${entityState}`
+        ) || entityState;
   }
 
   private _handlePadClick(e: MouseEvent): void {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -144,12 +144,14 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       `;
     }
 
+    const stateLabel = this._stateDisplay(stateObj.state);
+
     return html`
       <ha-card>
         <h1 class="card-header">
           ${this._config.name ||
           stateObj.attributes.friendly_name ||
-          this._stateDisplay(stateObj.state)}
+          stateLabel}
           <ha-chip
             hasIcon
             class=${classMap({ [stateObj.state]: true })}
@@ -157,7 +159,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
           >
             <ha-svg-icon slot="icon" .path=${alarmPanelIcon(stateObj.state)}>
             </ha-svg-icon>
-            ${this._stateDisplay(stateObj.state)}
+            ${stateLabel}
           </ha-chip>
         </h1>
         <div id="armActions" class="actions">
@@ -223,8 +225,10 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
   }
 
   private _stateDisplay(entityState: string): string {
-    return this.hass!.localize(
-      `component.alarm_control_panel.state._.${entityState}`
+    return (
+      this.hass!.localize(
+        `component.alarm_control_panel.state._.${entityState}`
+      ) || this.hass!.localize("state.default.unavailable")
     );
   }
 
@@ -270,11 +274,17 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       ha-chip {
         --ha-chip-background-color: var(--alarm-state-color);
         --ha-chip-text-color: var(--text-primary-color);
+        line-height: initial;
       }
 
       .card-header {
         display: flex;
         justify-content: space-between;
+        align-items: center;
+      }
+
+      .unavailable {
+        --alarm-state-color: var(--state-unavailable-color);
       }
 
       .disarmed {

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -231,7 +231,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
     }
     return this.hass!.localize(
       `component.alarm_control_panel.state._.${entityState}`
-    );
+    ) || entityState;
   }
 
   private _handlePadClick(e: MouseEvent): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Based on this comment <https://github.com/home-assistant/frontend/issues/9389#issuecomment-950860859>

Old: https://dev--home-assistant-gallery.netlify.app/#demo-hui-alarm-panel-card
New: https://6176a272c117980007b77a4e--home-assistant-gallery.netlify.app/#demo-hui-alarm-panel-card

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9389
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
