### PR TITLE
RTL fixes

### DIFF
--- a/src/components/ha-combo-box.ts
+++ b/src/components/ha-combo-box.ts
@@ -250,6 +250,18 @@ export class HaComboBox extends LitElement {
         top: -7px;
         right: 36px;
       }
+
+      :host-context([style*="direction: rtl;"]) .toggle-button {
+        left: 12px;
+        right: auto;
+        top: -10px;
+      }
+      :host-context([style*="direction: rtl;"]) .clear-button {
+        --mdc-icon-size: 20px;
+        top: -7px;
+        left: 36px;
+        right: auto;
+      }
     `;
   }
 }

--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -98,6 +98,10 @@ export class HaDialog extends DialogBase {
         margin-left: 40px;
         margin-right: 0px;
       }
+      :host-context([style*="direction: rtl;"]) .dialog-actions {
+        left: 0px !important;
+        right: auto !important;
+      }
     `,
   ];
 }

--- a/src/components/ha-fab.ts
+++ b/src/components/ha-fab.ts
@@ -1,5 +1,6 @@
 import { Fab } from "@material/mwc-fab";
 import { customElement } from "lit/decorators";
+import { css } from "lit";
 
 @customElement("ha-fab")
 export class HaFab extends Fab {
@@ -7,6 +8,18 @@ export class HaFab extends Fab {
     super.firstUpdated(changedProperties);
     this.style.setProperty("--mdc-theme-secondary", "var(--primary-color)");
   }
+
+  static override styles = [
+    Fab.styles,
+    css`
+      :host-context([style*="direction: rtl;"])
+        .mdc-fab--extended
+        .mdc-fab__icon {
+        margin-left: 12px !important;
+        margin-right: calc(12px - 20px) !important;
+      }
+    `,
+  ];
 }
 
 declare global {

--- a/src/components/ha-fab.ts
+++ b/src/components/ha-fab.ts
@@ -9,8 +9,7 @@ export class HaFab extends Fab {
     this.style.setProperty("--mdc-theme-secondary", "var(--primary-color)");
   }
 
-  static override styles = [
-    Fab.styles,
+  static override styles = Fab.styles.concat([
     css`
       :host-context([style*="direction: rtl;"])
         .mdc-fab--extended
@@ -19,7 +18,7 @@ export class HaFab extends Fab {
         margin-right: calc(12px - 20px) !important;
       }
     `,
-  ];
+  ]);
 }
 
 declare global {

--- a/src/components/ha-file-upload.ts
+++ b/src/components/ha-file-upload.ts
@@ -176,9 +176,23 @@ export class HaFileUpload extends LitElement {
         .mdc-text-field__icon--leading {
           margin-bottom: 12px;
         }
+        :host-context([style*="direction: rtl;"])
+          .mdc-text-field__icon--leading {
+          margin-right: 0px;
+        }
         .mdc-text-field--filled .mdc-floating-label--float-above {
           transform: scale(0.75);
           top: 8px;
+        }
+        :host-context([style*="direction: rtl;"]) .mdc-floating-label {
+          left: initial;
+          right: 16px;
+        }
+        :host-context([style*="direction: rtl;"])
+          .mdc-text-field--filled
+          .mdc-floating-label {
+          left: initial;
+          right: 48px;
         }
         .dragged:before {
           position: var(--layout-fit_-_position);

--- a/src/components/ha-select.ts
+++ b/src/components/ha-select.ts
@@ -47,6 +47,10 @@ export class HaSelect extends SelectBase {
       .mdc-select__anchor {
         width: var(--ha-select-min-width, 200px);
       }
+      :host-context([style*="direction: rtl;"]) .mdc-floating-label {
+        right: 16px !important;
+        left: initial !important;
+      }
     `,
   ];
 }

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -616,6 +616,10 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
         opacity: var(--light-disabled-opacity);
         pointer-events: none;
       }
+      :host-context([style*="direction: rtl;"]) .mdc-chip__icon {
+        margin-right: -14px !important;
+        margin-left: 4px !important;
+      }
     `;
   }
 }

--- a/src/components/ha-textfield.ts
+++ b/src/components/ha-textfield.ts
@@ -91,6 +91,19 @@ export class HaTextField extends TextFieldBase {
       .mdc-text-field {
         overflow: var(--text-field-overflow);
       }
+
+      :host-context([style*="direction: rtl;"]) .mdc-floating-label {
+        right: 10px !important;
+        left: initial !important;
+      }
+
+      :host-context([style*="direction: rtl;"])
+        .mdc-text-field--with-leading-icon.mdc-text-field--filled
+        .mdc-floating-label {
+        max-width: calc(100% - 48px);
+        right: 48px !important;
+        left: initial !important;
+      }
     `,
   ];
 }

--- a/src/dialogs/config-flow/dialog-data-entry-flow.ts
+++ b/src/dialogs/config-flow/dialog-data-entry-flow.ts
@@ -11,7 +11,6 @@ import {
 } from "lit";
 import { customElement, state } from "lit/decorators";
 import { fireEvent, HASSDomEvent } from "../../common/dom/fire_event";
-import { computeRTL } from "../../common/util/compute_rtl";
 import "../../components/ha-circular-progress";
 import "../../components/ha-dialog";
 import "../../components/ha-icon-button";
@@ -261,7 +260,6 @@ class DataEntryFlowDialog extends LitElement {
                           <ha-icon-button
                             .label=${this.hass.localize("ui.common.help")}
                             .path=${mdiHelpCircle}
-                            ?rtl=${computeRTL(this.hass)}
                           >
                           </ha-icon-button
                         ></a>
@@ -273,7 +271,6 @@ class DataEntryFlowDialog extends LitElement {
                     )}
                     .path=${mdiClose}
                     dialogAction="close"
-                    ?rtl=${computeRTL(this.hass)}
                   ></ha-icon-button>
                 </div>
                 ${this._step === null
@@ -521,7 +518,7 @@ class DataEntryFlowDialog extends LitElement {
           top: 0;
           right: 0;
         }
-        .dialog-actions[rtl] {
+        :host-context([style*="direction: rtl;"]) .dialog-actions {
           right: auto;
           left: 0;
         }

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -194,6 +194,10 @@ class StepFlowForm extends LitElement {
           word-break: break-word;
           padding-right: 72px;
         }
+        :host-context([style*="direction: rtl;"]) h2 {
+          padding-right: auto !important;
+          padding-left: 72px !important;
+        }
       `,
     ];
   }

--- a/src/dialogs/config-flow/step-flow-pick-flow.ts
+++ b/src/dialogs/config-flow/step-flow-pick-flow.ts
@@ -106,6 +106,10 @@ class StepFlowPickFlow extends LitElement {
         h2 {
           padding-right: 66px;
         }
+        :host-context([style*="direction: rtl;"]) h2 {
+          padding-right: auto !important;
+          padding-left: 66px !important;
+        }
         @media all and (max-height: 900px) {
           div {
             max-height: calc(100vh - 134px);

--- a/src/dialogs/config-flow/step-flow-pick-handler.ts
+++ b/src/dialogs/config-flow/step-flow-pick-handler.ts
@@ -313,6 +313,10 @@ class StepFlowPickHandler extends LitElement {
         h2 {
           padding-right: 66px;
         }
+        :host-context([style*="direction: rtl;"]) h2 {
+          padding-right: auto !important;
+          padding-left: 66px !important;
+        }
         @media all and (max-height: 900px) {
           mwc-list {
             max-height: calc(100vh - 134px);

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -410,7 +410,7 @@ export default class HaAutomationActionRow extends LitElement {
           z-index: 3;
           --mdc-theme-text-primary-on-background: var(--primary-text-color);
         }
-        .rtl .card-menu {
+        :host-context([style*="direction: rtl;"]) .card-menu {
           right: initial;
           left: 16px;
         }

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -245,7 +245,7 @@ export default class HaAutomationConditionRow extends LitElement {
           display: flex;
           align-items: center;
         }
-        .rtl .card-menu {
+        :host-context([style*="direction: rtl;"]) .card-menu {
           float: left;
         }
         mwc-list-item[disabled] {

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -442,7 +442,7 @@ export default class HaAutomationTriggerRow extends LitElement {
           z-index: 3;
           --mdc-theme-text-primary-on-background: var(--primary-text-color);
         }
-        .rtl .card-menu {
+        :host-context([style*="direction: rtl;"]) .card-menu {
           float: left;
         }
         .triggered {

--- a/src/panels/config/integrations/ha-integration-header.ts
+++ b/src/panels/config/integrations/ha-integration-header.ts
@@ -143,6 +143,10 @@ export class HaIntegrationHeader extends LitElement {
       width: 40px;
       height: 40px;
     }
+    :host-context([style*="direction: rtl;"]) .header img {
+      margin-right: auto !important;
+      margin-left: 16px;
+    }
     .header .info {
       flex: 1;
       align-self: center;

--- a/src/panels/config/logs/dialog-system-log-detail.ts
+++ b/src/panels/config/logs/dialog-system-log-detail.ts
@@ -228,6 +228,7 @@ class DialogSystemLogDetail extends LitElement {
         .contents {
           padding: 16px;
           outline: none;
+          direction: ltr;
         }
         .error {
           color: var(--error-color);


### PR DESCRIPTION
## Proposed change

Fixes to various RTL issues

- [X] Bugfix (non-breaking change which fixes an issue)


## Additional information

1
ha-textfield
Before:

![image](https://user-images.githubusercontent.com/37745463/164310118-eb13808f-b5a5-4db8-bba5-a19da605d408.png)

After (fixed label orientation)

![image](https://user-images.githubusercontent.com/37745463/164310137-28fb8dec-f875-46fc-9ada-c18d32b231ca.png)
 
2
Ha-fab
Before:

![image](https://user-images.githubusercontent.com/37745463/164310152-3d4fe425-9d12-4b24-a521-87585b8246e0.png)
 
After (fixed SVG spacing)

![image](https://user-images.githubusercontent.com/37745463/164310161-6fc353dc-d1b4-4b11-a5e3-2ab38b8f9cfd.png)


3
Ha-select
Before:

![image](https://user-images.githubusercontent.com/37745463/164310191-5f3eb3cb-6110-4709-b2f0-9397f3de3d3c.png)
 
After (fixed label orientation)

![image](https://user-images.githubusercontent.com/37745463/164310207-1e05a4d6-9c9c-46fc-a0b1-cdf9c896c9b2.png)
 
(couldn’t make it better – MWC sucks with RTL).

4
Ha-combo-box
Before:

![image](https://user-images.githubusercontent.com/37745463/164310228-5dc9d49d-9699-4807-af8c-6f12e182365b.png)
 
After (fixed orientation):

![image](https://user-images.githubusercontent.com/37745463/164310237-53f8c46a-5c35-4a81-81a5-bd2ca0db40bd.png)
 
5
Ha-dialog
(added style is because not all dialogs use the close heading from ha-dialog)
Before (new integration dialog):

![image](https://user-images.githubusercontent.com/37745463/164310248-de44e844-ad41-42ca-8139-ef59a2794a0b.png)
 
After (fixed button positions)
 
![image](https://user-images.githubusercontent.com/37745463/164310260-df111661-0e02-49b0-97ba-1b81ae0d797f.png)


6
Ha-target-picker
Before:

![image](https://user-images.githubusercontent.com/37745463/164310318-ce3b9413-a23a-4571-bbab-f3f64605ac4e.png)
 
After (fixed SVG spacing):

![image](https://user-images.githubusercontent.com/37745463/164310326-c3b8563f-ed02-4ed3-9411-6635cf850efa.png)
 
7
Ha-integration-header
Before

![image](https://user-images.githubusercontent.com/37745463/164310356-95fcb3ad-59b0-49ca-a1ca-00cf93dcd064.png)
 
After (fixed margin of image)

![image](https://user-images.githubusercontent.com/37745463/164310383-2f64fbf5-714c-4dde-9804-c6d706fbaa56.png)
 
8
Ha-automation-action-row, ha-automation-trigger-row, ha-automation-condition-row
Before

![image](https://user-images.githubusercontent.com/37745463/164310403-f1999020-7de9-4f22-925e-4d7465361994.png)
 
After (fixed menu button location – someone broke it since I fixed this years ago)
 
![image](https://user-images.githubusercontent.com/37745463/164310419-c77efe2b-a7d6-459a-a79a-76c1dc03fd30.png)

9
Ha-file-upload

Before

![image](https://user-images.githubusercontent.com/37745463/164310431-e5fc33e4-8cb0-4c03-812d-4eb2fa9fc423.png)
 
After
 
![image](https://user-images.githubusercontent.com/37745463/164310448-1e7ca134-b69c-48c2-9637-03831bf2b69b.png)

10
dialog-system-log-detail

Before

![image](https://user-images.githubusercontent.com/37745463/164310484-40514c86-dd18-45fa-969f-6630c6898241.png)
 
After (always align to left since it’s in English)

![image](https://user-images.githubusercontent.com/37745463/164310504-2f922e63-ec8e-4ef3-ab0f-fd4fa58d7124.png)
 

## Checklist

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
