### PR TITLE
Add support for menu data entry flow option

### DIFF
--- a/src/data/data_entry_flow.ts
+++ b/src/data/data_entry_flow.ts
@@ -28,7 +28,7 @@ export interface DataEntryFlowStepForm {
   step_id: string;
   data_schema: HaFormSchema[];
   errors: Record<string, string>;
-  description_placeholders: Record<string, string>;
+  description_placeholders?: Record<string, string>;
   last_step: boolean | null;
 }
 
@@ -49,7 +49,7 @@ export interface DataEntryFlowStepCreateEntry {
   title: string;
   result?: ConfigEntry;
   description: string;
-  description_placeholders: Record<string, string>;
+  description_placeholders?: Record<string, string>;
 }
 
 export interface DataEntryFlowStepAbort {
@@ -57,7 +57,7 @@ export interface DataEntryFlowStepAbort {
   flow_id: string;
   handler: string;
   reason: string;
-  description_placeholders: Record<string, string>;
+  description_placeholders?: Record<string, string>;
 }
 
 export interface DataEntryFlowStepProgress {
@@ -66,7 +66,17 @@ export interface DataEntryFlowStepProgress {
   handler: string;
   step_id: string;
   progress_action: string;
-  description_placeholders: Record<string, string>;
+  description_placeholders?: Record<string, string>;
+}
+
+export interface DataEntryFlowStepMenu {
+  type: "menu";
+  flow_id: string;
+  handler: string;
+  step_id: string;
+  /** If array, use value to lookup translations in strings.json */
+  menu_options: string[] | Record<string, string>;
+  description_placeholders?: Record<string, string>;
 }
 
 export type DataEntryFlowStep =
@@ -74,7 +84,8 @@ export type DataEntryFlowStep =
   | DataEntryFlowStepExternal
   | DataEntryFlowStepCreateEntry
   | DataEntryFlowStepAbort
-  | DataEntryFlowStepProgress;
+  | DataEntryFlowStepProgress
+  | DataEntryFlowStepMenu;
 
 export const subscribeDataEntryFlowProgressed = (
   conn: Connection,

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -46,6 +46,7 @@ import "./step-flow-loading";
 import "./step-flow-pick-flow";
 import "./step-flow-pick-handler";
 import "./step-flow-progress";
+import "./step-flow-menu";
 
 let instance = 0;
 
@@ -292,6 +293,14 @@ class DataEntryFlowDialog extends LitElement {
                         .hass=${this.hass}
                       ></step-flow-progress>
                     `
+                  : this._step.type === "menu"
+                  ? html`
+                      <step-flow-menu
+                        .flowConfig=${this._params.flowConfig}
+                        .step=${this._step}
+                        .hass=${this.hass}
+                      ></step-flow-menu>
+                    `
                   : this._devices === undefined || this._areas === undefined
                   ? // When it's a create entry result, we will fetch device & area registry
                     html`
@@ -421,7 +430,7 @@ class DataEntryFlowDialog extends LitElement {
           title: this.hass.localize(
             "ui.panel.config.integrations.config_flow.error"
           ),
-          text: err.message || err.body,
+          text: err?.body?.message,
         });
         return;
       } finally {

--- a/src/dialogs/config-flow/show-dialog-config-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-config-flow.ts
@@ -181,6 +181,21 @@ export const showConfigFlowDialog = (
         : "";
     },
 
+    renderMenuHeader(hass, step) {
+      return (
+        hass.localize(
+          `component.${step.handler}.config.step.${step.step_id}.title`
+        ) || hass.localize(`component.${step.handler}.title`)
+      );
+    },
+
+    renderMenuOption(hass, step, option) {
+      return hass.localize(
+        `component.${step.handler}.config.step.${step.step_id}.menu_options.${option}`,
+        step.description_placeholders
+      );
+    },
+
     renderLoadingDescription(hass, reason, handler, step) {
       if (!["loading_flow", "loading_step"].includes(reason)) {
         return "";

--- a/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-data-entry-flow.ts
@@ -7,6 +7,7 @@ import {
   DataEntryFlowStepCreateEntry,
   DataEntryFlowStepExternal,
   DataEntryFlowStepForm,
+  DataEntryFlowStepMenu,
   DataEntryFlowStepProgress,
 } from "../../data/data_entry_flow";
 import { HomeAssistant } from "../../types";
@@ -79,6 +80,14 @@ export interface FlowConfig {
     hass: HomeAssistant,
     step: DataEntryFlowStepProgress
   ): TemplateResult | "";
+
+  renderMenuHeader(hass: HomeAssistant, step: DataEntryFlowStepMenu): string;
+
+  renderMenuOption(
+    hass: HomeAssistant,
+    step: DataEntryFlowStepMenu,
+    option: string
+  ): string;
 
   renderLoadingDescription(
     hass: HomeAssistant,

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -134,6 +134,21 @@ export const showOptionsFlowDialog = (
           : "";
       },
 
+      renderMenuHeader(hass, step) {
+        return (
+          hass.localize(
+            `component.${step.handler}.option.step.${step.step_id}.title`
+          ) || hass.localize(`component.${step.handler}.title`)
+        );
+      },
+
+      renderMenuOption(hass, step, option) {
+        return hass.localize(
+          `component.${step.handler}.options.step.${step.step_id}.menu_options.${option}`,
+          step.description_placeholders
+        );
+      },
+
       renderLoadingDescription(hass, reason) {
         return (
           hass.localize(`component.${configEntry.domain}.options.loading`) ||

--- a/src/dialogs/config-flow/step-flow-menu.ts
+++ b/src/dialogs/config-flow/step-flow-menu.ts
@@ -1,9 +1,9 @@
 import "@material/mwc-list/mwc-list-item";
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
-import { DataEntryFlowStepMenu } from "../../data/data_entry_flow";
-import { HomeAssistant } from "../../types";
-import { FlowConfig } from "./show-dialog-data-entry-flow";
+import type { DataEntryFlowStepMenu } from "../../data/data_entry_flow";
+import type { HomeAssistant } from "../../types";
+import type { FlowConfig } from "./show-dialog-data-entry-flow";
 import "../../components/ha-icon-next";
 import { configFlowContentStyles } from "./styles";
 import { fireEvent } from "../../common/dom/fire_event";

--- a/src/dialogs/config-flow/step-flow-menu.ts
+++ b/src/dialogs/config-flow/step-flow-menu.ts
@@ -1,0 +1,80 @@
+import "@material/mwc-list/mwc-list-item";
+import { css, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators";
+import { DataEntryFlowStepMenu } from "../../data/data_entry_flow";
+import { HomeAssistant } from "../../types";
+import { FlowConfig } from "./show-dialog-data-entry-flow";
+import "../../components/ha-icon-next";
+import { configFlowContentStyles } from "./styles";
+import { fireEvent } from "../../common/dom/fire_event";
+
+@customElement("step-flow-menu")
+class StepFlowMenu extends LitElement {
+  @property({ attribute: false }) public flowConfig!: FlowConfig;
+
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public step!: DataEntryFlowStepMenu;
+
+  protected render(): TemplateResult {
+    let options: string[];
+    let translations: Record<string, string>;
+
+    if (Array.isArray(this.step.menu_options)) {
+      options = this.step.menu_options;
+      translations = {};
+      for (const option of options) {
+        translations[option] = this.flowConfig.renderMenuOption(
+          this.hass,
+          this.step,
+          option
+        );
+      }
+    } else {
+      options = Object.keys(this.step.menu_options);
+      translations = this.step.menu_options;
+    }
+
+    return html`
+      <h2>${this.flowConfig.renderMenuHeader(this.hass, this.step)}</h2>
+      <div class="options">
+        ${options.map(
+          (option) => html`
+            <mwc-list-item hasMeta .step=${option} @click=${this._handleStep}>
+              <span>${translations[option]}</span>
+              <ha-icon-next slot="meta"></ha-icon-next>
+            </mwc-list-item>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private _handleStep(ev) {
+    fireEvent(this, "flow-update", {
+      stepPromise: this.flowConfig.handleFlowStep(
+        this.hass,
+        this.step.flow_id,
+        {
+          next_step_id: ev.currentTarget.step,
+        }
+      ),
+    });
+  }
+
+  static styles = [
+    configFlowContentStyles,
+    css`
+      .options {
+        margin-top: 20px;
+        margin-bottom: 8px;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "step-flow-menu": StepFlowMenu;
+  }
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Add support for navigational step to data entry flow.

Backcend: https://github.com/home-assistant/core/pull/68203

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
