### PR TITLE
Separate supervisor localize key exceptions and disallow string

### DIFF
--- a/hassio/src/backups/hassio-backups.ts
+++ b/hassio/src/backups/hassio-backups.ts
@@ -176,7 +176,7 @@ export class HassioBackups extends LitElement {
           : supervisorTabs(this.hass)}
         .hass=${this.hass}
         .localizeFunc=${this.supervisor.localize}
-        .searchLabel=${this.supervisor.localize("search")}
+        .searchLabel=${this.supervisor.localize("backup.search")}
         .noDataText=${this.supervisor.localize("backup.no_backups")}
         .narrow=${this.narrow}
         .route=${this.route}
@@ -240,7 +240,7 @@ export class HassioBackups extends LitElement {
                   : html`
                       <ha-icon-button
                         .label=${this.supervisor.localize(
-                          "snapshot.delete_selected"
+                          "backup.delete_selected"
                         )}
                         .path=${mdiDelete}
                         id="delete-btn"

--- a/hassio/src/supervisor-base-element.ts
+++ b/hassio/src/supervisor-base-element.ts
@@ -22,10 +22,11 @@ import {
   Supervisor,
   SupervisorObject,
   supervisorCollection,
+  SupervisorKeys,
 } from "../../src/data/supervisor/supervisor";
 import { ProvideHassLitMixin } from "../../src/mixins/provide-hass-lit-mixin";
 import { urlSyncMixin } from "../../src/state/url-sync-mixin";
-import { HomeAssistant, Route, TranslationDict } from "../../src/types";
+import { HomeAssistant, Route } from "../../src/types";
 import { getTranslation } from "../../src/util/common-translation";
 
 declare global {
@@ -124,7 +125,7 @@ export class SupervisorBaseElement extends urlSyncMixin(
 
     this.supervisor = {
       ...this.supervisor,
-      localize: await computeLocalize<TranslationDict["supervisor"]>(
+      localize: await computeLocalize<SupervisorKeys>(
         this.constructor.prototype,
         language,
         {

--- a/src/common/translations/localize.ts
+++ b/src/common/translations/localize.ts
@@ -9,18 +9,18 @@ import { getLocalLanguage } from "../../util/common-translation";
 // Exclude some patterns from key type checking for now
 // These are intended to be removed as errors are fixed
 // Fixing component category will require tighter definition of types from backend and/or web socket
-type LocalizeKeyExceptions =
+export type LocalizeKeys =
+  | FlattenObjectKeys<Omit<TranslationDict, "supervisor">>
   | `${string}`
   | `panel.${string}`
   | `state.${string}`
   | `state_attributes.${string}`
   | `state_badge.${string}`
   | `ui.${string}`
-  | `${keyof TranslationDict["supervisor"]}.${string}`
   | `component.${string}`;
 
 // Tweaked from https://www.raygesualdo.com/posts/flattening-object-keys-with-typescript-types
-type FlattenObjectKeys<
+export type FlattenObjectKeys<
   T extends Record<string, any>,
   Key extends keyof T = keyof T
 > = Key extends string
@@ -29,10 +29,8 @@ type FlattenObjectKeys<
     : `${Key}`
   : never;
 
-export type LocalizeFunc<
-  Dict extends Record<string, unknown> = TranslationDict
-> = (
-  key: FlattenObjectKeys<Dict> | LocalizeKeyExceptions,
+export type LocalizeFunc<Keys extends string = LocalizeKeys> = (
+  key: Keys,
   ...args: any[]
 ) => string;
 
@@ -94,14 +92,12 @@ export const polyfillsLoaded =
  * }
  */
 
-export const computeLocalize = async <
-  Dict extends Record<string, unknown> = TranslationDict
->(
+export const computeLocalize = async <Keys extends string = LocalizeKeys>(
   cache: any,
   language: string,
   resources: Resources,
   formats?: FormatsType
-): Promise<LocalizeFunc<Dict>> => {
+): Promise<LocalizeFunc<Keys>> => {
   if (polyfillsLoaded) {
     await polyfillsLoaded;
   }

--- a/src/data/supervisor/supervisor.ts
+++ b/src/data/supervisor/supervisor.ts
@@ -1,6 +1,9 @@
 import { Connection, getCollection } from "home-assistant-js-websocket";
 import { Store } from "home-assistant-js-websocket/dist/store";
-import { LocalizeFunc } from "../../common/translations/localize";
+import {
+  FlattenObjectKeys,
+  LocalizeFunc,
+} from "../../common/translations/localize";
 import { HomeAssistant, TranslationDict } from "../../types";
 import { HassioAddonsInfo } from "../hassio/addon";
 import { HassioHassOSInfo, HassioHostInfo } from "../hassio/host";
@@ -57,6 +60,10 @@ export interface SupervisorEvent {
   [key: string]: any;
 }
 
+export type SupervisorKeys =
+  | FlattenObjectKeys<TranslationDict["supervisor"]>
+  | `${keyof TranslationDict["supervisor"]}.${string}`;
+
 export interface Supervisor {
   host: HassioHostInfo;
   supervisor: HassioSupervisorInfo;
@@ -67,7 +74,7 @@ export interface Supervisor {
   os: HassioHassOSInfo;
   addon: HassioAddonsInfo;
   store: SupervisorStore;
-  localize: LocalizeFunc<TranslationDict["supervisor"]>;
+  localize: LocalizeFunc<SupervisorKeys>;
 }
 
 export const supervisorApiWsRequest = <T>(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4955,6 +4955,7 @@
       }
     },
     "backup": {
+      "search": "[%key:ui::panel::config::backup::picker::search%]",
       "no_backups": "You don't have any backups yet.",
       "create_blocked_not_running": "Creating a backup is not possible right now because the system is in {state} state.",
       "delete_selected": "Delete selected backups",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This refactors the `LocalizeFunc` type to accept keys instead of a dictionary, which allows for easier separating of the supervisor keys and also easier debugging.  A type error is also fixed so that the supervisor keys are at least checked at the top category now.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

