### PR TITLE
Fix Lovelace Empty Menu when not advanced or admin

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -276,137 +276,159 @@ class HUIRoot extends LitElement {
                         ></ha-icon-button>
                       `
                     : ""}
-                  <ha-button-menu corner="BOTTOM_START">
-                    <ha-icon-button
-                      slot="trigger"
-                      .label=${this.hass!.localize(
-                        "ui.panel.lovelace.editor.menu.open"
-                      )}
-                      .path=${mdiDotsVertical}
-                    ></ha-icon-button>
-                    ${this.narrow &&
-                    this._conversation(this.hass.config.components)
-                      ? html`
-                          <mwc-list-item
+                  ${this._editMode ||
+                  (this.hass!.user?.is_admin && !this.hass!.config.safe_mode) ||
+                  (this.hass.panels.lovelace?.config as LovelacePanelConfig)
+                    ?.mode === "yaml" ||
+                  this._yamlMode ||
+                  (this.narrow &&
+                    this._conversation(this.hass.config.components))
+                    ? html`
+                        <ha-button-menu corner="BOTTOM_START">
+                          <ha-icon-button
+                            slot="trigger"
                             .label=${this.hass!.localize(
-                              "ui.panel.lovelace.menu.start_conversation"
+                              "ui.panel.lovelace.editor.menu.open"
                             )}
-                            graphic="icon"
-                            @request-selected=${this._showVoiceCommandDialog}
-                          >
-                            <span
-                              >${this.hass!.localize(
-                                "ui.panel.lovelace.menu.start_conversation"
-                              )}</span
-                            >
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiMicrophone}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                        `
-                      : ""}
-                    ${this._yamlMode
-                      ? html`
-                          <mwc-list-item
-                            aria-label=${this.hass!.localize(
-                              "ui.common.refresh"
-                            )}
-                            graphic="icon"
-                            @request-selected=${this._handleRefresh}
-                          >
-                            <span
-                              >${this.hass!.localize("ui.common.refresh")}</span
-                            >
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiRefresh}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                          <mwc-list-item
-                            aria-label=${this.hass!.localize(
-                              "ui.panel.lovelace.unused_entities.title"
-                            )}
-                            graphic="icon"
-                            @request-selected=${this._handleUnusedEntities}
-                          >
-                            <span
-                              >${this.hass!.localize(
-                                "ui.panel.lovelace.unused_entities.title"
-                              )}</span
-                            >
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiShape}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                        `
-                      : ""}
-                    ${(this.hass.panels.lovelace?.config as LovelacePanelConfig)
-                      ?.mode === "yaml"
-                      ? html`
-                          <mwc-list-item
-                            graphic="icon"
-                            aria-label=${this.hass!.localize(
-                              "ui.panel.lovelace.menu.reload_resources"
-                            )}
-                            @request-selected=${this._handleReloadResources}
-                          >
-                            ${this.hass!.localize(
-                              "ui.panel.lovelace.menu.reload_resources"
-                            )}
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiRefresh}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                        `
-                      : ""}
-                    ${this.hass!.user?.is_admin && !this.hass!.config.safe_mode
-                      ? html`
-                          <mwc-list-item
-                            graphic="icon"
-                            aria-label=${this.hass!.localize(
-                              "ui.panel.lovelace.menu.configure_ui"
-                            )}
-                            @request-selected=${this._handleEnableEditMode}
-                          >
-                            ${this.hass!.localize(
-                              "ui.panel.lovelace.menu.configure_ui"
-                            )}
-                            <ha-svg-icon
-                              slot="graphic"
-                              .path=${mdiPencil}
-                            ></ha-svg-icon>
-                          </mwc-list-item>
-                        `
-                      : ""}
-                    ${this._editMode
-                      ? html`
-                          <a
-                            href=${documentationUrl(this.hass, "/lovelace/")}
-                            rel="noreferrer"
-                            class="menu-link"
-                            target="_blank"
-                          >
-                            <mwc-list-item
-                              graphic="icon"
-                              aria-label=${this.hass!.localize(
-                                "ui.panel.lovelace.menu.help"
-                              )}
-                            >
-                              ${this.hass!.localize(
-                                "ui.panel.lovelace.menu.help"
-                              )}
-                              <ha-svg-icon
-                                slot="graphic"
-                                .path=${mdiHelp}
-                              ></ha-svg-icon>
-                            </mwc-list-item>
-                          </a>
-                        `
-                      : ""}
-                  </ha-button-menu>
+                            .path=${mdiDotsVertical}
+                          ></ha-icon-button>
+                          ${this.narrow &&
+                          this._conversation(this.hass.config.components)
+                            ? html`
+                                <mwc-list-item
+                                  .label=${this.hass!.localize(
+                                    "ui.panel.lovelace.menu.start_conversation"
+                                  )}
+                                  graphic="icon"
+                                  @request-selected=${this
+                                    ._showVoiceCommandDialog}
+                                >
+                                  <span
+                                    >${this.hass!.localize(
+                                      "ui.panel.lovelace.menu.start_conversation"
+                                    )}</span
+                                  >
+                                  <ha-svg-icon
+                                    slot="graphic"
+                                    .path=${mdiMicrophone}
+                                  ></ha-svg-icon>
+                                </mwc-list-item>
+                              `
+                            : ""}
+                          ${this._yamlMode
+                            ? html`
+                                <mwc-list-item
+                                  aria-label=${this.hass!.localize(
+                                    "ui.common.refresh"
+                                  )}
+                                  graphic="icon"
+                                  @request-selected=${this._handleRefresh}
+                                >
+                                  <span
+                                    >${this.hass!.localize(
+                                      "ui.common.refresh"
+                                    )}</span
+                                  >
+                                  <ha-svg-icon
+                                    slot="graphic"
+                                    .path=${mdiRefresh}
+                                  ></ha-svg-icon>
+                                </mwc-list-item>
+                                <mwc-list-item
+                                  aria-label=${this.hass!.localize(
+                                    "ui.panel.lovelace.unused_entities.title"
+                                  )}
+                                  graphic="icon"
+                                  @request-selected=${this
+                                    ._handleUnusedEntities}
+                                >
+                                  <span
+                                    >${this.hass!.localize(
+                                      "ui.panel.lovelace.unused_entities.title"
+                                    )}</span
+                                  >
+                                  <ha-svg-icon
+                                    slot="graphic"
+                                    .path=${mdiShape}
+                                  ></ha-svg-icon>
+                                </mwc-list-item>
+                              `
+                            : ""}
+                          ${(
+                            this.hass.panels.lovelace
+                              ?.config as LovelacePanelConfig
+                          )?.mode === "yaml"
+                            ? html`
+                                <mwc-list-item
+                                  graphic="icon"
+                                  aria-label=${this.hass!.localize(
+                                    "ui.panel.lovelace.menu.reload_resources"
+                                  )}
+                                  @request-selected=${this
+                                    ._handleReloadResources}
+                                >
+                                  ${this.hass!.localize(
+                                    "ui.panel.lovelace.menu.reload_resources"
+                                  )}
+                                  <ha-svg-icon
+                                    slot="graphic"
+                                    .path=${mdiRefresh}
+                                  ></ha-svg-icon>
+                                </mwc-list-item>
+                              `
+                            : ""}
+                          ${this.hass!.user?.is_admin &&
+                          !this.hass!.config.safe_mode
+                            ? html`
+                                <mwc-list-item
+                                  graphic="icon"
+                                  aria-label=${this.hass!.localize(
+                                    "ui.panel.lovelace.menu.configure_ui"
+                                  )}
+                                  @request-selected=${this
+                                    ._handleEnableEditMode}
+                                >
+                                  ${this.hass!.localize(
+                                    "ui.panel.lovelace.menu.configure_ui"
+                                  )}
+                                  <ha-svg-icon
+                                    slot="graphic"
+                                    .path=${mdiPencil}
+                                  ></ha-svg-icon>
+                                </mwc-list-item>
+                              `
+                            : ""}
+                          ${this._editMode
+                            ? html`
+                                <a
+                                  href=${documentationUrl(
+                                    this.hass,
+                                    "/lovelace/"
+                                  )}
+                                  rel="noreferrer"
+                                  class="menu-link"
+                                  target="_blank"
+                                >
+                                  <mwc-list-item
+                                    graphic="icon"
+                                    aria-label=${this.hass!.localize(
+                                      "ui.panel.lovelace.menu.help"
+                                    )}
+                                  >
+                                    ${this.hass!.localize(
+                                      "ui.panel.lovelace.menu.help"
+                                    )}
+                                    <ha-svg-icon
+                                      slot="graphic"
+                                      .path=${mdiHelp}
+                                    ></ha-svg-icon>
+                                  </mwc-list-item>
+                                </a>
+                              `
+                            : ""}
+                        </ha-button-menu>
+                      `
+                    : ""}
                 </app-toolbar>
               `}
           ${this._editMode

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -276,13 +276,7 @@ class HUIRoot extends LitElement {
                         ></ha-icon-button>
                       `
                     : ""}
-                  ${this._editMode ||
-                  (this.hass!.user?.is_admin && !this.hass!.config.safe_mode) ||
-                  (this.hass.panels.lovelace?.config as LovelacePanelConfig)
-                    ?.mode === "yaml" ||
-                  this._yamlMode ||
-                  (this.narrow &&
-                    this._conversation(this.hass.config.components))
+                  ${this._showButtonMenu
                     ? html`
                         <ha-button-menu corner="BOTTOM_START">
                           <ha-icon-button
@@ -641,6 +635,17 @@ class HUIRoot extends LitElement {
 
   private get _viewRoot(): HTMLDivElement {
     return this.shadowRoot!.getElementById("view") as HTMLDivElement;
+  }
+
+  private get _showButtonMenu(): boolean {
+    return (
+      (this.narrow && this._conversation(this.hass.config.components)) ||
+      this._editMode ||
+      (this.hass!.user?.is_admin && !this.hass!.config.safe_mode) ||
+      (this.hass.panels.lovelace?.config as LovelacePanelConfig)?.mode ===
+        "yaml" ||
+      this._yamlMode
+    );
   }
 
   private _handleRefresh(ev: CustomEvent<RequestSelectedDetail>): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Fixes : 
![image](https://user-images.githubusercontent.com/18730868/153622033-74dfc464-ff5d-4c5f-bde5-8ded66749961.png)


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
