### PR TITLE
Added state as a selectable option in the ui for the statistics graph.

### DIFF
--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -63,7 +63,7 @@ export interface HistoryResult {
   timeline: TimelineEntity[];
 }
 
-export type StatisticType = "sum" | "min" | "max" | "mean";
+export type StatisticType = "sum" | "min" | "max" | "mean" | "state";
 
 export interface Statistics {
   [statisticId: string]: StatisticValue[];

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -92,7 +92,10 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
     if (typeof config.stat_types === "string") {
       this._config = { ...config, stat_types: [config.stat_types] };
     } else if (!config.stat_types) {
-      this._config = { ...config, stat_types: ["sum", "min", "max", "mean"] };
+      this._config = {
+        ...config,
+        stat_types: ["sum", "min", "max", "mean", "state"],
+      };
     } else {
       this._config = config;
     }

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -29,6 +29,7 @@ const statTypeStruct = union([
   literal("min"),
   literal("max"),
   literal("mean"),
+  literal("state"),
 ]);
 
 const cardConfigStruct = assign(
@@ -105,6 +106,7 @@ export class HuiStatisticsGraphCardEditor
             ["min", "Min"],
             ["max", "Max"],
             ["sum", "Sum"],
+            ["state", "State"],
           ],
         },
         {
@@ -130,7 +132,7 @@ export class HuiStatisticsGraphCardEditor
       ? Array.isArray(this._config!.stat_types)
         ? this._config!.stat_types
         : [this._config!.stat_types]
-      : ["mean", "min", "max", "sum"];
+      : ["mean", "min", "max", "sum", "state"];
     const data = {
       chart_type: "line",
       period: "hour",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Added state as a selectable option in the ui for the statistics graph.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
