### PR TITLE
Make zwave_js config panel inclusion state aware

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -2,6 +2,19 @@ import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { HomeAssistant } from "../types";
 import { DeviceRegistryEntry } from "./device_registry";
 
+export enum InclusionState {
+  /** The controller isn't doing anything regarding inclusion. */
+  Idle,
+  /** The controller is waiting for a node to be included. */
+  Including,
+  /** The controller is waiting for a node to be excluded. */
+  Excluding,
+  /** The controller is busy including or excluding a node. */
+  Busy,
+  /** The controller listening for SmartStart nodes to announce themselves. */
+  SmartStart,
+}
+
 export const enum InclusionStrategy {
   /**
    * Always uses Security S2 if supported, otherwise uses Security S0 for certain devices which don't work without encryption and uses no encryption otherwise.
@@ -113,9 +126,26 @@ export interface ZWaveJSClient {
 }
 
 export interface ZWaveJSController {
-  home_id: string;
-  nodes: number[];
+  home_id: number;
+  library_version: string;
+  type: number;
+  own_node_id: number;
+  is_secondary: boolean;
+  is_using_home_id_from_other_network: boolean;
+  is_sis_present: boolean;
+  was_real_primary: boolean;
+  is_static_update_controller: boolean;
+  is_slave: boolean;
+  serial_api_version: string;
+  manufacturer_id: number;
+  product_id: number;
+  product_type: number;
+  supported_function_types: number[];
+  suc_node_id: number;
+  supports_timers: boolean;
   is_heal_network_active: boolean;
+  inclusion_state: InclusionState;
+  nodes: number[];
 }
 
 export interface ZWaveJSNodeStatus {
@@ -305,6 +335,12 @@ export const subscribeAddZwaveNode = (
 export const stopZwaveInclusion = (hass: HomeAssistant, entry_id: string) =>
   hass.callWS({
     type: "zwave_js/stop_inclusion",
+    entry_id,
+  });
+
+export const stopZwaveExclusion = (hass: HomeAssistant, entry_id: string) =>
+  hass.callWS({
+    type: "zwave_js/stop_exclusion",
     entry_id,
   });
 

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -119,7 +119,7 @@ export interface ZWaveJSNetwork {
 }
 
 export interface ZWaveJSClient {
-  state: string;
+  state: "connected" | "disconnected";
   ws_server_url: string;
   server_version: string;
   driver_version: string;

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -118,13 +118,10 @@ class ZWaveJSConfigDashboard extends LitElement {
               InclusionState.Excluding)
             ? html`
                 <ha-alert alert-type="info">
-                  ${this._network?.controller.inclusion_state ===
+                  ${this.hass.localize(
+                        `ui.panel.config.zwave_js.common.${this._network.controller.inclusion_state ===
                   InclusionState.Including
-                    ? this.hass.localize(
-                        "ui.panel.config.zwave_js.common.inclusion_in_progress"
-                      )
-                    : this.hass.localize(
-                        "ui.panel.config.zwave_js.common.exclusion_in_progress"
+                    ? "inclusion" : "exclusion"}_in_progress`
                       )}
                   <mwc-button
                     slot="action"

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -63,7 +63,7 @@ class ZWaveJSConfigDashboard extends LitElement {
 
   @state() private _provisioningEntries?: ZwaveJSProvisioningEntry[];
 
-  @state() private _status = "unknown";
+  @state() private _status = "connected" || "disconnected";
 
   @state() private _icon = mdiCircle;
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -125,13 +125,10 @@ class ZWaveJSConfigDashboard extends LitElement {
                       )}
                   <mwc-button
                     slot="action"
-                    .label=${this._network?.controller.inclusion_state ===
-                    InclusionState.Including
-                      ? this.hass.localize(
-                          "ui.panel.config.zwave_js.common.cancel_inclusion"
-                        )
-                      : this.hass.localize(
-                          "ui.panel.config.zwave_js.common.cancel_exclusion"
+                    .label=${this.hass.localize(
+                          `ui.panel.config.zwave_js.common.cancel_${this._network.controller.inclusion_state ===
+                  InclusionState.Including
+                    ? "inclusion" : "exclusion"}`
                         )}
                     @click=${this._network?.controller.inclusion_state ===
                     InclusionState.Including

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -120,22 +120,12 @@ class ZWaveJSConfigDashboard extends LitElement {
             ? html`
                 <ha-alert alert-type="info">
                   ${this.hass.localize(
-                    `ui.panel.config.zwave_js.common.${
-                      this._network.controller.inclusion_state ===
-                      InclusionState.Including
-                        ? "inclusion"
-                        : "exclusion"
-                    }_in_progress`
+                    `ui.panel.config.zwave_js.common.in_progress_inclusion_exclusion`
                   )}
                   <mwc-button
                     slot="action"
                     .label=${this.hass.localize(
-                      `ui.panel.config.zwave_js.common.cancel_${
-                        this._network.controller.inclusion_state ===
-                        InclusionState.Including
-                          ? "inclusion"
-                          : "exclusion"
-                      }`
+                      `ui.panel.config.zwave_js.common.cancel_inclusion_exclusion`
                     )}
                     @click=${this._network?.controller.inclusion_state ===
                     InclusionState.Including

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -23,6 +23,7 @@ import {
   setZwaveDataCollectionPreference,
   stopZwaveExclusion,
   stopZwaveInclusion,
+  ZWaveJSClient,
   ZWaveJSNetwork,
   ZWaveJSNodeStatus,
   ZwaveJSProvisioningEntry,
@@ -63,7 +64,7 @@ class ZWaveJSConfigDashboard extends LitElement {
 
   @state() private _provisioningEntries?: ZwaveJSProvisioningEntry[];
 
-  @state() private _status = "connected" || "disconnected";
+  @state() private _status?: ZWaveJSClient["state"];
 
   @state() private _icon = mdiCircle;
 
@@ -159,7 +160,7 @@ class ZWaveJSConfigDashboard extends LitElement {
                               <ha-svg-icon
                                 .path=${this._icon}
                                 class="network-status-icon ${classMap({
-                                  [this._status]: true,
+                                  [this._status!]: true,
                                 })}"
                                 slot="item-icon"
                               ></ha-svg-icon>

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -304,6 +304,19 @@ class ZWaveJSConfigDashboard extends LitElement {
               `
             : ``}
         </ha-config-section>
+        <ha-fab
+          slot="fab"
+          .label=${this.hass.localize(
+            "ui.panel.config.zwave_js.common.add_node"
+          )}
+          extended
+          ?rtl=${computeRTL(this.hass)}
+          @click=${this._addNodeClicked}
+          .disabled=${this._status !== "connected" ||
+          this._network?.controller.inclusion_state !== InclusionState.Idle}
+        >
+          <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
+        </ha-fab>
         ${this._status === "connected" &&
         this._network?.controller.inclusion_state === InclusionState.Idle
           ? html`

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -119,17 +119,23 @@ class ZWaveJSConfigDashboard extends LitElement {
             ? html`
                 <ha-alert alert-type="info">
                   ${this.hass.localize(
-                        `ui.panel.config.zwave_js.common.${this._network.controller.inclusion_state ===
-                  InclusionState.Including
-                    ? "inclusion" : "exclusion"}_in_progress`
-                      )}
+                    `ui.panel.config.zwave_js.common.${
+                      this._network.controller.inclusion_state ===
+                      InclusionState.Including
+                        ? "inclusion"
+                        : "exclusion"
+                    }_in_progress`
+                  )}
                   <mwc-button
                     slot="action"
                     .label=${this.hass.localize(
-                          `ui.panel.config.zwave_js.common.cancel_${this._network.controller.inclusion_state ===
-                  InclusionState.Including
-                    ? "inclusion" : "exclusion"}`
-                        )}
+                      `ui.panel.config.zwave_js.common.cancel_${
+                        this._network.controller.inclusion_state ===
+                        InclusionState.Including
+                          ? "inclusion"
+                          : "exclusion"
+                      }`
+                    )}
                     @click=${this._network?.controller.inclusion_state ===
                     InclusionState.Including
                       ? this._cancelInclusion
@@ -237,17 +243,16 @@ class ZWaveJSConfigDashboard extends LitElement {
                     ${this._network.client.ws_server_url}<br />
                   </div>
                   <div class="card-actions">
-                    ${this._status === "connected" &&
-                    this._network?.controller.inclusion_state ===
-                      InclusionState.Idle
-                      ? html`
-                          <mwc-button @click=${this._removeNodeClicked}>
-                            ${this.hass.localize(
-                              "ui.panel.config.zwave_js.common.remove_node"
-                            )}
-                          </mwc-button>
-                        `
-                      : ""}
+                    <mwc-button
+                      @click=${this._removeNodeClicked}
+                      .disabled=${this._status !== "connected" ||
+                      this._network?.controller.inclusion_state !==
+                        InclusionState.Idle}
+                    >
+                      ${this.hass.localize(
+                        "ui.panel.config.zwave_js.common.remove_node"
+                      )}
+                    </mwc-button>
                     <mwc-button
                       @click=${this._healNetworkClicked}
                       .disabled=${this._status === "disconnected"}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -317,22 +317,6 @@ class ZWaveJSConfigDashboard extends LitElement {
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
         </ha-fab>
-        ${this._status === "connected" &&
-        this._network?.controller.inclusion_state === InclusionState.Idle
-          ? html`
-              <ha-fab
-                slot="fab"
-                .label=${this.hass.localize(
-                  "ui.panel.config.zwave_js.common.add_node"
-                )}
-                extended
-                ?rtl=${computeRTL(this.hass)}
-                @click=${this._addNodeClicked}
-              >
-                <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
-              </ha-fab>
-            `
-          : ""}
       </hass-tabs-subpage>
     `;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2923,7 +2923,11 @@
             "add_node": "Add device",
             "remove_node": "Remove device",
             "reconfigure_server": "Re-configure Server",
-            "heal_network": "Heal Network"
+            "heal_network": "Heal Network",
+            "cancel_inclusion": "Cancel Inclusion",
+            "inclusion_in_progress": "Inclusion in progress",
+            "cancel_exclusion": "Cancel Exclusion",
+            "exclusion_in_progress": "Exclusion in progress"
           },
           "dashboard": {
             "header": "Manage your Z-Wave Network",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2924,10 +2924,8 @@
             "remove_node": "Remove device",
             "reconfigure_server": "Re-configure Server",
             "heal_network": "Heal Network",
-            "cancel_inclusion": "Cancel Inclusion",
-            "inclusion_in_progress": "Inclusion in progress",
-            "cancel_exclusion": "Cancel Exclusion",
-            "exclusion_in_progress": "Exclusion in progress"
+            "in_progress_inclusion_exclusion": "Z-Wave JS is searching for devices",
+            "cancel_inclusion_exclusion": "Stop Searching"
           },
           "dashboard": {
             "header": "Manage your Z-Wave Network",


### PR DESCRIPTION
## Proposed change
Related to https://github.com/home-assistant/core/pull/65398

This code probably needs some work as it feels a bit hacked together, but the end result is that when a user loads the `zwave_js` config panel while an inclusion/exclusion is in progress, the buttons to add and remove devices disappear and an alert is shown with an option to cancel (see screenshot below). A couple of things to consider/improve:

1. If you cancel the inclusion/exclusion from the alert, you have to press it twice before the frontend re-renders and the buttons come back. I hope there's a simple way to fix this.
2. There are more inclusion state's beyond Idle, Including, and Excluding. But you can only cancel on Including or Excluding. I can probably fix this up so the alert shows but the button doesn't or is disabled, I just thought it would add more complexity and wanted to hear back on another approach if needed before fixing it.

![image](https://user-images.githubusercontent.com/7243222/152624932-e688a617-2c6c-404d-be5c-fb24e515a717.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
