### PR TITLE
Add overflow menu to discovered integration item

### DIFF
--- a/src/panels/config/integrations/ha-config-flow-card.ts
+++ b/src/panels/config/integrations/ha-config-flow-card.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { mdiDotsVertical, mdiOpenInNew } from "@mdi/js";
@@ -12,7 +12,6 @@ import {
 import type { IntegrationManifest } from "../../../data/integration";
 import { showConfigFlowDialog } from "../../../dialogs/config-flow/show-dialog-config-flow";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
-import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import type { DataEntryFlowProgressExtended } from "./ha-config-integrations";
 import "./ha-integration-action-card";
@@ -160,6 +159,10 @@ export class HaConfigFlowCard extends LitElement {
     .discovered {
       --state-color: var(--primary-color);
       --text-on-state-color: var(--text-primary-color);
+    }
+    a {
+      text-decoration: none;
+      color: var(--primary-color);
     }
   `;
 }

--- a/src/panels/config/integrations/ha-config-flow-card.ts
+++ b/src/panels/config/integrations/ha-config-flow-card.ts
@@ -58,7 +58,7 @@ export class HaConfigFlowCard extends LitElement {
             .path=${mdiDotsVertical}
           ></ha-icon-button>
           ${this.flow.context.configuration_url
-            ? html` <a
+            ? html`<a
                 href=${this.flow.context.configuration_url.replace(
                   /^homeassistant:\/\//,
                   ""

--- a/src/panels/config/integrations/ha-config-flow-card.ts
+++ b/src/panels/config/integrations/ha-config-flow-card.ts
@@ -1,6 +1,7 @@
-import { css, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { mdiDotsVertical, mdiOpenInNew } from "@mdi/js";
 import { fireEvent } from "../../../common/dom/fire_event";
 import {
   ATTENTION_SOURCES,
@@ -11,6 +12,7 @@ import {
 import type { IntegrationManifest } from "../../../data/integration";
 import { showConfigFlowDialog } from "../../../dialogs/config-flow/show-dialog-config-flow";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
+import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import type { DataEntryFlowProgressExtended } from "./ha-config-integrations";
 import "./ha-integration-action-card";
@@ -50,17 +52,62 @@ export class HaConfigFlowCard extends LitElement {
             }`
           )}
         ></mwc-button>
-        ${DISCOVERY_SOURCES.includes(this.flow.context.source) &&
-        this.flow.context.unique_id
-          ? html`
-              <mwc-button
-                @click=${this._ignoreFlow}
-                .label=${this.hass.localize(
-                  "ui.panel.config.integrations.ignore.ignore"
+        <ha-button-menu corner="BOTTOM_START">
+          <ha-icon-button
+            slot="trigger"
+            .label=${this.hass.localize("ui.common.menu")}
+            .path=${mdiDotsVertical}
+          ></ha-icon-button>
+          ${this.flow.context.configuration_url
+            ? html` <a
+                href=${this.flow.context.configuration_url.replace(
+                  /^homeassistant:\/\//,
+                  ""
                 )}
-              ></mwc-button>
-            `
-          : ""}
+                rel="noreferrer"
+                target=${this.flow.context.configuration_url.startsWith(
+                  "homeassistant://"
+                )
+                  ? "_self"
+                  : "_blank"}
+              >
+                <mwc-list-item hasMeta>
+                  ${this.hass.localize(
+                    "ui.panel.config.integrations.config_entry.open_configuration_url"
+                  )}<ha-svg-icon
+                    slot="meta"
+                    .path=${mdiOpenInNew}
+                  ></ha-svg-icon>
+                </mwc-list-item>
+              </a>`
+            : ""}
+          ${this.manifest
+            ? html` <a
+                href=${this.manifest.documentation}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <mwc-list-item hasMeta>
+                  ${this.hass.localize(
+                    "ui.panel.config.integrations.config_entry.documentation"
+                  )}<ha-svg-icon
+                    slot="meta"
+                    .path=${mdiOpenInNew}
+                  ></ha-svg-icon>
+                </mwc-list-item>
+              </a>`
+            : ""}
+          ${DISCOVERY_SOURCES.includes(this.flow.context.source) &&
+          this.flow.context.unique_id
+            ? html`
+                <mwc-list-item @click=${this._ignoreFlow}>
+                  ${this.hass.localize(
+                    "ui.panel.config.integrations.ignore.ignore"
+                  )}
+                </mwc-list-item>
+              `
+            : ""}
+        </ha-button-menu>
       </ha-integration-action-card>
     `;
   }

--- a/src/panels/config/integrations/ha-config-flow-card.ts
+++ b/src/panels/config/integrations/ha-config-flow-card.ts
@@ -81,7 +81,7 @@ export class HaConfigFlowCard extends LitElement {
               </a>`
             : ""}
           ${this.manifest
-            ? html` <a
+            ? html`<a
                 href=${this.manifest.documentation}
                 rel="noreferrer"
                 target="_blank"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2478,7 +2478,8 @@
               "setup_retry": "Retrying setup",
               "not_loaded": "Not loaded",
               "failed_unload": "Failed to unload"
-            }
+            },
+            "open_configuration_url": "Visit external configuration page"
           },
           "config_flow": {
             "aborted": "Aborted",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2479,7 +2479,7 @@
               "not_loaded": "Not loaded",
               "failed_unload": "Failed to unload"
             },
-            "open_configuration_url": "Visit external configuration page"
+            "open_configuration_url": "Visit device"
           },
           "config_flow": {
             "aborted": "Aborted",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Before:

![image](https://user-images.githubusercontent.com/195327/149138131-2a898748-468a-4b82-a3a4-ac00f856807d.png)

After:

![image](https://user-images.githubusercontent.com/195327/149141022-f8cdd29c-55d2-470a-8304-051740df9208.png)

Added/changes:

- Adds overflow menu to discovered items
- Adds documentation link
- Adds support for setting a configuration URL on the discovered items

Reasoning behind this change:
- Making the card look / work similar (regardless if they are discovered or existing items)
- Allow finding the documentation even before setting it up
- Allow visiting the device, which was driven by the following:

![image](https://user-images.githubusercontent.com/195327/149138462-190038eb-d7a1-4922-9801-1b346f22082a.png)

In the above case, I need to adjust the name of one of those (or both), for which I need to configure the device itself.

In the backend it would look something like this:

```py
        self.context.update(
            {
                "title_placeholders": {"name": self.discovered_device.info.name},
                "configuration_url": f"http://{discovery_info.host}",
            }
        )
```

~~As shown in the first screenshot, the styling is wrong. And for the love of pete, I cannot figure out how to fix it. Help/hints/commits for that are welcome.~~ Fixed. Thanks Bram.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
