### PR TITLE
Allow selecting multiple entities for state trigger

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -69,7 +69,7 @@ export interface BaseTrigger {
 
 export interface StateTrigger extends BaseTrigger {
   platform: "state";
-  entity_id: string;
+  entity_id: string | string[];
   attribute?: string;
   from?: string | number;
   to?: string | string[] | number;

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -93,7 +93,8 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
 
     const data = {
       ...this.trigger,
-      ...{ entity_id: ensureArray(this.trigger.entity_id), for: trgFor },
+      entity_id: ensureArray(this.trigger.entity_id),
+      for: trgFor,
     };
     const schema = this._schema(this.trigger.entity_id);
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -1,6 +1,7 @@
 import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import {
+  array,
   assert,
   assign,
   literal,
@@ -10,6 +11,7 @@ import {
   union,
 } from "superstruct";
 import memoizeOne from "memoize-one";
+import { ensureArray } from "../../../../../common/ensure-array";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { hasTemplate } from "../../../../../common/string/has-template";
 import { StateTrigger } from "../../../../../data/automation";
@@ -24,7 +26,7 @@ const stateTriggerStruct = assign(
   baseTriggerStruct,
   object({
     platform: literal("state"),
-    entity_id: optional(string()),
+    entity_id: optional(union([string(), array(string())])),
     attribute: optional(string()),
     from: optional(string()),
     to: optional(string()),
@@ -39,11 +41,15 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
   @property() public trigger!: StateTrigger;
 
   public static get defaultConfig() {
-    return { entity_id: "" };
+    return { entity_id: [] };
   }
 
   private _schema = memoizeOne((entityId) => [
-    { name: "entity_id", required: true, selector: { entity: {} } },
+    {
+      name: "entity_id",
+      required: true,
+      selector: { entity: { multiple: true } },
+    },
     {
       name: "attribute",
       selector: { attribute: { entity_id: entityId } },
@@ -85,7 +91,10 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
   protected render() {
     const trgFor = createDurationData(this.trigger.for);
 
-    const data = { ...this.trigger, ...{ for: trgFor } };
+    const data = {
+      ...this.trigger,
+      ...{ entity_id: ensureArray(this.trigger.entity_id), for: trgFor },
+    };
     const schema = this._schema(this.trigger.entity_id);
 
     return html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Our state trigger supports selecting multiple entity IDs to trigger on; this PR brings that feature to the frontend (now the selectors support it).

This can reduce the visual size of the total automation length in the editor tremendously.

![CleanShot 2022-04-15 at 19 47 25](https://user-images.githubusercontent.com/195327/163603895-126f08d0-705e-4f30-9c6f-a02392d8ff86.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
