### PR TITLE
Add announce: true when sending TTS from media browser

### DIFF
--- a/src/components/media-player/ha-browse-media-tts.ts
+++ b/src/components/media-player/ha-browse-media-tts.ts
@@ -36,7 +36,7 @@ declare global {
 class BrowseMediaTTS extends LitElement {
   @property() public hass!: HomeAssistant;
 
-  @property() public item;
+  @property() public item!: MediaPlayerItem;
 
   @property() public action!: MediaPlayerBrowseAction;
 

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -36,6 +36,7 @@ import { supportsFeature } from "../common/entity/supports-feature";
 import { MediaPlayerItemId } from "../components/media-player/ha-media-player-browse";
 import type { HomeAssistant } from "../types";
 import { UNAVAILABLE_STATES } from "./entity";
+import { isTTSMediaSource } from "./tts";
 
 interface MediaPlayerEntityAttributes extends HassEntityAttributeBase {
   media_content_id?: string;
@@ -441,3 +442,29 @@ export const handleMediaControlClick = (
           entity_id: stateObj!.entity_id,
         }
   );
+
+export const mediaPlayerPlayMedia = (
+  hass: HomeAssistant,
+  entity_id: string,
+  media_content_id: string,
+  media_content_type: string,
+  extra: {
+    enqueue?: "play" | "next" | "add" | "replace";
+    announce?: boolean;
+  } = {}
+) => {
+  // We set text-to-speech to announce.
+  if (
+    !extra.enqueue &&
+    extra.announce === undefined &&
+    isTTSMediaSource(media_content_id)
+  ) {
+    extra.announce = true;
+  }
+  return hass.callService("media_player", "play_media", {
+    entity_id,
+    media_content_id,
+    media_content_type,
+    ...extra,
+  });
+};

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -26,6 +26,7 @@ import {
   handleMediaControlClick,
   MediaPickedEvent,
   MediaPlayerEntity,
+  mediaPlayerPlayMedia,
   SUPPORT_BROWSE_MEDIA,
   SUPPORT_PLAY_MEDIA,
   SUPPORT_SELECT_SOUND_MODE,
@@ -305,18 +306,12 @@ class MoreInfoMediaPlayer extends LitElement {
       action: "play",
       entityId: this.stateObj!.entity_id,
       mediaPickedCallback: (pickedMedia: MediaPickedEvent) =>
-        this._playMedia(
+        mediaPlayerPlayMedia(
+          this.hass,
+          this.stateObj!.entity_id,
           pickedMedia.item.media_content_id,
           pickedMedia.item.media_content_type
         ),
-    });
-  }
-
-  private _playMedia(media_content_id: string, media_content_type: string) {
-    this.hass!.callService("media_player", "play_media", {
-      entity_id: this.stateObj!.entity_id,
-      media_content_id,
-      media_content_type,
     });
   }
 }

--- a/src/panels/lovelace/cards/hui-media-control-card.ts
+++ b/src/panels/lovelace/cards/hui-media-control-card.ts
@@ -31,6 +31,7 @@ import {
   handleMediaControlClick,
   MediaPickedEvent,
   MediaPlayerEntity,
+  mediaPlayerPlayMedia,
   SUPPORT_BROWSE_MEDIA,
   SUPPORT_SEEK,
   SUPPORT_TURN_ON,
@@ -489,18 +490,12 @@ export class HuiMediaControlCard extends LitElement implements LovelaceCard {
       action: "play",
       entityId: this._config!.entity,
       mediaPickedCallback: (pickedMedia: MediaPickedEvent) =>
-        this._playMedia(
+        mediaPlayerPlayMedia(
+          this.hass,
+          this._config!.entity,
           pickedMedia.item.media_content_id,
           pickedMedia.item.media_content_type
         ),
-    });
-  }
-
-  private _playMedia(media_content_id: string, media_content_type: string) {
-    this.hass!.callService("media_player", "play_media", {
-      entity_id: this._config!.entity,
-      media_content_id,
-      media_content_type,
     });
   }
 

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -27,6 +27,7 @@ import {
   BROWSER_PLAYER,
   MediaPickedEvent,
   MediaPlayerItem,
+  mediaPlayerPlayMedia,
 } from "../../data/media-player";
 import {
   ResolvedMediaSource,
@@ -208,11 +209,12 @@ class PanelMediaBrowser extends LitElement {
     if (this._entityId !== BROWSER_PLAYER) {
       this._player.showResolvingNewMediaPicked();
       try {
-        await this.hass!.callService("media_player", "play_media", {
-          entity_id: this._entityId,
-          media_content_id: item.media_content_id,
-          media_content_type: item.media_content_type,
-        });
+        await mediaPlayerPlayMedia(
+          this.hass,
+          this._entityId,
+          item.media_content_id,
+          item.media_content_type
+        );
       } catch (err) {
         this._player.hideResolvingNewMediaPicked();
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Default `announce` to `true` when sending TTS to a media player when TTS triggered via the frontend (media browser).

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
