### PR TITLE
Add py.typed

### DIFF
--- a/public/__init__.py
+++ b/public/__init__.py
@@ -2,6 +2,6 @@
 from pathlib import Path
 
 
-def where():
+def where() -> Path:
     """Return path to the frontend."""
     return Path(__file__).parent

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,8 @@ python_requires = >= 3.4.0
 [options.packages.find]
 include =
     hass_frontend*
+
+[mypy]
+python_version = 3.4
+show_error_codes = True
+strict = True


### PR DESCRIPTION
## Proposed change
Add a `py.typed` file for the `hass_frontend` package. Specified by [PEP 561](https://www.python.org/dev/peps/pep-0561/), `py.typed` is required if distribution packages what to express they are fully typed. The `setuptools` config already includes all files within the `hass_frontend` package, no further action is required there.

Additionally, add the return type for `where()` and a (very) basic mypy configuration.

--
In the end this change should allow us to get rid of a `cast` in `homeassistant`.
```py
def _frontend_root(dev_repo_path: str | None) -> pathlib.Path:
    ...
    return cast(pathlib.Path, hass_frontend.where())
```

--
Additional resources
* https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/
* https://jugmac00.github.io/blog/bite-my-shiny-type-annotated-library/
* https://setuptools.pypa.io/en/latest/userguide/datafiles.html

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
