### PR TITLE
Add context data option to template tab

### DIFF
--- a/src/panels/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/developer-tools/template/developer-tools-template.ts
@@ -54,7 +54,7 @@ class HaPanelDevTemplate extends LitElement {
 
   private _context_data = "";
 
-  private _context_variables?: Record<string, any>;
+  private _context_variables?;
 
   private _inited = false;
 
@@ -346,10 +346,7 @@ class HaPanelDevTemplate extends LitElement {
     await this._unsubscribeTemplate();
     try {
       if (this._context_data && !this._context_variables) {
-        this._context_variables = load(this._context_data) as Record<
-          string,
-          any
-        >;
+        this._context_variables = load(this._context_data);
       }
       this._unsubRenderTemplate = subscribeRenderTemplate(
         this.hass.connection,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4093,6 +4093,7 @@
             "no_listeners": "This template does not listen for any events and will not update automatically.",
             "listeners": "This template listens for the following state changed events:",
             "entity": "Entity",
+            "context_data": "Context data for template",
             "domain": "Domain"
           },
           "statistics": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds a way to provide context data to set initial variables for templates in Developer Tools -> Template. The primary purpose of this change is to allow you copythe data in `changed variables` from a trace like this:

<img width="644" alt="Screen Shot 2022-02-20 at 4 51 33 PM" src="https://user-images.githubusercontent.com/2037026/154865903-4c37d61f-d936-4afa-a040-15c8d2872d75.png">

And paste it in to the new context data field. Then you can iterate on and debug the template that isn't working correctly in your automation with exactly the same context info it would have when actually run in that automation. And paste it back in to the automation afterwards when you're done fixing it.

It also helps in any other use cases when you are debugging a template that normally has passed in variables when actually run by HA. Like templates used in template switch, light, vacuum, select, etc. entities. Instead of having to change your template by adding lines at the top like this:

```j2
{% set brightness = 100 %}
{% set color_temp = 100 %}
{% set white_value = 100 %}
...
```

Just set all that info as context data using YAML and keep it out of your template like you would in the config.

Note here is what the UI of this tab looks like after this change. I put the context data field below the template because it can get quite long when you copy and paste from a trace and I didn't want it to take over the screen and push the template way down as that's the focus.

<img width="1245" alt="Screen Shot 2022-02-20 at 5 35 09 PM" src="https://user-images.githubusercontent.com/2037026/154867436-3aafa867-1ad3-44a7-8573-6771d86ade9b.png">

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Not config but you can paste this below yaml into context data and the below template in to try it out:

```j2
{{ trigger.platform == "homeassistant" and trigger.event == "start" }}
```

```yaml
this:
  entity_id: automation.auto_dismiss_ha_update_alerts
  state: 'on'
  attributes:
    last_triggered: '2022-02-20T07:45:27.409825+00:00'
    mode: single
    current: 0
    id: '1610853218162'
    friendly_name: Start up tasks
  last_changed: '2022-02-20T07:50:47.833188+00:00'
  last_updated: '2022-02-20T07:50:47.833188+00:00'
  context:
    id: 8a409a59fda11b42416765c67d040d50
    parent_id: null
    user_id: null
trigger:
  id: '0'
  idx: '0'
  platform: homeassistant
  event: start
  description: Home Assistant starting
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/21725

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
