### PR TITLE
Add CSS var for `ha-dialog` border radius

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -71,7 +71,10 @@ export class HaDialog extends Dialog {
           position: var(--dialog-surface-position, relative);
           top: var(--dialog-surface-top);
           min-height: var(--mdc-dialog-min-height, auto);
-          border-radius: var(--ha-dialog-border-radius, 4px);
+          border-radius: var(
+            --ha-dialog-border-radius,
+            var(--mdc-shape-medium, 4px)
+          );
         }
         :host([flexContent]) .mdc-dialog .mdc-dialog__content {
           display: flex;

--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -72,7 +72,7 @@ export class HaDialog extends Dialog {
           top: var(--dialog-surface-top);
           min-height: var(--mdc-dialog-min-height, auto);
           border-radius: var(
-            --ha-dialog-border-radius,
+            --ha-card-border-radius,
             var(--mdc-shape-medium, 4px)
           );
         }

--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -72,8 +72,8 @@ export class HaDialog extends Dialog {
           top: var(--dialog-surface-top);
           min-height: var(--mdc-dialog-min-height, auto);
           border-radius: var(
-            --ha-card-border-radius,
-            var(--mdc-shape-medium, 4px)
+            --ha-dialog-border-radius,
+            var(--ha-card-border-radius, 4px)
           );
         }
         :host([flexContent]) .mdc-dialog .mdc-dialog__content {

--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -71,6 +71,7 @@ export class HaDialog extends Dialog {
           position: var(--dialog-surface-position, relative);
           top: var(--dialog-surface-top);
           min-height: var(--mdc-dialog-min-height, auto);
+          border-radius: var(--ha-dialog-border-radius, 4px);
         }
         :host([flexContent]) .mdc-dialog .mdc-dialog__content {
           display: flex;

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -331,11 +331,8 @@ export const haStyleDialog = css`
       );
       --mdc-dialog-min-height: 100%;
       --mdc-dialog-max-height: 100%;
-      /* both mdc-shape-medium and ha-card-border-radius affect the border radius
-        and should not take effect in fullscreen */
-      --mdc-shape-medium: 0px;
-      --ha-card-border-radius: 0px;
       --vertial-align-dialog: flex-end;
+      --ha-dialog-border-radius: 0px;
     }
   }
   mwc-button.warning {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -333,6 +333,7 @@ export const haStyleDialog = css`
       --mdc-dialog-max-height: 100%;
       --mdc-shape-medium: 0px;
       --vertial-align-dialog: flex-end;
+      --ha-card-border-radius: 0px;
     }
   }
   mwc-button.warning {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -331,9 +331,11 @@ export const haStyleDialog = css`
       );
       --mdc-dialog-min-height: 100%;
       --mdc-dialog-max-height: 100%;
+      /* both mdc-shape-medium and ha-card-border-radius affect the border radius
+        and should not take effect in fullscreen */
       --mdc-shape-medium: 0px;
-      --vertial-align-dialog: flex-end;
       --ha-card-border-radius: 0px;
+      --vertial-align-dialog: flex-end;
     }
   }
   mwc-button.warning {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

We already have `ha-card-border-radius` and now it will also be used so that e.g. more-info popups can follow the same style for a consistent look.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
