### PR TITLE
Replace host-context with css properties

### DIFF
--- a/src/components/ha-fab.ts
+++ b/src/components/ha-fab.ts
@@ -12,8 +12,9 @@ export class HaFab extends Fab {
   static override styles = Fab.styles.concat([
     css`
       .mdc-fab--extended .mdc-fab__icon {
-        margin-left: var(--rtl-12px, -8px) !important;
-        margin-right: var(--rtl--8px, 12px) !important;
+        margin-inline-start: -8px !important;
+        margin-inline-end: 12px !important;
+        direction: var(--direction) !important;
       }
     `,
   ]);

--- a/src/components/ha-fab.ts
+++ b/src/components/ha-fab.ts
@@ -1,23 +1,25 @@
-import { Fab } from "@material/mwc-fab";
+import { FabBase } from "@material/mwc-fab/mwc-fab-base";
+import { styles } from "@material/mwc-fab/mwc-fab.css";
 import { customElement } from "lit/decorators";
 import { css } from "lit";
 
 @customElement("ha-fab")
-export class HaFab extends Fab {
+export class HaFab extends FabBase {
   protected firstUpdated(changedProperties) {
     super.firstUpdated(changedProperties);
     this.style.setProperty("--mdc-theme-secondary", "var(--primary-color)");
   }
 
-  static override styles = Fab.styles.concat([
+  static override styles = [
+    styles,
     css`
       .mdc-fab--extended .mdc-fab__icon {
-        margin-inline-start: -8px !important;
-        margin-inline-end: 12px !important;
-        direction: var(--direction) !important;
+        margin-inline-start: -8px;
+        margin-inline-end: 12px;
+        direction: var(--direction);
       }
     `,
-  ]);
+  ];
 }
 
 declare global {

--- a/src/components/ha-fab.ts
+++ b/src/components/ha-fab.ts
@@ -11,11 +11,9 @@ export class HaFab extends Fab {
 
   static override styles = Fab.styles.concat([
     css`
-      :host-context([style*="direction: rtl;"])
-        .mdc-fab--extended
-        .mdc-fab__icon {
-        margin-left: 12px !important;
-        margin-right: calc(12px - 20px) !important;
+      .mdc-fab--extended .mdc-fab__icon {
+        margin-left: var(--rtl-12px, calc(12px - 20px)) !important;
+        margin-right: var(--rtl--8px, 12px) !important;
       }
     `,
   ]);

--- a/src/components/ha-fab.ts
+++ b/src/components/ha-fab.ts
@@ -13,7 +13,7 @@ export class HaFab extends FabBase {
   static override styles = [
     styles,
     css`
-      .mdc-fab--extended .mdc-fab__icon {
+      :host .mdc-fab--extended .mdc-fab__icon {
         margin-inline-start: -8px;
         margin-inline-end: 12px;
         direction: var(--direction);

--- a/src/components/ha-fab.ts
+++ b/src/components/ha-fab.ts
@@ -12,7 +12,7 @@ export class HaFab extends Fab {
   static override styles = Fab.styles.concat([
     css`
       .mdc-fab--extended .mdc-fab__icon {
-        margin-left: var(--rtl-12px, calc(12px - 20px)) !important;
+        margin-left: var(--rtl-12px, -8px) !important;
         margin-right: var(--rtl--8px, 12px) !important;
       }
     `,

--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -236,7 +236,7 @@ class ErrorLogCard extends LitElement {
     }
 
     mwc-button {
-      direction: var(--rtl-dir, ltr);
+      direction: var(--direction);
     }
   `;
 }

--- a/src/panels/config/logs/error-log-card.ts
+++ b/src/panels/config/logs/error-log-card.ts
@@ -235,8 +235,8 @@ class ErrorLogCard extends LitElement {
       color: var(--warning-color);
     }
 
-    :host-context([style*="direction: rtl;"]) mwc-button {
-      direction: rtl;
+    mwc-button {
+      direction: var(--rtl-dir, ltr);
     }
   `;
 }

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -1,6 +1,6 @@
 import { atLeastVersion } from "../common/config/version";
 import { computeLocalize, LocalizeFunc } from "../common/translations/localize";
-import { computeRTL } from "../common/util/compute_rtl";
+import { computeRTLDirection } from "../common/util/compute_rtl";
 import { debounce } from "../common/util/debounce";
 import {
   getHassTranslations,
@@ -187,18 +187,10 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
     }
 
     private _applyDirection(hass: HomeAssistant) {
-      if (computeRTL(hass)) {
-        this.style.direction = "rtl";
-        // apply custom properties used to fix RTL appearance throughout the system
-        this.style.setProperty("--rtl-12px", "12px");
-        this.style.setProperty("--rtl--8px", "-8px");
-        this.style.setProperty("--dir", "rtl");
-      } else {
-        // clear all custom properties (can't use "all" for this)
-        this.style.cssText = "";
-
-        this.style.direction = "ltr";
-      }
+      const direction = computeRTLDirection(hass);
+      this.style.direction = direction;
+      document.dir = direction;
+      this.style.setProperty("--direction", direction);
     }
 
     /**

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -192,10 +192,10 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         // apply custom properties used to fix RTL appearance throughout the system
         this.style.setProperty("--rtl-12px", "12px");
         this.style.setProperty("--rtl--8px", "-8px");
-        this.style.setProperty("--rtl-dir", "rtl");
+        this.style.setProperty("--dir", "rtl");
       } else {
         // clear all custom properties (can't use "all" for this)
-        this.style = "";
+        this.style.cssText = "";
 
         this.style.direction = "ltr";
       }

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -195,9 +195,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         this.style.setProperty("--rtl-dir", "rtl");
       } else {
         // clear all custom properties (can't use "all" for this)
-        for (let i = this.style.length; i--; ) {
-          this.style.removeProperty(this.style[i]);
-        }
+        this.style = "";
 
         this.style.direction = "ltr";
       }

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -180,10 +180,27 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
 
     private _applyTranslations(hass: HomeAssistant) {
       document.querySelector("html")!.setAttribute("lang", hass.language);
-      this.style.direction = computeRTL(hass) ? "rtl" : "ltr";
+      this._applyDirection(hass);
       this._loadCoreTranslations(hass.language);
       this.__loadedFragmetTranslations = new Set();
       this._loadFragmentTranslations(hass.language, hass.panelUrl);
+    }
+
+    private _applyDirection(hass: HomeAssistant) {
+      if (computeRTL(hass)) {
+        this.style.direction = "rtl";
+        // apply custom properties used to fix RTL appearance throughout the system
+        this.style.setProperty("--rtl-12px", "12px");
+        this.style.setProperty("--rtl--8px", "-8px");
+        this.style.setProperty("--rtl-dir", "rtl");
+      } else {
+        // clear all custom properties (can't use "all" for this)
+        for (let i = this.style.length; i--; ) {
+          this.style.removeProperty(this.style[i]);
+        }
+
+        this.style.direction = "ltr";
+      }
     }
 
     /**


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

:host-context is not supported by Safari or Mozilla.
The right approach is to define css properties on <host-assistant> tag when in RTL and then use the right expressions to apply the styles.

This PR does this for fab and for error-log card. Once approved I will do it in the other 20+ places that it's needed.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
