### PR TITLE
Use tags and aliases when filtering icons in Icon Picker

### DIFF
--- a/build-scripts/gulp/gen-icons-json.js
+++ b/build-scripts/gulp/gen-icons-json.js
@@ -26,6 +26,7 @@ const getMeta = () => {
       path: svg.match(/ d="([^"]+)"/)[1],
       name: icon.name,
       tags: icon.tags,
+      aliases: icon.aliases,
     };
   });
 };
@@ -37,6 +38,7 @@ const addRemovedMeta = (meta) => {
     path: removeIcon.path,
     name: removeIcon.name,
     tags: [],
+    aliases: [],
   }));
   const combinedMeta = [...meta, ...removedMeta];
   return combinedMeta.sort((a, b) => a.name.localeCompare(b.name));
@@ -141,7 +143,13 @@ gulp.task("gen-icons-json", (done) => {
 
   fs.writeFileSync(
     path.resolve(OUTPUT_DIR, "iconList.json"),
-    JSON.stringify(orderMeta(meta).map((icon) => icon.name))
+    JSON.stringify(
+      orderMeta(meta).map((icon) => ({
+        name: icon.name,
+        tags: icon.tags.map((t) => t.toLowerCase().replaceAll(" / ", " ")),
+        aliases: icon.aliases,
+      }))
+    )
   );
 
   done();

--- a/build-scripts/gulp/gen-icons-json.js
+++ b/build-scripts/gulp/gen-icons-json.js
@@ -146,8 +146,10 @@ gulp.task("gen-icons-json", (done) => {
     JSON.stringify(
       orderMeta(meta).map((icon) => ({
         name: icon.name,
-        tags: icon.tags.map((t) => t.toLowerCase().replace(/\s\/\s/g, " ")),
-        aliases: icon.aliases,
+        keywords: [
+          ...icon.tags.map((t) => t.toLowerCase().replace(/\s\/\s/g, " ")),
+          ...icon.aliases,
+        ],
       }))
     )
   );

--- a/build-scripts/gulp/gen-icons-json.js
+++ b/build-scripts/gulp/gen-icons-json.js
@@ -146,7 +146,7 @@ gulp.task("gen-icons-json", (done) => {
     JSON.stringify(
       orderMeta(meta).map((icon) => ({
         name: icon.name,
-        tags: icon.tags.map((t) => t.toLowerCase().replaceAll(" / ", " ")),
+        tags: icon.tags.map((t) => t.toLowerCase().replace(/\s\/\s/g, " ")),
         aliases: icon.aliases,
       }))
     )

--- a/src/components/ha-icon-picker.ts
+++ b/src/components/ha-icon-picker.ts
@@ -13,7 +13,7 @@ import "./ha-icon-button";
 
 type IconItem = {
   icon: string;
-  tagsAndAliases: string[];
+  keywords: string[];
 };
 let iconItems: IconItem[] = [];
 
@@ -113,7 +113,7 @@ export class HaIconPicker extends LitElement {
       const iconList = await import("../../build/mdi/iconList.json");
       iconItems = iconList.default.map((icon) => ({
         icon: `mdi:${icon.name}`,
-        tagsAndAliases: [...icon.tags, ...icon.aliases],
+        keywords: [...icon.tags, ...icon.aliases],
       }));
       (this.comboBox as any).filteredItems = iconItems;
     }
@@ -144,13 +144,13 @@ export class HaIconPicker extends LitElement {
         item.icon.includes(filterString)
       );
 
-      const filteredItemsByTagsOrAliases = iconItems.filter(
+      const filteredItemsByKeywords = iconItems.filter(
         (item) =>
           !item.icon.includes(filterString) &&
-          item.tagsAndAliases.some((t) => t.includes(filterString))
+          item.keywords.some((k) => k.includes(filterString))
       );
 
-      filteredItems.push(...filteredItemsByTagsOrAliases);
+      filteredItems.push(...filteredItemsByKeywords);
 
       if (filteredItems.length > 0) {
         (this.comboBox as any).filteredItems = filteredItems;

--- a/src/components/ha-icon-picker.ts
+++ b/src/components/ha-icon-picker.ts
@@ -13,9 +13,7 @@ import "./ha-icon-button";
 
 type IconItem = {
   icon: string;
-  name: string;
-  aliases: string[];
-  tags: string[];
+  tagsAndAliases: string[];
 };
 let iconItems: IconItem[] = [];
 
@@ -114,8 +112,8 @@ export class HaIconPicker extends LitElement {
     if (this._opened && !iconItems.length) {
       const iconList = await import("../../build/mdi/iconList.json");
       iconItems = iconList.default.map((icon) => ({
-        ...icon,
         icon: `mdi:${icon.name}`,
+        tagsAndAliases: [...icon.tags, ...icon.aliases],
       }));
       (this.comboBox as any).filteredItems = iconItems;
     }
@@ -145,8 +143,7 @@ export class HaIconPicker extends LitElement {
       const filteredItems = iconItems.filter(
         (item) =>
           item.icon.includes(filterString) ||
-          item.tags.some((tag) => tag.includes(filterString)) ||
-          item.aliases.some((alias) => alias.includes(filterString))
+          item.tagsAndAliases.some((t) => t.includes(filterString))
       );
 
       const getItemScore = (item: IconItem): number =>

--- a/src/components/ha-icon-picker.ts
+++ b/src/components/ha-icon-picker.ts
@@ -140,15 +140,18 @@ export class HaIconPicker extends LitElement {
     const filterString = ev.detail.value.toLowerCase();
     const characterCount = filterString.length;
     if (characterCount >= 2) {
-      const filteredItems = iconItems.filter((item) =>
-        item.icon.includes(filterString)
-      );
+      const filteredItems: IconItem[] = [];
+      const filteredItemsByKeywords: IconItem[] = [];
 
-      const filteredItemsByKeywords = iconItems.filter(
-        (item) =>
-          !item.icon.includes(filterString) &&
-          item.keywords.some((k) => k.includes(filterString))
-      );
+      iconItems.forEach((item) => {
+        if (item.icon.includes(filterString)) {
+          filteredItems.push(item);
+          return;
+        }
+        if (item.keywords.some((t) => t.includes(filterString))) {
+          filteredItemsByKeywords.push(item);
+        }
+      });
 
       filteredItems.push(...filteredItemsByKeywords);
 

--- a/src/components/ha-icon-picker.ts
+++ b/src/components/ha-icon-picker.ts
@@ -140,16 +140,17 @@ export class HaIconPicker extends LitElement {
     const filterString = ev.detail.value.toLowerCase();
     const characterCount = filterString.length;
     if (characterCount >= 2) {
-      const filteredItems = iconItems.filter(
+      const filteredItems = iconItems.filter((item) =>
+        item.icon.includes(filterString)
+      );
+
+      const filteredItemsByTagsOrAliases = iconItems.filter(
         (item) =>
-          item.icon.includes(filterString) ||
+          !item.icon.includes(filterString) &&
           item.tagsAndAliases.some((t) => t.includes(filterString))
       );
 
-      const getItemScore = (item: IconItem): number =>
-        item.icon.includes(filterString) ? 1 : 0;
-
-      filteredItems.sort((i1, i2) => getItemScore(i2) - getItemScore(i1));
+      filteredItems.push(...filteredItemsByTagsOrAliases);
 
       if (filteredItems.length > 0) {
         (this.comboBox as any).filteredItems = filteredItems;

--- a/src/components/ha-icon-picker.ts
+++ b/src/components/ha-icon-picker.ts
@@ -113,7 +113,7 @@ export class HaIconPicker extends LitElement {
       const iconList = await import("../../build/mdi/iconList.json");
       iconItems = iconList.default.map((icon) => ({
         icon: `mdi:${icon.name}`,
-        keywords: [...icon.tags, ...icon.aliases],
+        keywords: icon.keywords,
       }));
       (this.comboBox as any).filteredItems = iconItems;
     }


### PR DESCRIPTION
## Breaking change

No breaking change

## Proposed change

Use the available tags and aliases in mdi icon meta to improve search experience in icon picker. 
If we merge that PR, we can update this PR https://github.com/home-assistant/frontend/pull/10399 to allow custom iconsets proposing tags and aliases too.

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml

```

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/10399
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
