### PR TITLE
Always show description field in automation editor

### DIFF
--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -1,8 +1,8 @@
 import "@material/mwc-button/mwc-button";
 import { mdiHelpCircle, mdiRobot } from "@mdi/js";
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, LitElement, PropertyValues } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { css, CSSResultGroup, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/ha-entity-toggle";
 import "../../../components/ha-card";
@@ -35,20 +35,16 @@ export class HaManualAutomationEditor extends LitElement {
 
   @property({ attribute: false }) public stateObj?: HassEntity;
 
-  @state() private _showDescription = false;
-
   protected render() {
     return html`
       <ha-card outlined>
-        ${
-          this.stateObj && this.stateObj.state === "off"
-            ? html`<div class="disabled-bar">
-                ${this.hass.localize(
-                  "ui.panel.config.automation.editor.disabled"
-                )}
-              </div>`
-            : ""
-        }
+        ${this.stateObj && this.stateObj.state === "off"
+          ? html`<div class="disabled-bar">
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.disabled"
+              )}
+            </div>`
+          : ""}
 
         <ha-expansion-panel leftChevron>
           <div slot="header">
@@ -58,33 +54,18 @@ export class HaManualAutomationEditor extends LitElement {
             )}
           </div>
           <div class="card-content">
-            </ha-textfield>
-            ${
-              this._showDescription
-                ? html`
-                    <ha-textarea
-                      .label=${this.hass.localize(
-                        "ui.panel.config.automation.editor.description.label"
-                      )}
-                      .placeholder=${this.hass.localize(
-                        "ui.panel.config.automation.editor.description.placeholder"
-                      )}
-                      name="description"
-                      autogrow
-                      .value=${this.config.description || ""}
-                      @change=${this._valueChanged}
-                    ></ha-textarea>
-                  `
-                : html`
-                    <div class="link-button-row">
-                      <button class="link" @click=${this._addDescription}>
-                        ${this.hass.localize(
-                          "ui.panel.config.automation.editor.description.add"
-                        )}
-                      </button>
-                    </div>
-                  `
-            }
+            <ha-textarea
+              .label=${this.hass.localize(
+                "ui.panel.config.automation.editor.description.label"
+              )}
+              .placeholder=${this.hass.localize(
+                "ui.panel.config.automation.editor.description.placeholder"
+              )}
+              name="description"
+              autogrow
+              .value=${this.config.description || ""}
+              @change=${this._valueChanged}
+            ></ha-textarea>
             <ha-select
               .label=${this.hass.localize(
                 "ui.panel.config.automation.editor.modes.label"
@@ -114,23 +95,21 @@ export class HaManualAutomationEditor extends LitElement {
                 `
               )}
             </ha-select>
-            ${
-              this.config.mode && isMaxMode(this.config.mode)
-                ? html`
-                    <br /><ha-textfield
-                      .label=${this.hass.localize(
-                        `ui.panel.config.automation.editor.max.${this.config.mode}`
-                      )}
-                      type="number"
-                      name="max"
-                      .value=${this.config.max || "10"}
-                      @change=${this._valueChanged}
-                      class="max"
-                    >
-                    </ha-textfield>
-                  `
-                : html``
-            }
+            ${this.config.mode && isMaxMode(this.config.mode)
+              ? html`
+                  <br /><ha-textfield
+                    .label=${this.hass.localize(
+                      `ui.panel.config.automation.editor.max.${this.config.mode}`
+                    )}
+                    type="number"
+                    name="max"
+                    .value=${this.config.max || "10"}
+                    @change=${this._valueChanged}
+                    class="max"
+                  >
+                  </ha-textfield>
+                `
+              : html``}
           </div>
         </ha-expansion-panel>
       </ha-card>
@@ -216,17 +195,6 @@ export class HaManualAutomationEditor extends LitElement {
     `;
   }
 
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (
-      !this._showDescription &&
-      changedProps.has("config") &&
-      this.config.description
-    ) {
-      this._showDescription = true;
-    }
-  }
-
   private _valueChanged(ev: CustomEvent) {
     ev.stopPropagation();
     const target = ev.target as any;
@@ -293,10 +261,6 @@ export class HaManualAutomationEditor extends LitElement {
     });
   }
 
-  private _addDescription() {
-    this._showDescription = true;
-  }
-
   static get styles(): CSSResultGroup {
     return [
       haStyle,
@@ -345,6 +309,9 @@ export class HaManualAutomationEditor extends LitElement {
         }
         .card-content {
           padding: 16px;
+        }
+        .card-content ha-textarea:first-child {
+          margin-top: -16px;
         }
         .settings-icon {
           display: none;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Since we collapse the automation settings using an expansion panel now, we can just as well just always show the description field:

![CleanShot 2022-08-26 at 15 09 50](https://user-images.githubusercontent.com/195327/186910959-f84f248d-efb5-4b18-9807-2628f140efc0.png) 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
