### PR TITLE
More granular control for row interaction catching and cursor

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -199,11 +199,12 @@ export const DOMAINS_HIDE_DEFAULT_MORE_INFO = [
   "select",
 ];
 
-/** Domains that render an input element instead of a text value when rendered in a row.
+/** Domains that render an input element instead of a text value when displayed in a row.
  *  Those rows should then not show a cursor pointer when hovered (which would normally
  *  be the default) unless the element itself enforces it (e.g. a button). Also those elements
  *  should not act as a click target to open the more info dialog (the row name and state icon
- *  still do of course) as the click might instead e.g. activate the input field that this row shows.
+ *  still do of course) as the click should instead e.g. activate the input field  or toggle
+ *  the button that this row shows.
  */
 export const DOMAINS_INPUT_ROW = [
   "cover",
@@ -223,6 +224,7 @@ export const DOMAINS_INPUT_ROW = [
   "script",
   "select",
   "switch",
+  "vacuum",
 ];
 
 /** Domains that should have the history hidden in the more info dialog. */

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -33,6 +33,13 @@ class HuiGenericEntityRow extends LitElement {
 
   @property({ type: Boolean }) public hideName = false;
 
+  // Allows to control if this row should capture the user interaction, e.g. with its
+  // toggle switch, button or input field. Some domains dynamically decide what to show
+  // => static determination will not work => the caller has to pass the desired value in.
+  // Same applies for custom components that want to override the default behavior.
+  // Default behavior is controlled by DOMAINS_INPUT_ROW.
+  @property({ type: Boolean }) public catchInteraction?;
+
   protected render(): TemplateResult {
     if (!this.hass || !this.config) {
       return html``;
@@ -144,7 +151,7 @@ class HuiGenericEntityRow extends LitElement {
               : ""}
           </div>`
         : html``}
-      ${!DOMAINS_INPUT_ROW.includes(domain)
+      ${this.catchInteraction ?? !DOMAINS_INPUT_ROW.includes(domain)
         ? html` <div
             class="text-content ${classMap({
               pointer,

--- a/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
@@ -41,11 +41,18 @@ class HuiToggleEntityRow extends LitElement implements LovelaceRow {
       `;
     }
 
+    const showToggle =
+      stateObj.state === "on" ||
+      stateObj.state === "off" ||
+      UNAVAILABLE_STATES.includes(stateObj.state);
+
     return html`
-      <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
-        ${stateObj.state === "on" ||
-        stateObj.state === "off" ||
-        UNAVAILABLE_STATES.includes(stateObj.state)
+      <hui-generic-entity-row
+        .hass=${this.hass}
+        .config=${this._config}
+        .catchInteraction=${!showToggle}
+      >
+        ${showToggle
           ? html`
               <ha-entity-toggle
                 .hass=${this.hass}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The new generic logic (#10025) of using a global static const to mark the domains that show an input element (toggle switch, button, input field, ...) in a row display, has two limitations:

1. Some rows actually dynamically decide what to show, e.g. the toggle switch row. It can either show the toggle switch or a text depending on the entity state => dynamic approach needed.
2. For custom card devs the new fixed non-overridable behavior posed issues since they could no longer catch the user interaction to add custom reaction logic. 

=> This PR adds the option to override the interaction behavior for the rows. The internal toggle switch row makes use of that and so can custom card devs.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #10961
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
