### PR TITLE
Add seek buttons to Lovelace media control card

### DIFF
--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -3,8 +3,8 @@ import type { LinearProgress } from "@material/mwc-linear-progress/mwc-linear-pr
 import {
   mdiDotsVertical,
   mdiPlayBoxMultiple,
-  mdiRotateLeft,
-  mdiRotateRight,
+  mdiReload,
+  mdiRestore,
 } from "@mdi/js";
 import {
   css,
@@ -300,18 +300,20 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
                             ${supportsFeature(stateObj, SUPPORT_SEEK)
                               ? html`
                                   <ha-icon-button
+                                    class="seek-button replay"
                                     .label=${this.hass.localize(
                                       `ui.card.media_player.seek_replay`
                                     )}
-                                    .path=${mdiRotateLeft}
+                                    .path=${mdiRestore}
                                     @click=${this._handleSeekReplay}
                                   >
                                   </ha-icon-button>
                                   <ha-icon-button
+                                    class="seek-button forward"
                                     .label=${this.hass.localize(
                                       `ui.card.media_player.seek_forward`
                                     )}
-                                    .path=${mdiRotateRight}
+                                    .path=${mdiReload}
                                     @click=${this._handleSeekForward}
                                   >
                                   </ha-icon-button>
@@ -771,8 +773,27 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
         --mdc-icon-size: 30px;
       }
 
+      .controls ha-icon-button.seek-button {
+        position: relative;
+      }
+      .controls ha-icon-button.seek-button::after {
+        content: "${SEEK_BUTTON_INCREMENT}";
+        pointer-events: none;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 0.7em;
+        font-weight: bold;
+      }
+      .controls ha-icon-button.seek-button.replay::after {
+        padding-left: 3px;
+      }
+      .controls ha-icon-button.seek-button.forward::after {
+        padding-right: 3px;
+      }
+
       .controls .seek-delta {
-        margin-left: 12px;
         font-size: 1.2em;
       }
 

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -47,7 +47,7 @@ import { createEntityNotFoundWarning } from "../components/hui-warning";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import { MediaControlCardConfig } from "./types";
 
-// Number of seconds to replay/forward when clicking seek buttons
+// Number of seconds to seek backward/forward when clicking seek buttons
 const SEEK_BUTTON_INCREMENT = 30;
 // Duration in milliseconds to wait before seeking to new position after pressing seek buttons
 const SEEK_BUTTON_DEBOUNCE = 2 * 1000; // 2 seconds
@@ -300,18 +300,18 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
                             ${supportsFeature(stateObj, SUPPORT_SEEK)
                               ? html`
                                   <ha-icon-button
-                                    class="seek-button replay"
+                                    class="seek-button backward"
                                     .label=${this.hass.localize(
-                                      `ui.card.media_player.seek_replay`
+                                      `ui.card.media_player.media_seek_backward`
                                     )}
                                     .path=${mdiRestore}
-                                    @click=${this._handleSeekReplay}
+                                    @click=${this._handleSeekBackward}
                                   >
                                   </ha-icon-button>
                                   <ha-icon-button
                                     class="seek-button forward"
                                     .label=${this.hass.localize(
-                                      `ui.card.media_player.seek_forward`
+                                      `ui.card.media_player.media_seek_forward`
                                     )}
                                     .path=${mdiReload}
                                     @click=${this._handleSeekForward}
@@ -584,7 +584,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
     });
   }
 
-  private _handleSeekReplay() {
+  private _handleSeekBackward() {
     this._seekDelta -= SEEK_BUTTON_INCREMENT;
     this._debouncedSeek();
   }
@@ -786,7 +786,7 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
         font-size: 0.7em;
         font-weight: bold;
       }
-      .controls ha-icon-button.seek-button.replay::after {
+      .controls ha-icon-button.seek-button.backward::after {
         padding-left: 3px;
       }
       .controls ha-icon-button.seek-button.forward::after {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -197,6 +197,8 @@
         "media_play_pause": "Play/pause",
         "media_next_track": "Next",
         "media_previous_track": "Previous",
+        "media_seek_backward": "Seek backward",
+        "media_seek_forward": "Seek forward",
         "text_to_speak": "Text to speak"
       },
       "persistent_notification": {

--- a/translations/frontend/de.json
+++ b/translations/frontend/de.json
@@ -619,6 +619,8 @@
                 "media_play": "Abspielen",
                 "media_play_pause": "Spielen/Pause",
                 "media_previous_track": "Vorheriger Titel",
+                "media_seek_backward": "Zurückspulen",
+                "media_seek_forward": "Vorspulen",
                 "sound_mode": "Sound-Modus",
                 "source": "Quelle",
                 "text_to_speak": "Text zum Sprechen",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds seek buttons to the Lovelace media control card that seek forward or backward by a fixed amount of time (30s). This provides an alternative input method for seeking to the progress bar, which is finicky to use for content with long duration, or on mobile with touch input. The use case for this input method is that you want to just skip a small amount of time, or repeat something that happened recently. For example skipping the intro of a show, skipping ad breaks in podcasts, or skipping breaks in recorded live-streams. The seek buttons are only displayed when playing content that supports seeking.

<img width="492" alt="seek-buttons" src="https://user-images.githubusercontent.com/357820/145672469-ebf77e83-b5b7-4e7f-bae5-9c7b6c34d20b.png">

Clicking one of the buttons will increment or decrement a time delta that is shown next to the buttons. The buttons can be clicked multiple times to increase or decrease the delta further. The delta will be applied to the current position debounced, two seconds after the last button click.

<img width="492" alt="seek-delta" src="https://user-images.githubusercontent.com/357820/145672537-c5ee5a5d-1d00-4ceb-b900-9365047925f8.png">

The controls are becoming quite stuffed with this change, and on mobile devices the seek delta might get cut off. I'm open to ideas on how to improve this.

<img width="352" alt="seek-delta-mobile" src="https://user-images.githubusercontent.com/357820/145672664-d692b452-9e44-4fe3-9a80-22dd15d629c9.png">

Other thoughts / considerations:
1. Consider reducing the icon size of all control bar buttons to create the required space on mobile.
2. Consider moving the media gallery button to some other place (for example next to more menu button) to create the required space on mobile.
2. Should the feature be configurable?
3. Should the feature be added to the `more-info-media_player` element as well?
4. Are there scenarios where the seek buttons can be hidden even if the content supports seeking? For music the buttons are probably not useful. This is a tricky subject, but maybe someone can identify some clear cases.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

N/A

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
