### PR TITLE
Return focus after dialogs close

### DIFF
--- a/src/common/dom/ancestors-with-property.ts
+++ b/src/common/dom/ancestors-with-property.ts
@@ -1,0 +1,41 @@
+const DEFAULT_OWN = true;
+
+// Finds the closest ancestor of an element that has a specific optionally owned property,
+// traversing slot and shadow root boundaries until the body element is reached
+export const closestWithProperty = (
+  element: Element | null,
+  property: string | symbol,
+  own = DEFAULT_OWN
+) => {
+  if (!element || element === document.body) return null;
+
+  element = element.assignedSlot ?? element;
+  if (element.parentElement) {
+    element = element.parentElement;
+  } else {
+    const root = element.getRootNode();
+    element = root instanceof ShadowRoot ? root.host : null;
+  }
+
+  if (
+    own
+      ? Object.prototype.hasOwnProperty.call(element, property)
+      : element && property in element
+  )
+    return element;
+  return closestWithProperty(element, property, own);
+};
+
+// Finds the set of all such ancestors and includes starting element as first in the set
+export const ancestorsWithProperty = (
+  element: Element | null,
+  property: string | symbol,
+  own = DEFAULT_OWN
+) => {
+  const ancestors: Set<Element> = new Set();
+  while (element) {
+    ancestors.add(element);
+    element = closestWithProperty(element, property, own);
+  }
+  return ancestors;
+};

--- a/src/common/dom/deep-active-element.ts
+++ b/src/common/dom/deep-active-element.ts
@@ -1,47 +1,8 @@
-import { HaDialog } from "../../components/ha-dialog";
-import { HaButtonMenu } from "../../components/ha-button-menu";
-
-export const deepActiveElement = <
-  modeType extends "normal" | "dialog" | "check"
->(
-  root: DocumentOrShadowRoot = document,
-  mode?: modeType,
-  checkElement?: Element | null
-): modeType extends "check"
-  ? boolean
-  : modeType extends "dialog"
-  ? [Element | null, HaDialog | null]
-  : Element | null => {
-  let activeElement = root.activeElement;
-  let activeDialog: HaDialog | null = null;
-  let deeperElement: Element | null | undefined;
-
-  do {
-    // Mode to check if a target is focused
-    if (mode === "check" && checkElement === activeElement) return true as any;
-
-    // Mode to determine closed dialog targets
-    if (mode === "dialog") {
-      // Detect when focus is slotted into certain components
-      const slotRoot = activeElement?.assignedSlot?.getRootNode();
-      if (slotRoot instanceof ShadowRoot) {
-        const slotHost = slotRoot.host;
-        if (slotHost instanceof HaButtonMenu) {
-          // Use trigger button since popup menu will be hidden again
-          activeElement = slotHost.querySelector('[slot="trigger"]');
-          break;
-        } else if (slotHost instanceof HaDialog) {
-          // Focus is inside another dialog
-          activeDialog = slotHost;
-        }
-      }
-    }
-
-    deeperElement = activeElement?.shadowRoot?.activeElement;
-    activeElement = deeperElement ?? activeElement;
-  } while (deeperElement);
-
-  if (mode === "check") return false as any;
-  if (mode === "dialog") return [activeElement, activeDialog] as any;
-  return activeElement as any;
+export const deepActiveElement = (
+  root: DocumentOrShadowRoot = document
+): Element | null => {
+  if (root.activeElement?.shadowRoot?.activeElement) {
+    return deepActiveElement(root.activeElement.shadowRoot);
+  }
+  return root.activeElement;
 };

--- a/src/common/dom/deep-active-element.ts
+++ b/src/common/dom/deep-active-element.ts
@@ -1,8 +1,47 @@
-export const deepActiveElement = (
-  root: DocumentOrShadowRoot = document
-): Element | null => {
-  if (root.activeElement?.shadowRoot?.activeElement) {
-    return deepActiveElement(root.activeElement.shadowRoot);
-  }
-  return root.activeElement;
+import { HaDialog } from "../../components/ha-dialog";
+import { HaButtonMenu } from "../../components/ha-button-menu";
+
+export const deepActiveElement = <
+  modeType extends "normal" | "dialog" | "check"
+>(
+  root: DocumentOrShadowRoot = document,
+  mode?: modeType,
+  checkElement?: Element | null
+): modeType extends "check"
+  ? boolean
+  : modeType extends "dialog"
+  ? [Element | null, HaDialog | null]
+  : Element | null => {
+  let activeElement = root.activeElement;
+  let activeDialog: HaDialog | null = null;
+  let deeperElement: Element | null | undefined;
+
+  do {
+    // Mode to check if a target is focused
+    if (mode === "check" && checkElement === activeElement) return true as any;
+
+    // Mode to determine closed dialog targets
+    if (mode === "dialog") {
+      // Detect when focus is slotted into certain components
+      const slotRoot = activeElement?.assignedSlot?.getRootNode();
+      if (slotRoot instanceof ShadowRoot) {
+        const slotHost = slotRoot.host;
+        if (slotHost instanceof HaButtonMenu) {
+          // Use trigger button since popup menu will be hidden again
+          activeElement = slotHost.querySelector('[slot="trigger"]');
+          break;
+        } else if (slotHost instanceof HaDialog) {
+          // Focus is inside another dialog
+          activeDialog = slotHost;
+        }
+      }
+    }
+
+    deeperElement = activeElement?.shadowRoot?.activeElement;
+    activeElement = deeperElement ?? activeElement;
+  } while (deeperElement);
+
+  if (mode === "check") return false as any;
+  if (mode === "dialog") return [activeElement, activeDialog] as any;
+  return activeElement as any;
 };

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -1,7 +1,14 @@
+import type { Button } from "@material/mwc-button";
 import "@material/mwc-menu";
 import type { Corner, Menu, MenuCorner } from "@material/mwc-menu";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, query } from "lit/decorators";
+import {
+  customElement,
+  property,
+  query,
+  queryAssignedElements,
+} from "lit/decorators";
+import type { HaIconButton } from "./ha-icon-button";
 
 @customElement("ha-button-menu")
 export class HaButtonMenu extends LitElement {
@@ -9,9 +16,9 @@ export class HaButtonMenu extends LitElement {
 
   @property() public menuCorner: MenuCorner = "START";
 
-  @property({ type: Number }) public x?: number;
+  @property({ type: Number }) public x: number | null = null;
 
-  @property({ type: Number }) public y?: number;
+  @property({ type: Number }) public y: number | null = null;
 
   @property({ type: Boolean }) public multi = false;
 
@@ -23,12 +30,26 @@ export class HaButtonMenu extends LitElement {
 
   @query("mwc-menu", true) private _menu?: Menu;
 
+  @queryAssignedElements({
+    slot: "trigger",
+    selector: "ha-icon-button, mwc-button",
+  })
+  private _triggerButton!: Array<HaIconButton | Button>;
+
   public get items() {
     return this._menu?.items;
   }
 
   public get selected() {
     return this._menu?.selected;
+  }
+
+  public override focus() {
+    if (this._menu?.open) {
+      this._menu.focusItemAtIndex(0);
+    } else {
+      this._triggerButton[0]?.focus();
+    }
   }
 
   protected render(): TemplateResult {

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -8,10 +8,13 @@ import {
   query,
   queryAssignedElements,
 } from "lit/decorators";
+import { FOCUS_TARGET } from "../dialogs/make-dialog-manager";
 import type { HaIconButton } from "./ha-icon-button";
 
 @customElement("ha-button-menu")
 export class HaButtonMenu extends LitElement {
+  protected readonly [FOCUS_TARGET];
+
   @property() public corner: Corner = "TOP_START";
 
   @property() public menuCorner: MenuCorner = "START";

--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -5,6 +5,7 @@ import { css, html, TemplateResult } from "lit";
 import { customElement } from "lit/decorators";
 import { computeRTLDirection } from "../common/util/compute_rtl";
 import type { HomeAssistant } from "../types";
+import { FOCUS_TARGET } from "../dialogs/make-dialog-manager";
 import "./ha-icon-button";
 
 export const createCloseHeading = (
@@ -23,6 +24,8 @@ export const createCloseHeading = (
 
 @customElement("ha-dialog")
 export class HaDialog extends DialogBase {
+  protected readonly [FOCUS_TARGET];
+
   public scrollToPos(x: number, y: number) {
     this.contentElement?.scrollTo(x, y);
   }

--- a/src/components/ha-icon-button.ts
+++ b/src/components/ha-icon-button.ts
@@ -1,6 +1,7 @@
 import "@material/mwc-icon-button";
+import type { IconButton } from "@material/mwc-icon-button";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import "./ha-svg-icon";
 
 @customElement("ha-icon-button")
@@ -14,6 +15,12 @@ export class HaIconButton extends LitElement {
   @property({ type: String }) label = "";
 
   @property({ type: Boolean }) hideTitle = false;
+
+  @query("mwc-icon-button", true) private _button?: IconButton;
+
+  public override focus() {
+    this._button?.focus();
+  }
 
   static shadowRootOptions: ShadowRootInit = {
     mode: "open",

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -1,6 +1,8 @@
 import { HASSDomEvent, ValidHassDomEvent } from "../common/dom/fire_event";
 import { mainWindow } from "../common/dom/get_main_window";
 import { ProvideHassElement } from "../mixins/provide-hass-lit-mixin";
+import { HaButtonMenu } from "../components/ha-button-menu";
+import { HaDialog } from "../components/ha-dialog";
 
 declare global {
   // for fire event
@@ -40,7 +42,17 @@ export interface DialogState {
   dialogParams?: unknown;
 }
 
-const LOADED = {};
+interface LoadedDialogInfo {
+  element: Promise<HassDialog>;
+  closedFocusTarget: Element | null;
+  closedFocusDialog: HaDialog | null;
+}
+
+interface LoadedDialogsDict {
+  [tag: string]: LoadedDialogInfo;
+}
+
+const LOADED: LoadedDialogsDict = {};
 
 export const showDialog = async (
   element: HTMLElement & ProvideHassElement,
@@ -60,11 +72,46 @@ export const showDialog = async (
       }
       return;
     }
-    LOADED[dialogTag] = dialogImport().then(() => {
-      const dialogEl = document.createElement(dialogTag) as HassDialog;
-      element.provideHass(dialogEl);
-      return dialogEl;
-    });
+    LOADED[dialogTag] = {
+      element: dialogImport().then(() => {
+        const dialogEl = document.createElement(dialogTag) as HassDialog;
+        element.provideHass(dialogEl);
+        return dialogEl;
+      }),
+      closedFocusTarget: null,
+      closedFocusDialog: null,
+    };
+  }
+
+  // Go down all components to find the active element,
+  // but keep the original focus target if dialog is being replaced
+  if (mainWindow.history.state?.replaced) {
+    LOADED[dialogTag].closedFocusTarget =
+      LOADED[mainWindow.history.state.dialog].closedFocusTarget;
+    LOADED[dialogTag].closedFocusDialog =
+      LOADED[mainWindow.history.state.dialog].closedFocusDialog;
+  } else {
+    let focusedDialog: LoadedDialogInfo["closedFocusDialog"] = null;
+    let focusedElement = document.activeElement;
+    while (focusedElement?.shadowRoot?.activeElement) {
+      focusedElement = focusedElement.shadowRoot.activeElement;
+
+      // Detect when focus is slotted into certain components
+      const slotRoot = focusedElement.assignedSlot?.getRootNode();
+      if (slotRoot instanceof ShadowRoot) {
+        const slotHost = slotRoot.host;
+        if (slotHost instanceof HaButtonMenu) {
+          // Use trigger button since popup menu will be hidden again
+          focusedElement = slotHost.querySelector('[slot="trigger"]');
+          break;
+        } else if (slotHost instanceof HaDialog) {
+          // Focus will return inside another dialog
+          focusedDialog = slotHost;
+        }
+      }
+    }
+    LOADED[dialogTag].closedFocusTarget = focusedElement;
+    LOADED[dialogTag].closedFocusDialog = focusedDialog;
   }
 
   if (addHistory) {
@@ -93,25 +140,29 @@ export const showDialog = async (
       );
     }
   }
-  const dialogElement = await LOADED[dialogTag];
+
+  const dialogElement = await LOADED[dialogTag].element;
+  dialogElement.addEventListener("dialog-closed", _handleClosedFocus);
+
   // Append it again so it's the last element in the root,
   // so it's guaranteed to be on top of the other elements
   root.appendChild(dialogElement);
   dialogElement.showDialog(dialogParams);
 };
 
-export const replaceDialog = () => {
+export const replaceDialog = (dialogElement: HassDialog) => {
   mainWindow.history.replaceState(
     { ...mainWindow.history.state, replaced: true },
     ""
   );
+  dialogElement.removeEventListener("dialog-closed", _handleClosedFocus);
 };
 
 export const closeDialog = async (dialogTag: string): Promise<boolean> => {
   if (!(dialogTag in LOADED)) {
     return true;
   }
-  const dialogElement: HassDialog = await LOADED[dialogTag];
+  const dialogElement = await LOADED[dialogTag].element;
   if (dialogElement.closeDialog) {
     return dialogElement.closeDialog() !== false;
   }
@@ -136,4 +187,35 @@ export const makeDialogManager = (
       );
     }
   );
+};
+
+const _handleClosedFocus = async (ev: HASSDomEvent<DialogClosedParams>) => {
+  const focusTarget = LOADED[ev.detail.dialog].closedFocusTarget;
+  const focusDialog = LOADED[ev.detail.dialog].closedFocusDialog;
+
+  // If target is in another dialog, make sure it is fully rendered before trying
+  await focusDialog?.updateComplete;
+  if (focusTarget instanceof HTMLElement) focusTarget.focus();
+
+  // Check if focusing was successful
+  let focusedElement = document.activeElement;
+  let focusSuccess = focusTarget === focusedElement;
+  while (!focusSuccess && focusedElement?.shadowRoot?.activeElement) {
+    focusedElement = focusedElement.shadowRoot.activeElement;
+    focusSuccess = focusTarget === focusedElement;
+  }
+
+  if (!focusSuccess) {
+    // Let dialog handle fallback if it exists
+    focusDialog?.focus();
+
+    if (__DEV__) {
+      // eslint-disable-next-line
+      console.warn(
+        "Tried to focus %o after closing dialog, but active element is %o",
+        focusTarget,
+        focusedElement
+      );
+    }
+  }
 };

--- a/src/dialogs/make-dialog-manager.ts
+++ b/src/dialogs/make-dialog-manager.ts
@@ -45,7 +45,7 @@ export interface DialogState {
 
 interface LoadedDialogInfo {
   element: Promise<HassDialog>;
-  closedFocusTargets: Set<Element>;
+  closedFocusTargets?: Set<Element>;
 }
 
 interface LoadedDialogsDict {
@@ -79,7 +79,6 @@ export const showDialog = async (
         element.provideHass(dialogEl);
         return dialogEl;
       }),
-      closedFocusTargets: new Set(),
     };
   }
 
@@ -171,6 +170,8 @@ export const makeDialogManager = (
 
 const _handleClosedFocus = async (ev: HASSDomEvent<DialogClosedParams>) => {
   const closedFocusTargets = LOADED[ev.detail.dialog].closedFocusTargets;
+  delete LOADED[ev.detail.dialog].closedFocusTargets;
+  if (!closedFocusTargets) return;
 
   // Undo whatever the browser focused to provide easy checking
   let focusedElement = deepActiveElement();
@@ -184,11 +185,11 @@ const _handleClosedFocus = async (ev: HASSDomEvent<DialogClosedParams>) => {
     if (focusTarget instanceof HTMLElement) {
       focusTarget.focus();
       focusedElement = deepActiveElement();
-      if (focusedElement && focusedElement !== document.body) break;
+      if (focusedElement && focusedElement !== document.body) return;
     }
   }
 
-  if (__DEV__ && (!focusedElement || focusedElement === document.body)) {
+  if (__DEV__) {
     // eslint-disable-next-line no-console
     console.warn(
       "Failed to focus any targets after closing dialog: %o",

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -295,7 +295,7 @@ export class MoreInfoDialog extends LitElement {
   }
 
   private _gotoSettings() {
-    replaceDialog();
+    replaceDialog(this);
     showEntityEditorDialog(this, {
       entity_id: this._entityId!,
     });

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -220,7 +220,7 @@ export class DialogEntityEditor extends LitElement {
   }
 
   private _openMoreInfo(): void {
-    replaceDialog();
+    replaceDialog(this);
     fireEvent(this, "hass-more-info", {
       entityId: this._params!.entity_id,
     });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds an event handler to return focus, where possible, to the button or control that opened the dialog.  This is best practice for good accessibility.  Here are some details on the implementation:
- Finds and stores the active element and possibly dialog generically right before new dialog is shown
- Data is stored in the module in tag dictionary same as created elements, and typing was added for better code quality
- Handles the common special case where dialog is opened from a popup menu and returns focus to the trigger
- Handles the replace situation for more info / entity settings
- When dialog is opened from another dialog, focus method for `mwc-dialog` becomes the fallback in case of failure
### Limitations
1. Assumes the dialog fires the `dialog-closed` event.  The majority of the 70+ dialogs do, but about 20 or so need to be updated in future changes.
2. Assumes the element that opened the dialog is focusable, which is not always the case, but should be for keyboard accessibility (e.g. entity settings dialogs from configuration page and some more info dialogs from certain cards)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #10754 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

