### PR TITLE
Enable http cache for local media-player-browse thumbnails

### DIFF
--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -663,6 +663,10 @@ export class HaMediaPlayerBrowse extends LitElement {
       return new Promise((resolve, reject) => {
         this.hass
           .fetchWithAuth(thumbnailUrl!)
+          // Since we are fetching with an authorization header, we cannot just put the
+          // URL directly into the document; we need to embed the image. We could do this
+          // using blob URLs, but then we would need to keep track of them in order to
+          // release them properly. Instead, we embed the thumbnail using base64.
           .then((response) => response.blob())
           .then((blob) => {
             const reader = new FileReader();


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The media player browser serves local thumbnails by using `getSignedPath()` to put a signed URL in the document. The use of authSig in the query params basically disallows the use of cache, as the Service Worker cache is [essentially junk when ignoring query params](https://bugs.chromium.org/p/chromium/issues/detail?id=682677), and the http cache won't cache these properly. In addition, with this method there's the waste of a round trip from the frontend to the core during the URL signing. Together. these can result in latency when scrolling in the media browser.
This PR uses the `fetchWithAuth()` to fetch the thumbnail using a request with a token in the header, allowing use of the http cache. In order to pass this to the document, it encodes the result in base64 to be embedded in the document. An alternative would be to use blob URLs, but that would require more bookkeeping to prevent memory leaks.
There seemed to be a similar usage in ha-selector-media, but I've never touched blueprints so have no idea how to test that - perhaps that can be addressed in a follow up PR.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
