### PR TITLE
Add aria-haspopup to button menus

### DIFF
--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -51,14 +51,14 @@ export class HaButtonMenu extends LitElement {
     if (this._menu?.open) {
       this._menu.focusItemAtIndex(0);
     } else {
-      this._triggerButton[0]?.focus();
+      this._triggerButton.shift()?.focus();
     }
   }
 
   protected render(): TemplateResult {
     return html`
       <div @click=${this._handleClick}>
-        <slot name="trigger"></slot>
+        <slot name="trigger" @slotchange=${this._setTriggerAria}></slot>
       </div>
       <mwc-menu
         .corner=${this.corner}
@@ -95,6 +95,11 @@ export class HaButtonMenu extends LitElement {
     }
     this._menu!.anchor = this;
     this._menu!.show();
+  }
+
+  private _setTriggerAria() {
+    const triggerButton = this._triggerButton.shift();
+    if (triggerButton) triggerButton.ariaHasPopup = "menu";
   }
 
   static get styles(): CSSResultGroup {

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -2,12 +2,7 @@ import type { Button } from "@material/mwc-button";
 import "@material/mwc-menu";
 import type { Corner, Menu, MenuCorner } from "@material/mwc-menu";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import {
-  customElement,
-  property,
-  query,
-  queryAssignedElements,
-} from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import { FOCUS_TARGET } from "../dialogs/make-dialog-manager";
 import type { HaIconButton } from "./ha-icon-button";
 
@@ -33,12 +28,6 @@ export class HaButtonMenu extends LitElement {
 
   @query("mwc-menu", true) private _menu?: Menu;
 
-  @queryAssignedElements({
-    slot: "trigger",
-    selector: "ha-icon-button, mwc-button",
-  })
-  private _triggerButton!: Array<HaIconButton | Button>;
-
   public get items() {
     return this._menu?.items;
   }
@@ -51,7 +40,7 @@ export class HaButtonMenu extends LitElement {
     if (this._menu?.open) {
       this._menu.focusItemAtIndex(0);
     } else {
-      this._triggerButton.shift()?.focus();
+      this._triggerButton?.focus();
     }
   }
 
@@ -97,10 +86,15 @@ export class HaButtonMenu extends LitElement {
     this._menu!.show();
   }
 
+  private get _triggerButton() {
+    return this.querySelector(
+      'ha-icon-button[slot="trigger"], mwc-button[slot="trigger"]'
+    ) as HaIconButton | Button | null;
+  }
+
   private _setTriggerAria() {
-    const triggerButton = this._triggerButton.shift();
-    if (triggerButton) {
-    	triggerButton.ariaHasPopup = "menu";
+    if (this._triggerButton) {
+      this._triggerButton.ariaHasPopup = "menu";
     }
   }
 

--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -99,7 +99,9 @@ export class HaButtonMenu extends LitElement {
 
   private _setTriggerAria() {
     const triggerButton = this._triggerButton.shift();
-    if (triggerButton) triggerButton.ariaHasPopup = "menu";
+    if (triggerButton) {
+    	triggerButton.ariaHasPopup = "menu";
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/components/ha-icon-button.ts
+++ b/src/components/ha-icon-button.ts
@@ -18,7 +18,7 @@ export class HaIconButton extends LitElement {
   // These should always be set as properties, not attributes,
   // so that only the <button> element gets the attribute
   @property({ type: String, attribute: "aria-haspopup" })
-  override ariaHasPopup: IconButton["ariaHasPopup"] = "false";
+  override ariaHasPopup!: IconButton["ariaHasPopup"];
 
   @property({ type: Boolean }) hideTitle = false;
 
@@ -38,7 +38,7 @@ export class HaIconButton extends LitElement {
       <mwc-icon-button
         aria-label=${ifDefined(this.label)}
         title=${ifDefined(this.hideTitle ? undefined : this.label)}
-        .ariaHasPopup=${this.ariaHasPopup}
+        aria-haspopup=${ifDefined(this.ariaHasPopup)}
         .disabled=${this.disabled}
       >
         ${this.path

--- a/src/components/ha-icon-button.ts
+++ b/src/components/ha-icon-button.ts
@@ -2,6 +2,7 @@ import "@material/mwc-icon-button";
 import type { IconButton } from "@material/mwc-icon-button";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators";
+import { ifDefined } from "lit/directives/if-defined";
 import "./ha-svg-icon";
 
 @customElement("ha-icon-button")
@@ -12,7 +13,12 @@ export class HaIconButton extends LitElement {
   @property({ type: String }) path?: string;
 
   // Label that is used for ARIA support and as tooltip
-  @property({ type: String }) label = "";
+  @property({ type: String }) label?: string;
+
+  // These should always be set as properties, not attributes,
+  // so that only the <button> element gets the attribute
+  @property({ type: String, attribute: "aria-haspopup" })
+  override ariaHasPopup: IconButton["ariaHasPopup"] = "false";
 
   @property({ type: Boolean }) hideTitle = false;
 
@@ -28,11 +34,11 @@ export class HaIconButton extends LitElement {
   };
 
   protected render(): TemplateResult {
-    // Note: `ariaLabel` required despite the `mwc-icon-button` docs saying `label` should be enough
     return html`
       <mwc-icon-button
-        .ariaLabel=${this.label}
-        .title=${this.hideTitle ? "" : this.label}
+        aria-label=${ifDefined(this.label)}
+        title=${ifDefined(this.hideTitle ? undefined : this.label)}
+        .ariaHasPopup=${this.ariaHasPopup}
         .disabled=${this.disabled}
       >
         ${this.path


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Moves the `ha-button-menu` component one step closer to conformance with ARIA Authoring Practices by adding `aria-haspopup="menu"` to the trigger button.  This is consumed by assistive technology to tell users the button opens a menu.  I also added a minor fix to prevent empty `aria-label` or `title` attributes which I've seen behave unexpectedly in the past.

The next step is to change the labels for most of these buttons, many of which are just labelled as "menu".  This is not very descriptive and is now redundant with the proper ARIA.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

