### PR TITLE
Omit Device info and actions for connected controller nodes

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -126,6 +126,7 @@ export interface ZWaveJSNodeStatus {
   is_routing: boolean | null;
   zwave_plus_version: number | null;
   highest_security_class: SecurityClass | null;
+  is_controller_node: boolean;
 }
 
 export interface ZwaveJSNodeMetadata {

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-info-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-info-zwave_js.ts
@@ -103,52 +103,58 @@ export class HaDeviceInfoZWaveJS extends LitElement {
         ${this.hass.localize("ui.panel.config.zwave_js.common.node_id")}:
         ${this._node.node_id}
       </div>
-      <div>
-        ${this.hass.localize(
-          "ui.panel.config.zwave_js.device_info.node_status"
-        )}:
-        ${this.hass.localize(
-          `ui.panel.config.zwave_js.node_status.${
-            nodeStatus[this._node.status]
-          }`
-        )}
-      </div>
-      <div>
-        ${this.hass.localize(
-          "ui.panel.config.zwave_js.device_info.node_ready"
-        )}:
-        ${this._node.ready
-          ? this.hass.localize("ui.common.yes")
-          : this.hass.localize("ui.common.no")}
-      </div>
-      <div>
-        ${this.hass.localize(
-          "ui.panel.config.zwave_js.device_info.highest_security"
-        )}:
-        ${this._node.highest_security_class !== null
-          ? this.hass.localize(
-              `ui.panel.config.zwave_js.security_classes.${
-                SecurityClass[this._node.highest_security_class]
-              }.title`
-            )
-          : this._node.is_secure === false
-          ? this.hass.localize(
-              "ui.panel.config.zwave_js.security_classes.none.title"
-            )
-          : this.hass.localize("ui.panel.config.zwave_js.device_info.unknown")}
-      </div>
-      <div>
-        ${this.hass.localize(
-          "ui.panel.config.zwave_js.device_info.zwave_plus"
-        )}:
-        ${this._node.zwave_plus_version
-          ? this.hass.localize(
-              "ui.panel.config.zwave_js.device_info.zwave_plus_version",
-              "version",
-              this._node.zwave_plus_version
-            )
-          : this.hass.localize("ui.common.no")}
-      </div>
+      ${!this._node.is_controller_node
+        ? html`
+            <div>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.device_info.node_status"
+              )}:
+              ${this.hass.localize(
+                `ui.panel.config.zwave_js.node_status.${
+                  nodeStatus[this._node.status]
+                }`
+              )}
+            </div>
+            <div>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.device_info.node_ready"
+              )}:
+              ${this._node.ready
+                ? this.hass.localize("ui.common.yes")
+                : this.hass.localize("ui.common.no")}
+            </div>
+            <div>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.device_info.highest_security"
+              )}:
+              ${this._node.highest_security_class !== null
+                ? this.hass.localize(
+                    `ui.panel.config.zwave_js.security_classes.${
+                      SecurityClass[this._node.highest_security_class]
+                    }.title`
+                  )
+                : this._node.is_secure === false
+                ? this.hass.localize(
+                    "ui.panel.config.zwave_js.security_classes.none.title"
+                  )
+                : this.hass.localize(
+                    "ui.panel.config.zwave_js.device_info.unknown"
+                  )}
+            </div>
+            <div>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.device_info.zwave_plus"
+              )}:
+              ${this._node.zwave_plus_version
+                ? this.hass.localize(
+                    "ui.panel.config.zwave_js.device_info.zwave_plus_version",
+                    "version",
+                    this._node.zwave_plus_version
+                  )
+                : this.hass.localize("ui.common.no")}
+            </div>
+          `
+        : ""}
     `;
   }
 


### PR DESCRIPTION
## Proposed change

Don't show Device info and actions that aren't applicable to "connected" Z-Wave controller nodes.

A "connected" controller node is the Z-Wave controller that the driver is talking to directly over the serial API. These controller nodes do not support device information and actions that other nodes in the network do. It can be confusing to users to see information that is incorrect, such as no support for Z-Wave Plus or Security.

Info not applicable:
- Z-Wave Plus
- Security
- Node readiness
- Node status (asleep, awake, dead)

Actions not supported:
- Configuration
- Re-Interview
- Remove failed
- Heal

Using the `is_controller_node` property of a node, we can omit the above when the connected controller device is selected. Depends on core PR https://github.com/home-assistant/core/pull/66404.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Before:
![image](https://user-images.githubusercontent.com/791794/153725487-9ff0b5a5-4217-41d6-9d08-0f81de626cb8.png)

After:
![image](https://user-images.githubusercontent.com/791794/153725502-306f649d-2a7e-43c4-b746-e968f1a4d481.png)

This is also the approach zwavejs2mqtt took for hiding the device info (they did not disable any actions though). See issue https://github.com/zwave-js/zwavejs2mqtt/issues/1886. In comparison:

![image](https://user-images.githubusercontent.com/791794/153735039-5d5daf61-8f23-4ee9-9319-6fe6f84616ba.png)

If there's a better way to communicate this, I'm open to implementing other ideas.

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io

