### PR TITLE
Always render groups/areas in a single column

### DIFF
--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -176,7 +176,18 @@ export const computeCards = (
     });
   }
 
-  return cards;
+  if (cards.length < 2) {
+    return cards;
+  }
+
+  return [
+    {
+      type: "grid",
+      square: false,
+      columns: 1,
+      cards,
+    },
+  ];
 };
 
 const computeDefaultViewStates = (

--- a/src/panels/lovelace/create-element/create-card-element.ts
+++ b/src/panels/lovelace/create-element/create-card-element.ts
@@ -5,11 +5,10 @@ import "../cards/hui-entities-card";
 import "../cards/hui-entity-button-card";
 import "../cards/hui-entity-card";
 import "../cards/hui-glance-card";
-import "../cards/hui-horizontal-stack-card";
+import "../cards/hui-grid-card";
 import "../cards/hui-light-card";
 import "../cards/hui-sensor-card";
 import "../cards/hui-thermostat-card";
-import "../cards/hui-vertical-stack-card";
 import "../cards/hui-weather-forecast-card";
 import {
   createLovelaceElement,
@@ -23,59 +22,59 @@ const ALWAYS_LOADED_TYPES = new Set([
   "button",
   "entity-button",
   "glance",
-  "horizontal-stack",
+  "grid",
   "light",
   "sensor",
   "thermostat",
-  "vertical-stack",
   "weather-forecast",
 ]);
 
 const LAZY_LOAD_TYPES = {
   "alarm-panel": () => import("../cards/hui-alarm-panel-card"),
   area: () => import("../cards/hui-area-card"),
-  error: () => import("../cards/hui-error-card"),
+  calendar: () => import("../cards/hui-calendar-card"),
+  conditional: () => import("../cards/hui-conditional-card"),
   "empty-state": () => import("../cards/hui-empty-state-card"),
-  "energy-usage-graph": () =>
-    import("../cards/energy/hui-energy-usage-graph-card"),
-  "energy-solar-graph": () =>
-    import("../cards/energy/hui-energy-solar-graph-card"),
-  "energy-gas-graph": () => import("../cards/energy/hui-energy-gas-graph-card"),
-  "energy-devices-graph": () =>
-    import("../cards/energy/hui-energy-devices-graph-card"),
-  "energy-sources-table": () =>
-    import("../cards/energy/hui-energy-sources-table-card"),
-  "energy-distribution": () =>
-    import("../cards/energy/hui-energy-distribution-card"),
-  "energy-solar-consumed-gauge": () =>
-    import("../cards/energy/hui-energy-solar-consumed-gauge-card"),
-  "energy-grid-neutrality-gauge": () =>
-    import("../cards/energy/hui-energy-grid-neutrality-gauge-card"),
   "energy-carbon-consumed-gauge": () =>
     import("../cards/energy/hui-energy-carbon-consumed-gauge-card"),
   "energy-date-selection": () =>
     import("../cards/energy/hui-energy-date-selection-card"),
-  grid: () => import("../cards/hui-grid-card"),
-  starting: () => import("../cards/hui-starting-card"),
+  "energy-devices-graph": () =>
+    import("../cards/energy/hui-energy-devices-graph-card"),
+  "energy-distribution": () =>
+    import("../cards/energy/hui-energy-distribution-card"),
+  "energy-gas-graph": () => import("../cards/energy/hui-energy-gas-graph-card"),
+  "energy-grid-neutrality-gauge": () =>
+    import("../cards/energy/hui-energy-grid-neutrality-gauge-card"),
+  "energy-solar-consumed-gauge": () =>
+    import("../cards/energy/hui-energy-solar-consumed-gauge-card"),
+  "energy-solar-graph": () =>
+    import("../cards/energy/hui-energy-solar-graph-card"),
+  "energy-sources-table": () =>
+    import("../cards/energy/hui-energy-sources-table-card"),
+  "energy-usage-graph": () =>
+    import("../cards/energy/hui-energy-usage-graph-card"),
   "entity-filter": () => import("../cards/hui-entity-filter-card"),
+  error: () => import("../cards/hui-error-card"),
+  gauge: () => import("../cards/hui-gauge-card"),
+  "history-graph": () => import("../cards/hui-history-graph-card"),
+  "horizontal-stack": () => import("../cards/hui-horizontal-stack-card"),
   humidifier: () => import("../cards/hui-humidifier-card"),
+  iframe: () => import("../cards/hui-iframe-card"),
+  logbook: () => import("../cards/hui-logbook-card"),
+  map: () => import("../cards/hui-map-card"),
+  markdown: () => import("../cards/hui-markdown-card"),
   "media-control": () => import("../cards/hui-media-control-card"),
   "picture-elements": () => import("../cards/hui-picture-elements-card"),
   "picture-entity": () => import("../cards/hui-picture-entity-card"),
   "picture-glance": () => import("../cards/hui-picture-glance-card"),
+  picture: () => import("../cards/hui-picture-card"),
   "plant-status": () => import("../cards/hui-plant-status-card"),
   "safe-mode": () => import("../cards/hui-safe-mode-card"),
   "shopping-list": () => import("../cards/hui-shopping-list-card"),
-  conditional: () => import("../cards/hui-conditional-card"),
-  gauge: () => import("../cards/hui-gauge-card"),
-  "history-graph": () => import("../cards/hui-history-graph-card"),
+  starting: () => import("../cards/hui-starting-card"),
   "statistics-graph": () => import("../cards/hui-statistics-graph-card"),
-  iframe: () => import("../cards/hui-iframe-card"),
-  map: () => import("../cards/hui-map-card"),
-  markdown: () => import("../cards/hui-markdown-card"),
-  picture: () => import("../cards/hui-picture-card"),
-  calendar: () => import("../cards/hui-calendar-card"),
-  logbook: () => import("../cards/hui-logbook-card"),
+  "vertical-stack": () => import("../cards/hui-vertical-stack-card"),
 };
 
 // This will not return an error card but will throw the error


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When generating a lovelace config, make sure that all entities belonging to a single group or area are shown in a single column.

Also promotes grid card to be always loaded and horizontal/vertical stack to be lazy loaded. Those should be phased out as it's just a grid with certain options.

Before:

![image](https://user-images.githubusercontent.com/1444314/142488806-f6fa4fad-5f76-4501-a8ac-4a76bc4c72e8.png)


After:

![image](https://user-images.githubusercontent.com/1444314/142488757-03f6f202-76ab-4ba3-871f-911ec8a37db0.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
