### PR TITLE
Align "Browse Media" button while being wrapped

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -72,6 +72,7 @@ class MoreInfoMediaPlayer extends LitElement {
         ${supportsFeature(stateObj, SUPPORT_BROWSE_MEDIA)
           ? html`
               <mwc-button
+                class="browse-media"
                 .label=${this.hass.localize(
                   "ui.card.media_player.browse_media"
                 )}
@@ -242,6 +243,10 @@ class MoreInfoMediaPlayer extends LitElement {
 
       mwc-button > ha-svg-icon {
         vertical-align: text-bottom;
+      }
+
+      .browse-media {
+        margin-left: 8px;
       }
     `;
   }

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -72,13 +72,13 @@ class MoreInfoMediaPlayer extends LitElement {
         ${supportsFeature(stateObj, SUPPORT_BROWSE_MEDIA)
           ? html`
               <mwc-button
-                class="browse-media"
                 .label=${this.hass.localize(
                   "ui.card.media_player.browse_media"
                 )}
                 @click=${this._showBrowseMedia}
               >
                 <ha-svg-icon
+                  class="browse-media-icon"
                   .path=${mdiPlayBoxMultiple}
                   slot="icon"
                 ></ha-svg-icon>
@@ -245,7 +245,7 @@ class MoreInfoMediaPlayer extends LitElement {
         vertical-align: text-bottom;
       }
 
-      .browse-media {
+      .browse-media-icon {
         margin-left: 8px;
       }
     `;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Now that "Browse Media" is wrapping into a second row, we should ensure that the icon button visually aligns with the icons in the first row.

**Before:**
![image](https://user-images.githubusercontent.com/114137/170525328-98dc5e19-02c2-45cd-a462-fe935ab06b7e.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
