### PR TITLE
List lights in group in the group's more-info dialog

### DIFF
--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -18,6 +18,7 @@ import "../../../components/ha-color-picker";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-labeled-slider";
 import "../../../components/ha-paper-dropdown-menu";
+import { EntitiesCardEntityConfig } from "../../../panels/lovelace/cards/types";
 import {
   getLightCurrentModeRgbColor,
   LightColorModes,
@@ -84,6 +85,8 @@ class MoreInfoLight extends LitElement {
 
     const supportsColor =
       supportsRgbww || supportsRgbw || lightSupportsColor(this.stateObj);
+
+    const memberLightsHeader = "Lights in this group";
 
     return html`
       <div class="content">
@@ -229,6 +232,20 @@ class MoreInfoLight extends LitElement {
                   `
                 : ""}
             `
+          : ""}
+        ${this.stateObj!.attributes.entity_id?.length > 0
+          ? html`<hr />
+              <ha-expansion-panel .header=${memberLightsHeader} outlined>
+                ${this.stateObj!.attributes.entity_id?.map((memberLight) => {
+                  const config: EntitiesCardEntityConfig = {
+                    entity: memberLight,
+                  };
+                  return html`<hui-generic-entity-row
+                    .hass=${this.hass}
+                    .config=${config}
+                  ></hui-generic-entity-row>`;
+                })}
+              </ha-expansion-panel> `
           : ""}
         <ha-attributes
           .hass=${this.hass}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The more info dialog for light groups used to show a list of the lights in the group, but this was removed with the launch of Lovelace (#9967). I would like to add them back, as shown in the screenshot of this change below:

![image](https://user-images.githubusercontent.com/1693960/141669026-65281799-1bc0-4874-8003-50974c2d4c27.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

No config changes.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #9967
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
