### PR TITLE
Use template selector in numeric state templates

### DIFF
--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -99,7 +99,7 @@ export default class HaNumericStateCondition extends LitElement {
         { name: "below", selector: { text: {} } },
         {
           name: "value_template",
-          selector: { text: { multiline: true } },
+          selector: { template: { } },
         },
       ] as const
   );

--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -99,7 +99,7 @@ export default class HaNumericStateCondition extends LitElement {
         { name: "below", selector: { text: {} } },
         {
           name: "value_template",
-          selector: { template: { } },
+          selector: { template: {} },
         },
       ] as const
   );

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -106,7 +106,7 @@ export class HaNumericStateTrigger extends LitElement {
       return;
     }
     // Check for templates in trigger. If found, revert to YAML mode.
-    if (this.trigger && hasTemplate(this.trigger)) {
+    if (this.trigger && hasTemplate(this.trigger.for)) {
       fireEvent(
         this,
         "ui-mode-not-available",

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -95,7 +95,7 @@ export class HaNumericStateTrigger extends LitElement {
         { name: "below", selector: { text: {} } },
         {
           name: "value_template",
-          selector: { text: { multiline: true } },
+          selector: { template: {} },
         },
         { name: "for", selector: { duration: {} } },
       ] as const


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Renders value template of numeric state triggers & conditions using the template selector.

![CleanShot 2022-08-20 at 22 05 42](https://user-images.githubusercontent.com/195327/185764350-9aa094c4-7f7c-474e-8502-fc7f0d921aeb.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
