### PR TITLE
Force reconnect when triggered from external bus

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "fuse.js": "^6.0.0",
     "google-timezones-json": "^1.0.2",
     "hls.js": "^1.0.11",
-    "home-assistant-js-websocket": "^5.11.3",
+    "home-assistant-js-websocket": "^5.12.0",
     "idb-keyval": "^5.1.3",
     "intl-messageformat": "^9.9.1",
     "js-yaml": "^4.1.0",

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -110,7 +110,7 @@ export class ExternalMessaging {
           },
         });
       } else if (msg.command === "restart") {
-        this.connection.socket.close();
+        this.connection.reconnect(true);
         this.fireMessage({
           id: msg.id,
           type: "result",

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -36,16 +36,16 @@ interface EMMessageResultError {
   error: EMError;
 }
 
-interface EMExternalMessageRestart {
+interface EMExternalMessageReconnect {
   id: number;
   type: "command";
-  command: "restart";
+  command: "reconnect";
 }
 
 type ExternalMessage =
   | EMMessageResultSuccess
   | EMMessageResultError
-  | EMExternalMessageRestart;
+  | EMExternalMessageReconnect;
 
 export class ExternalMessaging {
   public commands: { [msgId: number]: CommandInFlight } = {};
@@ -109,7 +109,7 @@ export class ExternalMessaging {
             message: `Commands connection not set`,
           },
         });
-      } else if (msg.command === "restart") {
+      } else if (msg.command === "reconnect") {
         this.connection.reconnect(true);
         this.fireMessage({
           id: msg.id,

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -36,16 +36,16 @@ interface EMMessageResultError {
   error: EMError;
 }
 
-interface EMExternalMessageReconnect {
+interface EMExternalMessageRestart {
   id: number;
   type: "command";
-  command: "reconnect";
+  command: "restart";
 }
 
 type ExternalMessage =
   | EMMessageResultSuccess
   | EMMessageResultError
-  | EMExternalMessageReconnect;
+  | EMExternalMessageRestart;
 
 export class ExternalMessaging {
   public commands: { [msgId: number]: CommandInFlight } = {};
@@ -109,7 +109,7 @@ export class ExternalMessaging {
             message: `Commands connection not set`,
           },
         });
-      } else if (msg.command === "reconnect") {
+      } else if (msg.command === "restart") {
         this.connection.reconnect(true);
         this.fireMessage({
           id: msg.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9113,7 +9113,7 @@ fsevents@^1.2.7:
     gulp-rename: ^2.0.0
     gulp-zopfli-green: ^3.0.1
     hls.js: ^1.0.11
-    home-assistant-js-websocket: ^5.11.3
+    home-assistant-js-websocket: ^5.12.0
     html-minifier: ^4.0.0
     husky: ^1.3.1
     idb-keyval: ^5.1.3
@@ -9184,10 +9184,10 @@ fsevents@^1.2.7:
   languageName: unknown
   linkType: soft
 
-"home-assistant-js-websocket@npm:^5.11.3":
-  version: 5.11.3
-  resolution: "home-assistant-js-websocket@npm:5.11.3"
-  checksum: 3ab90e5105c5f379d77fb23ab53eaec2789be7bf1fd507a7520d9cf329d36942b8e978a591b822cff96100630d43bd036a4e25e2f49c40d0c56a111808fb90a5
+"home-assistant-js-websocket@npm:^5.12.0":
+  version: 5.12.0
+  resolution: "home-assistant-js-websocket@npm:5.12.0"
+  checksum: 62171c10e55e3245c9a4fc77dbd2641f234a66b4e3d0adaf8c4364c567473555dbf34f3d737bf3f31e92f2a198051b57f2782fd71f8406784693e64496809501
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

When the socket gets unresponse on iOS 15, it also won't respond to `close()`. This changes the external reconnect command to use the new force reconnect feature in HAWS which doesn't wait for old socket to trigger close.

~~Also renames the external command to `reconnect` instead of `restart` as that makes more sense.~~ Not renaming because it's already available in iOS 2021.12.

Requires https://github.com/home-assistant/home-assistant-js-websocket/pull/224

FYI @zacwest

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
