### PR TITLE
RTL calendar fix - arrows fix and views fix

### DIFF
--- a/src/components/ha-button-toggle-group.ts
+++ b/src/components/ha-button-toggle-group.ts
@@ -117,6 +117,19 @@ export class HaButtonToggleGroup extends LitElement {
         --mdc-shape-small: 4px;
         border-right-width: 1px;
       }
+
+      :host([dir="rtl"]) ha-icon-button:first-child,
+      :host([dir="rtl"]) mwc-button:first-child {
+        border-radius: 0 4px 4px 0;
+        border-right-width: 1px;
+        --mdc-shape-small: 0 4px 4px 0;
+        --mdc-button-outline-width: 1px;
+      }
+      :host([dir="rtl"]) ha-icon-button:last-child,
+      :host([dir="rtl"]) mwc-button:last-child {
+        --mdc-shape-small: 4px 0 0 4px;
+        border-radius: 4px 0 0 4px;
+      }
     `;
   }
 }

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -34,7 +34,10 @@ import { useAmPm } from "../../common/datetime/use_am_pm";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-button-toggle-group";
 import "../../components/ha-icon-button";
+import "../../components/ha-icon-button-prev";
+import "../../components/ha-icon-button-next";
 import { haStyle } from "../../resources/styles";
+import { computeRTLDirection } from "../../common/util/compute_rtl";
 import type {
   CalendarEvent,
   CalendarViewChanged,
@@ -124,26 +127,27 @@ export class HAFullCalendar extends LitElement {
                           "ui.components.calendar.today"
                         )}</mwc-button
                       >
-                      <ha-icon-button
+                      <ha-icon-button-prev
                         .label=${this.hass.localize("ui.common.previous")}
                         .path=${mdiChevronLeft}
                         class="prev"
                         @click=${this._handlePrev}
                       >
-                      </ha-icon-button>
-                      <ha-icon-button
+                      </ha-icon-button-prev>
+                      <ha-icon-button-next
                         .label=${this.hass.localize("ui.common.next")}
                         .path=${mdiChevronRight}
                         class="next"
                         @click=${this._handleNext}
                       >
-                      </ha-icon-button>
+                      </ha-icon-button-next>
                     </div>
                     <h1>${this.calendar.view.title}</h1>
                     <ha-button-toggle-group
                       .buttons=${viewToggleButtons}
                       .active=${this._activeView}
                       @value-changed=${this._handleView}
+                      .dir=${computeRTLDirection(this.hass)}
                     ></ha-button-toggle-group>
                   `
                 : html`
@@ -179,6 +183,7 @@ export class HAFullCalendar extends LitElement {
                         .buttons=${viewToggleButtons}
                         .active=${this._activeView}
                         @value-changed=${this._handleView}
+                        .dir=${computeRTLDirection(this.hass)}
                       ></ha-button-toggle-group>
                     </div>
                   `}

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -129,14 +129,12 @@ export class HAFullCalendar extends LitElement {
                       >
                       <ha-icon-button-prev
                         .label=${this.hass.localize("ui.common.previous")}
-                        .path=${mdiChevronLeft}
                         class="prev"
                         @click=${this._handlePrev}
                       >
                       </ha-icon-button-prev>
                       <ha-icon-button-next
                         .label=${this.hass.localize("ui.common.next")}
-                        .path=${mdiChevronRight}
                         class="next"
                         @click=${this._handleNext}
                       >


### PR DESCRIPTION
## Proposed change
Fix for how calendar page supports RTL.

Before:

Note arrows are pointing wrong and view list has wrong borders:

![image](https://user-images.githubusercontent.com/37745463/162973419-6e1f5f13-a0d0-4fb1-99d1-e1e3d418e64f.png)


After:

![image](https://user-images.githubusercontent.com/37745463/162973217-17b3e196-ada0-4022-9649-f7f1c046f8f0.png)

## Checklist

- [X ] The code change is tested and works locally.
- [X ] There is no commented out code in this PR.
