### PR TITLE
Revert Use unit system definitions for weather units (#10657)

### DIFF
--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -178,11 +178,17 @@ export const getWeatherUnit = (
   hass: HomeAssistant,
   measure: string
 ): string => {
+  const lengthUnit = hass.config.unit_system.length || "";
   switch (measure) {
+    case "pressure":
+      return lengthUnit === "km" ? "hPa" : "inHg";
+    case "wind_speed":
+      return `${lengthUnit}/h`;
     case "visibility":
-      return hass.config.unit_system.length || "";
+    case "length":
+      return lengthUnit;
     case "precipitation":
-      return hass.config.unit_system.accumulated_precipitation || "";
+      return lengthUnit === "km" ? "mm" : "in";
     case "humidity":
     case "precipitation_probability":
       return "%";


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This reverts "Use unit system definitions for weather units" (#10657) which breaks display of the weather card and also does not match the documentation: https://developers.home-assistant.io/docs/core/entity/weather

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
