### PR TITLE
Add config entry selector

### DIFF
--- a/gallery/src/pages/components/ha-form.ts
+++ b/gallery/src/pages/components/ha-form.ts
@@ -3,6 +3,7 @@ import "@material/mwc-button";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators";
 import { mockAreaRegistry } from "../../../../demo/src/stubs/area_registry";
+import { mockConfigEntries } from "../../../../demo/src/stubs/config_entries";
 import { mockDeviceRegistry } from "../../../../demo/src/stubs/device_registry";
 import { mockEntityRegistry } from "../../../../demo/src/stubs/entity_registry";
 import { mockHassioSupervisor } from "../../../../demo/src/stubs/hassio_supervisor";
@@ -153,6 +154,7 @@ const SCHEMAS: {
         context: { filter_entity: "entity", filter_attribute: "Attribute" },
       },
       { name: "Device", selector: { device: {} } },
+      { name: "Config entry", selector: { config_entry: {} } },
       { name: "Duration", selector: { duration: {} } },
       { name: "area", selector: { area: {} } },
       { name: "target", selector: { target: {} } },
@@ -434,6 +436,7 @@ class DemoHaForm extends LitElement {
     hass.addEntities(ENTITIES);
     mockEntityRegistry(hass);
     mockDeviceRegistry(hass, DEVICES);
+    mockConfigEntries(hass);
     mockAreaRegistry(hass, AREAS);
     mockHassioSupervisor(hass);
   }

--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -126,7 +126,7 @@ const SCHEMAS: {
       },
       device: { name: "Device", selector: { device: {} } },
       config_entry: {
-        name: "Config entry",
+        name: "Integration",
         selector: { config_entry: {} },
       },
       duration: { name: "Duration", selector: { duration: {} } },

--- a/gallery/src/pages/components/ha-selector.ts
+++ b/gallery/src/pages/components/ha-selector.ts
@@ -3,6 +3,7 @@ import "@material/mwc-button";
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators";
 import { mockAreaRegistry } from "../../../../demo/src/stubs/area_registry";
+import { mockConfigEntries } from "../../../../demo/src/stubs/config_entries";
 import { mockDeviceRegistry } from "../../../../demo/src/stubs/device_registry";
 import { mockEntityRegistry } from "../../../../demo/src/stubs/entity_registry";
 import { mockHassioSupervisor } from "../../../../demo/src/stubs/hassio_supervisor";
@@ -124,6 +125,10 @@ const SCHEMAS: {
         selector: { attribute: { entity_id: "" } },
       },
       device: { name: "Device", selector: { device: {} } },
+      config_entry: {
+        name: "Config entry",
+        selector: { config_entry: {} },
+      },
       duration: { name: "Duration", selector: { duration: {} } },
       addon: { name: "Addon", selector: { addon: {} } },
       area: { name: "Area", selector: { area: {} } },
@@ -280,6 +285,7 @@ class DemoHaSelector extends LitElement implements ProvideHassElement {
     hass.addEntities(ENTITIES);
     mockEntityRegistry(hass);
     mockDeviceRegistry(hass, DEVICES);
+    mockConfigEntries(hass);
     mockAreaRegistry(hass, AREAS);
     mockHassioSupervisor(hass);
     hass.mockWS("auth/sign_path", (params) => params);

--- a/src/components/ha-config-entry-picker.ts
+++ b/src/components/ha-config-entry-picker.ts
@@ -80,7 +80,7 @@ class HaConfigEntryPicker extends LitElement {
         .hass=${this.hass}
         .label=${this.label === undefined && this.hass
           ? this.hass.localize(
-              "ui.components.config-entries-picker.config_entry"
+              "ui.components.config-entry-picker.config_entry"
             )
           : this.label}
         .value=${this._value}

--- a/src/components/ha-config-entry-picker.ts
+++ b/src/components/ha-config-entry-picker.ts
@@ -1,14 +1,16 @@
+import "@material/mwc-list/mwc-list-item";
 import { html, LitElement, TemplateResult } from "lit";
 import { ComboBoxLitRenderer } from "lit-vaadin-helpers";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import { PolymerChangedEvent } from "../polymer-types";
 import { HomeAssistant } from "../types";
-import { HaComboBox } from "./ha-combo-box";
+import type { HaComboBox } from "./ha-combo-box";
 import { ConfigEntry, getConfigEntries } from "../data/config_entries";
 import { domainToName } from "../data/integration";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
 import { brandsUrl } from "../util/brands-url";
+import "./ha-combo-box";
 
 export interface ConfigEntryExtended extends ConfigEntry {
   localized_domain_name?: string;

--- a/src/components/ha-config-entry-picker.ts
+++ b/src/components/ha-config-entry-picker.ts
@@ -79,9 +79,7 @@ class HaConfigEntryPicker extends LitElement {
       <ha-combo-box
         .hass=${this.hass}
         .label=${this.label === undefined && this.hass
-          ? this.hass.localize(
-              "ui.components.config-entry-picker.config_entry"
-            )
+          ? this.hass.localize("ui.components.config-entry-picker.config_entry")
           : this.label}
         .value=${this._value}
         .required=${this.required}

--- a/src/components/ha-config-entry-picker.ts
+++ b/src/components/ha-config-entry-picker.ts
@@ -119,13 +119,12 @@ class HaConfigEntryPicker extends LitElement {
           })
         )
         .sort((conf1, conf2) =>
-            caseInsensitiveStringCompare(
-              conf1.localized_domain_name + conf1.title,
-              conf2.localized_domain_name + conf2.title
-            )
-          );
-      }
-    );
+          caseInsensitiveStringCompare(
+            conf1.localized_domain_name + conf1.title,
+            conf2.localized_domain_name + conf2.title
+          )
+        );
+    });
   }
 
   private get _value() {

--- a/src/components/ha-config-entry-picker.ts
+++ b/src/components/ha-config-entry-picker.ts
@@ -1,0 +1,161 @@
+import { html, LitElement, TemplateResult } from "lit";
+import { ComboBoxLitRenderer } from "lit-vaadin-helpers";
+import { customElement, property, query, state } from "lit/decorators";
+import { fireEvent } from "../common/dom/fire_event";
+import { PolymerChangedEvent } from "../polymer-types";
+import { HomeAssistant } from "../types";
+import { HaComboBox } from "./ha-combo-box";
+import { ConfigEntry, getConfigEntries } from "../data/config_entries";
+import { domainToName } from "../data/integration";
+import { caseInsensitiveStringCompare } from "../common/string/compare";
+import { brandsUrl } from "../util/brands-url";
+
+export interface ConfigEntryExtended extends ConfigEntry {
+  localized_domain_name?: string;
+}
+
+@customElement("ha-config-entry-picker")
+class HaConfigEntryPicker extends LitElement {
+  public hass!: HomeAssistant;
+
+  @property() public integration?: string;
+
+  @property() public label?: string;
+
+  @property() public value = "";
+
+  @property() public helper?: string;
+
+  @state() private _configEntries?: ConfigEntryExtended[];
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = false;
+
+  @query("ha-combo-box") private _comboBox!: HaComboBox;
+
+  public open() {
+    this._comboBox?.open();
+  }
+
+  public focus() {
+    this._comboBox?.focus();
+  }
+
+  protected firstUpdated() {
+    this._getConfigEntries();
+  }
+
+  private _rowRenderer: ComboBoxLitRenderer<ConfigEntryExtended> = (
+    item
+  ) => html`<mwc-list-item twoline graphic="icon">
+    <span
+      >${item.title ||
+      this.hass.localize(
+        "ui.panel.config.integrations.config_entry.unnamed_entry"
+      )}</span
+    >
+    <span slot="secondary">${item.localized_domain_name}</span>
+    <img
+      slot="graphic"
+      src=${brandsUrl({
+        domain: item.domain,
+        type: "icon",
+        darkOptimized: this.hass.themes?.darkMode,
+      })}
+      referrerpolicy="no-referrer"
+      @error=${this._onImageError}
+      @load=${this._onImageLoad}
+    />
+  </mwc-list-item>`;
+
+  protected render(): TemplateResult {
+    if (!this._configEntries) {
+      return html``;
+    }
+    return html`
+      <ha-combo-box
+        .hass=${this.hass}
+        .label=${this.label === undefined && this.hass
+          ? this.hass.localize(
+              "ui.components.config-entries-picker.config_entry"
+            )
+          : this.label}
+        .value=${this._value}
+        .required=${this.required}
+        .disabled=${this.disabled}
+        .helper=${this.helper}
+        .renderer=${this._rowRenderer}
+        .items=${this._configEntries}
+        item-value-path="entry_id"
+        item-id-path="entry_id"
+        item-label-path="title"
+        @value-changed=${this._valueChanged}
+      ></ha-combo-box>
+    `;
+  }
+
+  private _onImageLoad(ev) {
+    ev.target.style.visibility = "initial";
+  }
+
+  private _onImageError(ev) {
+    ev.target.style.visibility = "hidden";
+  }
+
+  private async _getConfigEntries() {
+    getConfigEntries(this.hass, { type: "integration" }).then(
+      (configEntries) => {
+        this._configEntries = configEntries
+          .filter((entry) => {
+            if (!this.integration) {
+              return true;
+            }
+            return entry.domain === this.integration;
+          })
+          .map(
+            (entry: ConfigEntry): ConfigEntryExtended => ({
+              ...entry,
+              localized_domain_name: domainToName(
+                this.hass.localize,
+                entry.domain
+              ),
+            })
+          )
+          .sort((conf1, conf2) =>
+            caseInsensitiveStringCompare(
+              conf1.localized_domain_name + conf1.title,
+              conf2.localized_domain_name + conf2.title
+            )
+          );
+      }
+    );
+  }
+
+  private get _value() {
+    return this.value || "";
+  }
+
+  private _valueChanged(ev: PolymerChangedEvent<string>) {
+    ev.stopPropagation();
+    const newValue = ev.detail.value;
+
+    if (newValue !== this._value) {
+      this._setValue(newValue);
+    }
+  }
+
+  private _setValue(value: string) {
+    this.value = value;
+    setTimeout(() => {
+      fireEvent(this, "value-changed", { value });
+      fireEvent(this, "change");
+    }, 0);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-config-entry-picker": HaConfigEntryPicker;
+  }
+}

--- a/src/components/ha-config-entry-picker.ts
+++ b/src/components/ha-config-entry-picker.ts
@@ -104,25 +104,21 @@ class HaConfigEntryPicker extends LitElement {
   }
 
   private async _getConfigEntries() {
-    getConfigEntries(this.hass, { type: "integration" }).then(
-      (configEntries) => {
-        this._configEntries = configEntries
-          .filter((entry) => {
-            if (!this.integration) {
-              return true;
-            }
-            return entry.domain === this.integration;
+    getConfigEntries(this.hass, {
+      type: "integration",
+      domain: this.integration,
+    }).then((configEntries) => {
+      this._configEntries = configEntries
+        .map(
+          (entry: ConfigEntry): ConfigEntryExtended => ({
+            ...entry,
+            localized_domain_name: domainToName(
+              this.hass.localize,
+              entry.domain
+            ),
           })
-          .map(
-            (entry: ConfigEntry): ConfigEntryExtended => ({
-              ...entry,
-              localized_domain_name: domainToName(
-                this.hass.localize,
-                entry.domain
-              ),
-            })
-          )
-          .sort((conf1, conf2) =>
+        )
+        .sort((conf1, conf2) =>
             caseInsensitiveStringCompare(
               conf1.localized_domain_name + conf1.title,
               conf2.localized_domain_name + conf2.title

--- a/src/components/ha-selector/ha-selector-config-entry.ts
+++ b/src/components/ha-selector/ha-selector-config-entry.ts
@@ -1,0 +1,47 @@
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import { ConfigEntrySelector } from "../../data/selector";
+import { HomeAssistant } from "../../types";
+import "../ha-config-entry-picker";
+
+@customElement("ha-selector-config_entry")
+export class HaConfigEntrySelector extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public selector!: ConfigEntrySelector;
+
+  @property() public value?: any;
+
+  @property() public label?: string;
+
+  @property() public helper?: string;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = true;
+
+  protected render() {
+    return html`<ha-config-entry-picker
+      .hass=${this.hass}
+      .value=${this.value}
+      .label=${this.label}
+      .helper=${this.helper}
+      .disabled=${this.disabled}
+      .required=${this.required}
+      .integration=${this.selector.config_entry.integration}
+      allow-custom-entity
+    ></ha-config-entry-picker>`;
+  }
+
+  static styles = css`
+    ha-config-entry-picker {
+      width: 100%;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-selector-config_entry": HaConfigEntrySelector;
+  }
+}

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -9,6 +9,7 @@ import "./ha-selector-area";
 import "./ha-selector-attribute";
 import "./ha-selector-boolean";
 import "./ha-selector-color-rgb";
+import "./ha-selector-config-entry";
 import "./ha-selector-date";
 import "./ha-selector-datetime";
 import "./ha-selector-device";

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -11,6 +11,7 @@ export type Selector =
   | BooleanSelector
   | ColorRGBSelector
   | ColorTempSelector
+  | ConfigEntrySelector
   | DateSelector
   | DateTimeSelector
   | DeviceSelector
@@ -83,6 +84,12 @@ export interface ColorTempSelector {
   color_temp: {
     min_mireds?: number;
     max_mireds?: number;
+  };
+}
+
+export interface ConfigEntrySelector {
+  config_entry: {
+    integration?: string;
   };
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -418,7 +418,7 @@
         "add_entity_id": "Choose entity"
       },
       "config-entry-picker": {
-        "config_entry": "Config entry"
+        "config_entry": "Integration"
       },
       "theme-picker": {
         "theme": "Theme",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -417,6 +417,9 @@
         "add_device_id": "Choose device",
         "add_entity_id": "Choose entity"
       },
+      "config-entry-picker": {
+        "config_entry": "Config entry"
+      },
       "theme-picker": {
         "theme": "Theme",
         "no_theme": "No theme"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds config entry selector:

![image](https://user-images.githubusercontent.com/195327/185765983-3a9a9aca-ebcf-44ec-bedc-6b7367c605ee.png)

Includes the possibility to filter/limit the list of config entries to a specific integration domain.

TODO:
 - [x] Backend PR: <https://github.com/home-assistant/core/pull/77108>
 - [x] Documentation PR: <https://github.com/home-assistant/home-assistant.io/pull/23836>
 - [x] Add to gallery

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/23836

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
