### PR TITLE
Add `entity_id` to states panel in developer tools

### DIFF
--- a/src/panels/developer-tools/state/developer-tools-state.js
+++ b/src/panels/developer-tools/state/developer-tools-state.js
@@ -199,6 +199,10 @@ class HaPanelDevState extends EventsMixin(LocalizeMixin(PolymerElement)) {
               class="state-input"
             ></ha-textfield>
             <p>
+              [[localize('ui.panel.developer-tools.tabs.states.entity_id')]]
+            </p>
+            <pre class="rendered">[[_entityId]]</pre>
+            <p>
               [[localize('ui.panel.developer-tools.tabs.states.state_attributes')]]
             </p>
             <ha-code-editor

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4122,6 +4122,7 @@
             "description1": "Set the current state representation of an entity within Home Assistant.",
             "description2": "If the entity belongs to a device, there will be no actual communication with that device.",
             "entity": "Entity",
+            "entity_id": "Entity ID",
             "state": "State",
             "attributes": "Attributes",
             "state_attributes": "State attributes (YAML, optional)",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This adds the entity_id to the states panel, as when using the entity picker it only shows the entity name in this panel.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion:
- https://community.home-assistant.io/t/2022-5-streamlining-settings/418477/95?u=theholyroger

As discussed on the forums. The alternative option would be to only use the entity_id when using the entiy picker of course, but think it's nicer to show the name there myself.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
