### PR TITLE
Add zwave_js device statistics

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -244,6 +244,41 @@ export interface ZWaveJSControllerStatisticsUpdatedMessage {
   timeout_callback: number;
 }
 
+export enum RssiError {
+  NotAvailable = 127,
+  ReceiverSaturated = 126,
+  NoSignalDetected = 125,
+}
+
+export enum ProtocolDataRate {
+  ZWave_9k6 = 0x01,
+  ZWave_40k = 0x02,
+  ZWave_100k = 0x03,
+  LongRange_100k = 0x04,
+}
+
+export interface ZWaveJSNodeStatisticsUpdatedMessage {
+  event: "statistics updated";
+  source: "node";
+  commands_tx: number;
+  commands_rx: number;
+  commands_dropped_tx: number;
+  commands_dropped_rx: number;
+  timeout_response: number;
+  rtt: number | null;
+  rssi: number | null;
+  lwr: ZWaveJSRouteStatistics | null;
+  nlwr: ZWaveJSRouteStatistics | null;
+}
+
+export interface ZWaveJSRouteStatistics {
+  protocol_data_rate: number;
+  repeaters: string[];
+  rssi: number | null;
+  repeater_rssi: number[];
+  route_failed_between: [string, string] | null;
+}
+
 export interface ZWaveJSRemovedNode {
   node_id: number;
   manufacturer: string;
@@ -594,6 +629,19 @@ export const subscribeZwaveControllerStatistics = (
     {
       type: "zwave_js/subscribe_controller_statistics",
       entry_id,
+    }
+  );
+
+export const subscribeZwaveNodeStatistics = (
+  hass: HomeAssistant,
+  device_id: string,
+  callbackFunction: (message: ZWaveJSNodeStatisticsUpdatedMessage) => void
+): Promise<UnsubscribeFunc> =>
+  hass.connection.subscribeMessage(
+    (message: any) => callbackFunction(message),
+    {
+      type: "zwave_js/subscribe_node_statistics",
+      device_id,
     }
   );
 

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -266,7 +266,7 @@ export interface ZWaveJSNodeStatisticsUpdatedMessage {
   commands_dropped_rx: number;
   timeout_response: number;
   rtt: number | null;
-  rssi: number | null;
+  rssi: RssiError | number | null;
   lwr: ZWaveJSRouteStatistics | null;
   nlwr: ZWaveJSRouteStatistics | null;
 }
@@ -274,8 +274,8 @@ export interface ZWaveJSNodeStatisticsUpdatedMessage {
 export interface ZWaveJSRouteStatistics {
   protocol_data_rate: number;
   repeaters: string[];
-  rssi: number | null;
-  repeater_rssi: number[];
+  rssi: RssiError | number | null;
+  repeater_rssi: (RssiError | number)[];
   route_failed_between: [string, string] | null;
 }
 

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
@@ -3,6 +3,7 @@ import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
 import { fetchZwaveNodeStatus } from "../../../../../../data/zwave_js";
 import type { HomeAssistant } from "../../../../../../types";
 import { showZWaveJSHealNodeDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-heal-node";
+import { showZWaveJSNodeStatisticsDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-node-statistics";
 import { showZWaveJSReinterviewNodeDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-reinterview-node";
 import { showZWaveJSRemoveFailedNodeDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-remove-failed-node";
 import type { DeviceAction } from "../../../ha-config-device-page";
@@ -62,6 +63,15 @@ export const getZwaveDeviceActions = async (
       action: () =>
         showZWaveJSRemoveFailedNodeDialog(el, {
           device_id: device.id,
+        }),
+    },
+    {
+      label: hass.localize(
+        "ui.panel.config.zwave_js.device_info.node_statistics"
+      ),
+      action: () =>
+        showZWaveJSNodeStatisticsDialog(el, {
+          device: device,
         }),
     },
   ];

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -43,7 +43,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
     rssi_translated?: TemplateResult | string;
   };
 
-  @state() private _deviceIDsToDevices: { [key: string]: DeviceRegistryEntry } =
+  @state() private _deviceIDsToName: { [key: string]: DeviceRegistryEntry } =
     {};
 
   @state() private _workingRoutes: {
@@ -330,10 +330,10 @@ class DialogZWaveJSNodeStatistics extends LitElement {
   }
 
   private _computeDeviceNameById(device_id: string): "unknown device" | string {
-    if (!this._deviceIDsToDevices) {
+    if (!this._deviceIDsToName) {
       return "unknown device";
     }
-    const device = this._deviceIDsToDevices[device_id];
+    const device = this._deviceIDsToName[device_id];
     if (!device) {
       return "unknown device";
     }

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -288,33 +288,30 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                           "ui.panel.config.zwave_js.route_statistics.repeaters.tooltip"
                         )}
                       >
-                      </ha-help-tooltip
-                    ></span>
-                    ${wrValue.repeater_rssi_table
-                      ? html`<span
-                          ><div class="row">
-                            <span class="key-cell"
-                              ><b
-                                >${this.hass.localize(
-                                  "ui.panel.config.zwave_js.route_statistics.repeaters.repeaters"
-                                )}:</b
-                              ></span
-                            >
-                            <span class="value-cell"
-                              ><b
-                                >${this.hass.localize(
-                                  "ui.panel.config.zwave_js.route_statistics.repeaters.rssi"
-                                )}:</b
-                              ></span
-                            >
-                          </div>
-                          ${wrValue.repeater_rssi_table}</span
-                        >`
-                      : html`<span
-                          >${this.hass.localize(
+                      </ha-help-tooltip></span
+                    ><span>
+                      ${wrValue.repeater_rssi_table
+                        ? html`<div class="row">
+                              <span class="key-cell"
+                                ><b
+                                  >${this.hass.localize(
+                                    "ui.panel.config.zwave_js.route_statistics.repeaters.repeaters"
+                                  )}:</b
+                                ></span
+                              >
+                              <span class="value-cell"
+                                ><b
+                                  >${this.hass.localize(
+                                    "ui.panel.config.zwave_js.route_statistics.repeaters.rssi"
+                                  )}:</b
+                                ></span
+                              >
+                            </div>
+                            ${wrValue.repeater_rssi_table}`
+                        : html`${this.hass.localize(
                             "ui.panel.config.zwave_js.route_statistics.repeaters.direct"
-                          )}</span
-                        >`}
+                          )}`}</span
+                    >
                   </div>
                 </ha-expansion-panel>
               `

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -279,12 +279,12 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                         >
                         </ha-help-tooltip
                       ></span>
-                      <span
+                      <span class="table"
                         >${Object.entries(wrRepeaterRSSIMap).map(
                           ([repeaterName, rssi]) => html`
                             <div class="row">
-                              <span>${repeaterName}: </span>
-                              <span>${rssi}</span>
+                              <span class="key-cell">${repeaterName}: </span>
+                              <span class="value-cell">${rssi}</span>
                             </div>
                           `
                         )}</span
@@ -373,6 +373,20 @@ class DialogZWaveJSNodeStatistics extends LitElement {
         .row {
           display: flex;
           justify-content: space-between;
+        }
+
+        .table {
+          display: table;
+        }
+
+        .key-cell {
+          display: table-cell;
+          padding-right: 5px;
+        }
+
+        .value-cell {
+          display: table-cell;
+          padding-left: 5px;
         }
       `,
     ];

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -96,9 +96,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.commands_tx.tooltip"
               )}
             </span>
-            <span slot="meta" class="statistics"
-              >${this._nodeStatistics?.commands_tx}</span
-            >
+            <span slot="meta">${this._nodeStatistics?.commands_tx}</span>
           </mwc-list-item>
           <mwc-list-item twoline hasmeta>
             <span>
@@ -111,9 +109,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.commands_rx.tooltip"
               )}
             </span>
-            <span slot="meta" class="statistics"
-              >${this._nodeStatistics?.commands_rx}</span
-            >
+            <span slot="meta">${this._nodeStatistics?.commands_rx}</span>
           </mwc-list-item>
           <mwc-list-item twoline hasmeta>
             <span>
@@ -126,7 +122,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.commands_dropped_tx.tooltip"
               )}
             </span>
-            <span slot="meta" class="statistics"
+            <span slot="meta"
               >${this._nodeStatistics?.commands_dropped_tx}</span
             >
           </mwc-list-item>
@@ -141,7 +137,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.commands_dropped_rx.tooltip"
               )}
             </span>
-            <span slot="meta" class="statistics"
+            <span slot="meta"
               >${this._nodeStatistics?.commands_dropped_rx}</span
             >
           </mwc-list-item>
@@ -156,9 +152,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.timeout_response.tooltip"
               )}
             </span>
-            <span slot="meta" class="statistics"
-              >${this._nodeStatistics?.timeout_response}</span
-            >
+            <span slot="meta">${this._nodeStatistics?.timeout_response}</span>
           </mwc-list-item>
           ${this._nodeStatistics?.rtt
             ? html`<mwc-list-item twoline hasmeta>
@@ -172,9 +166,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                     "ui.panel.config.zwave_js.node_statistics.rtt.tooltip"
                   )}
                 </span>
-                <span slot="meta" class="statistics"
-                  >${this._nodeStatistics.rtt}</span
-                >
+                <span slot="meta">${this._nodeStatistics.rtt}</span>
               </mwc-list-item>`
             : ``}
           ${this._nodeStatistics?.rssi_translated
@@ -189,9 +181,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                     "ui.panel.config.zwave_js.node_statistics.rssi.tooltip"
                   )}
                 </span>
-                <span slot="meta" class="statistics"
-                  >${this._nodeStatistics.rssi_translated}</span
-                >
+                <span slot="meta">${this._nodeStatistics.rssi_translated}</span>
               </mwc-list-item>`
             : ``}
         </mwc-list>
@@ -472,7 +462,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
           padding-left: 5px;
         }
 
-        .statistics {
+        span[slot="meta"] {
           font-size: 0.95em;
           color: var(--primary-text-color);
         }

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -43,8 +43,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
     rssi_translated?: TemplateResult | string;
   };
 
-  @state() private _deviceIDsToName: { [key: string]: string } =
-    {};
+  @state() private _deviceIDsToName: { [key: string]: string } = {};
 
   @state() private _workingRoutes: {
     lwr?: WorkingRouteStatistics;

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -193,17 +193,36 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 <div class="row">
                   <span>
                     ${this.hass.localize(
-                      "ui.panel.config.zwave_js.route_statistics.protocol_data_rate.label"
+                      "ui.panel.config.zwave_js.route_statistics.protocol.label"
                     )}<ha-help-tooltip
                       .label=${this.hass.localize(
-                        "ui.panel.config.zwave_js.route_statistics.protocol_data_rate.tooltip"
+                        "ui.panel.config.zwave_js.route_statistics.protocol.tooltip"
                       )}
                     >
                     </ha-help-tooltip
                   ></span>
                   <span
                     >${this.hass.localize(
-                      `ui.panel.config.zwave_js.protocol_data_rate.${
+                      `ui.panel.config.zwave_js.route_statistics.protocol.protocol_data_rate.${
+                        ProtocolDataRate[wrValue.protocol_data_rate]
+                      }`
+                    )}</span
+                  >
+                </div>
+                <div class="row">
+                  <span>
+                    ${this.hass.localize(
+                      "ui.panel.config.zwave_js.route_statistics.data_rate.label"
+                    )}<ha-help-tooltip
+                      .label=${this.hass.localize(
+                        "ui.panel.config.zwave_js.route_statistics.data_rate.tooltip"
+                      )}
+                    >
+                    </ha-help-tooltip
+                  ></span>
+                  <span
+                    >${this.hass.localize(
+                      `ui.panel.config.zwave_js.route_statistics.data_rate.protocol_data_rate.${
                         ProtocolDataRate[wrValue.protocol_data_rate]
                       }`
                     )}</span

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -96,7 +96,9 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.commands_tx.tooltip"
               )}
             </span>
-            <span slot="meta">${this._nodeStatistics?.commands_tx}</span>
+            <span slot="meta" class="statistics"
+              >${this._nodeStatistics?.commands_tx}</span
+            >
           </mwc-list-item>
           <mwc-list-item twoline hasmeta>
             <span>
@@ -109,7 +111,9 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.commands_rx.tooltip"
               )}
             </span>
-            <span slot="meta">${this._nodeStatistics?.commands_rx}</span>
+            <span slot="meta" class="statistics"
+              >${this._nodeStatistics?.commands_rx}</span
+            >
           </mwc-list-item>
           <mwc-list-item twoline hasmeta>
             <span>
@@ -122,7 +126,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.commands_dropped_tx.tooltip"
               )}
             </span>
-            <span slot="meta"
+            <span slot="meta" class="statistics"
               >${this._nodeStatistics?.commands_dropped_tx}</span
             >
           </mwc-list-item>
@@ -137,7 +141,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.commands_dropped_rx.tooltip"
               )}
             </span>
-            <span slot="meta"
+            <span slot="meta" class="statistics"
               >${this._nodeStatistics?.commands_dropped_rx}</span
             >
           </mwc-list-item>
@@ -152,7 +156,9 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                 "ui.panel.config.zwave_js.node_statistics.timeout_response.tooltip"
               )}
             </span>
-            <span slot="meta">${this._nodeStatistics?.timeout_response}</span>
+            <span slot="meta" class="statistics"
+              >${this._nodeStatistics?.timeout_response}</span
+            >
           </mwc-list-item>
           ${this._nodeStatistics?.rtt
             ? html`<mwc-list-item twoline hasmeta>
@@ -166,7 +172,9 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                     "ui.panel.config.zwave_js.node_statistics.rtt.tooltip"
                   )}
                 </span>
-                <span slot="meta">${this._nodeStatistics.rtt}</span>
+                <span slot="meta" class="statistics"
+                  >${this._nodeStatistics.rtt}</span
+                >
               </mwc-list-item>`
             : ``}
           ${this._nodeStatistics?.rssi_translated
@@ -181,7 +189,9 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                     "ui.panel.config.zwave_js.node_statistics.rssi.tooltip"
                   )}
                 </span>
-                <span slot="meta">${this._nodeStatistics.rssi_translated}</span>
+                <span slot="meta" class="statistics"
+                  >${this._nodeStatistics.rssi_translated}</span
+                >
               </mwc-list-item>`
             : ``}
         </mwc-list>
@@ -467,6 +477,11 @@ class DialogZWaveJSNodeStatistics extends LitElement {
         .value-cell {
           display: table-cell;
           padding-left: 5px;
+        }
+
+        .statistics {
+          font-size: 1em;
+          color: var(--primary-text-color);
         }
       `,
     ];

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -3,6 +3,8 @@ import "@material/mwc-list/mwc-list";
 import "@material/mwc-list/mwc-list-item";
 import "../../../../../components/ha-expansion-panel";
 import "../../../../../components/ha-help-tooltip";
+import "../../../../../components/ha-svg-icon";
+import { mdiSwapHorizontal } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
@@ -256,11 +258,12 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                         </ha-help-tooltip
                       ></span>
                       <span
-                        >${`${this._computeDeviceNameById(
+                        >${this._computeDeviceNameById(
                           wrValue.route_failed_between[0]
-                        )} <-> ${this._computeDeviceNameById(
+                        )}<ha-svg-icon .path=${mdiSwapHorizontal}></ha-svg-icon
+                        >${this._computeDeviceNameById(
                           wrValue.route_failed_between[1]
-                        )}`}</span
+                        )}</span
                       >
                     </div>`
                   : ``}

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -43,7 +43,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
     rssi_translated?: TemplateResult | string;
   };
 
-  @state() private _deviceIDsToName: { [key: string]: DeviceRegistryEntry } =
+  @state() private _deviceIDsToName: { [key: string]: string } =
     {};
 
   @state() private _workingRoutes: {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -185,126 +185,131 @@ class DialogZWaveJSNodeStatistics extends LitElement {
               </mwc-list-item>`
             : ``}
         </mwc-list>
-        ${Object.entries(this._workingRoutes).map(([wrKey, wrValue]) => {
-          if (wrValue) {
-            return html`
-              <ha-expansion-panel
-                .header=${this.hass.localize(
-                  `ui.panel.config.zwave_js.node_statistics.${wrKey}`
-                )}
-              >
-                <div class="row">
-                  <span>
-                    ${this.hass.localize(
-                      "ui.panel.config.zwave_js.route_statistics.protocol.label"
-                    )}<ha-help-tooltip
-                      .label=${this.hass.localize(
-                        "ui.panel.config.zwave_js.route_statistics.protocol.tooltip"
-                      )}
-                    >
-                    </ha-help-tooltip
-                  ></span>
-                  <span
-                    >${this.hass.localize(
-                      `ui.panel.config.zwave_js.route_statistics.protocol.protocol_data_rate.${
-                        ProtocolDataRate[wrValue.protocol_data_rate]
-                      }`
-                    )}</span
-                  >
-                </div>
-                <div class="row">
-                  <span>
-                    ${this.hass.localize(
-                      "ui.panel.config.zwave_js.route_statistics.data_rate.label"
-                    )}<ha-help-tooltip
-                      .label=${this.hass.localize(
-                        "ui.panel.config.zwave_js.route_statistics.data_rate.tooltip"
-                      )}
-                    >
-                    </ha-help-tooltip
-                  ></span>
-                  <span
-                    >${this.hass.localize(
-                      `ui.panel.config.zwave_js.route_statistics.data_rate.protocol_data_rate.${
-                        ProtocolDataRate[wrValue.protocol_data_rate]
-                      }`
-                    )}</span
-                  >
-                </div>
-                ${wrValue.rssi_translated
-                  ? html`<div class="row">
-                      <span>
-                        ${this.hass.localize(
-                          "ui.panel.config.zwave_js.route_statistics.rssi.label"
-                        )}<ha-help-tooltip
-                          .label=${this.hass.localize(
-                            "ui.panel.config.zwave_js.route_statistics.rssi.tooltip"
-                          )}
-                        >
-                        </ha-help-tooltip
-                      ></span>
-                      <span>${wrValue.rssi_translated}</span>
-                    </div>`
-                  : ``}
-                ${wrValue.route_failed_between_translated
-                  ? html`<div class="row">
-                      <span>
-                        ${this.hass.localize(
-                          "ui.panel.config.zwave_js.route_statistics.route_failed_between.label"
-                        )}<ha-help-tooltip
-                          .label=${this.hass.localize(
-                            "ui.panel.config.zwave_js.route_statistics.route_failed_between.tooltip"
-                          )}
-                        >
-                        </ha-help-tooltip
-                      ></span>
-                      <span
-                        >${wrValue
-                          .route_failed_between_translated[0]}<ha-svg-icon
-                          .path=${mdiSwapHorizontal}
-                        ></ha-svg-icon
-                        >${wrValue.route_failed_between_translated[1]}</span
+        ${Object.entries(this._workingRoutes).map(([wrKey, wrValue]) =>
+          wrValue
+            ? html`
+                <ha-expansion-panel
+                  .header=${this.hass.localize(
+                    `ui.panel.config.zwave_js.node_statistics.${wrKey}`
+                  )}
+                >
+                  <div class="row">
+                    <span>
+                      ${this.hass.localize(
+                        "ui.panel.config.zwave_js.route_statistics.protocol.label"
+                      )}<ha-help-tooltip
+                        .label=${this.hass.localize(
+                          "ui.panel.config.zwave_js.route_statistics.protocol.tooltip"
+                        )}
                       >
-                    </div>`
-                  : ``}
-                ${wrValue.repeater_rssi_table
-                  ? html`<div class="row">
-                      <span>
-                        ${this.hass.localize(
-                          "ui.panel.config.zwave_js.route_statistics.repeaters.label"
-                        )}<ha-help-tooltip
-                          .label=${this.hass.localize(
-                            "ui.panel.config.zwave_js.route_statistics.repeaters.tooltip"
-                          )}
-                        >
-                        </ha-help-tooltip
-                      ></span>
-                      <span
-                        ><div class="row">
-                          <span class="key-cell"
-                            ><b
-                              >${this.hass.localize(
-                                "ui.panel.config.zwave_js.route_statistics.repeaters.repeaters"
-                              )}:</b
-                            ></span
-                          >
-                          <span class="value-cell"
-                            ><b
-                              >${this.hass.localize(
-                                "ui.panel.config.zwave_js.route_statistics.repeaters.rssi"
-                              )}:</b
-                            ></span
-                          >
-                        </div>
-                        ${wrValue.repeater_rssi_table}</span
+                      </ha-help-tooltip
+                    ></span>
+                    <span
+                      >${this.hass.localize(
+                        `ui.panel.config.zwave_js.route_statistics.protocol.protocol_data_rate.${
+                          ProtocolDataRate[wrValue.protocol_data_rate]
+                        }`
+                      )}</span
+                    >
+                  </div>
+                  <div class="row">
+                    <span>
+                      ${this.hass.localize(
+                        "ui.panel.config.zwave_js.route_statistics.data_rate.label"
+                      )}<ha-help-tooltip
+                        .label=${this.hass.localize(
+                          "ui.panel.config.zwave_js.route_statistics.data_rate.tooltip"
+                        )}
                       >
-                    </div>`
-                  : ``}
-              </ha-expansion-panel>
-            `;
-          }
-          return ``;
-        })}
+                      </ha-help-tooltip
+                    ></span>
+                    <span
+                      >${this.hass.localize(
+                        `ui.panel.config.zwave_js.route_statistics.data_rate.protocol_data_rate.${
+                          ProtocolDataRate[wrValue.protocol_data_rate]
+                        }`
+                      )}</span
+                    >
+                  </div>
+                  ${wrValue.rssi_translated
+                    ? html`<div class="row">
+                        <span>
+                          ${this.hass.localize(
+                            "ui.panel.config.zwave_js.route_statistics.rssi.label"
+                          )}<ha-help-tooltip
+                            .label=${this.hass.localize(
+                              "ui.panel.config.zwave_js.route_statistics.rssi.tooltip"
+                            )}
+                          >
+                          </ha-help-tooltip
+                        ></span>
+                        <span>${wrValue.rssi_translated}</span>
+                      </div>`
+                    : ``}
+                  <div class="row">
+                    <span>
+                      ${this.hass.localize(
+                        "ui.panel.config.zwave_js.route_statistics.route_failed_between.label"
+                      )}<ha-help-tooltip
+                        .label=${this.hass.localize(
+                          "ui.panel.config.zwave_js.route_statistics.route_failed_between.tooltip"
+                        )}
+                      >
+                      </ha-help-tooltip
+                    ></span>
+                    <span>
+                      ${wrValue.route_failed_between_translated
+                        ? html`${wrValue
+                              .route_failed_between_translated[0]}<ha-svg-icon
+                              .path=${mdiSwapHorizontal}
+                            ></ha-svg-icon
+                            >${wrValue.route_failed_between_translated[1]}`
+                        : this.hass.localize(
+                            "ui.panel.config.zwave_js.route_statistics.route_failed_between.not_applicable"
+                          )}
+                    </span>
+                  </div>
+                  <div class="row">
+                    <span>
+                      ${this.hass.localize(
+                        "ui.panel.config.zwave_js.route_statistics.repeaters.label"
+                      )}<ha-help-tooltip
+                        .label=${this.hass.localize(
+                          "ui.panel.config.zwave_js.route_statistics.repeaters.tooltip"
+                        )}
+                      >
+                      </ha-help-tooltip
+                    ></span>
+                    ${wrValue.repeater_rssi_table
+                      ? html`<span
+                          ><div class="row">
+                            <span class="key-cell"
+                              ><b
+                                >${this.hass.localize(
+                                  "ui.panel.config.zwave_js.route_statistics.repeaters.repeaters"
+                                )}:</b
+                              ></span
+                            >
+                            <span class="value-cell"
+                              ><b
+                                >${this.hass.localize(
+                                  "ui.panel.config.zwave_js.route_statistics.repeaters.rssi"
+                                )}:</b
+                              ></span
+                            >
+                          </div>
+                          ${wrValue.repeater_rssi_table}</span
+                        >`
+                      : html`<span
+                          >${this.hass.localize(
+                            "ui.panel.config.zwave_js.route_statistics.repeaters.direct"
+                          )}</span
+                        >`}
+                  </div>
+                </ha-expansion-panel>
+              `
+            : ``
+        )}
       </ha-dialog>
     `;
   }
@@ -382,7 +387,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
               ];
             }
 
-            if (wrValue.repeaters) {
+            if (wrValue.repeaters && wrValue.repeaters.length) {
               this._workingRoutes[
                 wrKey
               ].repeater_rssi_table = html` ${wrValue.repeaters.map(

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -47,9 +47,9 @@ class DialogZWaveJSNodeStatistics extends LitElement {
     {};
 
   @state() private _workingRoutes: {
-    lwr: WorkingRouteStatistics;
-    nlwr: WorkingRouteStatistics;
-  } = { lwr: undefined, nlwr: undefined };
+    lwr?: WorkingRouteStatistics;
+    nlwr?: WorkingRouteStatistics;
+  } = {};
 
   private _subscribedNodeStatistics?: Promise<UnsubscribeFunc>;
 
@@ -360,7 +360,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
       this.device!.id,
       (message: ZWaveJSNodeStatisticsUpdatedMessage) => {
         this._nodeStatistics = message;
-        this._nodeStatistics.rssi_translated = undefined;
+
         if (this._nodeStatistics.rssi) {
           this._nodeStatistics.rssi_translated = this._computeRSSI(
             this._nodeStatistics.rssi,
@@ -370,34 +370,30 @@ class DialogZWaveJSNodeStatistics extends LitElement {
 
         const workingRoutes: [
           string,
-          ZWaveJSRouteStatistics | null | undefined
+          WorkingRouteStatistics | null | undefined
         ][] = [
           ["lwr", this._nodeStatistics?.lwr],
           ["nlwr", this._nodeStatistics?.nlwr],
         ];
 
+        this._workingRoutes = {};
         workingRoutes.forEach(([wrKey, wrValue]) => {
           this._workingRoutes[wrKey] = wrValue;
 
           if (wrValue) {
             if (wrValue.rssi) {
-              this._workingRoutes[wrKey].rssi_translated = this._computeRSSI(
-                wrValue.rssi,
-                true
-              );
+              wrValue.rssi_translated = this._computeRSSI(wrValue.rssi, true);
             }
 
             if (wrValue.route_failed_between) {
-              this._workingRoutes[wrKey].route_failed_between_translated = [
+              wrValue.route_failed_between_translated = [
                 this._computeDeviceNameById(wrValue.route_failed_between[0]),
                 this._computeDeviceNameById(wrValue.route_failed_between[1]),
               ];
             }
 
             if (wrValue.repeaters && wrValue.repeaters.length) {
-              this._workingRoutes[
-                wrKey
-              ].repeater_rssi_table = html` ${wrValue.repeaters.map(
+              wrValue.repeater_rssi_table = html`${wrValue.repeaters.map(
                 (_, idx) =>
                   html`<div class="row">
                     <span class="key-cell"

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -1,0 +1,364 @@
+import { UnsubscribeFunc } from "home-assistant-js-websocket";
+import "@material/mwc-list/mwc-list";
+import "@material/mwc-list/mwc-list-item";
+import "../../../../../components/ha-expansion-panel";
+import "../../../../../components/ha-help-tooltip";
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import {
+  DeviceRegistryEntry,
+  computeDeviceName,
+  subscribeDeviceRegistry,
+} from "../../../../../data/device_registry";
+import {
+  subscribeZwaveNodeStatistics,
+  ProtocolDataRate,
+  ZWaveJSNodeStatisticsUpdatedMessage,
+  ZWaveJSRouteStatistics,
+  RssiError,
+} from "../../../../../data/zwave_js";
+import { haStyleDialog } from "../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../types";
+import { ZWaveJSNodeStatisticsDialogParams } from "./show-dialog-zwave_js-node-statistics";
+import { createCloseHeading } from "../../../../../components/ha-dialog";
+
+@customElement("dialog-zwave_js-node-statistics")
+class DialogZWaveJSNodeStatistics extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private device?: DeviceRegistryEntry;
+
+  @state() private _nodeStatistics?: ZWaveJSNodeStatisticsUpdatedMessage;
+
+  @state() private _devices?: DeviceRegistryEntry[];
+
+  private _subscribedNodeStatistics?: Promise<UnsubscribeFunc>;
+
+  private _subscribedDeviceRegistry?: UnsubscribeFunc;
+
+  public showDialog(params: ZWaveJSNodeStatisticsDialogParams): void {
+    this.device = params.device;
+    this._subscribeNodeStatistics();
+    this._subscribeDeviceRegistry();
+  }
+
+  public closeDialog(): void {
+    this._nodeStatistics = undefined;
+    this.device = undefined;
+
+    this._unsubscribe();
+
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render(): TemplateResult {
+    if (!this.device) {
+      return html``;
+    }
+
+    const workingRoutes: [ZWaveJSRouteStatistics | null | undefined, string][] =
+      [
+        [this._nodeStatistics?.lwr, "lwr"],
+        [this._nodeStatistics?.nlwr, "nlwr"],
+      ];
+
+    return html`
+      <ha-dialog
+        open
+        @closed=${this.closeDialog}
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass.localize("ui.panel.config.zwave_js.node_statistics.title")
+        )}
+      >
+        <mwc-list noninteractive>
+          <mwc-list-item twoline hasmeta>
+            <span>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.commands_tx.label"
+              )}</span
+            >
+            <span slot="secondary">
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.commands_tx.tooltip"
+              )}
+            </span>
+            <span slot="meta">${this._nodeStatistics?.commands_tx}</span>
+          </mwc-list-item>
+          <mwc-list-item twoline hasmeta>
+            <span>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.commands_rx.label"
+              )}</span
+            >
+            <span slot="secondary">
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.commands_rx.tooltip"
+              )}
+            </span>
+            <span slot="meta">${this._nodeStatistics?.commands_rx}</span>
+          </mwc-list-item>
+          <mwc-list-item twoline hasmeta>
+            <span>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.commands_dropped_tx.label"
+              )}</span
+            >
+            <span slot="secondary">
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.commands_dropped_tx.tooltip"
+              )}
+            </span>
+            <span slot="meta"
+              >${this._nodeStatistics?.commands_dropped_tx}</span
+            >
+          </mwc-list-item>
+          <mwc-list-item twoline hasmeta>
+            <span>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.commands_dropped_rx.label"
+              )}</span
+            >
+            <span slot="secondary">
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.commands_dropped_rx.tooltip"
+              )}
+            </span>
+            <span slot="meta"
+              >${this._nodeStatistics?.commands_dropped_rx}</span
+            >
+          </mwc-list-item>
+          <mwc-list-item twoline hasmeta>
+            <span>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.timeout_response.label"
+              )}</span
+            >
+            <span slot="secondary">
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.node_statistics.timeout_response.tooltip"
+              )}
+            </span>
+            <span slot="meta">${this._nodeStatistics?.timeout_response}</span>
+          </mwc-list-item>
+          ${this._nodeStatistics?.rtt
+            ? html`<mwc-list-item twoline hasmeta>
+                <span>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.node_statistics.rtt.label"
+                  )}</span
+                >
+                <span slot="secondary">
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.node_statistics.rtt.tooltip"
+                  )}
+                </span>
+                <span slot="meta">${this._nodeStatistics?.rtt}</span>
+              </mwc-list-item>`
+            : ``}
+          ${this._nodeStatistics?.rssi
+            ? html`<mwc-list-item twoline hasmeta>
+                <span>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.node_statistics.rssi.label"
+                  )}</span
+                >
+                <span slot="secondary">
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.node_statistics.rssi.tooltip"
+                  )}
+                </span>
+                <span slot="meta"
+                  >${this._computeRSSI(this._nodeStatistics?.rssi, false)}</span
+                >
+              </mwc-list-item>`
+            : ``}
+        </mwc-list>
+        ${workingRoutes.map(([wrValue, wrLabel]) => {
+          if (wrValue) {
+            const wrRepeaterRSSIMap: { [key: string]: string } = {};
+            for (let idx = 0; idx < wrValue.repeaters.length; idx++) {
+              wrRepeaterRSSIMap[
+                this._computeDeviceNameById(wrValue.repeaters[idx])
+              ] = this._computeRSSI(wrValue.repeater_rssi[idx], true);
+            }
+
+            return html`
+              <ha-expansion-panel
+                .header=${this.hass.localize(
+                  `ui.panel.config.zwave_js.node_statistics.${wrLabel}`
+                )}
+              >
+                <div class="row">
+                  <span>
+                    ${this.hass.localize(
+                      "ui.panel.config.zwave_js.route_statistics.protocol_data_rate.label"
+                    )}<ha-help-tooltip
+                      .label=${this.hass.localize(
+                        "ui.panel.config.zwave_js.route_statistics.protocol_data_rate.tooltip"
+                      )}
+                    >
+                    </ha-help-tooltip
+                  ></span>
+                  <span
+                    >${this.hass.localize(
+                      `ui.panel.config.zwave_js.protocol_data_rate.${
+                        ProtocolDataRate[wrValue.protocol_data_rate]
+                      }`
+                    )}</span
+                  >
+                </div>
+                ${wrValue.rssi
+                  ? html`<div class="row">
+                      <span>
+                        ${this.hass.localize(
+                          "ui.panel.config.zwave_js.route_statistics.rssi.label"
+                        )}<ha-help-tooltip
+                          .label=${this.hass.localize(
+                            "ui.panel.config.zwave_js.route_statistics.rssi.tooltip"
+                          )}
+                        >
+                        </ha-help-tooltip
+                      ></span>
+                      <span>${this._computeRSSI(wrValue.rssi, true)}</span>
+                    </div>`
+                  : ``}
+                ${wrValue.route_failed_between
+                  ? html`<div class="row">
+                      <span>
+                        ${this.hass.localize(
+                          "ui.panel.config.zwave_js.route_statistics.route_failed_between.label"
+                        )}<ha-help-tooltip
+                          .label=${this.hass.localize(
+                            "ui.panel.config.zwave_js.route_statistics.route_failed_between.tooltip"
+                          )}
+                        >
+                        </ha-help-tooltip
+                      ></span>
+                      <span
+                        >${`${this._computeDeviceNameById(
+                          wrValue.route_failed_between[0]
+                        )} <-> ${this._computeDeviceNameById(
+                          wrValue.route_failed_between[1]
+                        )}`}</span
+                      >
+                    </div>`
+                  : ``}
+                ${wrValue.repeaters.length > 0
+                  ? html`<div class="row">
+                      <span>
+                        ${this.hass.localize(
+                          "ui.panel.config.zwave_js.route_statistics.repeaters.label"
+                        )}<ha-help-tooltip
+                          .label=${this.hass.localize(
+                            "ui.panel.config.zwave_js.route_statistics.repeaters.tooltip"
+                          )}
+                        >
+                        </ha-help-tooltip
+                      ></span>
+                      <span
+                        >${Object.entries(wrRepeaterRSSIMap).map(
+                          ([repeaterName, rssi]) => html`
+                            <div class="row">
+                              <span>${repeaterName}: </span>
+                              <span>${rssi}</span>
+                            </div>
+                          `
+                        )}</span
+                      >
+                    </div>`
+                  : ``}
+              </ha-expansion-panel>
+            `;
+          }
+          return ``;
+        })}
+      </ha-dialog>
+    `;
+  }
+
+  private _computeRSSI(rssi: number, includeUnit: boolean): string {
+    if (Object.values(RssiError).includes(rssi)) {
+      return this.hass.localize(
+        `ui.panel.config.zwave_js.rssi.rssi_error.${RssiError[rssi]}`
+      );
+    }
+    if (includeUnit) {
+      return `${rssi} ${this.hass.localize(
+        "ui.panel.config.zwave_js.rssi.unit"
+      )}`;
+    }
+    return rssi.toString();
+  }
+
+  private _computeDeviceNameById(device_id: string): string {
+    if (!this._devices) {
+      return device_id;
+    }
+    const device = this._devices.find((dev) => dev.id === device_id);
+    if (!device) {
+      return device_id;
+    }
+
+    return computeDeviceName(device, this.hass);
+  }
+
+  private _subscribeNodeStatistics(): void {
+    if (!this.hass) {
+      return;
+    }
+    this._subscribedNodeStatistics = subscribeZwaveNodeStatistics(
+      this.hass,
+      this.device!.id,
+      (message: ZWaveJSNodeStatisticsUpdatedMessage) => {
+        this._nodeStatistics = message;
+      }
+    );
+  }
+
+  private _subscribeDeviceRegistry(): void {
+    if (!this.hass) {
+      return;
+    }
+    this._subscribedDeviceRegistry = subscribeDeviceRegistry(
+      this.hass.connection,
+      (devices: DeviceRegistryEntry[]) => {
+        this._devices = devices;
+      }
+    );
+  }
+
+  private _unsubscribe(): void {
+    if (this._subscribedNodeStatistics) {
+      this._subscribedNodeStatistics.then((unsub) => unsub());
+      this._subscribedNodeStatistics = undefined;
+    }
+    if (this._subscribedDeviceRegistry) {
+      this._subscribedDeviceRegistry();
+      this._subscribedDeviceRegistry = undefined;
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyleDialog,
+      css`
+        mwc-list-item {
+          height: 60px;
+        }
+
+        .row {
+          display: flex;
+          justify-content: space-between;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-zwave_js-node-statistics": DialogZWaveJSNodeStatistics;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -413,13 +413,9 @@ class DialogZWaveJSNodeStatistics extends LitElement {
     this._subscribedDeviceRegistry = subscribeDeviceRegistry(
       this.hass.connection,
       (devices: DeviceRegistryEntry[]) => {
-        Object.entries(this._deviceIDsToDevices).forEach(([_, device]) => {
-          if (!devices.includes(device))
-            delete this._deviceIDsToDevices[device.id];
-        });
-        devices.forEach((device) => {
-          this._deviceIDsToDevices[device.id] = device;
-        });
+        const devicesIdToName = {};
+        devices.forEach(device => {devicesIdToName[device.id] = computeDeviceName(device, this.hass)});
+        this._deviceIDsToName = devicesIdToName;
       }
     );
   }

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -358,7 +358,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
           );
         }
 
-        const workingRoutes: [
+        const workingRoutesValueMap: [
           string,
           WorkingRouteStatistics | null | undefined
         ][] = [
@@ -366,9 +366,12 @@ class DialogZWaveJSNodeStatistics extends LitElement {
           ["nlwr", this._nodeStatistics?.nlwr],
         ];
 
-        this._workingRoutes = {};
-        workingRoutes.forEach(([wrKey, wrValue]) => {
-          this._workingRoutes[wrKey] = wrValue;
+        const workingRoutes: {
+          lwr?: WorkingRouteStatistics;
+          nlwr?: WorkingRouteStatistics;
+        } = {};
+        workingRoutesValueMap.forEach(([wrKey, wrValue]) => {
+          workingRoutes[wrKey] = wrValue;
 
           if (wrValue) {
             if (wrValue.rssi) {
@@ -402,6 +405,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
             }
           }
         });
+        this._workingRoutes = workingRoutes;
       }
     );
   }
@@ -414,7 +418,9 @@ class DialogZWaveJSNodeStatistics extends LitElement {
       this.hass.connection,
       (devices: DeviceRegistryEntry[]) => {
         const devicesIdToName = {};
-        devices.forEach(device => {devicesIdToName[device.id] = computeDeviceName(device, this.hass)});
+        devices.forEach((device) => {
+          devicesIdToName[device.id] = computeDeviceName(device, this.hass);
+        });
         this._deviceIDsToName = devicesIdToName;
       }
     );

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -283,7 +283,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
                         >${Object.entries(wrRepeaterRSSIMap).map(
                           ([repeaterName, rssi]) => html`
                             <div class="row">
-                              <span class="key-cell">${repeaterName}: </span>
+                              <span class="key-cell">${repeaterName}:</span>
                               <span class="value-cell">${rssi}</span>
                             </div>
                           `

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -349,14 +349,12 @@ class DialogZWaveJSNodeStatistics extends LitElement {
       this.hass,
       this.device!.id,
       (message: ZWaveJSNodeStatisticsUpdatedMessage) => {
-        this._nodeStatistics = message;
-
-        if (this._nodeStatistics.rssi) {
-          this._nodeStatistics.rssi_translated = this._computeRSSI(
-            this._nodeStatistics.rssi,
-            false
-          );
-        }
+        this._nodeStatistics = {
+          ...message,
+          rssi_translated: message.rssi
+            ? this._computeRSSI(message.rssi, false)
+            : undefined,
+        };
 
         const workingRoutesValueMap: [
           string,

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -480,7 +480,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
         }
 
         .statistics {
-          font-size: 1em;
+          font-size: 0.95em;
           color: var(--primary-text-color);
         }
       `,

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-node-statistics.ts
@@ -338,7 +338,7 @@ class DialogZWaveJSNodeStatistics extends LitElement {
       return "unknown device";
     }
 
-    return computeDeviceName(device, this.hass);
+    return this._deviceIDsToName[device_id] || "unknown device";
   }
 
   private _subscribeNodeStatistics(): void {

--- a/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-node-statistics.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-node-statistics.ts
@@ -1,0 +1,20 @@
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import { DeviceRegistryEntry } from "../../../../../data/device_registry";
+
+export interface ZWaveJSNodeStatisticsDialogParams {
+  device: DeviceRegistryEntry;
+}
+
+export const loadNodeStatisticsDialog = () =>
+  import("./dialog-zwave_js-node-statistics");
+
+export const showZWaveJSNodeStatisticsDialog = (
+  element: HTMLElement,
+  nodeStatisticsDialogParams: ZWaveJSNodeStatisticsDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-zwave_js-node-statistics",
+    dialogImport: loadNodeStatisticsDialog,
+    dialogParams: nodeStatisticsDialogParams,
+  });
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3153,9 +3153,9 @@
               "tooltip": "The used data rate for this route",
               "protocol_data_rate": {
                 "ZWave_9k6": "9600",
-                "ZWave_40k": "40K",
-                "ZWave_100k": "100K",
-                "LongRange_100k": "100K"
+                "ZWave_40k": "40k",
+                "ZWave_100k": "100k",
+                "LongRange_100k": "100k"
               }
             },
             "repeaters": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3161,7 +3161,7 @@
             "repeaters": {
               "label": "Repeaters + RSSI",
               "tooltip": "Which nodes are repeaters for this route and their RSSI",
-              "repeaters": "Repeater Devices",
+              "repeaters": "Repeater Device",
               "rssi": "RSSI",
               "direct": "None, direct connection"
             },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3101,7 +3101,73 @@
             "highest_security": "Highest Security",
             "unknown": "Unknown",
             "zwave_plus": "Z-Wave Plus",
-            "zwave_plus_version": "Version {version}"
+            "zwave_plus_version": "Version {version}",
+            "node_statistics": "Show Device Statistics"
+          },
+          "node_statistics": {
+            "title": "Device Statistics",
+            "commands_tx": {
+              "label": "Commands TX",
+              "tooltip": "# of commands successfully sent to the node"
+            },
+            "commands_rx": {
+              "label": "Commands RX",
+              "tooltip": "# of commands received from the node, including responses to sent commands"
+            },
+            "commands_dropped_tx": {
+              "label": "Commands Dropped TX",
+              "tooltip": "# of outgoing commands that were dropped because they could not be sent"
+            },
+            "commands_dropped_rx": {
+              "label": "Commands Dropped RX",
+              "tooltip": "# of commands from the node that were dropped by the host"
+            },
+            "timeout_response": {
+              "label": "Timeout Response",
+              "tooltip": "# of Get-type commands where the node's response did not come in time"
+            },
+            "rtt": {
+              "label": "RTT",
+              "tooltip": "Average round-trip-time in ms of commands to this node"
+            },
+            "rssi": {
+              "label": "RSSI",
+              "tooltip": "Average RSSI in dBm of frames received by this node"
+            },
+            "lwr": "Last Working Route",
+            "nlwr": "Next to Last Working Route"
+          },
+          "route_statistics": {
+            "protocol_data_rate": {
+              "label": "Protocol Data Rate",
+              "tooltip": "The protocol and used data rate for this route"
+            },
+            "repeaters": {
+              "label": "Repeaters + RSSI",
+              "tooltip": "Which nodes are repeaters for this route and their RSSI"
+            },
+            "rssi": {
+              "label": "RSSI",
+              "tooltip": "The RSSI of the ACK frame received by the controller"
+            },
+            "route_failed_between": {
+              "label": "Route Failed Between",
+              "tooltip": "The nodes between which the transmission failed most recently"
+            }
+          },
+          "rssi": {
+            "unit": "dBm",
+            "rssi_error": {
+              "NotAvailable": "Not Available",
+              "ReceiverSaturated": "Receiver Saturated",
+              "NoSignalDetected": "No Signal Detected"
+            }
+          },
+          "protocol_data_rate": {
+            "ZWave_9k6": "Z-Wave 9600",
+            "ZWave_40k": "Z-Wave 40K",
+            "ZWave_100k": "Z-Wave 100K",
+            "LongRange_100k": "Long Range 100K"
           },
           "node_config": {
             "header": "Z-Wave Device Configuration",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3152,17 +3152,18 @@
               "label": "Data Rate",
               "tooltip": "The used data rate for this route",
               "protocol_data_rate": {
-                "ZWave_9k6": "9600",
-                "ZWave_40k": "40k",
-                "ZWave_100k": "100k",
-                "LongRange_100k": "100k"
+                "ZWave_9k6": "9.6 kbps",
+                "ZWave_40k": "40 kbps",
+                "ZWave_100k": "100 kbps",
+                "LongRange_100k": "100 kbps"
               }
             },
             "repeaters": {
               "label": "Repeaters + RSSI",
               "tooltip": "Which nodes are repeaters for this route and their RSSI",
               "repeaters": "Repeater Devices",
-              "rssi": "RSSI"
+              "rssi": "RSSI",
+              "direct": "None, direct connection"
             },
             "rssi": {
               "label": "RSSI",
@@ -3170,22 +3171,17 @@
             },
             "route_failed_between": {
               "label": "Route Failed Between",
-              "tooltip": "The nodes between which the transmission failed most recently"
+              "tooltip": "The nodes between which the transmission failed most recently",
+              "not_applicable": "N/A"
             }
           },
           "rssi": {
             "unit": "dBm",
             "rssi_error": {
-              "NotAvailable": "Not Available",
-              "ReceiverSaturated": "Receiver Saturated",
-              "NoSignalDetected": "No Signal Detected"
+              "NotAvailable": "Not available",
+              "ReceiverSaturated": "Receiver saturated",
+              "NoSignalDetected": "No signal detected"
             }
-          },
-          "protocol_data_rate": {
-            "ZWave_9k6": "Z-Wave 9600",
-            "ZWave_40k": "Z-Wave 40K",
-            "ZWave_100k": "Z-Wave 100K",
-            "LongRange_100k": "Long Range 100K"
           },
           "node_config": {
             "header": "Z-Wave Device Configuration",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3138,9 +3138,25 @@
             "nlwr": "Next to Last Working Route"
           },
           "route_statistics": {
-            "protocol_data_rate": {
-              "label": "Protocol Data Rate",
-              "tooltip": "The protocol and used data rate for this route"
+            "protocol": {
+              "label": "Protocol",
+              "tooltip": "The protocol for this route",
+              "protocol_data_rate": {
+                "ZWave_9k6": "Z-Wave",
+                "ZWave_40k": "Z-Wave",
+                "ZWave_100k": "Z-Wave",
+                "LongRange_100k": "Z-Wave Long Range"
+              }
+            },
+            "data_rate": {
+              "label": "Data Rate",
+              "tooltip": "The used data rate for this route",
+              "protocol_data_rate": {
+                "ZWave_9k6": "9600",
+                "ZWave_40k": "40K",
+                "ZWave_100k": "100K",
+                "LongRange_100k": "100K"
+              }
             },
             "repeaters": {
               "label": "Repeaters + RSSI",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3160,7 +3160,9 @@
             },
             "repeaters": {
               "label": "Repeaters + RSSI",
-              "tooltip": "Which nodes are repeaters for this route and their RSSI"
+              "tooltip": "Which nodes are repeaters for this route and their RSSI",
+              "repeaters": "Repeater Devices",
+              "rssi": "RSSI"
             },
             "rssi": {
               "label": "RSSI",


### PR DESCRIPTION
## Proposed change
Adds a new zwave_js device action to show device statistics. Dependent on https://github.com/home-assistant/core/pull/72520

The screenshot below doesn't show that I split protocol and data rate into two separate rows

Looks like this:
![image](https://user-images.githubusercontent.com/7243222/170433558-c11748b5-2ef7-4f93-bbac-bd672c980c51.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/72520

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
