### PR TITLE
Open external device configuration url to a new tab/window

### DIFF
--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -80,6 +80,8 @@ export interface EntityRegistryStateEntry extends EntityRegistryEntry {
 
 export interface DeviceAction {
   href?: string;
+  target?: string;
+  rel?: string;
   action?: (ev: any) => void;
   label: string;
   icon?: string;
@@ -699,7 +701,11 @@ export class HaConfigDevicePage extends LitElement {
                     ? html`
                         <div class="card-actions" slot="actions">
                           <div>
-                            <a href=${ifDefined(firstDeviceAction!.href)}>
+                            <a
+                              href=${ifDefined(firstDeviceAction!.href)}
+                              rel=${ifDefined(firstDeviceAction!.rel)}
+                              target=${ifDefined(firstDeviceAction!.target)}
+                            >
                               <mwc-button
                                 class=${ifDefined(firstDeviceAction!.classes)}
                                 .action=${firstDeviceAction!.action}
@@ -742,7 +748,11 @@ export class HaConfigDevicePage extends LitElement {
                                   ></ha-icon-button>
                                   ${actions.map(
                                     (deviceAction) => html`
-                                      <a href=${ifDefined(deviceAction.href)}>
+                                      <a
+                                        href=${ifDefined(deviceAction.href)}
+                                        rel=${ifDefined(deviceAction.rel)}
+                                        target=${ifDefined(deviceAction.target)}
+                                      >
                                         <mwc-list-item
                                           class=${ifDefined(
                                             deviceAction.classes
@@ -981,6 +991,8 @@ export class HaConfigDevicePage extends LitElement {
     if (configurationUrl) {
       deviceActions.push({
         href: configurationUrl,
+        rel: "noreferrer",
+        target: configurationUrlIsHomeAssistant ? "_self" : "_blank",
         icon: mdiCog,
         label: this.hass.localize(
           "ui.panel.config.devices.open_configuration_url"

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -81,7 +81,6 @@ export interface EntityRegistryStateEntry extends EntityRegistryEntry {
 export interface DeviceAction {
   href?: string;
   target?: string;
-  rel?: string;
   action?: (ev: any) => void;
   label: string;
   icon?: string;
@@ -703,7 +702,11 @@ export class HaConfigDevicePage extends LitElement {
                           <div>
                             <a
                               href=${ifDefined(firstDeviceAction!.href)}
-                              rel=${ifDefined(firstDeviceAction!.rel)}
+                              rel=${ifDefined(
+                                firstDeviceAction!.target
+                                  ? "noreferrer"
+                                  : undefined
+                              )}
                               target=${ifDefined(firstDeviceAction!.target)}
                             >
                               <mwc-button
@@ -750,8 +753,12 @@ export class HaConfigDevicePage extends LitElement {
                                     (deviceAction) => html`
                                       <a
                                         href=${ifDefined(deviceAction.href)}
-                                        rel=${ifDefined(deviceAction.rel)}
                                         target=${ifDefined(deviceAction.target)}
+                                        rel=${ifDefined(
+                                          deviceAction.target
+                                            ? "noreferrer"
+                                            : undefined
+                                        )}
                                       >
                                         <mwc-list-item
                                           class=${ifDefined(
@@ -991,8 +998,7 @@ export class HaConfigDevicePage extends LitElement {
     if (configurationUrl) {
       deviceActions.push({
         href: configurationUrl,
-        rel: "noreferrer",
-        target: configurationUrlIsHomeAssistant ? "_self" : "_blank",
+        target: configurationUrlIsHomeAssistant ? undefined : "_blank",
         icon: mdiCog,
         label: this.hass.localize(
           "ui.panel.config.devices.open_configuration_url"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Open external device configuration url to a new tab or window.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #12904
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
