### PR TITLE
Conditions state_filter support

### DIFF
--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -1,5 +1,21 @@
 import { HassEntity } from "home-assistant-js-websocket";
 
+export const validFilter = (filter: any): boolean => {
+  if (typeof filter === "string") {
+    return true;
+  }
+
+  if (Array.isArray(filter)) {
+    return filter.every((f) => typeof f === "string");
+  }
+
+  if (typeof filter === "object") {
+    return !!filter.value;
+  }
+
+  return false;
+};
+
 export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
   const operator = filter.operator || "==";
   let value = filter.value ?? filter;

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -1,10 +1,11 @@
-import { UNAVAILABLE } from "../../../data/entity";
 import { HomeAssistant } from "../../../types";
+import { evaluateFilter, validFilter } from "./evaluate-filter";
 
 export interface Condition {
   entity: string;
-  state?: string;
-  state_not?: string;
+  state?: string | string[] | any[];
+  state_not?: string | string[];
+  state_filter?: Array<{ key: string } | string>;
 }
 
 export function checkConditionsMet(
@@ -12,18 +13,45 @@ export function checkConditionsMet(
   hass: HomeAssistant
 ): boolean {
   return conditions.every((c) => {
-    const state = hass.states[c.entity]
-      ? hass!.states[c.entity].state
-      : UNAVAILABLE;
-
-    return c.state != null ? state === c.state : state !== c.state_not;
+    const stateObj = hass.states[c.entity];
+    if (!stateObj) {
+      return false;
+    }
+    if (
+      c.state_filter &&
+      !c.state_filter.some((f) => evaluateFilter(stateObj, f))
+    ) {
+      return false;
+    }
+    if (c.state != null && c.state !== stateObj.state) {
+      return false;
+    }
+    if (c.state_not != null && c.state_not === stateObj.state) {
+      return false;
+    }
+    return true;
   });
 }
 
 export function validateConditionalConfig(conditions: Condition[]): boolean {
-  return conditions.every(
-    (c) =>
-      (c.entity &&
-        (c.state != null || c.state_not != null)) as unknown as boolean
-  );
+  return conditions.every((c) => {
+    if (!c.entity) {
+      return false;
+    }
+    if (c.state != null && typeof c.state !== "string") {
+      return false;
+    }
+    if (c.state_not != null && typeof c.state_not !== "string") {
+      return false;
+    }
+    if (c.state_filter) {
+      if (!Array.isArray(c.state_filter)) {
+        return false;
+      }
+      if (!c.state_filter.some((f) => validFilter(f))) {
+        return false;
+      }
+    }
+    return true;
+  });
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Support state_filter for conditional cards. This behaves the same as entity-filter.

I think eventually state and state_not should probably be removed, but that would be an ugly breaking change.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: conditional
conditions:
  - entity: button.broadlink_mini_loxjie_display
    state_filter:
      - operator: 'in'
        value:
          - unavailable
          - jlkas
card:
  type: button
  tap_action:
    action: toggle
  entity: switch.test1
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Solves this feature request: https://github.com/home-assistant/frontend/discussions/9809
- Documentation update: https://github.com/home-assistant/home-assistant.io/pull/21519

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
