### PR TITLE
Logbook card: place a gap between an icon/image & a text

### DIFF
--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -560,6 +560,7 @@ class HaLogbookRenderer extends LitElement {
         .icon-message {
           display: flex;
           align-items: center;
+          column-gap: 8px;
         }
 
         .no-entries {

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -560,7 +560,6 @@ class HaLogbookRenderer extends LitElement {
         .icon-message {
           display: flex;
           align-items: center;
-          column-gap: 8px;
         }
 
         .no-entries {
@@ -615,7 +614,8 @@ class HaLogbookRenderer extends LitElement {
         .narrow .icon-message state-badge {
           margin-left: 0;
           margin-inline-start: 0;
-          margin-inline-end: initial;
+          margin-inline-end: 8px;
+          margin-right: 8px;
           direction: var(--direction);
         }
       `,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add a horizontal gap between an icon/image and a text.
Currently w/o this gap a placement of these elements is very tight.

For details - see https://github.com/home-assistant/frontend/issues/13131

![изображение](https://user-images.githubusercontent.com/71872483/183262057-e73acfa1-0f40-41f4-8c4d-da26feab0484.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/13131
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [x ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
