### PR TITLE
Fix shortcuts for non-qwerty keyboard layouts (revert #12892)

### DIFF
--- a/src/state/quick-bar-mixin.ts
+++ b/src/state/quick-bar-mixin.ts
@@ -48,6 +48,11 @@ export default <T extends Constructor<HassElement>>(superClass: T) =>
 
     private _registerShortcut() {
       tinykeys(window, {
+        // Those are for latin keyboards that have e, c, m keys
+        e: (ev) => this._showQuickBar(ev),
+        c: (ev) => this._showQuickBar(ev, true),
+        m: (ev) => this._createMyLink(ev),
+        // Those are fallbacks for non-latin keyboards that don't have e, c, m keys (qwerty-based shortcuts)
         KeyE: (ev) => this._showQuickBar(ev),
         KeyC: (ev) => this._showQuickBar(ev, true),
         KeyM: (ev) => this._createMyLink(ev),


### PR DESCRIPTION
## Proposed change

After https://github.com/home-assistant/frontend/pull/12892 was merged, shortcuts did NOT work anymore on non-qwerty keyboards. It was working fine before.

I'm using Bépo and the issue appeared ~ last week on all my devices (Windows, Linux). After some investigation and testing, I discovered this pull request that actually broke what it was claiming to fix.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

The documentation of `tinykeys`, the library used, specifies (https://github.com/jamiebuilds/tinykeys):

> ```
> // Matches `event.key`:
> "d"
> // Matches: `event.code`:
> "KeyD"
> ```

And you can check [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) that:
* KeyboardEvent.code returns a string with the code value of the physical key represented by the event.
* KeyboardEvent.key returns the value of the key pressed by the user, taking into consideration the state of modifier keys such as Shift as well as the keyboard locale and layout.


## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
