### PR TITLE
Fix gas energy graph units if stats added by external source

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -345,6 +345,17 @@ export const getStatisticIds = (
     statistic_type,
   });
 
+export const getStatisticMetadata = (
+  hass: HomeAssistant,
+  statistic_ids?: string[],
+  statistic_type?: "mean" | "sum"
+) =>
+  hass.callWS<StatisticsMetaData[]>({
+    type: "recorder/get_statistics_metadata",
+    statistic_ids,
+    statistic_type,
+  });
+
 export const fetchStatistics = (
   hass: HomeAssistant,
   startTime: Date,

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -347,13 +347,11 @@ export const getStatisticIds = (
 
 export const getStatisticMetadata = (
   hass: HomeAssistant,
-  statistic_ids?: string[],
-  statistic_type?: "mean" | "sum"
+  statistic_ids?: string[]
 ) =>
   hass.callWS<StatisticsMetaData[]>({
     type: "recorder/get_statistics_metadata",
     statistic_ids,
-    statistic_type,
   });
 
 export const fetchStatistics = (

--- a/src/panels/config/energy/components/ha-energy-gas-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-gas-settings.ts
@@ -121,6 +121,7 @@ export class EnergyGasSettings extends LitElement {
     showEnergySettingsGasDialog(this, {
       unit: getEnergyGasUnitCategory(this.hass, this.preferences),
       saveCallback: async (source) => {
+        delete source.unit_of_measurement;
         await this._savePreferences({
           ...this.preferences,
           energy_sources: this.preferences.energy_sources.concat(source),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

By default Energy dashboard get units from entity.
If stats for gas are added by `async_add_external_statistics` then entity don't exists, so energy dashboard is falling back to m³ units.
This PR fixes this issue and get unit from statistic_meta if entity doesn't exists.

Depends on core PR https://github.com/home-assistant/core/pull/68471

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
