### PR TITLE
Update style of zwave_js controller statistics

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -286,7 +286,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_tx.tooltip"
                             )}
                           </span>
-                          <span slot="meta"
+                          <span slot="meta" class="statistics"
                             >${this._statistics?.messages_tx ?? 0}</span
                           >
                         </mwc-list-item>
@@ -301,7 +301,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_rx.tooltip"
                             )}
                           </span>
-                          <span slot="meta"
+                          <span slot="meta" class="statistics"
                             >${this._statistics?.messages_rx ?? 0}</span
                           >
                         </mwc-list-item>
@@ -316,7 +316,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_tx.tooltip"
                             )}
                           </span>
-                          <span slot="meta"
+                          <span slot="meta" class="statistics"
                             >${this._statistics?.messages_dropped_tx ?? 0}</span
                           >
                         </mwc-list-item>
@@ -331,7 +331,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_rx.tooltip"
                             )}
                           </span>
-                          <span slot="meta"
+                          <span slot="meta" class="statistics"
                             >${this._statistics?.messages_dropped_rx ?? 0}</span
                           >
                         </mwc-list-item>
@@ -346,7 +346,9 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.nak.tooltip"
                             )}
                           </span>
-                          <span slot="meta">${this._statistics?.nak ?? 0}</span>
+                          <span slot="meta" class="statistics"
+                            >${this._statistics?.nak ?? 0}</span
+                          >
                         </mwc-list-item>
                         <mwc-list-item twoline hasmeta>
                           <span>
@@ -359,7 +361,9 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.can.tooltip"
                             )}
                           </span>
-                          <span slot="meta">${this._statistics?.can ?? 0}</span>
+                          <span slot="meta" class="statistics"
+                            >${this._statistics?.can ?? 0}</span
+                          >
                         </mwc-list-item>
                         <mwc-list-item twoline hasmeta>
                           <span>
@@ -372,7 +376,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_ack.tooltip"
                             )}
                           </span>
-                          <span slot="meta"
+                          <span slot="meta" class="statistics"
                             >${this._statistics?.timeout_ack ?? 0}</span
                           >
                         </mwc-list-item>
@@ -387,7 +391,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_response.tooltip"
                             )}
                           </span>
-                          <span slot="meta"
+                          <span slot="meta" class="statistics"
                             >${this._statistics?.timeout_response ?? 0}</span
                           >
                         </mwc-list-item>
@@ -402,7 +406,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_callback.tooltip"
                             )}
                           </span>
-                          <span slot="meta"
+                          <span slot="meta" class="statistics"
                             >${this._statistics?.timeout_callback ?? 0}</span
                           >
                         </mwc-list-item>
@@ -692,6 +696,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
         .row {
           display: flex;
           justify-content: space-between;
+        }
+
+        .statistics {
+          font-size: 1em;
+          color: var(--primary-text-color);
         }
 
         .network-status div.heading {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -286,7 +286,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_tx.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
+                          <span slot="meta"
                             >${this._statistics?.messages_tx ?? 0}</span
                           >
                         </mwc-list-item>
@@ -301,7 +301,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_rx.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
+                          <span slot="meta"
                             >${this._statistics?.messages_rx ?? 0}</span
                           >
                         </mwc-list-item>
@@ -316,7 +316,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_tx.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
+                          <span slot="meta"
                             >${this._statistics?.messages_dropped_tx ?? 0}</span
                           >
                         </mwc-list-item>
@@ -331,7 +331,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.messages_dropped_rx.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
+                          <span slot="meta"
                             >${this._statistics?.messages_dropped_rx ?? 0}</span
                           >
                         </mwc-list-item>
@@ -346,9 +346,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.nak.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
-                            >${this._statistics?.nak ?? 0}</span
-                          >
+                          <span slot="meta">${this._statistics?.nak ?? 0}</span>
                         </mwc-list-item>
                         <mwc-list-item twoline hasmeta>
                           <span>
@@ -361,9 +359,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.can.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
-                            >${this._statistics?.can ?? 0}</span
-                          >
+                          <span slot="meta">${this._statistics?.can ?? 0}</span>
                         </mwc-list-item>
                         <mwc-list-item twoline hasmeta>
                           <span>
@@ -376,7 +372,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_ack.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
+                          <span slot="meta"
                             >${this._statistics?.timeout_ack ?? 0}</span
                           >
                         </mwc-list-item>
@@ -391,7 +387,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_response.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
+                          <span slot="meta"
                             >${this._statistics?.timeout_response ?? 0}</span
                           >
                         </mwc-list-item>
@@ -406,7 +402,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
                               "ui.panel.config.zwave_js.dashboard.statistics.timeout_callback.tooltip"
                             )}
                           </span>
-                          <span slot="meta" class="statistics"
+                          <span slot="meta"
                             >${this._statistics?.timeout_callback ?? 0}</span
                           >
                         </mwc-list-item>
@@ -698,7 +694,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
           justify-content: space-between;
         }
 
-        .statistics {
+        span[slot="meta"] {
           font-size: 0.95em;
           color: var(--primary-text-color);
         }

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -699,7 +699,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
         }
 
         .statistics {
-          font-size: 1em;
+          font-size: 0.95em;
           color: var(--primary-text-color);
         }
 


### PR DESCRIPTION
## Proposed change
Update styles to make statistics more readable. We should tag this for the beta.

**Before**
<img width="588" alt="image" src="https://user-images.githubusercontent.com/7243222/170608483-b645fc10-1eb9-47d4-b168-db0ddb679730.png">

**After**
<img width="587" alt="image" src="https://user-images.githubusercontent.com/7243222/170608822-7054420b-e8f7-42be-995c-18d736935f51.png">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
