### PR TITLE
change device_tracker icon to reflect state

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -1,6 +1,7 @@
 /** Constants to be used in the frontend. */
 
 import {
+  mdiAccount,
   mdiAirFilter,
   mdiAlert,
   mdiAngleAcute,
@@ -75,7 +76,6 @@ export const FIXED_DOMAIN_ICONS = {
   configurator: mdiCog,
   conversation: mdiTextToSpeech,
   counter: mdiCounter,
-  device_tracker: mdiAccount,
   fan: mdiFan,
   google_assistant: mdiGoogleAssistant,
   group: mdiGoogleCirclesCommunities,

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -1,7 +1,6 @@
 /** Constants to be used in the frontend. */
 
 import {
-  mdiAccount,
   mdiAirFilter,
   mdiAlert,
   mdiAngleAcute,

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -1,4 +1,5 @@
 import {
+  mdiAccount,
   mdiAirHumidifierOff,
   mdiAirHumidifier,
   mdiLanConnect,

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -57,7 +57,8 @@ export const domainIcon = (
               return mdiDisconnect;
             default:
               return mdiAccount;
-      }
+           }
+        }
 
     case "humidifier":
       return state && state === "off" ? mdiAirHumidifierOff : mdiAirHumidifier;

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -48,13 +48,15 @@ export const domainIcon = (
       return coverIcon(compareState, stateObj);
 
     case "device_tracker":
-      switch (compareState) {
-        case "home":
-          return mdiLanConnect;
-        case "not_home":
-          return mdiLanDisconnect;
-        default:
-          return mdiAccount;
+      switch (stateObj?.attributes.source_type) {
+        case "router":
+          switch (state) {
+            case "home":
+              return mdiConnect;
+            case "not_home":
+              return mdiDisconnect;
+            default:
+              return mdiAccount;
       }
 
     case "humidifier":

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -48,12 +48,10 @@ export const domainIcon = (
       return coverIcon(compareState, stateObj);
 
     case "device_tracker":
-      switch (stateObj?.attributes.source_type) {
-        case "router":
+      if (stateObj?.attributes.source_type === "router") {
           return compareState === "home" ? mdiLanConnect : mdiLanDisconnect;
-        default:
-          return mdiAccount;
       }
+      return mdiAccount;
 
     case "humidifier":
       return state && state === "off" ? mdiAirHumidifierOff : mdiAirHumidifier;

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -50,15 +50,15 @@ export const domainIcon = (
     case "device_tracker":
       switch (stateObj?.attributes.source_type) {
         case "router":
-          switch (state) {
+          switch (compareState) {
             case "home":
               return mdiConnect;
             case "not_home":
               return mdiDisconnect;
             default:
               return mdiAccount;
-           }
-        }
+          }
+      }
 
     case "humidifier":
       return state && state === "off" ? mdiAirHumidifierOff : mdiAirHumidifier;

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -55,9 +55,9 @@ export const domainIcon = (
               return mdiLanConnect;
             case "not_home":
               return mdiLanDisconnect;
-            default:
-              return mdiAccount;
           }
+        default:
+          return mdiAccount;
       }
 
     case "humidifier":

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -1,6 +1,8 @@
 import {
   mdiAirHumidifierOff,
   mdiAirHumidifier,
+  mdiLanConnect,
+  mdiLanDisconnect,
   mdiLockOpen,
   mdiLockAlert,
   mdiLockClock,
@@ -43,6 +45,16 @@ export const domainIcon = (
 
     case "cover":
       return coverIcon(compareState, stateObj);
+
+    case "device_tracker":
+      switch (compareState) {
+        case "home":
+          return mdiLanConnect;
+        case "not_home":
+          return mdiLanDisconnect;
+        default:
+          return mdiAccount;
+      }
 
     case "humidifier":
       return state && state === "off" ? mdiAirHumidifierOff : mdiAirHumidifier;

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -52,9 +52,9 @@ export const domainIcon = (
         case "router":
           switch (compareState) {
             case "home":
-              return mdiConnect;
+              return mdiLanConnect;
             case "not_home":
-              return mdiDisconnect;
+              return mdiLanDisconnect;
             default:
               return mdiAccount;
           }

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -50,12 +50,7 @@ export const domainIcon = (
     case "device_tracker":
       switch (stateObj?.attributes.source_type) {
         case "router":
-          switch (compareState) {
-            case "home":
-              return mdiLanConnect;
-            case "not_home":
-              return mdiLanDisconnect;
-          }
+          return compareState === "home" ? mdiLanConnect : mdiLanDisconnect;
         default:
           return mdiAccount;
       }

--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -49,7 +49,7 @@ export const domainIcon = (
 
     case "device_tracker":
       if (stateObj?.attributes.source_type === "router") {
-          return compareState === "home" ? mdiLanConnect : mdiLanDisconnect;
+        return compareState === "home" ? mdiLanConnect : mdiLanDisconnect;
       }
       return mdiAccount;
 


### PR DESCRIPTION
initial pr, need to add test for attribute `source_type: router`

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
