### PR TITLE
Keep targets when switching services

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -373,8 +373,13 @@ export class HaServiceControl extends LitElement {
     if (ev.detail.value === this._value?.service) {
       return;
     }
+    const value = {
+      ...this._value,
+      service: ev.detail.value || "",
+      data: { ...this._value?.data },
+    };
     fireEvent(this, "value-changed", {
-      value: { service: ev.detail.value || "" },
+      value,
     });
   }
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

It is a common workflow to clone an automation and service call from off from on, or open to close.

Right now when you do that the targets get cleared which makes it much more difficult.

Before:
![switch_open_close](https://user-images.githubusercontent.com/663432/163304072-1d0fb2ff-d53f-45db-afb8-aff6e1393548.gif)

After:
![keep_entity](https://user-images.githubusercontent.com/663432/163304087-0173183e-93e5-48d2-99ef-b912b8da1c16.gif)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
