### PR TITLE
Fix Duration Selector Default

### DIFF
--- a/src/components/ha-form/compute-initial-ha-form-data.ts
+++ b/src/components/ha-form/compute-initial-ha-form-data.ts
@@ -1,4 +1,5 @@
-import { HaFormSchema } from "./types";
+import type { Selector } from "../../data/selector";
+import type { HaFormSchema } from "./types";
 
 export const computeInitialHaFormData = (
   schema: HaFormSchema[]
@@ -31,6 +32,25 @@ export const computeInitialHaFormData = (
         minutes: 0,
         seconds: 0,
       };
+    } else if ("selector" in field) {
+      const selector: Selector = field.selector;
+      if ("boolean" in selector) {
+        data[field.name] = false;
+      } else if ("text" in selector) {
+        data[field.name] = "";
+      } else if ("number" in selector) {
+        data[field.name] = "min" in selector.number ? selector.number.min : 0;
+      } else if ("select" in selector) {
+        if (selector.select.options.length) {
+          data[field.name] = selector.select.options[0][0];
+        }
+      } else if ("duration" in selector) {
+        data[field.name] = {
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        };
+      }
     }
   });
   return data;

--- a/src/components/ha-selector/ha-selector-duration.ts
+++ b/src/components/ha-selector/ha-selector-duration.ts
@@ -1,8 +1,9 @@
-import "../ha-duration-input";
-import { html, LitElement } from "lit";
+import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../common/dom/fire_event";
 import { DurationSelector } from "../../data/selector";
 import { HomeAssistant } from "../../types";
+import "../ha-duration-input";
 
 @customElement("ha-selector-duration")
 export class HaTimeDuration extends LitElement {
@@ -17,6 +18,19 @@ export class HaTimeDuration extends LitElement {
   @property({ type: Boolean }) public disabled = false;
 
   @property({ type: Boolean }) public required = true;
+
+  protected firstUpdated(changedProps: PropertyValues): void {
+    super.firstUpdated(changedProps);
+    if (!changedProps.has("selector")) {
+      return;
+    }
+    // Set the initial value via event so HA Form is aware
+    if (["", undefined].includes(this.value)) {
+      fireEvent(this, "value-changed", {
+        value: { hours: 0, minutes: 0, seconds: 0 },
+      });
+    }
+  }
 
   protected render() {
     return html`

--- a/src/components/ha-selector/ha-selector-duration.ts
+++ b/src/components/ha-selector/ha-selector-duration.ts
@@ -1,8 +1,7 @@
-import { html, LitElement, PropertyValues } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
-import { fireEvent } from "../../common/dom/fire_event";
-import { DurationSelector } from "../../data/selector";
-import { HomeAssistant } from "../../types";
+import type { DurationSelector } from "../../data/selector";
+import type { HomeAssistant } from "../../types";
 import "../ha-duration-input";
 
 @customElement("ha-selector-duration")
@@ -18,19 +17,6 @@ export class HaTimeDuration extends LitElement {
   @property({ type: Boolean }) public disabled = false;
 
   @property({ type: Boolean }) public required = true;
-
-  protected firstUpdated(changedProps: PropertyValues): void {
-    super.firstUpdated(changedProps);
-    if (!changedProps.has("selector")) {
-      return;
-    }
-    // Set the initial value via event so HA Form is aware
-    if (["", undefined].includes(this.value)) {
-      fireEvent(this, "value-changed", {
-        value: { hours: 0, minutes: 0, seconds: 0 },
-      });
-    }
-  }
 
   protected render() {
     return html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Sets the value via Value Changed event on first updated. This make sure that HA form is aware without changing any lower element functionality 

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
