### PR TITLE
Setup stronger type for localize key

### DIFF
--- a/hassio/src/supervisor-base-element.ts
+++ b/hassio/src/supervisor-base-element.ts
@@ -25,7 +25,7 @@ import {
 } from "../../src/data/supervisor/supervisor";
 import { ProvideHassLitMixin } from "../../src/mixins/provide-hass-lit-mixin";
 import { urlSyncMixin } from "../../src/state/url-sync-mixin";
-import { HomeAssistant, Route } from "../../src/types";
+import { HomeAssistant, Route, TranslationDict } from "../../src/types";
 import { getTranslation } from "../../src/util/common-translation";
 
 declare global {
@@ -124,9 +124,13 @@ export class SupervisorBaseElement extends urlSyncMixin(
 
     this.supervisor = {
       ...this.supervisor,
-      localize: await computeLocalize(this.constructor.prototype, language, {
-        [language]: data,
-      }),
+      localize: await computeLocalize<TranslationDict["supervisor"]>(
+        this.constructor.prototype,
+        language,
+        {
+          [language]: data,
+        }
+      ),
     };
   }
 

--- a/src/common/translations/localize.ts
+++ b/src/common/translations/localize.ts
@@ -3,27 +3,22 @@ import { shouldPolyfill as shouldPolyfillPluralRules } from "@formatjs/intl-plur
 import { shouldPolyfill as shouldPolyfillRelativeTime } from "@formatjs/intl-relativetimeformat/lib/should-polyfill";
 import { shouldPolyfill as shouldPolyfillDateTime } from "@formatjs/intl-datetimeformat/lib/should-polyfill";
 import IntlMessageFormat from "intl-messageformat";
-import { Resources } from "../../types";
+import { Resources, TranslationDict } from "../../types";
 import { getLocalLanguage } from "../../util/common-translation";
 
-type TranslationKeys = typeof import("../../translations/en.json");
-type TopKeys = keyof TranslationKeys;
 // From https://www.raygesualdo.com/posts/flattening-object-keys-with-typescript-types
 type FlattenObjectKeys<
   T extends Record<string, unknown>,
-  Key = keyof T
+  Key extends keyof T = keyof T
 > = Key extends string
   ? T[Key] extends Record<string, unknown>
     ? `${Key}.${FlattenObjectKeys<T[Key]>}`
     : `${Key}`
   : never;
 
-export type LocalizeFunc<key extends TopKeys | null = null> = (
-  key: FlattenObjectKeys<
-    key extends TopKeys ? TranslationKeys[key] : TranslationKeys
-  >,
-  ...args: any[]
-) => string;
+export type LocalizeFunc<
+  Dict extends Record<string, unknown> = TranslationDict
+> = (key: FlattenObjectKeys<Dict>, ...args: any[]) => string;
 
 interface FormatType {
   [format: string]: any;
@@ -83,12 +78,14 @@ export const polyfillsLoaded =
  * }
  */
 
-export const computeLocalize = async (
+export const computeLocalize = async <
+  Dict extends Record<string, unknown> = TranslationDict
+>(
   cache: any,
   language: string,
   resources: Resources,
   formats?: FormatsType
-): Promise<LocalizeFunc> => {
+): Promise<LocalizeFunc<Dict>> => {
   if (polyfillsLoaded) {
     await polyfillsLoaded;
   }

--- a/src/common/translations/localize.ts
+++ b/src/common/translations/localize.ts
@@ -6,7 +6,22 @@ import IntlMessageFormat from "intl-messageformat";
 import { Resources } from "../../types";
 import { getLocalLanguage } from "../../util/common-translation";
 
-export type LocalizeFunc = (key: string, ...args: any[]) => string;
+type TranslationKeys = typeof import("../../translations/en.json");
+// From https://www.raygesualdo.com/posts/flattening-object-keys-with-typescript-types
+type FlattenObjectKeys<
+  T extends Record<string, unknown>,
+  Key = keyof T
+> = Key extends string
+  ? T[Key] extends Record<string, unknown>
+    ? `${Key}.${FlattenObjectKeys<T[Key]>}`
+    : `${Key}`
+  : never;
+
+export type LocalizeFunc = (
+  key: FlattenObjectKeys<TranslationKeys>,
+  ...args: any[]
+) => string;
+
 interface FormatType {
   [format: string]: any;
 }

--- a/src/common/translations/localize.ts
+++ b/src/common/translations/localize.ts
@@ -7,6 +7,7 @@ import { Resources } from "../../types";
 import { getLocalLanguage } from "../../util/common-translation";
 
 type TranslationKeys = typeof import("../../translations/en.json");
+type TopKeys = keyof TranslationKeys;
 // From https://www.raygesualdo.com/posts/flattening-object-keys-with-typescript-types
 type FlattenObjectKeys<
   T extends Record<string, unknown>,
@@ -17,8 +18,10 @@ type FlattenObjectKeys<
     : `${Key}`
   : never;
 
-export type LocalizeFunc = (
-  key: FlattenObjectKeys<TranslationKeys>,
+export type LocalizeFunc<key extends TopKeys | null = null> = (
+  key: FlattenObjectKeys<
+    key extends TopKeys ? TranslationKeys[key] : TranslationKeys
+  >,
   ...args: any[]
 ) => string;
 

--- a/src/common/translations/localize.ts
+++ b/src/common/translations/localize.ts
@@ -7,8 +7,19 @@ import { Resources, TranslationDict } from "../../types";
 import { getLocalLanguage } from "../../util/common-translation";
 
 // Exclude some patterns from key type checking for now
-// Fixing requires tighter definition of types from backend and/or web socket
-type LocalizeKeyExceptions = `component.${string}`;
+// These are intended to be removed as errors are fixed
+// Fixing component category will require tighter definition of types from backend and/or web socket
+type LocalizeKeyExceptions =
+  | `${string}`
+  | `panel.${string}`
+  | `state.${string}`
+  | `state_attributes.${string}`
+  | `state_badge.${string}`
+  | `groups.${string}`
+  | `config_entry.${string}`
+  | `ui.${string}`
+  | `${keyof TranslationDict["supervisor"]}.${string}`
+  | `component.${string}`;
 
 // Tweaked from https://www.raygesualdo.com/posts/flattening-object-keys-with-typescript-types
 type FlattenObjectKeys<

--- a/src/common/translations/localize.ts
+++ b/src/common/translations/localize.ts
@@ -6,9 +6,13 @@ import IntlMessageFormat from "intl-messageformat";
 import { Resources, TranslationDict } from "../../types";
 import { getLocalLanguage } from "../../util/common-translation";
 
-// From https://www.raygesualdo.com/posts/flattening-object-keys-with-typescript-types
+// Exclude some patterns from key type checking for now
+// Fixing requires tighter definition of types from backend and/or web socket
+type LocalizeKeyExceptions = `component.${string}`;
+
+// Tweaked from https://www.raygesualdo.com/posts/flattening-object-keys-with-typescript-types
 type FlattenObjectKeys<
-  T extends Record<string, unknown>,
+  T extends Record<string, any>,
   Key extends keyof T = keyof T
 > = Key extends string
   ? T[Key] extends Record<string, unknown>
@@ -18,7 +22,10 @@ type FlattenObjectKeys<
 
 export type LocalizeFunc<
   Dict extends Record<string, unknown> = TranslationDict
-> = (key: FlattenObjectKeys<Dict>, ...args: any[]) => string;
+> = (
+  key: FlattenObjectKeys<Dict> | LocalizeKeyExceptions,
+  ...args: any[]
+) => string;
 
 interface FormatType {
   [format: string]: any;

--- a/src/data/supervisor/supervisor.ts
+++ b/src/data/supervisor/supervisor.ts
@@ -1,7 +1,7 @@
 import { Connection, getCollection } from "home-assistant-js-websocket";
 import { Store } from "home-assistant-js-websocket/dist/store";
 import { LocalizeFunc } from "../../common/translations/localize";
-import { HomeAssistant } from "../../types";
+import { HomeAssistant, TranslationDict } from "../../types";
 import { HassioAddonsInfo } from "../hassio/addon";
 import { HassioHassOSInfo, HassioHostInfo } from "../hassio/host";
 import { NetworkInfo } from "../hassio/network";
@@ -67,7 +67,7 @@ export interface Supervisor {
   os: HassioHassOSInfo;
   addon: HassioAddonsInfo;
   store: SupervisorStore;
-  localize: LocalizeFunc<"supervisor">;
+  localize: LocalizeFunc<TranslationDict["supervisor"]>;
 }
 
 export const supervisorApiWsRequest = <T>(

--- a/src/data/supervisor/supervisor.ts
+++ b/src/data/supervisor/supervisor.ts
@@ -67,7 +67,7 @@ export interface Supervisor {
   os: HassioHassOSInfo;
   addon: HassioAddonsInfo;
   store: SupervisorStore;
-  localize: LocalizeFunc;
+  localize: LocalizeFunc<"supervisor">;
 }
 
 export const supervisorApiWsRequest = <T>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,9 @@ export interface TranslationMetadata {
   };
 }
 
+export type TranslationDict = typeof import("./translations/en.json") &
+  typeof import("../translations/backend/en.json");
+
 export interface IconMetaFile {
   version: string;
   parts: IconMeta[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,8 +151,7 @@ export interface TranslationMetadata {
   };
 }
 
-export type TranslationDict = typeof import("./translations/en.json") &
-  typeof import("../translations/backend/en.json");
+export type TranslationDict = typeof import("./translations/en.json");
 
 export interface IconMetaFile {
   version: string;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Sets up stronger type requirement for localize function to require an existing key instead of just any string.  This is the base change from Pr #13004 but aims to take a more incremental approach given the many errors to be fixed.  A blanket exception is given here which can be whittled down in future pull requests.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

