### PR TITLE
Adjust logbook stream consumer to handle new metadata

### DIFF
--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -13,6 +13,13 @@ import { UNAVAILABLE_STATES } from "./entity";
 const LOGBOOK_LOCALIZE_PATH = "ui.components.logbook.messages";
 export const CONTINUOUS_DOMAINS = ["proximity", "sensor"];
 
+export interface LogbookStreamMessage {
+  events: LogbookEntry[];
+  start_time?: number; // Start time of this historical chunk
+  end_time?: number; // End time of this historical chunk
+  partial?: boolean; // Indiciates more historical chunks are coming
+}
+
 export interface LogbookEntry {
   // Base data
   when: number; // Python timestamp. Do *1000 to get JS timestamp.
@@ -163,7 +170,7 @@ const getLogbookDataFromServer = (
 
 export const subscribeLogbook = (
   hass: HomeAssistant,
-  callbackFunction: (message: LogbookEntry[]) => void,
+  callbackFunction: (message: LogbookStreamMessage) => void,
   startDate: string,
   endDate: string,
   entityIds?: string[],
@@ -188,8 +195,8 @@ export const subscribeLogbook = (
   if (deviceIds?.length) {
     params.device_ids = deviceIds;
   }
-  return hass.connection.subscribeMessage<LogbookEntry[]>(
-    (message?) => callbackFunction(message),
+  return hass.connection.subscribeMessage<LogbookStreamMessage>(
+    (message) => callbackFunction(message),
     params
   );
 };


### PR DESCRIPTION
Wait for https://github.com/home-assistant/core/pull/72394



## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adjust logbook stream consumer to handle new metadata

The response format has changed to allow for metadata:
```
{
  'events': list[...],
  'start_time': float | None
  'end_time': float | None
  'partial': bool
}
```
`events` now contains the event stream
`start_time` is the start time of the query against the historical data (only present for historical data)
`end_time` is the end time of the query against the historical data (only present for historical data)
`partial` if present indicates more historical data is coming in a future message.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
