### PR TITLE
Add back blank before percent sign ("%") based on language

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -2,17 +2,18 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity";
 import { FrontendLocaleData } from "../../data/translation";
 import {
-  UPDATE_SUPPORT_PROGRESS,
   updateIsInstallingFromAttributes,
+  UPDATE_SUPPORT_PROGRESS,
 } from "../../data/update";
+import { formatDuration, UNIT_TO_SECOND_CONVERT } from "../datetime/duration";
 import { formatDate } from "../datetime/format_date";
 import { formatDateTime } from "../datetime/format_date_time";
 import { formatTime } from "../datetime/format_time";
 import { formatNumber, isNumericFromAttributes } from "../number/format_number";
+import { blankBeforePercent } from "../translations/blank_before_percent";
 import { LocalizeFunc } from "../translations/localize";
-import { supportsFeatureFromAttributes } from "./supports-feature";
-import { formatDuration, UNIT_TO_SECOND_CONVERT } from "../datetime/duration";
 import { computeDomain } from "./compute_domain";
+import { supportsFeatureFromAttributes } from "./supports-feature";
 
 export const computeStateDisplay = (
   localize: LocalizeFunc,
@@ -67,7 +68,7 @@ export const computeStateDisplayFromEntityAttributes = (
     const unit = !attributes.unit_of_measurement
       ? ""
       : attributes.unit_of_measurement === "%"
-      ? "%"
+      ? blankBeforePercent(locale) + "%"
       : ` ${attributes.unit_of_measurement}`;
     return `${formatNumber(state, locale)}${unit}`;
   }

--- a/src/common/translations/blank_before_percent.ts
+++ b/src/common/translations/blank_before_percent.ts
@@ -10,7 +10,6 @@ export const blankBeforePercent = (
     case "en-gb":
     case "fi":
     case "fr":
-    case "nl":
     case "ru":
     case "sk":
     case "sv":

--- a/src/common/translations/blank_before_percent.ts
+++ b/src/common/translations/blank_before_percent.ts
@@ -1,0 +1,20 @@
+import { FrontendLocaleData } from "../../data/translation";
+
+// Logic based on https://en.wikipedia.org/wiki/Percent_sign#Form_and_spacing
+export const blankBeforePercent = (
+  localeOptions: FrontendLocaleData
+): string => {
+  switch (localeOptions.language) {
+    case "cz":
+    case "de":
+    case "en-gb":
+    case "fi":
+    case "fr":
+    case "nl":
+    case "sk":
+    case "sv":
+      return " ";
+    default:
+      return "";
+  }
+};

--- a/src/common/translations/blank_before_percent.ts
+++ b/src/common/translations/blank_before_percent.ts
@@ -7,7 +7,6 @@ export const blankBeforePercent = (
   switch (localeOptions.language) {
     case "cz":
     case "de":
-    case "en-gb":
     case "fi":
     case "fr":
     case "sk":

--- a/src/common/translations/blank_before_percent.ts
+++ b/src/common/translations/blank_before_percent.ts
@@ -10,7 +10,6 @@ export const blankBeforePercent = (
     case "en-gb":
     case "fi":
     case "fr":
-    case "ru":
     case "sk":
     case "sv":
       return " ";

--- a/src/common/translations/blank_before_percent.ts
+++ b/src/common/translations/blank_before_percent.ts
@@ -11,6 +11,7 @@ export const blankBeforePercent = (
     case "fi":
     case "fr":
     case "nl":
+    case "ru":
     case "sk":
     case "sv":
       return " ";

--- a/src/components/ha-gauge.ts
+++ b/src/components/ha-gauge.ts
@@ -2,6 +2,7 @@ import { css, LitElement, PropertyValues, svg, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import { formatNumber } from "../common/number/format_number";
+import { blankBeforePercent } from "../common/translations/blank_before_percent";
 import { afterNextRender } from "../common/util/render-status";
 import { FrontendLocaleData } from "../data/translation";
 import { getValueInPercentage, normalize } from "../util/calculate";
@@ -133,7 +134,11 @@ export class Gauge extends LitElement {
               ? this._segment_label
               : this.valueText || formatNumber(this.value, this.locale)
           }${
-      this._segment_label ? "" : this.label === "%" ? "%" : ` ${this.label}`
+      this._segment_label
+        ? ""
+        : this.label === "%"
+        ? blankBeforePercent(this.locale) + "%"
+        : ` ${this.label}`
     }
         </text>
       </svg>`;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Reaction to PR https://github.com/home-assistant/frontend/pull/13458 based on the discussion we had here: https://discord.com/channels/330944238910963714/351047592588869643/1015149768927870987

Now the blanks are back in front of the percent sign ("%") based on the language.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
