### PR TITLE
Energy setup wizard missing localization entries

### DIFF
--- a/src/panels/energy/cards/energy-setup-wizard-card.ts
+++ b/src/panels/energy/cards/energy-setup-wizard-card.ts
@@ -51,7 +51,10 @@ export class EnergySetupWizard extends LitElement implements LovelaceCard {
 
   protected render(): TemplateResult {
     return html`
-      <p>Step ${this._step + 1} of 5</p>
+      <p>
+        ${this.hass.localize("ui.panel.energy.setup.step")} ${this._step + 1}
+        ${this.hass.localize("ui.panel.energy.setup.of")} 5
+      </p>
       ${this._step === 0
         ? html`<ha-energy-grid-settings
             .hass=${this.hass}

--- a/src/panels/energy/cards/energy-setup-wizard-card.ts
+++ b/src/panels/energy/cards/energy-setup-wizard-card.ts
@@ -52,8 +52,10 @@ export class EnergySetupWizard extends LitElement implements LovelaceCard {
   protected render(): TemplateResult {
     return html`
       <p>
-        ${this.hass.localize("ui.panel.energy.setup.step")} ${this._step + 1}
-        ${this.hass.localize("ui.panel.energy.setup.step_of")} 5
+        ${this.hass.localize("ui.panel.energy.setup.step", {
+          step: this._step + 1,
+          steps: 5,
+        })}
       </p>
       ${this._step === 0
         ? html`<ha-energy-grid-settings

--- a/src/panels/energy/cards/energy-setup-wizard-card.ts
+++ b/src/panels/energy/cards/energy-setup-wizard-card.ts
@@ -53,7 +53,7 @@ export class EnergySetupWizard extends LitElement implements LovelaceCard {
     return html`
       <p>
         ${this.hass.localize("ui.panel.energy.setup.step")} ${this._step + 1}
-        ${this.hass.localize("ui.panel.energy.setup.of")} 5
+        ${this.hass.localize("ui.panel.energy.setup.step_of")} 5
       </p>
       ${this._step === 0
         ? html`<ha-energy-grid-settings

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4097,8 +4097,7 @@
           "next": "Next",
           "back": "Back",
           "done": "Show me my energy dashboard!",
-          "step": "Step",
-          "step_of": "of"
+          "step": "Step {step} of {steps}"
         },
         "charts": {
           "stat_house_energy_meter": "Total energy consumption",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4098,7 +4098,7 @@
           "back": "Back",
           "done": "Show me my energy dashboard!",
           "step": "Step",
-          "of": "of"
+          "step_of": "of"
         },
         "charts": {
           "stat_house_energy_meter": "Total energy consumption",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4096,7 +4096,9 @@
         "setup": {
           "next": "Next",
           "back": "Back",
-          "done": "Show me my energy dashboard!"
+          "done": "Show me my energy dashboard!",
+          "step": "Step",
+          "of": "of"
         },
         "charts": {
           "stat_house_energy_meter": "Total energy consumption",


### PR DESCRIPTION
## Proposed change

The Step 1 of 5 text in the energy setup wizard was hardcoded. Added to translations.

- [X ] Bugfix (non-breaking change which fixes an issue)

- [X ] The code change is tested and works locally.
- [ X] There is no commented out code in this PR.

