### PR TITLE
Use alias instead of description in case set in actions/conditions

### DIFF
--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -145,7 +145,7 @@ export default class HaAutomationActionRow extends LitElement {
           : ""}
         <ha-expansion-panel
           leftChevron
-          .header=${describeAction(this.hass, this.action)}
+          .header=${this.action.alias || describeAction(this.hass, this.action)}
         >
           ${this.index !== 0
             ? html`

--- a/src/panels/config/automation/action/types/ha-automation-action-service.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-service.ts
@@ -10,6 +10,7 @@ import type { HomeAssistant } from "../../../../../types";
 import { ActionElement } from "../ha-automation-action-row";
 
 const actionStruct = object({
+  alias: optional(string()),
   service: optional(string()),
   entity_id: optional(entityIdOrAll()),
   target: optional(any()),

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -80,7 +80,7 @@ export default class HaAutomationConditionRow extends LitElement {
 
         <ha-expansion-panel
           leftChevron
-          .header=${describeCondition(this.condition)}
+          .header=${this.condition.alias || describeCondition(this.condition)}
         >
           <ha-progress-button slot="icons" @click=${this._testCondition}>
             ${this.hass.localize(

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -12,6 +12,7 @@ import { forDictStruct } from "../../structs";
 import type { ConditionElement } from "../ha-automation-condition-row";
 
 const stateConditionStruct = object({
+  alias: optional(string()),
   condition: literal("state"),
   entity_id: optional(string()),
   attribute: optional(string()),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR makes sure we use the `alias` set for an action or condition instead of describing; this makes it consistent with the trace timelines.

![CleanShot 2022-08-22 at 20 01 56](https://user-images.githubusercontent.com/195327/185988526-12ad4ebd-ad05-4436-9a76-5ab271bdf5de.gif)


This also fixes a bug, where service call actions and state conditions where considered invalid for UI use when they had an alias (which is not correct).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
