### PR TITLE
Enable/Disable LL-HLS support based on http/2 availability

### DIFF
--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -186,11 +186,12 @@ class HaHLSPlayer extends LitElement {
     });
   };
 
-  private _isLLHLSSupported(): bool {
+  private _isLLHLSSupported(): boolean {
     // LL-HLS requires use of an http/2 proxy to avoid opening too many connections
-    const protocol =
-      performance.getEntriesByType("navigation")[0].nextHopProtocol;
-    return protocol === "h2";
+    return (
+      performance.getEntriesByType("navigation")[0] &&
+      performance.getEntriesByType("navigation")[0].nextHopProtocol === "H2"
+    );
   }
 
   private async _renderHLSPolyfill(

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -196,7 +196,7 @@ class HaHLSPlayer extends LitElement {
     // once should be OK.
     // The stream count may be incremented multiple times before this function is called to check
     // the count e.g. when loading a page with many streams on it. The race can work in our favor
-    // so we know have a better idea on if we'll use too many browser connections later.
+    // so we now have a better idea on if we'll use too many browser connections later.
     if (HaHLSPlayer.streamCount <= 2) {
       return true;
     }

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -186,6 +186,13 @@ class HaHLSPlayer extends LitElement {
     });
   };
 
+  private _isLLHLSSupported(): bool {
+    // LL-HLS requires use of an http/2 proxy to avoid opening too many connections
+    const protocol =
+      performance.getEntriesByType("navigation")[0].nextHopProtocol;
+    return protocol === "h2";
+  }
+
   private async _renderHLSPolyfill(
     videoEl: HTMLVideoElement,
     Hls: typeof HlsType,
@@ -197,6 +204,7 @@ class HaHLSPlayer extends LitElement {
       manifestLoadingTimeOut: 30000,
       levelLoadingTimeOut: 30000,
       maxLiveSyncPlaybackRate: 2,
+      lowLatencyMode: this._isLLHLSSupported(),
     });
     this._hlsPolyfillInstance = hls;
     hls.attachMedia(videoEl);

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -48,7 +48,7 @@ class HaHLSPlayer extends LitElement {
 
   private _exoPlayer = false;
 
-  private static streamCount: int = 0;
+  private static streamCount = 0;
 
   public connectedCallback() {
     super.connectedCallback();
@@ -203,7 +203,9 @@ class HaHLSPlayer extends LitElement {
     ) {
       return false;
     }
-    const perfEntry = performance.getEntriesByType("resource")[0];
+    const perfEntry = performance.getEntriesByType(
+      "resource"
+    )[0] as PerformanceResourceTiming;
     return "nextHopProtocol" in perfEntry && perfEntry.nextHopProtocol === "h2";
   }
 

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -189,6 +189,7 @@ class HaHLSPlayer extends LitElement {
   private _isLLHLSSupported(): boolean {
     // LL-HLS requires use of an http/2 proxy to avoid opening too many connections
     return (
+      "performance" in window &&
       performance.getEntriesByType("navigation")[0] &&
       performance.getEntriesByType("navigation")[0].nextHopProtocol === "H2"
     );

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -194,6 +194,9 @@ class HaHLSPlayer extends LitElement {
     // LL-HLS keeps multiple requests in flight, which can run into browser limitations without
     // an http/2 proxy to pipeline requests. However, a small number of streams active at
     // once should be OK.
+    // The stream count may be incremented multiple times before this function is called to check
+    // the count e.g. when loading a page with many streams on it. The race can work in our favor
+    // so we know have a better idea on if we'll use too many browser connections later.
     if (HaHLSPlayer.streamCount <= 2) {
       return true;
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Enable/Disable LL-HLS based on whether or not the current request is using an http/2 proxy (e.g.
nginx etc). This will allow us to turn on LL-HLS by default in more places.

This is a follow up after discussion on trying to auto detect on the server side.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
