### PR TITLE
Add dynamic header/footer config determination and update struct

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -49,6 +49,7 @@ import {
   SubElementEditorConfig,
 } from "../types";
 import { configElementStyle } from "./config-elements-style";
+import { buttonEntityConfigStruct } from "../structs/button-entity-struct";
 
 const buttonEntitiesRowConfigStruct = object({
   type: literal("button"),
@@ -110,24 +111,9 @@ const webLinkEntitiesRowConfigStruct = object({
   icon: optional(string()),
 });
 
-export const buttonsEntitiesConfigStruct = union([
-  object({
-    entity: string(),
-    name: optional(string()),
-    icon: optional(string()),
-    image: optional(string()),
-    show_name: optional(boolean()),
-    show_icon: optional(boolean()),
-    tap_action: optional(actionConfigStruct),
-    hold_action: optional(actionConfigStruct),
-    double_tap_action: optional(actionConfigStruct),
-  }),
-  string(),
-]);
-
 const buttonsEntitiesRowConfigStruct = object({
   type: literal("buttons"),
-  entities: array(buttonsEntitiesConfigStruct),
+  entities: array(buttonEntityConfigStruct),
 });
 
 const attributeEntitiesRowConfigStruct = object({

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -110,24 +110,24 @@ const webLinkEntitiesRowConfigStruct = object({
   icon: optional(string()),
 });
 
+export const buttonsEntitiesConfigStruct = union([
+  object({
+    entity: string(),
+    name: optional(string()),
+    icon: optional(string()),
+    image: optional(string()),
+    show_name: optional(boolean()),
+    show_icon: optional(boolean()),
+    tap_action: optional(actionConfigStruct),
+    hold_action: optional(actionConfigStruct),
+    double_tap_action: optional(actionConfigStruct),
+  }),
+  string(),
+]);
+
 const buttonsEntitiesRowConfigStruct = object({
   type: literal("buttons"),
-  entities: array(
-    union([
-      object({
-        entity: string(),
-        name: optional(string()),
-        icon: optional(string()),
-        image: optional(string()),
-        show_name: optional(boolean()),
-        show_icon: optional(boolean()),
-        tap_action: optional(actionConfigStruct),
-        hold_action: optional(actionConfigStruct),
-        double_tap_action: optional(actionConfigStruct),
-      }),
-      string(),
-    ])
-  ),
+  entities: array(buttonsEntitiesConfigStruct),
 });
 
 const attributeEntitiesRowConfigStruct = object({

--- a/src/panels/lovelace/editor/structs/button-entity-struct.ts
+++ b/src/panels/lovelace/editor/structs/button-entity-struct.ts
@@ -1,0 +1,14 @@
+import { boolean, object, optional, string } from "superstruct";
+import { actionConfigStruct } from "./action-struct";
+
+export const buttonEntityConfigStruct = object({
+  entity: string(),
+  name: optional(string()),
+  icon: optional(string()),
+  image: optional(string()),
+  show_name: optional(boolean()),
+  show_icon: optional(boolean()),
+  tap_action: optional(actionConfigStruct),
+  hold_action: optional(actionConfigStruct),
+  double_tap_action: optional(actionConfigStruct),
+});

--- a/src/panels/lovelace/editor/structs/entities-struct.ts
+++ b/src/panels/lovelace/editor/structs/entities-struct.ts
@@ -14,6 +14,8 @@ export const entitiesConfigStruct = union([
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),
+    show_icon: optional(boolean()),
+    show_name: optional(boolean()),
   }),
   string(),
 ]);

--- a/src/panels/lovelace/editor/structs/entities-struct.ts
+++ b/src/panels/lovelace/editor/structs/entities-struct.ts
@@ -14,8 +14,6 @@ export const entitiesConfigStruct = union([
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),
-    show_icon: optional(boolean()),
-    show_name: optional(boolean()),
   }),
   string(),
 ]);

--- a/src/panels/lovelace/header-footer/structs.ts
+++ b/src/panels/lovelace/header-footer/structs.ts
@@ -1,6 +1,14 @@
-import { array, dynamic, number, object, optional, string } from "superstruct";
+import {
+  array,
+  dynamic,
+  number,
+  object,
+  optional,
+  union,
+  string,
+} from "superstruct";
+import { buttonsEntitiesConfigStruct } from "../editor/config-elements/hui-entities-card-editor";
 import { actionConfigStruct } from "../editor/structs/action-struct";
-import { entitiesConfigStruct } from "../editor/structs/entities-struct";
 import { LovelaceHeaderFooterConfig } from "./types";
 
 export const pictureHeaderFooterConfigStruct = object({
@@ -13,7 +21,7 @@ export const pictureHeaderFooterConfigStruct = object({
 
 export const buttonsHeaderFooterConfigStruct = object({
   type: string(),
-  entities: array(entitiesConfigStruct),
+  entities: array(buttonsEntitiesConfigStruct),
 });
 
 export const graphHeaderFooterConfigStruct = object({
@@ -38,7 +46,10 @@ export const headerFooterConfigStructs = dynamic<any>((value) => {
     }
   }
 
-  // No "type" property => we fallback to one random variant, which ensure that user gets informed
-  // about missing "type", as all variants have that marked as required.
-  return pictureHeaderFooterConfigStruct;
+  // No "type" property => we fallback to a union of all potential types
+  return union([
+    buttonsHeaderFooterConfigStruct,
+    graphHeaderFooterConfigStruct,
+    pictureHeaderFooterConfigStruct,
+  ]);
 });

--- a/src/panels/lovelace/header-footer/structs.ts
+++ b/src/panels/lovelace/header-footer/structs.ts
@@ -7,8 +7,8 @@ import {
   union,
   string,
 } from "superstruct";
-import { buttonsEntitiesConfigStruct } from "../editor/config-elements/hui-entities-card-editor";
 import { actionConfigStruct } from "../editor/structs/action-struct";
+import { buttonEntityConfigStruct } from "../editor/structs/button-entity-struct";
 import { LovelaceHeaderFooterConfig } from "./types";
 
 export const pictureHeaderFooterConfigStruct = object({
@@ -21,7 +21,7 @@ export const pictureHeaderFooterConfigStruct = object({
 
 export const buttonsHeaderFooterConfigStruct = object({
   type: string(),
-  entities: array(buttonsEntitiesConfigStruct),
+  entities: array(buttonEntityConfigStruct),
 });
 
 export const graphHeaderFooterConfigStruct = object({

--- a/src/panels/lovelace/header-footer/structs.ts
+++ b/src/panels/lovelace/header-footer/structs.ts
@@ -1,6 +1,7 @@
-import { object, string, optional, array, number, union } from "superstruct";
+import { array, dynamic, number, object, optional, string } from "superstruct";
 import { actionConfigStruct } from "../editor/structs/action-struct";
 import { entitiesConfigStruct } from "../editor/structs/entities-struct";
+import { LovelaceHeaderFooterConfig } from "./types";
 
 export const pictureHeaderFooterConfigStruct = object({
   type: string(),
@@ -22,8 +23,22 @@ export const graphHeaderFooterConfigStruct = object({
   hours_to_show: optional(number()),
 });
 
-export const headerFooterConfigStructs = union([
-  pictureHeaderFooterConfigStruct,
-  buttonsHeaderFooterConfigStruct,
-  graphHeaderFooterConfigStruct,
-]);
+export const headerFooterConfigStructs = dynamic<any>((value) => {
+  if (value && typeof value === "object" && "type" in value) {
+    switch ((value as LovelaceHeaderFooterConfig).type!) {
+      case "buttons": {
+        return buttonsHeaderFooterConfigStruct;
+      }
+      case "graph": {
+        return graphHeaderFooterConfigStruct;
+      }
+      case "picture": {
+        return pictureHeaderFooterConfigStruct;
+      }
+    }
+  }
+
+  // No "type" property => we fallback to one random variant, which ensure that user gets informed
+  // about missing "type", as all variants have that marked as required.
+  return pictureHeaderFooterConfigStruct;
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Alternative / addition to https://github.com/home-assistant/frontend/pull/12792. Ensures we correctly and dynamically determine which config variant applies based on the "type" (similarly to what I added a while back to the entities card config).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #11668
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
