### PR TITLE
20220531.0

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -181,7 +181,7 @@
     {
       "label": "Run HA Core for Supervisor in devcontainer",
       "type": "shell",
-      "command": "HASSIO=${input:supervisorHost} HASSIO_TOKEN=${input:supervisorToken} script/core",
+      "command": "SUPERVISOR=${input:supervisorHost} SUPERVISOR_TOKEN=${input:supervisorToken} script/core",
       "isBackground": true,
       "group": {
         "kind": "build",

--- a/cast/public/_redirects
+++ b/cast/public/_redirects
@@ -1,0 +1,9 @@
+# These redirects are handled by Netlify
+#
+
+# Some custom cards are not prefixing the instance URL when fetching data
+# and can end up fetching the data from the Cast domain instead of HA.
+# This will make sure that some common ones are replaced with a placeholder.
+/api/camera_proxy/* /images/google-nest-hub.png
+/api/camera_proxy_stream/* /images/google-nest-hub.png
+/api/media_player_proxy/* /images/google-nest-hub.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name         = "home-assistant-frontend"
-version      = "20220526.0"
+version      = "20220531.0"
 license      = {text = "Apache-2.0"}
 description  = "The Home Assistant frontend"
 readme       = "README.md"

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -70,7 +70,9 @@ export const iconColorCSS = css`
     }
   }
 
-  ha-state-icon[data-domain="plant"][data-state="problem"],
+  ha-state-icon[data-domain="plant"][data-state="problem"] {
+    color: var(--state-icon-error-color);
+  }
 
   /* Color the icon if unavailable */
   ha-state-icon[data-state="unavailable"] {

--- a/src/common/util/compute_rtl.ts
+++ b/src/common/util/compute_rtl.ts
@@ -1,3 +1,4 @@
+import { LitElement } from "lit";
 import { HomeAssistant } from "../../types";
 
 export function computeRTL(hass: HomeAssistant) {
@@ -14,4 +15,22 @@ export function computeRTLDirection(hass: HomeAssistant) {
 
 export function emitRTLDirection(rtl: boolean) {
   return rtl ? "rtl" : "ltr";
+}
+
+export function computeDirectionStyles(isRTL: boolean, element: LitElement) {
+  const direction: string = emitRTLDirection(isRTL);
+  setDirectionStyles(direction, element);
+}
+
+export function setDirectionStyles(direction: string, element: LitElement) {
+  element.style.direction = direction;
+  element.style.setProperty("--direction", direction);
+  element.style.setProperty(
+    "--float-start",
+    direction === "ltr" ? "left" : "right"
+  );
+  element.style.setProperty(
+    "--float-end",
+    direction === "ltr" ? "right" : "left"
+  );
 }

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -37,6 +37,26 @@ export default class HaChartBase extends LitElement {
 
   @state() private _hiddenDatasets: Set<number> = new Set();
 
+  private _releaseCanvas() {
+    // release the canvas memory to prevent
+    // safari from running out of memory.
+    if (this.chart) {
+      this.chart.destroy();
+    }
+  }
+
+  public disconnectedCallback() {
+    this._releaseCanvas();
+    super.disconnectedCallback();
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    if (this.hasUpdated) {
+      this._setupChart();
+    }
+  }
+
   protected firstUpdated() {
     this._setupChart();
     this.data.datasets.forEach((dataset, index) => {

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -28,11 +28,11 @@ class StateHistoryChartLine extends LitElement {
 
   @property({ type: Boolean }) public isSingleDevice = false;
 
-  @property({ attribute: false }) public endTime?: Date;
+  @property({ attribute: false }) public endTime!: Date;
 
   @state() private _chartData?: ChartData<"line">;
 
-  @state() private _chartOptions?: ChartOptions<"line">;
+  @state() private _chartOptions?: ChartOptions;
 
   protected render() {
     return html`
@@ -57,6 +57,7 @@ class StateHistoryChartLine extends LitElement {
                 locale: this.hass.locale,
               },
             },
+            suggestedMax: this.endTime,
             ticks: {
               maxRotation: 0,
               sampleSize: 5,
@@ -130,28 +131,11 @@ class StateHistoryChartLine extends LitElement {
     const computedStyles = getComputedStyle(this);
     const entityStates = this.data;
     const datasets: ChartDataset<"line">[] = [];
-    let endTime: Date;
-
     if (entityStates.length === 0) {
       return;
     }
 
-    endTime =
-      this.endTime ||
-      // Get the highest date from the last date of each device
-      new Date(
-        Math.max(
-          ...entityStates.map((devSts) =>
-            new Date(
-              devSts.states[devSts.states.length - 1].last_changed
-            ).getTime()
-          )
-        )
-      );
-    if (endTime > new Date()) {
-      endTime = new Date();
-    }
-
+    const endTime = this.endTime;
     const names = this.names || {};
     entityStates.forEach((states) => {
       const domain = states.domain;

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -1,3 +1,4 @@
+import "@lit-labs/virtualizer";
 import {
   css,
   CSSResultGroup,
@@ -6,12 +7,29 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state, eventOptions } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
-import { HistoryResult } from "../../data/history";
+import {
+  HistoryResult,
+  LineChartUnit,
+  TimelineEntity,
+} from "../../data/history";
 import type { HomeAssistant } from "../../types";
 import "./state-history-chart-line";
 import "./state-history-chart-timeline";
+import { restoreScroll } from "../../common/decorators/restore-scroll";
+
+const CANVAS_TIMELINE_ROWS_CHUNK = 10; // Split up the canvases to avoid hitting the render limit
+
+const chunkData = (inputArray: any[], chunks: number) =>
+  inputArray.reduce((results, item, idx) => {
+    const chunkIdx = Math.floor(idx / chunks);
+    if (!results[chunkIdx]) {
+      results[chunkIdx] = [];
+    }
+    results[chunkIdx].push(item);
+    return results;
+  }, []);
 
 @customElement("state-history-charts")
 class StateHistoryCharts extends LitElement {
@@ -19,7 +37,12 @@ class StateHistoryCharts extends LitElement {
 
   @property({ attribute: false }) public historyData!: HistoryResult;
 
+  @property() public narrow!: boolean;
+
   @property({ type: Boolean }) public names = false;
+
+  @property({ type: Boolean, attribute: "virtualize", reflect: true })
+  public virtualize = false;
 
   @property({ attribute: false }) public endTime?: Date;
 
@@ -29,6 +52,14 @@ class StateHistoryCharts extends LitElement {
 
   @property({ type: Boolean }) public isLoadingData = false;
 
+  @state() private _computedStartTime!: Date;
+
+  @state() private _computedEndTime!: Date;
+
+  // @ts-ignore
+  @restoreScroll(".container") private _savedScrollPos?: number;
+
+  @eventOptions({ passive: true })
   protected render(): TemplateResult {
     if (!isComponentLoaded(this.hass, "history")) {
       return html` <div class="info">
@@ -48,39 +79,75 @@ class StateHistoryCharts extends LitElement {
       </div>`;
     }
 
-    const computedEndTime = this.upToNow
-      ? new Date()
-      : this.endTime || new Date();
+    const now = new Date();
 
-    return html`
-      ${this.historyData.timeline.length
-        ? html`
-            <state-history-chart-timeline
-              .hass=${this.hass}
-              .data=${this.historyData.timeline}
-              .endTime=${computedEndTime}
-              .noSingle=${this.noSingle}
-              .names=${this.names}
-            ></state-history-chart-timeline>
-          `
-        : html``}
-      ${this.historyData.line.map(
-        (line) => html`
-          <state-history-chart-line
-            .hass=${this.hass}
-            .unit=${line.unit}
-            .data=${line.data}
-            .identifier=${line.identifier}
-            .isSingleDevice=${!this.noSingle &&
-            line.data &&
-            line.data.length === 1}
-            .endTime=${computedEndTime}
-            .names=${this.names}
-          ></state-history-chart-line>
-        `
-      )}
-    `;
+    this._computedEndTime =
+      this.upToNow || !this.endTime || this.endTime > now ? now : this.endTime;
+
+    this._computedStartTime = new Date(
+      this.historyData.timeline.reduce(
+        (minTime, stateInfo) =>
+          Math.min(minTime, new Date(stateInfo.data[0].last_changed).getTime()),
+        new Date().getTime()
+      )
+    );
+
+    const combinedItems = chunkData(
+      this.historyData.timeline,
+      CANVAS_TIMELINE_ROWS_CHUNK
+    ).concat(this.historyData.line);
+
+    return this.virtualize
+      ? html`<div class="container ha-scrollbar" @scroll=${this._saveScrollPos}>
+          <lit-virtualizer
+            scroller
+            class="ha-scrollbar"
+            .items=${combinedItems}
+            .renderItem=${this._renderHistoryItem}
+          >
+          </lit-virtualizer>
+        </div>`
+      : html`${combinedItems.map((item, index) =>
+          this._renderHistoryItem(item, index)
+        )}`;
   }
+
+  private _renderHistoryItem = (
+    item: TimelineEntity[] | LineChartUnit,
+    index: number
+  ): TemplateResult => {
+    if (!item || index === undefined) {
+      return html``;
+    }
+    if (!Array.isArray(item)) {
+      return html`<div class="entry-container">
+        <state-history-chart-line
+          .hass=${this.hass}
+          .unit=${item.unit}
+          .data=${item.data}
+          .identifier=${item.identifier}
+          .isSingleDevice=${!this.noSingle &&
+          this.historyData.line &&
+          this.historyData.line.length === 1}
+          .endTime=${this._computedEndTime}
+          .names=${this.names}
+        ></state-history-chart-line>
+      </div> `;
+    }
+    return html`<div class="entry-container">
+      <state-history-chart-timeline
+        .hass=${this.hass}
+        .data=${item}
+        .startTime=${this._computedStartTime}
+        .endTime=${this._computedEndTime}
+        .noSingle=${this.noSingle}
+        .names=${this.names}
+        .narrow=${this.narrow}
+        .dataHasMultipleRows=${this.historyData.timeline.length &&
+        this.historyData.timeline.length > 1}
+      ></state-history-chart-timeline>
+    </div> `;
+  };
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     return !(changedProps.size === 1 && changedProps.has("hass"));
@@ -96,6 +163,11 @@ class StateHistoryCharts extends LitElement {
     return !this.isLoadingData && historyDataEmpty;
   }
 
+  @eventOptions({ passive: true })
+  private _saveScrollPos(e: Event) {
+    this._savedScrollPos = (e.target as HTMLDivElement).scrollTop;
+  }
+
   static get styles(): CSSResultGroup {
     return css`
       :host {
@@ -103,10 +175,46 @@ class StateHistoryCharts extends LitElement {
         /* height of single timeline chart = 60px */
         min-height: 60px;
       }
+
+      :host([virtualize]) {
+        height: 100%;
+      }
+
       .info {
         text-align: center;
         line-height: 60px;
         color: var(--secondary-text-color);
+      }
+      .container {
+        max-height: var(--history-max-height);
+      }
+
+      .entry-container {
+        width: 100%;
+      }
+
+      .entry-container:hover {
+        z-index: 1;
+      }
+
+      :host([virtualize]) .entry-container {
+        padding-left: 1px;
+        padding-right: 1px;
+      }
+
+      .container,
+      lit-virtualizer {
+        height: 100%;
+        width: 100%;
+      }
+
+      lit-virtualizer {
+        contain: size layout !important;
+      }
+
+      state-history-chart-timeline,
+      state-history-chart-line {
+        width: 100%;
       }
     `;
   }

--- a/src/components/ha-combo-box.ts
+++ b/src/components/ha-combo-box.ts
@@ -1,13 +1,17 @@
 import "@material/mwc-list/mwc-list-item";
 import { mdiClose, mdiMenuDown, mdiMenuUp } from "@mdi/js";
 import "@vaadin/combo-box/theme/material/vaadin-combo-box-light";
-import type { ComboBoxLight } from "@vaadin/combo-box/vaadin-combo-box-light";
+import type {
+  ComboBoxLight,
+  ComboBoxLightFilterChangedEvent,
+  ComboBoxLightOpenedChangedEvent,
+  ComboBoxLightValueChangedEvent,
+} from "@vaadin/combo-box/vaadin-combo-box-light";
 import { registerStyles } from "@vaadin/vaadin-themable-mixin/register-styles";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { ComboBoxLitRenderer, comboBoxRenderer } from "lit-vaadin-helpers";
 import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
-import { PolymerChangedEvent } from "../polymer-types";
 import { HomeAssistant } from "../types";
 import "./ha-icon-button";
 import "./ha-textfield";
@@ -203,7 +207,7 @@ export class HaComboBox extends LitElement {
     }
   }
 
-  private _openedChanged(ev: PolymerChangedEvent<boolean>) {
+  private _openedChanged(ev: ComboBoxLightOpenedChangedEvent) {
     const opened = ev.detail.value;
     // delay this so we can handle click event before setting _opened
     setTimeout(() => {
@@ -229,14 +233,12 @@ export class HaComboBox extends LitElement {
         mutations.forEach((mutation) => {
           if (
             mutation.type === "attributes" &&
-            mutation.attributeName === "inert" &&
-            // @ts-expect-error
-            overlay.inert === true
+            mutation.attributeName === "inert"
           ) {
-            // @ts-expect-error
-            overlay.inert = false;
             this._overlayMutationObserver?.disconnect();
             this._overlayMutationObserver = undefined;
+            // @ts-expect-error
+            overlay.inert = false;
           } else if (mutation.type === "childList") {
             mutation.removedNodes.forEach((node) => {
               if (node.nodeName === "VAADIN-COMBO-BOX-OVERLAY") {
@@ -257,12 +259,12 @@ export class HaComboBox extends LitElement {
     }
   }
 
-  private _filterChanged(ev: PolymerChangedEvent<string>) {
+  private _filterChanged(ev: ComboBoxLightFilterChangedEvent) {
     // @ts-ignore
     fireEvent(this, ev.type, ev.detail, { composed: false });
   }
 
-  private _valueChanged(ev: PolymerChangedEvent<string>) {
+  private _valueChanged(ev: ComboBoxLightValueChangedEvent) {
     ev.stopPropagation();
     const newValue = ev.detail.value;
 

--- a/src/components/ha-selector/ha-selector-text.ts
+++ b/src/components/ha-selector/ha-selector-text.ts
@@ -103,6 +103,9 @@ export class HaTextSelector extends LitElement {
         --mdc-icon-button-size: 24px;
         --mdc-icon-size: 20px;
         color: var(--secondary-text-color);
+        inset-inline-start: initial;
+        inset-inline-end: 16px;
+        direction: var(--direction);
       }
     `;
   }

--- a/src/components/ha-textfield.ts
+++ b/src/components/ha-textfield.ts
@@ -100,6 +100,7 @@ export class HaTextField extends TextFieldBase {
         inset-inline-end: initial !important;
         transform-origin: var(--float-start);
         direction: var(--direction);
+        transform-origin: var(--float-start);
       }
 
       .mdc-text-field--with-leading-icon.mdc-text-field--filled

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -43,7 +43,11 @@ import { showAlertDialog } from "../../dialogs/generic/show-dialog-box";
 import { installResizeObserver } from "../../panels/lovelace/common/install-resize-observer";
 import { haStyle } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
-import { brandsUrl, extractDomainFromBrandUrl } from "../../util/brands-url";
+import {
+  brandsUrl,
+  extractDomainFromBrandUrl,
+  isBrandUrl,
+} from "../../util/brands-url";
 import { documentationUrl } from "../../util/documentation-url";
 import "../entity/ha-entity-picker";
 import "../ha-alert";
@@ -563,6 +567,8 @@ export class HaMediaPlayerBrowse extends LitElement {
                   <div
                     class="${["app", "directory"].includes(child.media_class)
                       ? "centered-image"
+                      : ""} ${isBrandUrl(child.thumbnail)
+                      ? "brand-image"
                       : ""} image"
                     style="background-image: ${until(backgroundImage, "")}"
                   ></div>
@@ -661,7 +667,7 @@ export class HaMediaPlayerBrowse extends LitElement {
       return (await getSignedPath(this.hass, thumbnailUrl)).path;
     }
 
-    if (thumbnailUrl.startsWith("https://brands.home-assistant.io")) {
+    if (isBrandUrl(thumbnailUrl)) {
       // The backend is not aware of the theme used by the users,
       // so we rewrite the URL to show a proper icon
       thumbnailUrl = brandsUrl({
@@ -1048,6 +1054,10 @@ export class HaMediaPlayerBrowse extends LitElement {
         .centered-image {
           margin: 0 8px;
           background-size: contain;
+        }
+
+        .brand-image {
+          background-size: 40%;
         }
 
         .children ha-card .icon-holder {

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -1,7 +1,10 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateDisplayFromEntityAttributes } from "../common/entity/compute_state_display";
-import { computeStateNameFromEntityAttributes } from "../common/entity/compute_state_name";
+import {
+  computeStateName,
+  computeStateNameFromEntityAttributes,
+} from "../common/entity/compute_state_name";
 import { LocalizeFunc } from "../common/translations/localize";
 import { HomeAssistant } from "../types";
 import { FrontendLocaleData } from "./translation";
@@ -547,3 +550,16 @@ export const adjustStatisticsSum = (
     start_time,
     adjustment,
   });
+
+export const getStatisticLabel = (
+  hass: HomeAssistant,
+  statisticsId: string,
+  statisticsMetaData: Record<string, StatisticsMetaData>
+): string => {
+  const entity = hass.states[statisticsId];
+  if (entity) {
+    return computeStateName(entity);
+  }
+  const statisticMetaData = statisticsMetaData[statisticsId];
+  return statisticMetaData?.name || statisticsId;
+};

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -78,6 +78,7 @@ class MoreInfoMediaPlayer extends LitElement {
                 @click=${this._showBrowseMedia}
               >
                 <ha-svg-icon
+                  class="browse-media-icon"
                   .path=${mdiPlayBoxMultiple}
                   slot="icon"
                 ></ha-svg-icon>
@@ -242,6 +243,10 @@ class MoreInfoMediaPlayer extends LitElement {
 
       mwc-button > ha-svg-icon {
         vertical-align: text-bottom;
+      }
+
+      .browse-media-icon {
+        margin-left: 8px;
       }
     `;
   }

--- a/src/entrypoints/custom-panel.ts
+++ b/src/entrypoints/custom-panel.ts
@@ -51,11 +51,15 @@ function initialize(
   const style = document.createElement("style");
 
   style.innerHTML = `
-  body { margin:0; }
+  body {
+    margin:0;
+    background-color: var(--primary-background-color, #fafafa);
+    color: var(--primary-text-color, #212121);
+  }
   @media (prefers-color-scheme: dark) {
     body {
-      background-color: #111111;
-      color: #e1e1e1;
+      background-color: var(--primary-background-color, #111111);
+      color: var(--primary-text-color, #e1e1e1);
     }
   }`;
   document.head.appendChild(style);

--- a/src/mixins/lit-localize-lite-mixin.ts
+++ b/src/mixins/lit-localize-lite-mixin.ts
@@ -3,6 +3,8 @@ import { property } from "lit/decorators";
 import { computeLocalize, LocalizeFunc } from "../common/translations/localize";
 import { Constructor, Resources } from "../types";
 import { getLocalLanguage, getTranslation } from "../util/common-translation";
+import { translationMetadata } from "../resources/translations-metadata";
+import { computeDirectionStyles } from "../common/util/compute_rtl";
 
 const empty = () => "";
 
@@ -23,6 +25,14 @@ export const litLocalizeLiteMixin = <T extends Constructor<LitElement>>(
     public connectedCallback(): void {
       super.connectedCallback();
       this._initializeLocalizeLite();
+    }
+
+    protected firstUpdated(changedProps: PropertyValues) {
+      super.firstUpdated(changedProps);
+      computeDirectionStyles(
+        translationMetadata.translations[this.language!].isRTL,
+        this
+      );
     }
 
     protected updated(changedProperties: PropertyValues) {

--- a/src/panels/config/application_credentials/ha-config-application-credentials.ts
+++ b/src/panels/config/application_credentials/ha-config-application-credentials.ts
@@ -53,7 +53,6 @@ export class HaConfigApplicationCredentials extends LitElement {
           title: localize(
             "ui.panel.config.application_credentials.picker.headers.name"
           ),
-          width: "40%",
           direction: "asc",
           grows: true,
           template: (_, entry: ApplicationCredential) => html`${entry.name}`,

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -315,7 +315,8 @@ export class HaBlueprintAutomationEditor extends LitElement {
           padding: 0 16px 16px;
         }
         ha-textarea,
-        ha-textfield {
+        ha-textfield,
+        ha-blueprint-picker {
           display: block;
         }
         h3 {

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
@@ -106,7 +106,9 @@ export class HaCalendarTrigger extends LitElement implements TriggerElement {
     const offsetType = ev.detail.value.offset_type === "before" ? "-" : "";
     const newTrigger = {
       ...ev.detail.value,
-      offset: `${offsetType}${duration.hours}:${duration.minutes}:${duration.seconds}`,
+      offset: `${offsetType}${duration.hours ?? 0}:${duration.minutes ?? 0}:${
+        duration.seconds ?? 0
+      }`,
     };
     delete newTrigger.offset_type;
     fireEvent(this, "value-changed", { value: newTrigger });

--- a/src/panels/config/hardware/ha-config-hardware.ts
+++ b/src/panels/config/hardware/ha-config-hardware.ts
@@ -125,6 +125,7 @@ class HaConfigHardware extends LitElement {
                   <div class="card-content">
                     <mwc-list>
                       <mwc-list-item
+                        noninteractive
                         graphic=${ifDefined(imageURL ? "medium" : undefined)}
                         .twoline=${Boolean(boardId)}
                       >

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -694,6 +694,11 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
           justify-content: space-between;
         }
 
+        span[slot="meta"] {
+          font-size: 0.95em;
+          color: var(--primary-text-color);
+        }
+
         .network-status div.heading {
           display: flex;
           align-items: center;

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -80,44 +80,44 @@ class HaPanelHistory extends LitElement {
           </app-toolbar>
         </app-header>
 
-        <div class="flex content">
-          <div class="filters">
-            <ha-date-range-picker
-              .hass=${this.hass}
-              ?disabled=${this._isLoading}
-              .startDate=${this._startDate}
-              .endDate=${this._endDate}
-              .ranges=${this._ranges}
-              @change=${this._dateRangeChanged}
-            ></ha-date-range-picker>
+        <div class="filters">
+          <ha-date-range-picker
+            .hass=${this.hass}
+            ?disabled=${this._isLoading}
+            .startDate=${this._startDate}
+            .endDate=${this._endDate}
+            .ranges=${this._ranges}
+            @change=${this._dateRangeChanged}
+          ></ha-date-range-picker>
 
-            <ha-entity-picker
-              .hass=${this.hass}
-              .value=${this._entityId}
-              .label=${this.hass.localize(
-                "ui.components.entity.entity-picker.entity"
-              )}
-              .disabled=${this._isLoading}
-              @change=${this._entityPicked}
-            ></ha-entity-picker>
-          </div>
-          ${this._isLoading
-            ? html`<div class="progress-wrapper">
-                <ha-circular-progress
-                  active
-                  alt=${this.hass.localize("ui.common.loading")}
-                ></ha-circular-progress>
-              </div>`
-            : html`
-                <state-history-charts
-                  .hass=${this.hass}
-                  .historyData=${this._stateHistory}
-                  .endTime=${this._endDate}
-                  no-single
-                >
-                </state-history-charts>
-              `}
+          <ha-entity-picker
+            .hass=${this.hass}
+            .value=${this._entityId}
+            .label=${this.hass.localize(
+              "ui.components.entity.entity-picker.entity"
+            )}
+            .disabled=${this._isLoading}
+            @change=${this._entityPicked}
+          ></ha-entity-picker>
         </div>
+        ${this._isLoading
+          ? html`<div class="progress-wrapper">
+              <ha-circular-progress
+                active
+                alt=${this.hass.localize("ui.common.loading")}
+              ></ha-circular-progress>
+            </div>`
+          : html`
+              <state-history-charts
+                virtualize
+                .hass=${this.hass}
+                .historyData=${this._stateHistory}
+                .endTime=${this._endDate}
+                .narrow=${this.narrow}
+                no-single
+              >
+              </state-history-charts>
+            `}
       </ha-app-layout>
     `;
   }
@@ -235,12 +235,24 @@ class HaPanelHistory extends LitElement {
           padding: 0 16px 16px;
         }
 
+        state-history-charts {
+          height: calc(100vh - 136px);
+        }
+
+        :host([narrow]) state-history-charts {
+          height: calc(100vh - 198px);
+        }
+
         .progress-wrapper {
           height: calc(100vh - 136px);
         }
 
         :host([narrow]) .progress-wrapper {
           height: calc(100vh - 198px);
+        }
+
+        :host([virtualize]) {
+          height: 100%;
         }
 
         .progress-wrapper {

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -310,7 +310,7 @@ export class HaLogbook extends LitElement {
     // Put newest ones on top. Reverse works in-place so
     // make a copy first.
     const newEntries = [...streamMessage.events].reverse();
-    if (!this._logbookEntries) {
+    if (!this._logbookEntries || !this._logbookEntries.length) {
       this._logbookEntries = newEntries;
       return;
     }
@@ -320,14 +320,16 @@ export class HaLogbook extends LitElement {
       return;
     }
     const nonExpiredRecords = this._nonExpiredRecords(purgeBeforePythonTime);
-    this._logbookEntries =
-      newEntries[0].when >= this._logbookEntries[0].when
-        ? // The new records are newer than the old records
-          // append the old records to the end of the new records
-          newEntries.concat(nonExpiredRecords)
-        : // The new records are older than the old records
-          // append the new records to the end of the old records
-          nonExpiredRecords.concat(newEntries);
+    this._logbookEntries = !nonExpiredRecords.length
+      ? // All existing entries expired
+        newEntries
+      : newEntries[0].when >= nonExpiredRecords[0].when
+      ? // The new records are newer than the old records
+        // append the old records to the end of the new records
+        newEntries.concat(nonExpiredRecords)
+      : // The new records are older than the old records
+        // append the new records to the end of the old records
+        nonExpiredRecords.concat(newEntries);
   };
 
   private _updateTraceContexts = throttle(async () => {

--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -315,7 +315,11 @@ class HuiEnergyDistrubutionCard
                         ${formatNumber(gasUsage || 0, this.hass.locale, {
                           maximumFractionDigits: 1,
                         })}
-                        ${getEnergyGasUnit(this.hass, prefs) || "m³"}
+                        ${getEnergyGasUnit(
+                          this.hass,
+                          prefs,
+                          this._data.statsMetadata
+                        ) || "m³"}
                       </div>
                       <svg width="80" height="30">
                         <path d="M40 0 v30" id="gas" />

--- a/src/panels/lovelace/cards/energy/hui-energy-solar-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-solar-graph-card.ts
@@ -40,7 +40,11 @@ import {
   getEnergySolarForecasts,
   SolarSourceTypeEnergyPreference,
 } from "../../../../data/energy";
-import { Statistics } from "../../../../data/history";
+import {
+  Statistics,
+  StatisticsMetaData,
+  getStatisticLabel,
+} from "../../../../data/history";
 import { FrontendLocaleData } from "../../../../data/translation";
 import { SubscribeMixin } from "../../../../mixins/subscribe-mixin";
 import { HomeAssistant } from "../../../../types";
@@ -289,7 +293,12 @@ export class HuiEnergySolarGraphCard
       .trim();
 
     datasets.push(
-      ...this._processDataSet(energyData.stats, solarSources, solarColor)
+      ...this._processDataSet(
+        energyData.stats,
+        energyData.statsMetadata,
+        solarSources,
+        solarColor
+      )
     );
 
     if (energyData.statsCompare) {
@@ -307,6 +316,7 @@ export class HuiEnergySolarGraphCard
       datasets.push(
         ...this._processDataSet(
           energyData.statsCompare,
+          energyData.statsMetadata,
           solarSources,
           solarColor,
           true
@@ -339,6 +349,7 @@ export class HuiEnergySolarGraphCard
 
   private _processDataSet(
     statistics: Statistics,
+    statisticsMetaData: Record<string, StatisticsMetaData>,
     solarSources: SolarSourceTypeEnergyPreference[],
     solarColor: string,
     compare = false
@@ -346,8 +357,6 @@ export class HuiEnergySolarGraphCard
     const data: ChartDataset<"bar", ScatterDataPoint[]>[] = [];
 
     solarSources.forEach((source, idx) => {
-      const entity = this.hass.states[source.stat_energy_from];
-
       const modifiedColor =
         idx > 0
           ? this.hass.themes.darkMode
@@ -393,7 +402,11 @@ export class HuiEnergySolarGraphCard
         label: this.hass.localize(
           "ui.panel.lovelace.cards.energy.energy_solar_graph.production",
           {
-            name: entity ? computeStateName(entity) : source.stat_energy_from,
+            name: getStatisticLabel(
+              this.hass,
+              source.stat_energy_from,
+              statisticsMetaData
+            ),
           }
         ),
         borderColor: compare ? borderColor + "7F" : borderColor,

--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -128,7 +128,9 @@ export class HuiEnergySourcesTableCard
           flow.stat_cost || flow.entity_energy_price || flow.number_energy_price
       );
 
-    const gasUnit = getEnergyGasUnit(this.hass, this._data.prefs) || "";
+    const gasUnit =
+      getEnergyGasUnit(this.hass, this._data.prefs, this._data.statsMetadata) ||
+      "";
 
     const compare = this._data.statsCompare !== undefined;
 

--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -851,7 +851,9 @@ export class HuiEnergySourcesTableCard
                       )}
                     </th>
                     ${compare
-                      ? html`<td class="mdc-data-table__cell">
+                      ? html`<td
+                            class="mdc-data-table__cell mdc-data-table__cell--numeric"
+                          >
                             ${formatNumber(
                               totalGasCostCompare + totalGridCostCompare,
                               this.hass.locale,
@@ -862,9 +864,7 @@ export class HuiEnergySourcesTableCard
                             )}
                           </td>
                           ${showCosts
-                            ? html`<td
-                                class="mdc-data-table__cell mdc-data-table__cell--numeric"
-                              ></td>`
+                            ? html`<td class="mdc-data-table__cell"></td>`
                             : ""}`
                       : ""}
                     <td class="mdc-data-table__cell"></td>

--- a/src/panels/lovelace/components/hui-energy-period-selector.ts
+++ b/src/panels/lovelace/components/hui-energy-period-selector.ts
@@ -1,5 +1,10 @@
 import "@material/mwc-button/mwc-button";
-import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
+import {
+  mdiChevronLeft,
+  mdiChevronRight,
+  mdiCompare,
+  mdiCompareRemove,
+} from "@mdi/js";
 import {
   addDays,
   addMonths,
@@ -40,13 +45,15 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
 
   @property() public collectionKey?: string;
 
+  @property({ type: Boolean, reflect: true }) public narrow = false;
+
   @state() _startDate?: Date;
 
   @state() _endDate?: Date;
 
   @state() private _period?: "day" | "week" | "month" | "year";
 
-  @state() private _compare? = false;
+  @state() private _compare = false;
 
   public connectedCallback() {
     super.connectedCallback();
@@ -136,14 +143,24 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
             dense
             @value-changed=${this._handleView}
           ></ha-button-toggle-group>
-          <mwc-button
-            class="compare ${this._compare ? "active" : ""}"
-            @click=${this._toggleCompare}
-            dense
-            outlined
-          >
-            Compare data
-          </mwc-button>
+          ${this.narrow
+            ? html`<ha-icon-button
+                class="compare ${this._compare ? "active" : ""}"
+                .path=${this._compare ? mdiCompareRemove : mdiCompare}
+                @click=${this._toggleCompare}
+                dense
+                outlined
+              >
+                Compare data
+              </ha-icon-button>`
+            : html`<mwc-button
+                class="compare ${this._compare ? "active" : ""}"
+                @click=${this._toggleCompare}
+                dense
+                outlined
+              >
+                Compare data
+              </mwc-button>`}
         </div>
       </div>
     `;
@@ -260,9 +277,6 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
       :host([narrow]) .row {
         flex-direction: column-reverse;
       }
-      :host([narrow]) .period {
-        margin-bottom: 8px;
-      }
       .label {
         display: flex;
         justify-content: flex-end;
@@ -275,6 +289,17 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
         justify-content: flex-end;
         align-items: flex-end;
       }
+      :host([narrow]) .period {
+        margin-bottom: 8px;
+      }
+      mwc-button {
+        margin-left: 8px;
+      }
+      ha-icon-button {
+        margin-left: 4px;
+        --mdc-icon-size: 20px;
+      }
+      ha-icon-button.active::before,
       mwc-button.active::before {
         top: 0;
         left: 0;
@@ -288,14 +313,11 @@ export class HuiEnergyPeriodSelector extends SubscribeMixin(LitElement) {
         transition: opacity 15ms linear, background-color 15ms linear;
         opacity: var(--mdc-icon-button-ripple-opacity, 0.12);
       }
+      ha-icon-button.active::before {
+        border-radius: 50%;
+      }
       .compare {
         position: relative;
-        margin-left: 8px;
-        width: max-content;
-      }
-      :host([narrow]) .compare {
-        margin-left: auto;
-        margin-top: 8px;
       }
       :host {
         --mdc-button-outline-color: currentColor;

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -1,6 +1,9 @@
 import { atLeastVersion } from "../common/config/version";
 import { computeLocalize, LocalizeFunc } from "../common/translations/localize";
-import { computeRTLDirection } from "../common/util/compute_rtl";
+import {
+  computeRTLDirection,
+  setDirectionStyles,
+} from "../common/util/compute_rtl";
 import { debounce } from "../common/util/debounce";
 import {
   getHassTranslations,
@@ -188,17 +191,8 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
 
     private _applyDirection(hass: HomeAssistant) {
       const direction = computeRTLDirection(hass);
-      this.style.direction = direction;
       document.dir = direction;
-      this.style.setProperty("--direction", direction);
-      this.style.setProperty(
-        "--float-start",
-        direction === "ltr" ? "left" : "right"
-      );
-      this.style.setProperty(
-        "--float-end",
-        direction === "ltr" ? "right" : "left"
-      );
+      setDirectionStyles(direction, this);
     }
 
     /**

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2376,6 +2376,7 @@
               "instance_is_available": "Your instance is available at your",
               "instance_will_be_available": "Your instance will be available at your",
               "link_learn_how_it_works": "Learn how it works",
+              "nabu_casa_url": "Nabu Casa URL",
               "certificate_info": "Certificate Info"
             },
             "alexa": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3405,7 +3405,8 @@
               "go_to_energy_dashboard": "Go to the energy dashboard"
             },
             "energy_devices_graph": {
-              "energy_usage": "Energy usage"
+              "energy_usage": "Energy usage",
+              "previous_energy_usage": "Previous energy usage"
             },
             "carbon_consumed_gauge": {
               "card_indicates_energy_used": "This card indicates how much of the energy consumed by your home was generated using non-fossil fuels like solar, wind and nuclear. The higher, the better!",

--- a/src/util/brands-url.ts
+++ b/src/util/brands-url.ts
@@ -23,3 +23,6 @@ export const hardwareBrandsUrl = (options: HardwareBrandsOptions): string =>
   }${options.manufacturer}${options.model ? `_${options.model}` : ""}.png`;
 
 export const extractDomainFromBrandUrl = (url: string) => url.split("/")[4];
+
+export const isBrandUrl = (thumbnail: string | ""): boolean =>
+  thumbnail.startsWith("https://brands.home-assistant.io/");


### PR DESCRIPTION
## What's Changed

* Add compare data to individual devices graph (#12829) @bramkragten
* Use icon button for compare on narrow (#12831) @bramkragten
* Add proper label for gas energy stats (#12828) @pszafer
* Fix live logbook starting empty (#12833) @bdraco
* Virtualize history panel (#12824) @bdraco
* Make blueprint picker wider (#12830) @bramkragten
* RTL Auth fix (#12746) @yosilevy
* Actually add Cloud URL Translation.... (#12813) @zsarnett
* Scale oversized brand thumbnails in media browser (#12820) @wizmo2
* Fallback to 0 for undefined offsets (#12823) @ludeeus
* Fix color of plant entity when state is problem (#12821) @tgl0be
* Prefer CSS variables in custom panel entrypoint (#12818) @ludeeus
* Use supervisor envs instead of hassio (#12812) @ludeeus
* Update style of zwave_js controller statistics (#12810) @raman325
* Align "Browse Media" button while being wrapped (#12800) @spacegaier
* Fix width of application creds page (#12806) @bramkragten
* Add redirects to cast to catch some common mistakes in custom cards (#12808) @balloob