### PR TITLE
Fix config-logs page RTL issues

### DIFF
--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -2,7 +2,9 @@ import "@material/mwc-button";
 import { mdiRefresh } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
 import "../../../components/ha-icon-button";
+import { computeRTL } from "../../../common/util/compute_rtl";
 import { fetchErrorLog } from "../../../data/error_log";
 import { HomeAssistant } from "../../../types";
 
@@ -26,7 +28,13 @@ class ErrorLogCard extends LitElement {
               </ha-card>
             `
           : html`
-              <mwc-button raised @click=${this._refreshErrorLog}>
+              <mwc-button
+                raised
+                @click=${this._refreshErrorLog}
+                class=${classMap({
+                  rtl: computeRTL(this.hass),
+                })}
+              >
                 ${this.hass.localize("ui.panel.config.logs.load_full_log")}
               </mwc-button>
             `}
@@ -67,6 +75,10 @@ class ErrorLogCard extends LitElement {
 
       .warning {
         color: var(--warning-color);
+      }
+
+      .rtl {
+        direction: rtl;
       }
     `;
   }

--- a/src/panels/config/logs/system-log-card.ts
+++ b/src/panels/config/logs/system-log-card.ts
@@ -2,11 +2,13 @@ import "@polymer/paper-item/paper-item";
 import "@polymer/paper-item/paper-item-body";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
 import "../../../components/buttons/ha-call-service-button";
 import "../../../components/buttons/ha-progress-button";
 import "../../../components/ha-card";
 import "../../../components/ha-circular-progress";
 import "../../../components/ha-icon-button";
+import { computeRTL } from "../../../common/util/compute_rtl";
 import { domainToName } from "../../../data/integration";
 import {
   fetchSystemLog,
@@ -101,7 +103,12 @@ export class SystemLogCard extends LitElement {
                       `
                     )}
 
-                <div class="card-actions">
+                <div
+                  class=${classMap({
+                    "card-actions": true,
+                    rtl: computeRTL(this.hass),
+                  })}
+                >
                   <ha-call-service-button
                     .hass=${this.hass}
                     domain="system_log"
@@ -173,6 +180,10 @@ export class SystemLogCard extends LitElement {
 
       .warning {
         color: var(--warning-color);
+      }
+
+      .rtl {
+        direction: rtl;
       }
     `;
   }

--- a/src/panels/config/logs/system-log-card.ts
+++ b/src/panels/config/logs/system-log-card.ts
@@ -104,10 +104,9 @@ export class SystemLogCard extends LitElement {
                     )}
 
                 <div
-                  class=${classMap({
-                    "card-actions": true,
+                  class="card-actions ${classMap({
                     rtl: computeRTL(this.hass),
-                  })}
+                  })}"
                 >
                   <ha-call-service-button
                     .hass=${this.hass}


### PR DESCRIPTION
## Proposed change

Fix RTL issues in config/logs page.
Orientation of actions buttons + the load log button which causes it to currently show malformed text because it's not RTL

Before:
![image](https://user-images.githubusercontent.com/37745463/151574846-9925b9f2-9cda-49f3-b33b-1a26290d056c.png)

After:
![image](https://user-images.githubusercontent.com/37745463/151574932-d4f5ce7b-418d-46a5-8665-cc93b8dcdc59.png)

- [X] Bugfix (non-breaking change which fixes an issue)

- [X ] The code change is tested and works locally.
- [X ] There is no commented out code in this PR.