### PR TITLE
Remove string exception for localize keys

### DIFF
--- a/src/auth/ha-auth-flow.ts
+++ b/src/auth/ha-auth-flow.ts
@@ -314,7 +314,8 @@ class HaAuthFlow extends litLocalizeLiteMixin(LitElement) {
   }
 
   private _computeStepDescription(step: DataEntryFlowStepForm) {
-    const resourceKey = `ui.panel.page-authorize.form.providers.${step.handler[0]}.step.${step.step_id}.description`;
+    const resourceKey =
+      `ui.panel.page-authorize.form.providers.${step.handler[0]}.step.${step.step_id}.description` as const;
     const args: string[] = [];
     const placeholders = step.description_placeholders || {};
     Object.keys(placeholders).forEach((key) => {

--- a/src/common/translations/localize.ts
+++ b/src/common/translations/localize.ts
@@ -11,7 +11,6 @@ import { getLocalLanguage } from "../../util/common-translation";
 // Fixing component category will require tighter definition of types from backend and/or web socket
 export type LocalizeKeys =
   | FlattenObjectKeys<Omit<TranslationDict, "supervisor">>
-  | `${string}`
   | `panel.${string}`
   | `state.${string}`
   | `state_attributes.${string}`

--- a/src/data/panel.ts
+++ b/src/data/panel.ts
@@ -21,16 +21,16 @@ export const getDefaultPanel = (hass: HomeAssistant): PanelInfo =>
     ? hass.panels[hass.defaultPanel]
     : hass.panels[DEFAULT_PANEL];
 
-export const getPanelNameTranslationKey = (panel: PanelInfo): string => {
+export const getPanelNameTranslationKey = (panel: PanelInfo) => {
   if (panel.url_path === "lovelace") {
-    return "panel.states";
+    return "panel.states" as const;
   }
 
   if (panel.url_path === "profile") {
-    return "panel.profile";
+    return "panel.profile" as const;
   }
 
-  return `panel.${panel.title}`;
+  return `panel.${panel.title}` as const;
 };
 
 export const getPanelTitle = (hass: HomeAssistant): string | undefined => {

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -550,7 +550,7 @@ export class QuickBar extends LitElement {
   }
 
   private _generateServerControlCommands(): CommandItem[] {
-    const serverActions = ["restart", "stop"];
+    const serverActions = ["restart", "stop"] as const;
 
     return serverActions.map((action) => {
       const categoryKey: CommandItem["categoryKey"] = "server_control";

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -673,6 +673,7 @@ export class QuickBar extends LitElement {
         this.hass.localize(
           `ui.dialogs.quick-bar.commands.navigation.${name}`
         )) ||
+      // @ts-expect-error
       (page.translationKey && this.hass.localize(page.translationKey));
 
     if (caption) {

--- a/src/panels/config/devices/device-detail/ha-device-actions-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-actions-card.ts
@@ -7,9 +7,9 @@ import { HaDeviceAutomationCard } from "./ha-device-automation-card";
 
 @customElement("ha-device-actions-card")
 export class HaDeviceActionsCard extends HaDeviceAutomationCard<DeviceAction> {
-  protected type = "action";
+  readonly type = "action";
 
-  protected headerKey = "ui.panel.config.devices.automation.actions.caption";
+  readonly headerKey = "ui.panel.config.devices.automation.actions.caption";
 
   constructor() {
     super(localizeDeviceAutomationAction);

--- a/src/panels/config/devices/device-detail/ha-device-automation-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-automation-card.ts
@@ -25,15 +25,15 @@ export abstract class HaDeviceAutomationCard<
 
   @property() public deviceId?: string;
 
-  @property() public script = false;
+  @property({ type: Boolean }) public script = false;
 
-  @property() public automations: T[] = [];
+  @property({ attribute: false }) public automations: T[] = [];
 
   @state() public _showSecondary = false;
 
-  protected headerKey = "";
+  abstract headerKey: Parameters<typeof this.hass.localize>[0];
 
-  protected type = "";
+  abstract type: "action" | "condition" | "trigger";
 
   private _localizeDeviceAutomation: (
     hass: HomeAssistant,

--- a/src/panels/config/devices/device-detail/ha-device-conditions-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-conditions-card.ts
@@ -7,9 +7,9 @@ import { HaDeviceAutomationCard } from "./ha-device-automation-card";
 
 @customElement("ha-device-conditions-card")
 export class HaDeviceConditionsCard extends HaDeviceAutomationCard<DeviceCondition> {
-  protected type = "condition";
+  readonly type = "condition";
 
-  protected headerKey = "ui.panel.config.devices.automation.conditions.caption";
+  readonly headerKey = "ui.panel.config.devices.automation.conditions.caption";
 
   constructor() {
     super(localizeDeviceAutomationCondition);

--- a/src/panels/config/devices/device-detail/ha-device-triggers-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-triggers-card.ts
@@ -7,9 +7,9 @@ import { HaDeviceAutomationCard } from "./ha-device-automation-card";
 
 @customElement("ha-device-triggers-card")
 export class HaDeviceTriggersCard extends HaDeviceAutomationCard<DeviceTrigger> {
-  protected type = "trigger";
+  readonly type = "trigger";
 
-  protected headerKey = "ui.panel.config.devices.automation.triggers.caption";
+  readonly headerKey = "ui.panel.config.devices.automation.triggers.caption";
 
   constructor() {
     super(localizeDeviceAutomationTrigger);

--- a/src/panels/config/entities/dialog-entity-editor.ts
+++ b/src/panels/config/entities/dialog-entity-editor.ts
@@ -31,7 +31,7 @@ interface Tabs {
 
 interface Tab {
   component: string;
-  translationKey: string;
+  translationKey: Parameters<HomeAssistant["localize"]>[0];
 }
 
 @customElement("dialog-entity-editor")

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-config-dashboard.ts
@@ -494,7 +494,7 @@ class ZWaveJSConfigDashboard extends SubscribeMixin(LitElement) {
 
   private _renderErrorScreen() {
     const item = this._configEntry!;
-    let stateText: [string, ...unknown[]] | undefined;
+    let stateText: Parameters<typeof this.hass.localize> | undefined;
     let stateTextExtra: TemplateResult | string | undefined;
 
     if (item.disabled_by) {

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -217,8 +217,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
                 slot="item-icon"
               ></ha-svg-icon>
               ${this.hass.localize(
-                "ui.panel.config.zwave_js.node_config.set_param_" +
-                  result.status
+                `ui.panel.config.zwave_js.node_config.set_param_${result.status}`
               )}
               ${result.status === "error" && result.error
                 ? html` <br /><em>${result.error}</em> `

--- a/src/panels/config/logs/dialog-system-log-detail.ts
+++ b/src/panels/config/logs/dialog-system-log-detail.ts
@@ -74,7 +74,7 @@ class DialogSystemLogDetail extends LitElement {
       "level",
       html`<span class=${item.level.toLowerCase()}
         >${this.hass.localize(
-          "ui.panel.config.logs.level." + item.level.toLowerCase()
+          `ui.panel.config.logs.level.${item.level.toLowerCase()}`
         )}</span
       >`
     );

--- a/src/panels/config/logs/system-log-card.ts
+++ b/src/panels/config/logs/system-log-card.ts
@@ -106,8 +106,7 @@ export class SystemLogCard extends LitElement {
                               ${this._timestamp(item)} –
                               ${html`(<span class=${item.level.toLowerCase()}
                                   >${this.hass.localize(
-                                    "ui.panel.config.logs.level." +
-                                      item.level.toLowerCase()
+                                    `ui.panel.config.logs.level.${item.level.toLowerCase()}`
                                   )}</span
                                 >) `}
                               ${integrations[idx]

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -72,8 +72,7 @@ export const handleAction = async (
             "action",
             serviceName ||
               hass.localize(
-                "ui.panel.lovelace.editor.action-editor.actions." +
-                  actionConfig.action
+                `ui.panel.lovelace.editor.action-editor.actions.${actionConfig.action}`
               ) ||
               actionConfig.action
           ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The goal here is just to remove `${string}` from the list of exceptions so that some keys can actually start being type checked.  Some associated errors are completely fixed while others are converted to literal types and caught by another exception for now.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

