### PR TITLE
Automation change mode dialog

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -9,6 +9,7 @@ import { DeviceCondition, DeviceTrigger } from "./device_automation";
 import { Action, MODES } from "./script";
 
 export const AUTOMATION_DEFAULT_MODE: typeof MODES[number] = "single";
+export const AUTOMATION_DEFAULT_MAX = 10;
 
 export interface AutomationEntity extends HassEntityBase {
   attributes: HassEntityAttributeBase & {

--- a/src/panels/config/automation/automation-mode-dialog/dialog-automation-mode.ts
+++ b/src/panels/config/automation/automation-mode-dialog/dialog-automation-mode.ts
@@ -1,0 +1,159 @@
+import "@material/mwc-button";
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import { createCloseHeading } from "../../../../components/ha-dialog";
+import "../../../../components/ha-textfield";
+import "../../../../components/ha-select";
+import { HassDialog } from "../../../../dialogs/make-dialog-manager";
+import { haStyle, haStyleDialog } from "../../../../resources/styles";
+import type { HomeAssistant } from "../../../../types";
+import type { AutomationModeDialog } from "./show-dialog-automation-mode";
+import { AUTOMATION_DEFAULT_MODE } from "../../../../data/automation";
+import { documentationUrl } from "../../../../util/documentation-url";
+import { isMaxMode, MODES } from "../../../../data/script";
+import "@material/mwc-list/mwc-list-item";
+import { stopPropagation } from "../../../../common/dom/stop_propagation";
+
+@customElement("ha-dialog-automation-mode")
+class DialogAutomationMode extends LitElement implements HassDialog {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _opened = false;
+
+  private _params!: AutomationModeDialog;
+
+  @state() private _newMode?: typeof MODES[number];
+
+  @state() private _newMax?: number;
+
+  public showDialog(params: AutomationModeDialog): void {
+    this._opened = true;
+    this._params = params;
+    this._newMode = params.config.mode || AUTOMATION_DEFAULT_MODE;
+    this._newMax = params.config.max;
+  }
+
+  public closeDialog(): void {
+    this._params.onClose();
+
+    if (this._opened) {
+      fireEvent(this, "dialog-closed", { dialog: this.localName });
+    }
+    this._opened = false;
+  }
+
+  protected render(): TemplateResult {
+    if (!this._opened) {
+      return html``;
+    }
+
+    return html`
+      <ha-dialog
+        open
+        @closed=${this.closeDialog}
+        .heading=${createCloseHeading(
+          this.hass,
+          this.hass.localize("ui.panel.config.automation.editor.change_mode")
+        )}
+      >
+        <ha-select
+          .label=${this.hass.localize(
+            "ui.panel.config.automation.editor.modes.label"
+          )}
+          .value=${this._newMode}
+          @selected=${this._modeChanged}
+          @closed=${stopPropagation}
+          fixedMenuPosition
+          .helper=${html`
+            <a
+              style="color: var(--secondary-text-color)"
+              href=${documentationUrl(this.hass, "/docs/automation/modes/")}
+              target="_blank"
+              rel="noreferrer"
+              >${this.hass.localize(
+                "ui.panel.config.automation.editor.modes.learn_more"
+              )}</a
+            >
+          `}
+        >
+          ${MODES.map(
+            (mode) => html`
+              <mwc-list-item .value=${mode}>
+                ${this.hass.localize(
+                  `ui.panel.config.automation.editor.modes.${mode}`
+                ) || mode}
+              </mwc-list-item>
+            `
+          )}
+        </ha-select>
+        ${this._newMode && isMaxMode(this._newMode)
+          ? html`
+              <br /><ha-textfield
+                .label=${this.hass.localize(
+                  `ui.panel.config.automation.editor.max.${this._newMode}`
+                )}
+                type="number"
+                name="max"
+                .value=${this._newMax || "10"}
+                @change=${this._valueChanged}
+                class="max"
+              >
+              </ha-textfield>
+            `
+          : html``}
+
+        <mwc-button @click=${this.closeDialog} slot="secondaryAction">
+          ${this.hass.localize("ui.dialogs.generic.cancel")}
+        </mwc-button>
+        <mwc-button @click=${this._save} slot="primaryAction">
+          ${this.hass.localize("ui.panel.config.automation.editor.change_mode")}
+        </mwc-button>
+      </ha-dialog>
+    `;
+  }
+
+  private _modeChanged(ev) {
+    const mode = ev.target.value;
+    this._newMode = mode;
+    if (!isMaxMode(mode)) {
+      this._newMax = undefined;
+    }
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const target = ev.target as any;
+    if (target.name === "max") {
+      this._newMax = Number(target.value);
+    }
+  }
+
+  private _save(): void {
+    this._params.updateAutomation({
+      ...this._params.config,
+      mode: this._newMode,
+      max: this._newMax,
+    });
+    this.closeDialog();
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      haStyleDialog,
+      css`
+        ha-textfield,
+        ha-textarea {
+          display: block;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-dialog-automation-mode": DialogAutomationMode;
+  }
+}

--- a/src/panels/config/automation/automation-mode-dialog/dialog-automation-mode.ts
+++ b/src/panels/config/automation/automation-mode-dialog/dialog-automation-mode.ts
@@ -9,7 +9,10 @@ import { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import { haStyle, haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import type { AutomationModeDialog } from "./show-dialog-automation-mode";
-import { AUTOMATION_DEFAULT_MODE } from "../../../../data/automation";
+import {
+  AUTOMATION_DEFAULT_MAX,
+  AUTOMATION_DEFAULT_MODE,
+} from "../../../../data/automation";
 import { documentationUrl } from "../../../../util/documentation-url";
 import { isMaxMode, MODES } from "../../../../data/script";
 import "@material/mwc-list/mwc-list-item";
@@ -23,7 +26,7 @@ class DialogAutomationMode extends LitElement implements HassDialog {
 
   private _params!: AutomationModeDialog;
 
-  @state() private _newMode?: typeof MODES[number];
+  @state() private _newMode: typeof MODES[number] = AUTOMATION_DEFAULT_MODE;
 
   @state() private _newMax?: number;
 
@@ -31,7 +34,9 @@ class DialogAutomationMode extends LitElement implements HassDialog {
     this._opened = true;
     this._params = params;
     this._newMode = params.config.mode || AUTOMATION_DEFAULT_MODE;
-    this._newMax = params.config.max;
+    this._newMax = isMaxMode(this._newMode)
+      ? params.config.max || AUTOMATION_DEFAULT_MAX
+      : undefined;
   }
 
   public closeDialog(): void {
@@ -87,7 +92,7 @@ class DialogAutomationMode extends LitElement implements HassDialog {
             `
           )}
         </ha-select>
-        ${this._newMode && isMaxMode(this._newMode)
+        ${isMaxMode(this._newMode)
           ? html`
               <br /><ha-textfield
                 .label=${this.hass.localize(
@@ -95,7 +100,7 @@ class DialogAutomationMode extends LitElement implements HassDialog {
                 )}
                 type="number"
                 name="max"
-                .value=${this._newMax || "10"}
+                .value=${this._newMax?.toString() ?? ""}
                 @change=${this._valueChanged}
                 class="max"
               >
@@ -118,6 +123,8 @@ class DialogAutomationMode extends LitElement implements HassDialog {
     this._newMode = mode;
     if (!isMaxMode(mode)) {
       this._newMax = undefined;
+    } else if (!this._newMax) {
+      this._newMax = AUTOMATION_DEFAULT_MAX;
     }
   }
 
@@ -143,8 +150,8 @@ class DialogAutomationMode extends LitElement implements HassDialog {
       haStyle,
       haStyleDialog,
       css`
-        ha-textfield,
-        ha-textarea {
+        ha-select,
+        ha-textfield {
           display: block;
         }
       `,

--- a/src/panels/config/automation/automation-mode-dialog/show-dialog-automation-mode.ts
+++ b/src/panels/config/automation/automation-mode-dialog/show-dialog-automation-mode.ts
@@ -1,0 +1,22 @@
+import { fireEvent } from "../../../../common/dom/fire_event";
+import type { AutomationConfig } from "../../../../data/automation";
+
+export const loadAutomationModeDialog = () =>
+  import("./dialog-automation-mode");
+
+export interface AutomationModeDialog {
+  config: AutomationConfig;
+  updateAutomation: (config: AutomationConfig) => void;
+  onClose: () => void;
+}
+
+export const showAutomationModeDialog = (
+  element: HTMLElement,
+  dialogParams: AutomationModeDialog
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "ha-dialog-automation-mode",
+    dialogImport: loadAutomationModeDialog,
+    dialogParams,
+  });
+};

--- a/src/panels/config/automation/automation-rename-dialog/dialog-automation-rename.ts
+++ b/src/panels/config/automation/automation-rename-dialog/dialog-automation-rename.ts
@@ -7,6 +7,8 @@ import { HassDialog } from "../../../../dialogs/make-dialog-manager";
 import { haStyle, haStyleDialog } from "../../../../resources/styles";
 import type { HomeAssistant } from "../../../../types";
 import type { AutomationRenameDialog } from "./show-dialog-automation-rename";
+import "../../../../components/ha-textarea";
+import "../../../../components/ha-textfield";
 
 @customElement("ha-dialog-automation-rename")
 class DialogAutomationRename extends LitElement implements HassDialog {
@@ -51,7 +53,7 @@ class DialogAutomationRename extends LitElement implements HassDialog {
       >
         <ha-textfield
           dialogInitialFocus
-          value=${this._newName}
+          .value=${this._newName}
           .placeholder=${this.hass.localize(
             "ui.panel.config.automation.editor.default_name"
           )}

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -10,6 +10,7 @@ import "../../../components/ha-markdown";
 import "../../../components/ha-selector/ha-selector";
 import "../../../components/ha-settings-row";
 import "../../../components/ha-textfield";
+import "../../../components/ha-alert";
 import { BlueprintAutomationConfig } from "../../../data/automation";
 import {
   BlueprintOrError,
@@ -49,6 +50,20 @@ export class HaBlueprintAutomationEditor extends LitElement {
   protected render() {
     const blueprint = this._blueprint;
     return html`
+      ${this.stateObj?.state === "off"
+        ? html`
+            <ha-alert alert-type="info">
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.disabled"
+              )}
+              <mwc-button slot="action" @click=${this._enable}>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.enable"
+                )}
+              </mwc-button>
+            </ha-alert>
+          `
+        : ""}
       <ha-card
         outlined
         class="blueprint"
@@ -178,6 +193,15 @@ export class HaBlueprintAutomationEditor extends LitElement {
     });
   }
 
+  private async _enable(): Promise<void> {
+    if (!this.hass || !this.stateObj) {
+      return;
+    }
+    await this.hass.callService("automation", "turn_on", {
+      entity_id: this.stateObj.entity_id,
+    });
+  }
+
   static get styles(): CSSResultGroup {
     return [
       haStyle,
@@ -219,6 +243,10 @@ export class HaBlueprintAutomationEditor extends LitElement {
           --settings-row-content-width: 100%;
           --settings-row-prefix-display: contents;
           border-top: 1px solid var(--divider-color);
+        }
+        ha-alert {
+          margin-bottom: 16px;
+          display: block;
         }
       `,
     ];

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -260,6 +260,20 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
                 })}"
                 @subscribe-automation-config=${this._subscribeAutomationConfig}
               >
+                ${!stateObj || stateObj.state === "off"
+                  ? html`
+                      <ha-alert alert-type="warning" @click=${this._toggle}>
+                        ${this.hass.localize(
+                          "ui.panel.config.automation.editor.disabled"
+                        )}
+                        <mwc-button slot="action">
+                          ${this.hass.localize(
+                            "ui.panel.config.automation.editor.enable"
+                          )}
+                        </mwc-button>
+                      </ha-alert>
+                    `
+                  : ""}
                 ${this._errors
                   ? html`<div class="errors">${this._errors}</div>`
                   : ""}

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -172,16 +172,23 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
             <ha-svg-icon slot="graphic" .path=${mdiRenameBox}></ha-svg-icon>
           </mwc-list-item>
 
-          <mwc-list-item
-            graphic="icon"
-            @click=${this._promptAutomationMode}
-            .disabled=${!this.automationId || this._mode === "yaml"}
-          >
-            ${this.hass.localize(
-              "ui.panel.config.automation.editor.change_mode"
-            )}
-            <ha-svg-icon slot="graphic" .path=${mdiDebugStepOver}></ha-svg-icon>
-          </mwc-list-item>
+          ${this._config && !("use_blueprint" in this._config)
+            ? html`
+                <mwc-list-item
+                  graphic="icon"
+                  @click=${this._promptAutomationMode}
+                  .disabled=${!this.automationId || this._mode === "yaml"}
+                >
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.editor.change_mode"
+                  )}
+                  <ha-svg-icon
+                    slot="graphic"
+                    .path=${mdiDebugStepOver}
+                  ></ha-svg-icon>
+                </mwc-list-item>
+              `
+            : ""}
 
           <mwc-list-item
             .disabled=${!this.automationId}
@@ -225,12 +232,12 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
             .disabled=${!stateObj}
             @click=${this._toggle}
           >
-            ${!stateObj || stateObj.state === "off"
+            ${stateObj?.state === "off"
               ? this.hass.localize("ui.panel.config.automation.editor.enable")
               : this.hass.localize("ui.panel.config.automation.editor.disable")}
             <ha-svg-icon
               slot="graphic"
-              .path=${!stateObj || stateObj.state === "off"
+              .path=${stateObj?.state === "off"
                 ? mdiPlayCircleOutline
                 : mdiStopCircleOutline}
             ></ha-svg-icon>
@@ -260,7 +267,7 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
                 })}"
                 @subscribe-automation-config=${this._subscribeAutomationConfig}
               >
-                ${!stateObj || stateObj.state === "off"
+                ${stateObj?.state === "off"
                   ? html`
                       <ha-alert alert-type="warning" @click=${this._toggle}>
                         ${this.hass.localize(

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -267,20 +267,6 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
                 })}"
                 @subscribe-automation-config=${this._subscribeAutomationConfig}
               >
-                ${stateObj?.state === "off"
-                  ? html`
-                      <ha-alert alert-type="warning" @click=${this._toggle}>
-                        ${this.hass.localize(
-                          "ui.panel.config.automation.editor.disabled"
-                        )}
-                        <mwc-button slot="action">
-                          ${this.hass.localize(
-                            "ui.panel.config.automation.editor.enable"
-                          )}
-                        </mwc-button>
-                      </ha-alert>
-                    `
-                  : ""}
                 ${this._errors
                   ? html`<div class="errors">${this._errors}</div>`
                   : ""}
@@ -308,18 +294,20 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
                       `
                   : this._mode === "yaml"
                   ? html`
-                      ${!this.narrow
+                      ${stateObj?.state === "off"
                         ? html`
-                            <ha-card outlined>
-                              <div class="card-header">
-                                ${this._config.alias ||
-                                this.hass.localize(
-                                  "ui.panel.config.automation.editor.default_name"
+                            <ha-alert alert-type="info">
+                              ${this.hass.localize(
+                                "ui.panel.config.automation.editor.disabled"
+                              )}
+                              <mwc-button slot="action" @click=${this._toggle}>
+                                ${this.hass.localize(
+                                  "ui.panel.config.automation.editor.enable"
                                 )}
-                              </div>
-                            </ha-card>
+                              </mwc-button>
+                            </ha-alert>
                           `
-                        : ``}
+                        : ""}
                       <ha-yaml-editor
                         .hass=${this.hass}
                         .defaultValue=${this._preprocessYaml()}

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -3,6 +3,7 @@ import {
   mdiCheck,
   mdiContentDuplicate,
   mdiContentSave,
+  mdiDebugStepOver,
   mdiDelete,
   mdiDotsVertical,
   mdiInformationOutline,
@@ -55,6 +56,7 @@ import { haStyle } from "../../../resources/styles";
 import { HomeAssistant, Route } from "../../../types";
 import { showToast } from "../../../util/toast";
 import "../ha-config-section";
+import { showAutomationModeDialog } from "./automation-mode-dialog/show-dialog-automation-mode";
 import { showAutomationRenameDialog } from "./automation-rename-dialog/show-dialog-automation-rename";
 import "./blueprint-automation-editor";
 import "./manual-automation-editor";
@@ -161,9 +163,24 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
               </a>`
             : ""}
 
-          <mwc-list-item graphic="icon" @click=${this._promptAutomationAlias}>
+          <mwc-list-item
+            graphic="icon"
+            @click=${this._promptAutomationAlias}
+            .disabled=${!this.automationId || this._mode === "yaml"}
+          >
             ${this.hass.localize("ui.panel.config.automation.editor.rename")}
             <ha-svg-icon slot="graphic" .path=${mdiRenameBox}></ha-svg-icon>
+          </mwc-list-item>
+
+          <mwc-list-item
+            graphic="icon"
+            @click=${this._promptAutomationMode}
+            .disabled=${!this.automationId || this._mode === "yaml"}
+          >
+            ${this.hass.localize(
+              "ui.panel.config.automation.editor.change_mode"
+            )}
+            <ha-svg-icon slot="graphic" .path=${mdiDebugStepOver}></ha-svg-icon>
           </mwc-list-item>
 
           <mwc-list-item
@@ -536,6 +553,21 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
   private async _promptAutomationAlias(): Promise<void> {
     return new Promise((resolve) => {
       showAutomationRenameDialog(this, {
+        config: this._config!,
+        updateAutomation: (config) => {
+          this._config = config;
+          this._dirty = true;
+          this.requestUpdate();
+          resolve();
+        },
+        onClose: () => resolve(),
+      });
+    });
+  }
+
+  private async _promptAutomationMode(): Promise<void> {
+    return new Promise((resolve) => {
+      showAutomationModeDialog(this, {
         config: this._config!,
         updateAutomation: (config) => {
           this._config = config;

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -207,6 +207,9 @@ export class HaManualAutomationEditor extends LitElement {
           display: flex;
           align-items: center;
         }
+        .header:first-child {
+          margin-top: -16px;
+        }
         .header .name {
           font-size: 20px;
           font-weight: 400;

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -41,6 +41,20 @@ export class HaManualAutomationEditor extends LitElement {
 
   protected render() {
     return html`
+      ${this.stateObj?.state === "off"
+        ? html`
+            <ha-alert alert-type="info">
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.disabled"
+              )}
+              <mwc-button slot="action" @click=${this._enable}>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.enable"
+                )}
+              </mwc-button>
+            </ha-alert>
+          `
+        : ""}
       <div class="header">
         <h2 id="triggers-heading" class="name">
           ${this.hass.localize(
@@ -175,6 +189,15 @@ export class HaManualAutomationEditor extends LitElement {
     ev.stopPropagation();
     fireEvent(this, "value-changed", {
       value: { ...this.config!, action: ev.detail.value as Action[] },
+    });
+  }
+
+  private async _enable(): Promise<void> {
+    if (!this.hass || !this.stateObj) {
+      return;
+    }
+    await this.hass.callService("automation", "turn_on", {
+      entity_id: this.stateObj.entity_id,
     });
   }
 

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -1,21 +1,19 @@
 import "@material/mwc-button/mwc-button";
-import { mdiHelpCircle, mdiRobot, mdiSort, mdiTextBoxEdit } from "@mdi/js";
+import { mdiHelpCircle, mdiSort, mdiTextBoxEdit } from "@mdi/js";
 import { HassEntity } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/ha-entity-toggle";
 import "../../../components/ha-card";
-import "../../../components/ha-textarea";
-import "../../../components/ha-textfield";
 import "../../../components/ha-icon-button";
+import "../../../components/ha-alert";
 import {
-  AUTOMATION_DEFAULT_MODE,
   Condition,
   ManualAutomationConfig,
   Trigger,
 } from "../../../data/automation";
-import { Action, isMaxMode, MODES } from "../../../data/script";
+import { Action } from "../../../data/script";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
@@ -43,71 +41,6 @@ export class HaManualAutomationEditor extends LitElement {
 
   protected render() {
     return html`
-      <ha-card outlined>
-        ${this.stateObj && this.stateObj.state === "off"
-          ? html`<div class="disabled-bar">
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.disabled"
-              )}
-            </div>`
-          : ""}
-
-        <ha-expansion-panel leftChevron>
-          <h3 slot="header">
-            <ha-svg-icon class="settings-icon" .path=${mdiRobot}></ha-svg-icon>
-            ${this.hass.localize(
-              "ui.panel.config.automation.editor.automation_settings"
-            )}
-          </h3>
-          <div class="card-content">
-            <ha-select
-              .label=${this.hass.localize(
-                "ui.panel.config.automation.editor.modes.label"
-              )}
-              .value=${this.config.mode || AUTOMATION_DEFAULT_MODE}
-              @selected=${this._modeChanged}
-              fixedMenuPosition
-              .helper=${html`
-                <a
-                  style="color: var(--secondary-text-color)"
-                  href=${documentationUrl(this.hass, "/docs/automation/modes/")}
-                  target="_blank"
-                  rel="noreferrer"
-                  >${this.hass.localize(
-                    "ui.panel.config.automation.editor.modes.learn_more"
-                  )}</a
-                >
-              `}
-            >
-              ${MODES.map(
-                (mode) => html`
-                  <mwc-list-item .value=${mode}>
-                    ${this.hass.localize(
-                      `ui.panel.config.automation.editor.modes.${mode}`
-                    ) || mode}
-                  </mwc-list-item>
-                `
-              )}
-            </ha-select>
-            ${this.config.mode && isMaxMode(this.config.mode)
-              ? html`
-                  <br /><ha-textfield
-                    .label=${this.hass.localize(
-                      `ui.panel.config.automation.editor.max.${this.config.mode}`
-                    )}
-                    type="number"
-                    name="max"
-                    .value=${this.config.max || "10"}
-                    @change=${this._valueChanged}
-                    class="max"
-                  >
-                  </ha-textfield>
-                `
-              : html``}
-          </div>
-        </ha-expansion-panel>
-      </ha-card>
-
       <div class="header">
         <h2 id="triggers-heading" class="name">
           ${this.hass.localize(
@@ -221,48 +154,6 @@ export class HaManualAutomationEditor extends LitElement {
     `;
   }
 
-  private _valueChanged(ev: CustomEvent) {
-    ev.stopPropagation();
-    const target = ev.target as any;
-    const name = target.name;
-    if (!name) {
-      return;
-    }
-    let newVal = target.value;
-    if (target.type === "number") {
-      newVal = Number(newVal);
-    }
-    if ((this.config![name] || "") === newVal) {
-      return;
-    }
-    fireEvent(this, "value-changed", {
-      value: { ...this.config!, [name]: newVal },
-    });
-  }
-
-  private _modeChanged(ev) {
-    const mode = ev.target.value;
-
-    if (
-      mode === this.config!.mode ||
-      (!this.config!.mode && mode === MODES[0])
-    ) {
-      return;
-    }
-    const value = {
-      ...this.config!,
-      mode,
-    };
-
-    if (!isMaxMode(mode)) {
-      delete value.max;
-    }
-
-    fireEvent(this, "value-changed", {
-      value,
-    });
-  }
-
   private _triggerChanged(ev: CustomEvent): void {
     ev.stopPropagation();
     fireEvent(this, "value-changed", {
@@ -300,10 +191,6 @@ export class HaManualAutomationEditor extends LitElement {
         .link-button-row {
           padding: 14px;
         }
-        ha-textarea,
-        ha-textfield {
-          display: block;
-        }
 
         p {
           margin-bottom: 0;
@@ -339,9 +226,6 @@ export class HaManualAutomationEditor extends LitElement {
         }
         .card-content {
           padding: 16px;
-        }
-        .card-content ha-textarea:first-child {
-          margin-top: -16px;
         }
         .settings-icon {
           display: none;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1847,6 +1847,7 @@
               "no_blueprints": "You don't have any blueprints",
               "no_inputs": "This blueprint doesn't have any inputs."
             },
+            "change_mode": "Change mode",
             "modes": {
               "label": "Mode",
               "learn_more": "Learn about modes",


### PR DESCRIPTION
## Proposed change

Add change mode action in overflow menu
Add alert for disabled state
I also fixed some lint issues in rename dialog
The name was duplicated in yaml mode, I removed it.

### Overflow menu
![Capture d’écran 2022-09-05 à 12 31 36](https://user-images.githubusercontent.com/5878303/188429153-e6e03b90-9a23-4d68-b3cb-083a2057ed1e.png)

### Change mode dialog 
![Capture d’écran 2022-09-05 à 12 31 29](https://user-images.githubusercontent.com/5878303/188429149-d5c53b0c-4f4b-4fde-8478-ec38d8b5e2da.png)

### Disable state (YAML)
<img width="893" alt="Capture d’écran 2022-09-05 à 15 35 18" src="https://user-images.githubusercontent.com/5878303/188462046-ba996c31-a153-4ccc-ab93-12755b0d4e60.png">

### Disable state (GUI)
<img width="915" alt="Capture d’écran 2022-09-05 à 15 35 11" src="https://user-images.githubusercontent.com/5878303/188462038-be33e954-34a9-4bd3-a9c1-bad692d1de26.png">

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
