### PR TITLE
Fix localize key types related to form schemas (Group 1)

### DIFF
--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -35,7 +35,7 @@ export class HaForm extends LitElement implements HaFormElement {
 
   @property({ attribute: false }) public data!: HaFormDataContainer;
 
-  @property({ attribute: false }) public schema!: HaFormSchema[];
+  @property({ attribute: false }) public schema!: readonly HaFormSchema[];
 
   @property() public error?: Record<string, string>;
 
@@ -44,7 +44,7 @@ export class HaForm extends LitElement implements HaFormElement {
   @property() public computeError?: (schema: HaFormSchema, error) => string;
 
   @property() public computeLabel?: (
-    schema: HaFormSchema,
+    schema: any,
     data?: HaFormDataContainer
   ) => string;
 
@@ -168,7 +168,7 @@ export class HaForm extends LitElement implements HaFormElement {
     return this.computeHelper ? this.computeHelper(schema) : "";
   }
 
-  private _computeError(error, schema: HaFormSchema | HaFormSchema[]) {
+  private _computeError(error, schema: HaFormSchema | readonly HaFormSchema[]) {
     return this.computeError ? this.computeError(error, schema) : error;
   }
 

--- a/src/components/ha-form/types.ts
+++ b/src/components/ha-form/types.ts
@@ -53,12 +53,15 @@ export interface HaFormIntegerSchema extends HaFormBaseSchema {
 
 export interface HaFormSelectSchema extends HaFormBaseSchema {
   type: "select";
-  options: Array<[string, string]>;
+  options: ReadonlyArray<readonly [string, string]>;
 }
 
 export interface HaFormMultiSelectSchema extends HaFormBaseSchema {
   type: "multi_select";
-  options: Record<string, string> | string[] | Array<[string, string]>;
+  options:
+    | Record<string, string>
+    | readonly string[]
+    | ReadonlyArray<readonly [string, string]>;
 }
 
 export interface HaFormFloatSchema extends HaFormBaseSchema {

--- a/src/components/ha-form/types.ts
+++ b/src/components/ha-form/types.ts
@@ -100,7 +100,7 @@ export type HaFormMultiSelectData = string[];
 export type HaFormTimeData = HaDurationData;
 
 export interface HaFormElement extends LitElement {
-  schema: HaFormSchema | HaFormSchema[];
+  schema: HaFormSchema | readonly HaFormSchema[];
   data?: HaFormDataContainer | HaFormData;
   label?: string;
 }

--- a/src/components/ha-form/types.ts
+++ b/src/components/ha-form/types.ts
@@ -31,7 +31,7 @@ export interface HaFormGridSchema extends HaFormBaseSchema {
   type: "grid";
   name: "";
   column_min_width?: string;
-  schema: HaFormSchema[];
+  schema: readonly HaFormSchema[];
 }
 
 export interface HaFormSelector extends HaFormBaseSchema {
@@ -80,6 +80,12 @@ export interface HaFormBooleanSchema extends HaFormBaseSchema {
 export interface HaFormTimeSchema extends HaFormBaseSchema {
   type: "positive_time_period_dict";
 }
+
+// Type utility to unionize a schema array by flattening any grid schemas
+export type SchemaUnion<
+  SchemaArray extends readonly HaFormSchema[],
+  Schema = SchemaArray[number]
+> = Schema extends HaFormGridSchema ? SchemaUnion<Schema["schema"]> : Schema;
 
 export interface HaFormDataContainer {
   [key: string]: HaFormData;

--- a/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
@@ -15,7 +15,7 @@ import "../ha-automation-action";
 import "../../../../../components/ha-textfield";
 import type { ActionElement } from "../ha-automation-action-row";
 
-const OPTIONS = ["count", "while", "until"];
+const OPTIONS = ["count", "while", "until"] as const;
 
 const getType = (action) => OPTIONS.find((option) => option in action);
 

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_template.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_template.ts
@@ -1,12 +1,11 @@
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
 import type { WaitAction } from "../../../../../data/script";
 import type { HomeAssistant } from "../../../../../types";
 import type { ActionElement } from "../ha-automation-action-row";
 import "../../../../../components/ha-form/ha-form";
 
-const SCHEMA: HaFormSchema[] = [
+const SCHEMA = [
   {
     name: "wait_template",
     selector: {
@@ -24,7 +23,7 @@ const SCHEMA: HaFormSchema[] = [
     name: "continue_on_timeout",
     selector: { boolean: {} },
   },
-];
+] as const;
 
 @customElement("ha-automation-action-wait_template")
 export class HaWaitAction extends LitElement implements ActionElement {
@@ -47,7 +46,7 @@ export class HaWaitAction extends LitElement implements ActionElement {
     `;
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (schema: typeof SCHEMA[number]): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.actions.type.wait_template.${
         schema.name === "continue_on_timeout" ? "continue_timeout" : schema.name

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_template.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_template.ts
@@ -4,6 +4,7 @@ import type { WaitAction } from "../../../../../data/script";
 import type { HomeAssistant } from "../../../../../types";
 import type { ActionElement } from "../ha-automation-action-row";
 import "../../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 const SCHEMA = [
   {
@@ -46,7 +47,9 @@ export class HaWaitAction extends LitElement implements ActionElement {
     `;
   }
 
-  private _computeLabelCallback = (schema: typeof SCHEMA[number]): string =>
+  private _computeLabelCallback = (
+    schema: SchemaUnion<typeof SCHEMA>
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.actions.type.wait_template.${
         schema.name === "continue_on_timeout" ? "continue_timeout" : schema.name

--- a/src/panels/config/automation/condition/ha-automation-condition-editor.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-editor.ts
@@ -36,15 +36,15 @@ const OPTIONS = [
   "time",
   "trigger",
   "zone",
-];
+] as const;
 
 @customElement("ha-automation-condition-editor")
 export default class HaAutomationConditionEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() condition!: Condition;
+  @property({ attribute: false }) condition!: Condition;
 
-  @property() public yamlMode = false;
+  @property({ type: Boolean }) public yamlMode = false;
 
   private _processedCondition = memoizeOne((condition) =>
     expandConditionWithShorthand(condition)

--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -3,7 +3,6 @@ import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
 import { NumericStateCondition } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 
@@ -19,19 +18,22 @@ export default class HaNumericStateCondition extends LitElement {
     };
   }
 
-  private _schema = memoizeOne((entityId): HaFormSchema[] => [
-    { name: "entity_id", required: true, selector: { entity: {} } },
-    {
-      name: "attribute",
-      selector: { attribute: { entity_id: entityId } },
-    },
-    { name: "above", selector: { text: {} } },
-    { name: "below", selector: { text: {} } },
-    {
-      name: "value_template",
-      selector: { text: { multiline: true } },
-    },
-  ]);
+  private _schema = memoizeOne(
+    (entityId) =>
+      [
+        { name: "entity_id", required: true, selector: { entity: {} } },
+        {
+          name: "attribute",
+          selector: { attribute: { entity_id: entityId } },
+        },
+        { name: "above", selector: { text: {} } },
+        { name: "below", selector: { text: {} } },
+        {
+          name: "value_template",
+          selector: { text: { multiline: true } },
+        },
+      ] as const
+  );
 
   public render() {
     const schema = this._schema(this.condition.entity_id);
@@ -53,7 +55,9 @@ export default class HaNumericStateCondition extends LitElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string => {
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string => {
     switch (schema.name) {
       case "entity_id":
         return this.hass.localize("ui.components.entity.entity-picker.entity");

--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -5,6 +5,7 @@ import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { NumericStateCondition } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 @customElement("ha-automation-condition-numeric_state")
 export default class HaNumericStateCondition extends LitElement {
@@ -56,7 +57,7 @@ export default class HaNumericStateCondition extends LitElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string => {
     switch (schema.name) {
       case "entity_id":

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -4,7 +4,6 @@ import memoizeOne from "memoize-one";
 import { assert, literal, object, optional, string, union } from "superstruct";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
 import type { StateCondition } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import { forDictStruct } from "../../structs";
@@ -29,15 +28,18 @@ export class HaStateCondition extends LitElement implements ConditionElement {
     return { entity_id: "", state: "" };
   }
 
-  private _schema = memoizeOne((entityId) => [
-    { name: "entity_id", required: true, selector: { entity: {} } },
-    {
-      name: "attribute",
-      selector: { attribute: { entity_id: entityId } },
-    },
-    { name: "state", selector: { text: {} } },
-    { name: "for", selector: { duration: {} } },
-  ]);
+  private _schema = memoizeOne(
+    (entityId) =>
+      [
+        { name: "entity_id", required: true, selector: { entity: {} } },
+        {
+          name: "attribute",
+          selector: { attribute: { entity_id: entityId } },
+        },
+        { name: "state", selector: { text: {} } },
+        { name: "for", selector: { duration: {} } },
+      ] as const
+  );
 
   public shouldUpdate(changedProperties: PropertyValues) {
     if (changedProperties.has("condition")) {
@@ -80,7 +82,9 @@ export class HaStateCondition extends LitElement implements ConditionElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string => {
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string => {
     switch (schema.name) {
       case "entity_id":
         return this.hass.localize("ui.components.entity.entity-picker.entity");

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -9,6 +9,7 @@ import type { HomeAssistant } from "../../../../../types";
 import { forDictStruct } from "../../structs";
 import type { ConditionElement } from "../ha-automation-condition-row";
 import "../../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 const stateConditionStruct = object({
   condition: literal("state"),
@@ -83,7 +84,7 @@ export class HaStateCondition extends LitElement implements ConditionElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string => {
     switch (schema.name) {
       case "entity_id":

--- a/src/panels/config/automation/condition/types/ha-automation-condition-sun.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-sun.ts
@@ -6,7 +6,6 @@ import type { SunCondition } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { ConditionElement } from "../ha-automation-condition-row";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
 import "../../../../../components/ha-form/ha-form";
 
 @customElement("ha-automation-condition-sun")
@@ -19,48 +18,51 @@ export class HaSunCondition extends LitElement implements ConditionElement {
     return {};
   }
 
-  private _schema = memoizeOne((localize: LocalizeFunc) => [
-    {
-      name: "before",
-      type: "select",
-      required: true,
-      options: [
-        [
-          "sunrise",
-          localize(
-            "ui.panel.config.automation.editor.conditions.type.sun.sunrise"
-          ),
-        ],
-        [
-          "sunset",
-          localize(
-            "ui.panel.config.automation.editor.conditions.type.sun.sunset"
-          ),
-        ],
-      ],
-    },
-    { name: "before_offset", selector: { text: {} } },
-    {
-      name: "after",
-      type: "select",
-      required: true,
-      options: [
-        [
-          "sunrise",
-          localize(
-            "ui.panel.config.automation.editor.conditions.type.sun.sunrise"
-          ),
-        ],
-        [
-          "sunset",
-          localize(
-            "ui.panel.config.automation.editor.conditions.type.sun.sunset"
-          ),
-        ],
-      ],
-    },
-    { name: "after_offset", selector: { text: {} } },
-  ]);
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        {
+          name: "before",
+          type: "select",
+          required: true,
+          options: [
+            [
+              "sunrise",
+              localize(
+                "ui.panel.config.automation.editor.conditions.type.sun.sunrise"
+              ),
+            ],
+            [
+              "sunset",
+              localize(
+                "ui.panel.config.automation.editor.conditions.type.sun.sunset"
+              ),
+            ],
+          ],
+        },
+        { name: "before_offset", selector: { text: {} } },
+        {
+          name: "after",
+          type: "select",
+          required: true,
+          options: [
+            [
+              "sunrise",
+              localize(
+                "ui.panel.config.automation.editor.conditions.type.sun.sunrise"
+              ),
+            ],
+            [
+              "sunset",
+              localize(
+                "ui.panel.config.automation.editor.conditions.type.sun.sunset"
+              ),
+            ],
+          ],
+        },
+        { name: "after_offset", selector: { text: {} } },
+      ] as const
+  );
 
   protected render() {
     const schema = this._schema(this.hass.localize);
@@ -81,7 +83,9 @@ export class HaSunCondition extends LitElement implements ConditionElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.conditions.type.sun.${schema.name}`
     );

--- a/src/panels/config/automation/condition/types/ha-automation-condition-sun.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-sun.ts
@@ -7,6 +7,7 @@ import type { HomeAssistant } from "../../../../../types";
 import type { ConditionElement } from "../ha-automation-condition-row";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import "../../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 @customElement("ha-automation-condition-sun")
 export class HaSunCondition extends LitElement implements ConditionElement {
@@ -84,7 +85,7 @@ export class HaSunCondition extends LitElement implements ConditionElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.conditions.type.sun.${schema.name}`

--- a/src/panels/config/automation/condition/types/ha-automation-condition-time.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-time.ts
@@ -6,18 +6,9 @@ import type { TimeCondition } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { ConditionElement } from "../ha-automation-condition-row";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
 import "../../../../../components/ha-form/ha-form";
 
-const DAYS = {
-  mon: 1,
-  tue: 2,
-  wed: 3,
-  thu: 4,
-  fri: 5,
-  sat: 6,
-  sun: 7,
-};
+const DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
 
 @customElement("ha-automation-condition-time")
 export class HaTimeCondition extends LitElement implements ConditionElement {
@@ -38,16 +29,8 @@ export class HaTimeCondition extends LitElement implements ConditionElement {
       localize: LocalizeFunc,
       inputModeAfter?: boolean,
       inputModeBefore?: boolean
-    ): HaFormSchema[] => {
-      const modeAfterSchema = inputModeAfter
-        ? { name: "after", selector: { entity: { domain: "input_datetime" } } }
-        : { name: "after", selector: { time: {} } };
-
-      const modeBeforeSchema = inputModeBefore
-        ? { name: "before", selector: { entity: { domain: "input_datetime" } } }
-        : { name: "before", selector: { time: {} } };
-
-      return [
+    ) =>
+      [
         {
           name: "mode_after",
           type: "select",
@@ -67,7 +50,12 @@ export class HaTimeCondition extends LitElement implements ConditionElement {
             ],
           ],
         },
-        modeAfterSchema,
+        {
+          name: "after",
+          selector: inputModeAfter
+            ? { entity: { domain: "input_datetime" } }
+            : { time: {} },
+        },
         {
           name: "mode_before",
           type: "select",
@@ -87,19 +75,26 @@ export class HaTimeCondition extends LitElement implements ConditionElement {
             ],
           ],
         },
-        modeBeforeSchema,
+        {
+          name: "before",
+          selector: inputModeBefore
+            ? { entity: { domain: "input_datetime" } }
+            : { time: {} },
+        },
         {
           type: "multi_select",
           name: "weekday",
-          options: Object.keys(DAYS).map((day) => [
-            day,
-            localize(
-              `ui.panel.config.automation.editor.conditions.type.time.weekdays.${day}`
-            ),
-          ]),
+          options: DAYS.map(
+            (day) =>
+              [
+                day,
+                localize(
+                  `ui.panel.config.automation.editor.conditions.type.time.weekdays.${day}`
+                ),
+              ] as const
+          ),
         },
-      ];
-    }
+      ] as const
   );
 
   protected render() {
@@ -110,7 +105,7 @@ export class HaTimeCondition extends LitElement implements ConditionElement {
       this._inputModeAfter ??
       this.condition.after?.startsWith("input_datetime.");
 
-    const schema: HaFormSchema[] = this._schema(
+    const schema = this._schema(
       this.hass.localize,
       inputModeAfter,
       inputModeBefore
@@ -152,7 +147,9 @@ export class HaTimeCondition extends LitElement implements ConditionElement {
     fireEvent(this, "value-changed", { value: newValue });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.conditions.type.time.${schema.name}`
     );

--- a/src/panels/config/automation/condition/types/ha-automation-condition-time.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-time.ts
@@ -7,6 +7,7 @@ import type { HomeAssistant } from "../../../../../types";
 import type { ConditionElement } from "../ha-automation-condition-row";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import "../../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 const DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
 
@@ -148,7 +149,7 @@ export class HaTimeCondition extends LitElement implements ConditionElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.conditions.type.time.${schema.name}`

--- a/src/panels/config/automation/condition/types/ha-automation-condition-zone.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-zone.ts
@@ -18,7 +18,7 @@ const includeDomains = ["zone"];
 export class HaZoneCondition extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public condition!: ZoneCondition;
+  @property({ attribute: false }) public condition!: ZoneCondition;
 
   public static get defaultConfig() {
     return {

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -60,7 +60,7 @@ const OPTIONS = [
   "time_pattern",
   "webhook",
   "zone",
-];
+] as const;
 
 export interface TriggerElement extends LitElement {
   trigger: Trigger;
@@ -92,7 +92,7 @@ export const handleChangeEvent = (element: TriggerElement, ev: CustomEvent) => {
 export default class HaAutomationTriggerRow extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: Trigger;
+  @property({ attribute: false }) public trigger!: Trigger;
 
   @state() private _warnings?: string[];
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
@@ -6,7 +6,7 @@ import type { CalendarTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
 import type { HaDurationData } from "../../../../../components/ha-duration-input";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
+import "../../../../../components/ha-form/ha-form";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 
@@ -16,52 +16,55 @@ export class HaCalendarTrigger extends LitElement implements TriggerElement {
 
   @property({ attribute: false }) public trigger!: CalendarTrigger;
 
-  private _schema = memoizeOne((localize: LocalizeFunc) => [
-    {
-      name: "entity_id",
-      required: true,
-      selector: { entity: { domain: "calendar" } },
-    },
-    {
-      name: "event",
-      type: "select",
-      required: true,
-      options: [
-        [
-          "start",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.calendar.start"
-          ),
-        ],
-        [
-          "end",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.calendar.end"
-          ),
-        ],
-      ],
-    },
-    { name: "offset", selector: { duration: {} } },
-    {
-      name: "offset_type",
-      type: "select",
-      required: true,
-      options: [
-        [
-          "before",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.calendar.before"
-          ),
-        ],
-        [
-          "after",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.calendar.after"
-          ),
-        ],
-      ],
-    },
-  ]);
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        {
+          name: "entity_id",
+          required: true,
+          selector: { entity: { domain: "calendar" } },
+        },
+        {
+          name: "event",
+          type: "select",
+          required: true,
+          options: [
+            [
+              "start",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.calendar.start"
+              ),
+            ],
+            [
+              "end",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.calendar.end"
+              ),
+            ],
+          ],
+        },
+        { name: "offset", selector: { duration: {} } },
+        {
+          name: "offset_type",
+          type: "select",
+          required: true,
+          options: [
+            [
+              "before",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.calendar.before"
+              ),
+            ],
+            [
+              "after",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.calendar.after"
+              ),
+            ],
+          ],
+        },
+      ] as const
+  );
 
   public static get defaultConfig() {
     return {
@@ -114,7 +117,9 @@ export class HaCalendarTrigger extends LitElement implements TriggerElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.calendar.${schema.name}`
     );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-calendar.ts
@@ -9,6 +9,7 @@ import type { HaDurationData } from "../../../../../components/ha-duration-input
 import "../../../../../components/ha-form/ha-form";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 @customElement("ha-automation-trigger-calendar")
 export class HaCalendarTrigger extends LitElement implements TriggerElement {
@@ -118,7 +119,7 @@ export class HaCalendarTrigger extends LitElement implements TriggerElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.calendar.${schema.name}`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-geo_location.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-geo_location.ts
@@ -3,7 +3,6 @@ import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import { HaFormSchema } from "../../../../../components/ha-form/types";
 import type { GeoLocationTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
@@ -14,29 +13,32 @@ export class HaGeolocationTrigger extends LitElement {
 
   @property({ attribute: false }) public trigger!: GeoLocationTrigger;
 
-  private _schema = memoizeOne((localize: LocalizeFunc) => [
-    { name: "source", selector: { text: {} } },
-    { name: "zone", selector: { entity: { domain: "zone" } } },
-    {
-      name: "event",
-      type: "select",
-      required: true,
-      options: [
-        [
-          "enter",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.geo_location.enter"
-          ),
-        ],
-        [
-          "leave",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.geo_location.leave"
-          ),
-        ],
-      ],
-    },
-  ]);
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        { name: "source", selector: { text: {} } },
+        { name: "zone", selector: { entity: { domain: "zone" } } },
+        {
+          name: "event",
+          type: "select",
+          required: true,
+          options: [
+            [
+              "enter",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.geo_location.enter"
+              ),
+            ],
+            [
+              "leave",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.geo_location.leave"
+              ),
+            ],
+          ],
+        },
+      ] as const
+  );
 
   public static get defaultConfig() {
     return {
@@ -64,7 +66,9 @@ export class HaGeolocationTrigger extends LitElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.geo_location.${schema.name}`
     );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-geo_location.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-geo_location.ts
@@ -6,6 +6,7 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import type { GeoLocationTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 @customElement("ha-automation-trigger-geo_location")
 export class HaGeolocationTrigger extends LitElement {
@@ -67,7 +68,7 @@ export class HaGeolocationTrigger extends LitElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.geo_location.${schema.name}`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-homeassistant.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-homeassistant.ts
@@ -5,7 +5,6 @@ import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import type { HassTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 
 @customElement("ha-automation-trigger-homeassistant")
@@ -14,27 +13,30 @@ export class HaHassTrigger extends LitElement {
 
   @property({ attribute: false }) public trigger!: HassTrigger;
 
-  private _schema = memoizeOne((localize: LocalizeFunc) => [
-    {
-      name: "event",
-      type: "select",
-      required: true,
-      options: [
-        [
-          "start",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.homeassistant.start"
-          ),
-        ],
-        [
-          "shutdown",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.homeassistant.shutdown"
-          ),
-        ],
-      ],
-    },
-  ]);
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        {
+          name: "event",
+          type: "select",
+          required: true,
+          options: [
+            [
+              "start",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.homeassistant.start"
+              ),
+            ],
+            [
+              "shutdown",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.homeassistant.shutdown"
+              ),
+            ],
+          ],
+        },
+      ] as const
+  );
 
   public static get defaultConfig() {
     return {
@@ -60,9 +62,11 @@ export class HaHassTrigger extends LitElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string =>
     this.hass.localize(
-      `ui.panel.config.automation.editor.triggers.type.geo_location.${schema.name}`
+      `ui.panel.config.automation.editor.triggers.type.homeassistant.${schema.name}`
     );
 
   static styles = css`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-homeassistant.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-homeassistant.ts
@@ -6,6 +6,7 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import type { HassTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 @customElement("ha-automation-trigger-homeassistant")
 export class HaHassTrigger extends LitElement {
@@ -63,7 +64,7 @@ export class HaHassTrigger extends LitElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.homeassistant.${schema.name}`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-mqtt.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-mqtt.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 import { MqttTrigger } from "../../../../../data/automation";
 import { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
@@ -39,7 +40,9 @@ export class HaMQTTTrigger extends LitElement implements TriggerElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: typeof SCHEMA[number]): string =>
+  private _computeLabelCallback = (
+    schema: SchemaUnion<typeof SCHEMA>
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.mqtt.${schema.name}`
     );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-mqtt.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-mqtt.ts
@@ -1,21 +1,21 @@
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
+import "../../../../../components/ha-form/ha-form";
 import { MqttTrigger } from "../../../../../data/automation";
 import { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
 
-const SCHEMA: HaFormSchema[] = [
+const SCHEMA = [
   { name: "topic", required: true, selector: { text: {} } },
   { name: "payload", selector: { text: {} } },
-];
+] as const;
 
 @customElement("ha-automation-trigger-mqtt")
 export class HaMQTTTrigger extends LitElement implements TriggerElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: MqttTrigger;
+  @property({ attribute: false }) public trigger!: MqttTrigger;
 
   public static get defaultConfig() {
     return { topic: "" };
@@ -39,7 +39,7 @@ export class HaMQTTTrigger extends LitElement implements TriggerElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (schema: typeof SCHEMA[number]): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.mqtt.${schema.name}`
     );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -7,6 +7,7 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import { hasTemplate } from "../../../../../common/string/has-template";
 import type { NumericStateTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 @customElement("ha-automation-trigger-numeric_state")
 export class HaNumericStateTrigger extends LitElement {
@@ -76,7 +77,7 @@ export class HaNumericStateTrigger extends LitElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string => {
     switch (schema.name) {
       case "entity_id":

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -2,7 +2,6 @@ import "../../../../../components/ha-form/ha-form";
 import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { hasTemplate } from "../../../../../common/string/has-template";
@@ -13,22 +12,25 @@ import type { HomeAssistant } from "../../../../../types";
 export class HaNumericStateTrigger extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: NumericStateTrigger;
+  @property({ attribute: false }) public trigger!: NumericStateTrigger;
 
-  private _schema = memoizeOne((entityId): HaFormSchema[] => [
-    { name: "entity_id", required: true, selector: { entity: {} } },
-    {
-      name: "attribute",
-      selector: { attribute: { entity_id: entityId } },
-    },
-    { name: "above", selector: { text: {} } },
-    { name: "below", selector: { text: {} } },
-    {
-      name: "value_template",
-      selector: { text: { multiline: true } },
-    },
-    { name: "for", selector: { duration: {} } },
-  ]);
+  private _schema = memoizeOne(
+    (entityId) =>
+      [
+        { name: "entity_id", required: true, selector: { entity: {} } },
+        {
+          name: "attribute",
+          selector: { attribute: { entity_id: entityId } },
+        },
+        { name: "above", selector: { text: {} } },
+        { name: "below", selector: { text: {} } },
+        {
+          name: "value_template",
+          selector: { text: { multiline: true } },
+        },
+        { name: "for", selector: { duration: {} } },
+      ] as const
+  );
 
   public willUpdate(changedProperties: PropertyValues) {
     if (!changedProperties.has("trigger")) {
@@ -73,7 +75,9 @@ export class HaNumericStateTrigger extends LitElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string => {
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string => {
     switch (schema.name) {
       case "entity_id":
         return this.hass.localize("ui.components.entity.entity-picker.entity");

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -20,7 +20,6 @@ import { baseTriggerStruct, forDictStruct } from "../../structs";
 import { TriggerElement } from "../ha-automation-trigger-row";
 import "../../../../../components/ha-form/ha-form";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
-import { HaFormSchema } from "../../../../../components/ha-form/types";
 
 const stateTriggerStruct = assign(
   baseTriggerStruct,
@@ -38,26 +37,29 @@ const stateTriggerStruct = assign(
 export class HaStateTrigger extends LitElement implements TriggerElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: StateTrigger;
+  @property({ attribute: false }) public trigger!: StateTrigger;
 
   public static get defaultConfig() {
     return { entity_id: [] };
   }
 
-  private _schema = memoizeOne((entityId) => [
-    {
-      name: "entity_id",
-      required: true,
-      selector: { entity: { multiple: true } },
-    },
-    {
-      name: "attribute",
-      selector: { attribute: { entity_id: entityId } },
-    },
-    { name: "from", selector: { text: {} } },
-    { name: "to", selector: { text: {} } },
-    { name: "for", selector: { duration: {} } },
-  ]);
+  private _schema = memoizeOne(
+    (entityId) =>
+      [
+        {
+          name: "entity_id",
+          required: true,
+          selector: { entity: { multiple: true } },
+        },
+        {
+          name: "attribute",
+          selector: { attribute: { entity_id: entityId } },
+        },
+        { name: "from", selector: { text: {} } },
+        { name: "to", selector: { text: {} } },
+        { name: "for", selector: { duration: {} } },
+      ] as const
+  );
 
   public shouldUpdate(changedProperties: PropertyValues) {
     if (!changedProperties.has("trigger")) {
@@ -122,7 +124,9 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string =>
     this.hass.localize(
       schema.name === "entity_id"
         ? "ui.components.entity.entity-picker.entity"

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -20,6 +20,7 @@ import { baseTriggerStruct, forDictStruct } from "../../structs";
 import { TriggerElement } from "../ha-automation-trigger-row";
 import "../../../../../components/ha-form/ha-form";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 const stateTriggerStruct = assign(
   baseTriggerStruct,
@@ -125,7 +126,7 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string =>
     this.hass.localize(
       schema.name === "entity_id"

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-sun.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-sun.ts
@@ -7,6 +7,7 @@ import type { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
 import "../../../../../components/ha-form/ha-form";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 @customElement("ha-automation-trigger-sun")
 export class HaSunTrigger extends LitElement implements TriggerElement {
@@ -67,7 +68,7 @@ export class HaSunTrigger extends LitElement implements TriggerElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.sun.${schema.name}`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-sun.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-sun.ts
@@ -5,7 +5,7 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import type { SunTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
+import "../../../../../components/ha-form/ha-form";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 
 @customElement("ha-automation-trigger-sun")
@@ -14,28 +14,31 @@ export class HaSunTrigger extends LitElement implements TriggerElement {
 
   @property({ attribute: false }) public trigger!: SunTrigger;
 
-  private _schema = memoizeOne((localize: LocalizeFunc) => [
-    {
-      name: "event",
-      type: "select",
-      required: true,
-      options: [
-        [
-          "sunrise",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.sun.sunrise"
-          ),
-        ],
-        [
-          "sunset",
-          localize(
-            "ui.panel.config.automation.editor.triggers.type.sun.sunset"
-          ),
-        ],
-      ],
-    },
-    { name: "offset", selector: { text: {} } },
-  ]);
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        {
+          name: "event",
+          type: "select",
+          required: true,
+          options: [
+            [
+              "sunrise",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.sun.sunrise"
+              ),
+            ],
+            [
+              "sunset",
+              localize(
+                "ui.panel.config.automation.editor.triggers.type.sun.sunset"
+              ),
+            ],
+          ],
+        },
+        { name: "offset", selector: { text: {} } },
+      ] as const
+  );
 
   public static get defaultConfig() {
     return {
@@ -63,7 +66,9 @@ export class HaSunTrigger extends LitElement implements TriggerElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.sun.${schema.name}`
     );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-time.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-time.ts
@@ -7,6 +7,7 @@ import type { TriggerElement } from "../ha-automation-trigger-row";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 @customElement("ha-automation-trigger-time")
 export class HaTimeTrigger extends LitElement implements TriggerElement {
@@ -111,7 +112,7 @@ export class HaTimeTrigger extends LitElement implements TriggerElement {
   }
 
   private _computeLabelCallback = (
-    schema: ReturnType<typeof this._schema>[number]
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
   ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.time.${schema.name}`

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-time.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-time.ts
@@ -5,7 +5,6 @@ import type { TimeTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-form/ha-form";
 
@@ -22,7 +21,7 @@ export class HaTimeTrigger extends LitElement implements TriggerElement {
   }
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc, inputMode?: boolean): HaFormSchema[] => {
+    (localize: LocalizeFunc, inputMode?: boolean) => {
       const atSelector = inputMode
         ? { entity: { domain: "input_datetime" } }
         : { time: {} };
@@ -48,7 +47,7 @@ export class HaTimeTrigger extends LitElement implements TriggerElement {
           ],
         },
         { name: "at", selector: atSelector },
-      ];
+      ] as const;
     }
   );
 
@@ -77,7 +76,7 @@ export class HaTimeTrigger extends LitElement implements TriggerElement {
       this._inputMode ??
       (at?.startsWith("input_datetime.") || at?.startsWith("sensor."));
 
-    const schema: HaFormSchema[] = this._schema(this.hass.localize, inputMode);
+    const schema = this._schema(this.hass.localize, inputMode);
 
     const data = {
       mode: inputMode ? "input" : "value",
@@ -111,7 +110,9 @@ export class HaTimeTrigger extends LitElement implements TriggerElement {
     fireEvent(this, "value-changed", { value: newValue });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (
+    schema: ReturnType<typeof this._schema>[number]
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.time.${schema.name}`
     );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-time_pattern.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-time_pattern.ts
@@ -2,6 +2,7 @@ import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 import type { TimePatternTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
@@ -40,7 +41,9 @@ export class HaTimePatternTrigger extends LitElement implements TriggerElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: typeof SCHEMA[number]): string =>
+  private _computeLabelCallback = (
+    schema: SchemaUnion<typeof SCHEMA>
+  ): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.time_pattern.${schema.name}`
     );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-time_pattern.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-time_pattern.ts
@@ -1,22 +1,22 @@
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
-import type { HaFormSchema } from "../../../../../components/ha-form/types";
+import "../../../../../components/ha-form/ha-form";
 import type { TimePatternTrigger } from "../../../../../data/automation";
 import type { HomeAssistant } from "../../../../../types";
 import type { TriggerElement } from "../ha-automation-trigger-row";
 
-const SCHEMA: HaFormSchema[] = [
+const SCHEMA = [
   { name: "hours", selector: { text: {} } },
   { name: "minutes", selector: { text: {} } },
   { name: "seconds", selector: { text: {} } },
-];
+] as const;
 
 @customElement("ha-automation-trigger-time_pattern")
 export class HaTimePatternTrigger extends LitElement implements TriggerElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: TimePatternTrigger;
+  @property({ attribute: false }) public trigger!: TimePatternTrigger;
 
   public static get defaultConfig() {
     return {};
@@ -40,7 +40,7 @@ export class HaTimePatternTrigger extends LitElement implements TriggerElement {
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema): string =>
+  private _computeLabelCallback = (schema: typeof SCHEMA[number]): string =>
     this.hass.localize(
       `ui.panel.config.automation.editor.triggers.type.time_pattern.${schema.name}`
     );

--- a/src/panels/lovelace/editor/config-elements/hui-area-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-area-card-editor.ts
@@ -3,7 +3,7 @@ import { customElement, property, state } from "lit/decorators";
 import { assert, assign, boolean, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-form/ha-form";
-import type { HaFormSchema } from "../../../../components/ha-form/types";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
 import type { AreaCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
@@ -19,7 +19,7 @@ const cardConfigStruct = assign(
   })
 );
 
-const SCHEMA: HaFormSchema[] = [
+const SCHEMA = [
   { name: "area", selector: { area: {} } },
   { name: "show_camera", required: false, selector: { boolean: {} } },
   {
@@ -30,7 +30,7 @@ const SCHEMA: HaFormSchema[] = [
       { name: "theme", required: false, selector: { theme: {} } },
     ],
   },
-];
+] as const;
 
 @customElement("hui-area-card-editor")
 export class HuiAreaCardEditor
@@ -67,7 +67,7 @@ export class HuiAreaCardEditor
     fireEvent(this, "config-changed", { config });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema) => {
+  private _computeLabelCallback = (schema: SchemaUnion<typeof SCHEMA>) => {
     switch (schema.name) {
       case "theme":
         return `${this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-button-card-editor.ts
@@ -7,7 +7,7 @@ import { fireEvent } from "../../../../common/dom/fire_event";
 import { computeDomain } from "../../../../common/entity/compute_domain";
 import { domainIcon } from "../../../../common/entity/domain_icon";
 import "../../../../components/ha-form/ha-form";
-import type { HaFormSchema } from "../../../../components/ha-form/types";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
 import { ActionConfig } from "../../../../data/lovelace";
 import type { HomeAssistant } from "../../../../types";
 import type { ButtonCardConfig } from "../../cards/types";
@@ -58,53 +58,50 @@ export class HuiButtonCardEditor
   }
 
   private _schema = memoizeOne(
-    (
-      entity?: string,
-      icon?: string,
-      entityState?: HassEntity
-    ): HaFormSchema[] => [
-      { name: "entity", selector: { entity: {} } },
-      {
-        name: "",
-        type: "grid",
-        schema: [
-          { name: "name", selector: { text: {} } },
-          {
-            name: "icon",
-            selector: {
-              icon: {
-                placeholder: icon || entityState?.attributes.icon,
-                fallbackPath:
-                  !icon &&
-                  !entityState?.attributes.icon &&
-                  entityState &&
-                  entity
-                    ? domainIcon(computeDomain(entity), entityState)
-                    : undefined,
+    (entity?: string, icon?: string, entityState?: HassEntity) =>
+      [
+        { name: "entity", selector: { entity: {} } },
+        {
+          name: "",
+          type: "grid",
+          schema: [
+            { name: "name", selector: { text: {} } },
+            {
+              name: "icon",
+              selector: {
+                icon: {
+                  placeholder: icon || entityState?.attributes.icon,
+                  fallbackPath:
+                    !icon &&
+                    !entityState?.attributes.icon &&
+                    entityState &&
+                    entity
+                      ? domainIcon(computeDomain(entity), entityState)
+                      : undefined,
+                },
               },
             },
-          },
-        ],
-      },
-      {
-        name: "",
-        type: "grid",
-        column_min_width: "100px",
-        schema: [
-          { name: "show_name", selector: { boolean: {} } },
-          { name: "show_state", selector: { boolean: {} } },
-          { name: "show_icon", selector: { boolean: {} } },
-        ],
-      },
-      {
-        name: "",
-        type: "grid",
-        schema: [
-          { name: "icon_height", selector: { text: { suffix: "px" } } },
-          { name: "theme", selector: { theme: {} } },
-        ],
-      },
-    ]
+          ],
+        },
+        {
+          name: "",
+          type: "grid",
+          column_min_width: "100px",
+          schema: [
+            { name: "show_name", selector: { boolean: {} } },
+            { name: "show_state", selector: { boolean: {} } },
+            { name: "show_icon", selector: { boolean: {} } },
+          ],
+        },
+        {
+          name: "",
+          type: "grid",
+          schema: [
+            { name: "icon_height", selector: { text: { suffix: "px" } } },
+            { name: "theme", selector: { theme: {} } },
+          ],
+        },
+      ] as const
   );
 
   get _tap_action(): ActionConfig | undefined {
@@ -193,7 +190,9 @@ export class HuiButtonCardEditor
     fireEvent(this, "config-changed", { config });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema) => {
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
     if (schema.name === "entity") {
       return `${this.hass!.localize(
         "ui.panel.lovelace.editor.card.generic.entity"

--- a/src/panels/lovelace/editor/config-elements/hui-calendar-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-calendar-card-editor.ts
@@ -15,7 +15,7 @@ import {
 } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { LocalizeFunc } from "../../../../common/translations/localize";
-import type { HaFormSchema } from "../../../../components/ha-form/types";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
 import type { CalendarCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
@@ -31,7 +31,7 @@ const cardConfigStruct = assign(
   })
 );
 
-const views = ["dayGridMonth", "dayGridDay", "listWeek"];
+const views = ["dayGridMonth", "dayGridDay", "listWeek"] as const;
 
 @customElement("hui-calendar-card-editor")
 export class HuiCalendarCardEditor
@@ -47,30 +47,33 @@ export class HuiCalendarCardEditor
     this._config = config;
   }
 
-  private _schema = memoizeOne((localize: LocalizeFunc) => [
-    {
-      name: "",
-      type: "grid",
-      schema: [
-        { name: "title", required: false, selector: { text: {} } },
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
         {
-          name: "initial_view",
-          required: false,
-          selector: {
-            select: {
-              options: views.map((view) => [
-                view,
-                localize(
-                  `ui.panel.lovelace.editor.card.calendar.views.${view}`
-                ),
-              ]),
+          name: "",
+          type: "grid",
+          schema: [
+            { name: "title", required: false, selector: { text: {} } },
+            {
+              name: "initial_view",
+              required: false,
+              selector: {
+                select: {
+                  options: views.map((view) => ({
+                    value: view,
+                    label: localize(
+                      `ui.panel.lovelace.editor.card.calendar.views.${view}`
+                    ),
+                  })),
+                },
+              },
             },
-          },
+          ],
         },
-      ],
-    },
-    { name: "theme", required: false, selector: { theme: {} } },
-  ]);
+        { name: "theme", required: false, selector: { theme: {} } },
+      ] as const
+  );
 
   protected render(): TemplateResult {
     if (!this.hass || !this._config) {
@@ -116,7 +119,9 @@ export class HuiCalendarCardEditor
     fireEvent(this, "config-changed", { config });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema) => {
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
     if (schema.name === "title") {
       return this.hass!.localize("ui.panel.lovelace.editor.card.generic.title");
     }

--- a/src/panels/lovelace/editor/config-elements/hui-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entity-card-editor.ts
@@ -7,7 +7,7 @@ import type { HassEntity } from "home-assistant-js-websocket/dist/types";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { computeDomain } from "../../../../common/entity/compute_domain";
 import { domainIcon } from "../../../../common/entity/domain_icon";
-import type { HaFormSchema } from "../../../../components/ha-form/types";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
 import type { EntityCardConfig } from "../../cards/types";
 import { headerFooterConfigStructs } from "../../header-footer/structs";
@@ -43,36 +43,37 @@ export class HuiEntityCardEditor
   }
 
   private _schema = memoizeOne(
-    (entity: string, icon: string, entityState: HassEntity): HaFormSchema[] => [
-      { name: "entity", required: true, selector: { entity: {} } },
-      {
-        type: "grid",
-        name: "",
-        schema: [
-          { name: "name", selector: { text: {} } },
-          {
-            name: "icon",
-            selector: {
-              icon: {
-                placeholder: icon || entityState?.attributes.icon,
-                fallbackPath:
-                  !icon && !entityState?.attributes.icon && entityState
-                    ? domainIcon(computeDomain(entity), entityState)
-                    : undefined,
+    (entity: string, icon: string, entityState: HassEntity) =>
+      [
+        { name: "entity", required: true, selector: { entity: {} } },
+        {
+          type: "grid",
+          name: "",
+          schema: [
+            { name: "name", selector: { text: {} } },
+            {
+              name: "icon",
+              selector: {
+                icon: {
+                  placeholder: icon || entityState?.attributes.icon,
+                  fallbackPath:
+                    !icon && !entityState?.attributes.icon && entityState
+                      ? domainIcon(computeDomain(entity), entityState)
+                      : undefined,
+                },
               },
             },
-          },
 
-          {
-            name: "attribute",
-            selector: { attribute: { entity_id: entity } },
-          },
-          { name: "unit", selector: { text: {} } },
-          { name: "theme", selector: { theme: {} } },
-          { name: "state_color", selector: { boolean: {} } },
-        ],
-      },
-    ]
+            {
+              name: "attribute",
+              selector: { attribute: { entity_id: entity } },
+            },
+            { name: "unit", selector: { text: {} } },
+            { name: "theme", selector: { theme: {} } },
+            { name: "state_color", selector: { boolean: {} } },
+          ],
+        },
+      ] as const
   );
 
   protected render(): TemplateResult {
@@ -105,7 +106,9 @@ export class HuiEntityCardEditor
     fireEvent(this, "config-changed", { config });
   }
 
-  private _computeLabelCallback = (schema: HaFormSchema) => {
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
     if (schema.name === "entity") {
       return this.hass!.localize(
         "ui.panel.lovelace.editor.card.generic.entity"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This fixes a chunk of errors caused by form schemas.  Don't be scared by the number of lines changed:
1. Prettier likes to make big changes when adding `as const` to big arrays, so definitely turn off whitespace in the diffs to cut them way down.
2. All schemas are modified with the exact same approach: make the schema read-only literal typed, then use that in the label callback and rearrange the conditionals where necessary.

These were cherry picked from #13004.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

