### PR TITLE
Reflect media browser panel state in URL

### DIFF
--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -582,10 +582,10 @@ export class HaMediaPlayerBrowse extends LitElement {
    * Load thumbnails for images on demand as they become visible.
    */
   private async _attachIntersectionObserver(): Promise<void> {
-    if (!this._thumbnails) {
+    if (!("IntersectionObserver" in window) || !this._thumbnails) {
       return;
     }
-    if (!this._intersectionObserver && "IntersectionObserver" in window) {
+    if (!this._intersectionObserver) {
       this._intersectionObserver = new IntersectionObserver(
         async (entries, observer) => {
           await Promise.all(

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -21,13 +21,11 @@ import "./home-assistant-main";
 
 const useHash = __DEMO__;
 const curPath = () =>
-  window.decodeURIComponent(
-    useHash ? location.hash.substr(1) : location.pathname
-  );
+  useHash ? location.hash.substring(1) : location.pathname;
 
 const panelUrl = (path: string) => {
   const dividerPos = path.indexOf("/", 1);
-  return dividerPos === -1 ? path.substr(1) : path.substr(1, dividerPos - 1);
+  return dividerPos === -1 ? path.substring(1) : path.substring(1, dividerPos);
 };
 
 @customElement("home-assistant")

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -16,6 +16,7 @@ import { supportsFeature } from "../../common/entity/supports-feature";
 import { navigate } from "../../common/navigate";
 import "../../components/ha-menu-button";
 import "../../components/media-player/ha-media-player-browse";
+import type { MediaPlayerItemId } from "../../components/media-player/ha-media-player-browse";
 import {
   BROWSER_PLAYER,
   MediaPickedEvent,
@@ -36,8 +37,14 @@ class PanelMediaBrowser extends LitElement {
 
   @property() public route!: Route;
 
-  // @ts-ignore
-  @LocalStorage("mediaBrowseEntityId", true)
+  private _navigateIds: MediaPlayerItemId[] = [
+    {
+      media_content_id: undefined,
+      media_content_type: undefined,
+    },
+  ];
+
+  @LocalStorage("mediaBrowseEntityId")
   private _entityId = BROWSER_PLAYER;
 
   protected render(): TemplateResult {
@@ -77,15 +84,17 @@ class PanelMediaBrowser extends LitElement {
           <ha-media-player-browse
             .hass=${this.hass}
             .entityId=${this._entityId}
+            .navigateIds=${this._navigateIds}
             @media-picked=${this._mediaPicked}
+            @media-browsed=${this._mediaBrowsed}
           ></ha-media-player-browse>
         </div>
       </ha-app-layout>
     `;
   }
 
-  public updated(changedProps: PropertyValues): void {
-    super.updated(changedProps);
+  public willUpdate(changedProps: PropertyValues): void {
+    super.willUpdate(changedProps);
 
     if (!changedProps.has("route")) {
       return;
@@ -96,10 +105,28 @@ class PanelMediaBrowser extends LitElement {
       return;
     }
 
-    const routePlayer = this.route.path.substring(1).split("/")[0];
+    const [routePlayer, ...navigateIdsEncoded] = this.route.path
+      .substring(1)
+      .split("/");
+
     if (routePlayer !== this._entityId) {
       this._entityId = routePlayer;
     }
+
+    this._navigateIds = [
+      {
+        media_content_type: undefined,
+        media_content_id: undefined,
+      },
+      ...navigateIdsEncoded.map((navigateId) => {
+        const [media_content_type, media_content_id] =
+          decodeURIComponent(navigateId).split(",");
+        return {
+          media_content_type,
+          media_content_id,
+        };
+      }),
+    ];
   }
 
   private _showSelectMediaPlayerDialog(): void {
@@ -109,6 +136,21 @@ class PanelMediaBrowser extends LitElement {
         navigate(`/media-browser/${entityId}`, { replace: true });
       },
     });
+  }
+
+  private _mediaBrowsed(ev) {
+    if (ev.detail.back) {
+      history.back();
+      return;
+    }
+    let path = "";
+    for (const item of ev.detail.ids.slice(1)) {
+      path = "/";
+      path += encodeURIComponent(
+        `${item.media_content_type},${item.media_content_id}`
+      );
+    }
+    navigate(`/media-browser/${this._entityId}${path}`);
   }
 
   private async _mediaPicked(

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -145,10 +145,11 @@ class PanelMediaBrowser extends LitElement {
     }
     let path = "";
     for (const item of ev.detail.ids.slice(1)) {
-      path = "/";
-      path += encodeURIComponent(
-        `${item.media_content_type},${item.media_content_id}`
-      );
+      path +=
+        "/" +
+        encodeURIComponent(
+          `${item.media_content_type},${item.media_content_id}`
+        );
     }
     navigate(`/media-browser/${this._entityId}${path}`);
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Update state management of the media browser and reflect the state in the URL so we can refresh the page and stay on same folder.

Fixes #10950

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
