### PR TITLE
Use startsWith for m shortcut for partial match

### DIFF
--- a/src/panels/my/ha-panel-my.ts
+++ b/src/panels/my/ha-panel-my.ts
@@ -41,14 +41,14 @@ export const getMyRedirects = (hasSupervisor: boolean): Redirects => ({
     component: "cloud",
     redirect: "/config/cloud",
   },
-  integrations: {
-    redirect: "/config/integrations",
-  },
   config_flow_start: {
     redirect: "/config/integrations/add",
     params: {
       domain: "string",
     },
+  },
+  integrations: {
+    redirect: "/config/integrations",
   },
   config_mqtt: {
     component: "mqtt",
@@ -79,16 +79,16 @@ export const getMyRedirects = (hasSupervisor: boolean): Redirects => ({
   areas: {
     redirect: "/config/areas/dashboard",
   },
-  blueprints: {
-    component: "blueprint",
-    redirect: "/config/blueprint/dashboard",
-  },
   blueprint_import: {
     component: "blueprint",
     redirect: "/config/blueprint/dashboard/import",
     params: {
       blueprint_url: "url",
     },
+  },
+  blueprints: {
+    component: "blueprint",
+    redirect: "/config/blueprint/dashboard",
   },
   automations: {
     component: "automation",

--- a/src/state/quick-bar-mixin.ts
+++ b/src/state/quick-bar-mixin.ts
@@ -58,7 +58,7 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
       for (const [slug, redirect] of Object.entries(
         myPanel.getMyRedirects(isComponentLoaded(this.hass, "hassio"))
       )) {
-        if (redirect.redirect === targetPath) {
+        if (targetPath.startsWith(redirect.redirect)) {
           window.open(
             `https://my.home-assistant.io/create-link/?redirect=${slug}`,
             "_blank"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adjusts the logic so panels like `/config/cloud/login` will match `/config/cloud`

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
