### PR TITLE
Use correct darkMode flag for image variant selection

### DIFF
--- a/src/dialogs/config-flow/step-flow-pick-flow.ts
+++ b/src/dialogs/config-flow/step-flow-pick-flow.ts
@@ -45,7 +45,7 @@ class StepFlowPickFlow extends LitElement {
                 domain: flow.handler,
                 type: "icon",
                 useFallback: true,
-                darkOptimized: this.hass.selectedTheme?.dark,
+                darkOptimized: this.hass.themes?.darkMode,
               })}
               referrerpolicy="no-referrer"
             />

--- a/src/dialogs/config-flow/step-flow-pick-handler.ts
+++ b/src/dialogs/config-flow/step-flow-pick-handler.ts
@@ -102,7 +102,7 @@ class StepFlowPickHandler extends LitElement {
                         domain: handler.slug,
                         type: "icon",
                         useFallback: true,
-                        darkOptimized: this.hass.selectedTheme?.dark,
+                        darkOptimized: this.hass.themes?.darkMode,
                       })}
                       referrerpolicy="no-referrer"
                     />

--- a/src/onboarding/onboarding-integrations.ts
+++ b/src/onboarding/onboarding-integrations.ts
@@ -81,7 +81,7 @@ class OnboardingIntegrations extends LitElement {
               .domain=${entry.domain}
               .title=${title}
               .badgeIcon=${mdiCheck}
-              .darkOptimizedIcon=${this.hass.selectedTheme?.dark}
+              .darkOptimizedIcon=${this.hass.themes?.darkMode}
             ></integration-badge>
           `,
         ];
@@ -98,7 +98,7 @@ class OnboardingIntegrations extends LitElement {
                 clickable
                 .domain=${flow.handler}
                 .title=${title}
-                .darkOptimizedIcon=${this.hass.selectedTheme?.dark}
+                .darkOptimizedIcon=${this.hass.themes?.darkMode}
               ></integration-badge>
             </button>
           `,

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -293,7 +293,7 @@ export class HaConfigDevicePage extends LitElement {
                             src=${brandsUrl({
                               domain: integrations[0],
                               type: "logo",
-                              darkOptimized: this.hass.selectedTheme?.dark,
+                              darkOptimized: this.hass.themes?.darkMode,
                             })}
                             referrerpolicy="no-referrer"
                             @load=${this._onImageLoad}

--- a/src/panels/config/energy/components/ha-energy-grid-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-grid-settings.ts
@@ -202,7 +202,7 @@ export class EnergyGridSettings extends LitElement {
                 src=${brandsUrl({
                   domain: "co2signal",
                   type: "icon",
-                  darkOptimized: this.hass.selectedTheme?.dark,
+                  darkOptimized: this.hass.themes?.darkMode,
                 })}
               />
               <span class="content">${entry.title}</span>
@@ -223,7 +223,7 @@ export class EnergyGridSettings extends LitElement {
                     src=${brandsUrl({
                       domain: "co2signal",
                       type: "icon",
-                      darkOptimized: this.hass.selectedTheme?.dark,
+                      darkOptimized: this.hass.themes?.darkMode,
                     })}
                   />
                   <mwc-button @click=${this._addCO2Sensor}>

--- a/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
@@ -136,7 +136,7 @@ export class DialogEnergySolarSettings
                       src=${brandsUrl({
                         domain: entry.domain,
                         type: "icon",
-                        darkOptimized: this.hass.selectedTheme?.dark,
+                        darkOptimized: this.hass.themes?.darkMode,
                       })}
                     />${entry.title}
                   </div>`}

--- a/src/panels/config/info/integrations-card.ts
+++ b/src/panels/config/info/integrations-card.ts
@@ -98,7 +98,7 @@ class IntegrationsCard extends LitElement {
                           domain: domain,
                           type: "icon",
                           useFallback: true,
-                          darkOptimized: this.hass.selectedTheme?.dark,
+                          darkOptimized: this.hass.themes?.darkMode,
                         })}
                         referrerpolicy="no-referrer"
                       />

--- a/src/panels/config/integrations/ha-integration-header.ts
+++ b/src/panels/config/integrations/ha-integration-header.ts
@@ -84,7 +84,7 @@ export class HaIntegrationHeader extends LitElement {
           src=${brandsUrl({
             domain: this.domain,
             type: "icon",
-            darkOptimized: this.hass.selectedTheme?.dark,
+            darkOptimized: this.hass.themes?.darkMode,
           })}
           referrerpolicy="no-referrer"
           @error=${this._onImageError}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

While investigating another issue, I saw that the `darkOptimized` attribute gets provided with the wrong value.

`hass.selectedTheme.dark` contains the configuration value from the user profile, which can be undefined (in "auto" mode), whereas `hass.themes.darkMode` contains the actual dark mode that is in effect (so resolved value from "auto" to whatever is used).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
