### PR TITLE
Add controller statistics to zwave_js config dashboard

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -237,7 +237,7 @@ export interface ZWaveJSControllerStatisticsUpdatedMessage {
   nak: number;
   can: number;
   timeout_ack: number;
-  timout_response: number;
+  timeout_response: number;
   timeout_callback: number;
 }
 

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -227,6 +227,20 @@ export interface ZWaveJSHealNetworkStatusMessage {
   heal_node_status: { [key: number]: string };
 }
 
+export interface ZWaveJSControllerStatisticsUpdatedMessage {
+  event: "statistics updated";
+  source: "controller";
+  messages_tx: number;
+  messages_rx: number;
+  messages_dropped_tx: number;
+  messages_dropped_rx: number;
+  nak: number;
+  can: number;
+  timeout_ack: number;
+  timout_response: number;
+  timeout_callback: number;
+}
+
 export interface ZWaveJSRemovedNode {
   node_id: number;
   manufacturer: string;
@@ -543,6 +557,19 @@ export const subscribeHealZwaveNetworkProgress = (
     (message: any) => callbackFunction(message),
     {
       type: "zwave_js/subscribe_heal_network_progress",
+      entry_id,
+    }
+  );
+
+export const subscribeZwaveControllerStatistics = (
+  hass: HomeAssistant,
+  entry_id: string,
+  callbackFunction: (message: ZWaveJSControllerStatisticsUpdatedMessage) => void
+): Promise<UnsubscribeFunc> =>
+  hass.connection.subscribeMessage(
+    (message: any) => callbackFunction(message),
+    {
+      type: "zwave_js/subscribe_controller_statistics",
       entry_id,
     }
   );

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -716,6 +716,10 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
           font-size: 1rem;
         }
 
+        mwc-list-item {
+          height: 60px;
+        }
+
         .card-header {
           display: flex;
         }

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -278,7 +278,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.messages_tx.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_tx.tooltip"
                             )}
@@ -291,7 +292,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.messages_rx.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_rx.tooltip"
                             )}
@@ -304,7 +306,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_tx.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_tx.tooltip"
                             )}
@@ -317,7 +320,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_rx.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_rx.tooltip"
                             )}
@@ -330,7 +334,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.nak.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.nak.tooltip"
                             )}
@@ -343,7 +348,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.can.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.can.tooltip"
                             )}
@@ -356,7 +362,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.timeout_ack.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_ack.tooltip"
                             )}
@@ -369,7 +376,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.timout_response.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.timout_response.tooltip"
                             )}
@@ -382,7 +390,8 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         <td>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.timeout_callback.label"
-                          )}:<ha-help-tooltip
+                          )}:
+                          <ha-help-tooltip
                             .label=${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_callback.tooltip"
                             )}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -13,9 +13,9 @@ import "../../../../../components/ha-card";
 import "../../../../../components/ha-icon-button";
 import "../../../../../components/ha-expansion-panel";
 import "../../../../../components/ha-fab";
+import "../../../../../components/ha-help-tooltip";
 import "../../../../../components/ha-icon-next";
 import "../../../../../components/ha-svg-icon";
-import "../../../../../components/ha-help-tooltip";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import {
   fetchZwaveDataCollectionStatus,

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -11,6 +11,7 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-icon-button";
+import "../../../../../components/ha-expansion-panel";
 import "../../../../../components/ha-fab";
 import "../../../../../components/ha-icon-next";
 import "../../../../../components/ha-svg-icon";
@@ -234,48 +235,46 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                 </ha-card>
                 <ha-card header="Diagnostics">
                   <div class="card-content">
-                    <table>
-                      <tr>
-                        <td>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.driver_version"
-                          )}:
-                        </td>
-                        <td>${this._network.client.driver_version}</td>
-                      </tr>
-                      <tr>
-                        <td>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.server_version"
-                          )}:
-                        </td>
-                        <td>${this._network.client.server_version}</td>
-                      </tr>
-                      <tr>
-                        <td>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.home_id"
-                          )}:
-                        </td>
-                        <td>${this._network.controller.home_id}</td>
-                      </tr>
-                      <tr>
-                        <td>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.server_url"
-                          )}:
-                        </td>
-                        <td>${this._network.client.ws_server_url}</td>
-                      </tr>
-                    </table>
-                    <h2>
-                      ${this.hass.localize(
+                    <div class="row">
+                      <span>
+                        ${this.hass.localize(
+                          "ui.panel.config.zwave_js.dashboard.driver_version"
+                        )}:
+                      </span>
+                      <span>${this._network.client.driver_version}</span>
+                    </div>
+                    <div class="row">
+                      <span>
+                        ${this.hass.localize(
+                          "ui.panel.config.zwave_js.dashboard.server_version"
+                        )}:
+                      </span>
+                      <span>${this._network.client.server_version}</span>
+                    </div>
+                    <div class="row">
+                      <span>
+                        ${this.hass.localize(
+                          "ui.panel.config.zwave_js.dashboard.home_id"
+                        )}:
+                      </span>
+                      <span>${this._network.controller.home_id}</span>
+                    </div>
+                    <div class="row">
+                      <span>
+                        ${this.hass.localize(
+                          "ui.panel.config.zwave_js.dashboard.server_url"
+                        )}:
+                      </span>
+                      <span>${this._network.client.ws_server_url}</span>
+                    </div>
+                    <br />
+                    <ha-expansion-panel
+                      .header=${this.hass.localize(
                         "ui.panel.config.zwave_js.dashboard.statistics.title"
                       )}
-                    </h2>
-                    <table>
-                      <tr>
-                        <td>
+                    >
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.messages_tx.label"
                           )}:
@@ -285,11 +284,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.messages_tx ?? 0}</td>
-                      </tr>
-                      <tr>
-                        <td>
+                        </span>
+                        <span>${this._statistics?.messages_tx ?? 0}</span>
+                      </div>
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.messages_rx.label"
                           )}:
@@ -299,11 +298,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.messages_rx ?? 0}</td>
-                      </tr>
-                      <tr>
-                        <td>
+                        </span>
+                        <span>${this._statistics?.messages_rx ?? 0}</span>
+                      </div>
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_tx.label"
                           )}:
@@ -313,11 +312,13 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.messages_dropped_tx ?? 0}</td>
-                      </tr>
-                      <tr>
-                        <td>
+                        </span>
+                        <span
+                          >${this._statistics?.messages_dropped_tx ?? 0}</span
+                        >
+                      </div>
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_rx.label"
                           )}:
@@ -327,11 +328,13 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.messages_dropped_rx ?? 0}</td>
-                      </tr>
-                      <tr>
-                        <td>
+                        </span>
+                        <span
+                          >${this._statistics?.messages_dropped_rx ?? 0}</span
+                        >
+                      </div>
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.nak.label"
                           )}:
@@ -341,11 +344,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.nak ?? 0}</td>
-                      </tr>
-                      <tr>
-                        <td>
+                        </span>
+                        <span>${this._statistics?.nak ?? 0}</span>
+                      </div>
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.can.label"
                           )}:
@@ -355,11 +358,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.can ?? 0}</td>
-                      </tr>
-                      <tr>
-                        <td>
+                        </span>
+                        <span>${this._statistics?.can ?? 0}</span>
+                      </div>
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.timeout_ack.label"
                           )}:
@@ -369,11 +372,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.timeout_ack ?? 0}</td>
-                      </tr>
-                      <tr>
-                        <td>
+                        </span>
+                        <span>${this._statistics?.timeout_ack ?? 0}</span>
+                      </div>
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.timout_response.label"
                           )}:
@@ -383,11 +386,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.timout_response ?? 0}</td>
-                      </tr>
-                      <tr>
-                        <td>
+                        </span>
+                        <span>${this._statistics?.timout_response ?? 0}</span>
+                      </div>
+                      <div class="row">
+                        <span>
                           ${this.hass.localize(
                             "ui.panel.config.zwave_js.dashboard.statistics.timeout_callback.label"
                           )}:
@@ -397,10 +400,10 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                             )}
                           >
                           </ha-help-tooltip>
-                        </td>
-                        <td>${this._statistics?.timeout_callback ?? 0}</td>
-                      </tr>
-                    </table>
+                        </span>
+                        <span>${this._statistics?.timeout_callback ?? 0}</span>
+                      </div>
+                    </ha-expansion-panel>
                   </div>
                   <div class="card-actions">
                     <mwc-button
@@ -680,6 +683,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
         .sectionHeader {
           position: relative;
           padding-right: 40px;
+        }
+
+        .row {
+          display: flex;
+          justify-content: space-between;
         }
 
         .network-status div.heading {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -1,4 +1,5 @@
-import "@material/mwc-button/mwc-button";
+import "@material/mwc-list/mwc-list";
+import "@material/mwc-list/mwc-list-item";
 import {
   mdiAlertCircle,
   mdiCheckCircle,
@@ -273,136 +274,139 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                         "ui.panel.config.zwave_js.dashboard.statistics.title"
                       )}
                     >
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.messages_tx.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
+                      <mwc-list noninteractive>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.messages_tx.label"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_tx.tooltip"
                             )}
+                          </span>
+                          <span slot="meta"
+                            >${this._statistics?.messages_tx ?? 0}</span
                           >
-                          </ha-help-tooltip>
-                        </span>
-                        <span>${this._statistics?.messages_tx ?? 0}</span>
-                      </div>
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.messages_rx.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
+                        </mwc-list-item>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.messages_rx.label"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_rx.tooltip"
                             )}
+                          </span>
+                          <span slot="meta"
+                            >${this._statistics?.messages_rx ?? 0}</span
                           >
-                          </ha-help-tooltip>
-                        </span>
-                        <span>${this._statistics?.messages_rx ?? 0}</span>
-                      </div>
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_tx.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
+                        </mwc-list-item>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_tx.label"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_tx.tooltip"
                             )}
+                          </span>
+                          <span slot="meta"
+                            >${this._statistics?.messages_dropped_tx ?? 0}</span
                           >
-                          </ha-help-tooltip>
-                        </span>
-                        <span
-                          >${this._statistics?.messages_dropped_tx ?? 0}</span
-                        >
-                      </div>
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_rx.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
+                        </mwc-list-item>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_rx.label"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_rx.tooltip"
                             )}
+                          </span>
+                          <span slot="meta"
+                            >${this._statistics?.messages_dropped_rx ?? 0}</span
                           >
-                          </ha-help-tooltip>
-                        </span>
-                        <span
-                          >${this._statistics?.messages_dropped_rx ?? 0}</span
-                        >
-                      </div>
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.nak.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
+                        </mwc-list-item>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.nak.label"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.nak.tooltip"
                             )}
-                          >
-                          </ha-help-tooltip>
-                        </span>
-                        <span>${this._statistics?.nak ?? 0}</span>
-                      </div>
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.can.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
+                          </span>
+                          <span slot="meta">${this._statistics?.nak ?? 0}</span>
+                        </mwc-list-item>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.can.label"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.can.tooltip"
                             )}
-                          >
-                          </ha-help-tooltip>
-                        </span>
-                        <span>${this._statistics?.can ?? 0}</span>
-                      </div>
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.timeout_ack.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
+                          </span>
+                          <span slot="meta">${this._statistics?.can ?? 0}</span>
+                        </mwc-list-item>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.timeout_ack.label"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_ack.tooltip"
                             )}
+                          </span>
+                          <span slot="meta"
+                            >${this._statistics?.timeout_ack ?? 0}</span
                           >
-                          </ha-help-tooltip>
-                        </span>
-                        <span>${this._statistics?.timeout_ack ?? 0}</span>
-                      </div>
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.timout_response.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
-                              "ui.panel.config.zwave_js.dashboard.statistics.timout_response.tooltip"
+                        </mwc-list-item>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.timeout_response.label"
                             )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.timeout_response.tooltip"
+                            )}
+                          </span>
+                          <span slot="meta"
+                            >${this._statistics?.timeout_response ?? 0}</span
                           >
-                          </ha-help-tooltip>
-                        </span>
-                        <span>${this._statistics?.timout_response ?? 0}</span>
-                      </div>
-                      <div class="row">
-                        <span>
-                          ${this.hass.localize(
-                            "ui.panel.config.zwave_js.dashboard.statistics.timeout_callback.label"
-                          )}:
-                          <ha-help-tooltip
-                            .label=${this.hass.localize(
+                        </mwc-list-item>
+                        <mwc-list-item twoline hasmeta>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.panel.config.zwave_js.dashboard.statistics.timeout_callback.label"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_callback.tooltip"
                             )}
+                          </span>
+                          <span slot="meta"
+                            >${this._statistics?.timeout_callback ?? 0}</span
                           >
-                          </ha-help-tooltip>
-                        </span>
-                        <span>${this._statistics?.timeout_callback ?? 0}</span>
-                      </div>
+                        </mwc-list-item>
+                      </mwc-list>
                     </ha-expansion-panel>
                   </div>
                   <div class="card-actions">
@@ -726,12 +730,6 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
         ha-card {
           margin: 0px auto 24px;
           max-width: 600px;
-        }
-
-        button.dump {
-          width: 100%;
-          text-align: center;
-          color: var(--secondary-text-color);
         }
 
         [hidden] {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3034,7 +3034,46 @@
             "server_url": "Server URL",
             "devices": "{count} {count, plural,\n  one {device}\n  other {devices}\n}",
             "provisioned_devices": "Provisioned devices",
-            "not_ready": "{count} not ready"
+            "not_ready": "{count} not ready",
+            "statistics": {
+              "title": "Controller Statistics",
+              "messages_tx": {
+                "label": "Messages TX",
+                "tooltip": "Number of messages successfully sent to the controller"
+              },
+              "messages_rx": {
+                "label": "Messages RX",
+                "tooltip": "Number of messages successfully received by the controller"
+              },
+              "messages_dropped_tx": {
+                "label": "Dropped Messages TX",
+                "tooltip": "Number of messages from the controller that were dropped by the host"
+              },
+              "messages_dropped_rx": {
+                "label": "Dropped Messages RX",
+                "tooltip": "Number of outgoing messages that were dropped because they could not be sent"
+              },
+              "nak": {
+                "label": "NAK",
+                "tooltip": "Number of messages that the controller did not accept"
+              },
+              "can": {
+                "label": "CAN",
+                "tooltip": "Number of collisions while sending a message to the controller"
+              },
+              "timeout_ack": {
+                "label": "Timeout ACK",
+                "tooltip": "Number of transmission attempts where an ACK was missing from the controller"
+              },
+              "timout_response": {
+                "label": "Timeout Response",
+                "tooltip": "Number of transmission attempts where the controller response did not come in time"
+              },
+              "timeout_callback": {
+                "label": "Timeout Callback",
+                "tooltip": "Number of transmission attempts where the controller callback did not come in time"
+              }
+            }
           },
           "device_info": {
             "zwave_info": "Z-Wave Info",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3065,7 +3065,7 @@
                 "label": "Timeout ACK",
                 "tooltip": "Number of transmission attempts where an ACK was missing from the controller"
               },
-              "timout_response": {
+              "timeout_response": {
                 "label": "Timeout Response",
                 "tooltip": "Number of transmission attempts where the controller response did not come in time"
               },


### PR DESCRIPTION
## Proposed change
Adds controller statistics to the zwave_js config dashboard (screenshot below). I added tooltips because the statistics are not easily understandable but the zwave-js provide clear definitions for each. An example of the tooltip is included in the screenshot. I also formatted the statistics and the properties above it into tables so that it's a little cleaner looking. I'm guessing there's probably a better approach than an HTML table so open to making changes as needed

Dependent on https://github.com/home-assistant/core/pull/71723 (merged)

<img width="287" alt="image" src="https://user-images.githubusercontent.com/7243222/168007534-b1aa96db-7749-4b9a-9a65-7351e36ffc7e.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
