### PR TITLE
Prevent empty brackets if no manufacturer during config entry creation

### DIFF
--- a/src/dialogs/config-flow/step-flow-create-entry.ts
+++ b/src/dialogs/config-flow/step-flow-create-entry.ts
@@ -28,7 +28,7 @@ class StepFlowCreateEntry extends LitElement {
     const localize = this.hass.localize;
 
     return html`
-      <h2>Success!</h2>
+      <h2>${localize("ui.panel.config.integrations.config_flow.success")}!</h2>
       <div class="content">
         ${this.flowConfig.renderCreateEntryDescription(this.hass, this.step)}
         ${this.step.result?.state === "not_loaded"
@@ -41,7 +41,11 @@ class StepFlowCreateEntry extends LitElement {
         ${this.devices.length === 0
           ? ""
           : html`
-              <p>We found the following devices:</p>
+              <p>
+                ${localize(
+                  "ui.panel.config.integrations.config_flow.found_following_devices"
+                )}:
+              </p>
               <div class="devices">
                 ${this.devices.map(
                   (device) =>
@@ -49,7 +53,12 @@ class StepFlowCreateEntry extends LitElement {
                       <div class="device">
                         <div>
                           <b>${computeDeviceName(device, this.hass)}</b><br />
-                          ${device.model} (${device.manufacturer})
+                          ${!device.model && !device.manufacturer
+                            ? html`&nbsp;`
+                            : html`${device.model}
+                              ${device.manufacturer
+                                ? html`(${device.manufacturer})`
+                                : ""}`}
                         </div>
                         <ha-area-picker
                           .hass=${this.hass}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2711,12 +2711,14 @@
             "open_configuration_url": "Visit device"
           },
           "config_flow": {
+            "success": "Success",
             "aborted": "Aborted",
             "close": "Close",
             "dismiss": "Dismiss dialog",
             "finish": "Finish",
             "submit": "Submit",
             "next": "Next",
+            "found_following_devices": "We found the following devices",
             "no_config_flow": "This integration does not support configuration via the UI. If you followed this link from the Home Assistant website, make sure you run the latest version of Home Assistant.",
             "not_all_required_fields": "Not all required fields are filled in.",
             "error_saving_area": "Error saving area: {error}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The success dialog after config entry creation always showed empty brackets if no model and manufacturer where provided.

This is now prevented, but we still ensure we have a (potentially empty) line below the entry name, so that if multiple config entries are created at once, all of them have the same size for a consistent grid rendering.

Before:
![image](https://user-images.githubusercontent.com/114137/162640300-5a111eb1-c0d7-4b04-8330-5d59cc84b00b.png)

Also added some missing translations.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
