### PR TITLE
Improve delete device button and confirmation dialog

### DIFF
--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -933,7 +933,18 @@ export class HaConfigDevicePage extends LitElement {
       buttons.push({
         action: async () => {
           const confirmed = await showConfirmationDialog(this, {
-            text: this.hass.localize("ui.panel.config.devices.confirm_delete"),
+            text:
+              this._integrations(device, this.entries).length > 1
+                ? this.hass.localize(
+                    `ui.panel.config.devices.confirm_delete_integration`,
+                    {
+                      integration: domainToName(
+                        this.hass.localize,
+                        entry.domain
+                      ),
+                    }
+                  )
+                : this.hass.localize(`ui.panel.config.devices.confirm_delete`),
           });
 
           if (!confirmed) {
@@ -949,7 +960,7 @@ export class HaConfigDevicePage extends LitElement {
         classes: "warning",
         icon: mdiDelete,
         label:
-          buttons.length > 1
+          this._integrations(device, this.entries).length > 1
             ? this.hass.localize(
                 `ui.panel.config.devices.delete_device_integration`,
                 {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2641,6 +2641,7 @@
           },
           "delete": "Delete",
           "confirm_delete": "Are you sure you want to delete this device?",
+          "confirm_delete_integration": "Are you sure you want to remove {integration} from this device?",
           "picker": {
             "search": "Search devices",
             "filter": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2564,7 +2564,7 @@
           "download_diagnostics": "Download diagnostics",
           "download_diagnostics_integration": "Download {integration} diagnostics",
           "delete_device": "Delete",
-          "delete_device_integration": "Remove {integration} from device",
+          "delete_device_integration": "Remove device from {integration}",
           "type": {
             "device_heading": "Device",
             "device": "device",
@@ -2641,7 +2641,7 @@
           },
           "delete": "Delete",
           "confirm_delete": "Are you sure you want to delete this device?",
-          "confirm_delete_integration": "Are you sure you want to remove {integration} from this device?",
+          "confirm_delete_integration": "Are you sure you want to remove this device from {integration}?",
           "picker": {
             "search": "Search devices",
             "filter": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Improve delete device button and confirmation dialog:
- If a device is attached to more than one config entry, the button is now labeled "Remove {integration} from device"
- If a device is attached to more than one config entry, the confirmation dialog now asks "Are you sure you want to remove {integration} from this device?"

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
