### PR TITLE
Add button to request an update

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -1,7 +1,7 @@
 import "@material/mwc-button";
 import "@material/mwc-tab";
 import "@material/mwc-tab-bar";
-import { mdiClose, mdiCog, mdiPencil } from "@mdi/js";
+import { mdiClose, mdiCog, mdiPencil, mdiUpdate } from "@mdi/js";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { cache } from "lit/directives/cache";
@@ -23,7 +23,10 @@ import { showEntityEditorDialog } from "../../panels/config/entities/show-dialog
 import { haStyleDialog } from "../../resources/styles";
 import "../../state-summary/state-card-content";
 import { HomeAssistant } from "../../types";
-import { showConfirmationDialog } from "../generic/show-dialog-box";
+import {
+  showAlertDialog,
+  showConfirmationDialog,
+} from "../generic/show-dialog-box";
 import { replaceDialog } from "../make-dialog-manager";
 import "./controls/more-info-default";
 import "./ha-more-info-history";
@@ -127,6 +130,14 @@ export class MoreInfoDialog extends LitElement {
             >
               ${name}
             </div>
+            <ha-icon-button
+              slot="actionItems"
+              .label=${this.hass.localize(
+                "ui.dialogs.more_info_control.request_update"
+              )}
+              .path=${mdiUpdate}
+              @click=${this._updateEntity}
+            ></ha-icon-button>
             ${this.hass.user!.is_admin
               ? html`
                   <ha-icon-button
@@ -291,6 +302,23 @@ export class MoreInfoDialog extends LitElement {
       confirm: () => {
         removeEntityRegistryEntry(this.hass, entityId);
       },
+    });
+  }
+
+  private _updateEntity() {
+    if (!this._entityId) {
+      return;
+    }
+    this.hass.callService("homeassistant", "update_entity", {
+      entity_id: this._entityId,
+    });
+    const stateObj = this.hass.states[this._entityId];
+    const name = computeStateName(stateObj);
+    showAlertDialog(this, {
+      text: this.hass.localize(
+        `ui.dialogs.more_info_control.update_requested`,
+        { name: name }
+      ),
     });
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -741,6 +741,8 @@
         "details": "Details",
         "history": "History",
         "logbook": "Logbook",
+        "request_update": "Request update",
+        "update_requested": "An update for {name} has been requested.",
         "last_changed": "Last changed",
         "last_updated": "Last updated",
         "show_more": "Show more",


### PR DESCRIPTION

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Unless I've missed it, there isn't an obvious way to request an entity update in the UI besides the developer tools.  This change adds a button to the more-info card to request one.  I'm not sure this is the best place, but it sure made testing polling entities easier.

![Jun-09-2022 13-55-00](https://user-images.githubusercontent.com/663432/172963861-7cf419b2-92a9-4a6c-9f00-be4204202222.gif)



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
