### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,9 @@ env:
   NODE_VERSION: 14
   NODE_OPTIONS: --max_old_space_size=6144
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,8 +7,15 @@ on:
     # The branches below must be a subset of the branches above
     branches: [dev]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,8 +5,14 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   lock:
+    permissions:
+      issues: write  # for dessant/lock-threads to lock issues
+      pull-requests: write  # for dessant/lock-threads to lock PRs
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2.0.1

--- a/.github/workflows/netflify.yml
+++ b/.github/workflows/netflify.yml
@@ -4,8 +4,13 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   trigger_builds:
+    permissions:
+      contents: none
     name: Trigger netlify build preview
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -5,8 +5,14 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,8 +5,14 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - name: 90 days stale policy

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -10,6 +10,9 @@ on:
 env:
   NODE_VERSION: 14
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     name: Upload


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
