### PR TITLE
Default to yaml editing when there are multiple states in condition

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -179,7 +179,7 @@ export interface StateCondition extends BaseCondition {
   condition: "state";
   entity_id: string;
   attribute?: string;
-  state: string | number;
+  state: string | number | string[];
   for?: string | number | ForDict;
 }
 

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -5,6 +5,7 @@ import "@polymer/paper-item/paper-item";
 import { css, CSSResultGroup, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import { handleStructError } from "../../../../common/structs/handle-errors";
 import "../../../../components/ha-button-menu";
 import "../../../../components/ha-card";
 import "../../../../components/ha-icon-button";
@@ -51,6 +52,8 @@ export default class HaAutomationConditionRow extends LitElement {
 
   @state() private _yamlMode = false;
 
+  @state() private _warnings?: string[];
+
   protected render() {
     if (!this.condition) {
       return html``;
@@ -88,6 +91,7 @@ export default class HaAutomationConditionRow extends LitElement {
             </ha-button-menu>
           </div>
           <ha-automation-condition-editor
+            @ui-mode-not-available=${this._handleUiModeNotAvailable}
             .yamlMode=${this._yamlMode}
             .hass=${this.hass}
             .condition=${this.condition}
@@ -95,6 +99,15 @@ export default class HaAutomationConditionRow extends LitElement {
         </div>
       </ha-card>
     `;
+  }
+
+  private _handleUiModeNotAvailable(ev: CustomEvent) {
+    // Prevent possible parent action-row from switching to yamlMode
+    ev.stopPropagation();
+    this._warnings = handleStructError(this.hass, ev.detail).warnings;
+    if (!this._yamlMode) {
+      this._yamlMode = true;
+    }
   }
 
   private _handleAction(ev: CustomEvent<ActionDetail>) {

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -155,6 +155,7 @@ export default class HaAutomationConditionRow extends LitElement {
   }
 
   private _switchYamlMode() {
+    this._warnings = undefined;
     this._yamlMode = !this._yamlMode;
   }
 

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -90,6 +90,23 @@ export default class HaAutomationConditionRow extends LitElement {
               </mwc-list-item>
             </ha-button-menu>
           </div>
+          ${this._warnings
+            ? html`<ha-alert
+                alert-type="warning"
+                .title=${this.hass.localize(
+                  "ui.errors.config.editor_not_supported"
+                )}
+              >
+                ${this._warnings!.length > 0 && this._warnings![0] !== undefined
+                  ? html` <ul>
+                      ${this._warnings!.map(
+                        (warning) => html`<li>${warning}</li>`
+                      )}
+                    </ul>`
+                  : ""}
+                ${this.hass.localize("ui.errors.config.edit_in_yaml_supported")}
+              </ha-alert>`
+            : ""}
           <ha-automation-condition-editor
             @ui-mode-not-available=${this._handleUiModeNotAvailable}
             .yamlMode=${this._yamlMode}

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -23,18 +23,16 @@ export class HaStateCondition extends LitElement implements ConditionElement {
     return { entity_id: "", state: "" };
   }
 
-  protected shouldUpdate(changedProperties: PropertyValues): boolean {
+  public willUpdate(changedProperties: PropertyValues): boolean {
     if (
       changedProperties.has("condition") &&
-      this._stateIsArray(this.condition)
+      Array.isArray(this.condition?.state)
     ) {
-      if (this._stateIsArray(this.condition)) {
-        fireEvent(
-          this,
-          "ui-mode-not-available",
-          Error(this.hass.localize("ui.errors.config.editor_not_supported"))
-        );
-      }
+      fireEvent(
+        this,
+        "ui-mode-not-available",
+        Error(this.hass.localize("ui.errors.config.no_state_array_support"))
+      );
       // We have to stop the update if state is an array.
       // Otherwise the state will be changed to a comma-separated string by the input element.
       return false;
@@ -86,10 +84,6 @@ export class HaStateCondition extends LitElement implements ConditionElement {
 
   private _valueChanged(ev: CustomEvent): void {
     handleChangeEvent(this, ev);
-  }
-
-  private _stateIsArray(condition: StateCondition): boolean {
-    return Array.isArray(condition?.state);
   }
 }
 

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -1,5 +1,5 @@
 import "@polymer/paper-input/paper-input";
-import { html, LitElement } from "lit";
+import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 import "../../../../../components/entity/ha-entity-attribute-picker";
@@ -11,6 +11,7 @@ import {
   handleChangeEvent,
 } from "../ha-automation-condition-row";
 import "../../../../../components/ha-duration-input";
+import { fireEvent } from "../../../../../common/dom/fire_event";
 
 @customElement("ha-automation-condition-state")
 export class HaStateCondition extends LitElement implements ConditionElement {
@@ -20,6 +21,21 @@ export class HaStateCondition extends LitElement implements ConditionElement {
 
   public static get defaultConfig() {
     return { entity_id: "", state: "" };
+  }
+
+  protected shouldUpdate(changedProperties: PropertyValues): boolean {
+    if (
+      changedProperties.has("condition") &&
+      this._stateIsArray(this.condition)
+    ) {
+      if (this._stateIsArray(this.condition)) {
+        fireEvent(this, "ui-mode-not-available", Error(this.hass.localize("")));
+      }
+      // We have to stop the update if state is an array.
+      // Otherwise the state will be changed to a comma-separated string by the input element.
+      return false;
+    }
+    return true;
   }
 
   protected render() {
@@ -66,6 +82,10 @@ export class HaStateCondition extends LitElement implements ConditionElement {
 
   private _valueChanged(ev: CustomEvent): void {
     handleChangeEvent(this, ev);
+  }
+
+  private _stateIsArray(condition: StateCondition): boolean {
+    return Array.isArray(condition?.state);
   }
 }
 

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -29,7 +29,11 @@ export class HaStateCondition extends LitElement implements ConditionElement {
       this._stateIsArray(this.condition)
     ) {
       if (this._stateIsArray(this.condition)) {
-        fireEvent(this, "ui-mode-not-available", Error(this.hass.localize("")));
+        fireEvent(
+          this,
+          "ui-mode-not-available",
+          Error(this.hass.localize("ui.errors.config.editor_not_supported"))
+        );
       }
       // We have to stop the update if state is an array.
       // Otherwise the state will be changed to a comma-separated string by the input element.

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -861,7 +861,8 @@
         "key_missing": "Required key ''{key}'' is missing.",
         "key_not_expected": "Key ''{key}'' is not expected or not supported by the visual editor.",
         "key_wrong_type": "The provided value for ''{key}'' is not supported by the visual editor. We support ({type_correct}) but received ({type_wrong}).",
-        "no_template_editor_support": "Templates not supported in visual editor"
+        "no_template_editor_support": "Templates not supported in visual editor",
+        "no_state_array_support": "Multiple state values not supported in visual editor"
       },
       "supervisor": {
         "title": "Could not load the Supervisor panel!",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Before, when editing an automation containing a condition with an array of states, the UI would convert them to a comma-separated list. Now, instead of trying to parse the array as a string, we default to yaml mode and show an error.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
automations.yaml
```yaml
- id: trigger_good_morning
  alias: 'Trigger: Good Morning'
  trigger:
  - entity_id: binary_sensor.master_closet_motion
    platform: state
    to: 'on'
  condition:
  - condition: state
    entity_id:
    - person.nathan
    attribute: friendly_name
    state:
    - Home
    - Away
  action:
  - data: {}
    service: script.good_morning
  mode: single
```

## Additional information
@bramkragten, this is a followup to your comment in #10384.
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6664 #10473
- This PR is related to issue or discussion:
- Link to documentation pull request:
- Follow up to #10384 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

## Demo
![yaml-mode](https://user-images.githubusercontent.com/11449043/139542317-7b727976-63e9-4afa-a497-7a8bd2027f7a.gif)

