### PR TITLE
Allow trigger reconnect from external bus

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -43,6 +43,7 @@ import {
   PersistentNotification,
   subscribeNotifications,
 } from "../data/persistent_notification";
+import { getExternalConfig } from "../external_app/external_config";
 import { actionHandler } from "../panels/lovelace/common/directives/action-handler-directive";
 import { haStyleScrollbar } from "../resources/styles";
 import type { HomeAssistant, PanelInfo, Route } from "../types";
@@ -266,6 +267,11 @@ class HaSidebar extends LitElement {
     subscribeNotifications(this.hass.connection, (notifications) => {
       this._notifications = notifications;
     });
+
+    // Temporary workaround for a bug in Android. Can be removed in Home Assistant 2022.2
+    if (this.hass.auth.external) {
+      getExternalConfig(this.hass.auth.external);
+    }
   }
 
   protected updated(changedProps) {

--- a/src/external_app/external_auth.ts
+++ b/src/external_app/external_auth.ts
@@ -2,7 +2,7 @@
  * Auth class that connects to a native app for authentication.
  */
 import { Auth } from "home-assistant-js-websocket";
-import { ExternalMessaging, Message } from "./external_messaging";
+import { ExternalMessaging, EMMessage } from "./external_messaging";
 
 const CALLBACK_SET_TOKEN = "externalAuthSetToken";
 const CALLBACK_REVOKE_TOKEN = "externalAuthRevokeToken";
@@ -36,7 +36,7 @@ declare global {
           postMessage(payload: BasePayload);
         };
         externalBus: {
-          postMessage(payload: Message);
+          postMessage(payload: EMMessage);
         };
       };
     };

--- a/src/external_app/external_auth.ts
+++ b/src/external_app/external_auth.ts
@@ -2,7 +2,7 @@
  * Auth class that connects to a native app for authentication.
  */
 import { Auth } from "home-assistant-js-websocket";
-import { ExternalMessaging, InternalMessage } from "./external_messaging";
+import { ExternalMessaging, Message } from "./external_messaging";
 
 const CALLBACK_SET_TOKEN = "externalAuthSetToken";
 const CALLBACK_REVOKE_TOKEN = "externalAuthRevokeToken";
@@ -36,7 +36,7 @@ declare global {
           postMessage(payload: BasePayload);
         };
         externalBus: {
-          postMessage(payload: InternalMessage);
+          postMessage(payload: Message);
         };
       };
     };

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -100,6 +100,15 @@ export class ExternalMessaging {
       if (!this.connection) {
         // eslint-disable-next-line no-console
         console.warn("Received command without having connection set", msg);
+        this.fireMessage({
+          id: msg.id,
+          type: "result",
+          success: false,
+          error: {
+            code: "commands_not_init",
+            message: `Commands connection not set`,
+          },
+        });
       } else if (msg.command === "restart") {
         this.connection.socket.close();
         this.fireMessage({
@@ -111,6 +120,15 @@ export class ExternalMessaging {
       } else {
         // eslint-disable-next-line no-console
         console.warn("Received unknown command", msg.command, msg);
+        this.fireMessage({
+          id: msg.id,
+          type: "result",
+          success: false,
+          error: {
+            code: "unknown_command",
+            message: `Unknown command ${msg.command}`,
+          },
+        });
       }
       return;
     }

--- a/src/state/external-mixin.ts
+++ b/src/state/external-mixin.ts
@@ -1,0 +1,15 @@
+import { Constructor } from "../types";
+import { HassBaseEl } from "./hass-base-mixin";
+
+export const ExternalMixin = <T extends Constructor<HassBaseEl>>(
+  superClass: T
+) =>
+  class extends superClass {
+    protected hassConnected() {
+      super.hassConnected();
+
+      if (this.hass!.auth.external) {
+        this.hass!.auth.external.connection = this.hass!.connection;
+      }
+    }
+  };

--- a/src/state/hass-element.ts
+++ b/src/state/hass-element.ts
@@ -6,6 +6,7 @@ import DisconnectToastMixin from "./disconnect-toast-mixin";
 import { hapticMixin } from "./haptic-mixin";
 import { HassBaseEl } from "./hass-base-mixin";
 import { loggingMixin } from "./logging-mixin";
+import { ExternalMixin } from "./external-mixin";
 import MoreInfoMixin from "./more-info-mixin";
 import NotificationMixin from "./notification-mixin";
 import { panelTitleMixin } from "./panel-title-mixin";
@@ -31,4 +32,5 @@ export class HassElement extends ext(HassBaseEl, [
   hapticMixin,
   panelTitleMixin,
   loggingMixin,
+  ExternalMixin,
 ]) {}

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -131,5 +131,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
           (themeMeta.getAttribute("default-content") as string);
         themeMeta.setAttribute("content", themeColor);
       }
+
+      this.hass!.auth.external?.fireMessage({ type: "theme-changed" });
     }
   };

--- a/src/state/themes-mixin.ts
+++ b/src/state/themes-mixin.ts
@@ -132,6 +132,6 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         themeMeta.setAttribute("content", themeColor);
       }
 
-      this.hass!.auth.external?.fireMessage({ type: "theme-changed" });
+      this.hass!.auth.external?.fireMessage({ type: "theme-update" });
     }
   };

--- a/test/external_app/external_messaging.spec.ts
+++ b/test/external_app/external_messaging.spec.ts
@@ -2,16 +2,16 @@ import { assert } from "chai";
 
 import {
   ExternalMessaging,
-  Message,
+  EMMessage,
 } from "../../src/external_app/external_messaging";
 
 // @ts-ignore
 global.__DEV__ = true;
 
 class MockExternalMessaging extends ExternalMessaging {
-  public mockSent: Message[] = [];
+  public mockSent: EMMessage[] = [];
 
-  protected _sendExternal(msg: Message) {
+  protected _sendExternal(msg: EMMessage) {
     this.mockSent.push(msg);
   }
 }

--- a/test/external_app/external_messaging.spec.ts
+++ b/test/external_app/external_messaging.spec.ts
@@ -2,16 +2,16 @@ import { assert } from "chai";
 
 import {
   ExternalMessaging,
-  InternalMessage,
+  Message,
 } from "../../src/external_app/external_messaging";
 
 // @ts-ignore
 global.__DEV__ = true;
 
 class MockExternalMessaging extends ExternalMessaging {
-  public mockSent: InternalMessage[] = [];
+  public mockSent: Message[] = [];
 
-  protected _sendExternal(msg: InternalMessage) {
+  protected _sendExternal(msg: Message) {
     this.mockSent.push(msg);
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Some external messaging fixes for 2021.21

- On iOS 15 we're seeing the websocket connection going stale when the app has been in the background without the webview being able to detect this. From iOS native land we can deteect this scenario and trigger a reconnect.
- Android relies on receiving `config/get` to sync theme to native parts. Re-instate this for 1 release while they ship a bug fix
- Add a new `theme-update` external messaging event when theme has been updated so app knows when to sync

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
