### PR TITLE
Add authenticated thumbnails to Media Player and lazy fetch thumbnails

### DIFF
--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -44,7 +44,7 @@ import type { HomeAssistant } from "../../types";
 import { documentationUrl } from "../../util/documentation-url";
 import "../entity/ha-entity-picker";
 import "../ha-button-menu";
-import "../ha-card";
+import type { HaCard } from "../ha-card";
 import "../ha-circular-progress";
 import "../ha-fab";
 import "../ha-icon-button";
@@ -603,7 +603,7 @@ export class HaMediaPlayerBrowse extends LitElement {
         }
       );
     }
-    const observer = this._interactionObserver;
+    const observer = this._interactionObserver!;
     this._thumbnails.forEach((thumbnailCard) => {
       observer.observe(thumbnailCard);
     });

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -27,11 +27,11 @@ import { styleMap } from "lit/directives/style-map";
 import { fireEvent } from "../../common/dom/fire_event";
 import { computeRTLDirection } from "../../common/util/compute_rtl";
 import { debounce } from "../../common/util/debounce";
+import { getSignedPath } from "../../data/auth";
 import type { MediaPlayerItem } from "../../data/media-player";
 import {
   browseLocalMediaPlayer,
   browseMediaPlayer,
-  getSignedThumbnailPath,
   BROWSER_PLAYER,
   MediaClassBrowserSettings,
   MediaPickedEvent,
@@ -594,10 +594,8 @@ export class HaMediaPlayerBrowse extends LitElement {
               }
               if (thumbnailUrl.startsWith("/")) {
                 // Thumbnails served by local API require authentication
-                thumbnailUrl = await getSignedThumbnailPath(
-                  this.hass,
-                  thumbnailUrl
-                );
+                const signedPath = await getSignedPath(this.hass, thumbnailUrl);
+                thumbnailUrl = signedPath.path;
               }
               thumbnailCard.style.backgroundImage = `url(${thumbnailUrl})`;
               observer.unobserve(thumbnailCard); // loaded, so no need to observe anymore

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -92,7 +92,8 @@ export class HaMediaPlayerBrowse extends LitElement {
 
   private _resizeObserver?: ResizeObserver;
 
-  private _interactionObserver?: InteractionObserver; // @ts-ignore
+  // @ts-ignore
+  private _interactionObserver?: InteractionObserver;
 
   public connectedCallback(): void {
     super.connectedCallback();

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -92,7 +92,7 @@ export class HaMediaPlayerBrowse extends LitElement {
 
   private _resizeObserver?: ResizeObserver;
 
-  private _interactionObserver?: InteractionObserver;
+  private _interactionObserver?: InteractionObserver; // @ts-ignore
 
   public connectedCallback(): void {
     super.connectedCallback();
@@ -600,10 +600,8 @@ export class HaMediaPlayerBrowse extends LitElement {
                   thumbnailUrl
                 );
               }
-              thumbnailCard.style =
-                "background-image:url(" + thumbnailUrl + ")";
+              thumbnailCard.style.backgroundImage = `url(${thumbnailUrl})`;
               observer.unobserve(thumbnailCard); // loaded, so no need to observe anymore
-              this.requestUpdate();
             })
           );
         }

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -577,6 +577,9 @@ export class HaMediaPlayerBrowse extends LitElement {
    * Load thumbnails for images on demand as they become visible.
    */
   private async _attachInteractionObserver(): Promise<void> {
+    if (!this._thumbnails) {
+      return;
+    }
     if (!this._interactionObserver) {
       this._interactionObserver = new IntersectionObserver(
         async (entries, observer) => {
@@ -585,10 +588,13 @@ export class HaMediaPlayerBrowse extends LitElement {
               if (!entry.isIntersecting) {
                 return;
               }
-              const thumbnailCard = entry.target as HACard;
+              const thumbnailCard = entry.target as HaCard;
               let thumbnailUrl = thumbnailCard.dataset.src;
-              // Any thumbnails served by the API required authentication
+              if (!thumbnailUrl) {
+                return;
+              }
               if (thumbnailUrl.startsWith("/")) {
+                // Thumbnails served by local API require authentication
                 thumbnailUrl = await getSignedThumbnailPath(
                   this.hass,
                   thumbnailUrl

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -337,7 +337,7 @@ export class HaMediaPlayerBrowse extends LitElement {
                       >
                         <div
                           class="graphic"
-                          data-style=${ifDefined(
+                          style=${ifDefined(
                             mediaClass.show_list_images && child.thumbnail
                               ? `background-image: url(${child.thumbnail})`
                               : undefined

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -93,7 +93,7 @@ export class HaMediaPlayerBrowse extends LitElement {
   private _resizeObserver?: ResizeObserver;
 
   // @ts-ignore
-  private _interactionObserver?: InteractionObserver;
+  private _intersectionObserver?: IntersectionObserver;
 
   public connectedCallback(): void {
     super.connectedCallback();
@@ -104,8 +104,8 @@ export class HaMediaPlayerBrowse extends LitElement {
     if (this._resizeObserver) {
       this._resizeObserver.disconnect();
     }
-    if (this._interactionObserver) {
-      this._interactionObserver.disconnect();
+    if (this._intersectionObserver) {
+      this._intersectionObserver.disconnect();
     }
   }
 
@@ -411,7 +411,7 @@ export class HaMediaPlayerBrowse extends LitElement {
       this._mediaPlayerItems.length
     ) {
       this._setHeaderHeight();
-      this._attachInteractionObserver();
+      this._attachIntersectionObserver();
     }
 
     if (
@@ -577,12 +577,12 @@ export class HaMediaPlayerBrowse extends LitElement {
   /**
    * Load thumbnails for images on demand as they become visible.
    */
-  private async _attachInteractionObserver(): Promise<void> {
+  private async _attachIntersectionObserver(): Promise<void> {
     if (!this._thumbnails) {
       return;
     }
-    if (!this._interactionObserver) {
-      this._interactionObserver = new IntersectionObserver(
+    if (!this._intersectionObserver) {
+      this._intersectionObserver = new IntersectionObserver(
         async (entries, observer) => {
           await Promise.all(
             entries.map(async (entry) => {
@@ -608,7 +608,7 @@ export class HaMediaPlayerBrowse extends LitElement {
         }
       );
     }
-    const observer = this._interactionObserver!;
+    const observer = this._intersectionObserver!;
     this._thumbnails.forEach((thumbnailCard) => {
       observer.observe(thumbnailCard);
     });

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -270,9 +270,7 @@ export class HaMediaPlayerBrowse extends LitElement {
                           <ha-card
                             outlined
                             class=${child.thumbnail ? "lazythumbnail" : ""}
-                            data-src=${child.thumbnail
-                              ? `${child.thumbnail}`
-                              : ""}
+                            data-src=${ifDefined(child.thumbnail)}
                           >
                             ${!child.thumbnail
                               ? html`

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -30,6 +30,7 @@ import type {
 import { supportsFeature } from "../common/entity/supports-feature";
 import type { HomeAssistant } from "../types";
 import { UNAVAILABLE_STATES } from "./entity";
+import { getSignedPath } from "./auth";
 
 interface MediaPlayerEntityAttributes extends HassEntityAttributeBase {
   media_content_type?: any;
@@ -193,6 +194,20 @@ export const browseLocalMediaPlayer = (
     type: "media_source/browse_media",
     media_content_id: mediaContentId,
   });
+
+export const getSignedThumbnailPath = async (
+  hass: HomeAssistant,
+  relativeUrl: string
+): Promise<string> => {
+  const thumbnailUrl = new URL(hass.hassUrl(relativeUrl));
+  const signedPath = await getSignedPath(hass, thumbnailUrl.pathname);
+  const updatedUrl = new URL(hass.hassUrl(signedPath.path));
+  // Append any query parameters from the original url onto the udpated url
+  for (const pair of thumbnailUrl.searchParams) {
+    updatedUrl.searchParams.append(pair[0], pair[1]);
+  }
+  return updatedUrl.toString();
+};
 
 export const getCurrentProgress = (stateObj: MediaPlayerEntity): number => {
   let progress = stateObj.attributes.media_position!;

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -30,7 +30,6 @@ import type {
 import { supportsFeature } from "../common/entity/supports-feature";
 import type { HomeAssistant } from "../types";
 import { UNAVAILABLE_STATES } from "./entity";
-import { getSignedPath } from "./auth";
 
 interface MediaPlayerEntityAttributes extends HassEntityAttributeBase {
   media_content_type?: any;
@@ -194,20 +193,6 @@ export const browseLocalMediaPlayer = (
     type: "media_source/browse_media",
     media_content_id: mediaContentId,
   });
-
-export const getSignedThumbnailPath = async (
-  hass: HomeAssistant,
-  relativeUrl: string
-): Promise<string> => {
-  const thumbnailUrl = new URL(hass.hassUrl(relativeUrl));
-  const signedPath = await getSignedPath(hass, thumbnailUrl.pathname);
-  const updatedUrl = new URL(hass.hassUrl(signedPath.path));
-  // Append any query parameters from the original url onto the updated url
-  for (const pair of thumbnailUrl.searchParams) {
-    updatedUrl.searchParams.append(pair[0], pair[1]);
-  }
-  return updatedUrl.toString();
-};
 
 export const getCurrentProgress = (stateObj: MediaPlayerEntity): number => {
   let progress = stateObj.attributes.media_position!;

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -202,7 +202,7 @@ export const getSignedThumbnailPath = async (
   const thumbnailUrl = new URL(hass.hassUrl(relativeUrl));
   const signedPath = await getSignedPath(hass, thumbnailUrl.pathname);
   const updatedUrl = new URL(hass.hassUrl(signedPath.path));
-  // Append any query parameters from the original url onto the udpated url
+  // Append any query parameters from the original url onto the updated url
   for (const pair of thumbnailUrl.searchParams) {
     updatedUrl.searchParams.append(pair[0], pair[1]);
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add support to the media browser to server thumbnails from core that require authentication. When I originally
attempted this, it was really slow because of needing to run websocket commands for 1k events at
once. This now uses an InteractionObserver to load thumbnail images only when they become in view, as
you scroll through the media browser.

The approach is roughly:
- Create the thumbnail ha-cards with the url as a data element, rather than as a loaded image
- Add an interaction observer to detect when the image is in view
- Sign the thumbnail url path, if needed, when it becomes in view
- Load the image

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
