### PR TITLE
Add templates to conditional card

### DIFF
--- a/src/panels/lovelace/cards/hui-conditional-card.ts
+++ b/src/panels/lovelace/cards/hui-conditional-card.ts
@@ -29,6 +29,8 @@ class HuiConditionalCard extends HuiConditionalBase implements LovelaceCard {
       throw new Error("No card configured");
     }
 
+    this._updateTemplates();
+
     this._element = this._createCardElement(config.card);
   }
 

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -1,5 +1,10 @@
+import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { PropertyValues, ReactiveElement } from "lit";
 import { customElement, property } from "lit/decorators";
+import {
+  RenderTemplateResult,
+  subscribeRenderTemplate,
+} from "../../../data/ws-templates";
 import { HomeAssistant } from "../../../types";
 import { ConditionalCardConfig } from "../cards/types";
 import {
@@ -16,6 +21,10 @@ export class HuiConditionalBase extends ReactiveElement {
   @property() public editMode?: boolean;
 
   @property() protected _config?: ConditionalCardConfig | ConditionalRowConfig;
+
+  protected _templateResults?: Record<string, RenderTemplateResult>;
+
+  protected _templateUnsubRender?: Promise<UnsubscribeFunc>[];
 
   @property({ type: Boolean, reflect: true }) public hidden = false;
 
@@ -47,8 +56,81 @@ export class HuiConditionalBase extends ReactiveElement {
     this._config = config;
   }
 
+  public connectedCallback() {
+    super.connectedCallback();
+    if (!this._config) {
+      return;
+    }
+
+    this._updateTemplates();
+  }
+
+  public disconnectedCallback() {
+    if (this._templateUnsubRender) {
+      this._templateUnsubRender.forEach(this._unsubscribeTemplate);
+    }
+  }
+
+  protected async _updateTemplates() {
+    if (this._templateUnsubRender) {
+      this._templateUnsubRender.forEach(this._unsubscribeTemplate);
+    }
+
+    this._templateUnsubRender = [];
+    this._templateResults = {};
+
+    this._config?.conditions
+      .filter((condition) => condition.template)
+      .forEach((condition) => {
+        this._subscribeTemplate(condition.template!);
+      });
+  }
+
+  private async _subscribeTemplate(template: string) {
+    if (!this.hass) {
+      return;
+    }
+    const unsub = subscribeRenderTemplate(
+      this.hass!.connection,
+      (result) => {
+        this._templateResults![template] = result;
+        this.updateVisible();
+      },
+      {
+        template: template,
+        timeout: 3,
+        strict: true,
+      }
+    );
+    this._templateUnsubRender?.push(unsub);
+    await unsub;
+  }
+
+  private async _unsubscribeTemplate(
+    unsubPromise: Promise<UnsubscribeFunc>
+  ): Promise<void> {
+    if (!unsubPromise) {
+      return;
+    }
+
+    try {
+      const unsub = await unsubPromise;
+      unsub();
+    } catch (err: any) {
+      if (err.code === "not_found") {
+        // If we get here, the connection was probably already closed. Ignore.
+      } else {
+        throw err;
+      }
+    }
+  }
+
   protected update(changed: PropertyValues): void {
     super.update(changed);
+    this.updateVisible();
+  }
+
+  protected updateVisible(): void {
     if (!this._element || !this.hass || !this._config) {
       return;
     }
@@ -56,7 +138,12 @@ export class HuiConditionalBase extends ReactiveElement {
     this._element.editMode = this.editMode;
 
     const visible =
-      this.editMode || checkConditionsMet(this._config.conditions, this.hass);
+      this.editMode ||
+      checkConditionsMet(
+        this._config.conditions,
+        this.hass,
+        this._templateResults!
+      );
     this.hidden = !visible;
 
     this.style.setProperty("display", visible ? "" : "none");

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -1,6 +1,6 @@
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { PropertyValues, ReactiveElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import {
   RenderTemplateResult,
   subscribeRenderTemplate,
@@ -18,9 +18,9 @@ import { LovelaceCard } from "../types";
 export class HuiConditionalBase extends ReactiveElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @property() public editMode?: boolean;
+  @property({ type: Boolean }) public editMode?: boolean;
 
-  @property() protected _config?: ConditionalCardConfig | ConditionalRowConfig;
+  @state() protected _config?: ConditionalCardConfig | ConditionalRowConfig;
 
   protected _templateResults?: Record<string, RenderTemplateResult>;
 

--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -399,6 +399,7 @@ export class HuiConditionalCardEditor
         .condition .template ha-code-editor,
         .condition .entity ha-entity-picker {
           flex-grow: 1;
+          min-width: 0; /* Avoid overflowing */
         }
         .remove-icon {
           --mdc-icon-button-size: 36px;

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -87,9 +87,10 @@ const conditionalEntitiesRowConfigStruct = object({
   row: any(),
   conditions: array(
     object({
-      entity: string(),
+      entity: optional(string()),
       state: optional(string()),
       state_not: optional(string()),
+      template: optional(string()),
     })
   ),
 });

--- a/src/panels/lovelace/elements/hui-conditional-element.ts
+++ b/src/panels/lovelace/elements/hui-conditional-element.ts
@@ -58,7 +58,7 @@ class HuiConditionalElement extends HTMLElement implements LovelaceElement {
       return;
     }
 
-    const visible = checkConditionsMet(this._config.conditions, this._hass);
+    const visible = checkConditionsMet(this._config.conditions, this._hass, {});
 
     this._elements.forEach((el: LovelaceElement) => {
       if (visible) {

--- a/src/panels/lovelace/special-rows/hui-conditional-row.ts
+++ b/src/panels/lovelace/special-rows/hui-conditional-row.ts
@@ -13,6 +13,8 @@ class HuiConditionalRow extends HuiConditionalBase implements LovelaceRow {
   public setConfig(config: ConditionalRowConfig): void {
     this.validateConfig(config);
 
+    this._updateTemplates();
+
     if (!config.row) {
       throw new Error("No row configured");
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3971,7 +3971,8 @@
               "state_not_equal": "State is not equal to",
               "current_state": "current",
               "condition_explanation": "The card will be shown when ALL conditions below are fulfilled.",
-              "change_type": "Change type"
+              "change_type": "Change type",
+              "template": "Template"
             },
             "config": {
               "required": "required",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3971,8 +3971,7 @@
               "state_not_equal": "State is not equal to",
               "current_state": "current",
               "condition_explanation": "The card will be shown when ALL conditions below are fulfilled.",
-              "change_type": "Change type",
-              "template": "Template"
+              "change_type": "Change type"
             },
             "config": {
               "required": "required",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This feature adds the ability to use a template rather than entity state to show/hide a conditional card.

The logic where all conditions must be met for the card to show still remains as is (ie AND logic). But this opens up the ability for much more in terms of custom logic or utilising attributes/template filters.

Similarly to the entity row card, the UI editor will default to entity state when adding a new row. However, if the configuration has a template configured, then the UI will allow editing of this including the entity autocomplete.

I have also added a remove button to the rows, to make deleting a condition in the UI easier.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Conditonal Card:
```yaml
type: conditional
conditions:
  - template: '{{ state_attr("climate.ecobee", "current_temperature") > 22 }}'
card:
  type: thermostat
  entity: climate.ecobee
```

Conditional Row in Entities Card:
```yaml
type: entities
entities:
  - entity: switch.ac
  - type: conditional
    conditions:
      - template: '{{ state_attr("climate.ecobee", "current_temperature") > 22 }}'
    row:
      entity: climate.ecobee
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

![image](https://user-images.githubusercontent.com/1644496/171972508-9bd88778-ee6e-4aac-aa69-0198996c60c5.png)


- This PR fixes or closes issue: fixes 
- This PR is related to issue or discussion: #11403
- Link to documentation pull request: TBD

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
