### PR TITLE
Only show firmware update warning if no firmware update is in progress

### DIFF
--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
@@ -97,21 +97,26 @@ export const getZwaveDeviceActions = async (
       label: hass.localize(
         "ui.panel.config.zwave_js.device_info.update_firmware"
       ),
-      action: async () => {
-        if (
-          await showConfirmationDialog(el, {
-            text: hass.localize(
-              "ui.panel.config.zwave_js.update_firmware.warning"
-            ),
-            dismissText: hass.localize("ui.common.no"),
-            confirmText: hass.localize("ui.common.yes"),
-          })
-        ) {
-          showZWaveJUpdateFirmwareNodeDialog(el, {
-            device,
-          });
-        }
-      },
+      action: isNodeFirmwareUpdateInProgress
+        ? () =>
+            showZWaveJUpdateFirmwareNodeDialog(el, {
+              device,
+            })
+        : async () => {
+            if (
+              await showConfirmationDialog(el, {
+                text: hass.localize(
+                  "ui.panel.config.zwave_js.update_firmware.warning"
+                ),
+                dismissText: hass.localize("ui.common.no"),
+                confirmText: hass.localize("ui.common.yes"),
+              })
+            ) {
+              showZWaveJUpdateFirmwareNodeDialog(el, {
+                device,
+              });
+            }
+          },
     });
   }
 

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
@@ -97,26 +97,28 @@ export const getZwaveDeviceActions = async (
       label: hass.localize(
         "ui.panel.config.zwave_js.device_info.update_firmware"
       ),
-      action: isNodeFirmwareUpdateInProgress
-        ? () =>
-            showZWaveJUpdateFirmwareNodeDialog(el, {
-              device,
-            })
-        : async () => {
-            if (
-              await showConfirmationDialog(el, {
-                text: hass.localize(
-                  "ui.panel.config.zwave_js.update_firmware.warning"
-                ),
-                dismissText: hass.localize("ui.common.no"),
-                confirmText: hass.localize("ui.common.yes"),
-              })
-            ) {
-              showZWaveJUpdateFirmwareNodeDialog(el, {
-                device,
-              });
-            }
-          },
+      action: async () => {
+        if (
+          isNodeFirmwareUpdateInProgress ||
+          (await fetchZwaveNodeIsFirmwareUpdateInProgress(hass, device.id))
+        ) {
+          showZWaveJUpdateFirmwareNodeDialog(el, {
+            device,
+          });
+        } else if (
+          await showConfirmationDialog(el, {
+            text: hass.localize(
+              "ui.panel.config.zwave_js.update_firmware.warning"
+            ),
+            dismissText: hass.localize("ui.common.no"),
+            confirmText: hass.localize("ui.common.yes"),
+          })
+        ) {
+          showZWaveJUpdateFirmwareNodeDialog(el, {
+            device,
+          });
+        }
+      },
     });
   }
 


### PR DESCRIPTION
## Proposed change
Hopefully the last issue with the firmware update for now. I noticed that we always show the disclaimer when you click "Update Device Firmware," even if a firmware update is already in progress for that node. With this change, it will only show the disclaimer before you initiate a firmware update. Not a bug per se but an improvement for sure

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
