### PR TITLE
Allow controlling an input_select in unknown state

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -4,7 +4,7 @@ import { customElement, property, state } from "lit/decorators";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/ha-select";
-import { UNAVAILABLE_STATES } from "../../../data/entity";
+import { UNAVAILABLE } from "../../../data/entity";
 import { forwardHaptic } from "../../../data/haptics";
 import {
   InputSelectEntity,
@@ -61,7 +61,9 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
         <ha-select
           .label=${this._config.name || computeStateName(stateObj)}
           .value=${stateObj.state}
-          .disabled=${UNAVAILABLE_STATES.includes(stateObj.state)}
+          .disabled=${
+            stateObj.state === UNAVAILABLE /* UNKNWON state is allowed */
+          }
           naturalMenuWidth
           @selected=${this._selectedChanged}
           @click=${stopPropagation}

--- a/src/state-summary/state-card-input_select.ts
+++ b/src/state-summary/state-card-input_select.ts
@@ -5,7 +5,7 @@ import { customElement, property } from "lit/decorators";
 import { stopPropagation } from "../common/dom/stop_propagation";
 import { computeStateName } from "../common/entity/compute_state_name";
 import "../components/entity/state-badge";
-import { UNAVAILABLE_STATES } from "../data/entity";
+import { UNAVAILABLE } from "../data/entity";
 import { InputSelectEntity, setInputSelectOption } from "../data/input_select";
 import type { HomeAssistant } from "../types";
 
@@ -21,7 +21,9 @@ class StateCardInputSelect extends LitElement {
       <ha-select
         .label=${computeStateName(this.stateObj)}
         .value=${this.stateObj.state}
-        .disabled=${UNAVAILABLE_STATES.includes(this.stateObj.state)}
+        .disabled=${
+          this.stateObj.state === UNAVAILABLE /* UNKNWON state is allowed */
+        }
         naturalMenuWidth
         fixedMenuPosition
         @selected=${this._selectedOptionChanged}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Allow controlling an `input_select` in unknown state

An `input_select` sets its state to unknown if no option is selected. It should still be possible to control it from the frontend if this happens.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/75673
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
