### PR TITLE
Display ZHA network settings and allow downloading backups

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -128,6 +128,54 @@ export interface ZHAConfiguration {
   schemas: Record<string, HaFormSchema[]>;
 }
 
+export interface ZHANetworkBackupNodeInfo {
+  nwk: string;
+  ieee: string;
+  logical_type: "coordinator" | "router" | "end_device";
+}
+
+export interface ZHANetworkBackupKey {
+  key: string;
+  tx_counter: number;
+  rx_counter: number;
+  seq: number;
+  partner_ieee: string;
+}
+
+export interface ZHANetworkBackupNetworkInfo {
+  extended_pan_id: string;
+  pan_id: string;
+  nwk_update_id: number;
+  nwk_manager_id: string;
+  channel: number;
+  channel_mask: number[];
+  security_level: number;
+  network_key: ZHANetworkBackupKey;
+  tc_link_key: ZHANetworkBackupKey;
+  key_table: ZHANetworkBackupKey[];
+  children: string[];
+  nwk_addresses: Record<string, string>;
+  stack_specific?: Record<string, any>;
+  metadata: Record<string, any>;
+  source: string;
+}
+
+export interface ZHANetworkBackup {
+  backup_time: string;
+  network_info: ZHANetworkBackupNetworkInfo;
+  node_info: ZHANetworkBackupNodeInfo;
+}
+
+export interface ZHANetworkSettings {
+  settings: ZHANetworkBackup;
+  radio_type: "ezsp" | "znp" | "deconz" | "zigate" | "xbee";
+}
+
+export interface ZHANetworkBackupAndMetadata {
+  backup: ZHANetworkBackup;
+  is_complete: boolean;
+}
+
 export interface ZHAGroupMember {
   ieee: string;
   endpoint_id: string;
@@ -347,6 +395,38 @@ export const updateZHAConfiguration = (
   hass.callWS({
     type: "zha/configuration/update",
     data: data,
+  });
+
+export const fetchZHANetworkSettings = (
+  hass: HomeAssistant
+): Promise<ZHANetworkSettings> =>
+  hass.callWS({
+    type: "zha/network/settings",
+  });
+
+export const createZHANetworkBackup = (
+  hass: HomeAssistant
+): Promise<ZHANetworkBackupAndMetadata> =>
+  hass.callWS({
+    type: "zha/network/backups/create",
+  });
+
+export const restoreZHANetworkBackup = (
+  hass: HomeAssistant,
+  backup: ZHANetworkBackup,
+  ezspForceWriteEUI64 = false
+): Promise<void> =>
+  hass.callWS({
+    type: "zha/network/backups/restore",
+    backup: backup,
+    ezsp_force_write_eui64: ezspForceWriteEUI64,
+  });
+
+export const listZHANetworkBackups = (
+  hass: HomeAssistant
+): Promise<ZHANetworkBackup[]> =>
+  hass.callWS({
+    type: "zha/network/backups/list",
   });
 
 export const INITIALIZED = "INITIALIZED";

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -220,6 +220,13 @@ class ZHAConfigDashboard extends LitElement {
 
     try {
       backup_and_metadata = await createZHANetworkBackup(this.hass!);
+    } catch (err: any) {
+      showAlertDialog(this, {
+        title: "Failed to create backup",
+        text: err.message,
+        warning: true,
+      });
+      return;
     } finally {
       this._generatingBackup = false;
     }

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -237,13 +237,13 @@ class ZHAConfigDashboard extends LitElement {
     const backupTime: Date = new Date(
       Date.parse(backup_and_metadata.backup.backup_time)
     );
-    let filename: string = backupTime.toISOString().replace(/:/g, "-");
+    let basename = `ZHA backup ${backupTime.toISOString().replace(/:/g, "-")}`;
 
     if (!backup_and_metadata.is_complete) {
-      filename += ", incomplete";
+      basename = `Incomplete ${basename}`;
     }
 
-    fileDownload(backupJSON, `ZHA backup ${filename}.json`);
+    fileDownload(backupJSON, `${basename}.json`);
   }
 
   private _dataChanged(ev) {

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -8,10 +8,11 @@ import {
   PropertyValues,
   TemplateResult,
 } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { computeRTL } from "../../../../../common/util/compute_rtl";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-fab";
+import { fileDownload } from "../../../../../util/file_download";
 import "../../../../../components/ha-icon-next";
 import "../../../../../layouts/hass-tabs-subpage";
 import type { PageNavigation } from "../../../../../layouts/hass-tabs-subpage";
@@ -19,11 +20,17 @@ import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant, Route } from "../../../../../types";
 import "../../../ha-config-section";
 import "../../../../../components/ha-form/ha-form";
+import "../../../../../components/buttons/ha-progress-button";
 import {
   fetchZHAConfiguration,
   updateZHAConfiguration,
   ZHAConfiguration,
+  fetchZHANetworkSettings,
+  createZHANetworkBackup,
+  ZHANetworkSettings,
+  ZHANetworkBackupAndMetadata,
 } from "../../../../../data/zha";
+import { showAlertDialog } from "../../../../../dialogs/generic/show-dialog-box";
 
 export const zhaTabs: PageNavigation[] = [
   {
@@ -57,11 +64,16 @@ class ZHAConfigDashboard extends LitElement {
 
   @property() private _configuration?: ZHAConfiguration;
 
+  @property() private _networkSettings?: ZHANetworkSettings;
+
+  @state() private _generatingBackup = false;
+
   protected firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
     if (this.hass) {
       this.hass.loadBackendTranslation("config_panel", "zha", false);
       this._fetchConfiguration();
+      this._fetchSettings();
     }
   }
 
@@ -102,6 +114,51 @@ class ZHAConfigDashboard extends LitElement {
               </div>`
             : ""}
         </ha-card>
+        ${this._networkSettings
+          ? html` <ha-card
+              header=${this.hass.localize(
+                "component.zha.config_panel.network_settings.title"
+              ) || "Network Settings"}
+            >
+              <div class="card-content network-settings">
+                <div>
+                  <strong>PAN ID:</strong>
+                  ${this._networkSettings.settings.network_info.pan_id}
+                </div>
+                <div>
+                  <strong>Extended PAN ID:</strong>
+                  ${this._networkSettings.settings.network_info.extended_pan_id}
+                </div>
+                <div>
+                  <strong>Channel:</strong>
+                  ${this._networkSettings.settings.network_info.channel}
+                </div>
+                <div>
+                  <strong>Coordinator IEEE:</strong>
+                  ${this._networkSettings.settings.node_info.ieee}
+                </div>
+                <div>
+                  <strong>Network key:</strong>
+                  ${this._networkSettings.settings.network_info.network_key.key}
+                </div>
+                <div>
+                  <strong>Radio type:</strong>
+                  ${this._networkSettings.radio_type}
+                </div>
+              </div>
+              <div class="card-actions">
+                <ha-progress-button
+                  @click=${this._createAndDownloadBackup}
+                  .progress=${this._generatingBackup}
+                  .disabled=${this._generatingBackup}
+                >
+                  ${this.hass.localize(
+                    "component.zha.config_panel.diagnostics.create_backup"
+                  ) || "Download Network Backup"}
+                </ha-progress-button>
+              </div>
+            </ha-card>`
+          : ""}
         ${this._configuration
           ? Object.entries(this._configuration.schemas).map(
               ([section, schema]) => html`<ha-card
@@ -152,6 +209,38 @@ class ZHAConfigDashboard extends LitElement {
     this._configuration = await fetchZHAConfiguration(this.hass!);
   }
 
+  private async _fetchSettings(): Promise<void> {
+    this._networkSettings = await fetchZHANetworkSettings(this.hass!);
+  }
+
+  private async _createAndDownloadBackup(): Promise<void> {
+    this._generatingBackup = true;
+    const backup_and_metadata: ZHANetworkBackupAndMetadata =
+      await createZHANetworkBackup(this.hass!);
+    this._generatingBackup = false;
+
+    if (!backup_and_metadata.is_complete) {
+      await showAlertDialog(this, {
+        title: "Backup is incomplete",
+        text: "A backup has been created but it is incomplete and cannot be restored. This is a coordinator firmware limitation.",
+      });
+    }
+
+    const backupJSON: string =
+      "data:text/plain;charset=utf-8," +
+      encodeURIComponent(JSON.stringify(backup_and_metadata.backup, null, 4));
+    const backupTime: Date = new Date(
+      Date.parse(backup_and_metadata.backup.backup_time)
+    );
+    let filename: string = backupTime.toISOString().replace(/:/g, "-");
+
+    if (!backup_and_metadata.is_complete) {
+      filename += ", incomplete";
+    }
+
+    fileDownload(backupJSON, `ZHA backup ${filename}.json`);
+  }
+
   private _dataChanged(ev) {
     this._configuration!.data[ev.currentTarget!.section] = ev.detail.value;
   }
@@ -175,6 +264,11 @@ class ZHAConfigDashboard extends LitElement {
           margin: auto;
           margin-top: 16px;
           max-width: 500px;
+        }
+
+        .network-settings > div {
+          word-break: break-all;
+          margin-top: 2px;
         }
       `,
     ];

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -117,8 +117,8 @@ class ZHAConfigDashboard extends LitElement {
         ${this._networkSettings
           ? html` <ha-card
               header=${this.hass.localize(
-                "component.zha.config_panel.network_settings.title"
-              ) || "Network Settings"}
+                "ui.panel.config.zha.configuration_page.network_settings_title"
+              )}
             >
               <div class="card-content network-settings">
                 <div>
@@ -153,8 +153,8 @@ class ZHAConfigDashboard extends LitElement {
                   .disabled=${this._generatingBackup}
                 >
                   ${this.hass.localize(
-                    "component.zha.config_panel.diagnostics.create_backup"
-                  ) || "Download Network Backup"}
+                    "ui.panel.config.zha.configuration_page.download_backup"
+                  )}
                 </ha-progress-button>
               </div>
             </ha-card>`

--- a/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-config-dashboard.ts
@@ -214,10 +214,15 @@ class ZHAConfigDashboard extends LitElement {
   }
 
   private async _createAndDownloadBackup(): Promise<void> {
+    let backup_and_metadata: ZHANetworkBackupAndMetadata;
+
     this._generatingBackup = true;
-    const backup_and_metadata: ZHANetworkBackupAndMetadata =
-      await createZHANetworkBackup(this.hass!);
-    this._generatingBackup = false;
+
+    try {
+      backup_and_metadata = await createZHANetworkBackup(this.hass!);
+    } finally {
+      this._generatingBackup = false;
+    }
 
     if (!backup_and_metadata.is_complete) {
       await showAlertDialog(this, {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2997,7 +2997,9 @@
           },
           "configuration_page": {
             "shortcuts_title": "Shortcuts",
-            "update_button": "Update Configuration"
+            "update_button": "Update Configuration",
+            "download_backup": "Download Network Backup",
+            "network_settings_title": "Network Settings"
           },
           "add_device_page": {
             "spinner": "Searching for Zigbee devices…",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This supersedes #13295 and provides a way to download backups. The websocket API is currently in Core so this is fully functional, there is just no way to restore network backups yet (https://github.com/home-assistant/core/pull/77044).  A future PR will add a second button to change the radio type and/or migrate radios.

<img width="457" alt="image" src="https://user-images.githubusercontent.com/32534428/185678920-a2267161-ce2c-4187-95dc-8fdca94e12c1.png">

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
