### PR TITLE
Quickly search for entities from the Overview Dashboard

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -53,7 +53,6 @@ import "./ha-icon-button";
 import "./ha-menu-button";
 import "./ha-svg-icon";
 import "./user/ha-user-badge";
-import { showQuickBar } from "../dialogs/quick-bar/show-dialog-quick-bar";
 
 const SHOW_AFTER_SPACER = ["config", "developer-tools"];
 
@@ -330,7 +329,6 @@ class HaSidebar extends LitElement {
       .actionHandler=${actionHandler({
         hasHold: !this.editMode,
         disabled: this.editMode,
-        hasDoubleClick: true,
       })}
     >
       ${!this.narrow
@@ -633,12 +631,10 @@ class HaSidebar extends LitElement {
   }
 
   private _handleAction(ev: CustomEvent<ActionHandlerDetail>) {
-    if (ev.detail.action === "double_tap") {
-      showQuickBar(this, {});
-      return;
-    } if (ev.detail.action !== "hold") {
+    if (ev.detail.action !== "hold") {
       return;
     }
+
     fireEvent(this, "hass-edit-sidebar", { editMode: true });
   }
 

--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -53,6 +53,7 @@ import "./ha-icon-button";
 import "./ha-menu-button";
 import "./ha-svg-icon";
 import "./user/ha-user-badge";
+import { showQuickBar } from "../dialogs/quick-bar/show-dialog-quick-bar";
 
 const SHOW_AFTER_SPACER = ["config", "developer-tools"];
 
@@ -329,6 +330,7 @@ class HaSidebar extends LitElement {
       .actionHandler=${actionHandler({
         hasHold: !this.editMode,
         disabled: this.editMode,
+        hasDoubleClick: true,
       })}
     >
       ${!this.narrow
@@ -631,10 +633,12 @@ class HaSidebar extends LitElement {
   }
 
   private _handleAction(ev: CustomEvent<ActionHandlerDetail>) {
-    if (ev.detail.action !== "hold") {
+    if (ev.detail.action === "double_tap") {
+      showQuickBar(this, {});
+      return;
+    } if (ev.detail.action !== "hold") {
       return;
     }
-
     fireEvent(this, "hass-edit-sidebar", { editMode: true });
   }
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -7,6 +7,7 @@ import {
   mdiFileMultiple,
   mdiFormatListBulletedTriangle,
   mdiHelp,
+  mdiMagnify,
   mdiHelpCircle,
   mdiMicrophone,
   mdiPencil,
@@ -72,6 +73,7 @@ import { showEditViewDialog } from "./editor/view-editor/show-edit-view-dialog";
 import type { Lovelace } from "./types";
 import "./views/hui-view";
 import type { HUIView } from "./views/hui-view";
+import { showQuickBar } from "../../dialogs/quick-bar/show-dialog-quick-bar";
 
 class HUIRoot extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -264,6 +266,10 @@ class HUIRoot extends LitElement {
                         </ha-tabs>
                       `
                     : html`<div main-title>${this.config.title}</div>`}
+                  <ha-icon-button
+                    .path=${mdiMagnify}
+                    @click=${this._showQuickBar}
+                  ></ha-icon-button>
                   ${!this.narrow &&
                   this._conversation(this.hass.config.components)
                     ? html`
@@ -670,6 +676,13 @@ class HUIRoot extends LitElement {
       confirmText: this.hass.localize("ui.common.refresh"),
       dismissText: this.hass.localize("ui.common.not_now"),
       confirm: () => location.reload(),
+    });
+  }
+
+  private _showQuickBar(): void {
+    showQuickBar(this, {
+      commandMode: false,
+      hint: this.hass.localize("ui.dialogs.quick-bar.key_e_hint"),
     });
   }
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

I was thinking about why the I still use HomeKit first on my phone and came to the conclusion its because its less taps to get what I want done.

With this change its faster to find the entity in Home Assistant vs HomeKit so I expect that will lead to a behavior change to choose Home Assistant first.

Edit: After using this for a just a bit, it completely changes the way I use HA on device (phone) pickup. The behavior change was pretty quick without even trying. I now pickup the phone and search right away instead of digging or scrolling through dashboards or opening HomeKit.

Builds on the work in #11375

![RPReplay_Final1649894862](https://user-images.githubusercontent.com/663432/163289631-84ba4c43-fed4-4268-9e4f-ec10951a2f2e.gif)


<img width="1046" alt="Screen Shot 2022-04-13 at 14 06 46" src="https://user-images.githubusercontent.com/663432/163289213-63784a36-911b-4008-8315-b800c4b50296.png">

<img width="1232" alt="Screen Shot 2022-04-13 at 13 59 51" src="https://user-images.githubusercontent.com/663432/163288880-7cb51e7d-e917-4c71-b65e-aec5f48b9853.png">
<img width="480" alt="Screen Shot 2022-04-13 at 13 59 41" src="https://user-images.githubusercontent.com/663432/163288888-e4aab360-d6f5-4c67-af59-519bd5a23d80.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
