### PR TITLE
Try to keep the browsing stack when changing players in media panel

### DIFF
--- a/src/panels/media-browser/ha-bar-media-player.ts
+++ b/src/panels/media-browser/ha-bar-media-player.ts
@@ -25,7 +25,6 @@ import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { computeStateName } from "../../common/entity/compute_state_name";
 import { domainIcon } from "../../common/entity/domain_icon";
 import { supportsFeature } from "../../common/entity/supports-feature";
-import { navigate } from "../../common/navigate";
 import "../../components/ha-button-menu";
 import "../../components/ha-icon-button";
 import { UNAVAILABLE_STATES } from "../../data/entity";
@@ -46,6 +45,12 @@ import {
 import type { HomeAssistant } from "../../types";
 import "../lovelace/components/hui-marquee";
 import { BrowserMediaPlayer } from "./browser-media-player";
+
+declare global {
+  interface HASSDomEvents {
+    "player-picked": { entityId: string };
+  }
+}
 
 @customElement("ha-bar-media-player")
 class BarMediaPlayer extends LitElement {
@@ -399,7 +404,7 @@ class BarMediaPlayer extends LitElement {
 
   private _selectPlayer(ev: CustomEvent): void {
     const entityId = (ev.currentTarget as any).player;
-    navigate(`/media-browser/${entityId}`, { replace: true });
+    fireEvent(this, "player-picked", { entityId });
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -190,7 +190,9 @@ class PanelMediaBrowser extends LitElement {
   }
 
   private _goBack() {
-    history.back();
+    navigate(
+      createMediaPanelUrl(this._entityId, this._navigateIds.slice(0, -1))
+    );
   }
 
   private _mediaBrowsed(ev: { detail: HASSDomEvents["media-browsed"] }) {

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -43,6 +43,16 @@ import {
   isCameraMediaSource,
 } from "../../data/camera";
 
+const createMediaPanelUrl = (entityId: string, items: MediaPlayerItemId[]) => {
+  let path = `/media-browser/${entityId}`;
+  for (const item of items.slice(1)) {
+    path +=
+      "/" +
+      encodeURIComponent(`${item.media_content_type},${item.media_content_id}`);
+  }
+  return path;
+};
+
 @customElement("ha-panel-media-browser")
 class PanelMediaBrowser extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -120,6 +130,7 @@ class PanelMediaBrowser extends LitElement {
         .hass=${this.hass}
         .entityId=${this._entityId}
         .narrow=${this.narrow}
+        @player-picked=${this._playerPicked}
       ></ha-bar-media-player>
     `;
   }
@@ -188,15 +199,9 @@ class PanelMediaBrowser extends LitElement {
       return;
     }
 
-    let path = "";
-    for (const item of ev.detail.ids.slice(1)) {
-      path +=
-        "/" +
-        encodeURIComponent(
-          `${item.media_content_type},${item.media_content_id}`
-        );
-    }
-    navigate(`/media-browser/${this._entityId}${path}`);
+    navigate(createMediaPanelUrl(this._entityId, ev.detail.ids), {
+      replace: ev.detail.replace,
+    });
   }
 
   private async _mediaPicked(
@@ -237,6 +242,14 @@ class PanelMediaBrowser extends LitElement {
       title: item.title,
       can_play: item.can_play,
     });
+  }
+
+  private _playerPicked(ev) {
+    const entityId: string = ev.detail.entityId;
+    if (entityId === this._entityId) {
+      return;
+    }
+    navigate(createMediaPanelUrl(entityId, this._navigateIds));
   }
 
   private async _startUpload() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Persist the current browsing page when changing devices.

https://user-images.githubusercontent.com/1444314/153800055-2c7aefc4-f586-43d9-b4ec-ffde009ef7f9.mp4

This works, but it has an issue: the back button will now change the device instead of going up a folder because it does a `history.back()` and that is now a different device.

This is very confusing as you might not notice that the device is changing.

The only solution that I can think of is that the back button adds new items to the history stack. History.back() means then that you go "back" to the child folder if you previously navigated up.

Marking it as draft as I am not convinced it's good solution yet. Hoping some people have alternative ideas. I thought about changing how the back button behaves only if you have changed a device, but that would result in a non-consistent experience.

Alternative idea from @zsarnett:

We remove the current target from the URL. It's already stored in the local storage so refresh works. We can add support for setting the target via a query param if we want to link to a specific device from somewhere else in the UI (which we don't do yet).


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
