### PR TITLE
Sort "Show as" values in entity registry

### DIFF
--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -17,6 +17,7 @@ import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { domainIcon } from "../../../common/entity/domain_icon";
 import { stringCompare } from "../../../common/string/compare";
+import { LocalizeFunc } from "../../../common/translations/localize";
 import "../../../components/ha-alert";
 import "../../../components/ha-area-picker";
 import "../../../components/ha-expansion-panel";
@@ -277,22 +278,24 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
               >
                 ${this._deviceClassesSorted(
                   domain,
-                  this._deviceClassOptions[0]
+                  this._deviceClassOptions[0],
+                  this.hass.localize
                 ).map(
                   (entry) => html`
                     <mwc-list-item .value=${entry.deviceClass}>
-                      ${entry.translation}
+                      ${entry.label}
                     </mwc-list-item>
                   `
                 )}
                 <li divider role="separator"></li>
                 ${this._deviceClassesSorted(
                   domain,
-                  this._deviceClassOptions[1]
+                  this._deviceClassOptions[1],
+                  this.hass.localize
                 ).map(
                   (entry) => html`
                     <mwc-list-item .value=${entry.deviceClass}>
-                      ${entry.translation}
+                      ${entry.label}
                     </mwc-list-item>
                   `
                 )}
@@ -724,15 +727,15 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
   }
 
   private _deviceClassesSorted = memoizeOne(
-    (domain: string, deviceClasses: string[]) =>
+    (domain: string, deviceClasses: string[], localize: LocalizeFunc) =>
       deviceClasses
         .map((entry) => ({
           deviceClass: entry,
-          translation: this.hass.localize(
+          label: localize(
             `ui.dialogs.entity_registry.editor.device_classes.${domain}.${entry}`
           ),
         }))
-        .sort((a, b) => stringCompare(a.translation, b.translation))
+        .sort((a, b) => stringCompare(a.label, b.label))
   );
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -200,13 +200,16 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
     }
 
     this._deviceClassOptions = [[], []];
-    for (const deviceClass of deviceClasses) {
-      if (deviceClass.includes(this.entry.original_device_class!)) {
-        this._deviceClassOptions[0] = deviceClass;
-      } else {
-        this._deviceClassOptions[1].push(...deviceClass);
+    for (const deviceClassSub of deviceClasses) {
+      for (const deviceClass of deviceClassSub) {
+        if (deviceClass.includes(this.entry.original_device_class!)) {
+          this._deviceClassOptions[0].push(deviceClass);
+        } else {
+          this._deviceClassOptions[1].push(deviceClass);
+        }
       }
     }
+    this._deviceClassOptions[1] = this._deviceClassOptions[1].sort();
   }
 
   protected render(): TemplateResult {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<s>I assume the goal was to show the original domain above the separator, however that did not actually work as `deviceClasses` is a multidimensional array.</s>

EDIT: Looks like that is by design since multiple device classes are considered "original" based on the domain.

Also now the options are sorted in the list which makes finding what you need much easier.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
