### PR TITLE
Move zwave_js node comments from device config to info page

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -447,13 +447,11 @@ export const fetchZwaveNodeMetadata = (
 
 export const fetchZwaveNodeComments = (
   hass: HomeAssistant,
-  entry_id: string,
-  node_id: number
+  device_id: string
 ): Promise<ZwaveJSNodeComments> =>
   hass.callWS({
     type: "zwave_js/node_comments",
-    entry_id,
-    node_id,
+    device_id,
   });
 
 export const fetchZwaveNodeConfigParameters = (

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -167,6 +167,9 @@ export interface ZwaveJSNodeMetadata {
   wakeup: string;
   reset: string;
   device_database_url: string;
+}
+
+export interface ZwaveJSNodeComments {
   comments: ZWaveJSNodeComment[];
 }
 
@@ -440,6 +443,17 @@ export const fetchZwaveNodeMetadata = (
   hass.callWS({
     type: "zwave_js/node_metadata",
     device_id,
+  });
+
+export const fetchZwaveNodeComments = (
+  hass: HomeAssistant,
+  entry_id: string,
+  node_id: number
+): Promise<ZwaveJSNodeComments> =>
+  hass.callWS({
+    type: "zwave_js/node_comments",
+    entry_id,
+    node_id,
   });
 
 export const fetchZwaveNodeConfigParameters = (

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -16,10 +16,6 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
 
   @property({ attribute: false }) public device!: DeviceRegistryEntry;
 
-  @state() private _entryId?: string;
-
-  @state() private _nodeId?: number;
-
   @state() private _nodeComments?: ZwaveJSNodeComments;
 
   protected willUpdate(changedProperties: PropertyValues) {
@@ -37,7 +33,6 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
     if (!identifiers) {
       return;
     }
-    this._nodeId = identifiers.node_id;
 
     const configEntries = await getConfigEntries(this.hass, {
       domain: "zwave_js",
@@ -51,12 +46,10 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
       return;
     }
 
-    this._entryId = configEntry.entry_id;
-
     this._nodeComments = await fetchZwaveNodeComments(
       this.hass,
-      this._entryId,
-      this._nodeId
+      configEntry.entry_id,
+      identifiers.node_id
     );
   }
 

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -15,8 +15,8 @@ import {
 import {
   getZwaveJsIdentifiersFromDevice,
   ZWaveJSNodeIdentifiers,
-  ZwaveJSNodeMetadata,
-  fetchZwaveNodeMetadata,
+  ZwaveJSNodeComments,
+  fetchZwaveNodeComments,
 } from "../../../../../../data/zwave_js";
 import { haStyle } from "../../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../../types";
@@ -35,7 +35,7 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
 
   @state() private _nodeId?: number;
 
-  @state() private _nodeMetadata?: ZwaveJSNodeMetadata;
+  @state() private _nodeComments?: ZwaveJSNodeComments;
 
   protected updated(changedProperties: PropertyValues) {
     if (changedProperties.has("device")) {
@@ -73,7 +73,7 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
       zwaveJsConfEntries++;
     }
 
-    this._nodeMetadata = await fetchZwaveNodeMetadata(
+    this._nodeComments = await fetchZwaveNodeComments(
       this.hass,
       this._entryId,
       this._nodeId
@@ -81,12 +81,12 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
   }
 
   protected render(): TemplateResult {
-    if (!this._nodeMetadata || this._nodeMetadata.comments?.length <= 0) {
+    if (!this._nodeComments || this._nodeComments.comments?.length <= 0) {
       return html``;
     }
     return html`
       <div>
-        ${this._nodeMetadata.comments.map(
+        ${this._nodeComments.comments.map(
           (comment) => html`<ha-alert .alertType=${comment.level}>
             ${comment.text}
           </ha-alert>`

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -61,18 +61,18 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
   }
 
   protected render(): TemplateResult {
-    if (this._nodeComments?.comments?.length <= 0) {
-      return html``;
+    if (this._nodeComments && this._nodeComments.comments?.length > 0) {
+      return html`
+        <div>
+          ${this._nodeComments.comments.map(
+            (comment) => html`<ha-alert .alertType=${comment.level}>
+              ${comment.text}
+            </ha-alert>`
+          )}
+        </div>
+      `;
     }
-    return html`
-      <div>
-        ${this._nodeComments.comments.map(
-          (comment) => html`<ha-alert .alertType=${comment.level}>
-            ${comment.text}
-          </ha-alert>`
-        )}
-      </div>
-    `;
+    return html``;
   }
 }
 

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -1,6 +1,4 @@
 import {
-  css,
-  CSSResultGroup,
   html,
   LitElement,
   PropertyValues,
@@ -15,7 +13,6 @@ import {
   ZwaveJSNodeComments,
   fetchZwaveNodeComments,
 } from "../../../../../../data/zwave_js";
-import { haStyle } from "../../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../../types";
 
 @customElement("ha-device-alerts-zwave_js")
@@ -38,6 +35,8 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
   }
 
   private async _fetchNodeDetails() {
+    this._nodeComments = undefined;
+
     const identifiers: ZWaveJSNodeIdentifiers | undefined =
       getZwaveJsIdentifiersFromDevice(this.device);
     if (!identifiers) {
@@ -81,20 +80,20 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
     `;
   }
 
-  static get styles(): CSSResultGroup {
-    return [
-      haStyle,
-      css`
-        h4 {
-          margin-bottom: 4px;
-        }
-        div {
-          word-break: break-all;
-          margin-top: 2px;
-        }
-      `,
-    ];
-  }
+  // static get styles(): CSSResultGroup {
+  //   return [
+  //     haStyle,
+  //     css`
+  //       h4 {
+  //         margin-bottom: 4px;
+  //       }
+  //       div {
+  //         word-break: break-all;
+  //         margin-top: 2px;
+  //       }
+  //     `,
+  //   ];
+  // }
 }
 
 declare global {

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -1,0 +1,118 @@
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  PropertyValues,
+  TemplateResult,
+} from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
+import {
+  ConfigEntry,
+  getConfigEntries,
+} from "../../../../../../data/config_entries";
+import {
+  getZwaveJsIdentifiersFromDevice,
+  ZWaveJSNodeIdentifiers,
+  ZwaveJSNodeMetadata,
+  fetchZwaveNodeMetadata,
+} from "../../../../../../data/zwave_js";
+import { haStyle } from "../../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../../types";
+
+@customElement("ha-device-alerts-zwave_js")
+export class HaDeviceAlertsZWaveJS extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public device!: DeviceRegistryEntry;
+
+  @state() private _entryId?: string;
+
+  @state() private _configEntry?: ConfigEntry;
+
+  @state() private _multipleConfigEntries = false;
+
+  @state() private _nodeId?: number;
+
+  @state() private _nodeMetadata?: ZwaveJSNodeMetadata;
+
+  protected updated(changedProperties: PropertyValues) {
+    if (changedProperties.has("device")) {
+      const identifiers: ZWaveJSNodeIdentifiers | undefined =
+        getZwaveJsIdentifiersFromDevice(this.device);
+      if (!identifiers) {
+        return;
+      }
+      this._nodeId = identifiers.node_id;
+      this._entryId = this.device.config_entries[0];
+
+      this._fetchNodeDetails();
+    }
+  }
+
+  protected async _fetchNodeDetails() {
+    if (!this._nodeId || !this._entryId) {
+      return;
+    }
+
+    const configEntries = await getConfigEntries(this.hass, {
+      domain: "zwave_js",
+    });
+    let zwaveJsConfEntries = 0;
+    for (const entry of configEntries) {
+      if (zwaveJsConfEntries) {
+        this._multipleConfigEntries = true;
+      }
+      if (entry.entry_id === this._entryId) {
+        this._configEntry = entry;
+      }
+      if (this._configEntry && this._multipleConfigEntries) {
+        break;
+      }
+      zwaveJsConfEntries++;
+    }
+
+    this._nodeMetadata = await fetchZwaveNodeMetadata(
+      this.hass,
+      this._entryId,
+      this._nodeId
+    );
+  }
+
+  protected render(): TemplateResult {
+    if (!this._nodeMetadata || this._nodeMetadata.comments?.length <= 0) {
+      return html``;
+    }
+    return html`
+      <div>
+        ${this._nodeMetadata.comments.map(
+          (comment) => html`<ha-alert .alertType=${comment.level}>
+            ${comment.text}
+          </ha-alert>`
+        )}
+      </div>
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      css`
+        h4 {
+          margin-bottom: 4px;
+        }
+        div {
+          word-break: break-all;
+          margin-top: 2px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-device-alerts-zwave_js": HaDeviceAlertsZWaveJS;
+  }
+}

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -37,7 +37,8 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
 
   @state() private _nodeComments?: ZwaveJSNodeComments;
 
-  protected updated(changedProperties: PropertyValues) {
+  protected willUpdate(changedProperties: PropertyValues) {
+  	super.willUpdate(changedProps);
     if (changedProperties.has("device")) {
       const identifiers: ZWaveJSNodeIdentifiers | undefined =
         getZwaveJsIdentifiersFromDevice(this.device);

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -52,7 +52,7 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
     }
   }
 
-  protected async _fetchNodeDetails() {
+  private async _fetchNodeDetails() {
     if (!this._nodeId || !this._entryId) {
       return;
     }

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -33,14 +33,6 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
   protected willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
     if (changedProperties.has("device")) {
-      const identifiers: ZWaveJSNodeIdentifiers | undefined =
-        getZwaveJsIdentifiersFromDevice(this.device);
-      if (!identifiers) {
-        return;
-      }
-      this._nodeId = identifiers.node_id;
-      this._entryId = this.device.config_entries[0];
-
       this._fetchNodeDetails();
     }
   }

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -1,9 +1,4 @@
-import {
-  html,
-  LitElement,
-  PropertyValues,
-  TemplateResult,
-} from "lit";
+import { html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
 import { getConfigEntries } from "../../../../../../data/config_entries";
@@ -79,21 +74,6 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
       </div>
     `;
   }
-
-  // static get styles(): CSSResultGroup {
-  //   return [
-  //     haStyle,
-  //     css`
-  //       h4 {
-  //         margin-bottom: 4px;
-  //       }
-  //       div {
-  //         word-break: break-all;
-  //         margin-top: 2px;
-  //       }
-  //     `,
-  //   ];
-  // }
 }
 
 declare global {

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -82,7 +82,7 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
   }
 
   protected render(): TemplateResult {
-    if (!this._nodeComments || this._nodeComments.comments?.length <= 0) {
+    if (this._nodeComments?.comments?.length <= 0) {
       return html``;
     }
     return html`

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js.ts
@@ -1,10 +1,7 @@
 import { html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
-import { getConfigEntries } from "../../../../../../data/config_entries";
 import {
-  getZwaveJsIdentifiersFromDevice,
-  ZWaveJSNodeIdentifiers,
   ZwaveJSNodeComments,
   fetchZwaveNodeComments,
 } from "../../../../../../data/zwave_js";
@@ -26,30 +23,9 @@ export class HaDeviceAlertsZWaveJS extends LitElement {
   }
 
   private async _fetchNodeDetails() {
-    this._nodeComments = undefined;
-
-    const identifiers: ZWaveJSNodeIdentifiers | undefined =
-      getZwaveJsIdentifiersFromDevice(this.device);
-    if (!identifiers) {
-      return;
-    }
-
-    const configEntries = await getConfigEntries(this.hass, {
-      domain: "zwave_js",
-    });
-
-    const configEntry = configEntries.find((entry) =>
-      this.device.config_entries.includes(entry.entry_id)
-    );
-
-    if (!configEntry) {
-      return;
-    }
-
     this._nodeComments = await fetchZwaveNodeComments(
       this.hass,
-      configEntry.entry_id,
-      identifiers.node_id
+      this.device.id
     );
   }
 

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -549,7 +549,7 @@ export class HaConfigDevicePage extends LitElement {
           ${
             deviceAlerts.length
               ? html`
-                  <div class="alerts fullwidth" slot="alerts">
+                  <div class="fullwidth">
                     ${deviceAlerts}
                   </div>
                 `

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -546,16 +546,12 @@ export class HaConfigDevicePage extends LitElement {
 
                 </div>
           </div>
-          ${
-            deviceAlerts.length
-              ? html`
-                  <div class="fullwidth">
-                    ${deviceAlerts}
-                  </div>
-                `
-              : ""
-          }
           <div class="column">
+              ${
+                deviceAlerts.length
+                  ? html` <div class="fullwidth">${deviceAlerts}</div> `
+                  : ""
+              }
               <ha-device-info-card
                 .hass=${this.hass}
                 .areas=${this.areas}

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -387,6 +387,7 @@ export class HaConfigDevicePage extends LitElement {
       : device.configuration_url;
 
     const deviceInfo: TemplateResult[] = [];
+    const deviceAlerts: TemplateResult[] = [];
 
     if (device.disabled_by) {
       deviceInfo.push(
@@ -443,7 +444,8 @@ export class HaConfigDevicePage extends LitElement {
       device,
       integrations,
       deviceInfo,
-      deviceActions
+      deviceActions,
+      deviceAlerts
     );
 
     if (Array.isArray(this._diagnosticDownloadLinks)) {
@@ -544,6 +546,15 @@ export class HaConfigDevicePage extends LitElement {
 
                 </div>
           </div>
+          ${
+            deviceAlerts.length
+              ? html`
+                  <div class="alerts fullwidth" slot="alerts">
+                    ${deviceAlerts}
+                  </div>
+                `
+              : ""
+          }
           <div class="column">
               <ha-device-info-card
                 .hass=${this.hass}
@@ -925,7 +936,8 @@ export class HaConfigDevicePage extends LitElement {
     device: DeviceRegistryEntry,
     integrations: ConfigEntry[],
     deviceInfo: TemplateResult[],
-    deviceActions: (string | TemplateResult)[]
+    deviceActions: (string | TemplateResult)[],
+    deviceAlerts: TemplateResult[]
   ) {
     const domains = integrations.map((int) => int.domain);
     if (domains.includes("mqtt")) {
@@ -957,11 +969,20 @@ export class HaConfigDevicePage extends LitElement {
     }
     if (domains.includes("zwave_js")) {
       import(
+        "./device-detail/integration-elements/zwave_js/ha-device-alerts-zwave_js"
+      );
+      import(
         "./device-detail/integration-elements/zwave_js/ha-device-info-zwave_js"
       );
       import(
         "./device-detail/integration-elements/zwave_js/ha-device-actions-zwave_js"
       );
+      deviceAlerts.push(html`
+        <ha-device-alerts-zwave_js
+          .hass=${this.hass}
+          .device=${device}
+        ></ha-device-alerts-zwave_js>
+      `);
       deviceInfo.push(html`
         <ha-device-info-zwave_js
           .hass=${this.hass}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -546,12 +546,6 @@ class ZWaveJSConfigDashboard extends LitElement {
           max-width: 600px;
         }
 
-        button.dump {
-          width: 100%;
-          text-align: center;
-          color: var(--secondary-text-color);
-        }
-
         [hidden] {
           display: none;
         }

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -166,17 +166,6 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
               </em>
             </p>
           </div>
-          ${this._nodeMetadata.comments?.length > 0
-            ? html`
-                <div>
-                  ${this._nodeMetadata.comments.map(
-                    (comment) => html`<ha-alert .alertType=${comment.level}>
-                      ${comment.text}
-                    </ha-alert>`
-                  )}
-                </div>
-              `
-            : ``}
           <ha-card>
             ${Object.entries(this._config).map(
               ([id, item]) => html` <ha-settings-row


### PR DESCRIPTION
## Proposed change
This PR moves node comments from the device config page to device info page (see screenshot below). Aside from the fact that this now supports controller nodes, it is a better UX decision overall.

This PR may need some mobile friendly CSS help, I am not an expert. It also must be merged alongside the corresponding core PR (https://github.com/home-assistant/core/pull/71513)

![image](https://user-images.githubusercontent.com/7243222/167284428-8b92e24e-4b0d-4f9d-86e5-13af79e7979a.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/71513

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
