### PR TITLE
Add support for media player assumed state

### DIFF
--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -261,8 +261,7 @@ export const computeMediaControls = (
     });
   }
 
-  const assumedState =
-    state === "on" && stateObj.attributes.assumed_state === true;
+  const assumedState = stateObj.attributes.assumed_state === true;
 
   if (
     (state === "playing" || state === "paused" || assumedState) &&

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -261,8 +261,11 @@ export const computeMediaControls = (
     });
   }
 
+  const assumedState =
+    state === "on" && stateObj.attributes.assumed_state === true;
+
   if (
-    (state === "playing" || state === "paused") &&
+    (state === "playing" || state === "paused" || assumedState) &&
     supportsFeature(stateObj, SUPPORT_PREVIOUS_TRACK)
   ) {
     buttons.push({
@@ -272,14 +275,15 @@ export const computeMediaControls = (
   }
 
   if (
-    (state === "playing" &&
+    !assumedState &&
+    ((state === "playing" &&
       (supportsFeature(stateObj, SUPPORT_PAUSE) ||
         supportsFeature(stateObj, SUPPORT_STOP))) ||
-    ((state === "paused" || state === "idle") &&
-      supportsFeature(stateObj, SUPPORT_PLAY)) ||
-    (state === "on" &&
-      (supportsFeature(stateObj, SUPPORT_PLAY) ||
-        supportsFeature(stateObj, SUPPORT_PAUSE)))
+      ((state === "paused" || state === "idle") &&
+        supportsFeature(stateObj, SUPPORT_PLAY)) ||
+      (state === "on" &&
+        (supportsFeature(stateObj, SUPPORT_PLAY) ||
+          supportsFeature(stateObj, SUPPORT_PAUSE))))
   ) {
     buttons.push({
       icon:
@@ -299,8 +303,29 @@ export const computeMediaControls = (
     });
   }
 
+  if (assumedState && supportsFeature(stateObj, SUPPORT_PLAY)) {
+    buttons.push({
+      icon: mdiPlay,
+      action: "media_play",
+    });
+  }
+
+  if (assumedState && supportsFeature(stateObj, SUPPORT_PAUSE)) {
+    buttons.push({
+      icon: mdiPause,
+      action: "media_pause",
+    });
+  }
+
+  if (assumedState && supportsFeature(stateObj, SUPPORT_STOP)) {
+    buttons.push({
+      icon: mdiStop,
+      action: "media_stop",
+    });
+  }
+
   if (
-    (state === "playing" || state === "paused") &&
+    (state === "playing" || state === "paused" || assumedState) &&
     supportsFeature(stateObj, SUPPORT_NEXT_TRACK)
   ) {
     buttons.push({

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -110,10 +110,11 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
 
     const entityState = stateObj.state;
     const controlButton = this._computeControlButton(stateObj);
+    const assumedState = stateObj.attributes.assumed_state === true;
 
     const buttons = html`
       ${!this._narrow &&
-      entityState === "playing" &&
+      (entityState === "playing" || assumedState) &&
       supportsFeature(stateObj, SUPPORT_PREVIOUS_TRACK)
         ? html`
             <ha-icon-button
@@ -125,14 +126,15 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
             ></ha-icon-button>
           `
         : ""}
-      ${(entityState === "playing" &&
+      ${!assumedState &&
+      ((entityState === "playing" &&
         (supportsFeature(stateObj, SUPPORT_PAUSE) ||
           supportsFeature(stateObj, SUPPORT_STOP))) ||
-      ((entityState === "paused" || entityState === "idle") &&
-        supportsFeature(stateObj, SUPPORT_PLAY)) ||
-      (entityState === "on" &&
-        (supportsFeature(stateObj, SUPPORT_PLAY) ||
-          supportsFeature(stateObj, SUPPORT_PAUSE)))
+        ((entityState === "paused" || entityState === "idle") &&
+          supportsFeature(stateObj, SUPPORT_PLAY)) ||
+        (entityState === "on" &&
+          (supportsFeature(stateObj, SUPPORT_PLAY) ||
+            supportsFeature(stateObj, SUPPORT_PAUSE))))
         ? html`
             <ha-icon-button
               .path=${controlButton.icon}
@@ -143,7 +145,34 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
             ></ha-icon-button>
           `
         : ""}
-      ${entityState === "playing" &&
+      ${assumedState && supportsFeature(stateObj, SUPPORT_PLAY)
+        ? html`
+            <ha-icon-button
+              .path=${mdiPlay}
+              .label=${this.hass.localize(`ui.card.media_player.media_play`)}
+              @click=${this._play}
+            ></ha-icon-button>
+          `
+        : ""}
+      ${assumedState && supportsFeature(stateObj, SUPPORT_PAUSE)
+        ? html`
+            <ha-icon-button
+              .path=${mdiPause}
+              .label=${this.hass.localize(`ui.card.media_player.media_pause`)}
+              @click=${this._pause}
+            ></ha-icon-button>
+          `
+        : ""}
+      ${assumedState && supportsFeature(stateObj, SUPPORT_STOP)
+        ? html`
+            <ha-icon-button
+              .path=${mdiStop}
+              .label=${this.hass.localize(`ui.card.media_player.media_stop`)}
+              @click=${this._stop}
+            ></ha-icon-button>
+          `
+        : ""}
+      ${(entityState === "playing" || assumedState) &&
       supportsFeature(stateObj, SUPPORT_NEXT_TRACK)
         ? html`
             <ha-icon-button
@@ -308,6 +337,24 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
         : "media_stop";
 
     this.hass!.callService("media_player", service, {
+      entity_id: this._config!.entity,
+    });
+  }
+
+  private _play(): void {
+    this.hass!.callService("media_player", "media_play", {
+      entity_id: this._config!.entity,
+    });
+  }
+
+  private _pause(): void {
+    this.hass!.callService("media_player", "media_pause", {
+      entity_id: this._config!.entity,
+    });
+  }
+
+  private _stop(): void {
+    this.hass!.callService("media_player", "media_stop", {
       entity_id: this._config!.entity,
     });
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The frontend media player card for integrations which sets the `assumed_state` to `True` and `state` to  `STATE_ON`/ `STATE_PLAYING`/`STATE_PAUSED`/ `STATE_IDLE` will change from:
![image](https://user-images.githubusercontent.com/1858925/151451865-7cea7bbf-3568-4a2b-8a79-61936f48bb98.png)
to:
![assumed_state](https://user-images.githubusercontent.com/1858925/153460117-7740afc2-140d-44a7-ac6b-ea2a5631b611.PNG)
The example assumes the following supported features are set: `SUPPORT_PREVIOUS_TRACK`, `SUPPORT_PLAY`, `SUPPORT_PAUSE`, `SUPPORT_STOP`, `SUPPORT_NEXT_TRACK`, if one of them is not set the corresponding button will not be displayed.

Currently there is one core integration which sets the `assumed_state` to `True`: [xiaomi_tv](https://github.com/home-assistant/core/blob/f5829173db5b56d7f52465440e340fcea1668b6c/homeassistant/components/xiaomi_tv/media_player.py#L85), but it does not set any of the required supported features to cause the media card to change.

**Custom integrations which meets these conditions will also have the frontend card changed.**
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Discussed in https://github.com/home-assistant/architecture/discussions/720, Add support for media player integrations which does not have a feedback from the device for the current playing mode (playing/paused/idle), if the integration sets the `assumed_state` to true the frontend will display all supported features in case the current state is `STATE_ON`/ `STATE_PLAYING`/`STATE_PAUSED`/ `STATE_IDLE`.

Current behavior:
| state	               | supported features  | assumed state | action                 | icon             |
| ------------------- | ---------------------- | ---------------- | -----------------  | ---------------- |
| playing/paused    | SUPPORT_PREVIOUS_TRACK | false        | media_previous_track   | mdiSkipPrevious  |
| playing                 | SUPPORT_PAUSE/STOP     | false        | media_pause+media_stop | mdiPause+mdiStop | 
| paused/idle          | SUPPORT_PLAY           | false        | media_play             | mdiPlay          |
| on                         | SUPPORT_PLAY/PAUSE     | false        | media_play             | mdiPlayPause     |
| playing/paused    | SUPPORT_NEXT_TRACK     | false        | media_next_track       | mdiSkipNext      |

New options when `assumed_state` is `True` and state is `on/playing/idle/paused`:

| supported features       | assumed state | action                 | icon             |
| ---------------------- | ------------ | ---------------------- | ---------------- |
| SUPPORT_PREVIOUS_TRACK | true         | media_previous_track   | mdiSkipPrevious  |
| SUPPORT_PLAY           | true         | media_play             | mdiPlay          | 
| SUPPORT_PAUSE          | true         | media_pause            | mdiPause         |
| SUPPORT_STOP           | true         | media_stop             | mdiStop          |
| SUPPORT_NEXT_TRACK     | true         | media_next_track       | mdiSkipNext      |


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/architecture/discussions/720
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
