### PR TITLE
Prevent devices with no entities in an area from crashing the history page

### DIFF
--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -396,13 +396,15 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
           for (const foundDevice of foundDevices) {
             const foundDeviceEntities =
               this._deviceIdToEntities[foundDevice.id];
-            for (const foundDeviceEntity of foundDeviceEntities) {
-              if (
-                (!foundDeviceEntity.area_id ||
-                  foundDeviceEntity.area_id === singleSearchingAreaId) &&
-                foundDeviceEntity.entity_category === null
-              ) {
-                entityIds.add(foundDeviceEntity.entity_id);
+            if (foundDeviceEntities !== undefined) {
+              for (const foundDeviceEntity of foundDeviceEntities) {
+                if (
+                  (!foundDeviceEntity.area_id ||
+                    foundDeviceEntity.area_id === singleSearchingAreaId) &&
+                  foundDeviceEntity.entity_category === null
+                ) {
+                  entityIds.add(foundDeviceEntity.entity_id);
+                }
               }
             }
           }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -396,7 +396,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
           for (const foundDevice of foundDevices) {
             const foundDeviceEntities =
               this._deviceIdToEntities[foundDevice.id];
-            if (foundDeviceEntities !== undefined) {
+            if (foundDeviceEntities?.length) {
               for (const foundDeviceEntity of foundDeviceEntities) {
                 if (
                   (!foundDeviceEntity.area_id ||
@@ -429,7 +429,13 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
     if (searchingEntityId !== undefined) {
       searchingEntityId = ensureArray(searchingEntityId);
       for (const singleSearchingEntityId of searchingEntityId) {
-        entityIds.add(singleSearchingEntityId);
+        if (
+          Object.keys(this._entities ?? {}).includes(singleSearchingEntityId) ||
+          Object.keys(this._stateEntities ?? {}).includes(
+            singleSearchingEntityId
+          )
+        )
+          entityIds.add(singleSearchingEntityId);
       }
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Prevents 'empty' devices from causing issues on the history page. For example assigning a z-wave controller to an area will likely cause that area to fail.

As a bonus I found an unknown (to me) feature of the target picker where you can enter an invalid entity_id and press return and it will accept it, at which point the web service returns an error.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13127 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
