### PR TITLE
Show browse media even if media player has no controls

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -50,42 +50,38 @@ class MoreInfoMediaPlayer extends LitElement {
     const controls = computeMediaControls(stateObj);
 
     return html`
-      ${!controls
-        ? ""
-        : html`
-            <div class="controls">
-              <div class="basic-controls">
-                ${controls!.map(
-                  (control) => html`
-                    <ha-icon-button
-                      action=${control.action}
-                      @click=${this._handleClick}
-                      .path=${control.icon}
-                      .label=${this.hass.localize(
-                        `ui.card.media_player.${control.action}`
-                      )}
-                    >
-                    </ha-icon-button>
-                  `
+      <div class="controls">
+        <div class="basic-controls">
+          ${controls!.map(
+            (control) => html`
+              <ha-icon-button
+                action=${control.action}
+                @click=${this._handleClick}
+                .path=${control.icon}
+                .label=${this.hass.localize(
+                  `ui.card.media_player.${control.action}`
                 )}
-              </div>
-              ${supportsFeature(stateObj, SUPPORT_BROWSE_MEDIA)
-                ? html`
-                    <mwc-button
-                      .label=${this.hass.localize(
-                        "ui.card.media_player.browse_media"
-                      )}
-                      @click=${this._showBrowseMedia}
-                    >
-                      <ha-svg-icon
-                        .path=${mdiPlayBoxMultiple}
-                        slot="icon"
-                      ></ha-svg-icon>
-                    </mwc-button>
-                  `
-                : ""}
-            </div>
-          `}
+              >
+              </ha-icon-button>
+            `
+          )}
+        </div>
+        ${supportsFeature(stateObj, SUPPORT_BROWSE_MEDIA)
+          ? html`
+              <mwc-button
+                .label=${this.hass.localize(
+                  "ui.card.media_player.browse_media"
+                )}
+                @click=${this._showBrowseMedia}
+              >
+                <ha-svg-icon
+                  .path=${mdiPlayBoxMultiple}
+                  slot="icon"
+                ></ha-svg-icon>
+              </mwc-button>
+            `
+          : ""}
+      </div>
       ${(supportsFeature(stateObj, SUPPORT_VOLUME_SET) ||
         supportsFeature(stateObj, SUPPORT_VOLUME_BUTTONS)) &&
       ![UNAVAILABLE, UNKNOWN, "off"].includes(stateObj.state)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Show browse media button even if the player has no controls.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
