### PR TITLE
RTL reading orders and alignments in system log

### DIFF
--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -84,6 +84,10 @@ class ErrorLogCard extends LitElement {
       .warning {
         color: var(--warning-color);
       }
+
+      :host-context([style*="direction: rtl;"]) mwc-button {
+        direction: rtl;
+      }
     `;
   }
 

--- a/src/panels/config/logs/system-log-card.ts
+++ b/src/panels/config/logs/system-log-card.ts
@@ -204,6 +204,10 @@ export class SystemLogCard extends LitElement {
       .warning {
         color: var(--warning-color);
       }
+
+      :host-context([style*="direction: rtl;"]) .card-actions {
+        direction: rtl;
+      }
     `;
   }
 }


### PR DESCRIPTION
## Type of change

Fixed button text issue (reading order was wrong since no RTL on the button or container)

Before (reads wrong):
![image](https://user-images.githubusercontent.com/37745463/164786500-4ced897f-ee7c-4483-b99d-dfbeca524d19.png)

After (reads right):
![image](https://user-images.githubusercontent.com/37745463/164786427-ebbb8e55-4af3-4c59-b3a5-347c7c745cea.png)

Fixed button orientation (these are the clear and refresh buttons at the bottom of the log)

Before:
![image](https://user-images.githubusercontent.com/37745463/164786540-1e469149-aeca-4b83-b1ca-f7e5041694ef.png)

After (properly aligned):
![image](https://user-images.githubusercontent.com/37745463/164786603-06b4316b-7a31-4250-9af5-161cb713e60c.png)

- [X] Bugfix (non-breaking change which fixes an issue)

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] Tests have been added to verify that the new code works.

