### PR TITLE
Set initial focus for device, area, and entity dialogs

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -164,6 +164,7 @@ export class MoreInfoDialog extends LitElement {
                     .label=${this.hass.localize(
                       "ui.dialogs.more_info_control.details"
                     )}
+                    dialogInitialFocus
                   ></mwc-tab>
                   <mwc-tab
                     .label=${this.hass.localize(
@@ -174,7 +175,7 @@ export class MoreInfoDialog extends LitElement {
               `
             : ""}
         </div>
-        <div class="content">
+        <div class="content" tabindex="-1" dialogInitialFocus>
           ${cache(
             this._currTabIndex === 0
               ? html`

--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -92,6 +92,7 @@ class DialogAreaDetail extends LitElement {
                 "ui.panel.config.areas.editor.name_required"
               )}
               .invalid=${nameInvalid}
+              dialogInitialFocus
             ></paper-input>
             <ha-picture-upload
               .hass=${this.hass}

--- a/src/panels/config/devices/device-registry-detail/dialog-device-registry-detail.ts
+++ b/src/panels/config/devices/device-registry-detail/dialog-device-registry-detail.ts
@@ -68,6 +68,7 @@ class DialogDeviceRegistryDetail extends LitElement {
               .label=${this.hass.localize("ui.panel.config.devices.name")}
               .placeholder=${device.name || ""}
               .disabled=${this._submitting}
+              dialogInitialFocus
             ></paper-input>
             <ha-area-picker
               .hass=${this.hass}

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -115,6 +115,7 @@ export class DialogEntityEditor extends LitElement {
               .label=${this.hass.localize(
                 "ui.dialogs.entity_registry.settings"
               )}
+              dialogInitialFocus
             >
             </mwc-tab>
             ${Object.entries(this._extraTabs).map(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
| Dialog Module | Initial Focus |
|:------ |:----:|
| dialog-area-registry-detail | Name field |
| dialog-device-registry-detail | Name field |
| dialog-entity-editor | Settings tab |
| ha-more-info-dialog | Details tab if present, otherwise content |

_There are 71 dialogs in the UI, the majority of which need initial focus set, so this will be the first of several pull requests._

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR partially fixes or closes issue: #10754 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

