### PR TITLE
Make entities and devices independent in the scene editor

### DIFF
--- a/src/data/scene.ts
+++ b/src/data/scene.ts
@@ -50,7 +50,9 @@ export interface SceneConfig {
 }
 
 export interface SceneEntities {
-  [entityId: string]: string | { state: string; [key: string]: any };
+  [entityId: string]:
+    | string
+    | { state: string; [key: string]: any; entity_only?: boolean | undefined };
 }
 
 export const activateScene = (

--- a/src/data/scene.ts
+++ b/src/data/scene.ts
@@ -47,12 +47,15 @@ export interface SceneConfig {
   name: string;
   icon?: string;
   entities: SceneEntities;
+  metadata?: SceneMetaData;
 }
 
 export interface SceneEntities {
-  [entityId: string]:
-    | string
-    | { state: string; [key: string]: any; entity_only?: boolean | undefined };
+  [entityId: string]: string | { state: string; [key: string]: any };
+}
+
+export interface SceneMetaData {
+  [entityId: string]: { entity_only?: boolean | undefined };
 }
 
 export const activateScene = (

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -636,7 +636,7 @@ export class HaSceneEditor extends SubscribeMixin(
       }
       if (
         !this._devices.includes(entityReg.device_id) &&
-        config.entities[entityReg.entity_id].include_device
+        !config.entities[entityReg.entity_id].entity_only
       ) {
         this._devices = [...this._devices, entityReg.device_id];
       }
@@ -819,8 +819,8 @@ export class HaSceneEditor extends SubscribeMixin(
       if (entityState) {
         output[entityReg.entity_id] = {
           ...entityState,
-          include_device:
-            entityReg.device_id && this._devices.includes(entityReg.device_id),
+          entity_only:
+            entityReg.device_id && !this._devices.includes(entityReg.device_id),
         };
       }
     }

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -637,9 +637,8 @@ export class HaSceneEditor extends SubscribeMixin(
       }
       const entityMetaData = config.metadata?.[entityReg.entity_id];
       if (
-        !this._devices.includes(entityReg.device_id) && entityMetaData
-          ? !entityMetaData.entity_only
-          : false
+        !this._devices.includes(entityReg.device_id) &&
+        (!entityMetaData || !entityMetaData.entity_only)
       ) {
         this._devices = [...this._devices, entityReg.device_id];
       }

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -634,9 +634,11 @@ export class HaSceneEditor extends SubscribeMixin(
       if (!entityReg.device_id) {
         continue;
       }
+      const entity = config.entities[entityReg.entity_id];
       if (
         !this._devices.includes(entityReg.device_id) &&
-        !config.entities[entityReg.entity_id].entity_only
+        !(typeof entity === "string") &&
+        !entity.entity_only
       ) {
         this._devices = [...this._devices, entityReg.device_id];
       }
@@ -819,8 +821,9 @@ export class HaSceneEditor extends SubscribeMixin(
       if (entityState) {
         output[entityReg.entity_id] = {
           ...entityState,
-          entity_only:
-            entityReg.device_id && !this._devices.includes(entityReg.device_id),
+          entity_only: !!(
+            entityReg.device_id && !this._devices.includes(entityReg.device_id)
+          ),
         };
       }
     }

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -635,12 +635,9 @@ export class HaSceneEditor extends SubscribeMixin(
       if (!entityReg.device_id) {
         continue;
       }
-      const entity = config.entities[entityReg.entity_id];
       const entityMetaData = config.metadata?.[entityReg.entity_id];
       if (
-        !this._devices.includes(entityReg.device_id) &&
-        !(typeof entity === "string") &&
-        entityMetaData
+        !this._devices.includes(entityReg.device_id) && entityMetaData
           ? !entityMetaData.entity_only
           : false
       ) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2252,15 +2252,14 @@
             "area": "Area",
             "devices": {
               "header": "Devices",
-              "introduction": "Add the devices that you want to be included in your scene. Set all the devices to the state you want for this scene.",
+              "introduction": "Add the devices that you want to be included in your scene. Set all entities in each device to the state you want for this scene.",
               "add": "Add a device",
               "delete": "Delete device"
             },
             "entities": {
               "header": "Entities",
-              "introduction": "Entities that do not belong to a device can be set here.",
-              "without_device": "Entities without device",
-              "device_entities": "If you add an entity that belongs to a device, the device will be added.",
+              "introduction": "Individual entities and entities that do not belong to a device can be added here.",
+              "without_device": "Entities",
               "add": "Add an entity",
               "delete": "Delete entity"
             }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2258,7 +2258,7 @@
             },
             "entities": {
               "header": "Entities",
-              "introduction": "Individual entities and entities that do not belong to a device can be added here.",
+              "introduction": "Individual entities can be added here.",
               "without_device": "Entities",
               "add": "Add an entity",
               "delete": "Delete entity"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The scene editor currently only works with devices. You can pick an entity but if it has an associated device the device is what is added to the scene. This "works" but falls down with devices such as multi-gang smart switches where the individual states for each gang should not be forced to be used together in a scene. It is very common for 1 gang to control the lighting for 1 room / area and another gang to control the lighting in another room / area. 

This change adds a key `entity_only` to the stored configuration in `scenes.yaml` so that it can be used by the editor as a hint when saving and loading the scene. This allows individual entities to be used in scenes regardless of whether or not they are associated to a device.

I have done some light testing and this appears to work. It needs a typing issue corrected but I wanted to open this to get some feedback on the change before trying to finish it.  

If this change is welcome it may also be worth discussing making the entity picker always available. I get the intention to make this as easy to use as possible but IMO it isn't intuitive to have this picker hidden behind advanced mode. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/issues/6468, https://github.com/home-assistant/core/issues/37582
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
