### PR TITLE
Show all network adapters on configuration pane

### DIFF
--- a/src/components/ha-network.ts
+++ b/src/components/ha-network.ts
@@ -8,10 +8,9 @@ import {
   nothing,
   TemplateResult,
 } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import {
-  Adapter,
   IPv4ConfiguredAddress,
   IPv6ConfiguredAddress,
   NetworkConfig,

--- a/src/components/ha-network.ts
+++ b/src/components/ha-network.ts
@@ -31,16 +31,6 @@ const format_addresses = (
     i < addresses.length - 1 ? ", " : nothing,
   ])}`;
 
-const format_auto_detected_interfaces = (
-  adapters: Adapter[]
-): Array<TemplateResult | string> =>
-  adapters.map((adapter) =>
-    adapter.auto
-      ? html`${adapter.name}
-        (${format_addresses([...adapter.ipv4, ...adapter.ipv6])})`
-      : ""
-  );
-
 declare global {
   interface HASSDomEvents {
     "network-config-changed": { configured_adapters: string[] };
@@ -52,84 +42,37 @@ export class HaNetwork extends LitElement {
 
   @property({ attribute: false }) public networkConfig?: NetworkConfig;
 
-  @state() private _expanded?: boolean;
-
   protected render(): TemplateResult {
     if (this.networkConfig === undefined) {
       return html``;
     }
     const configured_adapters = this.networkConfig.configured_adapters || [];
     return html`
-      <ha-settings-row>
-        <span slot="prefix">
-          <ha-checkbox
-            id="auto_configure"
-            @change=${this._handleAutoConfigureCheckboxClick}
-            .checked=${!configured_adapters.length}
-            name="auto_configure"
-          >
-          </ha-checkbox>
-        </span>
-        <span slot="heading" data-for="auto_configure"> Auto Configure </span>
-        <span slot="description" data-for="auto_configure">
-          Detected:
-          ${format_auto_detected_interfaces(this.networkConfig.adapters)}
-        </span>
-      </ha-settings-row>
-      ${configured_adapters.length || this._expanded
-        ? this.networkConfig.adapters.map(
-            (adapter) =>
-              html`<ha-settings-row>
-                <span slot="prefix">
-                  <ha-checkbox
-                    id=${adapter.name}
-                    @change=${this._handleAdapterCheckboxClick}
-                    .checked=${configured_adapters.includes(adapter.name)}
-                    .adapter=${adapter.name}
-                    name=${adapter.name}
-                  >
-                  </ha-checkbox>
-                </span>
-                <span slot="heading">
-                  Adapter: ${adapter.name}
-                  ${adapter.default
-                    ? html`<ha-svg-icon .path=${mdiStar}></ha-svg-icon>
-                        (Default)`
-                    : ""}
-                </span>
-                <span slot="description">
-                  ${format_addresses([...adapter.ipv4, ...adapter.ipv6])}
-                </span>
-              </ha-settings-row>`
-          )
-        : ""}
+      ${this.networkConfig.adapters.map(
+        (adapter) =>
+          html`<ha-settings-row>
+            <span slot="prefix">
+              <ha-checkbox
+                id=${adapter.name}
+                @change=${this._handleAdapterCheckboxClick}
+                .checked=${configured_adapters.includes(adapter.name)}
+                .adapter=${adapter.name}
+                name=${adapter.name}
+              >
+              </ha-checkbox>
+            </span>
+            <span slot="heading">
+              Adapter: ${adapter.name}
+              ${adapter.default
+                ? html`<ha-svg-icon .path=${mdiStar}></ha-svg-icon> (Default)`
+                : ""}
+            </span>
+            <span slot="description">
+              ${format_addresses([...adapter.ipv4, ...adapter.ipv6])}
+            </span>
+          </ha-settings-row>`
+      )}
     `;
-  }
-
-  private _handleAutoConfigureCheckboxClick(ev: Event) {
-    const checkbox = ev.currentTarget as HaCheckbox;
-    if (this.networkConfig === undefined) {
-      return;
-    }
-
-    let configured_adapters = [...this.networkConfig.configured_adapters];
-
-    if (checkbox.checked) {
-      this._expanded = false;
-      configured_adapters = [];
-    } else {
-      this._expanded = true;
-      for (const adapter of this.networkConfig.adapters) {
-        if (adapter.default) {
-          configured_adapters = [adapter.name];
-          break;
-        }
-      }
-    }
-
-    fireEvent(this, "network-config-changed", {
-      configured_adapters: configured_adapters,
-    });
   }
 
   private _handleAdapterCheckboxClick(ev: Event) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR changes the behavior of the network configuration pane to show all available adapters, and removing the "auto-detected" checkbox that toggles whether to show only the auto-detected default adapter or all of them. The default adapter is already marked with a star and with the default description, which should be enough indication that it's the auto-detected one.

The reason for this change is that not showing the available adapters in the network configuration is really confusing, as there is no indication on _why_ homeassistant is not detecting other adapters – I had to dug deep into the network integration code to figure out why my network adapters are not visible just to find out they are hidden on purpose...

The pane looks currently similar to this and only unchecking the auto-detected adapter will show other adapters:
![image](https://user-images.githubusercontent.com/3705853/155046786-1f78855c-2171-4e9d-8a9e-619c432394a5.png)

The new pane looks like this (w/ only the auto-detected interface being selected, ignore my already selected another network...):
![image](https://user-images.githubusercontent.com/3705853/155044913-28138bfe-d100-4bb9-a11a-30b695b4cd4d.png)

This is just a draft/RFC; when done properly, clicking "save" when only the auto-detected adapter is selected should probably clear the configuration to allow auto-detection as expected when the device is moved into another network. As I have no clue about frontend development, I just wanted to push this out for some feedback before going to study more how to do this properly.

Btw, the message on the pane is not accurate anymore, as there are several integrations that use the network configuration also for broadcast purposes (steamist, wiz, elkm1, flux_led, and tplink call `async_get_ipv4_broadcast_addresses`).

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
