### PR TITLE
Improve `stripPrefixFromEntityName` to handle colon and space separator

### DIFF
--- a/src/common/entity/strip_prefix_from_entity_name.ts
+++ b/src/common/entity/strip_prefix_from_entity_name.ts
@@ -1,24 +1,32 @@
+const SUFFIXES = [" ", ": "];
+
 /**
  * Strips a device name from an entity name.
  * @param entityName the entity name
- * @param lowerCasedPrefixWithSpaceSuffix the prefix to strip, lower cased with a space suffix
+ * @param lowerCasedPrefix the prefix to strip, lower cased
  * @returns
  */
 export const stripPrefixFromEntityName = (
   entityName: string,
-  lowerCasedPrefixWithSpaceSuffix: string
+  lowerCasedPrefix: string
 ) => {
-  if (!entityName.toLowerCase().startsWith(lowerCasedPrefixWithSpaceSuffix)) {
-    return undefined;
+  const lowerCasedEntityName = entityName.toLowerCase();
+
+  for (const suffix of SUFFIXES) {
+    const lowerCasedPrefixWithSuffix = `${lowerCasedPrefix}${suffix}`;
+
+    if (lowerCasedEntityName.startsWith(lowerCasedPrefixWithSuffix)) {
+      const newName = entityName.substring(lowerCasedPrefixWithSuffix.length);
+
+      // If first word already has an upper case letter (e.g. from brand name)
+      // leave as-is, otherwise capitalize the first word.
+      return hasUpperCase(newName.substr(0, newName.indexOf(" ")))
+        ? newName
+        : newName[0].toUpperCase() + newName.slice(1);
+    }
   }
 
-  const newName = entityName.substring(lowerCasedPrefixWithSpaceSuffix.length);
-
-  // If first word already has an upper case letter (e.g. from brand name)
-  // leave as-is, otherwise capitalize the first word.
-  return hasUpperCase(newName.substr(0, newName.indexOf(" ")))
-    ? newName
-    : newName[0].toUpperCase() + newName.slice(1);
+  return undefined;
 };
 
 const hasUpperCase = (str: string): boolean => str.toLowerCase() !== str;

--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -165,7 +165,7 @@ export class HaDeviceEntitiesCard extends LitElement {
       const stateObj = this.hass.states[entry.entity_id];
       const name = stripPrefixFromEntityName(
         computeStateName(stateObj),
-        `${this.deviceName} `.toLowerCase()
+        this.deviceName.toLowerCase()
       );
       if (name) {
         config.name = name;
@@ -198,7 +198,7 @@ export class HaDeviceEntitiesCard extends LitElement {
             ${name
               ? stripPrefixFromEntityName(
                   name,
-                  `${this.deviceName} `.toLowerCase()
+                  this.deviceName.toLowerCase()
                 ) || name
               : entry.entity_id}
           </div>

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -96,7 +96,7 @@ export const computeCards = (
   const entities: Array<string | LovelaceRowConfig> = [];
 
   const titlePrefix = entityCardOptions.title
-    ? `${entityCardOptions.title} `.toLowerCase()
+    ? entityCardOptions.title.toLowerCase()
     : undefined;
 
   const footerEntities: ButtonsHeaderFooterConfig["entities"] = [];


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
I noticed that the Z-Wave JS integration (and possibly others) uses a colon and a space to separate device names from entity names. This causes the `stripPrefixFromEntityName` logic to fail because it is expecting just a space. This has the undesired effect of the full entity names being shown on the device page:

![Screenshot 2022-02-04 203916](https://user-images.githubusercontent.com/2292715/153991570-520f4b79-f6be-4197-a316-8e2cb4cdb724.png)

This PR expands `stripPrefixFromEntityName` to strip the prefix regardless of whether it is separated by a space, or a colon and a space. This improves the UX by shortening the displayed entity names:

![image](https://user-images.githubusercontent.com/2292715/153991793-ada7e8ee-4476-4b72-a817-056dd71c0154.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
