### PR TITLE
Improve blueprint editor layout

### DIFF
--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -62,41 +62,25 @@ export class HaBlueprintAutomationEditor extends LitElement {
   protected render() {
     const blueprint = this._blueprint;
     return html`
-      <ha-config-section vertical .isWide=${this.isWide}>
-        <span slot="introduction">
-          ${this.hass.localize(
-            "ui.panel.config.automation.editor.introduction"
-          )}
-        </span>
-        <ha-card outlined>
-          <div class="card-content">
-            ${this._showDescription
-              ? html`
-                  <ha-textarea
-                    .label=${this.hass.localize(
-                      "ui.panel.config.automation.editor.description.label"
-                    )}
-                    .placeholder=${this.hass.localize(
-                      "ui.panel.config.automation.editor.description.placeholder"
-                    )}
-                    name="description"
-                    autogrow
-                    .value=${this.config.description || ""}
-                    @change=${this._valueChanged}
-                  ></ha-textarea>
-                `
-              : html`
-                  <div class="link-button-row">
-                    <button class="link" @click=${this._addDescription}>
-                      ${this.hass.localize(
-                        "ui.panel.config.automation.editor.description.add"
-                      )}
-                    </button>
-                  </div>
-                `}
-          </div>
-        </ha-card>
-      </ha-config-section>
+      <p class="introduction">
+        ${this.hass.localize("ui.panel.config.automation.editor.introduction")}
+      </p>
+      <ha-card outlined>
+        <div class="card-content">
+          <ha-textarea
+            .label=${this.hass.localize(
+              "ui.panel.config.automation.editor.description.label"
+            )}
+            .placeholder=${this.hass.localize(
+              "ui.panel.config.automation.editor.description.placeholder"
+            )}
+            name="description"
+            autogrow
+            .value=${this.config.description || ""}
+            @change=${this._valueChanged}
+          ></ha-textarea>
+        </div>
+      </ha-card>
 
       <ha-card
         outlined
@@ -251,8 +235,10 @@ export class HaBlueprintAutomationEditor extends LitElement {
     return [
       haStyle,
       css`
+        :host {
+          display: block;
+        }
         ha-card.blueprint {
-          max-width: 1040px;
           margin: 24px auto;
         }
         .padding {
@@ -272,7 +258,11 @@ export class HaBlueprintAutomationEditor extends LitElement {
         h3 {
           margin: 16px;
         }
-        span[slot="introduction"] a {
+        .introduction {
+          margin-top: 0;
+          margin-bottom: 12px;
+        }
+        .introduction a {
           color: var(--primary-color);
         }
         p {

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -1,6 +1,6 @@
 import "@material/mwc-button/mwc-button";
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, LitElement, PropertyValues } from "lit";
+import { css, CSSResultGroup, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-blueprint-picker";
@@ -34,8 +34,6 @@ export class HaBlueprintAutomationEditor extends LitElement {
 
   @state() private _blueprints?: Blueprints;
 
-  @state() private _showDescription = false;
-
   protected firstUpdated(changedProps) {
     super.firstUpdated(changedProps);
     this._getBlueprints();
@@ -46,17 +44,6 @@ export class HaBlueprintAutomationEditor extends LitElement {
       return undefined;
     }
     return this._blueprints[this.config.use_blueprint.path];
-  }
-
-  protected willUpdate(changedProps: PropertyValues): void {
-    super.willUpdate(changedProps);
-    if (
-      !this._showDescription &&
-      changedProps.has("config") &&
-      this.config.description
-    ) {
-      this._showDescription = true;
-    }
   }
 
   protected render() {
@@ -225,10 +212,6 @@ export class HaBlueprintAutomationEditor extends LitElement {
     fireEvent(this, "value-changed", {
       value: { ...this.config!, [name]: newVal },
     });
-  }
-
-  private _addDescription() {
-    this._showDescription = true;
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -640,7 +640,8 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
           flex-direction: column;
           padding-bottom: 0;
         }
-        manual-automation-editor {
+        manual-automation-editor,
+        blueprint-automation-editor {
           margin: 0 auto;
           max-width: 1040px;
           padding: 28px 20px 0;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Improve blueprint layout. Use same margin as manual editor. 
I also always display the description field to keep consistency with manual editor.

### Before

![Capture d’écran 2022-09-02 à 10 13 10](https://user-images.githubusercontent.com/5878303/188095748-3a1b7f9d-4656-4470-afc1-c42cecdb663a.png)

### After

![Capture d’écran 2022-09-02 à 10 12 03](https://user-images.githubusercontent.com/5878303/188095737-23a89aa2-e37d-46b3-9513-75a4a9e721e3.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
