### PR TITLE
Ensure we always have an active theme name (fixes dark theme issues)

### DIFF
--- a/gallery/src/components/demo-black-white-row.ts
+++ b/gallery/src/components/demo-black-white-row.ts
@@ -52,18 +52,13 @@ class DemoBlackWhiteRow extends LitElement {
 
   firstUpdated(changedProps) {
     super.firstUpdated(changedProps);
-    applyThemesOnElement(
-      this.shadowRoot!.querySelector(".dark"),
-      {
-        default_theme: "default",
-        default_dark_theme: "default",
-        themes: {},
-        darkMode: false,
-        theme: "default",
-      },
-      "default",
-      { dark: true }
-    );
+    applyThemesOnElement(this.shadowRoot!.querySelector(".dark"), {
+      default_theme: "default",
+      default_dark_theme: "default",
+      themes: {},
+      darkMode: true,
+      theme: "default",
+    });
   }
 
   handleSubmit(ev) {

--- a/gallery/src/components/demo-black-white-row.ts
+++ b/gallery/src/components/demo-black-white-row.ts
@@ -59,6 +59,7 @@ class DemoBlackWhiteRow extends LitElement {
         default_dark_theme: "default",
         themes: {},
         darkMode: false,
+        theme: "default",
       },
       "default",
       { dark: true }

--- a/gallery/src/demos/demo-ha-alert.ts
+++ b/gallery/src/demos/demo-ha-alert.ts
@@ -159,17 +159,13 @@ export class DemoHaAlert extends LitElement {
 
   firstUpdated(changedProps) {
     super.firstUpdated(changedProps);
-    applyThemesOnElement(
-      this.shadowRoot!.querySelector(".dark"),
-      {
-        default_theme: "default",
-        default_dark_theme: "default",
-        themes: {},
-        darkMode: false,
-      },
-      "default",
-      { dark: true }
-    );
+    applyThemesOnElement(this.shadowRoot!.querySelector(".dark"), {
+      default_theme: "default",
+      default_dark_theme: "default",
+      themes: {},
+      darkMode: true,
+      theme: "default",
+    });
   }
 
   static get styles() {

--- a/src/auth/ha-authorize.ts
+++ b/src/auth/ha-authorize.ts
@@ -101,17 +101,13 @@ class HaAuthorize extends litLocalizeLiteMixin(LitElement) {
     this._fetchAuthProviders();
 
     if (matchMedia("(prefers-color-scheme: dark)").matches) {
-      applyThemesOnElement(
-        document.documentElement,
-        {
-          default_theme: "default",
-          default_dark_theme: null,
-          themes: {},
-          darkMode: false,
-        },
-        "default",
-        { dark: true }
-      );
+      applyThemesOnElement(document.documentElement, {
+        default_theme: "default",
+        default_dark_theme: null,
+        themes: {},
+        darkMode: true,
+        theme: "default",
+      });
     }
 
     if (!this.redirectUri) {

--- a/src/common/dom/apply_themes_on_element.ts
+++ b/src/common/dom/apply_themes_on_element.ts
@@ -23,9 +23,9 @@ let PROCESSED_THEMES: Record<string, ProcessedTheme> = {};
  * Apply a theme to an element by setting the CSS variables on it.
  *
  * element: Element to apply theme on.
- * themes: HASS theme information.
+ * themes: HASS theme information (e.g. active dark mode and globally active theme name).
  * selectedTheme: Selected theme (used to override the globally active theme for this element).
- * themeSettings: Settings such as selected colors.
+ * themeSettings: Additional settings such as selected colors.
  */
 export const applyThemesOnElement = (
   element,

--- a/src/common/dom/apply_themes_on_element.ts
+++ b/src/common/dom/apply_themes_on_element.ts
@@ -24,8 +24,8 @@ let PROCESSED_THEMES: Record<string, ProcessedTheme> = {};
  *
  * element: Element to apply theme on.
  * themes: HASS theme information.
- * selectedTheme: Selected theme.
- * themeSettings: Settings such as selected dark mode and colors.
+ * selectedTheme: Selected theme (used to override the globally active theme for this element).
+ * themeSettings: Settings such as selected colors.
  */
 export const applyThemesOnElement = (
   element,
@@ -34,15 +34,11 @@ export const applyThemesOnElement = (
   themeSettings?: Partial<HomeAssistant["selectedTheme"]>
 ) => {
   // If there is no explicitly desired theme provided, we automatically
-  // use the active one from hass.themes.
-  const themeToApply =
-    selectedTheme ||
-    (themeSettings && themeSettings?.theme !== undefined
-      ? selectedTheme || themeSettings?.theme
-      : themes.theme);
+  // use the active one from `themes`.
+  const themeToApply = selectedTheme || themes.theme;
 
   // If there is no explicitly desired dark mode provided, we automatically
-  // use the active one from hass.themes.
+  // use the active one from `themes`.
   const darkMode =
     themeSettings && themeSettings?.dark !== undefined
       ? themeSettings?.dark
@@ -63,7 +59,7 @@ export const applyThemesOnElement = (
     const primaryColor = themeSettings?.primaryColor;
     const accentColor = themeSettings?.accentColor;
 
-    if (themeSettings?.dark && primaryColor) {
+    if (darkMode && primaryColor) {
       themeRules["app-header-background-color"] = hexBlend(
         primaryColor,
         "#121212",

--- a/src/data/ws-themes.ts
+++ b/src/data/ws-themes.ts
@@ -23,6 +23,8 @@ export interface Themes {
   // in theme picker, this property will still contain either true or false based on
   // what has been determined via system preferences and support from the selected theme.
   darkMode: boolean;
+  // Currently globally active theme name
+  theme: string;
 }
 
 const fetchThemes = (conn) =>

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -201,6 +201,7 @@ export const provideHass = (
       default_dark_theme: null,
       themes: {},
       darkMode: false,
+      theme: "default",
     },
     panels: demoPanels,
     services: demoServices,

--- a/src/onboarding/ha-onboarding.ts
+++ b/src/onboarding/ha-onboarding.ts
@@ -133,18 +133,13 @@ class HaOnboarding extends litLocalizeLiteMixin(HassElement) {
       import("./particles");
     }
     if (matchMedia("(prefers-color-scheme: dark)").matches) {
-      applyThemesOnElement(
-        document.documentElement,
-        {
-          default_theme: "default",
-          default_dark_theme: null,
-          themes: {},
-          darkMode: false,
-          theme: "default",
-        },
-        "default",
-        { dark: true }
-      );
+      applyThemesOnElement(document.documentElement, {
+        default_theme: "default",
+        default_dark_theme: null,
+        themes: {},
+        darkMode: true,
+        theme: "default",
+      });
     }
   }
 

--- a/src/onboarding/ha-onboarding.ts
+++ b/src/onboarding/ha-onboarding.ts
@@ -140,6 +140,7 @@ class HaOnboarding extends litLocalizeLiteMixin(HassElement) {
           default_dark_theme: null,
           themes: {},
           darkMode: false,
+          theme: "default",
         },
         "default",
         { dark: true }

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -45,6 +45,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
             default_dark_theme: null,
             themes: {},
             darkMode: false,
+            theme: "default",
           },
           "default",
           { dark: true }
@@ -89,6 +90,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       }
 
       themeSettings = { ...this.hass.selectedTheme, dark: darkMode };
+      this.hass.themes.theme = themeName;
 
       applyThemesOnElement(
         document.documentElement,

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -85,7 +85,9 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       }
 
       themeSettings = { ...this.hass.selectedTheme, dark: darkMode };
-      this.hass.themes.theme = themeName;
+      this._updateHass({
+          themes: { ...this.hass.themes!, theme: themeName },
+      });
 
       applyThemesOnElement(
         document.documentElement,

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -38,18 +38,13 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       });
       mql.addListener((ev) => this._applyTheme(ev.matches));
       if (!this._themeApplied && mql.matches) {
-        applyThemesOnElement(
-          document.documentElement,
-          {
-            default_theme: "default",
-            default_dark_theme: null,
-            themes: {},
-            darkMode: false,
-            theme: "default",
-          },
-          "default",
-          { dark: true }
-        );
+        applyThemesOnElement(document.documentElement, {
+          default_theme: "default",
+          default_dark_theme: null,
+          themes: {},
+          darkMode: true,
+          theme: "default",
+        });
       }
     }
 

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -86,7 +86,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
 
       themeSettings = { ...this.hass.selectedTheme, dark: darkMode };
       this._updateHass({
-          themes: { ...this.hass.themes!, theme: themeName },
+        themes: { ...this.hass.themes!, theme: themeName },
       });
 
       applyThemesOnElement(

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,9 +84,12 @@ export interface CurrentUser {
 }
 
 // Currently selected theme and its settings. These are the values stored in local storage.
+// Note: These values are not meant to be used at runtime to check whether dark mode is active
+// or which theme name to use, as this interface represents the config data for the theme picker.
+// The actually active dark mode and theme name can be read from hass.themes.
 export interface ThemeSettings {
   theme: string;
-  // Radio box selection for theme picker. Do not use in cards as
+  // Radio box selection for theme picker. Do not use in Lovelace rendering as
   // it can be undefined == auto.
   // Property hass.themes.darkMode carries effective current mode.
   dark?: boolean;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Some calls to `apply_themes_on_element` did not have an actual `selectedTheme` value resulting in themes being applied only partially.

With this PR we now have a globally active theme name in `hass.themes.theme` similar to the existing `darkMode`. Those values are different from the `themeSettings` since those represent the settings made on the theme picker, but do not necessarily represent the actually active values during runtime (e.g. dark mode can be auto `undefined/auto in `themeSettings` and the real value is in `hass.themes` and similar for backend-selected them names).

With this PR we have a clear separation of concerns. So the parameters for `apply_themes_on_element()` are:

1. `element`: The element to apply the theme on
2. `themes`: The hass.themes active info (includes the active dark mode and the active global theme e.g. derived from "Backend-selected")
3. `selectedTheme` Parameter to override the global theme, in case e.g. a card has another theme set in the card config
4. `themeSettings`:  Used only to pass additional attributes in = selected colors for default theme. The theme name and dark flag have no runtime relevance as they represent the theme settings for the theme picker.

**Note**: I don't have a hassio dev instance, so untested in that area.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10529 fixes #10514
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
