### PR TITLE
Don't check zwave_js node firmware update capabilities

### DIFF
--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
@@ -2,7 +2,6 @@ import { getConfigEntries } from "../../../../../../data/config_entries";
 import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
 import {
   fetchZwaveIsAnyFirmwareUpdateInProgress,
-  fetchZwaveNodeFirmwareUpdateCapabilities,
   fetchZwaveNodeIsFirmwareUpdateInProgress,
   fetchZwaveNodeStatus,
 } from "../../../../../../data/zwave_js";
@@ -87,20 +86,13 @@ export const getZwaveDeviceActions = async (
     return actions;
   }
 
-  const [
-    firmwareUpdateCapabilities,
-    isAnyFirmwareUpdateInProgress,
-    isNodeFirmwareUpdateInProgress,
-  ] = await Promise.all([
-    fetchZwaveNodeFirmwareUpdateCapabilities(hass, device.id),
-    fetchZwaveIsAnyFirmwareUpdateInProgress(hass, entryId),
-    fetchZwaveNodeIsFirmwareUpdateInProgress(hass, device.id),
-  ]);
+  const [isAnyFirmwareUpdateInProgress, isNodeFirmwareUpdateInProgress] =
+    await Promise.all([
+      fetchZwaveIsAnyFirmwareUpdateInProgress(hass, entryId),
+      fetchZwaveNodeIsFirmwareUpdateInProgress(hass, device.id),
+    ]);
 
-  if (
-    firmwareUpdateCapabilities.firmware_upgradable &&
-    (!isAnyFirmwareUpdateInProgress || isNodeFirmwareUpdateInProgress)
-  ) {
+  if (!isAnyFirmwareUpdateInProgress || isNodeFirmwareUpdateInProgress) {
     actions.push({
       label: hass.localize(
         "ui.panel.config.zwave_js.device_info.update_firmware"
@@ -117,7 +109,6 @@ export const getZwaveDeviceActions = async (
         ) {
           showZWaveJUpdateFirmwareNodeDialog(el, {
             device,
-            firmwareUpdateCapabilities,
           });
         }
       },

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
@@ -98,6 +98,7 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
     const schema: HaFormIntegerSchema = {
       name: "firmware_target",
       type: "integer",
+      valueMin: 0,
     };
 
     const beginFirmwareUpdateHTML = html`<ha-file-upload

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
@@ -64,11 +64,6 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
 
   private _deviceName?: string;
 
-  private _schema: HaFormIntegerSchema = {
-    name: "firmware_target",
-    type: "integer",
-  };
-
   public showDialog(params: ZWaveJSUpdateFirmwareNodeDialogParams): void {
     this._deviceName = computeDeviceName(params.device, this.hass!);
     this.device = params.device;
@@ -100,6 +95,11 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
       return html``;
     }
 
+    const schema: HaFormIntegerSchema = {
+      name: "firmware_target",
+      type: "integer",
+    };
+
     const beginFirmwareUpdateHTML = html`<ha-file-upload
         .hass=${this.hass}
         .uploading=${this._uploading}
@@ -118,7 +118,7 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
       <ha-form
         .hass=${this.hass}
         .data=${{ firmware_target: this._firmwareTarget }}
-        .schema=${[this._schema]}
+        .schema=${[schema]}
         @value-changed=${this._firmwareTargetChanged}
       ></ha-form>
       <mwc-button

--- a/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-update-firmware-node.ts
@@ -1,10 +1,8 @@
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { DeviceRegistryEntry } from "../../../../../data/device_registry";
-import { ZWaveJSNodeFirmwareUpdateCapabilities } from "../../../../../data/zwave_js";
 
 export interface ZWaveJSUpdateFirmwareNodeDialogParams {
   device: DeviceRegistryEntry;
-  firmwareUpdateCapabilities: ZWaveJSNodeFirmwareUpdateCapabilities;
 }
 
 export const loadUpdateFirmwareNodeDialog = () =>


### PR DESCRIPTION
## Proposed change
It was previously assumed that we could check the firmware update capabilities of a node always and so we used that information to generate the appropriate device actions list as well as to improve the user experience of picking a target chip for the upgrade. In the beta we learned that is not the case - sleeping nodes will not respond with this information which means the device actions won't load until the device is woken up.

There's probably a way to fix this in a way that doesn't remove this feature entirely, but after talking to @AlCalzone it appears we may introduce a way in the future to check the firmware update capabilities without having to communicate with the node which would allow us to reintroduce this feature in a much simpler way.

CC - @AlCalzone @kpine @Mariusthvdb @balloob @MartinHjelmare 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/13052
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
