### PR TITLE
Change integration enable/disable icons to match automations

### DIFF
--- a/src/panels/config/integrations/ha-integration-card.ts
+++ b/src/panels/config/integrations/ha-integration-card.ts
@@ -11,10 +11,10 @@ import {
   mdiDotsVertical,
   mdiDownload,
   mdiOpenInNew,
+  mdiPlayCircleOutline,
   mdiReload,
   mdiRenameBox,
-  mdiToggleSwitch,
-  mdiToggleSwitchOff,
+  mdiStopCircleOutline,
 } from "@mdi/js";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-listbox";
@@ -429,7 +429,7 @@ export class HaIntegrationCard extends LitElement {
                 ${this.hass.localize("ui.common.enable")}
                 <ha-svg-icon
                   slot="graphic"
-                  .path=${mdiToggleSwitch}
+                  .path=${mdiPlayCircleOutline}
                 ></ha-svg-icon>
               </mwc-list-item>`
             : item.source !== "system"
@@ -442,7 +442,7 @@ export class HaIntegrationCard extends LitElement {
                 <ha-svg-icon
                   slot="graphic"
                   class="warning"
-                  .path=${mdiToggleSwitchOff}
+                  .path=${mdiStopCircleOutline}
                 ></ha-svg-icon>
               </mwc-list-item>`
             : ""}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

We changed the enable/disable icons for automation triggers/conditions/actions yesterday.
This PR adjusts the enable/disable icons for integration to use those same icons for consistency.

![CleanShot 2022-08-24 at 14 19 45](https://user-images.githubusercontent.com/195327/186417172-a27c3307-6e32-4d5d-928a-d387e6e68e59.png)

As per comment from @matthiasdebaat in https://github.com/home-assistant/frontend/pull/13468#issuecomment-1225633282


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
