### PR TITLE
Add bottom padding to config links list with safe-area-inset-bottom

### DIFF
--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -192,6 +192,9 @@ class HaConfigDashboard extends LitElement {
     return [
       haStyle,
       css`
+        :host ha-card:last-child {
+          margin-bottom: env(safe-area-inset-bottom);
+        }
         :host(:not([narrow])) ha-card:last-child {
           margin-bottom: 24px;
         }

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -192,7 +192,7 @@ class HaConfigDashboard extends LitElement {
     return [
       haStyle,
       css`
-        :host ha-card:last-child {
+        ha-card:last-child {
           margin-bottom: env(safe-area-inset-bottom);
         }
         :host(:not([narrow])) ha-card:last-child {

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -196,7 +196,7 @@ class HaConfigDashboard extends LitElement {
           margin-bottom: env(safe-area-inset-bottom);
         }
         :host(:not([narrow])) ha-card:last-child {
-          margin-bottom: 24px;
+          margin-bottom: max(24px, env(safe-area-inset-bottom));
         }
         ha-config-section {
           margin: auto;


### PR DESCRIPTION
## Proposed change

On the iOS app on an iPhone with a Home Bar, the last item in the **Configuration** list (Settings) is partially covered by the Home Bar. This adds padding using the `safe-area-inset-bottom` environment variable so that when the screen is scrolled down all the way, the last item is not obscured. This is most noticeable when there are updates available that make this screen too tall for the phone display.

Current behavior:
<img src="https://user-images.githubusercontent.com/1522068/154321415-feb2108f-d0ba-43db-8597-0410ae78ed72.PNG" width="400" />


New behavior:
<img src="https://user-images.githubusercontent.com/1522068/154321480-64b335e1-6f17-45f1-b644-286fcad3e7a3.png" width="400" />


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Open the Configuration screen in the iOS app when there are updates available. The Home Bar at the bottom should no longer cover/obscure part of the Settings link at the bottom of the screen when it is scrolled all the way down.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
