### PR TITLE
zwave_js config param should only be a toggle if there are 2 states

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -330,7 +330,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
     if (!(0 in item.metadata.states) || !(1 in item.metadata.states)) {
       return false;
     }
-    if (item.metadata.states.length !== 2) {
+    if (Object.keys(item.metadata.states).length !== 2) {
       return false;
     }
     if (

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -330,6 +330,9 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
     if (!(0 in item.metadata.states) || !(1 in item.metadata.states)) {
       return false;
     }
+    if (item.metadata.states.length !== 2) {
+      return false;
+    }
     if (
       disabledStates.includes(item.metadata.states[0].toLowerCase()) &&
       enabledStates.includes(item.metadata.states[1].toLowerCase())

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -327,10 +327,10 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
     if (!("states" in item.metadata)) {
       return false;
     }
-    if (!(0 in item.metadata.states) || !(1 in item.metadata.states)) {
+    if (Object.keys(item.metadata.states).length !== 2) {
       return false;
     }
-    if (Object.keys(item.metadata.states).length !== 2) {
+    if (!(0 in item.metadata.states) || !(1 in item.metadata.states)) {
       return false;
     }
     if (


### PR DESCRIPTION
## Proposed change
Right now we show a toggle to the user if `enabled`/`enable` and `disabled`/`disable` are in the available options for the config parameter, even if there are more than two options available. We should not do that and should instead use a dropdown to show the additional states when there are more than two options available.

I was not able to test this as I don't have a device that meets this criteria, but this should fix https://github.com/zwave-js/node-zwave-js/issues/3836

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
