### PR TITLE
Use duration input for timeout in wait_for_trigger action

### DIFF
--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -155,9 +155,17 @@ export interface WaitAction extends BaseAction {
   continue_on_timeout?: boolean;
 }
 
+export interface WaitForTriggerActionParts extends BaseAction {
+  milliseconds?: number;
+  seconds?: number;
+  minutes?: number;
+  hours?: number;
+  days?: number;
+}
+
 export interface WaitForTriggerAction extends BaseAction {
   wait_for_trigger: Trigger | Trigger[];
-  timeout?: number;
+  timeout?: number | Partial<WaitForTriggerActionParts> | string;
   continue_on_timeout?: boolean;
 }
 

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
@@ -7,6 +7,8 @@ import { WaitForTriggerAction } from "../../../../../data/script";
 import { HomeAssistant } from "../../../../../types";
 import "../../trigger/ha-automation-trigger";
 import { ActionElement, handleChangeEvent } from "../ha-automation-action-row";
+import "../../../../../components/ha-duration-input";
+import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 
 @customElement("ha-automation-action-wait_for_trigger")
 export class HaWaitForTriggerAction
@@ -22,17 +24,18 @@ export class HaWaitForTriggerAction
   }
 
   protected render() {
-    const { wait_for_trigger, continue_on_timeout, timeout } = this.action;
+    const { wait_for_trigger, continue_on_timeout } = this.action;
+    const timeData = createDurationData(this.action.timeout);
 
     return html`
-      <ha-textfield
+      <ha-duration-input
         .label=${this.hass.localize(
           "ui.panel.config.automation.editor.actions.type.wait_for_trigger.timeout"
         )}
-        .name=${"timeout"}
-        .value=${timeout || ""}
-        @change=${this._valueChanged}
-      ></ha-textfield>
+        .data=${timeData}
+        enableMillisecond
+        @value-changed=${this._timeoutChanged}
+      ></ha-duration-input>
       <ha-formfield
         .label=${this.hass.localize(
           "ui.panel.config.automation.editor.actions.type.wait_for_trigger.continue_timeout"
@@ -52,6 +55,17 @@ export class HaWaitForTriggerAction
     `;
   }
 
+  private _timeoutChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const value = ev.detail.value;
+    if (!value) {
+      return;
+    }
+    fireEvent(this, "value-changed", {
+      value: { ...this.action, timeout: value },
+    });
+  }
+
   private _continueChanged(ev) {
     fireEvent(this, "value-changed", {
       value: { ...this.action, continue_on_timeout: ev.target.checked },
@@ -64,7 +78,7 @@ export class HaWaitForTriggerAction
 
   static get styles(): CSSResultGroup {
     return css`
-      ha-textfield {
+      ha-duration-input {
         display: block;
         margin-bottom: 24px;
       }

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
@@ -9,6 +9,7 @@ import "../../trigger/ha-automation-trigger";
 import { ActionElement, handleChangeEvent } from "../ha-automation-action-row";
 import "../../../../../components/ha-duration-input";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
+import { TimeChangedEvent } from "../../../../../components/ha-base-time-input";
 
 @customElement("ha-automation-action-wait_for_trigger")
 export class HaWaitForTriggerAction
@@ -55,7 +56,7 @@ export class HaWaitForTriggerAction
     `;
   }
 
-  private _timeoutChanged(ev: CustomEvent): void {
+  private _timeoutChanged(ev: CustomEvent<{ value: TimeChangedEvent }>): void {
     ev.stopPropagation();
     const value = ev.detail.value;
     if (!value) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Use the duration input for the timeout field of the wait for trigger action (currently, it is a text field).

![CleanShot 2022-08-20 at 21 31 13](https://user-images.githubusercontent.com/195327/185763379-9a60f311-2cee-4d22-bec2-5e72bb940c9d.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
