### PR TITLE
Fix history charts not auto refreshing with cached history

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -11,6 +11,8 @@ import { classMap } from "lit/directives/class-map";
 import { styleMap } from "lit/directives/style-map";
 import { clamp } from "../../common/number/clamp";
 
+export const MIN_TIME_BETWEEN_UPDATES = 60 * 5 * 1000;
+
 interface Tooltip extends TooltipModel<any> {
   top: string;
   left: string;

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -9,7 +9,7 @@ import { numberFormatToLocale } from "../../common/number/format_number";
 import { computeRTL } from "../../common/util/compute_rtl";
 import { TimelineEntity } from "../../data/history";
 import { HomeAssistant } from "../../types";
-import "./ha-chart-base";
+import { MIN_TIME_BETWEEN_UPDATES } from "./ha-chart-base";
 import type { TimeLineData } from "./timeline-chart/const";
 
 /** Binary sensor device classes for which the static colors for on/off are NOT inverted.
@@ -102,6 +102,8 @@ export class StateHistoryChartTimeline extends LitElement {
   @state() private _chartData?: ChartData<"timeline">;
 
   @state() private _chartOptions?: ChartOptions<"timeline">;
+
+  private _chartTime: Date = new Date();
 
   protected render() {
     return html`
@@ -211,7 +213,13 @@ export class StateHistoryChartTimeline extends LitElement {
         locale: numberFormatToLocale(this.hass.locale),
       };
     }
-    if (changedProps.has("data")) {
+    if (
+      changedProps.has("data") ||
+      this._chartTime <
+        new Date(this.endTime.getTime() - MIN_TIME_BETWEEN_UPDATES)
+    ) {
+      // If the line is more than 5 minutes old, re-gen it
+      // so the X axis grows even if there is no new data
       this._generateData();
     }
   }
@@ -224,6 +232,7 @@ export class StateHistoryChartTimeline extends LitElement {
       stateHistory = [];
     }
 
+    this._chartTime = new Date();
     const startTime = this.startTime;
     const endTime = this.endTime;
     const labels: string[] = [];

--- a/src/data/cached-history.ts
+++ b/src/data/cached-history.ts
@@ -162,9 +162,10 @@ export const getRecentWithCache = (
         mergeLine(stateHistory.line, cache.data.line);
       }
       if (stateHistory.timeline.length) {
-        mergeTimeline(stateHistory.timeline, cache.data.timeline);
-        // Replace the timeline array to force an update
-        cache.data.timeline = [...cache.data.timeline];
+        cache.data.timeline = mergeTimeline(
+          stateHistory.timeline,
+          cache.data.timeline
+        );
       }
       pruneStartTime(startTime, cache.data);
     } else {
@@ -209,16 +210,18 @@ const mergeTimeline = (
   historyTimelines: TimelineEntity[],
   cacheTimelines: TimelineEntity[]
 ) => {
+  const mergedTimelines: TimelineEntity[] = [];
   historyTimelines.forEach((timeline) => {
     const oldTimeline = cacheTimelines.find(
       (cacheTimeline) => cacheTimeline.entity_id === timeline.entity_id
     );
-    if (oldTimeline) {
-      oldTimeline.data = oldTimeline.data.concat(timeline.data);
-    } else {
-      cacheTimelines.push(timeline);
-    }
+    mergedTimelines.push(
+      oldTimeline
+        ? { ...oldTimeline, data: oldTimeline.data.concat(timeline.data) }
+        : timeline
+    );
   });
+  return mergedTimelines;
 };
 
 const pruneArray = (originalStartTime: Date, arr) => {

--- a/src/data/cached-history.ts
+++ b/src/data/cached-history.ts
@@ -162,10 +162,9 @@ export const getRecentWithCache = (
         mergeLine(stateHistory.line, cache.data.line);
       }
       if (stateHistory.timeline.length) {
-        cache.data.timeline = mergeTimeline(
-          stateHistory.timeline,
-          cache.data.timeline
-        );
+        mergeTimeline(stateHistory.timeline, cache.data.timeline);
+        // Replace the timeline array to force an update
+        cache.data.timeline = [...cache.data.timeline];
       }
       pruneStartTime(startTime, cache.data);
     } else {
@@ -210,18 +209,16 @@ const mergeTimeline = (
   historyTimelines: TimelineEntity[],
   cacheTimelines: TimelineEntity[]
 ) => {
-  const mergedTimelines: TimelineEntity[] = [];
   historyTimelines.forEach((timeline) => {
     const oldTimeline = cacheTimelines.find(
       (cacheTimeline) => cacheTimeline.entity_id === timeline.entity_id
     );
-    mergedTimelines.push(
-      oldTimeline
-        ? { ...oldTimeline, data: oldTimeline.data.concat(timeline.data) }
-        : timeline
-    );
+    if (oldTimeline) {
+      oldTimeline.data = oldTimeline.data.concat(timeline.data);
+    } else {
+      cacheTimelines.push(timeline);
+    }
   });
-  return mergedTimelines;
 };
 
 const pruneArray = (originalStartTime: Date, arr) => {

--- a/src/data/cached-history.ts
+++ b/src/data/cached-history.ts
@@ -158,8 +158,14 @@ export const getRecentWithCache = (
     }
     const stateHistory = computeHistory(hass, fetchedHistory, localize);
     if (appendingToCache) {
-      mergeLine(stateHistory.line, cache.data.line);
-      mergeTimeline(stateHistory.timeline, cache.data.timeline);
+      if (stateHistory.line.length) {
+        mergeLine(stateHistory.line, cache.data.line);
+      }
+      if (stateHistory.timeline.length) {
+        mergeTimeline(stateHistory.timeline, cache.data.timeline);
+        // Replace the timeline array to force an update
+        cache.data.timeline = [...cache.data.timeline];
+      }
       pruneStartTime(startTime, cache.data);
     } else {
       cache.data = stateHistory;
@@ -191,6 +197,8 @@ const mergeLine = (
           oldLine.data.push(entity);
         }
       });
+      // Replace the cached line data to force an update
+      oldLine.data = [...oldLine.data];
     } else {
       cacheLines.push(line);
     }


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The git archaeology on this is very difficult to sort out. Best I can tell: while fixing the history caching in https://github.com/home-assistant/frontend/pull/12788 made the cache work now (so we aren't constantly overloading the backend with history requests), it also re-introduced a regression similar to #2061 . I'm not sure that original issue was completely fixed, but the working theory is that since the history cache was no longer effective after #7072 it had the effect of solving it and fixing the history cache reintroduced the regression.

Fixes #12859

Unrelated to this PR, but I think `getRecent`  (not `getRecentWithCache`) is dead code AFAICT.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
