### PR TITLE
Fix enter key support for generic dialog box

### DIFF
--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -1,12 +1,13 @@
 import "@material/mwc-button/mwc-button";
 import { mdiAlertOutline } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
+import { ifDefined } from "lit/directives/if-defined";
 import { fireEvent } from "../../common/dom/fire_event";
 import "../../components/ha-dialog";
 import "../../components/ha-svg-icon";
 import "../../components/ha-switch";
-import "../../components/ha-textfield";
+import { HaTextField } from "../../components/ha-textfield";
 import { haStyleDialog } from "../../resources/styles";
 import { HomeAssistant } from "../../types";
 import { DialogBoxParams } from "./show-dialog-box";
@@ -17,13 +18,10 @@ class DialogBox extends LitElement {
 
   @state() private _params?: DialogBoxParams;
 
-  @state() private _value?: string;
+  @query("ha-textfield") private _textField?: HaTextField;
 
   public async showDialog(params: DialogBoxParams): Promise<void> {
     this._params = params;
-    if (params.prompt) {
-      this._value = params.defaultValue;
-    }
   }
 
   public closeDialog(): boolean {
@@ -75,9 +73,7 @@ class DialogBox extends LitElement {
             ? html`
                 <ha-textfield
                   dialogInitialFocus
-                  .value=${this._value || ""}
-                  @keyup=${this._handleKeyUp}
-                  @input=${this._valueChanged}
+                  value=${ifDefined(this._params.defaultValue)}
                   .label=${this._params.inputLabel
                     ? this._params.inputLabel
                     : ""}
@@ -109,10 +105,6 @@ class DialogBox extends LitElement {
     `;
   }
 
-  private _valueChanged(ev) {
-    this._value = ev.target.value;
-  }
-
   private _dismiss(): void {
     if (this._params?.cancel) {
       this._params.cancel();
@@ -120,15 +112,9 @@ class DialogBox extends LitElement {
     this._close();
   }
 
-  private _handleKeyUp(ev: KeyboardEvent) {
-    if (ev.keyCode === 13) {
-      this._confirm();
-    }
-  }
-
   private _confirm(): void {
     if (this._params!.confirm) {
-      this._params!.confirm(this._value);
+      this._params!.confirm(this._textField?.value);
     }
     this._close();
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fix enter key support for generic dialog box by removing unnecessary handlers as described in my comment and review of #12360.  The `mwc-dialog` component handles the key press, so all this dialog has to do is grab the current value.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #12206 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

