### PR TITLE
Add aria-label to table headers with no title

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -295,6 +295,7 @@ export class HaDataTable extends LitElement {
               };
               return html`
                 <div
+                  aria-label=${column.ariaLabel}
                   class="mdc-data-table__header-cell ${classMap(classes)}"
                   style=${column.width
                     ? styleMap({
@@ -322,7 +323,7 @@ export class HaDataTable extends LitElement {
                         ></ha-svg-icon>
                       `
                     : ""}
-                  <span aria-label=${column.ariaLabel}>${column.title}</span>
+                  <span>${column.title}</span>
                 </div>
               `;
             })}

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -70,7 +70,7 @@ export interface DataTableSortColumnData {
 
 export interface DataTableColumnData<T = any> extends DataTableSortColumnData {
   title: TemplateResult | string;
-  ariaLabel: TemplateResult | string;
+  ariaLabel?: TemplateResult | string;
   type?: "numeric" | "icon" | "icon-button" | "overflow-menu";
   template?: (data: any, row: T) => TemplateResult | string;
   width?: string;

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -70,6 +70,7 @@ export interface DataTableSortColumnData {
 
 export interface DataTableColumnData<T = any> extends DataTableSortColumnData {
   title: TemplateResult | string;
+  ariaLabel: TemplateResult | string;
   type?: "numeric" | "icon" | "icon-button" | "overflow-menu";
   template?: (data: any, row: T) => TemplateResult | string;
   width?: string;
@@ -321,7 +322,7 @@ export class HaDataTable extends LitElement {
                         ></ha-svg-icon>
                       `
                     : ""}
-                  <span>${column.title}</span>
+                  <span aria-label=${column.ariaLabel}>${column.title}</span>
                 </div>
               `;
             })}

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -70,7 +70,7 @@ export interface DataTableSortColumnData {
 
 export interface DataTableColumnData<T = any> extends DataTableSortColumnData {
   title: TemplateResult | string;
-  ariaLabel?: TemplateResult | string;
+  label?: TemplateResult | string;
   type?: "numeric" | "icon" | "icon-button" | "overflow-menu";
   template?: (data: any, row: T) => TemplateResult | string;
   width?: string;
@@ -295,7 +295,7 @@ export class HaDataTable extends LitElement {
               };
               return html`
                 <div
-                  aria-label=${column.ariaLabel}
+                  aria-label=${column.label}
                   class="mdc-data-table__header-cell ${classMap(classes)}"
                   style=${column.width
                     ? styleMap({

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -81,7 +81,7 @@ class HaAutomationPicker extends LitElement {
       const columns: DataTableColumnContainer = {
         toggle: {
           title: "",
-          ariaLabel: this.hass.localize(
+          label: this.hass.localize(
             "ui.panel.config.automation.picker.headers.toggle"
           ),
           type: "icon",
@@ -130,7 +130,7 @@ class HaAutomationPicker extends LitElement {
           `,
         };
         columns.trigger = {
-          ariaLabel: this.hass.localize(
+          label: this.hass.localize(
             "ui.panel.config.automation.picker.headers.trigger"
           ),
           title: html`
@@ -152,7 +152,7 @@ class HaAutomationPicker extends LitElement {
       }
       columns.actions = {
         title: "",
-        ariaLabel: this.hass.localize(
+        label: this.hass.localize(
           "ui.panel.config.automation.picker.headers.actions"
         ),
         type: "overflow-menu",

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -81,6 +81,9 @@ class HaAutomationPicker extends LitElement {
       const columns: DataTableColumnContainer = {
         toggle: {
           title: "",
+          ariaLabel: this.hass.localize(
+            "ui.panel.config.automation.picker.headers.toggle"
+          ),
           type: "icon",
           template: (_toggle, automation: any) =>
             html`
@@ -127,6 +130,9 @@ class HaAutomationPicker extends LitElement {
           `,
         };
         columns.trigger = {
+          ariaLabel: this.hass.localize(
+            "ui.panel.config.automation.picker.headers.trigger"
+          ),
           title: html`
             <mwc-button style="visibility: hidden">
               ${this.hass.localize("ui.card.automation.trigger")}
@@ -146,6 +152,9 @@ class HaAutomationPicker extends LitElement {
       }
       columns.actions = {
         title: "",
+        ariaLabel: this.hass.localize(
+          "ui.panel.config.automation.picker.headers.actions"
+        ),
         type: "overflow-menu",
         template: (_info, automation: any) => html`
           <ha-icon-overflow-menu

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -326,6 +326,9 @@ export class HaConfigDeviceDashboard extends LitElement {
       if (showDisabled) {
         columns.disabled_by = {
           title: "",
+          ariaLabel: this.hass.localize(
+            "ui.panel.config.devices.data_table.disabled_by"
+          ),
           type: "icon",
           template: (disabled_by) =>
             disabled_by

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -326,7 +326,7 @@ export class HaConfigDeviceDashboard extends LitElement {
       if (showDisabled) {
         columns.disabled_by = {
           title: "",
-          ariaLabel: this.hass.localize(
+          label: this.hass.localize(
             "ui.panel.config.devices.data_table.disabled_by"
           ),
           type: "icon",

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -168,6 +168,9 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
     (narrow, _language, showDisabled): DataTableColumnContainer<EntityRow> => ({
       icon: {
         title: "",
+        ariaLabel: this.hass.localize(
+          "ui.panel.config.entities.picker.headers.icon"
+        ),
         type: "icon",
         template: (_, entry: EntityRow) => html`
           <ha-state-icon

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -169,7 +169,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
       icon: {
         title: "",
         ariaLabel: this.hass.localize(
-          "ui.panel.config.entities.picker.headers.icon"
+          "ui.panel.config.entities.picker.headers.state_icon"
         ),
         type: "icon",
         template: (_, entry: EntityRow) => html`

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -168,7 +168,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
     (narrow, _language, showDisabled): DataTableColumnContainer<EntityRow> => ({
       icon: {
         title: "",
-        ariaLabel: this.hass.localize(
+        label: this.hass.localize(
           "ui.panel.config.entities.picker.headers.state_icon"
         ),
         type: "icon",

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -41,6 +41,9 @@ export class HaConfigHelpers extends LitElement {
     const columns: DataTableColumnContainer = {
       icon: {
         title: "",
+        label: this.hass.localize(
+          "ui.panel.config.helpers.picker.headers.icon"
+        ),
         type: "icon",
         template: (icon, helper: any) =>
           icon
@@ -88,6 +91,9 @@ export class HaConfigHelpers extends LitElement {
     };
     columns.editable = {
       title: "",
+      label: this.hass.localize(
+        "ui.panel.config.helpers.picker.headers.editable"
+      ),
       type: "icon",
       template: (editable) => html`
         ${!editable

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -53,6 +53,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
       const columns: DataTableColumnContainer = {
         icon: {
           title: "",
+          label: this.hass.localize(
+            "ui.panel.config.lovelace.dashboards.picker.headers.icon"
+          ),
           type: "icon",
           template: (icon, dashboard) =>
             icon
@@ -161,6 +164,9 @@ export class HaConfigLovelaceDashboards extends LitElement {
 
       columns.url_path = {
         title: "",
+        label: this.hass.localize(
+          "ui.panel.config.lovelace.dashboards.picker.headers.url"
+        ),
         filterable: true,
         width: "100px",
         template: (urlPath) =>

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -67,6 +67,9 @@ class HaSceneDashboard extends LitElement {
     (_language): DataTableColumnContainer => ({
       activate: {
         title: "",
+        label: this.hass.localize(
+          "ui.panel.config.scene.picker.headers.activate"
+        ),
         type: "icon-button",
         template: (_toggle, scene) =>
           html`
@@ -82,6 +85,7 @@ class HaSceneDashboard extends LitElement {
       },
       icon: {
         title: "",
+        label: this.hass.localize("ui.panel.config.scene.picker.headers.state"),
         type: "icon",
         template: (_, scene) =>
           html` <ha-state-icon .state=${scene}></ha-state-icon> `,
@@ -95,6 +99,9 @@ class HaSceneDashboard extends LitElement {
       },
       info: {
         title: "",
+        label: this.hass.localize(
+          "ui.panel.config.scene.picker.headers.show_info"
+        ),
         type: "icon-button",
         template: (_info, scene) => html`
           <ha-icon-button
@@ -109,6 +116,7 @@ class HaSceneDashboard extends LitElement {
       },
       edit: {
         title: "",
+        label: this.hass.localize("ui.panel.config.scene.picker.headers.edit"),
         type: "icon-button",
         template: (_info, scene: any) => html`
           <a

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -69,6 +69,9 @@ class HaScriptPicker extends LitElement {
     const columns: DataTableColumnContainer = {
       activate: {
         title: "",
+        ariaLabel: this.hass.localize(
+          "ui.panel.config.script.picker.run_script"
+        ),
         type: "icon-button",
         template: (_toggle, script) =>
           html`
@@ -84,6 +87,9 @@ class HaScriptPicker extends LitElement {
       },
       icon: {
         title: "",
+        ariaLabel: this.hass.localize(
+          "ui.panel.config.script.picker.headers.state"
+        ),
         type: "icon",
         template: (_icon, script) =>
           html` <ha-state-icon .state=${script}></ha-state-icon>`,
@@ -124,6 +130,7 @@ class HaScriptPicker extends LitElement {
     }
     columns.info = {
       title: "",
+      ariaLabel: this.hass.localize("ui.panel.config.script.picker.show_info"),
       type: "icon-button",
       template: (_info, script) => html`
         <ha-icon-button
@@ -138,6 +145,7 @@ class HaScriptPicker extends LitElement {
     };
     columns.trace = {
       title: "",
+      ariaLabel: this.hass.localize("ui.panel.config.script.picker.dev_script"),
       type: "icon-button",
       template: (_info, script: any) => html`
         <a href="/config/script/trace/${script.entity_id}">
@@ -152,6 +160,9 @@ class HaScriptPicker extends LitElement {
     };
     columns.edit = {
       title: "",
+      ariaLabel: this.hass.localize(
+        "ui.panel.config.script.picker.edit_script"
+      ),
       type: "icon-button",
       template: (_info, script: any) => html`
         <a href="/config/script/edit/${script.entity_id}">

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -69,9 +69,7 @@ class HaScriptPicker extends LitElement {
     const columns: DataTableColumnContainer = {
       activate: {
         title: "",
-        ariaLabel: this.hass.localize(
-          "ui.panel.config.script.picker.run_script"
-        ),
+        label: this.hass.localize("ui.panel.config.script.picker.run_script"),
         type: "icon-button",
         template: (_toggle, script) =>
           html`
@@ -87,7 +85,7 @@ class HaScriptPicker extends LitElement {
       },
       icon: {
         title: "",
-        ariaLabel: this.hass.localize(
+        label: this.hass.localize(
           "ui.panel.config.script.picker.headers.state"
         ),
         type: "icon",
@@ -130,7 +128,7 @@ class HaScriptPicker extends LitElement {
     }
     columns.info = {
       title: "",
-      ariaLabel: this.hass.localize("ui.panel.config.script.picker.show_info"),
+      label: this.hass.localize("ui.panel.config.script.picker.show_info"),
       type: "icon-button",
       template: (_info, script) => html`
         <ha-icon-button
@@ -145,7 +143,7 @@ class HaScriptPicker extends LitElement {
     };
     columns.trace = {
       title: "",
-      ariaLabel: this.hass.localize("ui.panel.config.script.picker.dev_script"),
+      label: this.hass.localize("ui.panel.config.script.picker.dev_script"),
       type: "icon-button",
       template: (_info, script: any) => html`
         <a href="/config/script/trace/${script.entity_id}">
@@ -160,9 +158,7 @@ class HaScriptPicker extends LitElement {
     };
     columns.edit = {
       title: "",
-      ariaLabel: this.hass.localize(
-        "ui.panel.config.script.picker.edit_script"
-      ),
+      label: this.hass.localize("ui.panel.config.script.picker.edit_script"),
       type: "icon-button",
       template: (_info, script: any) => html`
         <a href="/config/script/edit/${script.entity_id}">

--- a/src/panels/config/tags/ha-config-tags.ts
+++ b/src/panels/config/tags/ha-config-tags.ts
@@ -61,6 +61,7 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
       const columns: DataTableColumnContainer = {
         icon: {
           title: "",
+          label: this.hass.localize("ui.panel.config.tag.headers.icon"),
           type: "icon",
           template: (_icon, tag) => html`<tag-image .tag=${tag}></tag-image>`,
         },
@@ -103,6 +104,7 @@ export class HaConfigTags extends SubscribeMixin(LitElement) {
       if (this._canWriteTags) {
         columns.write = {
           title: "",
+          label: this.hass.localize("ui.panel.config.tag.headers.write"),
           type: "icon-button",
           template: (_write, tag: any) => html` <ha-icon-button
             .tag=${tag}

--- a/src/panels/config/users/ha-config-users.ts
+++ b/src/panels/config/users/ha-config-users.ts
@@ -120,6 +120,9 @@ export class HaConfigUsers extends LitElement {
         },
         icons: {
           title: "",
+          label: this.hass.localize(
+            "ui.panel.config.users.picker.headers.icon"
+          ),
           type: "icon",
           sortable: false,
           filterable: false,

--- a/src/panels/lovelace/editor/card-editor/hui-entity-picker-table.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-entity-picker-table.ts
@@ -50,6 +50,9 @@ export class HuiEntityPickerTable extends LitElement {
     const columns: DataTableColumnContainer = {
       icon: {
         title: "",
+        label: this.hass!.localize(
+          "ui.panel.lovelace.unused_entities.state_icon"
+        ),
         type: "icon",
         template: (_icon, entity: any) => html`
           <state-badge

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1272,6 +1272,7 @@
           },
           "picker": {
             "headers": {
+              "icon": "Icon",
               "name": "Name",
               "entity_id": "Entity ID",
               "type": "Type",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1928,7 +1928,8 @@
             "edit_script": "Edit script",
             "dev_script": "Debug script",
             "headers": {
-              "name": "Name"
+              "name": "Name",
+              "state": "State"
             },
             "duplicate_script": "Duplicate script",
             "duplicate": "[%key:ui::panel::config::automation::picker::duplicate%]"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2568,7 +2568,8 @@
               "group": "Group",
               "system": "System",
               "is_active": "Active",
-              "local": "Local"
+              "local": "Local",
+              "icon": "Icon"
             },
             "add_user": "Add user"
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1519,7 +1519,10 @@
             "duplicate_automation": "Duplicate automation",
             "duplicate": "Duplicate",
             "headers": {
-              "name": "Name"
+              "toggle": "Enable/disable",
+              "name": "Name",
+              "trigger": "Trigger",
+              "actions": "Actions"
             }
           },
           "dialog_new": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1071,8 +1071,10 @@
           "confirm_remove": "Are you sure you want to remove tag {tag}?",
           "automation_title": "Tag {name} is scanned",
           "headers": {
+            "icon": "Icon",
             "name": "Name",
-            "last_scanned": "Last scanned"
+            "last_scanned": "Last scanned",
+            "write": "Write"
           },
           "detail": {
             "new_tag": "New tag",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3206,6 +3206,7 @@
           "title": "Unused entities",
           "available_entities": "These are the entities that you have available, but are not in your Lovelace UI yet.",
           "select_to_add": "Select the entities you want to add to a card and then click the add card button.",
+          "state_icon": "State",
           "entity": "Entity",
           "entity_id": "Entity ID",
           "domain": "Domain",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2339,7 +2339,7 @@
               "ok": "Ok"
             },
             "headers": {
-              "icon": "Icon",
+              "state_icon": "State icon",
               "name": "Name",
               "entity_id": "Entity ID",
               "integration": "Integration",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2298,6 +2298,7 @@
             "area": "Area",
             "integration": "Integration",
             "battery": "Battery",
+            "disabled_by": "Disabled",
             "no_devices": "No devices",
             "no_integration": "No integration"
           },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1377,12 +1377,14 @@
             },
             "picker": {
               "headers": {
+                "icon": "Icon",
                 "title": "Title",
                 "conf_mode": "Configuration method",
                 "default": "Default",
                 "require_admin": "Admin only",
                 "sidebar": "Show in sidebar",
-                "filename": "Filename"
+                "filename": "Filename",
+                "url": "Open"
               },
               "open": "Open",
               "add_dashboard": "Add dashboard"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2337,6 +2337,7 @@
               "ok": "Ok"
             },
             "headers": {
+              "icon": "Icon",
               "name": "Name",
               "entity_id": "Entity ID",
               "integration": "Integration",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1993,7 +1993,11 @@
             "duplicate_scene": "Duplicate scene",
             "duplicate": "Duplicate",
             "headers": {
-              "name": "Name"
+              "activate": "Activate",
+              "state": "State",
+              "name": "Name",
+              "show_info": "Show information",
+              "edit": "Edit"
             }
           },
           "editor": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Some table headers, especialy in different configurations, has no visible title which produce empty cells.
Empty cells could cause somme issues for screen readers users I.E. NVDA.
Using aria-label attribute for these headers allows having content for screen readers which is invisible on screen, adding an `aria-label` property to `ha-data-table` allows to add them on config parts which have empty headers.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #6487
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
