### PR TITLE
Add weekday to formatTimeWeekday()

### DIFF
--- a/src/common/datetime/format_time.ts
+++ b/src/common/datetime/format_time.ts
@@ -43,9 +43,9 @@ export const formatTimeWeekday = (dateObj: Date, locale: FrontendLocaleData) =>
 const formatTimeWeekdayMem = memoizeOne(
   (locale: FrontendLocaleData) =>
     new Intl.DateTimeFormat(locale.language, {
+      weekday: "long",
       hour: useAmPm(locale) ? "numeric" : "2-digit",
       minute: "2-digit",
-      second: "2-digit",
       hour12: useAmPm(locale),
     })
 );

--- a/test/common/datetime/format_time.ts
+++ b/test/common/datetime/format_time.ts
@@ -58,7 +58,7 @@ describe("formatTimeWeekday", () => {
 
   it("Formats English times", () => {
     assert.strictEqual(
-      formatTime(dateObj, {
+      formatTimeWeekday(dateObj, {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.am_pm,
@@ -66,7 +66,7 @@ describe("formatTimeWeekday", () => {
       "Wednesday 11:12 PM"
     );
     assert.strictEqual(
-      formatTime(dateObj, {
+      formatTimeWeekday(dateObj, {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.twenty_four,

--- a/test/common/datetime/format_time.ts
+++ b/test/common/datetime/format_time.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 import {
   formatTime,
   formatTimeWithSeconds,
+  formatTimeWeekday,
 } from "../../../src/common/datetime/format_time";
 import { NumberFormat, TimeFormat } from "../../../src/data/translation";
 
@@ -48,6 +49,29 @@ describe("formatTimeWithSeconds", () => {
         time_format: TimeFormat.twenty_four,
       }),
       "23:12:13"
+    );
+  });
+});
+
+describe("formatTimeWeekday", () => {
+  const dateObj = new Date(2017, 10, 18, 23, 12, 13, 1400);
+
+  it("Formats English times", () => {
+    assert.strictEqual(
+      formatTime(dateObj, {
+        language: "en",
+        number_format: NumberFormat.language,
+        time_format: TimeFormat.am_pm,
+      }),
+      "Wednesday 11:12 PM"
+    );
+    assert.strictEqual(
+      formatTime(dateObj, {
+        language: "en",
+        number_format: NumberFormat.language,
+        time_format: TimeFormat.twenty_four,
+      }),
+      "Wednesday 23:12"
     );
   });
 });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

According to the existing code comment, `formatTimeWeekday()` is supposed to return "Tuesday 19:00" but instead it returns "19:00:00". This makes a day/night weather forecast render like this: 
![Screenshot from 2021-12-24 14-23-32](https://user-images.githubusercontent.com/183923/147373777-3d0acfeb-f434-45a8-ba76-948f1f20f60f.png)

This PR changes `formatTimeWeekday()` to include the weekday and exclude seconds, changing the render to this: 
![Screenshot from 2021-12-24 14-44-28](https://user-images.githubusercontent.com/183923/147373799-638ce049-e983-4a74-8a03-b9174255597d.png)

The forecast dialog seems to be the only use of `formatTimeWeekday()`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

No config implications.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:



<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
