### PR TITLE
Fix automation/script conditions editor

### DIFF
--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -66,7 +66,10 @@ export class HaStateCondition extends LitElement implements ConditionElement {
         },
         {
           name: "state",
-          selector: { state: { entity_id: entityId, attribute: attribute } },
+          required: true,
+          selector: {
+            state: { entity_id: entityId, attribute: attribute },
+          },
         },
         { name: "for", selector: { duration: {} } },
       ] as const
@@ -105,15 +108,21 @@ export class HaStateCondition extends LitElement implements ConditionElement {
 
   private _valueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
-    const newTrigger = ev.detail.value;
+    const newCondition = ev.detail.value;
 
-    Object.keys(newTrigger).forEach((key) =>
-      newTrigger[key] === undefined || newTrigger[key] === ""
-        ? delete newTrigger[key]
+    Object.keys(newCondition).forEach((key) =>
+      newCondition[key] === undefined || newCondition[key] === ""
+        ? delete newCondition[key]
         : {}
     );
 
-    fireEvent(this, "value-changed", { value: newTrigger });
+    // We should not cleanup state in the above, as it is required.
+    // Set it to empty string if it is undefined.
+    if (!newCondition.state) {
+      newCondition.state = "";
+    }
+
+    fireEvent(this, "value-changed", { value: newCondition });
   }
 
   private _computeLabelCallback = (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

It fixes an error as seen in the nightly:

```
Home Assistant 2022.9.0.dev20220824
Supervisor 2022.08.dev2305
Operating System 9.0.dev20220818
Frontend 20220824.0.dev - latest
```

When adding an state condition, and only select an entity:

![CleanShot 2022-08-24 at 10 38 11](https://user-images.githubusercontent.com/195327/186371878-17f49a0a-f2cf-4664-a842-a84822e163c8.png)

This is caused by the logic cleaning up unused keys, also cleaning up the required `state` key.
I adjusted it to be an empty string and marked the field required as well (which wasn't the case).

Includes a small variable rename, which probably originates from a copy & paste from the trigger state code.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
