### PR TITLE
Allow area, device, and entity selectors to optionally support multiple selections like target selector

### DIFF
--- a/src/components/device/ha-device-multi-picker.ts
+++ b/src/components/device/ha-device-multi-picker.ts
@@ -1,0 +1,331 @@
+// @ts-ignore
+import chipStyles from "@material/chips/dist/mdc.chips.min.css";
+import "@material/mwc-button/mwc-button";
+import "@polymer/paper-tooltip/paper-tooltip";
+import { mdiClose, mdiDevices, mdiPlus } from "@mdi/js";
+import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
+import { css, CSSResultGroup, html, LitElement, unsafeCSS } from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import { fireEvent } from "../../common/dom/fire_event";
+import { ensureArray } from "../../common/ensure-array";
+import {
+  computeDeviceName,
+  DeviceRegistryEntry,
+  subscribeDeviceRegistry,
+} from "../../data/device_registry";
+import { EntityRegistryEntry } from "../../data/entity_registry";
+import { SubscribeMixin } from "../../mixins/subscribe-mixin";
+import { HomeAssistant } from "../../types";
+import { HaDevicePickerDeviceFilterFunc } from "./ha-device-picker";
+import "../ha-icon-button";
+import "../ha-state-icon";
+import "../ha-svg-icon";
+
+@customElement("ha-device-multi-picker")
+export class HaDeviceMultiPicker extends SubscribeMixin(LitElement) {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public disabled?: boolean;
+
+  @property() public label?: string;
+
+  @property() public value?: any;
+
+  /**
+   * Show only devices with entities from specific domains.
+   * @type {Array}
+   * @attr include-domains
+   */
+
+  @property({ type: Array, attribute: "include-domains" })
+  public includeDomains?: string[];
+
+  /**
+   * Show no devices with entities of these domains.
+   * @type {Array}
+   * @attr exclude-domains
+   */
+  @property({ type: Array, attribute: "exclude-domains" })
+  public excludeDomains?: string[];
+
+  /**
+   * Show only devices with entities of these device classes.
+   * @type {Array}
+   * @attr include-device-classes
+   */
+  @property({ type: Array, attribute: "include-device-classes" })
+  public includeDeviceClasses?: string[];
+
+  @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
+
+  @property() public entityFilter?: (entity: EntityRegistryEntry) => boolean;
+
+  @property({ type: Boolean, attribute: "multiple" })
+  public multiple?: boolean;
+
+  @state() private _devices?: { [deviceId: string]: DeviceRegistryEntry };
+
+  @state() private _addMode?: "device_id";
+
+  @query("#input") private _inputElement?;
+
+  public hassSubscribe(): UnsubscribeFunc[] {
+    return [
+      subscribeDeviceRegistry(this.hass.connection!, (devices) => {
+        const deviceLookup: { [deviceId: string]: DeviceRegistryEntry } = {};
+        for (const device of devices) {
+          deviceLookup[device.id] = device;
+        }
+        this._devices = deviceLookup;
+      }),
+    ];
+  }
+
+  protected render() {
+    if (!this._devices) {
+      return html``;
+    }
+    return html`
+      <div class="mdc-chip-set items">
+        ${this.value
+          ? ensureArray(this.value).map((device_id) => {
+              const device = this._devices![device_id];
+              return this._renderChip(
+                "device_id",
+                device_id,
+                device ? computeDeviceName(device, this.hass) : device_id,
+                undefined,
+                mdiDevices
+              );
+            })
+          : ""}
+      </div>
+      ${this._renderPicker()}
+      <div class="mdc-chip-set">
+        <div
+          class="mdc-chip device_id add"
+          .type=${"device_id"}
+          @click=${this._showPicker}
+        >
+          <div class="mdc-chip__ripple"></div>
+          <ha-svg-icon
+            class="mdc-chip__icon mdc-chip__icon--leading"
+            .path=${mdiPlus}
+          ></ha-svg-icon>
+          <span role="gridcell">
+            <span role="button" tabindex="0" class="mdc-chip__primary-action">
+              <span class="mdc-chip__text"
+                >${this.hass.localize(
+                  "ui.components.target-picker.add_device_id"
+                )}</span
+              >
+            </span>
+          </span>
+        </div>
+      </div>
+    `;
+  }
+
+  private async _showPicker(ev) {
+    this._addMode = ev.currentTarget.type;
+    await this.updateComplete;
+    setTimeout(() => {
+      this._inputElement?.open();
+      this._inputElement?.focus();
+    }, 0);
+  }
+
+  private _renderChip(
+    type: string,
+    id: string,
+    name: string,
+    entityState?: HassEntity,
+    iconPath?: string
+  ) {
+    return html`
+      <div
+        class="mdc-chip ${classMap({
+          [type]: true,
+        })}"
+      >
+        ${iconPath
+          ? html`<ha-svg-icon
+              class="mdc-chip__icon mdc-chip__icon--leading"
+              .path=${iconPath}
+            ></ha-svg-icon>`
+          : ""}
+        ${entityState
+          ? html`<ha-state-icon
+              class="mdc-chip__icon mdc-chip__icon--leading"
+              .state=${entityState}
+            ></ha-state-icon>`
+          : ""}
+        <span role="gridcell">
+          <span role="button" tabindex="0" class="mdc-chip__primary-action">
+            <span class="mdc-chip__text">${name}</span>
+          </span>
+        </span>
+        <span role="gridcell">
+          <ha-icon-button
+            class="mdc-chip__icon mdc-chip__icon--trailing"
+            tabindex="-1"
+            role="button"
+            .label=${this.hass.localize("ui.components.target-picker.remove_")}
+            .path=${mdiClose}
+            hideTooltip
+            .id=${id}
+            .type=${type}
+            @click=${this._handleRemove}
+          ></ha-icon-button>
+          <paper-tooltip animation-delay="0"
+            >${this.hass.localize(
+              `ui.components.target-picker.remove_${type}`
+            )}</paper-tooltip
+          >
+        </span>
+      </div>
+    `;
+  }
+
+  private _renderPicker() {
+    switch (this._addMode) {
+      case "device_id":
+        return html`<ha-device-picker
+          .hass=${this.hass}
+          id="input"
+          .type=${"device_id"}
+          .label=${this.hass.localize(
+            "ui.components.target-picker.add_device_id"
+          )}
+          no-add
+          .deviceFilter=${this.deviceFilter}
+          .entityFilter=${this.entityFilter}
+          .includeDeviceClasses=${this.includeDeviceClasses}
+          .includeDomains=${this.includeDomains}
+          .disabled=${this.disabled}
+          @value-changed=${this._targetPicked}
+        ></ha-device-picker>`;
+    }
+    return html``;
+  }
+
+  private _targetPicked(ev) {
+    ev.stopPropagation();
+    if (!ev.detail.value) {
+      return;
+    }
+    const value =
+      this.multiple && this.value
+        ? [...ensureArray(this.value), ev.detail.value]
+        : ev.detail.value;
+    const target = ev.currentTarget;
+    target.value = "";
+    this._addMode = undefined;
+    fireEvent(this, "value-changed", { value });
+  }
+
+  private _handleRemove(ev) {
+    const target = ev.currentTarget as any;
+    fireEvent(this, "value-changed", {
+      value: this._removeItem(this.value, target.id),
+    });
+  }
+
+  private _removeItem(value: this["value"], id: string): this["value"] {
+    const newVal = ensureArray(value!)!.filter((val) => String(val) !== id);
+    if (newVal.length) {
+      return newVal;
+    }
+    return undefined;
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      ${unsafeCSS(chipStyles)}
+      .mdc-chip {
+        color: var(--primary-text-color);
+      }
+      .items {
+        z-index: 2;
+      }
+      .mdc-chip-set {
+        padding: 4px 0;
+      }
+      .mdc-chip.add {
+        color: rgba(0, 0, 0, 0.87);
+      }
+      .mdc-chip:not(.add) {
+        cursor: default;
+      }
+      .mdc-chip ha-icon-button {
+        --mdc-icon-button-size: 24px;
+        display: flex;
+        align-items: center;
+        outline: none;
+      }
+      .mdc-chip ha-icon-button ha-svg-icon {
+        border-radius: 50%;
+        background: var(--secondary-text-color);
+      }
+      .mdc-chip__icon.mdc-chip__icon--trailing {
+        width: 16px;
+        height: 16px;
+        --mdc-icon-size: 14px;
+        color: var(--secondary-text-color);
+      }
+      .mdc-chip__icon--leading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        --mdc-icon-size: 20px;
+        border-radius: 50%;
+        padding: 6px;
+        margin-left: -14px !important;
+      }
+      .expand-btn {
+        margin-right: 0;
+      }
+      .mdc-chip.area_id:not(.add) {
+        border: 2px solid #fed6a4;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.area_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.area_id.add {
+        background: #fed6a4;
+      }
+      .mdc-chip.device_id:not(.add) {
+        border: 2px solid #a8e1fb;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.device_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.device_id.add {
+        background: #a8e1fb;
+      }
+      .mdc-chip.entity_id:not(.add) {
+        border: 2px solid #d2e7b9;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.entity_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.entity_id.add {
+        background: #d2e7b9;
+      }
+      .mdc-chip:hover {
+        z-index: 5;
+      }
+      paper-tooltip.expand {
+        min-width: 200px;
+      }
+      :host([disabled]) .mdc-chip {
+        opacity: var(--light-disabled-opacity);
+        pointer-events: none;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-device-multi-picker": HaDeviceMultiPicker;
+  }
+}

--- a/src/components/entity/ha-entity-multi-picker.ts
+++ b/src/components/entity/ha-entity-multi-picker.ts
@@ -1,0 +1,330 @@
+// @ts-ignore
+import chipStyles from "@material/chips/dist/mdc.chips.min.css";
+import "@material/mwc-button/mwc-button";
+import "@polymer/paper-tooltip/paper-tooltip";
+import { mdiClose, mdiPlus } from "@mdi/js";
+import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
+import { css, CSSResultGroup, html, LitElement, unsafeCSS } from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import { fireEvent } from "../../common/dom/fire_event";
+import { ensureArray } from "../../common/ensure-array";
+import { computeStateName } from "../../common/entity/compute_state_name";
+import {
+  EntityRegistryEntry,
+  subscribeEntityRegistry,
+} from "../../data/entity_registry";
+import { SubscribeMixin } from "../../mixins/subscribe-mixin";
+import { HomeAssistant } from "../../types";
+import type { HaDevicePickerDeviceFilterFunc } from "../device/ha-device-picker";
+import type { HaEntityPickerEntityFilterFunc } from "./ha-entity-picker";
+import "../ha-icon-button";
+import "../ha-state-icon";
+import "../ha-svg-icon";
+
+@customElement("ha-entity-multi-picker")
+export class HaEntityMultiPicker extends SubscribeMixin(LitElement) {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public disabled?: boolean;
+
+  @property() public label?: string;
+
+  @property() public value?: any;
+
+  /**
+   * Show only entitys with entities from specific domains.
+   * @type {Array}
+   * @attr include-domains
+   */
+
+  @property({ type: Array, attribute: "include-domains" })
+  public includeDomains?: string[];
+
+  /**
+   * Show no entitys with entities of these domains.
+   * @type {Array}
+   * @attr exclude-domains
+   */
+  @property({ type: Array, attribute: "exclude-domains" })
+  public excludeDomains?: string[];
+
+  /**
+   * Show only entitys with entities of these device classes.
+   * @type {Array}
+   * @attr include-device-classes
+   */
+  @property({ type: Array, attribute: "include-device-classes" })
+  public includeDeviceClasses?: string[];
+
+  @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
+
+  @property() public entityFilter?: HaEntityPickerEntityFilterFunc;
+
+  @property({ type: Boolean, attribute: "multiple" })
+  public multiple?: boolean;
+
+  @state() private _entities?: { [entityId: string]: EntityRegistryEntry };
+
+  @state() private _addMode?: "entity_id";
+
+  @query("#input") private _inputElement?;
+
+  public hassSubscribe(): UnsubscribeFunc[] {
+    return [
+      subscribeEntityRegistry(this.hass.connection!, (entities) => {
+        const entityLookup: { [entityId: string]: EntityRegistryEntry } = {};
+        for (const entity of entities) {
+          entityLookup[entity.entity_id] = entity;
+        }
+        this._entities = entityLookup;
+      }),
+    ];
+  }
+
+  protected render() {
+    if (!this._entities) {
+      return html``;
+    }
+    return html`
+      <div class="mdc-chip-set items">
+        ${this.value
+          ? ensureArray(this.value).map((entity_id) => {
+              const entity = this.hass.states[entity_id];
+              return this._renderChip(
+                "entity_id",
+                entity_id,
+                entity ? computeStateName(entity) : entity_id,
+                entity
+              );
+            })
+          : ""}
+      </div>
+      ${this._renderPicker()}
+      <div class="mdc-chip-set">
+        <div
+          class="mdc-chip entity_id add"
+          .type=${"entity_id"}
+          @click=${this._showPicker}
+        >
+          <div class="mdc-chip__ripple"></div>
+          <ha-svg-icon
+            class="mdc-chip__icon mdc-chip__icon--leading"
+            .path=${mdiPlus}
+          ></ha-svg-icon>
+          <span role="gridcell">
+            <span role="button" tabindex="0" class="mdc-chip__primary-action">
+              <span class="mdc-chip__text"
+                >${this.hass.localize(
+                  "ui.components.target-picker.add_entity_id"
+                )}</span
+              >
+            </span>
+          </span>
+        </div>
+      </div>
+    `;
+  }
+
+  private async _showPicker(ev) {
+    this._addMode = ev.currentTarget.type;
+    await this.updateComplete;
+    setTimeout(() => {
+      this._inputElement?.open();
+      this._inputElement?.focus();
+    }, 0);
+  }
+
+  private _renderChip(
+    type: string,
+    id: string,
+    name: string,
+    entityState?: HassEntity,
+    iconPath?: string
+  ) {
+    return html`
+      <div
+        class="mdc-chip ${classMap({
+          [type]: true,
+        })}"
+      >
+        ${iconPath
+          ? html`<ha-svg-icon
+              class="mdc-chip__icon mdc-chip__icon--leading"
+              .path=${iconPath}
+            ></ha-svg-icon>`
+          : ""}
+        ${entityState
+          ? html`<ha-state-icon
+              class="mdc-chip__icon mdc-chip__icon--leading"
+              .state=${entityState}
+            ></ha-state-icon>`
+          : ""}
+        <span role="gridcell">
+          <span role="button" tabindex="0" class="mdc-chip__primary-action">
+            <span class="mdc-chip__text">${name}</span>
+          </span>
+        </span>
+        <span role="gridcell">
+          <ha-icon-button
+            class="mdc-chip__icon mdc-chip__icon--trailing"
+            tabindex="-1"
+            role="button"
+            .label=${this.hass.localize("ui.components.target-picker.remove_")}
+            .path=${mdiClose}
+            hideTooltip
+            .id=${id}
+            .type=${type}
+            @click=${this._handleRemove}
+          ></ha-icon-button>
+          <paper-tooltip animation-delay="0"
+            >${this.hass.localize(
+              `ui.components.target-picker.remove_${type}`
+            )}</paper-tooltip
+          >
+        </span>
+      </div>
+    `;
+  }
+
+  private _renderPicker() {
+    switch (this._addMode) {
+      case "entity_id":
+        return html`<ha-entity-picker
+          .hass=${this.hass}
+          id="input"
+          .type=${"entity_id"}
+          .label=${this.hass.localize(
+            "ui.components.target-picker.add_entity_id"
+          )}
+          no-add
+          .deviceFilter=${this.deviceFilter}
+          .entityFilter=${this.entityFilter}
+          .includeDeviceClasses=${this.includeDeviceClasses}
+          .includeDomains=${this.includeDomains}
+          .disabled=${this.disabled}
+          @value-changed=${this._targetPicked}
+        ></ha-entity-picker>`;
+    }
+    return html``;
+  }
+
+  private _targetPicked(ev) {
+    ev.stopPropagation();
+    if (!ev.detail.value) {
+      return;
+    }
+    const value =
+      this.multiple && this.value
+        ? [...ensureArray(this.value), ev.detail.value]
+        : ev.detail.value;
+    const target = ev.currentTarget;
+    target.value = "";
+    this._addMode = undefined;
+    fireEvent(this, "value-changed", { value });
+  }
+
+  private _handleRemove(ev) {
+    const target = ev.currentTarget as any;
+    fireEvent(this, "value-changed", {
+      value: this._removeItem(this.value, target.id),
+    });
+  }
+
+  private _removeItem(value: this["value"], id: string): this["value"] {
+    const newVal = ensureArray(value!)!.filter((val) => String(val) !== id);
+    if (newVal.length) {
+      return newVal;
+    }
+    return undefined;
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      ${unsafeCSS(chipStyles)}
+      .mdc-chip {
+        color: var(--primary-text-color);
+      }
+      .items {
+        z-index: 2;
+      }
+      .mdc-chip-set {
+        padding: 4px 0;
+      }
+      .mdc-chip.add {
+        color: rgba(0, 0, 0, 0.87);
+      }
+      .mdc-chip:not(.add) {
+        cursor: default;
+      }
+      .mdc-chip ha-icon-button {
+        --mdc-icon-button-size: 24px;
+        display: flex;
+        align-items: center;
+        outline: none;
+      }
+      .mdc-chip ha-icon-button ha-svg-icon {
+        border-radius: 50%;
+        background: var(--secondary-text-color);
+      }
+      .mdc-chip__icon.mdc-chip__icon--trailing {
+        width: 16px;
+        height: 16px;
+        --mdc-icon-size: 14px;
+        color: var(--secondary-text-color);
+      }
+      .mdc-chip__icon--leading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        --mdc-icon-size: 20px;
+        border-radius: 50%;
+        padding: 6px;
+        margin-left: -14px !important;
+      }
+      .expand-btn {
+        margin-right: 0;
+      }
+      .mdc-chip.area_id:not(.add) {
+        border: 2px solid #fed6a4;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.area_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.area_id.add {
+        background: #fed6a4;
+      }
+      .mdc-chip.device_id:not(.add) {
+        border: 2px solid #a8e1fb;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.device_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.device_id.add {
+        background: #a8e1fb;
+      }
+      .mdc-chip.entity_id:not(.add) {
+        border: 2px solid #d2e7b9;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.entity_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.entity_id.add {
+        background: #d2e7b9;
+      }
+      .mdc-chip:hover {
+        z-index: 5;
+      }
+      paper-tooltip.expand {
+        min-width: 200px;
+      }
+      :host([disabled]) .mdc-chip {
+        opacity: var(--light-disabled-opacity);
+        pointer-events: none;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-entity-multi-picker": HaEntityMultiPicker;
+  }
+}

--- a/src/components/ha-area-multi-picker.ts
+++ b/src/components/ha-area-multi-picker.ts
@@ -1,0 +1,331 @@
+// @ts-ignore
+import chipStyles from "@material/chips/dist/mdc.chips.min.css";
+import "@material/mwc-button/mwc-button";
+import "@polymer/paper-tooltip/paper-tooltip";
+import { mdiClose, mdiPlus, mdiSofa } from "@mdi/js";
+import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
+import { css, CSSResultGroup, html, LitElement, unsafeCSS } from "lit";
+import { customElement, property, query, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import { fireEvent } from "../common/dom/fire_event";
+import { ensureArray } from "../common/ensure-array";
+import {
+  AreaRegistryEntry,
+  subscribeAreaRegistry,
+} from "../data/area_registry";
+import { EntityRegistryEntry } from "../data/entity_registry";
+import { SubscribeMixin } from "../mixins/subscribe-mixin";
+import { HomeAssistant } from "../types";
+import type { HaDevicePickerDeviceFilterFunc } from "./device/ha-device-picker";
+import "./ha-area-picker";
+import "./ha-icon-button";
+import "./ha-state-icon";
+import "./ha-svg-icon";
+
+@customElement("ha-area-multi-picker")
+export class HaAreaMultiPicker extends SubscribeMixin(LitElement) {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public disabled?: boolean;
+
+  @property() public label?: string;
+
+  @property() public value?: any;
+
+  /**
+   * Show only areas with entities from specific domains.
+   * @type {Array}
+   * @attr include-domains
+   */
+
+  @property({ type: Array, attribute: "include-domains" })
+  public includeDomains?: string[];
+
+  /**
+   * Show no areas with entities of these domains.
+   * @type {Array}
+   * @attr exclude-domains
+   */
+  @property({ type: Array, attribute: "exclude-domains" })
+  public excludeDomains?: string[];
+
+  /**
+   * Show only areas with entities of these device classes.
+   * @type {Array}
+   * @attr include-device-classes
+   */
+  @property({ type: Array, attribute: "include-device-classes" })
+  public includeDeviceClasses?: string[];
+
+  @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
+
+  @property() public entityFilter?: (entity: EntityRegistryEntry) => boolean;
+
+  @property({ type: Boolean, attribute: "multiple" })
+  public multiple?: boolean;
+
+  @state() private _areas?: { [areaId: string]: AreaRegistryEntry };
+
+  @state() private _addMode?: "area_id";
+
+  @query("#input") private _inputElement?;
+
+  public hassSubscribe(): UnsubscribeFunc[] {
+    return [
+      subscribeAreaRegistry(this.hass.connection!, (areas) => {
+        const areaLookup: { [areaId: string]: AreaRegistryEntry } = {};
+        for (const area of areas) {
+          areaLookup[area.area_id] = area;
+        }
+        this._areas = areaLookup;
+      }),
+    ];
+  }
+
+  protected render() {
+    if (!this._areas) {
+      return html``;
+    }
+    return html`
+      <div class="mdc-chip-set items">
+        ${this.value
+          ? ensureArray(this.value).map((area_id) => {
+              const area = this._areas![area_id];
+              return this._renderChip(
+                "area_id",
+                area_id,
+                area?.name || area_id,
+                undefined,
+                mdiSofa
+              );
+            })
+          : ""}
+      </div>
+      ${this._renderPicker()}
+      <div class="mdc-chip-set">
+        <div
+          class="mdc-chip area_id add"
+          .type=${"area_id"}
+          @click=${this._showPicker}
+        >
+          <div class="mdc-chip__ripple"></div>
+          <ha-svg-icon
+            class="mdc-chip__icon mdc-chip__icon--leading"
+            .path=${mdiPlus}
+          ></ha-svg-icon>
+          <span role="gridcell">
+            <span role="button" tabindex="0" class="mdc-chip__primary-action">
+              <span class="mdc-chip__text"
+                >${this.hass.localize(
+                  "ui.components.target-picker.add_area_id"
+                )}</span
+              >
+            </span>
+          </span>
+        </div>
+      </div>
+    `;
+  }
+
+  private async _showPicker(ev) {
+    this._addMode = ev.currentTarget.type;
+    await this.updateComplete;
+    setTimeout(() => {
+      this._inputElement?.open();
+      this._inputElement?.focus();
+    }, 0);
+  }
+
+  private _renderChip(
+    type: string,
+    id: string,
+    name: string,
+    entityState?: HassEntity,
+    iconPath?: string
+  ) {
+    return html`
+      <div
+        class="mdc-chip ${classMap({
+          [type]: true,
+        })}"
+      >
+        ${iconPath
+          ? html`<ha-svg-icon
+              class="mdc-chip__icon mdc-chip__icon--leading"
+              .path=${iconPath}
+            ></ha-svg-icon>`
+          : ""}
+        ${entityState
+          ? html`<ha-state-icon
+              class="mdc-chip__icon mdc-chip__icon--leading"
+              .state=${entityState}
+            ></ha-state-icon>`
+          : ""}
+        <span role="gridcell">
+          <span role="button" tabindex="0" class="mdc-chip__primary-action">
+            <span class="mdc-chip__text">${name}</span>
+          </span>
+        </span>
+        <span role="gridcell">
+          <ha-icon-button
+            class="mdc-chip__icon mdc-chip__icon--trailing"
+            tabindex="-1"
+            role="button"
+            .label=${this.hass.localize("ui.components.target-picker.remove_")}
+            .path=${mdiClose}
+            hideTooltip
+            .id=${id}
+            .type=${type}
+            @click=${this._handleRemove}
+          ></ha-icon-button>
+          <paper-tooltip animation-delay="0"
+            >${this.hass.localize(
+              `ui.components.target-picker.remove_${type}`
+            )}</paper-tooltip
+          >
+        </span>
+      </div>
+    `;
+  }
+
+  private _renderPicker() {
+    switch (this._addMode) {
+      case "area_id":
+        return html`<ha-area-picker
+          .hass=${this.hass}
+          id="input"
+          .type=${"area_id"}
+          .label=${this.hass.localize(
+            "ui.components.target-picker.add_area_id"
+          )}
+          no-add
+          .deviceFilter=${this.deviceFilter}
+          .entityFilter=${this.entityFilter}
+          .includeDeviceClasses=${this.includeDeviceClasses}
+          .includeDomains=${this.includeDomains}
+          .disabled=${this.disabled}
+          @value-changed=${this._targetPicked}
+        ></ha-area-picker>`;
+    }
+    return html``;
+  }
+
+  private _targetPicked(ev) {
+    ev.stopPropagation();
+    if (!ev.detail.value) {
+      return;
+    }
+    const value =
+      this.multiple && this.value
+        ? [...ensureArray(this.value), ev.detail.value]
+        : ev.detail.value;
+    const target = ev.currentTarget;
+    target.value = "";
+    this._addMode = undefined;
+    fireEvent(this, "value-changed", { value });
+  }
+
+  private _handleRemove(ev) {
+    const target = ev.currentTarget as any;
+    fireEvent(this, "value-changed", {
+      value: this._removeItem(this.value, target.id),
+    });
+  }
+
+  private _removeItem(value: this["value"], id: string): this["value"] {
+    const newVal = ensureArray(value!)!.filter((val) => String(val) !== id);
+    if (newVal.length) {
+      return newVal;
+    }
+    return undefined;
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      ${unsafeCSS(chipStyles)}
+      .mdc-chip {
+        color: var(--primary-text-color);
+      }
+      .items {
+        z-index: 2;
+      }
+      .mdc-chip-set {
+        padding: 4px 0;
+      }
+      .mdc-chip.add {
+        color: rgba(0, 0, 0, 0.87);
+      }
+      .mdc-chip:not(.add) {
+        cursor: default;
+      }
+      .mdc-chip ha-icon-button {
+        --mdc-icon-button-size: 24px;
+        display: flex;
+        align-items: center;
+        outline: none;
+      }
+      .mdc-chip ha-icon-button ha-svg-icon {
+        border-radius: 50%;
+        background: var(--secondary-text-color);
+      }
+      .mdc-chip__icon.mdc-chip__icon--trailing {
+        width: 16px;
+        height: 16px;
+        --mdc-icon-size: 14px;
+        color: var(--secondary-text-color);
+      }
+      .mdc-chip__icon--leading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        --mdc-icon-size: 20px;
+        border-radius: 50%;
+        padding: 6px;
+        margin-left: -14px !important;
+      }
+      .expand-btn {
+        margin-right: 0;
+      }
+      .mdc-chip.area_id:not(.add) {
+        border: 2px solid #fed6a4;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.area_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.area_id.add {
+        background: #fed6a4;
+      }
+      .mdc-chip.device_id:not(.add) {
+        border: 2px solid #a8e1fb;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.device_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.device_id.add {
+        background: #a8e1fb;
+      }
+      .mdc-chip.entity_id:not(.add) {
+        border: 2px solid #d2e7b9;
+        background: var(--card-background-color);
+      }
+      .mdc-chip.entity_id:not(.add) .mdc-chip__icon--leading,
+      .mdc-chip.entity_id.add {
+        background: #d2e7b9;
+      }
+      .mdc-chip:hover {
+        z-index: 5;
+      }
+      paper-tooltip.expand {
+        min-width: 200px;
+      }
+      :host([disabled]) .mdc-chip {
+        opacity: var(--light-disabled-opacity);
+        pointer-events: none;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-area-multi-picker": HaAreaMultiPicker;
+  }
+}

--- a/src/components/ha-selector/ha-selector-area.ts
+++ b/src/components/ha-selector/ha-selector-area.ts
@@ -5,7 +5,7 @@ import { DeviceRegistryEntry } from "../../data/device_registry";
 import { EntityRegistryEntry } from "../../data/entity_registry";
 import { AreaSelector } from "../../data/selector";
 import { HomeAssistant } from "../../types";
-import "../ha-area-picker";
+import "../ha-area-multi-picker";
 
 @customElement("ha-selector-area")
 export class HaAreaSelector extends LitElement {
@@ -34,11 +34,10 @@ export class HaAreaSelector extends LitElement {
   }
 
   protected render() {
-    return html`<ha-area-picker
+    return html`<ha-area-multi-picker
       .hass=${this.hass}
       .value=${this.value}
       .label=${this.label}
-      no-add
       .deviceFilter=${this._filterDevices}
       .entityFilter=${this._filterEntities}
       .includeDeviceClasses=${this.selector.area.entity?.device_class
@@ -48,7 +47,8 @@ export class HaAreaSelector extends LitElement {
         ? [this.selector.area.entity.domain]
         : undefined}
       .disabled=${this.disabled}
-    ></ha-area-picker>`;
+      .multiple=${this.selector.area.multiple}
+    ></ha-area-multi-picker>`;
   }
 
   private _filterEntities = (entity: EntityRegistryEntry): boolean => {

--- a/src/components/ha-selector/ha-selector-device.ts
+++ b/src/components/ha-selector/ha-selector-device.ts
@@ -4,7 +4,7 @@ import { ConfigEntry, getConfigEntries } from "../../data/config_entries";
 import { DeviceRegistryEntry } from "../../data/device_registry";
 import { DeviceSelector } from "../../data/selector";
 import { HomeAssistant } from "../../types";
-import "../device/ha-device-picker";
+import "../device/ha-device-multi-picker";
 
 @customElement("ha-selector-device")
 export class HaDeviceSelector extends LitElement {
@@ -30,7 +30,7 @@ export class HaDeviceSelector extends LitElement {
   }
 
   protected render() {
-    return html`<ha-device-picker
+    return html`<ha-device-multi-picker
       .hass=${this.hass}
       .value=${this.value}
       .label=${this.label}
@@ -43,7 +43,8 @@ export class HaDeviceSelector extends LitElement {
         : undefined}
       .disabled=${this.disabled}
       allow-custom-entity
-    ></ha-device-picker>`;
+      .multiple=${this.selector.device.multiple}
+    ></ha-device-multi-picker>`;
   }
 
   private _filterDevices = (device: DeviceRegistryEntry): boolean => {

--- a/src/components/ha-selector/ha-selector-entity.ts
+++ b/src/components/ha-selector/ha-selector-entity.ts
@@ -6,7 +6,7 @@ import { subscribeEntityRegistry } from "../../data/entity_registry";
 import { EntitySelector } from "../../data/selector";
 import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import { HomeAssistant } from "../../types";
-import "../entity/ha-entity-picker";
+import "../entity/ha-entity-multi-picker";
 
 @customElement("ha-selector-entity")
 export class HaEntitySelector extends SubscribeMixin(LitElement) {
@@ -23,14 +23,15 @@ export class HaEntitySelector extends SubscribeMixin(LitElement) {
   @property({ type: Boolean }) public disabled = false;
 
   protected render() {
-    return html`<ha-entity-picker
+    return html`<ha-entity-multi-picker
       .hass=${this.hass}
       .value=${this.value}
       .label=${this.label}
       .entityFilter=${this._filterEntities}
       .disabled=${this.disabled}
       allow-custom-entity
-    ></ha-entity-picker>`;
+      .multiple=${this.selector.entity.multiple}
+    ></ha-entity-multi-picker>`;
   }
 
   public hassSubscribe(): UnsubscribeFunc[] {

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -16,6 +16,7 @@ export interface EntitySelector {
     integration?: string;
     domain?: string;
     device_class?: string;
+    multiple?: boolean;
   };
 }
 
@@ -28,6 +29,7 @@ export interface DeviceSelector {
       domain?: EntitySelector["entity"]["domain"];
       device_class?: EntitySelector["entity"]["device_class"];
     };
+    multiple?: boolean;
   };
 }
 
@@ -50,6 +52,7 @@ export interface AreaSelector {
       manufacturer?: DeviceSelector["device"]["manufacturer"];
       model?: DeviceSelector["device"]["model"];
     };
+    multiple?: boolean;
   };
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Changes to the Area, Device, and Entity selectors to allow them to select multiple entities.
The user interface is similar to the Area, Device and Entity selector component of the target selector.
Single or multi select is configured with the optional multiple option on the selector configuration.
The selectors can now potentially return a list of area, device, or entity IDs.

This is motivated by the need to have multiple entity selector so a blueprint can trigger on multiple entities.
But brings a consistent UI for the Area, Device, Entity, and Target selector.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
```
blueprint:
  name: Test Selectors
  description: This is used to test the variois Selectors
  domain: automation
  source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/test.yaml
  input:
    target_selector:
      name: My Target Selector
      selector:
        target:
    entity_selector:
      name: My Entity Selector
      selector:
        entity:
          multiple: True
    area_selector:
      name: My Area Selector
      selector:
        area:
          multiple: True
          device:
            model: Forecast
    device_selector:
      name: My Device Selector
      selector:
        device:
          multiple: True

mode: single
max_exceeded: silent

trigger:
  platform: state
  entity_id: !input entity_selector

action:
    delay: 30

```

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Associated core PR  [#63138](https://github.com/home-assistant/core/pull/63138)

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:  [#20961](https://github.com/home-assistant/home-assistant.io/pull/20961)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
