### PR TITLE
Dynamically determine the correct action config struct

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -159,6 +159,7 @@ export interface CustomActionConfig extends BaseActionConfig {
 }
 
 export interface BaseActionConfig {
+  action: string;
   confirmation?: ConfirmationRestrictionConfig;
 }
 

--- a/src/panels/lovelace/editor/structs/action-struct.ts
+++ b/src/panels/lovelace/editor/structs/action-struct.ts
@@ -1,14 +1,16 @@
 import {
-  object,
-  string,
-  union,
-  boolean,
-  optional,
   array,
-  literal,
+  boolean,
+  dynamic,
   enums,
+  literal,
+  object,
+  optional,
+  string,
   type,
+  union,
 } from "superstruct";
+import { BaseActionConfig } from "../../../../data/lovelace";
 
 const actionConfigStructUser = object({
   user: string(),
@@ -65,10 +67,23 @@ export const actionConfigStructType = object({
   confirmation: optional(actionConfigStructConfirmation),
 });
 
-export const actionConfigStruct = union([
-  actionConfigStructType,
-  actionConfigStructUrl,
-  actionConfigStructNavigate,
-  actionConfigStructService,
-  actionConfigStructCustom,
-]);
+export const actionConfigStruct = dynamic<any>((value) => {
+  if (value && typeof value === "object" && "action" in value) {
+    switch ((value as BaseActionConfig).action!) {
+      case "call-service": {
+        return actionConfigStructService;
+      }
+      case "fire-dom-event": {
+        return actionConfigStructCustom;
+      }
+      case "navigate": {
+        return actionConfigStructNavigate;
+      }
+      case "url": {
+        return actionConfigStructUrl;
+      }
+    }
+  }
+
+  return actionConfigStructType;
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Improves the error handling (= better info for user) since we correctly enforce e.g. that an action of type "url" needs to have a "url_path" key in order to peroply work during action tapping.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
