### PR TITLE
20211220.0

### DIFF
--- a/gallery/src/demos/demo-integration-card.ts
+++ b/gallery/src/demos/demo-integration-card.ts
@@ -206,6 +206,7 @@ const createDeviceRegistryEntries = (
     model: "Mock Device",
     name: "Tag Reader",
     sw_version: null,
+    hw_version: "1.0.0",
     id: "mock-device-id",
     identifiers: [],
     via_device_id: null,

--- a/hassio/src/addon-view/info/hassio-addon-info.ts
+++ b/hassio/src/addon-view/info/hassio-addon-info.ts
@@ -133,6 +133,7 @@ class HassioAddonInfo extends LitElement {
               .narrow=${this.narrow}
               .supervisor=${this.supervisor}
               .addonSlug=${this.addon.slug}
+              @update-complete=${this._updateComplete}
             ></update-available-card>
           `
         : ""}
@@ -863,6 +864,15 @@ class HassioAddonInfo extends LitElement {
         text: extractApiErrorMessage(err),
       });
     }
+  }
+
+  private _updateComplete() {
+    const eventdata = {
+      success: true,
+      response: undefined,
+      path: "install",
+    };
+    fireEvent(this, "hass-api-called", eventdata);
   }
 
   private async _installClicked(ev: CustomEvent): Promise<void> {

--- a/hassio/src/components/supervisor-backup-content.ts
+++ b/hassio/src/components/supervisor-backup-content.ts
@@ -350,9 +350,7 @@ export class SupervisorBackupContent extends LitElement {
     if (folders?.length) {
       data.folders = folders;
     }
-    if (this.homeAssistant) {
-      data.homeassistant = this.homeAssistant;
-    }
+    data.homeassistant = this.homeAssistant;
 
     return data;
   }

--- a/hassio/src/update-available/update-available-dashboard.ts
+++ b/hassio/src/update-available/update-available-dashboard.ts
@@ -46,6 +46,7 @@ class UpdateAvailableDashboard extends LitElement {
       update-available-card {
         margin: auto;
         margin-top: 16px;
+        margin-bottom: 24px;
         max-width: 600px;
       }
     `;

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "fuse.js": "^6.0.0",
     "google-timezones-json": "^1.0.2",
     "hls.js": "^1.0.11",
-    "home-assistant-js-websocket": "^5.11.3",
+    "home-assistant-js-websocket": "^5.12.0",
     "idb-keyval": "^5.1.3",
     "intl-messageformat": "^9.9.1",
     "js-yaml": "^4.1.0",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="home-assistant-frontend",
-    version="20211215.0",
+    version="20211220.0",
     description="The Home Assistant frontend",
     url="https://github.com/home-assistant/frontend",
     author="The Home Assistant Authors",

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -206,6 +206,8 @@ export const DOMAINS_HIDE_DEFAULT_MORE_INFO = [
  *  still do of course) as the click might instead e.g. activate the input field that this row shows.
  */
 export const DOMAINS_INPUT_ROW = [
+  "automation",
+  "button",
   "cover",
   "fan",
   "group",

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -199,11 +199,12 @@ export const DOMAINS_HIDE_DEFAULT_MORE_INFO = [
   "select",
 ];
 
-/** Domains that render an input element instead of a text value when rendered in a row.
+/** Domains that render an input element instead of a text value when displayed in a row.
  *  Those rows should then not show a cursor pointer when hovered (which would normally
  *  be the default) unless the element itself enforces it (e.g. a button). Also those elements
  *  should not act as a click target to open the more info dialog (the row name and state icon
- *  still do of course) as the click might instead e.g. activate the input field that this row shows.
+ *  still do of course) as the click should instead e.g. activate the input field  or toggle
+ *  the button that this row shows.
  */
 export const DOMAINS_INPUT_ROW = [
   "automation",
@@ -225,6 +226,7 @@ export const DOMAINS_INPUT_ROW = [
   "script",
   "select",
   "switch",
+  "vacuum",
 ];
 
 /** Domains that should have the history hidden in the more info dialog. */

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -13,6 +13,7 @@ export interface DeviceRegistryEntry {
   model: string | null;
   name: string | null;
   sw_version: string | null;
+  hw_version: string | null;
   via_device_id: string | null;
   area_id: string | null;
   name_by_user: string | null;

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -110,7 +110,7 @@ export class ExternalMessaging {
           },
         });
       } else if (msg.command === "restart") {
-        this.connection.socket.close();
+        this.connection.reconnect(true);
         this.fireMessage({
           id: msg.id,
           type: "result",

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -271,7 +271,10 @@ export const provideHass = (
     updateStates,
     updateTranslations,
     addTranslations,
-    loadFragmentTranslation: async (_fragment: string) => hass().localize,
+    loadFragmentTranslation: async (fragment: string) => {
+      await updateTranslations(fragment);
+      return hass().localize;
+    },
     addEntities,
     mockWS(type, callback) {
       wsCommands[type] = callback;

--- a/src/panels/config/devices/device-detail/ha-device-info-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-info-card.ts
@@ -118,9 +118,9 @@ export class HaDeviceCard extends LitElement {
         word-wrap: break-word;
       }
       .manuf,
-      .entity-id,
       .model {
         color: var(--secondary-text-color);
+        word-wrap: break-word;
       }
     `;
   }

--- a/src/panels/config/devices/device-detail/ha-device-info-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-info-card.ts
@@ -66,6 +66,17 @@ export class HaDeviceCard extends LitElement {
                 </div>
               `
             : ""}
+          ${this.device.hw_version
+            ? html`
+                <div class="extra-info">
+                  ${this.hass.localize(
+                    "ui.panel.config.integrations.config_entry.hardware",
+                    "version",
+                    this.device.hw_version
+                  )}
+                </div>
+              `
+            : ""}
           <slot></slot>
         </div>
         <slot name="actions"></slot>

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -218,9 +218,11 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
         .device .manuf {
           color: var(--secondary-text-color);
           margin-bottom: 20px;
+          word-wrap: break-word;
         }
         .extra-info {
           margin-top: 8px;
+          word-wrap: break-word;
         }
         state-badge {
           cursor: pointer;

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -163,16 +163,16 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     if (!this._config || !this._hass) {
       return;
     }
-    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+    const oldHass = changedProps.get("_hass") as HomeAssistant | undefined;
     const oldConfig = changedProps.get("_config") as
       | EntitiesCardConfig
       | undefined;
 
     if (
-      !oldHass ||
-      !oldConfig ||
-      oldHass.themes !== this.hass.themes ||
-      oldConfig.theme !== this._config.theme
+      (changedProps.has("_hass") &&
+        (!oldHass || oldHass.themes !== this._hass.themes)) ||
+      (changedProps.has("_config") &&
+        (!oldConfig || oldConfig.theme !== this._config.theme))
     ) {
       applyThemesOnElement(this, this._hass.themes, this._config.theme);
     }

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -33,6 +33,13 @@ class HuiGenericEntityRow extends LitElement {
 
   @property({ type: Boolean }) public hideName = false;
 
+  // Allows to control if this row should capture the user interaction, e.g. with its
+  // toggle switch, button or input field. Some domains dynamically decide what to show
+  // => static determination will not work => the caller has to pass the desired value in.
+  // Same applies for custom components that want to override the default behavior.
+  // Default behavior is controlled by DOMAINS_INPUT_ROW.
+  @property({ type: Boolean }) public catchInteraction?;
+
   protected render(): TemplateResult {
     if (!this.hass || !this.config) {
       return html``;
@@ -147,7 +154,7 @@ class HuiGenericEntityRow extends LitElement {
               : ""}
           </div>`
         : html``}
-      ${!DOMAINS_INPUT_ROW.includes(domain)
+      ${this.catchInteraction ?? !DOMAINS_INPUT_ROW.includes(domain)
         ? html` <div
             class="text-content ${classMap({
               pointer,

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -50,8 +50,11 @@ class HuiGenericEntityRow extends LitElement {
     }
 
     const domain = computeDomain(this.config.entity);
+    // By default, we always show a pointer, since if there is no explicit configuration provided,
+    // the frontend always assumes "more-info" in the action handler. We only need to hide the pointer
+    // if the tap action is explicitly set to "none".
     const pointer = !(
-      this.config.tap_action && this.config.tap_action.action !== "none"
+      this.config.tap_action && this.config.tap_action.action === "none"
     );
 
     const hasSecondary = this.secondaryText || this.config.secondary_info;

--- a/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-toggle-entity-row.ts
@@ -41,11 +41,18 @@ class HuiToggleEntityRow extends LitElement implements LovelaceRow {
       `;
     }
 
+    const showToggle =
+      stateObj.state === "on" ||
+      stateObj.state === "off" ||
+      UNAVAILABLE_STATES.includes(stateObj.state);
+
     return html`
-      <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
-        ${stateObj.state === "on" ||
-        stateObj.state === "off" ||
-        UNAVAILABLE_STATES.includes(stateObj.state)
+      <hui-generic-entity-row
+        .hass=${this.hass}
+        .config=${this._config}
+        .catchInteraction=${!showToggle}
+      >
+        ${showToggle
           ? html`
               <ha-entity-toggle
                 .hass=${this.hass}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2444,6 +2444,7 @@
             "manuf": "by {manufacturer}",
             "via": "Connected via",
             "firmware": "Firmware: {version}",
+            "hardware": "Hardware: {version}",
             "unnamed_entry": "Unnamed entry",
             "unknown_via_device": "Unknown device",
             "area": "In {area}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4466,7 +4466,8 @@
       "repositories": {
         "title": "Manage add-on repositories",
         "add": "Add",
-        "remove": "Remove"
+        "remove": "Remove",
+        "used": "Repository is in use for installed add-ons and can't be removed."
       },
       "restart_addon": {
         "confirm_text": "Restart add-on",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1461,7 +1461,8 @@
               "telegram": "Telegram notify services",
               "smtp": "SMTP notify services",
               "mqtt": "Manually configured MQTT entities",
-              "rpi_gpio": "Raspberry Pi GPIO entities"
+              "rpi_gpio": "Raspberry Pi GPIO entities",
+              "timer": "Timers"
             },
             "server_management": {
               "heading": "Server management",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9113,7 +9113,7 @@ fsevents@^1.2.7:
     gulp-rename: ^2.0.0
     gulp-zopfli-green: ^3.0.1
     hls.js: ^1.0.11
-    home-assistant-js-websocket: ^5.11.3
+    home-assistant-js-websocket: ^5.12.0
     html-minifier: ^4.0.0
     husky: ^1.3.1
     idb-keyval: ^5.1.3
@@ -9184,10 +9184,10 @@ fsevents@^1.2.7:
   languageName: unknown
   linkType: soft
 
-"home-assistant-js-websocket@npm:^5.11.3":
-  version: 5.11.3
-  resolution: "home-assistant-js-websocket@npm:5.11.3"
-  checksum: 3ab90e5105c5f379d77fb23ab53eaec2789be7bf1fd507a7520d9cf329d36942b8e978a591b822cff96100630d43bd036a4e25e2f49c40d0c56a111808fb90a5
+"home-assistant-js-websocket@npm:^5.12.0":
+  version: 5.12.0
+  resolution: "home-assistant-js-websocket@npm:5.12.0"
+  checksum: 62171c10e55e3245c9a4fc77dbd2641f234a66b4e3d0adaf8c4364c567473555dbf34f3d737bf3f31e92f2a198051b57f2782fd71f8406784693e64496809501
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What's Changed

* Fix theme updating entities card (#10979) @bramkragten
* More granular control for row interaction catching and cursor (#10971) @spacegaier
* Make "Timers" plural on server control reload page (#10972) @spacegaier
* Show correct cursor if `tap_action` is set to "none" (#10963) @spacegaier
* Add word wrap to device model and manufacturer (#10941) @spacegaier
* Ensure button and automation row inputs are clickable on mobile (#10940) @spacegaier
* Force reconnect when triggered from external bus (#10938) @balloob
* Disable repository removal if used for installed add-ons (#10922) @ludeeus
* Always send homeassistant for partial restore (#10927) @ludeeus
* Handle update-complete event on add-on page (#10929) @ludeeus
* Add bottom margin to update card (#10948) @ludeeus
* Add hardware version to the device info card (#10914) @bdraco
