### PR TITLE
Default to using Google STUN server for WebRTC player

### DIFF
--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -83,7 +83,11 @@ class HaWebRtcPlayer extends LitElement {
   private async _startWebRtc(): Promise<void> {
     this._error = undefined;
 
-    const peerConnection = new RTCPeerConnection();
+    const peerConnection = new RTCPeerConnection({
+      iceServers: [{
+        urls: ["stun:stun.l.google.com:19302"]
+      }]
+    });
     // Some cameras (such as nest) require a data channel to establish a stream
     // however, not used by any integrations.
     peerConnection.createDataChannel("dataSendChannel");

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -84,9 +84,11 @@ class HaWebRtcPlayer extends LitElement {
     this._error = undefined;
 
     const peerConnection = new RTCPeerConnection({
-      iceServers: [{
-        urls: ["stun:stun.l.google.com:19302"]
-      }]
+      iceServers: [
+        {
+          urls: ["stun:stun.l.google.com:19302"],
+        },
+      ],
     });
     // Some cameras (such as nest) require a data channel to establish a stream
     // however, not used by any integrations.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Defaults the `ha-web-rtc-player` to using Google's STUN server (`stun.l.google.com:19302`) so that external WebRTC connections have a better chance of working.

The new WebRTC integration doesn't work for me remotely, so I've gone and opened a PR on both the RTSPtoWeb and stream-addons repos so that these use STUN on the server side, but we also need STUN on the client side for proper two-way NAT traversal. This change doesn't require the other two PRs to be merged, FYI.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

No config as-of-yet, if someone can point me in the right direction as to where this sort of config should sit, I can implement

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to PR: https://github.com/allenporter/stream-addons/pull/59
- This PR is related to PR: https://github.com/deepch/RTSPtoWeb/pull/128

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
