### PR TITLE
Fix multiple races in logbook subscriptions

### DIFF
--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -1,4 +1,4 @@
-import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
+import { HassEntity } from "home-assistant-js-websocket";
 import {
   BINARY_STATE_OFF,
   BINARY_STATE_ON,
@@ -175,7 +175,7 @@ export const subscribeLogbook = (
   endDate: string,
   entityIds?: string[],
   deviceIds?: string[]
-): Promise<UnsubscribeFunc> => {
+): Promise<() => Promise<void>> => {
   // If all specified filters are empty lists, we can return an empty list.
   if (
     (entityIds || deviceIds) &&

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -206,7 +206,14 @@ export class HaLogbook extends LitElement {
   private _unsubscribeAndEmptyEntries() {
     this._logbookEntries = [];
     if (this._subscribed) {
-      this._subscribed.then((unsub) => (unsub ? unsub() : undefined));
+      this._subscribed
+        .then((unsub) => (unsub ? unsub() : undefined))
+        .catch(() => {
+          // The backend will cancel the subscription if
+          // we subscribe to entities that will all be
+          // filtered away
+          this._subscribed = undefined;
+        });
       this._subscribed = undefined;
     }
   }

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -212,7 +212,6 @@ export class HaLogbook extends LitElement {
           // The backend will cancel the subscription if
           // we subscribe to entities that will all be
           // filtered away
-          this._subscribed = undefined;
         });
       this._subscribed = undefined;
     }

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -136,7 +136,7 @@ export class HaLogbook extends LitElement {
       return;
     }
 
-    this._unsubscribeAndEmptyEntries();
+    this._unsubscribe();
     this._throttleGetLogbookEntries.cancel();
     this._updateTraceContexts.cancel();
     this._updateUsers.cancel();
@@ -148,6 +148,7 @@ export class HaLogbook extends LitElement {
       );
     }
 
+    this._logbookEntries = undefined;
     this._throttleGetLogbookEntries();
   }
 
@@ -189,6 +190,13 @@ export class HaLogbook extends LitElement {
       (!entityIds || entityIds.length === 0) &&
       (!deviceIds || deviceIds.length === 0)
     );
+  }
+
+  private _unsubscribe(): void {
+    if (this._subscribed) {
+      this._subscribed.then((unsub) => (unsub ? unsub() : undefined));
+      this._subscribed = undefined;
+    }
   }
 
   public connectedCallback() {

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -216,19 +216,21 @@ export class HaLogbook extends LitElement {
     this._unsubscribeSetLoading();
   }
 
+  /** Unsubscribe because we are unloading
+   * or about to resubscribe.
+   * Setting this._logbookEntries to undefined
+   * will put the page in a loading state.
+   */
   private _unsubscribeSetLoading() {
-    // Unsubscribe because we are unloading
-    // or about to resubscribe.
-    // Setting this._logbookEntries to undefined
-    // will put the page in a loading state.
     this._logbookEntries = undefined;
     this._unsubscribe();
   }
 
+  /** Unsubscribe because there are no results.
+   * Setting this._logbookEntries to an empty
+   * list will show a no results message.
+   */
   private _unsubscribeNoResults() {
-    // Unsubscribe because there are no results.
-    // Setting this._logbookEntries to an empty
-    // list will show a no results message.
     this._logbookEntries = [];
     this._unsubscribe();
   }

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -151,9 +151,16 @@ export class HaLogbook extends LitElement {
     this._throttleGetLogbookEntries();
   }
 
-  protected updated(changedProps: PropertyValues): void {
-    super.updated(changedProps);
+  protected shouldUpdate(changedProps: PropertyValues): boolean {
+    if (changedProps.size !== 1 || !changedProps.has("hass")) {
+      return true;
+    }
+    // We only respond to hass changes if the translations changed
+    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+    return !oldHass || oldHass.localize !== this.hass.localize;
+  }
 
+  protected updated(changedProps: PropertyValues): void {
     let changed = changedProps.has("time");
 
     for (const key of ["entityIds", "deviceIds"]) {
@@ -287,8 +294,8 @@ export class HaLogbook extends LitElement {
       ensureArray(this.entityIds),
       ensureArray(this.deviceIds)
     ).catch((err) => {
-      this._error = err.message;
       this._subscribed = undefined;
+      this._error = err;
     });
     return true;
   }

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -136,7 +136,7 @@ export class HaLogbook extends LitElement {
       return;
     }
 
-    this._unsubscribe();
+    this._unsubscribeAndEmptyEntries();
     this._throttleGetLogbookEntries.cancel();
     this._updateTraceContexts.cancel();
     this._updateUsers.cancel();
@@ -148,7 +148,6 @@ export class HaLogbook extends LitElement {
       );
     }
 
-    this._logbookEntries = undefined;
     this._throttleGetLogbookEntries();
   }
 
@@ -192,13 +191,6 @@ export class HaLogbook extends LitElement {
     );
   }
 
-  private _unsubscribe(): void {
-    if (this._subscribed) {
-      this._subscribed.then((unsub) => (unsub ? unsub() : undefined));
-      this._subscribed = undefined;
-    }
-  }
-
   public connectedCallback() {
     super.connectedCallback();
     if (this.hasUpdated) {
@@ -212,7 +204,7 @@ export class HaLogbook extends LitElement {
   }
 
   private _unsubscribeAndEmptyEntries() {
-    this._logbookEntries = [];
+    this._logbookEntries = undefined;
     if (this._subscribed) {
       this._subscribed
         .then((unsub) => (unsub ? unsub() : undefined))


### PR DESCRIPTION

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

- If the user switched between tabs quickly there could be
  logbook messages delivered after we switch tabs but before
  we complete the unsubscribe

- If they return to the tab to quickly the logbook data would
  not have been removed and the new subscription could get
  appended to it causing duplicate events to appear

- Catch the backend unsubscribing the stream when everything requested
  is filtered (like the error seen here https://github.com/home-assistant/core/issues/72963#issuecomment-1145773415)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
