### PR TITLE
Add icon to trigger/condition/action editor rows

### DIFF
--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -156,12 +156,15 @@ export default class HaAutomationActionRow extends LitElement {
               )}
             </div>`
           : ""}
-        <ha-expansion-panel
-          leftChevron
-          .header=${capitalizeFirstLetter(
-            describeAction(this.hass, this.action)
-          )}
-        >
+        <ha-expansion-panel leftChevron>
+          <div slot="header">
+            <ha-svg-icon
+              class="action-icon"
+              .path=${ACTION_TYPES[type!]}
+            ></ha-svg-icon>
+            ${capitalizeFirstLetter(describeAction(this.hass, this.action))}
+          </div>
+
           ${this.index !== 0
             ? html`
                 <ha-icon-button
@@ -503,6 +506,10 @@ export default class HaAutomationActionRow extends LitElement {
         ha-expansion-panel {
           --expansion-panel-summary-padding: 0 0 0 8px;
           --expansion-panel-content-padding: 0;
+        }
+        .action-icon {
+          color: var(--sidebar-icon-color);
+          padding-right: 8px;
         }
         .card-content {
           padding: 16px;

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -23,6 +23,7 @@ import "../../../../components/ha-expansion-panel";
 import "../../../../components/ha-icon-button";
 import { Condition, testCondition } from "../../../../data/automation";
 import { describeCondition } from "../../../../data/automation_i18n";
+import { CONDITION_TYPES } from "../../../../data/condition";
 import { validateConfig } from "../../../../data/config";
 import {
   showAlertDialog,
@@ -88,12 +89,17 @@ export default class HaAutomationConditionRow extends LitElement {
             </div>`
           : ""}
 
-        <ha-expansion-panel
-          leftChevron
-          .header=${capitalizeFirstLetter(
-            describeCondition(this.condition, this.hass)
-          )}
-        >
+        <ha-expansion-panel leftChevron>
+          <div slot="header">
+            <ha-svg-icon
+              class="condition-icon"
+              .path=${CONDITION_TYPES[this.condition.condition]}
+            ></ha-svg-icon>
+            ${capitalizeFirstLetter(
+              describeCondition(this.condition, this.hass)
+            )}
+          </div>
+
           <ha-progress-button slot="icons" @click=${this._testCondition}>
             ${this.hass.localize(
               "ui.panel.config.automation.editor.conditions.test"
@@ -397,6 +403,10 @@ export default class HaAutomationConditionRow extends LitElement {
         ha-expansion-panel {
           --expansion-panel-summary-padding: 0 0 0 8px;
           --expansion-panel-content-padding: 0;
+        }
+        .condition-icon {
+          color: var(--sidebar-icon-color);
+          padding-right: 8px;
         }
         .card-content {
           padding: 16px;

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -29,6 +29,7 @@ import { HaYamlEditor } from "../../../../components/ha-yaml-editor";
 import { subscribeTrigger, Trigger } from "../../../../data/automation";
 import { describeTrigger } from "../../../../data/automation_i18n";
 import { validateConfig } from "../../../../data/config";
+import { TRIGGER_TYPES } from "../../../../data/trigger";
 import {
   showAlertDialog,
   showConfirmationDialog,
@@ -119,12 +120,14 @@ export default class HaAutomationTriggerRow extends LitElement {
             `
           : ""}
 
-        <ha-expansion-panel
-          leftChevron
-          .header=${capitalizeFirstLetter(
-            describeTrigger(this.trigger, this.hass)
-          )}
-        >
+        <ha-expansion-panel leftChevron>
+          <div slot="header">
+            <ha-svg-icon
+              class="trigger-icon"
+              .path=${TRIGGER_TYPES[this.trigger.platform]}
+            ></ha-svg-icon>
+            ${capitalizeFirstLetter(describeTrigger(this.trigger, this.hass))}
+          </div>
           <ha-button-menu
             slot="icons"
             fixed
@@ -528,6 +531,10 @@ export default class HaAutomationTriggerRow extends LitElement {
         ha-expansion-panel {
           --expansion-panel-summary-padding: 0 0 0 8px;
           --expansion-panel-content-padding: 0;
+        }
+        .trigger-icon {
+          color: var(--sidebar-icon-color);
+          padding-right: 8px;
         }
         .card-content {
           padding: 16px;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR adds icons to the automation editor rows for triggers, conditions, and actions.
With the expansion panels closed, I feel these provide visual context that can be glanced at.

![CleanShot 2022-08-25 at 10 01 52](https://user-images.githubusercontent.com/195327/186611278-2058cdf4-e26c-496d-b2ac-3f93d7117877.png)




## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
