### PR TITLE
Hide column if no children are visible

### DIFF
--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -1,5 +1,6 @@
 import { PropertyValues, ReactiveElement } from "lit";
 import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../common/dom/fire_event";
 import { HomeAssistant } from "../../../types";
 import { ConditionalCardConfig } from "../cards/types";
 import {
@@ -8,6 +9,13 @@ import {
 } from "../common/validate-condition";
 import { ConditionalRowConfig, LovelaceRow } from "../entity-rows/types";
 import { LovelaceCard } from "../types";
+
+declare global {
+  // for fire event
+  interface HASSDomEvents {
+    "update-layout": undefined;
+  }
+}
 
 @customElement("hui-conditional-base")
 export class HuiConditionalBase extends ReactiveElement {
@@ -53,6 +61,8 @@ export class HuiConditionalBase extends ReactiveElement {
       return;
     }
 
+    const oldVisibility = !this.hidden;
+
     this._element.editMode = this.editMode;
 
     const visible =
@@ -66,6 +76,10 @@ export class HuiConditionalBase extends ReactiveElement {
       if (!this._element.parentElement) {
         this.appendChild(this._element);
       }
+    }
+
+    if (visible !== oldVisibility) {
+      fireEvent(this, "update-layout");
     }
   }
 }

--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -92,7 +92,7 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
       ${this.badges.length > 0
         ? html` <div class="badges">${this.badges}</div>`
         : ""}
-      <div id="columns"></div>
+      <div id="columns" @update-layout=${this._handleUpdateLayout}></div>
       ${this.lovelace?.editMode
         ? html`
             <ha-fab
@@ -257,6 +257,10 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
         column.parentElement!.removeChild(column);
       }
     });
+
+    if (!this.lovelace!.editMode || this.isStrategy) {
+      columnElements.forEach(this._hideColumnIfAllChildrenAreHidden);
+    }
   }
 
   private _addCardToColumn(columnEl, index, editMode) {
@@ -273,6 +277,18 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
       wrapper.appendChild(card);
       columnEl.appendChild(wrapper);
     }
+  }
+
+  private _hideColumnIfAllChildrenAreHidden(columnEl: HTMLDivElement) {
+    const childrenCards = [...columnEl.children] as LovelaceCard[];
+    columnEl.hidden = childrenCards.every(
+      (card) => card.hidden || card.style.getPropertyValue("display") === "none"
+    );
+  }
+
+  private _handleUpdateLayout(ev: Event) {
+    ev.stopPropagation();
+    this._createColumns();
   }
 
   private _updateColumns() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
If a conditional card takes up a whole column, and the condition is not met, there used to be a blank column still taking up space. Now, the column will hide itself when all of its children become invisible.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
* Conditional card emits new event when its visibility changes
* Masonry view redraws columns when event fires
* Masonry view hides entire column if none of its children are visible
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #6632 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
