### PR TITLE
Mobile click accessibility

### DIFF
--- a/src/entrypoints/app.ts
+++ b/src/entrypoints/app.ts
@@ -1,9 +1,13 @@
-import { setPassiveTouchGestures } from "@polymer/polymer/lib/utils/settings";
+import {
+  setPassiveTouchGestures,
+  setCancelSyntheticClickEvents,
+} from "@polymer/polymer/lib/utils/settings";
 import "../layouts/home-assistant";
 import "../resources/ha-style";
 import "../resources/roboto";
 import "../util/legacy-support";
 
 setPassiveTouchGestures(true);
+setCancelSyntheticClickEvents(false);
 
 (window as any).frontendVersion = __VERSION__;

--- a/src/entrypoints/authorize.ts
+++ b/src/entrypoints/authorize.ts
@@ -1,10 +1,13 @@
 // Compat needs to be first import
 import "../resources/compatibility";
+import { setCancelSyntheticClickEvents } from "@polymer/polymer/lib/utils/settings";
 import "../auth/ha-authorize";
 import "../resources/ha-style";
 import "../resources/roboto";
 import "../resources/safari-14-attachshadow-patch";
 import "../resources/array.flat.polyfill";
+
+setCancelSyntheticClickEvents(false);
 
 /* polyfill for paper-dropdown */
 setTimeout(

--- a/src/entrypoints/custom-panel.ts
+++ b/src/entrypoints/custom-panel.ts
@@ -1,5 +1,6 @@
 // Compat needs to be first import
 import "../resources/compatibility";
+import { setCancelSyntheticClickEvents } from "@polymer/polymer/lib/utils/settings";
 import "../resources/safari-14-attachshadow-patch";
 
 import { PolymerElement } from "@polymer/polymer";
@@ -14,6 +15,8 @@ import { baseEntrypointStyles } from "../resources/styles";
 import { createCustomPanelElement } from "../util/custom-panel/create-custom-panel-element";
 import { loadCustomPanel } from "../util/custom-panel/load-custom-panel";
 import { setCustomPanelProperties } from "../util/custom-panel/set-custom-panel-properties";
+
+setCancelSyntheticClickEvents(false);
 
 declare global {
   interface Window {
@@ -47,7 +50,7 @@ function initialize(
 ) {
   const style = document.createElement("style");
 
-  style.innerHTML = `body { margin:0; } 
+  style.innerHTML = `body { margin:0; }
   @media (prefers-color-scheme: dark) {
     body {
       background-color: #111111;

--- a/src/entrypoints/onboarding.ts
+++ b/src/entrypoints/onboarding.ts
@@ -1,10 +1,13 @@
 // Compat needs to be first import
 import "../resources/compatibility";
+import { setCancelSyntheticClickEvents } from "@polymer/polymer/lib/utils/settings";
 import "../onboarding/ha-onboarding";
 import "../resources/ha-style";
 import "../resources/roboto";
 import "../resources/safari-14-attachshadow-patch";
 import "../resources/array.flat.polyfill";
+
+setCancelSyntheticClickEvents(false);
 
 declare global {
   interface Window {

--- a/src/resources/compatibility.ts
+++ b/src/resources/compatibility.ts
@@ -1,3 +1,4 @@
+// Caution before editing - For latest builds, this module is replaced with emptiness and thus not imported (see build-scripts/bundle.js)
 import "core-js";
 import "regenerator-runtime/runtime";
 import "lit/polyfill-support";


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Change the Polymer setting `cancelSyntheticClickEvents` to false globally in the UI.  When left to true, it ends up breaking nearly all buttons in the UI for mobile screen readers.

_PS - I know the 2nd commit is only loosely related, but that comment would have saved me a bunch of time trying to figure out why putting the code there wasn't working_

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
N/A - Just flip VoiceOver or Talkback on with and without this change.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #8178, fixes #10617
- This PR is related to issue or discussion: Polymer/polymer#5697

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

