### PR TITLE
Make "Show more" show everything starting from yesterday

### DIFF
--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -23,6 +23,8 @@ export class MoreInfoHistory extends LitElement {
 
   @state() private _stateHistory?: HistoryResult;
 
+  private _showMoreHref = "";
+
   private _throttleGetStateHistory = throttle(() => {
     this._getStateHistory();
   }, 10000);
@@ -32,18 +34,12 @@ export class MoreInfoHistory extends LitElement {
       return html``;
     }
 
-    const href =
-      "/history?entity_id=" +
-      this.entityId +
-      "&start_date=" +
-      startOfYesterday().getTime();
-
     return html`${isComponentLoaded(this.hass, "history")
       ? html` <div class="header">
             <div class="title">
               ${this.hass.localize("ui.dialogs.more_info_control.history")}
             </div>
-            <a href=${href} @click=${this._close}
+            <a href=${this._showMoreHref} @click=${this._close}
               >${this.hass.localize(
                 "ui.dialogs.more_info_control.show_more"
               )}</a
@@ -56,6 +52,14 @@ export class MoreInfoHistory extends LitElement {
             .isLoadingData=${!this._stateHistory}
           ></state-history-charts>`
       : ""}`;
+  }
+
+  protected firstUpdated(): void {
+    this._showMoreHref =
+      "/history?entity_id=" +
+      this.entityId +
+      "&start_date=" +
+      startOfYesterday().toISOString();
   }
 
   protected updated(changedProps: PropertyValues): void {

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -54,19 +54,15 @@ export class MoreInfoHistory extends LitElement {
       : ""}`;
   }
 
-  protected firstUpdated(): void {
-    this._showMoreHref =
-      "/history?entity_id=" +
-      this.entityId +
-      "&start_date=" +
-      startOfYesterday().toISOString();
-  }
-
   protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
 
     if (changedProps.has("entityId")) {
       this._stateHistory = undefined;
+
+      this._showMoreHref = `/history?entity_id=${
+        this.entityId
+      }&start_date=${startOfYesterday().toISOString()}`;
 
       if (!this.entityId) {
         return;

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -1,3 +1,4 @@
+import { startOfYesterday } from "date-fns";
 import { css, html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
@@ -31,7 +32,11 @@ export class MoreInfoHistory extends LitElement {
       return html``;
     }
 
-    const href = "/history?entity_id=" + this.entityId;
+    const href =
+      "/history?entity_id=" +
+      this.entityId +
+      "&start_date=" +
+      startOfYesterday().getTime();
 
     return html`${isComponentLoaded(this.hass, "history")
       ? html` <div class="header">

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -60,13 +60,13 @@ export class MoreInfoHistory extends LitElement {
     if (changedProps.has("entityId")) {
       this._stateHistory = undefined;
 
-      this._showMoreHref = `/history?entity_id=${
-        this.entityId
-      }&start_date=${startOfYesterday().toISOString()}`;
-
       if (!this.entityId) {
         return;
       }
+
+      this._showMoreHref = `/history?entity_id=${
+        this.entityId
+      }&start_date=${startOfYesterday().toISOString()}`;
 
       this._throttleGetStateHistory();
       return;

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -103,13 +103,13 @@ export class MoreInfoLogbook extends LitElement {
       this._lastLogbookDate = undefined;
       this._logbookEntries = undefined;
 
-      this._showMoreHref = `/logbook?entity_id=${
-        this.entityId
-      }&start_date=${startOfYesterday().toISOString()}`;
-
       if (!this.entityId) {
         return;
       }
+
+      this._showMoreHref = `/logbook?entity_id=${
+        this.entityId
+      }&start_date=${startOfYesterday().toISOString()}`;
 
       this._throttleGetLogbookEntries();
       return;

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -1,3 +1,4 @@
+import { startOfYesterday } from "date-fns";
 import { css, html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
@@ -44,7 +45,11 @@ export class MoreInfoLogbook extends LitElement {
       return html``;
     }
 
-    const href = "/logbook?entity_id=" + this.entityId;
+    const href =
+      "/logbook?entity_id=" +
+      this.entityId +
+      "&start_date=" +
+      startOfYesterday().getTime();
 
     return html`
       ${isComponentLoaded(this.hass, "logbook")

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -94,11 +94,6 @@ export class MoreInfoLogbook extends LitElement {
 
   protected firstUpdated(): void {
     this._fetchUserPromise = this._fetchUserNames();
-    this._showMoreHref =
-      "/logbook?entity_id=" +
-      this.entityId +
-      "&start_date=" +
-      startOfYesterday().toISOString();
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -107,6 +102,10 @@ export class MoreInfoLogbook extends LitElement {
     if (changedProps.has("entityId")) {
       this._lastLogbookDate = undefined;
       this._logbookEntries = undefined;
+
+      this._showMoreHref = `/logbook?entity_id=${
+        this.entityId
+      }&start_date=${startOfYesterday().toISOString()}`;
 
       if (!this.entityId) {
         return;

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -31,6 +31,8 @@ export class MoreInfoLogbook extends LitElement {
 
   private _error?: string;
 
+  private _showMoreHref = "";
+
   private _throttleGetLogbookEntries = throttle(() => {
     this._getLogBookData();
   }, 10000);
@@ -44,12 +46,6 @@ export class MoreInfoLogbook extends LitElement {
     if (!stateObj) {
       return html``;
     }
-
-    const href =
-      "/logbook?entity_id=" +
-      this.entityId +
-      "&start_date=" +
-      startOfYesterday().getTime();
 
     return html`
       ${isComponentLoaded(this.hass, "logbook")
@@ -72,7 +68,7 @@ export class MoreInfoLogbook extends LitElement {
                 <div class="title">
                   ${this.hass.localize("ui.dialogs.more_info_control.logbook")}
                 </div>
-                <a href=${href} @click=${this._close}
+                <a href=${this._showMoreHref} @click=${this._close}
                   >${this.hass.localize(
                     "ui.dialogs.more_info_control.show_more"
                   )}</a
@@ -98,6 +94,11 @@ export class MoreInfoLogbook extends LitElement {
 
   protected firstUpdated(): void {
     this._fetchUserPromise = this._fetchUserNames();
+    this._showMoreHref =
+      "/logbook?entity_id=" +
+      this.entityId +
+      "&start_date=" +
+      startOfYesterday().toISOString();
   }
 
   protected updated(changedProps: PropertyValues): void {

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -140,7 +140,7 @@ class HaPanelHistory extends LitElement {
 
     this._entityId = extractSearchParam("entity_id") ?? "";
 
-    const startDate = Number(extractSearchParam("start_date"));
+    const startDate = extractSearchParam("start_date");
     if (startDate) {
       this._startDate = new Date(startDate);
     }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -139,6 +139,11 @@ class HaPanelHistory extends LitElement {
     };
 
     this._entityId = extractSearchParam("entity_id") ?? "";
+
+    const startDate = Number(extractSearchParam("start_date"));
+    if (startDate) {
+      this._startDate = new Date(startDate);
+    }
   }
 
   protected updated(changedProps: PropertyValues) {

--- a/src/panels/logbook/ha-panel-logbook.ts
+++ b/src/panels/logbook/ha-panel-logbook.ts
@@ -161,6 +161,11 @@ export class HaPanelLogbook extends LitElement {
     };
 
     this._entityId = extractSearchParam("entity_id") ?? "";
+
+    const startDate = Number(extractSearchParam("start_date"));
+    if (startDate) {
+      this._startDate = new Date(startDate);
+    }
   }
 
   protected updated(changedProps: PropertyValues<this>) {

--- a/src/panels/logbook/ha-panel-logbook.ts
+++ b/src/panels/logbook/ha-panel-logbook.ts
@@ -162,7 +162,7 @@ export class HaPanelLogbook extends LitElement {
 
     this._entityId = extractSearchParam("entity_id") ?? "";
 
-    const startDate = Number(extractSearchParam("start_date"));
+    const startDate = extractSearchParam("start_date");
     if (startDate) {
       this._startDate = new Date(startDate);
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Added a new query parameter "start_date" that expects an ISO timestamp string. The more-info dialog will set it to the start of yesterday for the navigation links.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10511
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
