### PR TITLE
Fix yaml reload button alignment

### DIFF
--- a/src/panels/config/server_control/ha-config-server-control.ts
+++ b/src/panels/config/server_control/ha-config-server-control.ts
@@ -277,6 +277,10 @@ export class HaConfigServerControl extends LitElement {
         ha-config-section {
           padding-bottom: 24px;
         }
+
+        .mdc-button {
+          justify-content: left;
+        }
       `,
     ];
   }

--- a/src/state/disconnect-toast-mixin.ts
+++ b/src/state/disconnect-toast-mixin.ts
@@ -110,7 +110,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       showToast(this, {
         message:
           this.hass!.localize(
-            "ui.notification_toast.intergration_starting",
+            "ui.notification_toast.integration_starting",
             "integration",
             domainToName(this.hass!.localize, integration)
           ) ||

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -851,7 +851,7 @@
       "started": "Home Assistant has started!",
       "starting": "Home Assistant is starting, not everything will be available until it is finished.",
       "wrapping_up_startup": "Wrapping up startup, not everything will be available until it is finished.",
-      "intergration_starting": "Starting {integration}, not everything will be available until it is finished.",
+      "integration_starting": "Starting {integration}, not everything will be available until it is finished.",
       "triggered": "Triggered {name}",
       "dismiss": "Dismiss"
     },

--- a/translations/frontend/ca.json
+++ b/translations/frontend/ca.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Connexió perduda. Tornant a connectar...",
             "dismiss": "Omet",
-            "intergration_starting": "Iniciant {integration}, no estarà tot disponible fins que acabi.",
+            "integration_starting": "Iniciant {integration}, no estarà tot disponible fins que acabi.",
             "service_call_failed": "Ha fallat la crida al servei {service}.",
             "started": "Home Assistant s'ha iniciat!",
             "starting": "Home Assistant està iniciant-se, no estarà tot disponible fins que acabi",

--- a/translations/frontend/cs.json
+++ b/translations/frontend/cs.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Připojení bylo ztraceno. Připojuji se znovu...",
             "dismiss": "Zavřít",
-            "intergration_starting": "Integrace {integration} se spouští - dokud nebude spuštění dokončeno, nemusí být vše k dispozici.",
+            "integration_starting": "Integrace {integration} se spouští - dokud nebude spuštění dokončeno, nemusí být vše k dispozici.",
             "service_call_failed": "Službu {service} se nepodařilo zavolat.",
             "started": "Home Assistant je spuštěn!",
             "starting": "Home Assistant se spouští, ne všechno bude k dispozici, dokud nebude spuštění dokončeno.",

--- a/translations/frontend/de.json
+++ b/translations/frontend/de.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Verbindung getrennt. Verbinde erneut...",
             "dismiss": "Ausblenden",
-            "intergration_starting": "Starte {integration}. Währenddessen ist noch nicht alles verfügbar.",
+            "integration_starting": "Starte {integration}. Währenddessen ist noch nicht alles verfügbar.",
             "service_call_failed": "Fehler beim Aufrufen des Diensts {service}.",
             "started": "Home Assistant wurde vollständig gestartet!",
             "starting": "Home Assistant startet. Währenddessen ist noch nicht alles verfügbar.",

--- a/translations/frontend/en.json
+++ b/translations/frontend/en.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Connection lost. Reconnecting…",
             "dismiss": "Dismiss",
-            "intergration_starting": "Starting {integration}, not everything will be available until it is finished.",
+            "integration_starting": "Starting {integration}, not everything will be available until it is finished.",
             "service_call_failed": "Failed to call service {service}.",
             "started": "Home Assistant has started!",
             "starting": "Home Assistant is starting, not everything will be available until it is finished.",

--- a/translations/frontend/es.json
+++ b/translations/frontend/es.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Conexión perdida. Reconectando...",
             "dismiss": "Descartar",
-            "intergration_starting": "Iniciando {integration}, no estará todo disponible hasta que finalice.",
+            "integration_starting": "Iniciando {integration}, no estará todo disponible hasta que finalice.",
             "service_call_failed": "Error al llamar al servicio {service}.",
             "started": "¡Home Assistant se ha iniciado!",
             "starting": "Home Assistant se está iniciando, no estará todo disponible hasta que finalice.",

--- a/translations/frontend/et.json
+++ b/translations/frontend/et.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Ühendus kadunud. Taasühendamine...",
             "dismiss": "Loobu",
-            "intergration_starting": "Sidumine {integration} käivitub, kõik elemendid pole veel saadaval.",
+            "integration_starting": "Sidumine {integration} käivitub, kõik elemendid pole veel saadaval.",
             "service_call_failed": "Teenuse {service} väljakutsumine ebaõnnestus.",
             "started": "Home Assistant on käivitunud!",
             "starting": "Home Assistant  käivitub, kõik elemendid ei pruugi veel saadaval olla",

--- a/translations/frontend/fr.json
+++ b/translations/frontend/fr.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Connexion perdue. Reconnexion en cours ...",
             "dismiss": "Ignorer",
-            "intergration_starting": "Démarrage de {integration}, tout ne sera pas disponible tant qu'il n'aura pas terminé",
+            "integration_starting": "Démarrage de {integration}, tout ne sera pas disponible tant qu'il n'aura pas terminé",
             "service_call_failed": "Échec d'appel du service \"{service}\".",
             "started": "Home Assistant a démarré !",
             "starting": "Home Assistant est en cours de démarrage, tout ne sera pas disponible tant qu’il n’aura pas terminé.",

--- a/translations/frontend/it.json
+++ b/translations/frontend/it.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Connessione persa. Riconnessione…",
             "dismiss": "Rimuovi",
-            "intergration_starting": "{integration} si sta avviando, non tutto sarà disponibile fino ad avvio completo.",
+            "integration_starting": "{integration} si sta avviando, non tutto sarà disponibile fino ad avvio completo.",
             "service_call_failed": "Fallita chiamata a servizio {service} .",
             "started": "Home Assistant si è avviato!",
             "starting": "Home Assistant si sta avviando, non tutto sarà disponibile fino ad avvio completo.",

--- a/translations/frontend/ko.json
+++ b/translations/frontend/ko.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "서버와 연결이 끊어졌습니다. 다시 연결하는 중...",
             "dismiss": "해제하기",
-            "intergration_starting": "{integration} 시작 중. 완료되기 전 일부 기능은 작동하지 않을 수 있습니다.",
+            "integration_starting": "{integration} 시작 중. 완료되기 전 일부 기능은 작동하지 않을 수 있습니다.",
             "service_call_failed": "{service} 서비스를 호출하지 못했습니다.",
             "started": "Home Assistant가 시작되었습니다!",
             "starting": "Home Assistant가 시작됩니다. 완료될 때까지 모든 기능을 사용할 수 있는 것은 아닙니다.",

--- a/translations/frontend/nb.json
+++ b/translations/frontend/nb.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Forbindelsen ble brutt. Kobler til på nytt...",
             "dismiss": "Avvis",
-            "intergration_starting": "Fra og med {integration} vil ikke alt være tilgjengelig før den er ferdig.",
+            "integration_starting": "Fra og med {integration} vil ikke alt være tilgjengelig før den er ferdig.",
             "service_call_failed": "Kunne ikke tilkalle tjenesten: {service}",
             "started": "Home Assistant har startet!",
             "starting": "Home Assistant starter, alt er ikke tilgjengelig før starten er fullført.",

--- a/translations/frontend/nl.json
+++ b/translations/frontend/nl.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Verbinding verbroken. Opnieuw verbinden...",
             "dismiss": "Afwijzen",
-            "intergration_starting": "Start {integration}, niet alles is beschikbaar totdat het voltooid is.",
+            "integration_starting": "Start {integration}, niet alles is beschikbaar totdat het voltooid is.",
             "service_call_failed": "Kan service {service} niet aanroepen",
             "started": "Home Assistant is gestart!",
             "starting": "Home Assistant is aan het opstarten. Tijdens het opstarten is niet alles beschikbaar.",

--- a/translations/frontend/pl.json
+++ b/translations/frontend/pl.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Utracono połączenie. Łączę ponownie...",
             "dismiss": "Ukryj",
-            "intergration_starting": "{integration} uruchamia się, nie wszystko będzie dostępne, dopóki uruchamianie się nie zakończy.",
+            "integration_starting": "{integration} uruchamia się, nie wszystko będzie dostępne, dopóki uruchamianie się nie zakończy.",
             "service_call_failed": "Nie udało się wywołać usługi {service}.",
             "started": "Home Assistant uruchomił się!",
             "starting": "Home Assistant uruchamia się, nie wszystko będzie dostępne, dopóki uruchamianie się nie zakończy.",

--- a/translations/frontend/ru.json
+++ b/translations/frontend/ru.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "Соединение потеряно. Повторное подключение ...",
             "dismiss": "Закрыть",
-            "intergration_starting": "Запуск {integration}, пока что не всё может быть доступно.",
+            "integration_starting": "Запуск {integration}, пока что не всё может быть доступно.",
             "service_call_failed": "Не удалось вызвать службу {service}.",
             "started": "Home Assistant работает!",
             "starting": "Home Assistant запускается, пока что не всё может быть доступно.",

--- a/translations/frontend/zh-Hans.json
+++ b/translations/frontend/zh-Hans.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "连接中断。正在重新连接...",
             "dismiss": "关闭",
-            "intergration_starting": "正在启动 {integration}。在启动完成前，部分功能暂不可用。",
+            "integration_starting": "正在启动 {integration}。在启动完成前，部分功能暂不可用。",
             "service_call_failed": "调用服务 {service} 失败。",
             "started": "Home Assistant 已启动！",
             "starting": "Home Assistant 正在启动。在启动完成前，部分功能暂不可用。",

--- a/translations/frontend/zh-Hant.json
+++ b/translations/frontend/zh-Hant.json
@@ -1239,7 +1239,7 @@
         "notification_toast": {
             "connection_lost": "連線中斷。重新連線中...",
             "dismiss": "關閉",
-            "intergration_starting": "{integration} 正在啟動，在完成載入前、可能無法顯示所有功能。",
+            "integration_starting": "{integration} 正在啟動，在完成載入前、可能無法顯示所有功能。",
             "service_call_failed": "服務 {service} 執行失敗。",
             "started": "Home Assistant 已啟動！",
             "starting": "Home Assistant 正在啟動，在完成載入前、可能無法顯示所有功能。",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This change fixes text alignment for the buttons in the `config/server_control` page. The text on the `Timer` button in particular has always been out of alignment with the buttons around it.

I also noticed a typo in a json value, which I quick-replaced across this entire repository.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

N/A; simply visit the page `config/server_control` before and after applying the new CSS. I was able to do this in my web browser by entering developer mode on the page on my current Home Assistant instance and modifying the contents of the appropriate `<style>` tag, which I found by searching for `.validate-container` (which is the CSS selector that comes immediately before the one I added).

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I did not create or search for an issue before diving in to figure out a potential solution. I am happy to put that together if necessary, just let me know.

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
