### PR TITLE
Fix timer entity exception

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-timer-entity-row.ts
@@ -23,6 +23,18 @@ class HuiTimerEntityRow extends LitElement {
       throw new Error("Invalid configuration");
     }
     this._config = config;
+
+    if (!this.hass) {
+      return;
+    }
+
+    const stateObj = this.hass!.states[this._config.entity];
+
+    if (stateObj) {
+      this._startInterval(stateObj);
+    } else {
+      this._clearInterval();
+    }
   }
 
   public disconnectedCallback(): void {
@@ -75,18 +87,19 @@ class HuiTimerEntityRow extends LitElement {
   protected updated(changedProps: PropertyValues) {
     super.updated(changedProps);
 
-    if (changedProps.has("hass")) {
-      const stateObj = this.hass!.states[this._config!.entity];
-      const oldHass = changedProps.get("hass") as this["hass"];
-      const oldStateObj = oldHass
-        ? oldHass.states[this._config!.entity]
-        : undefined;
+    if (!this._config || !changedProps.has("hass")) {
+      return;
+    }
+    const stateObj = this.hass!.states[this._config!.entity];
+    const oldHass = changedProps.get("hass") as this["hass"];
+    const oldStateObj = oldHass
+      ? oldHass.states[this._config!.entity]
+      : undefined;
 
-      if (oldStateObj !== stateObj) {
-        this._startInterval(stateObj);
-      } else if (!stateObj) {
-        this._clearInterval();
-      }
+    if (oldStateObj !== stateObj) {
+      this._startInterval(stateObj);
+    } else if (!stateObj) {
+      this._clearInterval();
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Noticed a stack trace in my dev env. This fixes it. Probably caused because `hass` is set before `config` because the element is asynchronously loaded.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
