### PR TITLE
Allow `unsafeHTML` and use it for update install confirmation

### DIFF
--- a/build-scripts/webpack.js
+++ b/build-scripts/webpack.js
@@ -137,6 +137,7 @@ const createWebpackConfig = ({
         "lit/directives/guard$": "lit/directives/guard.js",
         "lit/directives/cache$": "lit/directives/cache.js",
         "lit/directives/repeat$": "lit/directives/repeat.js",
+        "lit/directives/unsafe-html$": "lit/directives/unsafe-html.js",
         "lit/polyfill-support$": "lit/polyfill-support.js",
         "@lit-labs/virtualizer/layouts/grid":
           "@lit-labs/virtualizer/layouts/grid.js",

--- a/src/dialogs/more-info/controls/more-info-update.ts
+++ b/src/dialogs/more-info/controls/more-info-update.ts
@@ -2,6 +2,7 @@ import "@material/mwc-button/mwc-button";
 import "@material/mwc-linear-progress/mwc-linear-progress";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { unsafeHTML } from "lit/directives/unsafe-html";
 import { BINARY_STATE_OFF } from "../../../common/const";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-alert";
@@ -198,15 +199,17 @@ class MoreInfoUpdate extends LitElement {
       title: this.hass.localize(
         "ui.dialogs.more_info_control.update.user_confirmation_title"
       ),
-      text: this.hass.localize(
-        "ui.dialogs.more_info_control.update.user_confirmation",
-        "title",
-        this.stateObj!.attributes.title,
-        "installed_version",
-        this.stateObj!.attributes.installed_version,
-        "latest_version",
-        this.stateObj!.attributes.latest_version
-      ),
+      text: html`${unsafeHTML(
+        this.hass.localize(
+          "ui.dialogs.more_info_control.update.user_confirmation",
+          "title",
+          "<b>" + this.stateObj!.attributes.title + "</b>",
+          "installed_version",
+          this.stateObj!.attributes.installed_version,
+          "latest_version",
+          this.stateObj!.attributes.latest_version
+        )
+      )}`,
       confirmText: this.hass.localize(
         "ui.dialogs.more_info_control.update.install"
       ),

--- a/src/dialogs/more-info/controls/more-info-update.ts
+++ b/src/dialogs/more-info/controls/more-info-update.ts
@@ -1,12 +1,13 @@
-import "../../../components/ha-alert";
-import "../../../components/ha-faded";
 import "@material/mwc-button/mwc-button";
 import "@material/mwc-linear-progress/mwc-linear-progress";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { BINARY_STATE_OFF } from "../../../common/const";
 import { supportsFeature } from "../../../common/entity/supports-feature";
+import "../../../components/ha-alert";
 import "../../../components/ha-checkbox";
 import "../../../components/ha-circular-progress";
+import "../../../components/ha-faded";
 import "../../../components/ha-formfield";
 import "../../../components/ha-markdown";
 import { UNAVAILABLE_STATES } from "../../../data/entity";
@@ -21,7 +22,7 @@ import {
   UPDATE_SUPPORT_SPECIFIC_VERSION,
 } from "../../../data/update";
 import type { HomeAssistant } from "../../../types";
-import { BINARY_STATE_OFF } from "../../../common/const";
+import { showConfirmationDialog } from "../../generic/show-dialog-box";
 
 @customElement("more-info-update")
 class MoreInfoUpdate extends LitElement {
@@ -192,7 +193,29 @@ class MoreInfoUpdate extends LitElement {
     return true;
   }
 
-  private _handleInstall(): void {
+  private async _handleInstall() {
+    const userConfirmed = await showConfirmationDialog(this, {
+      title: this.hass.localize(
+        "ui.dialogs.more_info_control.update.user_confirmation_title"
+      ),
+      text: this.hass.localize(
+        "ui.dialogs.more_info_control.update.user_confirmation",
+        "title",
+        this.stateObj!.attributes.title,
+        "installed_version",
+        this.stateObj!.attributes.installed_version,
+        "latest_version",
+        this.stateObj!.attributes.latest_version
+      ),
+      confirmText: this.hass.localize(
+        "ui.dialogs.more_info_control.update.install"
+      ),
+      dismissText: this.hass.localize("ui.common.cancel"),
+      warning: true,
+    });
+
+    if (!userConfirmed) return;
+
     const installData: Record<string, any> = {
       entity_id: this.stateObj!.entity_id,
     };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -737,7 +737,9 @@
           "skip": "Skip",
           "clear_skipped": "Clear skipped",
           "install": "Install",
-          "create_backup": "Create backup before updating"
+          "create_backup": "Create backup before updating",
+          "user_confirmation_title": "Are you sure?",
+          "user_confirmation": "Are you sure you want to update {title} from version {installed_version} to {latest_version}?"
         },
         "updater": {
           "title": "Update Instructions"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Builds upon https://github.com/home-assistant/frontend/pull/12449 to show the integration title in bold as well (same as is already done in the update more-info).

Separate PR since I am not sure if we want to go this way.

![image](https://user-images.githubusercontent.com/114137/165381877-d9ddad9b-6c21-4ace-8223-44fc214279e5.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
