### PR TITLE
Fix strict error handling in developer tools templates

### DIFF
--- a/src/data/ws-templates.ts
+++ b/src/data/ws-templates.ts
@@ -20,6 +20,7 @@ export const subscribeRenderTemplate = (
     entity_ids?: string | string[];
     variables?: Record<string, unknown>;
     timeout?: number;
+    strict?: boolean;
   }
 ): Promise<UnsubscribeFunc> =>
   conn.subscribeMessage((msg: RenderTemplateResult) => onChange(msg), {

--- a/src/panels/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/developer-tools/template/developer-tools-template.ts
@@ -329,6 +329,7 @@ class HaPanelDevTemplate extends LitElement {
         {
           template: this._template,
           timeout: 3,
+          strict: true,
         }
       );
       await this._unsubRenderTemplate;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Currently, some templating errors, while in the template dev tools, are logged in the Home Asssistant logs.

```
2022-04-19 09:56:03 WARNING (Thread-27) [homeassistant.helpers.template] Template variable warning: 'unkowf' is undefined when rendering '{{ unkowf  }}'
2022-04-19 09:56:03 WARNING (MainThread) [homeassistant.helpers.template] Template variable warning: 'unkowf' is undefined when rendering '{{ unkowf  }}'
2022-04-19 09:56:03 WARNING (MainThread) [homeassistant.helpers.template] Template variable warning: 'unkowf' is undefined when rendering '{{ unkowf  }}'
2022-04-19 09:56:11 WARNING (Thread-28) [homeassistant.helpers.template] Template variable warning: 'unkowf' is undefined when rendering '{{ unkowf  }}'
2022-04-19 09:56:11 WARNING (MainThread) [homeassistant.helpers.template] Template variable warning: 'unkowf' is undefined when rendering '{{ unkowf  }}'
2022-04-19 09:56:11 WARNING (MainThread) [homeassistant.helpers.template] Template variable warning: 'unkowf' is undefined when rendering '{{ unkowf  }}'
```

However, they should not be logged there, they should show up in the frontend. This PR sets the strict flag, to get feedback over the WebSocket instead.

Originally the backend was implemented in: <https://github.com/home-assistant/core/pull/48933>
But it seems like the frontend change for it was never made, came up in home-assistant/core#70259.

Now these errors will also nicely show up in the frontend, and are no longer logged in the logs.

![CleanShot 2022-04-19 at 10 03 30](https://user-images.githubusercontent.com/195327/163955310-63150a36-38bc-4148-8aa4-cdaec6ef1d88.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#70259
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
