### PR TITLE
Add state selector

### DIFF
--- a/gallery/src/pages/components/ha-form.ts
+++ b/gallery/src/pages/components/ha-form.ts
@@ -137,6 +137,11 @@ const SCHEMAS: {
       { name: "addon", selector: { addon: {} } },
       { name: "entity", selector: { entity: {} } },
       {
+        name: "State",
+        selector: { state: { entity_id: "" } },
+        context: { filter_entity: "entity" },
+      },
+      {
         name: "Attribute",
         selector: { attribute: { entity_id: "" } },
         context: { filter_entity: "entity" },

--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -115,6 +115,10 @@ const SCHEMAS: {
     name: "One of each",
     input: {
       entity: { name: "Entity", selector: { entity: {} } },
+      state: {
+        name: "State",
+        selector: { state: { entity_id: "alarm_control_panel.alarm" } },
+      },
       attribute: {
         name: "Attribute",
         selector: { attribute: { entity_id: "" } },

--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -5,7 +5,7 @@ import { UNAVAILABLE_STATES } from "../../data/entity";
 const FIXED_DOMAIN_STATES = {
   alarm_control_panel: [
     "armed_away",
-    "armed_custom_bypass 	",
+    "armed_custom_bypass",
     "armed_home",
     "armed_night",
     "armed_vacation",

--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -1,0 +1,89 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { computeStateDomain } from "./compute_state_domain";
+import { UNAVAILABLE_STATES } from "../../data/entity";
+
+const FIXED_DOMAIN_STATES = {
+  alarm_control_panel: [
+    "armed_away",
+    "armed_custom_bypass 	",
+    "armed_home",
+    "armed_night",
+    "armed_vacation",
+    "arming",
+    "disarmed",
+    "disarming",
+    "pending",
+    "triggered",
+  ],
+  automation: ["on", "off"],
+  binary_sensor: ["on", "off"],
+  button: [],
+  calendar: ["on", "off"],
+  camera: ["idle", "recording", "streaming"],
+  cover: ["closed", "closing", "open", "opening"],
+  device_tracker: ["home", "not_home"],
+  fan: ["on", "off"],
+  humidifier: ["on", "off"],
+  input_boolean: ["on", "off"],
+  input_button: [],
+  light: ["on", "off"],
+  lock: ["jammed", "locked", "locking", "unlocked", "unlocking"],
+  media_player: ["idle", "off", "paused", "playing", "standby"],
+  person: ["home", "not_home"],
+  remote: ["on", "off"],
+  scene: [],
+  schedule: ["on", "off"],
+  script: ["on", "off"],
+  siren: ["on", "off"],
+  sun: ["above_horizon", "below_horizon"],
+  switch: ["on", "off"],
+  update: ["on", "off"],
+  vacuum: ["cleaning", "docked", "error", "idle", "paused", "returning"],
+  weather: [
+    "clear-night",
+    "cloudy",
+    "exceptional",
+    "fog",
+    "hail",
+    "lightning-rainy",
+    "lightning",
+    "partlycloudy",
+    "pouring",
+    "rainy",
+    "snowy-rainy",
+    "snowy",
+    "sunny",
+    "windy-variant",
+    "windy",
+  ],
+};
+
+export const getStates = (state: HassEntity): string[] => {
+  const domain = computeStateDomain(state);
+  const result: string[] = [];
+
+  if (domain in FIXED_DOMAIN_STATES) {
+    result.push(...FIXED_DOMAIN_STATES[domain]);
+  } else {
+    // If not fixed, we at least know the current state
+    result.push(state.state);
+  }
+
+  // Dynamic values based on the entities
+  switch (domain) {
+    case "climate":
+      result.push(...state.attributes.hvac_modes);
+      break;
+    case "input_select":
+    case "select":
+      result.push(...state.attributes.options);
+      break;
+    case "water_heater":
+      result.push(...state.attributes.operation_list);
+      break;
+  }
+
+  // All entities can have unavailable states
+  result.push(...UNAVAILABLE_STATES);
+  return [...new Set(result)];
+};

--- a/src/components/entity/ha-entity-state-picker.ts
+++ b/src/components/entity/ha-entity-state-picker.ts
@@ -1,0 +1,107 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement, PropertyValues, TemplateResult } from "lit";
+import { customElement, property, query } from "lit/decorators";
+import { computeStateDisplay } from "../../common/entity/compute_state_display";
+import { PolymerChangedEvent } from "../../polymer-types";
+import { getStates } from "../../common/entity/get_states";
+import { HomeAssistant } from "../../types";
+import "../ha-combo-box";
+import type { HaComboBox } from "../ha-combo-box";
+
+export type HaEntityPickerEntityFilterFunc = (entityId: HassEntity) => boolean;
+
+@customElement("ha-entity-state-picker")
+class HaEntityStatePicker extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public entityId?: string;
+
+  @property({ type: Boolean }) public autofocus = false;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = false;
+
+  @property({ type: Boolean, attribute: "allow-custom-value" })
+  public allowCustomValue;
+
+  @property() public label?: string;
+
+  @property() public value?: string;
+
+  @property() public helper?: string;
+
+  @property({ type: Boolean }) private _opened = false;
+
+  @query("ha-combo-box", true) private _comboBox!: HaComboBox;
+
+  protected shouldUpdate(changedProps: PropertyValues) {
+    return !(!changedProps.has("_opened") && this._opened);
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    if (changedProps.has("_opened") && this._opened) {
+      const state = this.entityId ? this.hass.states[this.entityId] : undefined;
+      (this._comboBox as any).items =
+        this.entityId && state
+          ? getStates(state).map((key) => ({
+              value: key,
+              label: computeStateDisplay(
+                this.hass.localize,
+                state,
+                this.hass.locale,
+                key
+              ),
+            }))
+          : [];
+    }
+  }
+
+  protected render(): TemplateResult {
+    if (!this.hass) {
+      return html``;
+    }
+
+    return html`
+      <ha-combo-box
+        .hass=${this.hass}
+        .value=${this.value
+          ? this.entityId && this.hass.states[this.entityId]
+            ? computeStateDisplay(
+                this.hass.localize,
+                this.hass.states[this.entityId],
+                this.hass.locale,
+                this.value
+              )
+            : this.value
+          : ""}
+        .autofocus=${this.autofocus}
+        .label=${this.label ??
+        this.hass.localize("ui.components.entity.entity-state-picker.state")}
+        .disabled=${this.disabled || !this.entityId}
+        .required=${this.required}
+        .helper=${this.helper}
+        .allowCustomValue=${this.allowCustomValue}
+        item-value-path="value"
+        item-label-path="label"
+        @opened-changed=${this._openedChanged}
+        @value-changed=${this._valueChanged}
+      >
+      </ha-combo-box>
+    `;
+  }
+
+  private _openedChanged(ev: PolymerChangedEvent<boolean>) {
+    this._opened = ev.detail.value;
+  }
+
+  private _valueChanged(ev: PolymerChangedEvent<string>) {
+    this.value = ev.detail.value;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-entity-state-picker": HaEntityStatePicker;
+  }
+}

--- a/src/components/ha-selector/ha-selector-state.ts
+++ b/src/components/ha-selector/ha-selector-state.ts
@@ -1,6 +1,5 @@
-import { html, LitElement, PropertyValues } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
-import { fireEvent } from "../../common/dom/fire_event";
 import { StateSelector } from "../../data/selector";
 import { SubscribeMixin } from "../../mixins/subscribe-mixin";
 import { HomeAssistant } from "../../types";
@@ -40,47 +39,6 @@ export class HaSelectorState extends SubscribeMixin(LitElement) {
         allow-custom-value
       ></ha-entity-state-picker>
     `;
-  }
-
-  protected updated(changedProps: PropertyValues): void {
-    super.updated(changedProps);
-    if (
-      // No need to filter value if no value
-      !this.value ||
-      // Only adjust value if we used the context
-      this.selector.state.entity_id ||
-      // Only check if context has changed
-      !changedProps.has("context")
-    ) {
-      return;
-    }
-
-    const oldContext = changedProps.get("context") as this["context"];
-
-    if (
-      !this.context ||
-      oldContext?.filter_entity === this.context.filter_entity
-    ) {
-      return;
-    }
-
-    // Validate that that the attribute is still valid for this entity, else unselect.
-    let invalid = false;
-    if (this.context.filter_entity) {
-      const stateObj = this.hass.states[this.context.filter_entity];
-
-      if (!(stateObj && this.value in stateObj.attributes)) {
-        invalid = true;
-      }
-    } else {
-      invalid = this.value !== undefined;
-    }
-
-    if (invalid) {
-      fireEvent(this, "value-changed", {
-        value: undefined,
-      });
-    }
   }
 }
 

--- a/src/components/ha-selector/ha-selector-state.ts
+++ b/src/components/ha-selector/ha-selector-state.ts
@@ -1,0 +1,91 @@
+import { html, LitElement, PropertyValues } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../common/dom/fire_event";
+import { StateSelector } from "../../data/selector";
+import { SubscribeMixin } from "../../mixins/subscribe-mixin";
+import { HomeAssistant } from "../../types";
+import "../entity/ha-entity-state-picker";
+
+@customElement("ha-selector-state")
+export class HaSelectorState extends SubscribeMixin(LitElement) {
+  @property() public hass!: HomeAssistant;
+
+  @property() public selector!: StateSelector;
+
+  @property() public value?: any;
+
+  @property() public label?: string;
+
+  @property() public helper?: string;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = true;
+
+  @property() public context?: {
+    filter_entity?: string;
+  };
+
+  protected render() {
+    return html`
+      <ha-entity-state-picker
+        .hass=${this.hass}
+        .entityId=${this.selector.state.entity_id ||
+        this.context?.filter_entity}
+        .value=${this.value}
+        .label=${this.label}
+        .helper=${this.helper}
+        .disabled=${this.disabled}
+        .required=${this.required}
+        allow-custom-value
+      ></ha-entity-state-picker>
+    `;
+  }
+
+  protected updated(changedProps: PropertyValues): void {
+    super.updated(changedProps);
+    if (
+      // No need to filter value if no value
+      !this.value ||
+      // Only adjust value if we used the context
+      this.selector.state.entity_id ||
+      // Only check if context has changed
+      !changedProps.has("context")
+    ) {
+      return;
+    }
+
+    const oldContext = changedProps.get("context") as this["context"];
+
+    if (
+      !this.context ||
+      oldContext?.filter_entity === this.context.filter_entity
+    ) {
+      return;
+    }
+
+    // Validate that that the attribute is still valid for this entity, else unselect.
+    let invalid = false;
+    if (this.context.filter_entity) {
+      const stateObj = this.hass.states[this.context.filter_entity];
+
+      if (!(stateObj && this.value in stateObj.attributes)) {
+        invalid = true;
+      }
+    } else {
+      invalid = this.value !== undefined;
+    }
+
+    if (invalid) {
+      fireEvent(this, "value-changed", {
+        value: undefined,
+      });
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-selector-state": HaSelectorState;
+  }
+}

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -18,6 +18,7 @@ import "./ha-selector-file";
 import "./ha-selector-number";
 import "./ha-selector-object";
 import "./ha-selector-select";
+import "./ha-selector-state";
 import "./ha-selector-target";
 import "./ha-selector-template";
 import "./ha-selector-text";

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -23,6 +23,7 @@ export type Selector =
   | NumberSelector
   | ObjectSelector
   | SelectSelector
+  | StateSelector
   | StringSelector
   | TargetSelector
   | TemplateSelector
@@ -188,6 +189,12 @@ export interface SelectSelector {
     custom_value?: boolean;
     mode?: "list" | "dropdown";
     options: readonly string[] | readonly SelectOption[];
+  };
+}
+
+export interface StateSelector {
+  state: {
+    entity_id?: string;
   };
 }
 

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -37,7 +37,7 @@ export class HaStateCondition extends LitElement implements ConditionElement {
           name: "attribute",
           selector: { attribute: { entity_id: entityId } },
         },
-        { name: "state", selector: { text: {} } },
+        { name: "state", selector: { state: { entity_id: entityId } } },
         { name: "for", selector: { duration: {} } },
       ] as const
   );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -56,8 +56,18 @@ export class HaStateTrigger extends LitElement implements TriggerElement {
           name: "attribute",
           selector: { attribute: { entity_id: entityId } },
         },
-        { name: "from", selector: { text: {} } },
-        { name: "to", selector: { text: {} } },
+        {
+          name: "from",
+          selector: {
+            state: { entity_id: entityId ? entityId[0] : undefined },
+          },
+        },
+        {
+          name: "to",
+          selector: {
+            state: { entity_id: entityId ? entityId[0] : undefined },
+          },
+        },
         { name: "for", selector: { duration: {} } },
       ] as const
   );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -400,6 +400,9 @@
         "entity-attribute-picker": {
           "attribute": "Attribute",
           "show_attributes": "Show attributes"
+        },
+        "entity-state-picker": {
+          "state": "State"
         }
       },
       "target-picker": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR adds the State selector, allowing to pick/select a state of a given entity.

Added this selector to the state triggers of automations (to & from states), and state conditions (works for both automations and scripts).


![CleanShot 2022-08-19 at 14 13 33](https://user-images.githubusercontent.com/195327/185616390-e2ecd8fe-2412-4144-ac8b-8f4f5b42b364.gif)


Light state:

![image](https://user-images.githubusercontent.com/195327/185602769-9c9141f2-0d3d-45b1-b349-d6468248c94f.png)


Climate entity (which has a limited set of HVAC modes):

![image](https://user-images.githubusercontent.com/195327/185602655-03b0367a-95b5-4566-95c0-ed31758c0261.png)


Custom input select:

![image](https://user-images.githubusercontent.com/195327/185602311-cb43ecc8-c073-4a26-beaf-eb66b97d67a1.png)


It currently relies mostly on static values based on the domain and a couple of "smart" things (like getting climate modes from the attributes for climate state).

For the future, it might be nice to extend this with support with the states for state attributes and quite possibly query state history in case we don't have a fixed list of states, or even extract a list of possible states from translations.

For now, this is meant as a first step, solving like 80% of the things people struggle with, what state should I enter here? (need docs, dev-tools or possibility entering translated states instead of raw states).


Backend PR: <https://github.com/home-assistant/core/pull/77024>

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to backend pull request: https://github.com/home-assistant/core/pull/77024
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23815

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
