### PR TITLE
Add calendar trigger offsets in automation editor

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -157,7 +157,7 @@ export interface CalendarTrigger extends BaseTrigger {
   platform: "calendar";
   event: "start" | "end";
   entity_id: string;
-  offset: number;
+  offset: string | DurationDict;
 }
 
 export type Trigger =

--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -157,6 +157,7 @@ export interface CalendarTrigger extends BaseTrigger {
   platform: "calendar";
   event: "start" | "end";
   entity_id: string;
+  offset: number;
 }
 
 export type Trigger =

--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -157,7 +157,7 @@ export interface CalendarTrigger extends BaseTrigger {
   platform: "calendar";
   event: "start" | "end";
   entity_id: string;
-  offset: string | DurationDict;
+  offset: string;
 }
 
 export type Trigger =

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
@@ -5,9 +5,10 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import type { CalendarTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
+import type { HaDurationData } from "../../../../../components/ha-duration-input";
 import type { HaFormSchema } from "../../../../../components/ha-form/types";
-import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
+import type { LocalizeFunc } from "../../../../../common/translations/localize";
 
 @customElement("ha-automation-trigger-calendar")
 export class HaCalendarTrigger extends LitElement implements TriggerElement {
@@ -72,14 +73,14 @@ export class HaCalendarTrigger extends LitElement implements TriggerElement {
   protected render() {
     const schema = this._schema(this.hass.localize);
     // Convert from string representation to ha form duration representation
-    const duration = createDurationData(this.trigger.offset);
+    const trigger_offset = this.trigger.offset;
+    const duration: HaDurationData = createDurationData(trigger_offset)!;
     let offset_type = "after";
     if (
-      (typeof this.trigger.offset === "object" && duration.hours < 0) ||
-      (typeof this.trigger.offset === "string" &&
-        this.trigger.offset.startsWith("-"))
+      (typeof trigger_offset === "object" && duration!.hours! < 0) ||
+      (typeof trigger_offset === "string" && trigger_offset.startsWith("-"))
     ) {
-      duration.hours = Math.abs(duration.hours);
+      duration.hours = Math.abs(duration.hours!);
       offset_type = "before";
     }
     const data = {

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
@@ -39,11 +39,13 @@ export class HaCalendarTrigger extends LitElement implements TriggerElement {
         ],
       ],
     },
+    { name: "offset", selector: { text: {} } },
   ]);
 
   public static get defaultConfig() {
     return {
       event: "start" as CalendarTrigger["event"],
+      offset: 0,
     };
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1782,7 +1782,9 @@
                   "event": "[%key:ui::panel::config::automation::editor::triggers::type::homeassistant::event%]",
                   "start": "Event Start",
                   "end": "Event End",
-                  "offset": "Offset (optional)"
+                  "offset": "Offset (optional)",
+                  "before": "Before",
+                  "after": "After"
                 },
                 "device": {
                   "label": "Device",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1781,7 +1781,8 @@
                   "label": "Calendar",
                   "event": "[%key:ui::panel::config::automation::editor::triggers::type::homeassistant::event%]",
                   "start": "Event Start",
-                  "end": "Event End"
+                  "end": "Event End",
+                  "offset": "Offset (optional)"
                 },
                 "device": {
                   "label": "Device",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add calendar trigger offsets in the automation editor.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/22554
- Core PR: https://github.com/home-assistant/core/pull/70963

<img width="648" alt="Screen Shot 2022-04-27 at 10 47 42 PM" src="https://user-images.githubusercontent.com/6026418/165686707-bc2efaa7-8a21-4fdd-a5c0-974829b2a402.png">


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
