### PR TITLE
Remove default actions/conditions from parallel and if actions

### DIFF
--- a/src/panels/config/automation/action/types/ha-automation-action-if.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-if.ts
@@ -2,8 +2,6 @@ import { CSSResultGroup, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { Action, IfAction } from "../../../../../data/script";
-import { HaDeviceCondition } from "../../condition/types/ha-automation-condition-device";
-import { HaDeviceAction } from "./ha-automation-action-device_id";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import type { Condition } from "../../../../lovelace/common/validate-condition";
@@ -19,8 +17,8 @@ export class HaIfAction extends LitElement implements ActionElement {
 
   public static get defaultConfig() {
     return {
-      if: [{ ...HaDeviceCondition.defaultConfig, condition: "device" }],
-      then: [HaDeviceAction.defaultConfig],
+      if: [],
+      then: [],
     };
   }
 

--- a/src/panels/config/automation/action/types/ha-automation-action-parallel.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-parallel.ts
@@ -2,7 +2,6 @@ import { CSSResultGroup, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import { Action, ParallelAction } from "../../../../../data/script";
-import { HaDeviceAction } from "./ha-automation-action-device_id";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import "../ha-automation-action";
@@ -17,7 +16,7 @@ export class HaParallelAction extends LitElement implements ActionElement {
 
   public static get defaultConfig() {
     return {
-      parallel: [HaDeviceAction.defaultConfig],
+      parallel: [],
     };
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Removes the default actions/conditions in the default configuration of the parallel & if actions.

They have been removed from other places, these have been missed. It keeps things nice, small and clean when using the automation editor.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
