### PR TITLE
Add container list and ARIA to create helper listbox

### DIFF
--- a/src/panels/config/helpers/dialog-helper-detail.ts
+++ b/src/panels/config/helpers/dialog-helper-detail.ts
@@ -133,45 +133,54 @@ export class DialogHelperDetail extends LitElement {
       items.sort((a, b) => a[1].localeCompare(b[1]));
 
       content = html`
-        ${items.map(([domain, label]) => {
-          // Only OG helpers need to be loaded prior adding one
-          const isLoaded =
-            !(domain in HELPERS) || isComponentLoaded(this.hass, domain);
-          return html`
-            <mwc-list-item
-              .disabled=${!isLoaded}
-              .domain=${domain}
-              @click=${this._domainPicked}
-              @keydown=${this._handleEnter}
-              dialogInitialFocus
-              graphic="icon"
-            >
-              <img
-                slot="graphic"
-                loading="lazy"
-                src=${brandsUrl({
-                  domain,
-                  type: "icon",
-                  useFallback: true,
-                  darkOptimized: this.hass.themes?.darkMode,
-                })}
-                referrerpolicy="no-referrer"
-              />
-              <span class="item-text"> ${label} </span>
-            </mwc-list-item>
-            ${!isLoaded
-              ? html`
-                  <paper-tooltip animation-delay="0"
-                    >${this.hass.localize(
-                      "ui.dialogs.helper_settings.platform_not_loaded",
-                      "platform",
-                      domain
-                    )}</paper-tooltip
-                  >
-                `
-              : ""}
-          `;
-        })}
+        <mwc-list
+          innerRole="listbox"
+          itemRoles="option"
+          innerAriaLabel=${this.hass.localize(
+            "ui.panel.config.helpers.dialog.create_helper"
+          )}
+          rootTabbable
+          dialogInitialFocus
+        >
+          ${items.map(([domain, label]) => {
+            // Only OG helpers need to be loaded prior adding one
+            const isLoaded =
+              !(domain in HELPERS) || isComponentLoaded(this.hass, domain);
+            return html`
+              <mwc-list-item
+                .disabled=${!isLoaded}
+                .domain=${domain}
+                @request-selected=${this._domainPicked}
+                graphic="icon"
+              >
+                <img
+                  slot="graphic"
+                  loading="lazy"
+                  src=${brandsUrl({
+                    domain,
+                    type: "icon",
+                    useFallback: true,
+                    darkOptimized: this.hass.themes?.darkMode,
+                  })}
+                  aria-hidden="true"
+                  referrerpolicy="no-referrer"
+                />
+                <span class="item-text"> ${label} </span>
+              </mwc-list-item>
+              ${!isLoaded
+                ? html`
+                    <paper-tooltip animation-delay="0"
+                      >${this.hass.localize(
+                        "ui.dialogs.helper_settings.platform_not_loaded",
+                        "platform",
+                        domain
+                      )}</paper-tooltip
+                    >
+                  `
+                : ""}
+            `;
+          })}
+        </mwc-list>
         <mwc-button slot="primaryAction" @click=${this.closeDialog}>
           ${this.hass!.localize("ui.common.cancel")}
         </mwc-button>
@@ -218,15 +227,6 @@ export class DialogHelperDetail extends LitElement {
     } finally {
       this._submitting = false;
     }
-  }
-
-  private _handleEnter(ev: KeyboardEvent) {
-    if (ev.keyCode !== 13) {
-      return;
-    }
-    ev.stopPropagation();
-    ev.preventDefault();
-    this._domainPicked(ev);
   }
 
   private _domainPicked(ev: Event): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This list had list items but no container list element, which is what provides good keyboard navigation.  This change adds the list element and proper ARIA roles.  The enter key handler is not needed as the list handles this correctly.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

