### PR TITLE
Allow setting `device_class` "outlet" again through entity settings

### DIFF
--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -582,11 +582,10 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
       return;
     }
 
-    // If value is "outlet" that means we kept the "switch" domain, but actually changed
+    // If value is "outlet" that means the user kept the "switch" domain, but actually changed
     // the device_class of the switch to "outlet".
-    if (ev.target.value !== "outlet") {
-      this._switchAs = ev.target.value;
-    }
+    const switchAs = ev.target.value === "outlet" ? "switch" : ev.target.value;
+    this._switchAs = switchAs;
 
     if (ev.target.value === "outlet" || ev.target.value === "switch") {
       this._deviceClass = ev.target.value;

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -340,8 +340,19 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
               @selected=${this._switchAsChanged}
               @closed=${stopPropagation}
             >
-              <mwc-list-item value="switch" selected>
+              <mwc-list-item
+                value="switch"
+                .selected=${this._deviceClass === "switch"}
+              >
                 ${domainToName(this.hass.localize, "switch")}</mwc-list-item
+              >
+              <mwc-list-item
+                value="outlet"
+                .selected=${this._deviceClass === "outlet"}
+              >
+                ${this.hass.localize(
+                  `ui.dialogs.entity_registry.editor.device_classes.switch.outlet`
+                )}</mwc-list-item
               >
               <li divider role="separator"></li>
               ${this._switchAsDomainsSorted(
@@ -570,7 +581,16 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
     if (ev.target.value === "") {
       return;
     }
-    this._switchAs = ev.target.value;
+
+    // If value is "outlet" that means we kept the "switch" domain, but actually changed
+    // the device_class of the switch to "outlet".
+    if (ev.target.value !== "outlet") {
+      this._switchAs = ev.target.value;
+    }
+
+    if (ev.target.value === "outlet" || ev.target.value === "switch") {
+      this._deviceClass = ev.target.value;
+    }
   }
 
   private _areaPicked(ev: CustomEvent) {

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -342,18 +342,22 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
             >
               <mwc-list-item
                 value="switch"
-                .selected=${this._deviceClass === "switch"}
-              >
-                ${domainToName(this.hass.localize, "switch")}</mwc-list-item
-              >
-              <mwc-list-item
-                value="outlet"
-                .selected=${this._deviceClass === "outlet"}
+                .selected=${!this._deviceClass ||
+                this._deviceClass === "switch"}
               >
                 ${this.hass.localize(
-                  `ui.dialogs.entity_registry.editor.device_classes.switch.outlet`
-                )}</mwc-list-item
+                  "ui.dialogs.entity_registry.editor.device_classes.switch.switch"
+                )}
+              </mwc-list-item>
+              <mwc-list-item
+                value="outlet"
+                .selected=${!this._deviceClass ||
+                this._deviceClass === "outlet"}
               >
+                ${this.hass.localize(
+                  "ui.dialogs.entity_registry.editor.device_classes.switch.outlet"
+                )}
+              </mwc-list-item>
               <li divider role="separator"></li>
               ${this._switchAsDomainsSorted(
                 SWITCH_AS_DOMAINS,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -844,6 +844,10 @@
               "curtain": "Curtain",
               "damper": "Damper",
               "shutter": "Shutter"
+            },
+            "switch": {
+              "outlet": "Outlet",
+              "switch": "Switch"
             }
           },
           "unavailable": "This entity is unavailable.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

For covers and binary sensors the "Show as" dropdown allows changing the `device_class` to whatever fits best. However, in the settings dialog of a switch entity the "Show as" dropdown controls the new `switch_as_x` behavior. That however means, that we lost the option to change the switch `device_class`.

With this PR this option is now back.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
