### PR TITLE
Add support for subscribing to config entry changes

### DIFF
--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -1,3 +1,4 @@
+import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { HomeAssistant } from "../types";
 
 export interface ConfigEntry {
@@ -54,7 +55,7 @@ export const subscribeConfigEntries = (
   hass: HomeAssistant,
   callbackFunction: (message: ConfigEntryUpdate[]) => void,
   filters?: { type?: "helper" | "integration"; domain?: string }
-) => {
+): Promise<UnsubscribeFunc> => {
   const params: any = {
     type: "config_entries/subscribe",
   };

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -44,6 +44,29 @@ export const RECOVERABLE_STATES: ConfigEntry["state"][] = [
   "setup_retry",
 ];
 
+export interface ConfigEntryUpdate {
+  // Base data
+  type: null | "added" | "removed" | "updated";
+  entry: ConfigEntry;
+}
+
+export const subscribeConfigEntries = (
+  hass: HomeAssistant,
+  callbackFunction: (message: ConfigEntryUpdate[]) => void,
+  filters?: { type?: "helper" | "integration"; domain?: string }
+) => {
+  const params: any = {
+    type: "config_entries/subscribe",
+  };
+  if (filters && filters.type) {
+    params.type_filter = filters.type;
+  }
+  return hass.connection.subscribeMessage<ConfigEntryUpdate[]>(
+    (message) => callbackFunction(message),
+    params
+  );
+};
+
 export const getConfigEntries = (
   hass: HomeAssistant,
   filters?: { type?: "helper" | "integration"; domain?: string }

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -46,7 +46,7 @@ export const RECOVERABLE_STATES: ConfigEntry["state"][] = [
 ];
 
 export interface ConfigEntryUpdate {
-  // Base data
+  // null means no update as is the current state
   type: null | "added" | "removed" | "updated";
   entry: ConfigEntry;
 }

--- a/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
@@ -170,7 +170,6 @@ class DialogConfigEntrySystemOptions extends LitElement {
           ),
         });
       }
-      this._params!.entryUpdated(result.config_entry);
       this.closeDialog();
     } catch (err: any) {
       this._error = err.message || "Unknown error";

--- a/src/dialogs/config-entry-system-options/show-dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/show-dialog-config-entry-system-options.ts
@@ -5,7 +5,6 @@ import { IntegrationManifest } from "../../data/integration";
 export interface ConfigEntrySystemOptionsDialogParams {
   entry: ConfigEntry;
   manifest?: IntegrationManifest;
-  entryUpdated(entry: ConfigEntry): void;
 }
 
 export const loadConfigEntrySystemOptionsDialog = () =>

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -154,9 +154,7 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
 
   @state() private _diagnosticHandlers?: Record<string, boolean>;
 
-  private _subscribedConfigEntries?: Promise<(() => Promise<void>) | void>;
-
-  public hassSubscribe(): UnsubscribeFunc[] {
+  public hassSubscribe(): Array<UnsubscribeFunc | Promise<UnsubscribeFunc>> {
     return [
       subscribeEntityRegistry(this.hass.connection, (entries) => {
         this._entityRegistryEntries = entries;
@@ -182,10 +180,56 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         await nextRender();
         this._configEntriesInProgress = flowsInProgress.map((flow) => ({
           ...flow,
-          localized_domain_name: domainToName(this.hass.localize, flow.handler),
           localized_title: localizeConfigFlowTitle(this.hass.localize, flow),
         }));
       }),
+      subscribeConfigEntries(
+        this.hass,
+        (messages) => {
+          let fullUpdate = false;
+          const newEntries: ConfigEntryExtended[] = [];
+          messages.forEach((message) => {
+            if (message.type === null || message.type === "added") {
+              newEntries.push({
+                ...message.entry,
+                localized_domain_name: domainToName(
+                  this.hass.localize,
+                  message.entry.domain
+                ),
+              });
+              if (message.type === null) {
+                fullUpdate = true;
+              }
+            } else if (message.type === "removed") {
+              this._configEntries = this._configEntries!.filter(
+                (entry) => entry.entry_id !== message.entry.entry_id
+              );
+            } else if (message.type === "updated") {
+              const newEntry = message.entry;
+              this._configEntries = this._configEntries!.map((entry) =>
+                entry.entry_id === newEntry.entry_id
+                  ? {
+                      ...newEntry,
+                      localized_domain_name: entry.localized_domain_name,
+                    }
+                  : entry
+              );
+            }
+          });
+          if (!newEntries.length && !fullUpdate) {
+            return;
+          }
+          const existingEntries = fullUpdate ? [] : this._configEntries;
+          this._configEntries = [...existingEntries!, ...newEntries].sort(
+            (conf1, conf2) =>
+              caseInsensitiveStringCompare(
+                conf1.localized_domain_name + conf1.title,
+                conf2.localized_domain_name + conf2.title
+              )
+          );
+        },
+        { type: "integration" }
+      ),
     ];
   }
 
@@ -261,81 +305,8 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
     }
   );
 
-  public connectedCallback() {
-    this._configEntries = undefined;
-    super.connectedCallback();
-    if (this.hasUpdated) {
-      this._subscribeConfigEntries();
-    }
-  }
-
-  public disconnectedCallback() {
-    super.disconnectedCallback();
-    this._unsubscribeConfigEntries();
-  }
-
-  private _subscribeConfigEntries() {
-    this._subscribedConfigEntries = subscribeConfigEntries(
-      this.hass,
-      (messages) => {
-        let fullUpdate = false;
-        const newEntries: ConfigEntryExtended[] = [];
-        messages.forEach((message) => {
-          if (message.type === null || message.type === "added") {
-            newEntries.push({
-              ...message.entry,
-              localized_domain_name: domainToName(
-                this.hass.localize,
-                message.entry.domain
-              ),
-            });
-            if (message.type === null) {
-              fullUpdate = true;
-            }
-          } else if (message.type === "removed") {
-            this._configEntries = this._configEntries!.filter(
-              (entry) => entry.entry_id !== message.entry.entry_id
-            );
-          } else if (message.type === "updated") {
-            const newEntry = message.entry;
-            this._configEntries = this._configEntries!.map((entry) =>
-              entry.entry_id === newEntry.entry_id
-                ? {
-                    ...newEntry,
-                    localized_domain_name: entry.localized_domain_name,
-                  }
-                : entry
-            );
-          }
-        });
-        if (!newEntries.length && !fullUpdate) {
-          return;
-        }
-        const existingEntries = fullUpdate ? [] : this._configEntries;
-        this._configEntries = [...existingEntries!, ...newEntries].sort(
-          (conf1, conf2) =>
-            caseInsensitiveStringCompare(
-              conf1.localized_domain_name + conf1.title,
-              conf2.localized_domain_name + conf2.title
-            )
-        );
-      },
-      { type: "integration" }
-    );
-  }
-
-  private _unsubscribeConfigEntries(): void {
-    if (this._subscribedConfigEntries) {
-      this._subscribedConfigEntries.then(
-        (unsubscribe) => unsubscribe && unsubscribe()
-      );
-      this._subscribedConfigEntries = undefined;
-    }
-  }
-
   protected firstUpdated(changed: PropertyValues) {
     super.firstUpdated(changed);
-    this._subscribeConfigEntries();
     const localizePromise = this.hass.loadBackendTranslation(
       "title",
       undefined,


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Needs https://github.com/home-assistant/core/pull/77803

The dispatcher is used to get events to the api since config entry state changes
are frequent and we do not want to broadcast them to the event bus.

I didn't use a collection here since config entries are rather noisy with retries
and state changes and I wanted to send everything in a single api so
there wasn't a race between fetching the initial payload and getting callbacks.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
