### PR TITLE
Workaround for incorrect 24h time display in Chrome (switches to hourCycle from hour12)

### DIFF
--- a/src/common/datetime/format_date_time.ts
+++ b/src/common/datetime/format_date_time.ts
@@ -21,6 +21,7 @@ const formatDateTimeMem = memoizeOne(
         day: "numeric",
         hour: useAmPm(locale) ? "numeric" : "2-digit",
         minute: "2-digit",
+        hour12: useAmPm(locale),
       }
     )
 );
@@ -42,6 +43,7 @@ const formatDateTimeWithSecondsMem = memoizeOne(
         hour: useAmPm(locale) ? "numeric" : "2-digit",
         minute: "2-digit",
         second: "2-digit",
+        hour12: useAmPm(locale),
       }
     )
 );
@@ -62,6 +64,7 @@ const formatDateTimeNumericMem = memoizeOne(
         day: "numeric",
         hour: "numeric",
         minute: "2-digit",
+        hour12: useAmPm(locale),
       }
     )
 );

--- a/src/common/datetime/format_date_time.ts
+++ b/src/common/datetime/format_date_time.ts
@@ -13,14 +13,16 @@ export const formatDateTime = (dateObj: Date, locale: FrontendLocaleData) =>
 
 const formatDateTimeMem = memoizeOne(
   (locale: FrontendLocaleData) =>
-    new Intl.DateTimeFormat(locale.language, {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: useAmPm(locale) ? "numeric" : "2-digit",
-      minute: "2-digit",
-      hour12: useAmPm(locale),
-    })
+    new Intl.DateTimeFormat(
+      locale.language + (useAmPm(locale) ? "-u-hc-h12" : "-u-hc-h23"),
+      {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: useAmPm(locale) ? "numeric" : "2-digit",
+        minute: "2-digit",
+      }
+    )
 );
 
 // August 9, 2021, 8:23:15 AM
@@ -31,15 +33,17 @@ export const formatDateTimeWithSeconds = (
 
 const formatDateTimeWithSecondsMem = memoizeOne(
   (locale: FrontendLocaleData) =>
-    new Intl.DateTimeFormat(locale.language, {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: useAmPm(locale) ? "numeric" : "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: useAmPm(locale),
-    })
+    new Intl.DateTimeFormat(
+      locale.language + (useAmPm(locale) ? "-u-hc-h12" : "-u-hc-h23"),
+      {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: useAmPm(locale) ? "numeric" : "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }
+    )
 );
 
 // 9/8/2021, 8:23 AM
@@ -50,12 +54,14 @@ export const formatDateTimeNumeric = (
 
 const formatDateTimeNumericMem = memoizeOne(
   (locale: FrontendLocaleData) =>
-    new Intl.DateTimeFormat(locale.language, {
-      year: "numeric",
-      month: "numeric",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: useAmPm(locale),
-    })
+    new Intl.DateTimeFormat(
+      locale.language + (useAmPm(locale) ? "-u-hc-h12" : "-u-hc-h23"),
+      {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }
+    )
 );

--- a/src/common/datetime/format_time.ts
+++ b/src/common/datetime/format_time.ts
@@ -13,11 +13,13 @@ export const formatTime = (dateObj: Date, locale: FrontendLocaleData) =>
 
 const formatTimeMem = memoizeOne(
   (locale: FrontendLocaleData) =>
-    new Intl.DateTimeFormat(locale.language, {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: useAmPm(locale),
-    })
+    new Intl.DateTimeFormat(
+      locale.language + (useAmPm(locale) ? "-u-hc-h12" : "-u-hc-h23"),
+      {
+        hour: "numeric",
+        minute: "2-digit",
+      }
+    )
 );
 
 // 9:15:24 PM || 21:15:24
@@ -28,12 +30,14 @@ export const formatTimeWithSeconds = (
 
 const formatTimeWithSecondsMem = memoizeOne(
   (locale: FrontendLocaleData) =>
-    new Intl.DateTimeFormat(locale.language, {
-      hour: useAmPm(locale) ? "numeric" : "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: useAmPm(locale),
-    })
+    new Intl.DateTimeFormat(
+      locale.language + (useAmPm(locale) ? "-u-hc-h12" : "-u-hc-h23"),
+      {
+        hour: useAmPm(locale) ? "numeric" : "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }
+    )
 );
 
 // Tuesday 7:00 PM || Tuesday 19:00
@@ -42,10 +46,12 @@ export const formatTimeWeekday = (dateObj: Date, locale: FrontendLocaleData) =>
 
 const formatTimeWeekdayMem = memoizeOne(
   (locale: FrontendLocaleData) =>
-    new Intl.DateTimeFormat(locale.language, {
-      hour: useAmPm(locale) ? "numeric" : "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: useAmPm(locale),
-    })
+    new Intl.DateTimeFormat(
+      locale.language + (useAmPm(locale) ? "-u-hc-h12" : "-u-hc-h23"),
+      {
+        hour: useAmPm(locale) ? "numeric" : "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }
+    )
 );

--- a/src/common/datetime/format_time.ts
+++ b/src/common/datetime/format_time.ts
@@ -18,6 +18,7 @@ const formatTimeMem = memoizeOne(
       {
         hour: "numeric",
         minute: "2-digit",
+        hour12: useAmPm(locale),
       }
     )
 );
@@ -36,6 +37,7 @@ const formatTimeWithSecondsMem = memoizeOne(
         hour: useAmPm(locale) ? "numeric" : "2-digit",
         minute: "2-digit",
         second: "2-digit",
+        hour12: useAmPm(locale),
       }
     )
 );
@@ -52,6 +54,7 @@ const formatTimeWeekdayMem = memoizeOne(
         hour: useAmPm(locale) ? "numeric" : "2-digit",
         minute: "2-digit",
         second: "2-digit",
+        hour12: useAmPm(locale),
       }
     )
 );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

In certain configurations, Home Assistant incorrectly displays times in the hour after midnight as 24:xx when set to 24h time (e.g., 24:20 instead of 00:20). 

Main issue tracking this: https://github.com/home-assistant/frontend/issues/9379
Also mentioned in core here https://github.com/home-assistant/core/issues/51974 and here https://github.com/home-assistant/core/issues/57899

Based on my testing/research, I think this happens when:

- Language is set to English
- Time is set to 24h
- Fronted is viewed in a Chromium-based browser

This bug has existed in Chrome since February 2020, and it doesn't look like it's being worked on (issue was closed):
https://support.google.com/chrome/thread/29828561/chrome-80-shows-timestamp-24-xx-instead-of-00-00?hl=en

The proposed change here is to switch from the `hour12` property to the `hourCycle` property. This property has 4 choices, as described here, which specifically describe the options for formatting 12h and 24h time: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle

The "bug" with Chromium-based browsers, is that for some reason it uses `h24` for 24h time with the `en` locale, which is the non-standard 24:xx format. It uses the correct `h23` option for other locales, like `en-GB`.

As mentioned in a comment on the fronted issue (https://github.com/home-assistant/frontend/issues/9379#issuecomment-906314078), `hourCycle` requires es2020 as a target, so it can't be used at the moment with Home Assistant with a simple property swap. From my testing though, it looks like one option is to append the parameter as part of the `locale`, as described here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat

So in light of the above, this PR removes `hour12` and instead adds "-u-hc-h12" to the language field if the user selects AM/PM and "-u-hc-h23" for 24h time. So theoretically it should use the "correct" 12h and 24h formatting irrespective of language:

- h12: The 12 hour clock, with midnight starting at 12:00 am
- h23: The 24 hour clock, with midnight starting at 0:00

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

n/a

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/9379
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/issues/9379, https://github.com/home-assistant/core/issues/51974, here https://github.com/home-assistant/core/issues/57899
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally **[tested Chrome only, not sure how to set up develop env for other browsers]**
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
