### PR TITLE
Fetch history with `no_attributes` for entities that do not need them

### DIFF
--- a/src/data/cached-history.ts
+++ b/src/data/cached-history.ts
@@ -7,6 +7,7 @@ import {
   HistoryResult,
   LineChartUnit,
   TimelineEntity,
+  entityIdHistoryNeedsAttributes,
 } from "./history";
 
 export interface CacheConfig {
@@ -53,7 +54,17 @@ export const getRecent = (
     return cache.data;
   }
 
-  const prom = fetchRecent(hass, entityId, startTime, endTime).then(
+  const noAttributes = !entityIdHistoryNeedsAttributes(hass, entityId);
+  const prom = fetchRecent(
+    hass,
+    entityId,
+    startTime,
+    endTime,
+    false,
+    undefined,
+    true,
+    noAttributes
+  ).then(
     (stateHistory) => computeHistory(hass, stateHistory, localize),
     (err) => {
       delete RECENT_CACHE[entityId];
@@ -120,6 +131,7 @@ export const getRecentWithCache = (
   }
 
   const curCacheProm = cache.prom;
+  const noAttributes = !entityIdHistoryNeedsAttributes(hass, entityId);
 
   const genProm = async () => {
     let fetchedHistory: HassEntity[][];
@@ -132,7 +144,10 @@ export const getRecentWithCache = (
           entityId,
           toFetchStartTime,
           endTime,
-          appendingToCache
+          appendingToCache,
+          undefined,
+          true,
+          noAttributes
         ),
       ]);
       fetchedHistory = results[1];

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -7,9 +7,12 @@ import { LocalizeFunc } from "../common/translations/localize";
 import { HomeAssistant } from "../types";
 import { FrontendLocaleData } from "./translation";
 
-export const DOMAINS_USE_LAST_UPDATED = [
+const DOMAINS_USE_LAST_UPDATED = ["climate", "humidifier", "water_heater"];
+const NEED_ATTRIBUTE_DOMAINS = [
   "climate",
   "humidifier",
+  "input_datetime",
+  "thermostat",
   "water_heater",
 ];
 const LINE_ATTRIBUTES_TO_KEEP = [
@@ -141,7 +144,7 @@ export const entityIdHistoryNeedsAttributes = (
   entityId: string
 ) =>
   !hass.states[entityId] ||
-  DOMAINS_USE_LAST_UPDATED.includes(computeDomain(entityId));
+  NEED_ATTRIBUTE_DOMAINS.includes(computeDomain(entityId));
 
 export const fetchRecent = (
   hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Dropping the attributes on the frontend in testing was much faster:

with - Run Time: real 1.891 user 0.041000 sys 0.053000
without - Run Time: real 0.074 user 0.034000 sys 0.040000

In testing all my entity history graphs on my production install load in < 1s now

This should be backwards compatible as the history api will ignore `no_attributes` if its not supported and we end up with the attributes in memory even if they aren't needed (as it currently functions).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
