### PR TITLE
Sort automation triggers with drag and drop

### DIFF
--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -1,6 +1,8 @@
 import { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
 import "@material/mwc-list/mwc-list-item";
 import {
+  mdiArrowDown,
+  mdiArrowUp,
   mdiCheck,
   mdiContentDuplicate,
   mdiDelete,
@@ -87,6 +89,10 @@ export default class HaAutomationTriggerRow extends LitElement {
 
   @property({ attribute: false }) public trigger!: Trigger;
 
+  @property() public index!: number;
+
+  @property() public totalTriggers!: number;
+
   @state() private _warnings?: string[];
 
   @state() private _yamlMode = false;
@@ -128,6 +134,31 @@ export default class HaAutomationTriggerRow extends LitElement {
             ></ha-svg-icon>
             ${capitalizeFirstLetter(describeTrigger(this.trigger, this.hass))}
           </div>
+
+          ${this.index !== 0
+            ? html`
+                <ha-icon-button
+                  slot="icons"
+                  .label=${this.hass.localize(
+                    "ui.panel.config.automation.editor.move_up"
+                  )}
+                  .path=${mdiArrowUp}
+                  @click=${this._moveUp}
+                ></ha-icon-button>
+              `
+            : ""}
+          ${this.index !== this.totalTriggers - 1
+            ? html`
+                <ha-icon-button
+                  slot="icons"
+                  .label=${this.hass.localize(
+                    "ui.panel.config.automation.editor.move_down"
+                  )}
+                  .path=${mdiArrowDown}
+                  @click=${this._moveDown}
+                ></ha-icon-button>
+              `
+            : ""}
           <ha-button-menu
             slot="icons"
             fixed
@@ -380,6 +411,16 @@ export default class HaAutomationTriggerRow extends LitElement {
     if (!this._yamlMode) {
       this._yamlMode = true;
     }
+  }
+
+  private _moveUp(ev) {
+    ev.preventDefault();
+    fireEvent(this, "move-action", { direction: "up" });
+  }
+
+  private _moveDown(ev) {
+    ev.preventDefault();
+    fireEvent(this, "move-action", { direction: "down" });
   }
 
   private async _handleAction(ev: CustomEvent<ActionDetail>) {

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -269,6 +269,7 @@ export default class HaAutomationTrigger extends LitElement {
 
         .trigger .handle {
           padding-top: 12px;
+          padding-bottom: 12px;
           padding-right: 8px;
           cursor: move;
           padding-inline-end: 8px;

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -282,11 +282,11 @@ export default class HaAutomationTrigger extends LitElement {
         }
 
         .trigger .handle {
-          padding-top: 12px;
-          padding-bottom: 12px;
-          padding-right: 8px;
+          padding-top: 15px;
+          padding-bottom: 15px;
+          padding-right: 4px;
           cursor: move;
-          padding-inline-end: 8px;
+          padding-inline-end: 4px;
           padding-inline-start: initial;
           direction: var(--direction);
         }

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -72,8 +72,10 @@ export default class HaAutomationTrigger extends LitElement {
               <ha-svg-icon class="handle" .path=${mdiDrag}></ha-svg-icon>
               <ha-automation-trigger-row
                 .index=${idx}
+                .totalTriggers=${this.triggers.length}
                 .trigger=${trg}
                 @duplicate=${this._duplicateTrigger}
+                @move-action=${this._move}
                 @value-changed=${this._triggerChanged}
                 .hass=${this.hass}
               ></ha-automation-trigger-row>
@@ -205,6 +207,18 @@ export default class HaAutomationTrigger extends LitElement {
     newTriggers.splice(ev.newIndex!, 0, newTriggers.splice(ev.oldIndex!, 1)[0]);
 
     fireEvent(this, "value-changed", { value: newTriggers });
+  }
+
+  private _move(ev: CustomEvent) {
+    // Prevent possible parent action-row from also moving
+    ev.stopPropagation();
+
+    const index = (ev.target as any).index;
+    const newIndex = ev.detail.direction === "up" ? index - 1 : index + 1;
+    const triggers = this.triggers.concat();
+    const trigger = triggers.splice(index, 1)[0];
+    triggers.splice(newIndex, 0, trigger);
+    fireEvent(this, "value-changed", { value: triggers });
   }
 
   private _triggerChanged(ev: CustomEvent) {

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -69,7 +69,9 @@ export default class HaAutomationTrigger extends LitElement {
           (trigger) => this._getKey(trigger),
           (trg, idx) => html`
             <div class="trigger">
-              <ha-svg-icon class="handle" .path=${mdiDrag}></ha-svg-icon>
+              <div class="handle">
+                <ha-svg-icon .path=${mdiDrag}></ha-svg-icon>
+              </div>
               <ha-automation-trigger-row
                 .index=${idx}
                 .totalTriggers=${this.triggers.length}
@@ -290,7 +292,9 @@ export default class HaAutomationTrigger extends LitElement {
           padding-inline-start: initial;
           direction: var(--direction);
         }
-
+        .trigger .handle > * {
+          pointer-events: none;
+        }
         .trigger ha-automation-trigger-row {
           flex-grow: 1;
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR allows triggers sorting with drag and drop gesture. (PR for conditions and actions will follow)

https://user-images.githubusercontent.com/5878303/186643958-70b1a756-dca9-4b2b-8f6b-0c3b6fd7850c.mp4


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

Inspired from `hui-entities-card-row-editor`. There is a lot of technical stuff to make it work (`_attached` and `_renderEmptySortable`). I'm wondering if it is possible de simplify all this stuff.

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
