### PR TITLE
Add ha-form context

### DIFF
--- a/gallery/src/pages/components/ha-form.ts
+++ b/gallery/src/pages/components/ha-form.ts
@@ -139,6 +139,7 @@ const SCHEMAS: {
       {
         name: "Attribute",
         selector: { attribute: { entity_id: "" } },
+        context: { filter_entity: "entity" },
       },
       { name: "Device", selector: { device: {} } },
       { name: "Duration", selector: { duration: {} } },

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -106,6 +106,7 @@ export class HaForm extends LitElement implements HaFormElement {
                   .disabled=${this.disabled}
                   .helper=${this._computeHelper(item)}
                   .required=${item.required || false}
+                  .context=${this._generateContext(item)}
                 ></ha-selector>`
               : dynamicElement(`ha-form-${item.type}`, {
                   schema: item,
@@ -115,11 +116,26 @@ export class HaForm extends LitElement implements HaFormElement {
                   hass: this.hass,
                   computeLabel: this.computeLabel,
                   computeHelper: this.computeHelper,
+                  context: this._generateContext(item),
                 })}
           `;
         })}
       </div>
     `;
+  }
+
+  private _generateContext(
+    schema: HaFormSchema
+  ): Record<string, any> | undefined {
+    if (!schema.context) {
+      return undefined;
+    }
+
+    const context = {};
+    for (const [context_key, data_key] of Object.entries(schema.context)) {
+      context[context_key] = this.data[data_key];
+    }
+    return context;
   }
 
   protected createRenderRoot() {

--- a/src/components/ha-form/types.ts
+++ b/src/components/ha-form/types.ts
@@ -24,6 +24,7 @@ export interface HaFormBaseSchema {
     // This value will be set initially when form is loaded
     suggested_value?: HaFormData;
   };
+  context?: Record<string, string>;
 }
 
 export interface HaFormGridSchema extends HaFormBaseSchema {

--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -1,9 +1,10 @@
 import "../entity/ha-entity-attribute-picker";
-import { html, LitElement } from "lit";
+import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import { AttributeSelector } from "../../data/selector";
 import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import { HomeAssistant } from "../../types";
+import { fireEvent } from "../../common/dom/fire_event";
 
 @customElement("ha-selector-attribute")
 export class HaSelectorAttribute extends SubscribeMixin(LitElement) {
@@ -17,17 +18,63 @@ export class HaSelectorAttribute extends SubscribeMixin(LitElement) {
 
   @property({ type: Boolean }) public disabled = false;
 
+  @property() public context?: {
+    filter_entity?: string;
+  };
+
   protected render() {
     return html`
       <ha-entity-attribute-picker
         .hass=${this.hass}
-        .entityId=${this.selector.attribute.entity_id}
+        .entityId=${this.selector.attribute.entity_id ||
+        this.context?.filter_entity}
         .value=${this.value}
         .label=${this.label}
         .disabled=${this.disabled}
         allow-custom-value
       ></ha-entity-attribute-picker>
     `;
+  }
+
+  protected updated(changedProps: PropertyValues): void {
+    super.updated(changedProps);
+    if (
+      // No need to filter value if no value
+      !this.value ||
+      // Only adjust value if we used the context
+      this.selector.attribute.entity_id ||
+      // Only check if context has changed
+      !changedProps.has("context")
+    ) {
+      return;
+    }
+
+    const oldContext = changedProps.get("context") as this["context"];
+
+    if (
+      !this.context ||
+      oldContext?.filter_entity === this.context.filter_entity
+    ) {
+      return;
+    }
+
+    // Validate that that the attribute is still valid for this entity, else unselect.
+    let invalid = false;
+    if (this.context.filter_entity) {
+      const stateObj = this.hass.states[this.context.filter_entity];
+
+      if (!(stateObj && this.value in stateObj.attributes)) {
+        invalid = true;
+      }
+    } else {
+      invalid = this.value !== undefined;
+    }
+
+    if (invalid) {
+      fireEvent(this, "value-changed", {
+        value: undefined,
+      });
+    }
   }
 }
 

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -42,6 +42,8 @@ export class HaSelector extends LitElement {
 
   @property({ type: Boolean }) public required = true;
 
+  @property() public context?: Record<string, any>;
+
   public focus() {
     this.shadowRoot?.getElementById("selector")?.focus();
   }
@@ -61,6 +63,7 @@ export class HaSelector extends LitElement {
         disabled: this.disabled,
         required: this.required,
         helper: this.helper,
+        context: this.context,
         id: "selector",
       })}
     `;

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -31,7 +31,7 @@ export interface EntitySelector {
 
 export interface AttributeSelector {
   attribute: {
-    entity_id: string;
+    entity_id?: string;
   };
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Add a new feature to selectors to allow specifying a context.

Each selector can define their own supported context keys. The values of context in a configuration are set to field names. `<ha-form>` will process context and substitute field names with the value of the field.

Currently only implemented in the attribute picker.

Important requirement: if context is used, the selector is responsible to adjust the value if a new context value is passed in. So in the case of attribute picker, if a new entity is passed in, set value to `undefined` if the new entity does not support the picked attribute.

```ts
const schema = [
      { name: "entity", selector: { entity: {} } },
      {
        name: "Attribute",
        selector: { attribute: { entity_id: "" } },
        context: { filter_entity: "entity" },
      },
]
```

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
