### PR TITLE
Update When entity can change enabled or hidden

### DIFF
--- a/src/panels/config/entities/entity-registry-basic-editor.ts
+++ b/src/panels/config/entities/entity-registry-basic-editor.ts
@@ -1,13 +1,13 @@
-import "../../../components/ha-expansion-panel";
 import "@material/mwc-formfield/mwc-formfield";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import "../../../components/ha-area-picker";
+import "../../../components/ha-expansion-panel";
+import "../../../components/ha-radio";
 import "../../../components/ha-switch";
 import "../../../components/ha-textfield";
-import "../../../components/ha-radio";
 import {
   DeviceRegistryEntry,
   subscribeDeviceRegistry,
@@ -182,9 +182,12 @@ export class HaEntityRegistryBasicEditor extends SubscribeMixin(LitElement) {
               name="hiddendisabled"
               value="enabled"
               .checked=${!this._hiddenBy && !this._disabledBy}
-              .disabled=${(this._hiddenBy && this._hiddenBy !== "user") ||
-              this._device?.disabled_by ||
-              (this._disabledBy && this._disabledBy !== "user")}
+              .disabled=${this._device?.disabled_by ||
+              (this._disabledBy &&
+                !(
+                  this._disabledBy === "user" ||
+                  this._disabledBy === "integration"
+                ))}
               @change=${this._viewStatusChanged}
             ></ha-radio>
           </mwc-formfield>
@@ -197,9 +200,12 @@ export class HaEntityRegistryBasicEditor extends SubscribeMixin(LitElement) {
               name="hiddendisabled"
               value="hidden"
               .checked=${this._hiddenBy !== null}
-              .disabled=${(this._hiddenBy && this._hiddenBy !== "user") ||
-              Boolean(this._device?.disabled_by) ||
-              (this._disabledBy && this._disabledBy !== "user")}
+              .disabled=${this._device?.disabled_by ||
+              (this._disabledBy &&
+                !(
+                  this._disabledBy === "user" ||
+                  this._disabledBy === "integration"
+                ))}
               @change=${this._viewStatusChanged}
             ></ha-radio>
           </mwc-formfield>
@@ -212,9 +218,12 @@ export class HaEntityRegistryBasicEditor extends SubscribeMixin(LitElement) {
               name="hiddendisabled"
               value="disabled"
               .checked=${this._disabledBy !== null}
-              .disabled=${(this._hiddenBy && this._hiddenBy !== "user") ||
-              Boolean(this._device?.disabled_by) ||
-              (this._disabledBy && this._disabledBy !== "user")}
+              .disabled=${this._device?.disabled_by ||
+              (this._disabledBy &&
+                !(
+                  this._disabledBy === "user" ||
+                  this._disabledBy === "integration"
+                ))}
               @change=${this._viewStatusChanged}
             ></ha-radio>
           </mwc-formfield>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Only disabled selection if disabled is set by anything other than user or integration and if the device is not disabled

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
