### PR TITLE
Media panel fix

### DIFF
--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -152,6 +152,7 @@ class DialogMediaPlayerBrowse extends LitElement {
         ha-media-player-browse {
           --media-browser-max-height: calc(100vh - 65px);
           height: calc(100vh - 65px);
+          direction: ltr;
         }
 
         @media (min-width: 800px) {

--- a/src/panels/media-browser/ha-bar-media-player.ts
+++ b/src/panels/media-browser/ha-bar-media-player.ts
@@ -686,6 +686,16 @@ export class BarMediaPlayer extends LitElement {
       mwc-list-item[selected] {
         font-weight: bold;
       }
+
+      :host-context([style*="direction: rtl;"]) ha-svg-icon[slot="icon"] {
+        margin-left: 8px !important;
+        margin-right: 8px !important;
+      }
+      :host-context([style*="direction: rtl;"])
+        ha-svg-icon[slot="trailingIcon"] {
+        margin-left: 0px !important;
+        margin-right: 8px !important;
+      }
     `;
   }
 }

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -278,6 +278,7 @@ class PanelMediaBrowser extends LitElement {
 
         ha-media-player-browse {
           height: calc(100vh - (100px + var(--header-height)));
+          direction: ltr;
         }
 
         :host([narrow]) ha-media-player-browse {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Media panel based on lit-visualizer does not support RTL. The internal absolute positioning does not work for RTL.
Fix is to force LTR.
Also fixed the media player bar spacing

Before:
![image](https://user-images.githubusercontent.com/37745463/165680110-65e0df59-65b1-4318-a767-ea3534b0e98a.png)

After:
![image](https://user-images.githubusercontent.com/37745463/165680157-626e7233-7ad2-448c-b11d-901ea0397247.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
