### PR TITLE
Set mandatory bool service data without a default value to false

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -84,7 +84,7 @@ export class HaServiceControl extends LitElement {
 
       if (this.value) {
         // Set mandatory bools without a default value to false
-        let mandatoryBools = {};
+        const mandatoryBools = {};
         serviceData?.fields.forEach((field) => {
           if (
             field.selector &&

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -82,24 +82,24 @@ export class HaServiceControl extends LitElement {
     if (oldValue?.service !== this.value?.service) {
       this._checkedKeys = new Set();
 
-      // Set mandatory bools without a default value to false
-      const mandatoryBools = serviceData?.fields.filter(
-        (field) =>
-          field.selector &&
-          field.required &&
-          field.default === undefined &&
-          "boolean" in field.selector
-      ).reduce((total, field) => {
-        total[field.key] = false;
-        return total
-      }, {});
       if (this.value) {
+        // Set mandatory bools without a default value to false
+        let mandatoryBools = {};
+        serviceData?.fields.forEach((field) => {
+          if (
+            field.selector &&
+            field.required &&
+            field.default === undefined &&
+            "boolean" in field.selector
+          ) {
+            mandatoryBools[field.key] = false;
+          }
+        });
         this.value.data = {
           ...this.value?.data,
           ...mandatoryBools,
         };
       }
-
     }
 
     // Fetch the manifest if we have a service selected and the service domain changed.

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -74,33 +74,14 @@ export class HaServiceControl extends LitElement {
       | undefined
       | this["value"];
 
+    if (oldValue?.service !== this.value?.service) {
+      this._checkedKeys = new Set();
+    }
+
     const serviceData = this._getServiceInfo(
       this.value?.service,
       this.hass.services
     );
-
-    if (oldValue?.service !== this.value?.service) {
-      this._checkedKeys = new Set();
-
-      if (this.value) {
-        // Set mandatory bools without a default value to false
-        const mandatoryBools = {};
-        serviceData?.fields.forEach((field) => {
-          if (
-            field.selector &&
-            field.required &&
-            field.default === undefined &&
-            "boolean" in field.selector
-          ) {
-            mandatoryBools[field.key] = false;
-          }
-        });
-        this.value.data = {
-          ...this.value?.data,
-          ...mandatoryBools,
-        };
-      }
-    }
 
     // Fetch the manifest if we have a service selected and the service domain changed.
     // If no service is selected, clear the manifest.
@@ -147,6 +128,24 @@ export class HaServiceControl extends LitElement {
       delete this._value.data!.area_id;
     } else {
       this._value = this.value;
+    }
+
+    if (oldValue?.service !== this.value?.service) {
+      if (this._value && serviceData) {
+        // Set mandatory bools without a default value to false
+        this._value.data ??= {};
+        serviceData.fields.forEach((field) => {
+          if (
+            field.selector &&
+            field.required &&
+            field.default === undefined &&
+            "boolean" in field.selector &&
+            this._value!.data![field.key] === undefined
+          ) {
+            this._value!.data![field.key] = false;
+          }
+        });
+      }
     }
 
     if (this._value?.data) {

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -131,6 +131,7 @@ export class HaServiceControl extends LitElement {
     }
 
     if (oldValue?.service !== this.value?.service) {
+      let updatedDefaultValue = false;
       if (this._value && serviceData) {
         // Set mandatory bools without a default value to false
         this._value.data ??= {};
@@ -142,8 +143,16 @@ export class HaServiceControl extends LitElement {
             "boolean" in field.selector &&
             this._value!.data![field.key] === undefined
           ) {
+            updatedDefaultValue = true;
             this._value!.data![field.key] = false;
           }
+        });
+      }
+      if (updatedDefaultValue) {
+        fireEvent(this, "value-changed", {
+          value: {
+            ...this._value,
+          },
         });
       }
     }

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -74,14 +74,33 @@ export class HaServiceControl extends LitElement {
       | undefined
       | this["value"];
 
-    if (oldValue?.service !== this.value?.service) {
-      this._checkedKeys = new Set();
-    }
-
     const serviceData = this._getServiceInfo(
       this.value?.service,
       this.hass.services
     );
+
+    if (oldValue?.service !== this.value?.service) {
+      this._checkedKeys = new Set();
+
+      // Set mandatory bools without a default value to false
+      const mandatoryBools = serviceData?.fields.filter(
+        (field) =>
+          field.selector &&
+          field.required &&
+          field.default === undefined &&
+          "boolean" in field.selector
+      ).reduce((total, field) => {
+        total[field.key] = false;
+        return total
+      }, {});
+      if (this.value) {
+        this.value.data = {
+          ...this.value?.data,
+          ...mandatoryBools,
+        };
+      }
+
+    }
 
     // Fetch the manifest if we have a service selected and the service domain changed.
     // If no service is selected, clear the manifest.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Set mandatory bool service data without a default value to false so the actual service data matches what's shown in the UI.

This PR does not prevent saving an automation with invalid services though, for example if a mandatory field is missing.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/10073

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
