### PR TITLE
Fix HLS player cleanup (null access to `removeAttribute`)

### DIFF
--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -98,7 +98,6 @@ class HaHLSPlayer extends LitElement {
   private async _startHls(): Promise<void> {
     this._error = undefined;
 
-    const videoEl = this._videoEl;
     const useExoPlayerPromise = this._getUseExoPlayer();
     const masterPlaylistPromise = fetch(this.url);
 
@@ -113,7 +112,7 @@ class HaHLSPlayer extends LitElement {
 
     if (!hlsSupported) {
       hlsSupported =
-        videoEl.canPlayType("application/vnd.apple.mpegurl") !== "";
+        this._videoEl.canPlayType("application/vnd.apple.mpegurl") !== "";
     }
 
     if (!hlsSupported) {
@@ -151,9 +150,9 @@ class HaHLSPlayer extends LitElement {
     if (useExoPlayer && match !== null && match[1] !== undefined) {
       this._renderHLSExoPlayer(playlist_url);
     } else if (Hls.isSupported()) {
-      this._renderHLSPolyfill(videoEl, Hls, playlist_url);
+      this._renderHLSPolyfill(this._videoEl, Hls, playlist_url);
     } else {
-      this._renderHLSNative(videoEl, playlist_url);
+      this._renderHLSNative(this._videoEl, playlist_url);
     }
   }
 
@@ -261,9 +260,10 @@ class HaHLSPlayer extends LitElement {
       this.hass!.auth.external!.fireMessage({ type: "exoplayer/stop" });
       this._exoPlayer = false;
     }
-    const videoEl = this._videoEl;
-    videoEl.removeAttribute("src");
-    videoEl.load();
+    if (this._videoEl) {
+      this._videoEl.removeAttribute("src");
+      this._videoEl.load();
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -136,9 +136,8 @@ class HaWebRtcPlayer extends LitElement {
       this._remoteStream = undefined;
     }
     if (this._videoEl) {
-      const videoEl = this._videoEl;
-      videoEl.removeAttribute("src");
-      videoEl.load();
+      this._videoEl.removeAttribute("src");
+      this._videoEl.load();
     }
     if (this._peerConnection) {
       this._peerConnection.close();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Previously we saw exceptions since the video element was `null` resulting in failed attempts to call `removeAttribute` probably after a video disconnect. Now we check first.

While I was at it, I removed some not needed data shifting / variable assignments for coding simplicity.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10908
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
