### PR TITLE
Add optional display for entity value

### DIFF
--- a/src/components/ha-gauge.ts
+++ b/src/components/ha-gauge.ts
@@ -50,7 +50,10 @@ export class Gauge extends LitElement {
 
   protected updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
-    if (!this._updated || !changedProperties.has("value")) {
+    if (
+      !this._updated ||
+      !(changedProperties.has("value") || changedProperties.has("valueText"))
+    ) {
       return;
     }
     this._angle = getAngle(this.value, this.min, this.max);

--- a/src/panels/lovelace/cards/hui-gauge-card.ts
+++ b/src/panels/lovelace/cards/hui-gauge-card.ts
@@ -129,11 +129,16 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
           .min=${this._config.min!}
           .max=${this._config.max!}
           .value=${stateObj.state}
+          .valueText=${this._config.entity_display
+            ? this.hass.states[this._config.entity_display].state
+            : ""}
           .locale=${this.hass!.locale}
-          .label=${this._config!.unit ||
-          this.hass?.states[this._config!.entity].attributes
-            .unit_of_measurement ||
-          ""}
+          .label=${this._config.entity_display
+            ? ""
+            : this._config!.unit ||
+              this.hass?.states[this._config!.entity].attributes
+                .unit_of_measurement ||
+              ""}
           style=${styleMap({
             "--gauge-color": this._computeSeverity(entityState),
           })}
@@ -145,8 +150,23 @@ class HuiGaugeCard extends LitElement implements LovelaceCard {
     `;
   }
 
+  protected hasEntityDisplayChanged(
+    element: any,
+    changedProps: PropertyValues
+  ): boolean {
+    const oldHass = changedProps.get("hass") as HomeAssistant;
+
+    return (
+      oldHass.states[element._config!.entity_display] !==
+      element.hass!.states[element._config!.entity_display]
+    );
+  }
+
   protected shouldUpdate(changedProps: PropertyValues): boolean {
-    return hasConfigOrEntityChanged(this, changedProps);
+    return (
+      hasConfigOrEntityChanged(this, changedProps) ||
+      this.hasEntityDisplayChanged(this, changedProps)
+    );
   }
 
   protected updated(changedProps: PropertyValues): void {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -189,6 +189,7 @@ export interface GaugeCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
   unit?: string;
+  entity_display?: string;
   min?: number;
   max?: number;
   severity?: SeverityConfig;

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -36,6 +36,7 @@ const cardConfigStruct = assign(
     theme: optional(string()),
     needle: optional(boolean()),
     segments: optional(array(gaugeSegmentStruct)),
+    entity_display: optional(string()),
   })
 );
 
@@ -70,6 +71,21 @@ export class HuiGaugeCardEditor
           { name: "name", selector: { text: {} } },
           { name: "unit", selector: { text: {} } },
         ],
+      },
+      {
+        name: "entity_display",
+        selector: {
+          entity: {
+            domain: [
+              "counter",
+              "input_number",
+              "input_text",
+              "input_select",
+              "number",
+              "sensor",
+            ],
+          },
+        },
       },
       { name: "theme", selector: { theme: {} } },
       {
@@ -182,6 +198,12 @@ export class HuiGaugeCardEditor
       case "theme":
         return `${this.hass!.localize(
           "ui.panel.lovelace.editor.card.generic.theme"
+        )} (${this.hass!.localize(
+          "ui.panel.lovelace.editor.card.config.optional"
+        )})`;
+      case "entity_display":
+        return `${this.hass!.localize(
+          "ui.panel.lovelace.editor.card.gauge.entity_display"
         )} (${this.hass!.localize(
           "ui.panel.lovelace.editor.card.config.optional"
         )})`;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3607,6 +3607,7 @@
             "gauge": {
               "name": "Gauge",
               "needle_gauge": "Display as needle gauge?",
+              "entity_display": "Display entity",
               "severity": {
                 "define": "Define Severity?",
                 "green": "Green",


### PR DESCRIPTION
Allow to specify the name of an entity to display in the gauge instead of only the numerical sensor value.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The current gauge only shows the sensor value and unit of measurement. This PR allows instead to show value from another specific sensor. This way it's possible to display some text or other values that describe the sensor value better.
Example:
![Gauge](https://user-images.githubusercontent.com/1550962/169530828-324b83ba-bcb6-4649-b785-5ac2dcfdfc70.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: gauge
entity: sensor.air_quality
min: 0
max: 120
needle: true
severity:
  green: 30
  yellow: 60
  red: 90
entity_display: sensor.air_quality_display
```

## Example test configuration
```yaml
input_number:
  air_quality:
    name: Air quality
    min: 0
    max: 150
    step: 10
    mode: slider

sensor:
  platform: template
  sensors:
    air_quality:
      friendly_name: "Air Quality"
      value_template: "{{ states('input_number.air_quality') }}"
      unit_of_measurement: "µg/m3"
    air_quality_display:
      friendly_name: "Air Quality Display"
      value_template: >
        {% set v = states('sensor.air_quality') | int %}
        {% if v<=30 %}
          Good
        {% elif v<=60 %}
          Satisfactory
        {% elif v<=90 %}
          Moderate
        {% elif v<=120 %}
          Poor
        {% else %}
          Very poor
        {% endif %}
```


## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
