### PR TITLE
Conditionally add extra divider in integration card overflow menu

### DIFF
--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -368,7 +368,12 @@ export class HaIntegrationCard extends LitElement {
               </a>`
             : ""}
 
-          <li divider role="separator"></li>
+          ${this.manifest &&
+          (this.manifest.is_built_in ||
+            this.manifest.issue_tracker ||
+            this.manifest.documentation)
+            ? html`<li divider role="separator"></li>`
+            : ""}
 
           ${this.manifest
             ? html` <a

--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -367,14 +367,12 @@ export class HaIntegrationCard extends LitElement {
                 </mwc-list-item>
               </a>`
             : ""}
-
           ${this.manifest &&
           (this.manifest.is_built_in ||
             this.manifest.issue_tracker ||
             this.manifest.documentation)
             ? html`<li divider role="separator"></li>`
             : ""}
-
           ${this.manifest
             ? html` <a
                 href=${this.manifest.is_built_in


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixes a tiny issue in the integration card overflow menu. In case an integration isn't built-in and hasn't got documentation & issue links, it can happen that two dividers are shown. 

![CleanShot 2022-08-24 at 13 11 14](https://user-images.githubusercontent.com/195327/186404478-5452e8be-1758-4029-8567-e63ba505b896.png)

This PR adds one of the dividers conditionally to prevent that.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
