### PR TITLE
Debounce refresh the cloud status if Google events happen

### DIFF
--- a/src/panels/config/cloud/account/cloud-account.ts
+++ b/src/panels/config/cloud/account/cloud-account.ts
@@ -222,11 +222,7 @@ export class CloudAccount extends SubscribeMixin(LitElement) {
   protected override hassSubscribe() {
     const googleCheck = debounce(
       () => {
-        if (
-          this.cloudStatus &&
-          (!this.cloudStatus.google_registered ||
-            !this.cloudStatus.google_local_connected)
-        ) {
+        if (this.cloudStatus && !this.cloudStatus.google_registered) {
           fireEvent(this, "ha-refresh-cloud-status");
         }
       },

--- a/src/panels/config/cloud/account/cloud-account.ts
+++ b/src/panels/config/cloud/account/cloud-account.ts
@@ -12,6 +12,7 @@ import "../../../../components/buttons/ha-call-api-button";
 import "../../../../components/ha-card";
 import "../../../../components/ha-button-menu";
 import "../../../../components/ha-icon-button";
+import { debounce } from "../../../../common/util/debounce";
 import {
   cloudLogout,
   CloudStatusLoggedIn,
@@ -219,11 +220,19 @@ export class CloudAccount extends SubscribeMixin(LitElement) {
   }
 
   protected override hassSubscribe() {
-    const googleCheck = () => {
-      if (!this.cloudStatus?.google_registered) {
-        fireEvent(this, "ha-refresh-cloud-status");
-      }
-    };
+    const googleCheck = debounce(
+      () => {
+        if (
+          this.cloudStatus &&
+          (!this.cloudStatus.google_registered ||
+            !this.cloudStatus.google_local_connected)
+        ) {
+          fireEvent(this, "ha-refresh-cloud-status");
+        }
+      },
+      10000,
+      true
+    );
     return [
       this.hass.connection.subscribeEvents(() => {
         if (!this.cloudStatus?.alexa_registered) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

We refresh cloud status when Google is talking to the HA instance. This makes sure that we don't refresh too often.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
