### PR TITLE
Correct updating input_datetime when the state includes timezone

### DIFF
--- a/src/data/input_datetime.ts
+++ b/src/data/input_datetime.ts
@@ -23,9 +23,6 @@ export const setInputDateTimeValue = (
   time: string | undefined = undefined,
   date: string | undefined = undefined
 ) => {
-  if (time !== undefined) {
-    time = time.split("+")[0];
-  }
   const param = { entity_id: entityId, time, date };
   hass.callService(entityId.split(".", 1)[0], "set_datetime", param);
 };

--- a/src/data/input_datetime.ts
+++ b/src/data/input_datetime.ts
@@ -23,6 +23,9 @@ export const setInputDateTimeValue = (
   time: string | undefined = undefined,
   date: string | undefined = undefined
 ) => {
+  if (time !== undefined) {
+    time = time.split("+")[0];
+  }
   const param = { entity_id: entityId, time, date };
   hass.callService(entityId.split(".", 1)[0], "set_datetime", param);
 };

--- a/src/dialogs/more-info/controls/more-info-input_datetime.ts
+++ b/src/dialogs/more-info/controls/more-info-input_datetime.ts
@@ -74,7 +74,7 @@ class MoreInfoInputDatetime extends LitElement {
       this.hass!,
       this.stateObj!.entity_id,
       this.stateObj!.attributes.has_time
-        ? this.stateObj!.state.split(" ")[1].split("+")[0]
+        ? this.stateObj!.state.split(" ")[1]
         : undefined,
       ev.detail.value
     );

--- a/src/dialogs/more-info/controls/more-info-input_datetime.ts
+++ b/src/dialogs/more-info/controls/more-info-input_datetime.ts
@@ -74,7 +74,7 @@ class MoreInfoInputDatetime extends LitElement {
       this.hass!,
       this.stateObj!.entity_id,
       this.stateObj!.attributes.has_time
-        ? this.stateObj!.state.split(" ")[1]
+        ? this.stateObj!.state.split(" ")[1].split("+")[0]
         : undefined,
       ev.detail.value
     );

--- a/src/panels/lovelace/entity-rows/hui-input-datetime-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-datetime-entity-row.ts
@@ -102,7 +102,9 @@ class HuiInputDatetimeEntityRow extends LitElement implements LovelaceRow {
     setInputDateTimeValue(
       this.hass!,
       stateObj.entity_id,
-      stateObj.attributes.has_time ? stateObj.state.split(" ")[1] : undefined,
+      stateObj.attributes.has_time
+        ? stateObj.state.split(" ")[1].split("+")[0]
+        : undefined,
       ev.detail.value
     );
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
# Proposed change
Needed to get PR: https://github.com/home-assistant/core/pull/61698 to work.
This is a bugfix to allow the `input_datetime` entity state to support timezones.
The frontend though splits the state in two parts (date and time). The time part also contains timezone info, that causes invalid service calls to happen.

This PR strips the timezone part from the state (if a timezone part exists).

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
