### PR TITLE
Add zwave-js node alerts to device configuration page

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -167,10 +167,16 @@ export interface ZwaveJSNodeMetadata {
   wakeup: string;
   reset: string;
   device_database_url: string;
+  comments: ZWaveJSNodeComment[];
 }
 
 export interface ZWaveJSNodeConfigParams {
   [key: string]: ZWaveJSNodeConfigParam;
+}
+
+export interface ZWaveJSNodeComment {
+  level: "info" | "warning" | "error";
+  text: string;
 }
 
 export interface ZWaveJSNodeConfigParam {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -179,29 +179,21 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
               </em>
             </p>
           </div>
-          ${this._nodeMetadata
-            ? html`
-                ${this._nodeMetadata.comments.map(
-                  (comment) => html`<ha-alert alert-type=${comment.level}>
-                    ${comment.text}
-                  </ha-alert>`
-                )}
-              `
-            : ``}
+          ${this._nodeMetadata.comments.map(
+            (comment) => html`<ha-alert alert-type=${comment.level}>
+              ${comment.text}
+            </ha-alert>`
+          )}
           <ha-card>
-            ${this._config
-              ? html`
-                  ${Object.entries(this._config).map(
-                    ([id, item]) => html` <ha-settings-row
-                      class="config-item"
-                      .configId=${id}
-                      .narrow=${this.narrow}
-                    >
-                      ${this._generateConfigBox(id, item)}
-                    </ha-settings-row>`
-                  )}
-                `
-              : ``}
+            ${Object.entries(this._config).map(
+              ([id, item]) => html` <ha-settings-row
+                class="config-item"
+                .configId=${id}
+                .narrow=${this.narrow}
+              >
+                ${this._generateConfigBox(id, item)}
+              </ha-settings-row>`
+            )}
           </ha-card>
         </ha-config-section>
       </hass-tabs-subpage>

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -19,6 +19,7 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import memoizeOne from "memoize-one";
 import { debounce } from "../../../../../common/util/debounce";
+import "../../../../../components/ha-alert";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-icon-next";
 import "../../../../../components/ha-select";
@@ -130,7 +131,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
       ></hass-error-screen>`;
     }
 
-    if (!this._config) {
+    if (!this._config || !this._nodeMetadata) {
       return html`<hass-loading-screen></hass-loading-screen>`;
     }
 
@@ -178,6 +179,15 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
               </em>
             </p>
           </div>
+          ${this._nodeMetadata
+            ? html`
+                ${this._nodeMetadata.comments.map(
+                  (comment) => html`<ha-alert alert-type=${comment.level}>
+                    ${comment.text}
+                  </ha-alert>`
+                )}
+              `
+            : ``}
           <ha-card>
             ${this._config
               ? html`

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -183,7 +183,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
             ? html`
                 <div>
                   ${this._nodeMetadata.comments.map(
-                    (comment) => html`<ha-alert alert-type=${comment.level}>
+                    (comment) => html`<ha-alert .alertType=${comment.level}>
                       ${comment.text}
                     </ha-alert>`
                   )}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -179,11 +179,17 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
               </em>
             </p>
           </div>
-          ${this._nodeMetadata.comments.map(
-            (comment) => html`<ha-alert alert-type=${comment.level}>
-              ${comment.text}
-            </ha-alert>`
-          )}
+          ${this._nodeMetadata.comments.length > 0
+            ? html`
+                <div>
+                  ${this._nodeMetadata.comments.map(
+                    (comment) => html`<ha-alert alert-type=${comment.level}>
+                      ${comment.text}
+                    </ha-alert>`
+                  )}
+                </div>
+              `
+            : ``}
           <ha-card>
             ${Object.entries(this._config).map(
               ([id, item]) => html` <ha-settings-row


### PR DESCRIPTION
## Proposed change
The Z-Wave JS device database supports showing alerts for devices that have known issues (example: https://devices.zwave-js.io/?jumpTo=0x0002:0x8003:0x8001:0.0). This PR adds these alerts to the device configuration page for a given node (dependent on https://github.com/home-assistant/core/pull/67210)

There may be a better way to display these alerts, I am open to suggestions. Here's how it currently looks:

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/7243222/160988008-7bda264a-1972-4867-8911-288ce36ad892.png">


CC @MartinHjelmare since we already request node metadata on this page I chose to keep comments as part of that call to avoid multiple calls.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
