### PR TITLE
Multiple entities on history panel bugfix and additional improvements

### DIFF
--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -186,6 +186,7 @@ class StateHistoryCharts extends LitElement {
         line-height: 60px;
         color: var(--secondary-text-color);
       }
+
       .container {
         max-height: var(--history-max-height);
       }

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -42,8 +42,8 @@ import "./entity/ha-entity-picker";
 import type { HaEntityPickerEntityFilterFunc } from "./entity/ha-entity-picker";
 import "./ha-area-picker";
 import "./ha-icon-button";
-import "./ha-svg-icon";
 import "./ha-input-helper-text";
+import "./ha-svg-icon";
 
 @customElement("ha-target-picker")
 export class HaTargetPicker extends SubscribeMixin(LitElement) {
@@ -119,55 +119,68 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     if (!this._areas || !this._devices || !this._entities) {
       return html``;
     }
-    return html`<div class=${this.horizontal ? "horizontal-container" : ""}>
-      ${this.horizontal ? this._renderChips() : this._renderItems()}
-      ${this._renderPicker()}
-      ${this.horizontal ? this._renderItems() : this._renderChips()}
-    </div>`;
+    return html`
+      ${this.horizontal
+        ? html`
+            <div class="horizontal-container">
+              ${this._renderChips()} ${this._renderPicker()}
+            </div>
+            ${this._renderItems()}
+          `
+        : html`
+            <div>
+              ${this._renderItems()} ${this._renderPicker()}
+              ${this._renderChips()}
+            </div>
+          `}
+    `;
   }
 
   private _renderItems() {
-    return html`<div class="mdc-chip-set items">
-      ${this.value?.area_id
-        ? ensureArray(this.value.area_id).map((area_id) => {
-            const area = this._areas![area_id];
-            return this._renderChip(
-              "area_id",
-              area_id,
-              area?.name || area_id,
-              undefined,
-              mdiSofa
-            );
-          })
-        : ""}
-      ${this.value?.device_id
-        ? ensureArray(this.value.device_id).map((device_id) => {
-            const device = this._devices![device_id];
-            return this._renderChip(
-              "device_id",
-              device_id,
-              device ? computeDeviceName(device, this.hass) : device_id,
-              undefined,
-              mdiDevices
-            );
-          })
-        : ""}
-      ${this.value?.entity_id
-        ? ensureArray(this.value.entity_id).map((entity_id) => {
-            const entity = this.hass.states[entity_id];
-            return this._renderChip(
-              "entity_id",
-              entity_id,
-              entity ? computeStateName(entity) : entity_id,
-              entity
-            );
-          })
-        : ""}
-    </div>`;
+    return html`
+      <div class="mdc-chip-set items">
+        ${this.value?.area_id
+          ? ensureArray(this.value.area_id).map((area_id) => {
+              const area = this._areas![area_id];
+              return this._renderChip(
+                "area_id",
+                area_id,
+                area?.name || area_id,
+                undefined,
+                mdiSofa
+              );
+            })
+          : ""}
+        ${this.value?.device_id
+          ? ensureArray(this.value.device_id).map((device_id) => {
+              const device = this._devices![device_id];
+              return this._renderChip(
+                "device_id",
+                device_id,
+                device ? computeDeviceName(device, this.hass) : device_id,
+                undefined,
+                mdiDevices
+              );
+            })
+          : ""}
+        ${this.value?.entity_id
+          ? ensureArray(this.value.entity_id).map((entity_id) => {
+              const entity = this.hass.states[entity_id];
+              return this._renderChip(
+                "entity_id",
+                entity_id,
+                entity ? computeStateName(entity) : entity_id,
+                entity
+              );
+            })
+          : ""}
+      </div>
+    `;
   }
 
   private _renderChips() {
-    return html`<div class="mdc-chip-set">
+    return html`
+      <div class="mdc-chip-set">
         <div
           class="mdc-chip area_id add"
           .type=${"area_id"}
@@ -231,7 +244,8 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       </div>
       ${this.helper
         ? html`<ha-input-helper-text>${this.helper}</ha-input-helper-text>`
-        : ""} `;
+        : ""}
+    `;
   }
 
   private async _showPicker(ev) {
@@ -320,51 +334,54 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
   private _renderPicker() {
     switch (this._addMode) {
       case "area_id":
-        return html`<ha-area-picker
-          .hass=${this.hass}
-          id="input"
-          .type=${"area_id"}
-          .label=${this.hass.localize(
-            "ui.components.target-picker.add_area_id"
-          )}
-          no-add
-          .deviceFilter=${this.deviceFilter}
-          .entityFilter=${this.entityRegFilter}
-          .includeDeviceClasses=${this.includeDeviceClasses}
-          .includeDomains=${this.includeDomains}
-          class=${this.horizontal ? "hidden-picker" : ""}
-          @value-changed=${this._targetPicked}
-        ></ha-area-picker>`;
+        return html`
+          <ha-area-picker
+            .hass=${this.hass}
+            id="input"
+            .type=${"area_id"}
+            .label=${this.hass.localize(
+              "ui.components.target-picker.add_area_id"
+            )}
+            no-add
+            .deviceFilter=${this.deviceFilter}
+            .entityFilter=${this.entityRegFilter}
+            .includeDeviceClasses=${this.includeDeviceClasses}
+            .includeDomains=${this.includeDomains}
+            @value-changed=${this._targetPicked}
+          ></ha-area-picker>
+        `;
       case "device_id":
-        return html`<ha-device-picker
-          .hass=${this.hass}
-          id="input"
-          .type=${"device_id"}
-          .label=${this.hass.localize(
-            "ui.components.target-picker.add_device_id"
-          )}
-          .deviceFilter=${this.deviceFilter}
-          .entityFilter=${this.entityRegFilter}
-          .includeDeviceClasses=${this.includeDeviceClasses}
-          .includeDomains=${this.includeDomains}
-          class=${this.horizontal ? "hidden-picker" : ""}
-          @value-changed=${this._targetPicked}
-        ></ha-device-picker>`;
+        return html`
+          <ha-device-picker
+            .hass=${this.hass}
+            id="input"
+            .type=${"device_id"}
+            .label=${this.hass.localize(
+              "ui.components.target-picker.add_device_id"
+            )}
+            .deviceFilter=${this.deviceFilter}
+            .entityFilter=${this.entityRegFilter}
+            .includeDeviceClasses=${this.includeDeviceClasses}
+            .includeDomains=${this.includeDomains}
+            @value-changed=${this._targetPicked}
+          ></ha-device-picker>
+        `;
       case "entity_id":
-        return html`<ha-entity-picker
-          .hass=${this.hass}
-          id="input"
-          .type=${"entity_id"}
-          .label=${this.hass.localize(
-            "ui.components.target-picker.add_entity_id"
-          )}
-          .entityFilter=${this.entityFilter}
-          .includeDeviceClasses=${this.includeDeviceClasses}
-          .includeDomains=${this.includeDomains}
-          class=${this.horizontal ? "hidden-picker" : ""}
-          @value-changed=${this._targetPicked}
-          allow-custom-entity
-        ></ha-entity-picker>`;
+        return html`
+          <ha-entity-picker
+            .hass=${this.hass}
+            id="input"
+            .type=${"entity_id"}
+            .label=${this.hass.localize(
+              "ui.components.target-picker.add_entity_id"
+            )}
+            .entityFilter=${this.entityFilter}
+            .includeDeviceClasses=${this.includeDeviceClasses}
+            .includeDomains=${this.includeDomains}
+            @value-changed=${this._targetPicked}
+            allow-custom-entity
+          ></ha-entity-picker>
+        `;
     }
     return html``;
   }
@@ -553,12 +570,6 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
   static get styles(): CSSResultGroup {
     return css`
       ${unsafeCSS(chipStyles)}
-      .hidden-picker {
-        height: 0px;
-        display: inline-block;
-        overflow: hidden;
-        position: absolute;
-      }
       .horizontal-container {
         display: flex;
         flex-wrap: wrap;

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -99,7 +99,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
           return accumulator;
         }, {});
         this._deviceIdToEntities = entities.reduce((accumulator, current) => {
-          if (current.device_id === undefined || current.device_id === null) {
+          if (!current.device_id) {
             return accumulator;
           }
           let found = accumulator[current.device_id];
@@ -111,7 +111,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
           return accumulator;
         }, {});
         this._areaIdToEntities = entities.reduce((accumulator, current) => {
-          if (current.area_id === undefined || current.area_id === null) {
+          if (!current.area_id) {
             return accumulator;
           }
           let found = accumulator[current.area_id];
@@ -129,7 +129,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
           return accumulator;
         }, {});
         this._areaIdToDevices = devices.reduce((accumulator, current) => {
-          if (current.area_id === undefined || current.area_id === null) {
+          if (!current.area_id) {
             return accumulator;
           }
           let found = accumulator[current.area_id];
@@ -201,7 +201,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                 ></ha-circular-progress>
               </div>`
             : this._targetPickerValue === undefined
-            ? html` <div class="start-search">
+            ? html`<div class="start-search">
                 ${this.hass.localize("ui.panel.history.start_search")}
               </div>`
             : html`
@@ -303,12 +303,10 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
 
   private _showAll() {
     this._targetPickerValue = { entity_id: Object.keys(this._entities ?? {}) };
-    this._getHistory();
   }
 
   private _removeAll() {
     this._targetPickerValue = undefined;
-    this._getHistory();
   }
 
   private _refreshHistory() {

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -194,7 +194,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                   alt=${this.hass.localize("ui.common.loading")}
                 ></ha-circular-progress>
               </div>`
-            : this._targetPickerValue === undefined
+            : !this._targetPickerValue
             ? html`<div class="start-search">
                 ${this.hass.localize("ui.panel.history.start_search")}
               </div>`

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -1,4 +1,4 @@
-import { mdiCollapseAll, mdiExpandAll, mdiRefresh } from "@mdi/js";
+import { mdiCollapseAll, mdiRefresh } from "@mdi/js";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import {
@@ -52,8 +52,6 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
   @property() _endDate: Date;
 
   @property() _targetPickerValue?;
-
-  @property() _showAllEntities = false;
 
   @property() _isLoading = false;
 
@@ -157,12 +155,6 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
             ></ha-menu-button>
             <div main-title>${this.hass.localize("panel.history")}</div>
             <ha-icon-button
-              @click=${this._showAll}
-              .disabled=${this._isLoading}
-              .path=${mdiExpandAll}
-              .label=${this.hass.localize("ui.panel.history.add_all")}
-            ></ha-icon-button>
-            <ha-icon-button
               @click=${this._removeAll}
               .disabled=${this._isLoading}
               .path=${mdiCollapseAll}
@@ -202,7 +194,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                   alt=${this.hass.localize("ui.common.loading")}
                 ></ha-circular-progress>
               </div>`
-            : this._targetPickerValue === undefined && !this._showAllEntities
+            : this._targetPickerValue === undefined
             ? html`<div class="start-search">
                 ${this.hass.localize("ui.panel.history.start_search")}
               </div>`
@@ -268,8 +260,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
       changedProps.has("_devices") ||
       changedProps.has("_deviceIdToEntities") ||
       changedProps.has("_areaIdToEntities") ||
-      changedProps.has("_areaIdToDevices") ||
-      changedProps.has("_showAllEntities")
+      changedProps.has("_areaIdToDevices")
     ) {
       this._getHistory();
     }
@@ -304,13 +295,8 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
     }
   }
 
-  private _showAll() {
-    this._showAllEntities = true;
-  }
-
   private _removeAll() {
     this._targetPickerValue = undefined;
-    this._showAllEntities = false;
   }
 
   private _refreshHistory() {
@@ -344,12 +330,6 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
   }
 
   private _getEntityIds(): string[] {
-    if (this._showAllEntities) {
-      return [
-        ...Object.keys(this._entities ?? []),
-        ...Object.keys(this._stateEntities ?? []),
-      ];
-    }
     if (
       this._targetPickerValue === undefined ||
       this._entities === undefined ||

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -158,13 +158,13 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
               @click=${this._showAll}
               .disabled=${this._isLoading}
               .path=${mdiExpandAll}
-              .label=${"Show All"}
+              .label=${this.hass.localize("ui.panel.history.add_all")}
             ></ha-icon-button>
             <ha-icon-button
               @click=${this._removeAll}
               .disabled=${this._isLoading}
               .path=${mdiCollapseAll}
-              .label=${"Clear All"}
+              .label=${this.hass.localize("ui.panel.history.remove_all")}
             ></ha-icon-button>
             <ha-icon-button
               @click=${this._refreshHistory}
@@ -201,8 +201,8 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                 ></ha-circular-progress>
               </div>`
             : this._targetPickerValue === undefined
-            ? html`<div class="info">
-                Select what you would like to see history for above
+            ? html` <div class="start-search">
+                ${this.hass.localize("ui.panel.history.start_search")}
               </div>`
             : html`
                 <state-history-charts
@@ -496,12 +496,6 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
           flex-wrap: wrap;
         }
 
-        .info {
-          text-align: center;
-          line-height: 60px;
-          color: var(--secondary-text-color);
-        }
-
         ha-date-range-picker {
           margin-right: 16px;
           margin-inline-end: 16px;
@@ -533,6 +527,12 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
         :host([narrow]) ha-entity-picker {
           max-width: none;
           width: 100%;
+        }
+
+        .start-search {
+          padding-top: 16px;
+          text-align: center;
+          color: var(--secondary-text-color);
         }
       `,
     ];

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -254,13 +254,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
     if (
       changedProps.has("_startDate") ||
       changedProps.has("_endDate") ||
-      changedProps.has("_targetPickerValue") ||
-      changedProps.has("_entities") ||
-      changedProps.has("_stateEntities") ||
-      changedProps.has("_devices") ||
-      changedProps.has("_deviceIdToEntities") ||
-      changedProps.has("_areaIdToEntities") ||
-      changedProps.has("_areaIdToDevices")
+      changedProps.has("_targetPickerValue")
     ) {
       this._getHistory();
     }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -313,6 +313,14 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
     this._getHistory();
   }
 
+  private _shouldShowEntityByLargerSelection(
+    entity: EntityRegistryEntry
+  ): boolean {
+    return (
+      entity.entity_category === null || entity.entity_category === "config"
+    );
+  }
+
   private async _getHistory() {
     this._isLoading = true;
     const entityIds = this._getEntityIds();
@@ -359,7 +367,9 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
         const foundEntities = this._areaIdToEntities[singleSearchingAreaId];
         if (foundEntities !== undefined) {
           for (const foundEntity of foundEntities) {
-            entityIds.add(foundEntity.entity_id);
+            if (this._shouldShowEntityByLargerSelection(foundEntity)) {
+              entityIds.add(foundEntity.entity_id);
+            }
           }
         }
         const foundDevices = this._areaIdToDevices[singleSearchingAreaId];
@@ -369,9 +379,9 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
               this._deviceIdToEntities[foundDevice.id];
             for (const foundDeviceEntity of foundDeviceEntities) {
               if (
-                foundDeviceEntity.area_id === undefined ||
-                foundDeviceEntity.area_id === null ||
-                foundDeviceEntity.area_id === singleSearchingAreaId
+                (!foundDeviceEntity.area_id ||
+                  foundDeviceEntity.area_id === singleSearchingAreaId) &&
+                this._shouldShowEntityByLargerSelection(foundDeviceEntity)
               ) {
                 entityIds.add(foundDeviceEntity.entity_id);
               }
@@ -388,7 +398,9 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
         const foundEntities = this._deviceIdToEntities[singleSearchingDeviceId];
         if (foundEntities !== undefined) {
           for (const foundEntity of foundEntities) {
-            entityIds.add(foundEntity.entity_id);
+            if (this._shouldShowEntityByLargerSelection(foundEntity)) {
+              entityIds.add(foundEntity.entity_id);
+            }
           }
         }
       }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -53,6 +53,8 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
 
   @property() _targetPickerValue?;
 
+  @property() _showAllEntities = false;
+
   @property() _isLoading = false;
 
   @property() _stateHistory?;
@@ -200,7 +202,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                   alt=${this.hass.localize("ui.common.loading")}
                 ></ha-circular-progress>
               </div>`
-            : this._targetPickerValue === undefined
+            : this._targetPickerValue === undefined && !this._showAllEntities
             ? html`<div class="start-search">
                 ${this.hass.localize("ui.panel.history.start_search")}
               </div>`
@@ -266,7 +268,8 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
       changedProps.has("_devices") ||
       changedProps.has("_deviceIdToEntities") ||
       changedProps.has("_areaIdToEntities") ||
-      changedProps.has("_areaIdToDevices")
+      changedProps.has("_areaIdToDevices") ||
+      changedProps.has("_showAllEntities")
     ) {
       this._getHistory();
     }
@@ -302,11 +305,12 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
   }
 
   private _showAll() {
-    this._targetPickerValue = { entity_id: Object.keys(this._entities ?? {}) };
+    this._showAllEntities = true;
   }
 
   private _removeAll() {
     this._targetPickerValue = undefined;
+    this._showAllEntities = false;
   }
 
   private _refreshHistory() {
@@ -340,6 +344,12 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
   }
 
   private _getEntityIds(): string[] {
+    if (this._showAllEntities) {
+      return [
+        ...Object.keys(this._entities ?? []),
+        ...Object.keys(this._stateEntities ?? []),
+      ];
+    }
     if (
       this._targetPickerValue === undefined ||
       this._entities === undefined ||

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -1,4 +1,4 @@
-import { mdiRefresh } from "@mdi/js";
+import { mdiCollapseAll, mdiExpandAll, mdiRefresh } from "@mdi/js";
 import "@polymer/app-layout/app-header/app-header";
 import "@polymer/app-layout/app-toolbar/app-toolbar";
 import {
@@ -34,6 +34,10 @@ import {
   EntityRegistryEntry,
   subscribeEntityRegistry,
 } from "../../data/entity_registry";
+import {
+  DeviceRegistryEntry,
+  subscribeDeviceRegistry,
+} from "../../data/device_registry";
 import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import { computeStateName } from "../../common/entity/compute_state_name";
 import { computeDomain } from "../../common/entity/compute_domain";
@@ -57,9 +61,23 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
 
   @state() private _ranges?: DateRangePickerRanges;
 
-  @state() private _entities?: EntityRegistryEntry[];
+  @state() private _devices?: { [deviceId: string]: DeviceRegistryEntry };
 
-  @state() private _stateEntities?: EntityRegistryEntry[];
+  @state() private _entities?: { [entityId: string]: EntityRegistryEntry };
+
+  @state() private _stateEntities?: { [entityId: string]: EntityRegistryEntry };
+
+  @state() private _deviceIdToEntities?: {
+    [deviceId: string]: EntityRegistryEntry[];
+  };
+
+  @state() private _areaIdToEntities?: {
+    [areaId: string]: EntityRegistryEntry[];
+  };
+
+  @state() private _areaIdToDevices?: {
+    [areaId: string]: DeviceRegistryEntry[];
+  };
 
   public constructor() {
     super();
@@ -76,7 +94,52 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
   public hassSubscribe(): UnsubscribeFunc[] {
     return [
       subscribeEntityRegistry(this.hass.connection!, (entities) => {
-        this._entities = entities;
+        this._entities = entities.reduce((accumulator, current) => {
+          accumulator[current.entity_id] = current;
+          return accumulator;
+        }, {});
+        this._deviceIdToEntities = entities.reduce((accumulator, current) => {
+          if (current.device_id === undefined || current.device_id === null) {
+            return accumulator;
+          }
+          let found = accumulator[current.device_id];
+          if (found === undefined) {
+            found = [];
+            accumulator[current.device_id] = found;
+          }
+          found.push(current);
+          return accumulator;
+        }, {});
+        this._areaIdToEntities = entities.reduce((accumulator, current) => {
+          if (current.area_id === undefined || current.area_id === null) {
+            return accumulator;
+          }
+          let found = accumulator[current.area_id];
+          if (found === undefined) {
+            found = [];
+            accumulator[current.area_id] = found;
+          }
+          found.push(current);
+          return accumulator;
+        }, {});
+      }),
+      subscribeDeviceRegistry(this.hass.connection!, (devices) => {
+        this._devices = devices.reduce((accumulator, current) => {
+          accumulator[current.id] = current;
+          return accumulator;
+        }, {});
+        this._areaIdToDevices = devices.reduce((accumulator, current) => {
+          if (current.area_id === undefined || current.area_id === null) {
+            return accumulator;
+          }
+          let found = accumulator[current.area_id];
+          if (found === undefined) {
+            found = [];
+            accumulator[current.area_id] = found;
+          }
+          found.push(current);
+          return accumulator;
+        }, {});
       }),
     ];
   }
@@ -91,6 +154,18 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
               .narrow=${this.narrow}
             ></ha-menu-button>
             <div main-title>${this.hass.localize("panel.history")}</div>
+            <ha-icon-button
+              @click=${this._showAll}
+              .disabled=${this._isLoading}
+              .path=${mdiExpandAll}
+              .label=${"Show All"}
+            ></ha-icon-button>
+            <ha-icon-button
+              @click=${this._removeAll}
+              .disabled=${this._isLoading}
+              .path=${mdiCollapseAll}
+              .label=${"Clear All"}
+            ></ha-icon-button>
             <ha-icon-button
               @click=${this._refreshHistory}
               .disabled=${this._isLoading}
@@ -125,6 +200,8 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                   alt=${this.hass.localize("ui.common.loading")}
                 ></ha-circular-progress>
               </div>`
+            : this._targetPickerValue === undefined
+            ? html`<div class="info">No selection made</div>`
             : html`
                 <state-history-charts
                   .hass=${this.hass}
@@ -135,24 +212,6 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                 </state-history-charts>
               `}
         </div>
-        ${this._isLoading
-          ? html`<div class="progress-wrapper">
-              <ha-circular-progress
-                active
-                alt=${this.hass.localize("ui.common.loading")}
-              ></ha-circular-progress>
-            </div>`
-          : html`
-              <state-history-charts
-                virtualize
-                .hass=${this.hass}
-                .historyData=${this._stateHistory}
-                .endTime=${this._endDate}
-                .narrow=${this.narrow}
-                no-single
-              >
-              </state-history-charts>
-            `}
       </ha-app-layout>
     `;
   }
@@ -211,15 +270,13 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
         this.rtl = computeRTL(this.hass);
       }
       if (this._entities) {
-        const stateEntities: EntityRegistryEntry[] = [];
-        const regEntityIds = new Set(
-          this._entities.map((entity) => entity.entity_id)
-        );
+        const stateEntities: { [entityId: string]: EntityRegistryEntry } = {};
+        const regEntityIds = new Set(Object.keys(this._entities));
         for (const entityId of Object.keys(this.hass.states)) {
           if (regEntityIds.has(entityId)) {
             continue;
           }
-          stateEntities.push({
+          stateEntities[entityId] = {
             name: computeStateName(this.hass.states[entityId]),
             entity_id: entityId,
             platform: computeDomain(entityId),
@@ -230,11 +287,21 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
             device_id: null,
             icon: null,
             entity_category: null,
-          });
+          };
         }
         this._stateEntities = stateEntities;
       }
     }
+  }
+
+  private _showAll() {
+    this._targetPickerValue = { entity_id: Object.keys(this._entities ?? {}) };
+    this._getHistory();
+  }
+
+  private _removeAll() {
+    this._targetPickerValue = undefined;
+    this._getHistory();
   }
 
   private _refreshHistory() {
@@ -261,50 +328,75 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
     this._isLoading = false;
   }
 
-  private _filterEntity(entity: EntityRegistryEntry): boolean {
-    const { area_id, device_id, entity_id } = this._targetPickerValue;
-    if (area_id !== undefined) {
-      if (typeof area_id === "string" && area_id === entity.area_id) {
-        return true;
-      }
-      if (Array.isArray(area_id) && area_id.includes(entity.area_id)) {
-        return true;
-      }
-    }
-    if (device_id !== undefined) {
-      if (typeof device_id === "string" && device_id === entity.device_id) {
-        return true;
-      }
-      if (Array.isArray(device_id) && device_id.includes(entity.device_id)) {
-        return true;
-      }
-    }
-    if (entity_id !== undefined) {
-      if (typeof entity_id === "string" && entity_id === entity.entity_id) {
-        return true;
-      }
-      if (Array.isArray(entity_id) && entity_id.includes(entity.entity_id)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private _getEntityIds(): string[] {
     if (
       this._targetPickerValue === undefined ||
       this._entities === undefined ||
-      this._stateEntities === undefined
+      this._stateEntities === undefined ||
+      this._devices === undefined ||
+      this._deviceIdToEntities === undefined ||
+      this._areaIdToEntities === undefined ||
+      this._areaIdToDevices === undefined
     ) {
       return [];
     }
-    const entityIds = this._entities
-      .filter((entity) => this._filterEntity(entity))
-      .map((entity) => entity.entity_id);
-    const stateEntityIds = this._stateEntities
-      .filter((entity) => this._filterEntity(entity))
-      .map((entity) => entity.entity_id);
-    return [...entityIds, ...stateEntityIds];
+    const entityIds = new Set<string>();
+    let {
+      area_id: searchingAreaId,
+      device_id: searchingDeviceId,
+      entity_id: searchingEntityId,
+    } = this._targetPickerValue;
+    if (searchingAreaId !== undefined) {
+      if (typeof searchingAreaId === "string") {
+        searchingAreaId = [searchingAreaId];
+      }
+      for (const singleSearchingAreaId of searchingAreaId) {
+        const foundEntities = this._areaIdToEntities[singleSearchingAreaId];
+        if (foundEntities !== undefined) {
+          for (const foundEntity of foundEntities) {
+            entityIds.add(foundEntity.entity_id);
+          }
+        }
+        const foundDevices = this._areaIdToDevices[singleSearchingAreaId];
+        if (foundDevices !== undefined) {
+          for (const foundDevice of foundDevices) {
+            const foundDeviceEntities =
+              this._deviceIdToEntities[foundDevice.id];
+            for (const foundDeviceEntity of foundDeviceEntities) {
+              if (
+                foundDeviceEntity.area_id === undefined ||
+                foundDeviceEntity.area_id === null ||
+                foundDeviceEntity.area_id === singleSearchingAreaId
+              ) {
+                entityIds.add(foundDeviceEntity.entity_id);
+              }
+            }
+          }
+        }
+      }
+    }
+    if (searchingDeviceId !== undefined) {
+      if (typeof searchingDeviceId === "string") {
+        searchingDeviceId = [searchingDeviceId];
+      }
+      for (const singleSearchingDeviceId of searchingDeviceId) {
+        const foundEntities = this._deviceIdToEntities[singleSearchingDeviceId];
+        if (foundEntities !== undefined) {
+          for (const foundEntity of foundEntities) {
+            entityIds.add(foundEntity.entity_id);
+          }
+        }
+      }
+    }
+    if (searchingEntityId !== undefined) {
+      if (typeof searchingEntityId === "string") {
+        searchingEntityId = [searchingEntityId];
+      }
+      for (const singleSearchingEntityId of searchingEntityId) {
+        entityIds.add(singleSearchingEntityId);
+      }
+    }
+    return [...entityIds];
   }
 
   private _dateRangeChanged(ev) {
@@ -389,12 +481,18 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
 
         .filters {
           display: flex;
-          align-items: flex-end;
+          align-items: flex-start;
           padding: 8px 16px 0;
         }
 
         :host([narrow]) .filters {
           flex-wrap: wrap;
+        }
+
+        .info {
+          text-align: center;
+          line-height: 60px;
+          color: var(--secondary-text-color);
         }
 
         ha-date-range-picker {

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -201,7 +201,9 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                 ></ha-circular-progress>
               </div>`
             : this._targetPickerValue === undefined
-            ? html`<div class="info">No selection made</div>`
+            ? html`<div class="info">
+                Select what you would like to see history for above
+              </div>`
             : html`
                 <state-history-charts
                   .hass=${this.hass}

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -259,7 +259,12 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
       changedProps.has("_startDate") ||
       changedProps.has("_endDate") ||
       changedProps.has("_targetPickerValue") ||
-      changedProps.has("_entities")
+      changedProps.has("_entities") ||
+      changedProps.has("_stateEntities") ||
+      changedProps.has("_devices") ||
+      changedProps.has("_deviceIdToEntities") ||
+      changedProps.has("_areaIdToEntities") ||
+      changedProps.has("_areaIdToDevices")
     ) {
       this._getHistory();
     }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -316,9 +316,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
   private _shouldShowEntityByLargerSelection(
     entity: EntityRegistryEntry
   ): boolean {
-    return (
-      entity.entity_category === null || entity.entity_category === "config"
-    );
+    return entity.entity_category === null;
   }
 
   private async _getHistory() {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4555,12 +4555,12 @@
           "energy_distribution_title": "Energy distribution",
           "energy_sources_table_title": "Sources",
           "energy_devices_graph_title": "Monitor individual devices"
-        },
-        "history": {
-          "start_search": "Start by selecting an area, device or entity above",
-          "add_all": "Add all entities",
-          "remove_all": "Remove all selections"
         }
+      },
+      "history": {
+        "start_search": "Start by selecting an area, device or entity above",
+        "add_all": "Add all entities",
+        "remove_all": "Remove all selections"
       }
     },
     "tips": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4555,6 +4555,11 @@
           "energy_distribution_title": "Energy distribution",
           "energy_sources_table_title": "Sources",
           "energy_devices_graph_title": "Monitor individual devices"
+        },
+        "history": {
+          "start_search": "Start by selecting an area, device or entity above",
+          "add_all": "Add all entities",
+          "remove_all": "Remove all selections"
         }
       }
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Additional changes to history screen and a bugfix

- Add buttons to add all possible entities, and remove all current selections. It is next to the refresh button as of now.
- Fix area id filtering
- Change strategy for finding entities, this removes the need to constantly iterate over what can be a really large array
- When the user has made no selection display an appropriate message instead of just no entities found

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: [9946](https://github.com/home-assistant/frontend/pull/9946)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
