### PR TITLE
Hide download diagnostics if config entry is not loaded

### DIFF
--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -210,25 +210,27 @@ export class HaConfigDevicePage extends LitElement {
     }
 
     return Promise.all(
-      this._integrations(device, this.entries).map(async (entry) => {
-        const info = await fetchDiagnosticHandler(this.hass, entry.domain);
+      this._integrations(device, this.entries)
+        .filter((entry) => entry.state === "loaded")
+        .map(async (entry) => {
+          const info = await fetchDiagnosticHandler(this.hass, entry.domain);
 
-        if (!info.handlers.device && !info.handlers.config_entry) {
-          return "";
-        }
-        const link = info.handlers.device
-          ? getDeviceDiagnosticsDownloadUrl(entry.entry_id, this.deviceId)
-          : getConfigEntryDiagnosticsDownloadUrl(entry.entry_id);
-        return html`
-          <a href=${link} @click=${this._signUrl}>
-            <mwc-button>
-              ${this.hass.localize(
-                `ui.panel.config.devices.download_diagnostics`
-              )}
-            </mwc-button>
-          </a>
-        `;
-      })
+          if (!info.handlers.device && !info.handlers.config_entry) {
+            return "";
+          }
+          const link = info.handlers.device
+            ? getDeviceDiagnosticsDownloadUrl(entry.entry_id, this.deviceId)
+            : getConfigEntryDiagnosticsDownloadUrl(entry.entry_id);
+          return html`
+            <a href=${link} @click=${this._signUrl}>
+              <mwc-button>
+                ${this.hass.localize(
+                  `ui.panel.config.devices.download_diagnostics`
+                )}
+              </mwc-button>
+            </a>
+          `;
+        })
     );
   }
 

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -362,7 +362,7 @@ export class HaIntegrationCard extends LitElement {
                 )}
               </mwc-list-item>`
             : ""}
-          ${this.supportsDiagnostics
+          ${this.supportsDiagnostics && item.state === "loaded"
             ? html`<a
                 href=${getConfigEntryDiagnosticsDownloadUrl(item.entry_id)}
                 target="_blank"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Hide download diagnostics if config entry not loaded.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
