### PR TITLE
extend optimistic state timeout to 10 seconds

### DIFF
--- a/src/components/entity/ha-entity-toggle.ts
+++ b/src/components/entity/ha-entity-toggle.ts
@@ -141,12 +141,12 @@ export class HaEntityToggle extends LitElement {
     });
 
     setTimeout(async () => {
-      // If after 2 seconds we have not received a state update
+      // If after 10 seconds we have not received a state update
       // reset the switch to it's original state.
       if (this.stateObj === currentState) {
         this._isOn = isOn(this.stateObj);
       }
-    }, 2000);
+    }, 10000);
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
## Proposed change

Discussed many times already in forums, discord etc.
Some integrations and/or devices are just a bit slow to update, for example some Z-Wave devices.

You send a call service to turn on a light but the new state only arrives seconds later.
This causes a weird "flip flop" in the UI. You turn on the toggle, 2 seconds later it turns off again and a few seconds later it will turn on again. For most people this will mean they will probably go wild toggling the entity as they do not understand why it toggled back in the UI.

Some attempts have been made to try to fix this in the integrations but that just feels hacky.
Not to say that this approach is better but it is way more simpler and works for all integrations at once.

This extends the optimistic timeout from the current 2 seconds to 10 seconds.
In other words: This will give the integration up to 10 seconds to report back the actual/updated state.



## Type of change


- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/core/pull/59385
- Link to documentation pull request:

## Checklist

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
