### PR TITLE
Scale oversized brand thumbnails in media browser

### DIFF
--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -567,13 +567,10 @@ export class HaMediaPlayerBrowse extends LitElement {
                   <div
                     class="${["app", "directory"].includes(child.media_class)
                       ? "centered-image"
+                      : ""} ${isBrandUrl(child.thumbnail)
+                      ? "brand-image"
                       : ""} image"
-                    style="background-image: ${until(
-                      backgroundImage,
-                      ""
-                    )}${isBrandUrl(child.thumbnail)
-                      ? "; background-size: 40%"
-                      : ""}"
+                    style="background-image: ${until(backgroundImage, "")}"
                   ></div>
                 `
               : html`
@@ -1057,6 +1054,10 @@ export class HaMediaPlayerBrowse extends LitElement {
         .centered-image {
           margin: 0 8px;
           background-size: contain;
+        }
+
+        .brand-image {
+          background-size: 40%;
         }
 
         .children ha-card .icon-holder {

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -43,7 +43,7 @@ import { showAlertDialog } from "../../dialogs/generic/show-dialog-box";
 import { installResizeObserver } from "../../panels/lovelace/common/install-resize-observer";
 import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
-import { brandsUrl, extractDomainFromBrandUrl } from "../../util/brands-url";
+import { brandsUrl, extractDomainFromBrandUrl, isBrandUrl } from "../../util/brands-url";
 import { documentationUrl } from "../../util/documentation-url";
 import "../entity/ha-entity-picker";
 import "../ha-alert";
@@ -564,7 +564,7 @@ export class HaMediaPlayerBrowse extends LitElement {
                     class="${["app", "directory"].includes(child.media_class)
                       ? "centered-image"
                       : ""} image"
-                    style="background-image: ${until(backgroundImage, "")}"
+                    style="background-image: ${until(backgroundImage, "")}${isBrandUrl(child.thumbnail) ? "; background-size: 40%" : ""}"
                   ></div>
                 `
               : html`
@@ -661,7 +661,7 @@ export class HaMediaPlayerBrowse extends LitElement {
       return (await getSignedPath(this.hass, thumbnailUrl)).path;
     }
 
-    if (thumbnailUrl.startsWith("https://brands.home-assistant.io")) {
+    if (isBrandUrl(thumbnailUrl)) {
       // The backend is not aware of the theme used by the users,
       // so we rewrite the URL to show a proper icon
       thumbnailUrl = brandsUrl({

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -43,7 +43,11 @@ import { showAlertDialog } from "../../dialogs/generic/show-dialog-box";
 import { installResizeObserver } from "../../panels/lovelace/common/install-resize-observer";
 import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
-import { brandsUrl, extractDomainFromBrandUrl, isBrandUrl } from "../../util/brands-url";
+import {
+  brandsUrl,
+  extractDomainFromBrandUrl,
+  isBrandUrl,
+} from "../../util/brands-url";
 import { documentationUrl } from "../../util/documentation-url";
 import "../entity/ha-entity-picker";
 import "../ha-alert";
@@ -564,7 +568,12 @@ export class HaMediaPlayerBrowse extends LitElement {
                     class="${["app", "directory"].includes(child.media_class)
                       ? "centered-image"
                       : ""} image"
-                    style="background-image: ${until(backgroundImage, "")}${isBrandUrl(child.thumbnail) ? "; background-size: 40%" : ""}"
+                    style="background-image: ${until(
+                      backgroundImage,
+                      ""
+                    )}${isBrandUrl(child.thumbnail)
+                      ? "; background-size: 40%"
+                      : ""}"
                   ></div>
                 `
               : html`

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -26,3 +26,4 @@ export const extractDomainFromBrandUrl = (url: string) => url.split("/")[4];
 
 export const isBrandUrl = (thumbnail: string | ""): boolean =>
   thumbnail.startsWith('https://brands.home-assistant.io/');
+  

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -23,3 +23,6 @@ export const hardwareBrandsUrl = (options: HardwareBrandsOptions): string =>
   }${options.manufacturer}${options.model ? `_${options.model}` : ""}.png`;
 
 export const extractDomainFromBrandUrl = (url: string) => url.split("/")[4];
+
+export const isBrandUrl = (thumbnail: string | ""): boolean =>
+  thumbnail.startsWith('https://brands.home-assistant.io/');

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -25,5 +25,4 @@ export const hardwareBrandsUrl = (options: HardwareBrandsOptions): string =>
 export const extractDomainFromBrandUrl = (url: string) => url.split("/")[4];
 
 export const isBrandUrl = (thumbnail: string | ""): boolean =>
-  thumbnail.startsWith('https://brands.home-assistant.io/');
-  
+  thumbnail.startsWith("https://brands.home-assistant.io/");


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The brand thumbnails in the new media-source libraries do not fit well with the overall look of the media browser cards

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

As brand thumbnails are typically raster icons, this PR proposes to identify brand thumbnails and resize similar to the original svg class icons.

![before](https://user-images.githubusercontent.com/11602094/170874420-864100eb-32ab-4c46-81aa-73f11936db0c.png)
Current View

![after](https://user-images.githubusercontent.com/11602094/170874455-c8b31022-bae4-49b6-9239-e00344383faf.png)
Proposed

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #12816 
- This PR is related to issue or discussion:
- Link to documentation pull request:

- This PR replaces #12819 

Please feel free to make direct changes or 'close' if you feel this does not fit with future plans. I'm not, by any means, a frontend developer/expert. My motivation is that this has merely bugged me for a while now!

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
My development setup has limited testing capabilities for frontend

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
