### PR TITLE
Fix config card rtl issues

### DIFF
--- a/src/panels/config/info/ha-config-info.ts
+++ b/src/panels/config/info/ha-config-info.ts
@@ -134,7 +134,7 @@ class HaConfigInfo extends LitElement {
               : ""}
           </p>
         </div>
-        <div class="content">
+        <div>
           <system-health-card .hass=${this.hass}></system-health-card>
           <integrations-card
             .hass=${this.hass}
@@ -165,10 +165,6 @@ class HaConfigInfo extends LitElement {
           -ms-user-select: initial;
           -webkit-user-select: initial;
           -moz-user-select: initial;
-        }
-
-        .content {
-          direction: ltr;
         }
 
         .about {

--- a/src/panels/config/info/integrations-card.ts
+++ b/src/panels/config/info/integrations-card.ts
@@ -176,6 +176,7 @@ class IntegrationsCard extends LitElement {
       td.setup {
         text-align: right;
         white-space: nowrap;
+        direction: ltr;
       }
       th {
         text-align: right;

--- a/src/panels/config/info/system-health-card.ts
+++ b/src/panels/config/info/system-health-card.ts
@@ -264,6 +264,10 @@ class SystemHealthCard extends LitElement {
         width: 45%;
       }
 
+      td:last-child {
+        direction: ltr;
+      }
+
       .loading-container {
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Proposed change

Fix RTL issues in config/info
Health card orientation fix + last column with value kept at LTR

Before:
![image](https://user-images.githubusercontent.com/37745463/151577822-a0715303-8212-49ad-bea1-5885f85fcb5f.png)

After:
![image](https://user-images.githubusercontent.com/37745463/151577886-1647ec51-4536-4111-be6b-6baa582496b6.png)


Integrations card orientation fix + last column kept at LTR since it's a number with English at the end (s for seconds)

Before:
![image](https://user-images.githubusercontent.com/37745463/151577943-973a015d-6a76-454b-a10b-f6bac00ee3a5.png)

After:
![image](https://user-images.githubusercontent.com/37745463/151577990-e2b027e8-cc30-420b-a5a3-60b1b1956fbd.png)


## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [X ] The code change is tested and works locally.
- [X ] There is no commented out code in this PR.
