### PR TITLE
Fixes remote icon state color

### DIFF
--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -15,6 +15,7 @@ export const iconColorCSS = css`
   ha-state-icon[data-domain="media_player"][data-state="on"],
   ha-state-icon[data-domain="media_player"][data-state="paused"],
   ha-state-icon[data-domain="media_player"][data-state="playing"],
+  ha-state-icon[data-domain="remote"][data-state="on"],
   ha-state-icon[data-domain="script"][data-state="on"],
   ha-state-icon[data-domain="sun"][data-state="above_horizon"],
   ha-state-icon[data-domain="switch"][data-state="on"],


### PR DESCRIPTION
The `<ha-state-icon>` component does not show the correct state color for the `remote` domain when the "color icons by state" option is turned on in Lovelace cards. This fixes that bug.

## Proposed change

This adds a CSS selector to include the `remote` domain when coloring an icon based on its state in Lovelace. Currently if a remote is "on" and a Lovelace card is configured to color the icons by state (i.e. yellow icon when "on"), the icon does not change color when the state changes. It is always the same color as it would be when "off."

Current behavior:
<img width="860" alt="Screen Shot 2022-02-15 at 1 44 38 PM" src="https://user-images.githubusercontent.com/1522068/154146352-1c6e49ce-5459-4d12-82e6-679c3e05f30e.png">

New behavior:
<img width="858" alt="Screen Shot 2022-02-15 at 1 46 56 PM" src="https://user-images.githubusercontent.com/1522068/154146467-86f31e89-90c8-4fdc-8fef-d81da98dd935.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Set up a `remote` integration, such as a Logitech Harmony Hub or smart tv. Add a Lovelace entity/entities/glance card and display the `remote` entity. Toggle on the option to change icon color based on state. It should now turn yellow (with the default theme) when the remote is on and back to the default color when off.

```yaml
type: entity
entity: remote.family_room
state_color: true
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
