### PR TITLE
Migrate a bunch of paper-dropdowns

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -945,6 +945,7 @@ export class HaDataTable extends LitElement {
         }
         .scroller {
           height: calc(100% - 57px);
+          overflow: overlay !important;
         }
 
         .mdc-data-table__table.auto-height .scroller {

--- a/src/components/ha-blueprint-picker.ts
+++ b/src/components/ha-blueprint-picker.ts
@@ -1,10 +1,10 @@
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
+import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-select/mwc-select";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../common/dom/fire_event";
+import { stopPropagation } from "../common/dom/stop_propagation";
 import { stringCompare } from "../common/string/compare";
 import { Blueprint, Blueprints, fetchBlueprints } from "../data/blueprint";
 import { HomeAssistant } from "../types";
@@ -24,7 +24,11 @@ class HaBluePrintPicker extends LitElement {
   @property({ type: Boolean }) public disabled = false;
 
   public open() {
-    this.shadowRoot!.querySelector("paper-dropdown-menu-light")!.open();
+    const select = this.shadowRoot?.querySelector("mwc-select");
+    if (select) {
+      // @ts-expect-error
+      select.menuOpen = true;
+    }
   }
 
   private _processedBlueprints = memoizeOne((blueprints?: Blueprints) => {
@@ -45,32 +49,29 @@ class HaBluePrintPicker extends LitElement {
       return html``;
     }
     return html`
-      <paper-dropdown-menu-light
+      <mwc-select
         .label=${this.label ||
         this.hass.localize("ui.components.blueprint-picker.label")}
+        fixedMenuPosition
+        naturalMenuWidth
+        .value=${this.value}
         .disabled=${this.disabled}
-        horizontal-align="left"
+        @selected=${this._blueprintChanged}
+        @closed=${stopPropagation}
       >
-        <paper-listbox
-          slot="dropdown-content"
-          .selected=${this.value}
-          attr-for-selected="data-blueprint-path"
-          @iron-select=${this._blueprintChanged}
-        >
-          <paper-item data-blueprint-path="">
-            ${this.hass.localize(
-              "ui.components.blueprint-picker.select_blueprint"
-            )}
-          </paper-item>
-          ${this._processedBlueprints(this.blueprints).map(
-            (blueprint) => html`
-              <paper-item data-blueprint-path=${blueprint.path}>
-                ${blueprint.name}
-              </paper-item>
-            `
+        <mwc-list-item value="">
+          ${this.hass.localize(
+            "ui.components.blueprint-picker.select_blueprint"
           )}
-        </paper-listbox>
-      </paper-dropdown-menu-light>
+        </mwc-list-item>
+        ${this._processedBlueprints(this.blueprints).map(
+          (blueprint) => html`
+            <mwc-list-item .value=${blueprint.path}>
+              ${blueprint.name}
+            </mwc-list-item>
+          `
+        )}
+      </mwc-select>
     `;
   }
 
@@ -84,10 +85,10 @@ class HaBluePrintPicker extends LitElement {
   }
 
   private _blueprintChanged(ev) {
-    const newValue = ev.detail.item.dataset.blueprintPath;
+    const newValue = ev.target.value;
 
     if (newValue !== this.value) {
-      this.value = ev.detail.value;
+      this.value = newValue;
       setTimeout(() => {
         fireEvent(this, "value-changed", { value: newValue });
         fireEvent(this, "change");
@@ -100,14 +101,10 @@ class HaBluePrintPicker extends LitElement {
       :host {
         display: inline-block;
       }
-      paper-dropdown-menu-light {
+      mwc-select {
         width: 100%;
         min-width: 200px;
         display: block;
-      }
-      paper-item {
-        cursor: pointer;
-        min-width: 200px;
       }
     `;
   }

--- a/src/components/ha-combo-box.ts
+++ b/src/components/ha-combo-box.ts
@@ -209,7 +209,6 @@ export class HaComboBox extends LitElement {
       :host {
         display: block;
         width: 100%;
-        margin-top: 4px;
       }
       vaadin-combo-box-light {
         position: relative;

--- a/src/components/user/ha-user-picker.ts
+++ b/src/components/user/ha-user-picker.ts
@@ -1,8 +1,3 @@
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
-import "@polymer/paper-input/paper-input";
-import "@polymer/paper-item/paper-icon-item";
-import "@polymer/paper-item/paper-item-body";
-import "@polymer/paper-listbox/paper-listbox";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { property } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -11,6 +6,8 @@ import { stringCompare } from "../../common/string/compare";
 import { fetchUsers, User } from "../../data/user";
 import { HomeAssistant } from "../../types";
 import "./ha-user-badge";
+import "@material/mwc-select/mwc-select";
+import "@material/mwc-list/mwc-list-item";
 
 class HaUserPicker extends LitElement {
   public hass?: HomeAssistant;
@@ -37,34 +34,31 @@ class HaUserPicker extends LitElement {
 
   protected render(): TemplateResult {
     return html`
-      <paper-dropdown-menu-light
+      <mwc-select
         .label=${this.label}
         .disabled=${this.disabled}
+        .value=${this.value}
+        @selected=${this._userChanged}
       >
-        <paper-listbox
-          slot="dropdown-content"
-          .selected=${this.value}
-          attr-for-selected="data-user-id"
-          @iron-select=${this._userChanged}
-        >
-          <paper-icon-item data-user-id="">
-            ${this.noUserLabel ||
-            this.hass?.localize("ui.components.user-picker.no_user")}
-          </paper-icon-item>
-          ${this._sortedUsers(this.users).map(
-            (user) => html`
-              <paper-icon-item data-user-id=${user.id}>
-                <ha-user-badge
-                  .hass=${this.hass}
-                  .user=${user}
-                  slot="item-icon"
-                ></ha-user-badge>
-                ${user.name}
-              </paper-icon-item>
-            `
-          )}
-        </paper-listbox>
-      </paper-dropdown-menu-light>
+        ${this.users?.length === 0
+          ? html`<mwc-list-item value="">
+              ${this.noUserLabel ||
+              this.hass?.localize("ui.components.user-picker.no_user")}
+            </mwc-list-item>`
+          : ""}
+        ${this._sortedUsers(this.users).map(
+          (user) => html`
+            <mwc-list-item graphic="avatar" .value=${user.id}>
+              <ha-user-badge
+                .hass=${this.hass}
+                .user=${user}
+                slot="graphic"
+              ></ha-user-badge>
+              ${user.name}
+            </mwc-list-item>
+          `
+        )}
+      </mwc-select>
     `;
   }
 
@@ -78,10 +72,10 @@ class HaUserPicker extends LitElement {
   }
 
   private _userChanged(ev) {
-    const newValue = ev.detail.item.dataset.userId;
+    const newValue = ev.target.value;
 
     if (newValue !== this.value) {
-      this.value = ev.detail.value;
+      this.value = newValue;
       setTimeout(() => {
         fireEvent(this, "value-changed", { value: newValue });
         fireEvent(this, "change");
@@ -94,14 +88,8 @@ class HaUserPicker extends LitElement {
       :host {
         display: inline-block;
       }
-      paper-dropdown-menu-light {
+      mwc-list {
         display: block;
-      }
-      paper-listbox {
-        min-width: 200px;
-      }
-      paper-icon-item {
-        cursor: pointer;
       }
     `;
   }

--- a/src/components/user/ha-users-picker.ts
+++ b/src/components/user/ha-users-picker.ts
@@ -75,7 +75,7 @@ class HaUsersPickerLight extends LitElement {
         )
       )}
       <ha-user-picker
-        .noUserLabel=${this.pickUserLabel ||
+        .label=${this.pickUserLabel ||
         this.hass!.localize("ui.components.user-picker.add_user")}
         .hass=${this.hass}
         .users=${notSelectedUsers}

--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -1,7 +1,4 @@
 import "@material/mwc-button";
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
@@ -121,13 +118,6 @@ class StepFlowCreateEntry extends LitElement {
         }
         .buttons > *:last-child {
           margin-left: auto;
-        }
-        paper-dropdown-menu-light {
-          cursor: pointer;
-        }
-        paper-item {
-          cursor: pointer;
-          white-space: nowrap;
         }
         @media all and (max-width: 450px), all and (max-height: 500px) {
           .device {

--- a/src/dialogs/more-info/controls/more-info-climate.ts
+++ b/src/dialogs/more-info/controls/more-info-climate.ts
@@ -1,6 +1,3 @@
-import "@polymer/iron-flex-layout/iron-flex-layout-classes";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import {
   css,
   CSSResultGroup,
@@ -15,7 +12,6 @@ import { fireEvent } from "../../../common/dom/fire_event";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import { computeRTLDirection } from "../../../common/util/compute_rtl";
 import "../../../components/ha-climate-control";
-import "../../../components/ha-paper-dropdown-menu";
 import "../../../components/ha-slider";
 import "../../../components/ha-switch";
 import {
@@ -30,6 +26,9 @@ import {
   compareClimateHvacModes,
 } from "../../../data/climate";
 import { HomeAssistant } from "../../../types";
+import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-select/mwc-select";
+import { stopPropagation } from "../../../common/dom/stop_propagation";
 
 class MoreInfoClimate extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -169,109 +168,93 @@ class MoreInfoClimate extends LitElement {
 
         <div class="container-hvac_modes">
           <div class="controls">
-            <ha-paper-dropdown-menu
-              label-float
-              dynamic-align
+            <mwc-select
               .label=${hass.localize("ui.card.climate.operation")}
+              .value=${stateObj.state}
+              fixedMenuPosition
+              naturalMenuWidth
+              @selected=${this._handleOperationmodeChanged}
+              @closed=${stopPropagation}
             >
-              <paper-listbox
-                slot="dropdown-content"
-                attr-for-selected="item-name"
-                .selected=${stateObj.state}
-                @selected-changed=${this._handleOperationmodeChanged}
-              >
-                ${stateObj.attributes.hvac_modes
-                  .concat()
-                  .sort(compareClimateHvacModes)
-                  .map(
-                    (mode) => html`
-                      <paper-item item-name=${mode}>
-                        ${hass.localize(`component.climate.state._.${mode}`)}
-                      </paper-item>
-                    `
-                  )}
-              </paper-listbox>
-            </ha-paper-dropdown-menu>
+              ${stateObj.attributes.hvac_modes
+                .concat()
+                .sort(compareClimateHvacModes)
+                .map(
+                  (mode) => html`
+                    <mwc-list-item .value=${mode}>
+                      ${hass.localize(`component.climate.state._.${mode}`)}
+                    </mwc-list-item>
+                  `
+                )}
+            </mwc-select>
           </div>
         </div>
 
         ${supportPresetMode && stateObj.attributes.preset_modes
           ? html`
               <div class="container-preset_modes">
-                <ha-paper-dropdown-menu
-                  label-float
-                  dynamic-align
+                <mwc-select
                   .label=${hass.localize("ui.card.climate.preset_mode")}
+                  .value=${stateObj.attributes.preset_mode}
+                  fixedMenuPosition
+                  naturalMenuWidth
+                  @selected=${this._handlePresetmodeChanged}
+                  @closed=${stopPropagation}
                 >
-                  <paper-listbox
-                    slot="dropdown-content"
-                    attr-for-selected="item-name"
-                    .selected=${stateObj.attributes.preset_mode}
-                    @selected-changed=${this._handlePresetmodeChanged}
-                  >
-                    ${stateObj.attributes.preset_modes!.map(
-                      (mode) => html`
-                        <paper-item item-name=${mode}>
-                          ${hass.localize(
-                            `state_attributes.climate.preset_mode.${mode}`
-                          ) || mode}
-                        </paper-item>
-                      `
-                    )}
-                  </paper-listbox>
-                </ha-paper-dropdown-menu>
+                  ${stateObj.attributes.preset_modes!.map(
+                    (mode) => html`
+                      <mwc-list-item .value=${mode}>
+                        ${hass.localize(
+                          `state_attributes.climate.preset_mode.${mode}`
+                        ) || mode}
+                      </mwc-list-item>
+                    `
+                  )}
+                </mwc-select>
               </div>
             `
           : ""}
         ${supportFanMode && stateObj.attributes.fan_modes
           ? html`
               <div class="container-fan_list">
-                <ha-paper-dropdown-menu
-                  label-float
-                  dynamic-align
+                <mwc-select
                   .label=${hass.localize("ui.card.climate.fan_mode")}
+                  .value=${stateObj.attributes.fan_mode}
+                  fixedMenuPosition
+                  naturalMenuWidth
+                  @selected=${this._handleFanmodeChanged}
+                  @closed=${stopPropagation}
                 >
-                  <paper-listbox
-                    slot="dropdown-content"
-                    attr-for-selected="item-name"
-                    .selected=${stateObj.attributes.fan_mode}
-                    @selected-changed=${this._handleFanmodeChanged}
-                  >
-                    ${stateObj.attributes.fan_modes!.map(
-                      (mode) => html`
-                        <paper-item item-name=${mode}>
-                          ${hass.localize(
-                            `state_attributes.climate.fan_mode.${mode}`
-                          ) || mode}
-                        </paper-item>
-                      `
-                    )}
-                  </paper-listbox>
-                </ha-paper-dropdown-menu>
+                  ${stateObj.attributes.fan_modes!.map(
+                    (mode) => html`
+                      <mwc-list-item .value=${mode}>
+                        ${hass.localize(
+                          `state_attributes.climate.fan_mode.${mode}`
+                        ) || mode}
+                      </mwc-list-item>
+                    `
+                  )}
+                </mwc-select>
               </div>
             `
           : ""}
         ${supportSwingMode && stateObj.attributes.swing_modes
           ? html`
               <div class="container-swing_list">
-                <ha-paper-dropdown-menu
-                  label-float
-                  dynamic-align
+                <mwc-select
                   .label=${hass.localize("ui.card.climate.swing_mode")}
+                  .value=${stateObj.attributes.swing_mode}
+                  fixedMenuPosition
+                  naturalMenuWidth
+                  @selected=${this._handleSwingmodeChanged}
+                  @closed=${stopPropagation}
                 >
-                  <paper-listbox
-                    slot="dropdown-content"
-                    attr-for-selected="item-name"
-                    .selected=${stateObj.attributes.swing_mode}
-                    @selected-changed=${this._handleSwingmodeChanged}
-                  >
-                    ${stateObj.attributes.swing_modes!.map(
-                      (mode) => html`
-                        <paper-item item-name=${mode}>${mode}</paper-item>
-                      `
-                    )}
-                  </paper-listbox>
-                </ha-paper-dropdown-menu>
+                  ${stateObj.attributes.swing_modes!.map(
+                    (mode) => html`
+                      <mwc-list-item .value=${mode}>${mode}</mwc-list-item>
+                    `
+                  )}
+                </mwc-select>
               </div>
             `
           : ""}
@@ -366,7 +349,7 @@ class MoreInfoClimate extends LitElement {
   }
 
   private _handleFanmodeChanged(ev) {
-    const newVal = ev.detail.value;
+    const newVal = ev.target.value;
     this._callServiceHelper(
       this.stateObj!.attributes.fan_mode,
       newVal,
@@ -376,14 +359,14 @@ class MoreInfoClimate extends LitElement {
   }
 
   private _handleOperationmodeChanged(ev) {
-    const newVal = ev.detail.value;
+    const newVal = ev.target.value;
     this._callServiceHelper(this.stateObj!.state, newVal, "set_hvac_mode", {
       hvac_mode: newVal,
     });
   }
 
   private _handleSwingmodeChanged(ev) {
-    const newVal = ev.detail.value;
+    const newVal = ev.target.value;
     this._callServiceHelper(
       this.stateObj!.attributes.swing_mode,
       newVal,
@@ -393,7 +376,7 @@ class MoreInfoClimate extends LitElement {
   }
 
   private _handlePresetmodeChanged(ev) {
-    const newVal = ev.detail.value || null;
+    const newVal = ev.target.value || null;
     this._callServiceHelper(
       this.stateObj!.attributes.preset_mode,
       newVal,
@@ -444,12 +427,9 @@ class MoreInfoClimate extends LitElement {
         color: var(--primary-text-color);
       }
 
-      ha-paper-dropdown-menu {
+      mwc-select {
         width: 100%;
-      }
-
-      paper-item {
-        cursor: pointer;
+        margin-top: 8px;
       }
 
       ha-slider {
@@ -488,3 +468,9 @@ class MoreInfoClimate extends LitElement {
 }
 
 customElements.define("more-info-climate", MoreInfoClimate);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "more-info-climate": MoreInfoClimate;
+  }
+}

--- a/src/dialogs/more-info/controls/more-info-fan.js
+++ b/src/dialogs/more-info/controls/more-info-fan.js
@@ -1,6 +1,4 @@
 import "@polymer/iron-flex-layout/iron-flex-layout-classes";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
 /* eslint-plugin-disable lit */
 import { PolymerElement } from "@polymer/polymer/polymer-element";
@@ -10,11 +8,12 @@ import "../../../components/ha-attributes";
 import "../../../components/ha-icon";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-labeled-slider";
-import "../../../components/ha-paper-dropdown-menu";
 import "../../../components/ha-switch";
 import { SUPPORT_SET_SPEED } from "../../../data/fan";
 import { EventsMixin } from "../../../mixins/events-mixin";
 import LocalizeMixin from "../../../mixins/localize-mixin";
+import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-select/mwc-select";
 
 /*
  * @appliesMixin EventsMixin
@@ -38,12 +37,8 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
           display: block;
         }
 
-        ha-paper-dropdown-menu {
+        mwc-select {
           width: 100%;
-        }
-
-        paper-item {
-          cursor: pointer;
         }
       </style>
 
@@ -62,25 +57,21 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
         </div>
 
         <div class="container-preset_modes">
-          <ha-paper-dropdown-menu
-            label-float=""
-            dynamic-align=""
+          <mwc-select
             label="[[localize('ui.card.fan.preset_mode')]]"
+            value="[[stateObj.attributes.preset_mode]]"
+            on-selected="presetModeChanged"
+            fixedMenuPosition
+            naturalMenuWidth
+            on-closed="stopPropagation"
           >
-            <paper-listbox
-              slot="dropdown-content"
-              selected="[[stateObj.attributes.preset_mode]]"
-              on-selected-changed="presetModeChanged"
-              attr-for-selected="item-name"
+            <template
+              is="dom-repeat"
+              items="[[stateObj.attributes.preset_modes]]"
             >
-              <template
-                is="dom-repeat"
-                items="[[stateObj.attributes.preset_modes]]"
-              >
-                <paper-item item-name$="[[item]]">[[item]]</paper-item>
-              </template>
-            </paper-listbox>
-          </ha-paper-dropdown-menu>
+              <mwc-list-item value="[[item]]">[[item]]</mwc-list-item>
+            </template>
+          </mwc-select>
         </div>
 
         <div class="container-oscillating">
@@ -180,7 +171,7 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   presetModeChanged(ev) {
     const oldVal = this.stateObj.attributes.preset_mode;
-    const newVal = ev.detail.value;
+    const newVal = ev.target.value;
 
     if (!newVal || oldVal === newVal) return;
 
@@ -188,6 +179,10 @@ class MoreInfoFan extends LocalizeMixin(EventsMixin(PolymerElement)) {
       entity_id: this.stateObj.entity_id,
       preset_mode: newVal,
     });
+  }
+
+  stopPropagation(ev) {
+    ev.stopPropagation();
   }
 
   percentageChanged(ev) {

--- a/src/dialogs/more-info/controls/more-info-humidifier.ts
+++ b/src/dialogs/more-info/controls/more-info-humidifier.ts
@@ -1,6 +1,3 @@
-import "@polymer/iron-flex-layout/iron-flex-layout-classes";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import {
   css,
   CSSResultGroup,
@@ -12,9 +9,9 @@ import {
 import { property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import { computeRTLDirection } from "../../../common/util/compute_rtl";
-import "../../../components/ha-paper-dropdown-menu";
 import "../../../components/ha-slider";
 import "../../../components/ha-switch";
 import {
@@ -22,6 +19,8 @@ import {
   HUMIDIFIER_SUPPORT_MODES,
 } from "../../../data/humidifier";
 import { HomeAssistant } from "../../../types";
+import "@material/mwc-list/mwc-list";
+import "@material/mwc-list/mwc-list-item";
 
 class MoreInfoHumidifier extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -69,28 +68,24 @@ class MoreInfoHumidifier extends LitElement {
         ${supportModes
           ? html`
               <div class="container-modes">
-                <ha-paper-dropdown-menu
-                  label-float
-                  dynamic-align
+                <mwc-list
                   .label=${hass.localize("ui.card.humidifier.mode")}
+                  .value=${stateObj.attributes.mode}
+                  fixedMenuPosition
+                  naturalMenuWidth
+                  @selected=${this._handleModeChanged}
+                  @closed=${stopPropagation}
                 >
-                  <paper-listbox
-                    slot="dropdown-content"
-                    attr-for-selected="item-name"
-                    .selected=${stateObj.attributes.mode}
-                    @selected-changed=${this._handleModeChanged}
-                  >
-                    ${stateObj.attributes.available_modes!.map(
-                      (mode) => html`
-                        <paper-item item-name=${mode}>
-                          ${hass.localize(
-                            `state_attributes.humidifier.mode.${mode}`
-                          ) || mode}
-                        </paper-item>
-                      `
-                    )}
-                  </paper-listbox>
-                </ha-paper-dropdown-menu>
+                  ${stateObj.attributes.available_modes!.map(
+                    (mode) => html`
+                      <mwc-list-item .value=${mode}>
+                        ${hass.localize(
+                          `state_attributes.humidifier.mode.${mode}`
+                        ) || mode}
+                      </mwc-list-item>
+                    `
+                  )}
+                </mwc-list>
               </div>
             `
           : ""}
@@ -124,7 +119,7 @@ class MoreInfoHumidifier extends LitElement {
   }
 
   private _handleModeChanged(ev) {
-    const newVal = ev.detail.value || null;
+    const newVal = ev.target.value || null;
     this._callServiceHelper(
       this.stateObj!.attributes.mode,
       newVal,
@@ -175,12 +170,8 @@ class MoreInfoHumidifier extends LitElement {
         color: var(--primary-text-color);
       }
 
-      ha-paper-dropdown-menu {
+      mwc-select {
         width: 100%;
-      }
-
-      paper-item {
-        cursor: pointer;
       }
 
       ha-slider {
@@ -207,3 +198,9 @@ class MoreInfoHumidifier extends LitElement {
 }
 
 customElements.define("more-info-humidifier", MoreInfoHumidifier);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "more-info-humidifier": MoreInfoHumidifier;
+  }
+}

--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -1,6 +1,6 @@
+import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-select/mwc-select";
 import { mdiPalette } from "@mdi/js";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import {
   css,
   CSSResultGroup,
@@ -11,13 +11,13 @@ import {
 } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-attributes";
 import "../../../components/ha-button-toggle-group";
 import "../../../components/ha-color-picker";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-labeled-slider";
-import "../../../components/ha-paper-dropdown-menu";
 import {
   getLightCurrentModeRgbColor,
   LightColorModes,
@@ -208,24 +208,22 @@ class MoreInfoLight extends LitElement {
               this.stateObj!.attributes.effect_list?.length
                 ? html`
                     <hr />
-                    <ha-paper-dropdown-menu
-                      dynamic-align
+                    <mwc-select
                       .label=${this.hass.localize("ui.card.light.effect")}
+                      .value=${this.stateObj.attributes.effect || ""}
+                      fixedMenuPosition
+                      naturalMenuWidth
+                      @selected=${this._effectChanged}
+                      @closed=${stopPropagation}
                     >
-                      <paper-listbox
-                        slot="dropdown-content"
-                        .selected=${this.stateObj.attributes.effect || ""}
-                        @iron-select=${this._effectChanged}
-                        attr-for-selected="item-name"
-                        >${this.stateObj.attributes.effect_list.map(
-                          (effect: string) => html`
-                            <paper-item .itemName=${effect}
-                              >${effect}</paper-item
-                            >
-                          `
-                        )}
-                      </paper-listbox>
-                    </ha-paper-dropdown-menu>
+                      ${this.stateObj.attributes.effect_list.map(
+                        (effect: string) => html`
+                          <mwc-list-item .value=${effect}>
+                            ${effect}
+                          </mwc-list-item>
+                        `
+                      )}
+                    </mwc-select>
                   `
                 : ""}
             `
@@ -322,8 +320,8 @@ class MoreInfoLight extends LitElement {
     this._mode = ev.detail.value;
   }
 
-  private _effectChanged(ev: CustomEvent) {
-    const newVal = ev.detail.item.itemName;
+  private _effectChanged(ev) {
+    const newVal = ev.target.value;
 
     if (!newVal || this.stateObj!.attributes.effect === newVal) {
       return;

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -1,4 +1,6 @@
 import "@material/mwc-button/mwc-button";
+import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-select/mwc-select";
 import {
   mdiLoginVariant,
   mdiMusicNote,
@@ -10,17 +12,15 @@ import {
   mdiVolumePlus,
 } from "@mdi/js";
 import "@polymer/paper-input/paper-input";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
+import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import { computeRTLDirection } from "../../../common/util/compute_rtl";
 import "../../../components/ha-icon-button";
-import "../../../components/ha-svg-icon";
-import "../../../components/ha-paper-dropdown-menu";
 import "../../../components/ha-slider";
+import "../../../components/ha-svg-icon";
 import { showMediaBrowserDialog } from "../../../components/media-player/show-media-browser-dialog";
 import { UNAVAILABLE, UNAVAILABLE_STATES, UNKNOWN } from "../../../data/entity";
 import {
@@ -139,23 +139,21 @@ class MoreInfoMediaPlayer extends LitElement {
                 class="source-input"
                 .path=${mdiLoginVariant}
               ></ha-svg-icon>
-              <ha-paper-dropdown-menu
+              <mwc-select
                 .label=${this.hass.localize("ui.card.media_player.source")}
+                .value=${stateObj.attributes.source!}
+                @selected=${this._handleSourceChanged}
+                fixedMenuPosition
+                naturalMenuWidth
+                @closed=${stopPropagation}
               >
-                <paper-listbox
-                  slot="dropdown-content"
-                  attr-for-selected="item-name"
-                  .selected=${stateObj.attributes.source!}
-                  @iron-select=${this._handleSourceChanged}
-                >
-                  ${stateObj.attributes.source_list!.map(
-                    (source) =>
-                      html`
-                        <paper-item .itemName=${source}>${source}</paper-item>
-                      `
-                  )}
-                </paper-listbox>
-              </ha-paper-dropdown-menu>
+                ${stateObj.attributes.source_list!.map(
+                  (source) =>
+                    html`
+                      <mwc-list-item .value=${source}>${source}</mwc-list-item>
+                    `
+                )}
+              </mwc-select>
             </div>
           `
         : ""}
@@ -164,24 +162,20 @@ class MoreInfoMediaPlayer extends LitElement {
         ? html`
             <div class="sound-input">
               <ha-svg-icon .path=${mdiMusicNote}></ha-svg-icon>
-              <ha-paper-dropdown-menu
-                dynamic-align
-                label-float
+              <mwc-select
                 .label=${this.hass.localize("ui.card.media_player.sound_mode")}
+                .value=${stateObj.attributes.sound_mode!}
+                fixedMenuPosition
+                naturalMenuWidth
+                @selected=${this._handleSoundModeChanged}
+                @closed=${stopPropagation}
               >
-                <paper-listbox
-                  slot="dropdown-content"
-                  attr-for-selected="item-name"
-                  .selected=${stateObj.attributes.sound_mode!}
-                  @iron-select=${this._handleSoundModeChanged}
-                >
-                  ${stateObj.attributes.sound_mode_list.map(
-                    (mode) => html`
-                      <paper-item .itemName=${mode}>${mode}</paper-item>
-                    `
-                  )}
-                </paper-listbox>
-              </ha-paper-dropdown-menu>
+                ${stateObj.attributes.sound_mode_list.map(
+                  (mode) => html`
+                    <mwc-list-item .value=${mode}>${mode}</mwc-list-item>
+                  `
+                )}
+              </mwc-select>
             </div>
           `
         : ""}
@@ -242,14 +236,10 @@ class MoreInfoMediaPlayer extends LitElement {
         margin-top: 24px;
       }
 
-      .source-input ha-paper-dropdown-menu,
-      .sound-input ha-paper-dropdown-menu {
+      .source-input mwc-select,
+      .sound-input mwc-select {
         margin-left: 10px;
         flex-grow: 1;
-      }
-
-      paper-item {
-        cursor: pointer;
       }
     `;
   }
@@ -279,8 +269,8 @@ class MoreInfoMediaPlayer extends LitElement {
     });
   }
 
-  private _handleSourceChanged(e: CustomEvent) {
-    const newVal = e.detail.item.itemName;
+  private _handleSourceChanged(e) {
+    const newVal = e.target.value;
 
     if (!newVal || this.stateObj!.attributes.source === newVal) {
       return;
@@ -292,8 +282,8 @@ class MoreInfoMediaPlayer extends LitElement {
     });
   }
 
-  private _handleSoundModeChanged(e: CustomEvent) {
-    const newVal = e.detail.item.itemName;
+  private _handleSoundModeChanged(e) {
+    const newVal = e.target.value;
 
     if (!newVal || this.stateObj?.attributes.sound_mode === newVal) {
       return;

--- a/src/dialogs/more-info/controls/more-info-remote.ts
+++ b/src/dialogs/more-info/controls/more-info-remote.ts
@@ -1,12 +1,12 @@
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-attributes";
-import "../../../components/ha-paper-dropdown-menu";
 import { RemoteEntity, REMOTE_SUPPORT_ACTIVITY } from "../../../data/remote";
 import { HomeAssistant } from "../../../types";
+import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-list/mwc-list";
+import { stopPropagation } from "../../../common/dom/stop_propagation";
 
 const filterExtraAttributes = "activity_list,current_activity";
 
@@ -26,24 +26,22 @@ class MoreInfoRemote extends LitElement {
     return html`
       ${supportsFeature(stateObj, REMOTE_SUPPORT_ACTIVITY)
         ? html`
-            <ha-paper-dropdown-menu
+            <mwc-list
               .label=${this.hass!.localize(
                 "ui.dialogs.more_info_control.remote.activity"
               )}
+              .value=${stateObj.attributes.current_activity}
+              @selected=${this.handleActivityChanged}
+              fixedMenuPosition
+              naturalMenuWidth
+              @closed=${stopPropagation}
             >
-              <paper-listbox
-                slot="dropdown-content"
-                .selected=${stateObj.attributes.current_activity}
-                @iron-select=${this.handleActivityChanged}
-                attr-for-selected="item-name"
-              >
-                ${stateObj.attributes.activity_list!.map(
-                  (activity) => html`
-                    <paper-item .itemName=${activity}> ${activity} </paper-item>
-                  `
-                )}
-              </paper-listbox>
-            </ha-paper-dropdown-menu>
+              ${stateObj.attributes.activity_list!.map(
+                (activity) => html`
+                  <mwc-list-item .value=${activity}>${activity}</mwc-list-item>
+                `
+              )}
+            </mwc-list>
           `
         : ""}
 
@@ -55,9 +53,9 @@ class MoreInfoRemote extends LitElement {
     `;
   }
 
-  private handleActivityChanged(ev: CustomEvent) {
+  private handleActivityChanged(ev) {
     const oldVal = this.stateObj!.attributes.current_activity;
-    const newVal = ev.detail.item.itemName;
+    const newVal = ev.target.value;
 
     if (!newVal || oldVal === newVal) {
       return;

--- a/src/dialogs/more-info/controls/more-info-vacuum.ts
+++ b/src/dialogs/more-info/controls/more-info-vacuum.ts
@@ -8,15 +8,13 @@ import {
   mdiStop,
   mdiTargetVariant,
 } from "@mdi/js";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
+import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-attributes";
 import "../../../components/ha-icon";
 import "../../../components/ha-icon-button";
-import "../../../components/ha-paper-dropdown-menu";
 import { UNAVAILABLE } from "../../../data/entity";
 import {
   VacuumEntity,
@@ -31,6 +29,8 @@ import {
   VACUUM_SUPPORT_STOP,
 } from "../../../data/vacuum";
 import { HomeAssistant } from "../../../types";
+import "@material/mwc-select/mwc-select";
+import "@material/mwc-list/mwc-list-item";
 
 interface VacuumCommand {
   translationKey: string;
@@ -173,25 +173,23 @@ class MoreInfoVacuum extends LitElement {
         ? html`
             <div>
               <div class="flex-horizontal">
-                <ha-paper-dropdown-menu
+                <mwc-select
                   .label=${this.hass!.localize(
                     "ui.dialogs.more_info_control.vacuum.fan_speed"
                   )}
                   .disabled=${stateObj.state === UNAVAILABLE}
+                  .value=${stateObj.attributes.fan_speed}
+                  @selected=${this.handleFanSpeedChanged}
+                  fixedMenuPosition
+                  naturalMenuWidth
+                  @closed=${stopPropagation}
                 >
-                  <paper-listbox
-                    slot="dropdown-content"
-                    .selected=${stateObj.attributes.fan_speed}
-                    @iron-select=${this.handleFanSpeedChanged}
-                    attr-for-selected="item-name"
-                  >
-                    ${stateObj.attributes.fan_speed_list!.map(
-                      (mode) => html`
-                        <paper-item .itemName=${mode}> ${mode} </paper-item>
-                      `
-                    )}
-                  </paper-listbox>
-                </ha-paper-dropdown-menu>
+                  ${stateObj.attributes.fan_speed_list!.map(
+                    (mode) => html`
+                      <mwc-list-item .value=${mode}>${mode}</mwc-list-item>
+                    `
+                  )}
+                </mwc-select>
                 <div
                   style="justify-content: center; align-self: center; padding-top: 1.3em"
                 >
@@ -221,9 +219,9 @@ class MoreInfoVacuum extends LitElement {
     });
   }
 
-  private handleFanSpeedChanged(ev: CustomEvent) {
+  private handleFanSpeedChanged(ev) {
     const oldVal = this.stateObj!.attributes.fan_speed;
-    const newVal = ev.detail.item.itemName;
+    const newVal = ev.target.value;
 
     if (!newVal || oldVal === newVal) {
       return;

--- a/src/dialogs/more-info/controls/more-info-water_heater.js
+++ b/src/dialogs/more-info/controls/more-info-water_heater.js
@@ -1,6 +1,4 @@
 import "@polymer/iron-flex-layout/iron-flex-layout-classes";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import { timeOut } from "@polymer/polymer/lib/utils/async";
 import { Debouncer } from "@polymer/polymer/lib/utils/debounce";
 import { html } from "@polymer/polymer/lib/utils/html-tag";
@@ -8,11 +6,12 @@ import { html } from "@polymer/polymer/lib/utils/html-tag";
 import { PolymerElement } from "@polymer/polymer/polymer-element";
 import { featureClassNames } from "../../../common/entity/feature_class_names";
 import { supportsFeature } from "../../../common/entity/supports-feature";
-import "../../../components/ha-paper-dropdown-menu";
 import "../../../components/ha-switch";
 import "../../../components/ha-water_heater-control";
 import { EventsMixin } from "../../../mixins/events-mixin";
 import LocalizeMixin from "../../../mixins/localize-mixin";
+import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-select/mwc-select";
 
 /*
  * @appliesMixin EventsMixin
@@ -27,12 +26,8 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
           color: var(--primary-text-color);
         }
 
-        ha-paper-dropdown-menu {
+        mwc-select {
           width: 100%;
-        }
-
-        paper-item {
-          cursor: pointer;
         }
 
         ha-water_heater-control.range-control-left,
@@ -75,27 +70,23 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
         <template is="dom-if" if="[[supportsOperationMode(stateObj)]]">
           <div class="container-operation_list">
             <div class="controls">
-              <ha-paper-dropdown-menu
-                label-float=""
-                dynamic-align=""
+              <mwc-select
                 label="[[localize('ui.card.water_heater.operation')]]"
+                value="[[stateObj.attributes.operation_mode]]"
+                on-selected="handleOperationmodeChanged"
+                fixedMenuPosition
+                naturalMenuWidth
+                on-closed="stopPropagation"
               >
-                <paper-listbox
-                  slot="dropdown-content"
-                  selected="[[stateObj.attributes.operation_mode]]"
-                  attr-for-selected="item-name"
-                  on-selected-changed="handleOperationmodeChanged"
+                <template
+                  is="dom-repeat"
+                  items="[[stateObj.attributes.operation_list]]"
                 >
-                  <template
-                    is="dom-repeat"
-                    items="[[stateObj.attributes.operation_list]]"
-                  >
-                    <paper-item item-name$="[[item]]"
-                      >[[_localizeOperationMode(localize, item)]]</paper-item
-                    >
-                  </template>
-                </paper-listbox>
-              </ha-paper-dropdown-menu>
+                  <mwc-list-item value="[[item]]">
+                    [[_localizeOperationMode(localize, item)]]
+                  </mwc-list-item>
+                </template>
+              </mwc-select>
             </div>
           </div>
         </template>
@@ -209,11 +200,15 @@ class MoreInfoWaterHeater extends LocalizeMixin(EventsMixin(PolymerElement)) {
 
   handleOperationmodeChanged(ev) {
     const oldVal = this.stateObj.attributes.operation_mode;
-    const newVal = ev.detail.value;
+    const newVal = ev.target.value;
     if (!newVal || oldVal === newVal) return;
     this.callServiceHelper("set_operation_mode", {
       operation_mode: newVal,
     });
+  }
+
+  stopPropagation(ev) {
+    ev.stopPropagation();
   }
 
   callServiceHelper(service, data) {

--- a/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
@@ -1,7 +1,5 @@
 import "@polymer/paper-input/paper-input";
-import type { PaperListboxElement } from "@polymer/paper-listbox";
-import "@polymer/paper-listbox/paper-listbox";
-import { CSSResultGroup, html, LitElement } from "lit";
+import { css, CSSResultGroup, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import {
@@ -35,31 +33,25 @@ export class HaRepeatAction extends LitElement implements ActionElement {
     const action = this.action.repeat;
 
     const type = getType(action);
-    const selected = type ? OPTIONS.indexOf(type) : -1;
 
     return html`
-      <paper-dropdown-menu-light
+      <mwc-select
         .label=${this.hass.localize(
           "ui.panel.config.automation.editor.actions.type.repeat.type_select"
         )}
-        no-animations
+        .value=${type}
+        @selected=${this._typeChanged}
       >
-        <paper-listbox
-          slot="dropdown-content"
-          .selected=${selected}
-          @iron-select=${this._typeChanged}
-        >
-          ${OPTIONS.map(
-            (opt) => html`
-              <paper-item .action=${opt}>
-                ${this.hass.localize(
-                  `ui.panel.config.automation.editor.actions.type.repeat.type.${opt}.label`
-                )}
-              </paper-item>
-            `
-          )}
-        </paper-listbox>
-      </paper-dropdown-menu-light>
+        ${OPTIONS.map(
+          (opt) => html`
+            <mwc-list-item .value=${opt}>
+              ${this.hass.localize(
+                `ui.panel.config.automation.editor.actions.type.repeat.type.${opt}.label`
+              )}
+            </mwc-list-item>
+          `
+        )}
+      </mwc-select>
       ${type === "count"
         ? html`<paper-input
             .label=${this.hass.localize(
@@ -107,9 +99,8 @@ export class HaRepeatAction extends LitElement implements ActionElement {
     `;
   }
 
-  private _typeChanged(ev: CustomEvent) {
-    const type = ((ev.target as PaperListboxElement)?.selectedItem as any)
-      ?.action;
+  private _typeChanged(ev) {
+    const type = ev.target.value;
 
     if (!type || type === getType(this.action.repeat)) {
       return;
@@ -166,7 +157,14 @@ export class HaRepeatAction extends LitElement implements ActionElement {
   }
 
   static get styles(): CSSResultGroup {
-    return haStyle;
+    return [
+      haStyle,
+      css`
+        mwc-select {
+          margin-top: 8px;
+        }
+      `,
+    ];
   }
 }
 

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -1,5 +1,4 @@
 import "@material/mwc-button/mwc-button";
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
 import "@polymer/paper-input/paper-textarea";
 import { HassEntity } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement } from "lit";

--- a/src/panels/config/automation/dialog-new-automation.ts
+++ b/src/panels/config/automation/dialog-new-automation.ts
@@ -94,10 +94,10 @@ class DialogNewAutomation extends LitElement implements HassDialog {
       haStyleDialog,
       css`
         mwc-list-item.blueprint {
-          height: 92px;
+          height: 110px;
         }
         ha-blueprint-picker {
-          margin-top: -16px;
+          margin-top: 8px;
         }
         ha-dialog {
           --dialog-content-padding: 0;

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -9,7 +9,6 @@ import {
 } from "@mdi/js";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
 import "@polymer/paper-input/paper-textarea";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import {

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -1,7 +1,5 @@
 import "@material/mwc-button/mwc-button";
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu-light";
 import "@polymer/paper-input/paper-textarea";
-import { PaperListboxElement } from "@polymer/paper-listbox";
 import { HassEntity } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
@@ -81,30 +79,23 @@ export class HaManualAutomationEditor extends LitElement {
                 >`
               )}
             </p>
-            <paper-dropdown-menu-light
+            <mwc-select
               .label=${this.hass.localize(
                 "ui.panel.config.automation.editor.modes.label"
               )}
-              no-animations
+              .value=${this.config.mode ? MODES.indexOf(this.config.mode) : 0}
+              @selected=${this._modeChanged}
             >
-              <paper-listbox
-                slot="dropdown-content"
-                .selected=${this.config.mode
-                  ? MODES.indexOf(this.config.mode)
-                  : 0}
-                @iron-select=${this._modeChanged}
-              >
-                ${MODES.map(
-                  (mode) => html`
-                    <paper-item .mode=${mode}>
-                      ${this.hass.localize(
-                        `ui.panel.config.automation.editor.modes.${mode}`
-                      ) || mode}
-                    </paper-item>
-                  `
-                )}
-              </paper-listbox>
-            </paper-dropdown-menu-light>
+              ${MODES.map(
+                (mode) => html`
+                  <mwc-list-item .value=${mode}>
+                    ${this.hass.localize(
+                      `ui.panel.config.automation.editor.modes.${mode}`
+                    ) || mode}
+                  </mwc-list-item>
+                `
+              )}
+            </mwc-select>
             ${this.config.mode && MODES_MAX.includes(this.config.mode)
               ? html`<paper-input
                   .label=${this.hass.localize(
@@ -263,9 +254,8 @@ export class HaManualAutomationEditor extends LitElement {
     });
   }
 
-  private _modeChanged(ev: CustomEvent) {
-    const mode = ((ev.target as PaperListboxElement)?.selectedItem as any)
-      ?.mode;
+  private _modeChanged(ev) {
+    const mode = ev.target.value;
 
     if (
       mode === this.config!.mode ||

--- a/src/panels/config/devices/device-registry-detail/dialog-device-registry-detail.ts
+++ b/src/panels/config/devices/device-registry-detail/dialog-device-registry-detail.ts
@@ -1,8 +1,5 @@
 import "@material/mwc-button/mwc-button";
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-input/paper-input";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -9,9 +9,6 @@ import {
   mdiRestoreAlert,
   mdiUndo,
 } from "@mdi/js";
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
-import "@polymer/paper-item/paper-icon-item";
-import "@polymer/paper-listbox/paper-listbox";
 import "@polymer/paper-tooltip/paper-tooltip";
 import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -1,7 +1,4 @@
 import { mdiPencilOff, mdiPlus } from "@mdi/js";
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
-import "@polymer/paper-item/paper-icon-item";
-import "@polymer/paper-listbox/paper-listbox";
 import "@polymer/paper-tooltip/paper-tooltip";
 import { HassEntity } from "home-assistant-js-websocket";
 import { html, LitElement, PropertyValues, TemplateResult } from "lit";

--- a/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-glance-card-editor.ts
@@ -1,6 +1,3 @@
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
-import "@polymer/paper-item/paper-item";
-import "@polymer/paper-listbox/paper-listbox";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import {
@@ -31,6 +28,7 @@ import { entitiesConfigStruct } from "../structs/entities-struct";
 import { EditorTarget, EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
+import "@polymer/paper-input/paper-input";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,

--- a/src/panels/lovelace/editor/config-elements/hui-graph-footer-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-graph-footer-editor.ts
@@ -1,4 +1,3 @@
-import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import "@polymer/paper-input/paper-input";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2103,6 +2103,7 @@
               "title": "Text to Speech",
               "info": "Bring personality to your home by having it speak to you by using our Text-to-Speech services. You can use this in automations and scripts by using the {service} service.",
               "default_language": "Default language to use",
+              "default_gender": "Default gender to use",
               "male": "Male",
               "female": "Female",
               "try": "Try",


### PR DESCRIPTION
## Proposed change

We need to get rid of all paper-dropdowns, as it is a blocked for fixing a accessibility issue on iOS.

Migrate a bunch of paper-dropdowns

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
