### PR TITLE
Allow stale ZHA coordinator entries to be deleted

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -26,6 +26,7 @@ export interface ZHADevice {
   power_source?: string;
   area_id?: string;
   device_type: string;
+  active_coordinator: boolean;
   signature: any;
   neighbors: Neighbor[];
   pairing_status?: string;

--- a/src/panels/config/devices/device-detail/integration-elements/zha/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zha/device-actions.ts
@@ -59,23 +59,25 @@ export const getZHADeviceActions = async (
   }
 
   actions.push(
-    ...[{
-      label: hass.localize(
-        "ui.dialogs.zha_device_info.buttons.zigbee_information"
-      ),
-      action: () => showZHADeviceZigbeeInfoDialog(el, { device: zhaDevice }),
-    },
-    {
-      label: hass.localize("ui.dialogs.zha_device_info.buttons.clusters"),
-      action: () => showZHAClusterDialog(el, { device: zhaDevice }),
-    },
-    {
-      label: hass.localize(
-        "ui.dialogs.zha_device_info.buttons.view_in_visualization"
-      ),
-      action: () =>
-        navigate(`/config/zha/visualization/${zhaDevice!.device_reg_id}`),
-    }]
+    ...[
+      {
+        label: hass.localize(
+          "ui.dialogs.zha_device_info.buttons.zigbee_information"
+        ),
+        action: () => showZHADeviceZigbeeInfoDialog(el, { device: zhaDevice }),
+      },
+      {
+        label: hass.localize("ui.dialogs.zha_device_info.buttons.clusters"),
+        action: () => showZHAClusterDialog(el, { device: zhaDevice }),
+      },
+      {
+        label: hass.localize(
+          "ui.dialogs.zha_device_info.buttons.view_in_visualization"
+        ),
+        action: () =>
+          navigate(`/config/zha/visualization/${zhaDevice!.device_reg_id}`),
+      },
+    ]
   );
 
   if (!zhaDevice.active_coordinator) {

--- a/src/panels/config/devices/device-detail/integration-elements/zha/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zha/device-actions.ts
@@ -30,7 +30,7 @@ export const getZHADeviceActions = async (
 
   const actions: DeviceAction[] = [];
 
-  if (zhaDevice.device_type !== "Coordinator") {
+  if (!zhaDevice.active_coordinator) {
     actions.push({
       label: hass.localize("ui.dialogs.zha_device_info.buttons.reconfigure"),
       action: () => showZHAReconfigureDeviceDialog(el, { device: zhaDevice }),
@@ -58,50 +58,48 @@ export const getZHADeviceActions = async (
     );
   }
 
-  if (zhaDevice.device_type !== "Coordinator") {
-    actions.push(
-      ...[
-        {
-          label: hass.localize(
-            "ui.dialogs.zha_device_info.buttons.zigbee_information"
+  actions.push(
+    {
+      label: hass.localize(
+        "ui.dialogs.zha_device_info.buttons.zigbee_information"
+      ),
+      action: () => showZHADeviceZigbeeInfoDialog(el, { device: zhaDevice }),
+    },
+    {
+      label: hass.localize("ui.dialogs.zha_device_info.buttons.clusters"),
+      action: () => showZHAClusterDialog(el, { device: zhaDevice }),
+    },
+    {
+      label: hass.localize(
+        "ui.dialogs.zha_device_info.buttons.view_in_visualization"
+      ),
+      action: () =>
+        navigate(`/config/zha/visualization/${zhaDevice!.device_reg_id}`),
+    }
+  );
+
+  if (!zhaDevice.active_coordinator) {
+    actions.push({
+      label: hass.localize("ui.dialogs.zha_device_info.buttons.remove"),
+      classes: "warning",
+      action: async () => {
+        const confirmed = await showConfirmationDialog(el, {
+          text: hass.localize(
+            "ui.dialogs.zha_device_info.confirmations.remove"
           ),
-          action: () =>
-            showZHADeviceZigbeeInfoDialog(el, { device: zhaDevice }),
-        },
-        {
-          label: hass.localize("ui.dialogs.zha_device_info.buttons.clusters"),
-          action: () => showZHAClusterDialog(el, { device: zhaDevice }),
-        },
-        {
-          label: hass.localize(
-            "ui.dialogs.zha_device_info.buttons.view_in_visualization"
-          ),
-          action: () =>
-            navigate(`/config/zha/visualization/${zhaDevice!.device_reg_id}`),
-        },
-        {
-          label: hass.localize("ui.dialogs.zha_device_info.buttons.remove"),
-          classes: "warning",
-          action: async () => {
-            const confirmed = await showConfirmationDialog(el, {
-              text: hass.localize(
-                "ui.dialogs.zha_device_info.confirmations.remove"
-              ),
-            });
+        });
 
-            if (!confirmed) {
-              return;
-            }
+        if (!confirmed) {
+          return;
+        }
 
-            await hass.callService("zha", "remove", {
-              ieee: zhaDevice.ieee,
-            });
+        await hass.callService("zha", "remove", {
+          ieee: zhaDevice.ieee,
+        });
 
-            history.back();
-          },
-        },
-      ]
-    );
+        history.back();
+      },
+    });
   }
 
   return actions;

--- a/src/panels/config/devices/device-detail/integration-elements/zha/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zha/device-actions.ts
@@ -59,7 +59,7 @@ export const getZHADeviceActions = async (
   }
 
   actions.push(
-    {
+    ...[{
       label: hass.localize(
         "ui.dialogs.zha_device_info.buttons.zigbee_information"
       ),
@@ -75,7 +75,7 @@ export const getZHADeviceActions = async (
       ),
       action: () =>
         navigate(`/config/zha/visualization/${zhaDevice!.device_reg_id}`),
-    }
+    }]
   );
 
   if (!zhaDevice.active_coordinator) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Allow deleting inactive ZHA coordinator devices.  Currently, no coordinator is allowed to be deleted.  Depends on https://github.com/home-assistant/core/pull/74739 being merged to add a new API response attribute.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
