### PR TITLE
The gauge card doesn't render correctly on iOS 15.2 / macOS 12.1 in the companion apps

### DIFF
--- a/src/components/ha-gauge.ts
+++ b/src/components/ha-gauge.ts
@@ -21,14 +21,15 @@ if (isSafari) {
 }
 
 const companionAppOnAppleDevices =
-  /.*Home Assistant\/\d{4}\.\d{1,2}(\.\d)? \(io.robbie.HomeAssistant; build:\d{4}\.\d{3,}; (macOS|iOS) (\d{2}\.\d).*/;
+  /.*Home Assistant\/\d{4}\.\d{1,2}(\.\d)? \(io.robbie.HomeAssistant; build:\d{4}\.\d{3,}; (macOS|iOS|iPadOS) (\d{2}\.\d).*/;
 let companionAppSafariGOEQ152 = false;
 const companionAppMatch = companionAppOnAppleDevices.exec(navigator.userAgent);
 if (companionAppMatch) {
   const os = companionAppMatch[2];
   const version = parseFloat(companionAppMatch[3]);
   companionAppSafariGOEQ152 =
-    (os === "iOS" && version >= 15.2) || (os === "macOS" && version >= 12.1);
+    ((os === "iOS" || os === "iPadOS") && version >= 15.2) ||
+    (os === "macOS" && version >= 12.1);
 }
 
 const isSafari152 = companionAppSafariGOEQ152 || safariVersion >= 15.2;

--- a/src/components/ha-gauge.ts
+++ b/src/components/ha-gauge.ts
@@ -21,7 +21,7 @@ if (isSafari) {
 }
 
 const companionAppOnAppleDevices =
-  /.*Home Assistant\/\d{4}\.\d{1,2}(\.\d)? \(io.robbie.HomeAssistant; build:\d{4}\.\d{3,}; (macOS|iOS|iPadOS) (\d{2}\.\d).*/;
+  /.*io\.robbie\.HomeAssistant([^;]+)?; [^;]+; (macOS|iOS|iPadOS) (\d{2}\.\d).*/;
 let companionAppSafariGOEQ152 = false;
 const companionAppMatch = companionAppOnAppleDevices.exec(navigator.userAgent);
 if (companionAppMatch) {

--- a/src/components/ha-gauge.ts
+++ b/src/components/ha-gauge.ts
@@ -10,7 +10,28 @@ import { isSafari } from "../util/is_safari";
 
 // Safari version 15.2 and up behaves differently than other Safari versions.
 // https://github.com/home-assistant/frontend/issues/10766
-const isSafari152 = isSafari && /Version\/15\.[^0-1]/.test(navigator.userAgent);
+// https://github.com/home-assistant/frontend/issues/11041
+const safariVersionPattern = /.*Version\/(\d{2}\.\d).*/;
+let safariVersion = 0;
+if (isSafari) {
+  const safariMatch = safariVersionPattern.exec(navigator.userAgent);
+  if (safariMatch) {
+    safariVersion = parseFloat(safariMatch[1]);
+  }
+}
+
+const companionAppOnAppleDevices =
+  /.*Home Assistant\/\d{4}\.\d{1,2}(\.\d)? \(io.robbie.HomeAssistant; build:\d{4}\.\d{3,}; (macOS|iOS) (\d{2}\.\d).*/;
+let companionAppSafariGOEQ152 = false;
+const companionAppMatch = companionAppOnAppleDevices.exec(navigator.userAgent);
+if (companionAppMatch) {
+  const os = companionAppMatch[2];
+  const version = parseFloat(companionAppMatch[3]);
+  companionAppSafariGOEQ152 =
+    (os === "iOS" && version >= 15.2) || (os === "macOS" && version >= 12.1);
+}
+
+const isSafari152 = companionAppSafariGOEQ152 || safariVersion >= 15.2;
 
 const getAngle = (value: number, min: number, max: number) => {
   const percentage = getValueInPercentage(normalize(value, min, max), min, max);


### PR DESCRIPTION
## Proposed change

1. enhanced the Safari test from #10766
2. added special handling for the HA Companion App on macOS/iOS - fixes #11041 


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #11041
- This PR is related to issue or discussion: #10766
- Link to documentation pull request:

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
