### PR TITLE
DevTools: Navigate to History from last changed/last updated

### DIFF
--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -1,3 +1,4 @@
+import { addHours } from "date-fns";
 import "@material/mwc-button";
 import {
   mdiClipboardTextMultipleOutline,
@@ -200,12 +201,18 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               <p>
                 <b
                   >[[localize('ui.panel.developer-tools.tabs.states.last_changed')]]:</b
-                ><br />[[lastChangedString(_entity)]]
+                ><br />
+                <a href="[[historyFromLastChanged(_entity)]]"
+                  >[[lastChangedString(_entity)]]</a
+                >
               </p>
               <p>
                 <b
                   >[[localize('ui.panel.developer-tools.tabs.states.last_updated')]]:</b
-                ><br />[[lastUpdatedString(_entity)]]
+                ><br />
+                <a href="[[historyFromLastUpdated(_entity)]]"
+                  >[[lastUpdatedString(_entity)]]</a
+                >
               </p>
             </template>
           </div>
@@ -405,6 +412,20 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
     this._state = state.state;
     this._stateAttributes = dump(state.attributes);
     this._expanded = true;
+  }
+
+  _getHistoryURL(entityId, inputDate) {
+    const date = new Date(inputDate);
+    const hourBefore = addHours(date, -1).toISOString();
+    return `/history?entity_id=${entityId}&start_date=${hourBefore}`;
+  }
+
+  historyFromLastChanged(entity) {
+    return this._getHistoryURL(entity.entity_id, entity.last_changed);
+  }
+
+  historyFromLastUpdated(entity) {
+    return this._getHistoryURL(entity.entity_id, entity.last_updated);
   }
 
   expandedChanged(ev) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
In DevTools "States" panel there's a section with "Last changed" and "Last updated" for selected entity.
This PR makes the dates there clickable, redirecting you to History view with preselected Entity and time range one hour before last change/update.

## Demo
![devtools-history](https://user-images.githubusercontent.com/2270505/148705006-1fc7ad5f-1901-4620-b639-ddf336a89171.gif)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
