### PR TITLE
Fix Logbook Icons, Card Editor Close/Cancel buttons, View Editor Dirty

### DIFF
--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -151,9 +151,10 @@ class HaLogbook extends LitElement {
                 html`
                   <state-badge
                     .hass=${this.hass}
-                    .overrideIcon=${item.icon || (item.domain && !stateObj)
+                    .overrideIcon=${item.icon ||
+                    (item.domain && !stateObj
                       ? domainIcon(item.domain!)
-                      : undefined}
+                      : undefined)}
                     .overrideImage=${DOMAINS_WITH_DYNAMIC_PICTURE.has(domain)
                       ? ""
                       : stateObj?.attributes.entity_picture_local ||

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -15,6 +15,7 @@ import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
 import { fireEvent } from "../../common/dom/fire_event";
 import { computeDomain } from "../../common/entity/compute_domain";
+import { domainIcon } from "../../common/entity/domain_icon";
 import { computeRTL, emitRTLDirection } from "../../common/util/compute_rtl";
 import "../../components/entity/state-badge";
 import "../../components/ha-circular-progress";
@@ -150,7 +151,9 @@ class HaLogbook extends LitElement {
                 html`
                   <state-badge
                     .hass=${this.hass}
-                    .overrideIcon=${item.icon}
+                    .overrideIcon=${item.icon || (item.domain && !stateObj)
+                      ? domainIcon(item.domain!)
+                      : undefined}
                     .overrideImage=${DOMAINS_WITH_DYNAMIC_PICTURE.has(domain)
                       ? ""
                       : stateObj?.attributes.entity_picture_local ||

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -245,7 +245,7 @@ export class HuiDialogEditCard
           <mwc-button @click=${this._cancel}>
             ${this.hass!.localize("ui.common.cancel")}
           </mwc-button>
-          ${this._cardConfig !== undefined
+          ${this._cardConfig !== undefined && this._dirty
             ? html`
                 <mwc-button
                   ?disabled=${!this._canSave || this._saving}
@@ -259,9 +259,7 @@ export class HuiDialogEditCard
                           size="small"
                         ></ha-circular-progress>
                       `
-                    : this._dirty
-                    ? this.hass!.localize("ui.common.save")
-                    : this.hass!.localize("ui.common.close")}
+                    : this.hass!.localize("ui.common.save")}
                 </mwc-button>
               `
             : ``}

--- a/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
@@ -217,24 +217,20 @@ export class HuiDialogEditView extends LitElement {
         <mwc-button @click=${this.closeDialog} slot="primaryAction"
           >${this.hass!.localize("ui.common.cancel")}</mwc-button
         >
-        ${this._dirty
-          ? html`
-              <mwc-button
-                slot="primaryAction"
-                ?disabled=${!this._config || this._saving}
-                @click=${this._save}
-              >
-                ${this._saving
-                  ? html`<ha-circular-progress
-                      active
-                      size="small"
-                      title="Saving"
-                    ></ha-circular-progress>`
-                  : ""}
-                ${this.hass!.localize("ui.common.save")}</mwc-button
-              >
-            `
-          : ""}
+        <mwc-button
+          slot="primaryAction"
+          ?disabled=${!this._config || this._saving || !this._dirty}
+          @click=${this._save}
+        >
+          ${this._saving
+            ? html`<ha-circular-progress
+                active
+                size="small"
+                title="Saving"
+              ></ha-circular-progress>`
+            : ""}
+          ${this.hass!.localize("ui.common.save")}</mwc-button
+        >
       </ha-dialog>
     `;
   }


### PR DESCRIPTION
## Proposed change

Overrides the icon for logbook if no state object and item icon with the Domain Icon

Removes one of the buttons when card editor not dirty

Removes save button on View editor if not dirty

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information

PR from UX Hitlist by @matthiasdebaat 

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.
