### PR TITLE
Missing translation, code editor make ltr, checkbox alignment in rtl

### DIFF
--- a/src/components/ha-yaml-editor.ts
+++ b/src/components/ha-yaml-editor.ts
@@ -60,6 +60,7 @@ export class HaYamlEditor extends LitElement {
         mode="yaml"
         .error=${this.isValid === false}
         @value-changed=${this._onChange}
+        dir="ltr"
       ></ha-code-editor>
     `;
   }

--- a/src/components/trace/ha-trace-blueprint-config.ts
+++ b/src/components/trace/ha-trace-blueprint-config.ts
@@ -17,6 +17,7 @@ export class HaTraceBlueprintConfig extends LitElement {
       <ha-code-editor
         .value=${dump(this.trace.blueprint_inputs || "").trimRight()}
         readOnly
+        dir="ltr"
       ></ha-code-editor>
     `;
   }

--- a/src/components/trace/ha-trace-config.ts
+++ b/src/components/trace/ha-trace-config.ts
@@ -17,6 +17,7 @@ export class HaTraceConfig extends LitElement {
       <ha-code-editor
         .value=${dump(this.trace.config).trimRight()}
         readOnly
+        dir="ltr"
       ></ha-code-editor>
     `;
   }

--- a/src/components/trace/ha-trace-path-details.ts
+++ b/src/components/trace/ha-trace-path-details.ts
@@ -150,6 +150,7 @@ export class HaTracePathDetails extends LitElement {
       ? html`<ha-code-editor
           .value=${dump(config).trimRight()}
           readOnly
+          dir="ltr"
         ></ha-code-editor>`
       : "Unable to find config";
   }

--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-config-panel.ts
@@ -61,6 +61,7 @@ class HaPanelDevMqtt extends LitElement {
                 mode="jinja2"
                 .value=${this.payload}
                 @value-changed=${this._handlePayload}
+                dir="ltr"
               ></ha-code-editor>
             </div>
             <div class="card-actions">

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-zigbee-info.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-zigbee-info.ts
@@ -42,7 +42,11 @@ class DialogZHADeviceZigbeeInfo extends LitElement {
           this.hass.localize(`ui.dialogs.zha_device_info.device_signature`)
         )}
       >
-        <ha-code-editor mode="yaml" readonly .value=${this._signature} dir="ltr">
+        <ha-code-editor 
+          mode="yaml"
+          readonly
+          .value=${this._signature} 
+          dir="ltr">
         </ha-code-editor>
       </ha-dialog>
     `;

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-zigbee-info.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-zigbee-info.ts
@@ -42,7 +42,7 @@ class DialogZHADeviceZigbeeInfo extends LitElement {
           this.hass.localize(`ui.dialogs.zha_device_info.device_signature`)
         )}
       >
-        <ha-code-editor mode="yaml" readonly .value=${this._signature}>
+        <ha-code-editor mode="yaml" readonly .value=${this._signature} dir="ltr">
         </ha-code-editor>
       </ha-dialog>
     `;

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-zigbee-info.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-device-zigbee-info.ts
@@ -42,11 +42,12 @@ class DialogZHADeviceZigbeeInfo extends LitElement {
           this.hass.localize(`ui.dialogs.zha_device_info.device_signature`)
         )}
       >
-        <ha-code-editor 
+        <ha-code-editor
           mode="yaml"
           readonly
-          .value=${this._signature} 
-          dir="ltr">
+          .value=${this._signature}
+          dir="ltr"
+        >
         </ha-code-editor>
       </ha-dialog>
     `;

--- a/src/panels/developer-tools/event/developer-tools-event.js
+++ b/src/panels/developer-tools/event/developer-tools-event.js
@@ -94,6 +94,7 @@ class HaPanelDevEvent extends EventsMixin(LocalizeMixin(PolymerElement)) {
               value="[[eventData]]"
               error="[[!validJSON]]"
               on-value-changed="_yamlChanged"
+              dir="ltr"
             ></ha-code-editor>
           </div>
           <mwc-button on-click="fireEvent" raised disabled="[[!validJSON]]"

--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -85,6 +85,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
 
         :host([rtl]) .entities th {
           text-align: right;
+          direction: rtl;
         }
 
         .entities tr {
@@ -145,7 +146,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
         [[localize('ui.panel.developer-tools.tabs.states.current_entities')]]
       </h1>
       <ha-expansion-panel
-        header="Set state"
+        header="[[localize('ui.panel.developer-tools.tabs.states.set_state')]]"
         outlined
         expanded="[[_expanded]]"
         on-expanded-changed="expandedChanged"
@@ -181,6 +182,7 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               value="[[_stateAttributes]]"
               error="[[!validJSON]]"
               on-value-changed="_yamlChanged"
+              dir="ltr"
             ></ha-code-editor>
             <div class="button-row">
               <mwc-button

--- a/src/panels/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/developer-tools/template/developer-tools-template.ts
@@ -132,6 +132,7 @@ class HaPanelDevTemplate extends LitElement {
             .error=${this._error}
             autofocus
             @value-changed=${this._templateChanged}
+            dir="ltr"
           ></ha-code-editor>
           <mwc-button @click=${this._restoreDemo}>
             ${this.hass.localize(

--- a/src/panels/lovelace/editor/hui-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-element-editor.ts
@@ -11,7 +11,6 @@ import {
 import { property, state, query } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { handleStructError } from "../../../common/structs/handle-errors";
-import { computeRTL } from "../../../common/util/compute_rtl";
 import { deepEqual } from "../../../common/util/deep-equal";
 import "../../../components/ha-circular-progress";
 import "../../../components/ha-code-editor";
@@ -200,9 +199,9 @@ export abstract class HuiElementEditor<T> extends LitElement {
                   autofocus
                   .value=${this.yaml}
                   .error=${Boolean(this._errors)}
-                  .rtl=${computeRTL(this.hass)}
                   @value-changed=${this._handleYAMLChanged}
                   @keydown=${this._ignoreKeydown}
+                  dir="ltr"
                 ></ha-code-editor>
               </div>
             `}

--- a/src/panels/lovelace/hui-editor.ts
+++ b/src/panels/lovelace/hui-editor.ts
@@ -15,7 +15,6 @@ import {
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { array, assert, object, optional, string, type } from "superstruct";
-import { computeRTL } from "../../common/util/compute_rtl";
 import { deepEqual } from "../../common/util/deep-equal";
 import "../../components/ha-circular-progress";
 import "../../components/ha-code-editor";
@@ -92,10 +91,10 @@ class LovelaceFullConfigEditor extends LitElement {
           <ha-code-editor
             mode="yaml"
             autofocus
-            .rtl=${computeRTL(this.hass)}
             .hass=${this.hass}
             @value-changed=${this._yamlChanged}
             @editor-save=${this._handleSave}
+            dir="ltr"
           >
           </ha-code-editor>
         </div>


### PR DESCRIPTION
## Proposed change

All in developer tools -> states :
Fixed missing translation (hardcoded test).
Code editor made LTR even in RTL
![image](https://user-images.githubusercontent.com/37745463/150850303-7e7c30ba-8201-42a6-af56-9e156af840d7.png)

Checkbox alignment in RTL fixed

![image](https://user-images.githubusercontent.com/37745463/150850397-3e70ef29-ae72-432b-862e-bf35526c4971.png)


General fix:
Fixed all code editors to be LTR
For example - hui-element-editor:
![image](https://user-images.githubusercontent.com/37745463/150849665-afb5b8f1-6af8-486d-81e8-81b38186688e.png)


## Type of change

- [X ] Bugfix (non-breaking change which fixes an issue)

- [X ] The code change is tested and works locally.
- [ X] There is no commented out code in this PR.