### PR TITLE
Rtl menu fix

### DIFF
--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -63,21 +63,24 @@ export class HaButtonMenu extends LitElement {
           ".rtl-fix, .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}";
         item.shadowRoot.appendChild(style);
         var span = item.shadowRoot?.querySelector("span:first-child");
-        span.className = "rtl-fix";
+        span!.classList.add("rtl-fix");
 
         item.getUpdateComplete = function () {
           var result = item._getUpdateComplete();
+
+          // re-apply class since something in ripple handler resets it even though no style changes
           var span = item.shadowRoot?.querySelector(".rtl-fix");
-          span!.className = "rtl-fix2";
+          span!.classList.remove("rtl-fix");
+          span!.classList.add("rtl-fix2");
+
           new Promise(function (resolve, reject) {
             setTimeout(() => resolve("done"), 0);
           }).then(() => {
-            span!.className = "rtl-fix";
+            span!.classList.remove("rtl-fix2");
+            span!.classList.add("rtl-fix");
           });
 
           return result;
-          // wait for all children to render... and then inject again.
-          // check if we need original injection
         };
       });
     });

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -55,10 +55,8 @@ export class HaButtonMenu extends LitElement {
   protected firstUpdated(changedProps): void {
     super.firstUpdated(changedProps);
 
-    document.querySelector("home-assistant")!.provideHass(this);
-
     // @ts-ignore
-    if (computeRTL(this.hass!)) {
+    if (document.dir === "rtl") {
       this.updateComplete.then(() => {
         this.querySelectorAll("mwc-list-item").forEach((item) => {
           const style = document.createElement("style");

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -56,16 +56,19 @@ export class HaButtonMenu extends LitElement {
 
     this.updateComplete.then(() => {
       this.querySelectorAll("mwc-list-item").forEach((item) => {
+        // eslint-disable-next-line
         item!._getUpdateComplete = item.getUpdateComplete;
 
         const style = document.createElement("style");
         style.innerHTML =
           ':host-context([style*="direction: rtl;"]) .rtl-fix, :host-context([style*="direction: rtl;"]) .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}';
-        item!.shadowRoot.appendChild(style);
+        item!.shadowRoot!.appendChild(style);
         const span = item.shadowRoot?.querySelector("span:first-child");
         span!.classList.add("rtl-fix");
 
+        // eslint-disable-next-line
         item.getUpdateComplete = function () {
+          // eslint-disable-next-line
           const result = item._getUpdateComplete();
 
           // re-apply class since something in ripple handler resets it even though no style changes

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -61,37 +61,10 @@ export class HaButtonMenu extends LitElement {
     if (computeRTL(this.hass!)) {
       this.updateComplete.then(() => {
         this.querySelectorAll("mwc-list-item").forEach((item) => {
-          // @ts-ignore
-          item!._getUpdateComplete = item.getUpdateComplete;
-
           const style = document.createElement("style");
           style.innerHTML =
-            ".rtl-fix, .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}";
+            "span.material-icons:first-of-type { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}";
           item!.shadowRoot!.appendChild(style);
-          const span = item.shadowRoot?.querySelector("span:first-child");
-          span!.classList.add("rtl-fix");
-
-          // @ts-ignore
-          item.getUpdateComplete = function () {
-            // @ts-ignore
-            const result = item._getUpdateComplete();
-
-            // re-apply class since something in ripple handler resets it even though no style changes
-            const rtlSpan = item.shadowRoot?.querySelector(".rtl-fix");
-            if (rtlSpan) {
-              rtlSpan!.classList.remove("rtl-fix");
-              rtlSpan!.classList.add("rtl-fix2");
-
-              new Promise((resolve) => {
-                setTimeout(() => resolve("done"), 0);
-              }).then(() => {
-                span!.classList.remove("rtl-fix2");
-                span!.classList.add("rtl-fix");
-              });
-            }
-
-            return result;
-          };
         });
       });
     }

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -103,34 +103,6 @@ export class HaButtonMenu extends LitElement {
       ::slotted([disabled]) {
         color: var(--disabled-text-color);
       }
-
-      /*
-      :host-context([style*="direction: rtl;"]) mwc-menu mwc-list-item {
-        background-color: red;
-        margin-right: 0px !important;
-        margin-left: var(--mdc-list-item-graphic-margin, 32px);
-      }
-      */
-
-      /*:host-context([style*="direction: rtl;"]) span([class*="graphic"]) {*/
-      /*
-            :host-context([style*="direction: rtl;"])
-        mwc-menu
-        ::slotted([mwc-list-item]) {
-        background-color: red;
-        margin-right: 0px !important;
-        margin-left: var(--mdc-list-item-graphic-margin, 32px);
-      }
-*/
-
-      /*
-      :host-context([style*="direction: rtl;"]) ::slotted([mwc-list-item]) {
-        background-color: red;
-        margin-right: 0px !important;
-        margin-left: var(--mdc-list-item-graphic-margin, 32px);
-      }
-      */
-      /*::slotted([mwc-list-item]) {*/
     `;
   }
 }

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -66,7 +66,7 @@ export class HaButtonMenu extends LitElement {
 
           const style = document.createElement("style");
           style.innerHTML =
-            ':host-context([style*="direction: rtl;"]) .rtl-fix, :host-context([style*="direction: rtl;"]) .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}';
+            ".rtl-fix, .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}";
           item!.shadowRoot!.appendChild(style);
           const span = item.shadowRoot?.querySelector("span:first-child");
           span!.classList.add("rtl-fix");

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -60,7 +60,7 @@ export class HaButtonMenu extends LitElement {
 
         var style = document.createElement("style");
         style.innerHTML =
-          ".rtl-fix, .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}";
+          ':host-context([style*="direction: rtl;"]) .rtl-fix, :host-context([style*="direction: rtl;"]) .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}';
         item.shadowRoot.appendChild(style);
         var span = item.shadowRoot?.querySelector("span:first-child");
         span!.classList.add("rtl-fix");

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -56,7 +56,7 @@ export class HaButtonMenu extends LitElement {
 
     this.updateComplete.then(() => {
       this.querySelectorAll("mwc-list-item").forEach((item) => {
-        // eslint-disable-next-line
+        // @ts-ignore
         item!._getUpdateComplete = item.getUpdateComplete;
 
         const style = document.createElement("style");
@@ -66,9 +66,9 @@ export class HaButtonMenu extends LitElement {
         const span = item.shadowRoot?.querySelector("span:first-child");
         span!.classList.add("rtl-fix");
 
-        // eslint-disable-next-line
+        // @ts-ignore
         item.getUpdateComplete = function () {
-          // eslint-disable-next-line
+          // @ts-ignore
           const result = item._getUpdateComplete();
 
           // re-apply class since something in ripple handler resets it even though no style changes

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -82,21 +82,7 @@ export class HaButtonMenu extends LitElement {
       });
     });
   }
-  /*
-  protected async firstUpdated(
-    _changedProperties: Map<string | number | symbol, unknown>
-  ): void {
-    const children = this.querySelectorAll("mwc-list-item");
-    await Promise.all(Array.from(children).map((c) => c.updateComplete));
 
-    this.querySelectorAll("mwc-list-item").forEach((item) => {
-      var style = document.createElement("style");
-      style.innerHTML =
-        "span:first-child { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}";
-      item.shadowRoot.appendChild(style);
-    });
-  }
-*/
   private _handleClick(): void {
     if (this.disabled) {
       return;

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -2,7 +2,6 @@ import "@material/mwc-menu";
 import type { Corner, Menu, MenuCorner } from "@material/mwc-menu";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators";
-import { computeRTL } from "../common/util/compute_rtl";
 
 @customElement("ha-button-menu")
 export class HaButtonMenu extends LitElement {

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -38,7 +38,6 @@ export class HaButtonMenu extends LitElement {
         <slot name="trigger"></slot>
       </div>
       <mwc-menu
-        id="menu"
         .corner=${this.corner}
         .menuCorner=${this.menuCorner}
         .fixed=${this.fixed}

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -56,29 +56,31 @@ export class HaButtonMenu extends LitElement {
 
     this.updateComplete.then(() => {
       this.querySelectorAll("mwc-list-item").forEach((item) => {
-        item._getUpdateComplete = item.getUpdateComplete;
+        item!._getUpdateComplete = item.getUpdateComplete;
 
-        var style = document.createElement("style");
+        const style = document.createElement("style");
         style.innerHTML =
           ':host-context([style*="direction: rtl;"]) .rtl-fix, :host-context([style*="direction: rtl;"]) .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}';
-        item.shadowRoot.appendChild(style);
-        var span = item.shadowRoot?.querySelector("span:first-child");
+        item!.shadowRoot.appendChild(style);
+        const span = item.shadowRoot?.querySelector("span:first-child");
         span!.classList.add("rtl-fix");
 
         item.getUpdateComplete = function () {
-          var result = item._getUpdateComplete();
+          const result = item._getUpdateComplete();
 
           // re-apply class since something in ripple handler resets it even though no style changes
-          var span = item.shadowRoot?.querySelector(".rtl-fix");
-          span!.classList.remove("rtl-fix");
-          span!.classList.add("rtl-fix2");
+          const rtlSpan = item.shadowRoot?.querySelector(".rtl-fix");
+          if (rtlSpan) {
+            rtlSpan!.classList.remove("rtl-fix");
+            rtlSpan!.classList.add("rtl-fix2");
 
-          new Promise(function (resolve, reject) {
-            setTimeout(() => resolve("done"), 0);
-          }).then(() => {
-            span!.classList.remove("rtl-fix2");
-            span!.classList.add("rtl-fix");
-          });
+            new Promise((resolve) => {
+              setTimeout(() => resolve("done"), 0);
+            }).then(() => {
+              span!.classList.remove("rtl-fix2");
+              span!.classList.add("rtl-fix");
+            });
+          }
 
           return result;
         };

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -37,6 +37,7 @@ export class HaButtonMenu extends LitElement {
         <slot name="trigger"></slot>
       </div>
       <mwc-menu
+        id="menu"
         .corner=${this.corner}
         .menuCorner=${this.menuCorner}
         .fixed=${this.fixed}
@@ -50,6 +51,52 @@ export class HaButtonMenu extends LitElement {
     `;
   }
 
+  protected firstUpdated(changedProps): void {
+    super.firstUpdated(changedProps);
+
+    this.updateComplete.then(() => {
+      this.querySelectorAll("mwc-list-item").forEach((item) => {
+        item._getUpdateComplete = item.getUpdateComplete;
+
+        var style = document.createElement("style");
+        style.innerHTML =
+          ".rtl-fix, .rtl-fix2 { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}";
+        item.shadowRoot.appendChild(style);
+        var span = item.shadowRoot?.querySelector("span:first-child");
+        span.className = "rtl-fix";
+
+        item.getUpdateComplete = function () {
+          var result = item._getUpdateComplete();
+          var span = item.shadowRoot?.querySelector(".rtl-fix");
+          span!.className = "rtl-fix2";
+          new Promise(function (resolve, reject) {
+            setTimeout(() => resolve("done"), 0);
+          }).then(() => {
+            span!.className = "rtl-fix";
+          });
+
+          return result;
+          // wait for all children to render... and then inject again.
+          // check if we need original injection
+        };
+      });
+    });
+  }
+  /*
+  protected async firstUpdated(
+    _changedProperties: Map<string | number | symbol, unknown>
+  ): void {
+    const children = this.querySelectorAll("mwc-list-item");
+    await Promise.all(Array.from(children).map((c) => c.updateComplete));
+
+    this.querySelectorAll("mwc-list-item").forEach((item) => {
+      var style = document.createElement("style");
+      style.innerHTML =
+        "span:first-child { margin-left: var(--mdc-list-item-graphic-margin, 32px) !important; margin-right: 0px !important;}";
+      item.shadowRoot.appendChild(style);
+    });
+  }
+*/
   private _handleClick(): void {
     if (this.disabled) {
       return;
@@ -67,6 +114,34 @@ export class HaButtonMenu extends LitElement {
       ::slotted([disabled]) {
         color: var(--disabled-text-color);
       }
+
+      /*
+      :host-context([style*="direction: rtl;"]) mwc-menu mwc-list-item {
+        background-color: red;
+        margin-right: 0px !important;
+        margin-left: var(--mdc-list-item-graphic-margin, 32px);
+      }
+      */
+
+      /*:host-context([style*="direction: rtl;"]) span([class*="graphic"]) {*/
+      /*
+            :host-context([style*="direction: rtl;"])
+        mwc-menu
+        ::slotted([mwc-list-item]) {
+        background-color: red;
+        margin-right: 0px !important;
+        margin-left: var(--mdc-list-item-graphic-margin, 32px);
+      }
+*/
+
+      /*
+      :host-context([style*="direction: rtl;"]) ::slotted([mwc-list-item]) {
+        background-color: red;
+        margin-right: 0px !important;
+        margin-left: var(--mdc-list-item-graphic-margin, 32px);
+      }
+      */
+      /*::slotted([mwc-list-item]) {*/
     `;
   }
 }

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -54,7 +54,6 @@ export class HaButtonMenu extends LitElement {
   protected firstUpdated(changedProps): void {
     super.firstUpdated(changedProps);
 
-    // @ts-ignore
     if (document.dir === "rtl") {
       this.updateComplete.then(() => {
         this.querySelectorAll("mwc-list-item").forEach((item) => {

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -1,6 +1,6 @@
 import { atLeastVersion } from "../common/config/version";
 import { computeLocalize, LocalizeFunc } from "../common/translations/localize";
-import { computeRTL } from "../common/util/compute_rtl";
+import { computeRTLDirection } from "../common/util/compute_rtl";
 import { debounce } from "../common/util/debounce";
 import {
   getHassTranslations,
@@ -180,7 +180,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
 
     private _applyTranslations(hass: HomeAssistant) {
       document.querySelector("html")!.setAttribute("lang", hass.language);
-      this.style.direction = computeRTL(hass) ? "rtl" : "ltr";
+      document.dir = computeRTLDirection(hass);
       this._loadCoreTranslations(hass.language);
       this.__loadedFragmetTranslations = new Set();
       this._loadFragmentTranslations(hass.language, hass.panelUrl);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

mwc-menu and list item do not support RTL.
Further more the style fix needs to be applied to the span within the shadow dom of the list element. The list element is slotted under the menu so there is no way to get to the internal span via plain css in an elegant way.
In addition hovering over the menu causes re-renders due to the ripple which makes any style change to be reset.

The proposed code adds a new style when each menu item is created and then toggles the class on/off whenever an update to a menu item occurs.
It's not elegant but there's no other way that works.
Since MWC is not going to fix their very poor RTL support any time soon, I suggest we accept this change.

Before:
![image](https://user-images.githubusercontent.com/37745463/166447703-f41f376a-5b91-40b6-9816-9c37a0bba50a.png)

After:
![image](https://user-images.githubusercontent.com/37745463/166447803-782979d6-5549-4fbd-aeb0-2e200203d26c.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
