### PR TITLE
Fix zwave_js 'add/remove device' disabled bug

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -113,9 +113,10 @@ class ZWaveJSConfigDashboard extends LitElement {
           </div>
           ${this._network &&
           this._status === "connected" &&
-          [InclusionState.Including, InclusionState.Excluding].includes(
-            this._network?.controller.inclusion_state
-          )
+          (this._network?.controller.inclusion_state ===
+            InclusionState.Including ||
+            this._network?.controller.inclusion_state ===
+              InclusionState.Excluding)
             ? html`
                 <ha-alert alert-type="info">
                   ${this.hass.localize(

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -113,10 +113,9 @@ class ZWaveJSConfigDashboard extends LitElement {
           </div>
           ${this._network &&
           this._status === "connected" &&
-          (this._network?.controller.inclusion_state ===
-            InclusionState.Including ||
-            this._network?.controller.inclusion_state ===
-              InclusionState.Excluding)
+          [InclusionState.Including, InclusionState.Excluding].includes(
+            this._network?.controller.inclusion_state
+          )
             ? html`
                 <ha-alert alert-type="info">
                   ${this.hass.localize(
@@ -237,8 +236,10 @@ class ZWaveJSConfigDashboard extends LitElement {
                     <mwc-button
                       @click=${this._removeNodeClicked}
                       .disabled=${this._status !== "connected" ||
-                      this._network?.controller.inclusion_state !==
-                        InclusionState.Idle}
+                      (this._network?.controller.inclusion_state !==
+                        InclusionState.Idle &&
+                        this._network?.controller.inclusion_state !==
+                          InclusionState.SmartStart)}
                     >
                       ${this.hass.localize(
                         "ui.panel.config.zwave_js.common.remove_node"
@@ -304,7 +305,9 @@ class ZWaveJSConfigDashboard extends LitElement {
           ?rtl=${computeRTL(this.hass)}
           @click=${this._addNodeClicked}
           .disabled=${this._status !== "connected" ||
-          this._network?.controller.inclusion_state !== InclusionState.Idle}
+          (this._network?.controller.inclusion_state !== InclusionState.Idle &&
+            this._network?.controller.inclusion_state !==
+              InclusionState.SmartStart)}
         >
           <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
         </ha-fab>


### PR DESCRIPTION
## Proposed change
This bug happens because a controller can be in SmartStart node and can still include/exclude new nodes: https://github.com/home-assistant/core/issues/67936

This PR fixes that

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#67936
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
