### PR TITLE
Fix icon picker in dialog

### DIFF
--- a/src/components/ha-icon-picker.ts
+++ b/src/components/ha-icon-picker.ts
@@ -13,7 +13,8 @@ type IconItem = {
   icon: string;
   keywords: string[];
 };
-let iconItems: IconItem[] = [];
+let iconItems: IconItem[] = [{ icon: "", keywords: [] }];
+let iconLoaded = false;
 
 // eslint-disable-next-line lit/prefer-static-styles
 const rowRenderer: ComboBoxLitRenderer<IconItem> = (item) => html`<mwc-list-item
@@ -88,15 +89,16 @@ export class HaIconPicker extends LitElement {
 
   private async _openedChanged(ev: PolymerChangedEvent<boolean>) {
     this._opened = ev.detail.value;
-    if (this._opened && !iconItems.length) {
+    if (this._opened && !iconLoaded) {
       const iconList = await import("../../build/mdi/iconList.json");
 
       iconItems = iconList.default.map((icon) => ({
         icon: `mdi:${icon.name}`,
         keywords: icon.keywords,
       }));
+      iconLoaded = true;
 
-      (this.comboBox as any).filteredItems = iconItems;
+      this.comboBox.filteredItems = iconItems;
 
       Object.keys(customIcons).forEach((iconSet) => {
         this._loadCustomIconItems(iconSet);
@@ -116,7 +118,7 @@ export class HaIconPicker extends LitElement {
         keywords: icon.keywords ?? [],
       }));
       iconItems.push(...customIconItems);
-      (this.comboBox as any).filteredItems = iconItems;
+      this.comboBox.filteredItems = iconItems;
     } catch (e) {
       // eslint-disable-next-line
       console.warn(`Unable to load icon list for ${iconsetPrefix} iconset`);
@@ -165,14 +167,12 @@ export class HaIconPicker extends LitElement {
       filteredItems.push(...filteredItemsByKeywords);
 
       if (filteredItems.length > 0) {
-        (this.comboBox as any).filteredItems = filteredItems;
+        this.comboBox.filteredItems = filteredItems;
       } else {
-        (this.comboBox as any).filteredItems = [
-          { icon: filterString, keywords: [] },
-        ];
+        this.comboBox.filteredItems = [{ icon: filterString, keywords: [] }];
       }
     } else {
-      (this.comboBox as any).filteredItems = iconItems;
+      this.comboBox.filteredItems = iconItems;
     }
   }
 


### PR DESCRIPTION
## Proposed change

The fix for combobox (#12805) doesn't work for icon picker because all icons are lazy loaded. During the first opening,no icons are loaded so the overlay is not displayed so the mutation observer is not created. It works for the second opening because icons are already loaded.

This PR add an initial empty icon item to have the overlay ready when opening the first time. It's not a perfect solution but it works 😅

I also removed the `as any` for combobox because we have the typings.

### Without the fix
https://user-images.githubusercontent.com/5878303/188600188-3b8b5eba-78de-4870-8fea-b0c93e6d79d9.mp4

### With the fix
https://user-images.githubusercontent.com/5878303/188600203-1534b726-732c-4264-b845-d32e9b8acf1d.mp4

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
