### PR TITLE
Add separator option to overflow icon menu

### DIFF
--- a/src/components/ha-icon-overflow-menu.ts
+++ b/src/components/ha-icon-overflow-menu.ts
@@ -19,6 +19,7 @@ export interface IconOverflowMenuItem {
   tooltip?: string;
   onClick: CallableFunction;
   warning?: boolean;
+  divider?: boolean;
 }
 
 @customElement("ha-icon-overflow-menu")
@@ -46,23 +47,23 @@ export class HaIconOverflowMenu extends LitElement {
                 slot="trigger"
               ></ha-icon-button>
 
-              ${this.items.map(
-                (item) => html`
-                  <mwc-list-item
-                    graphic="icon"
-                    .disabled=${item.disabled}
-                    @click=${item.action}
-                    class=${classMap({ warning: Boolean(item.warning) })}
-                  >
-                    <div slot="graphic">
-                      <ha-svg-icon
-                        class=${classMap({ warning: Boolean(item.warning) })}
-                        .path=${item.path}
-                      ></ha-svg-icon>
-                    </div>
-                    ${item.label}
-                  </mwc-list-item>
-                `
+              ${this.items.map((item) =>
+                item.divider
+                  ? html`<li divider role="separator"></li>`
+                  : html`<mwc-list-item
+                      graphic="icon"
+                      .disabled=${item.disabled}
+                      @click=${item.action}
+                      class=${classMap({ warning: Boolean(item.warning) })}
+                    >
+                      <div slot="graphic">
+                        <ha-svg-icon
+                          class=${classMap({ warning: Boolean(item.warning) })}
+                          .path=${item.path}
+                        ></ha-svg-icon>
+                      </div>
+                      ${item.label}
+                    </mwc-list-item> `
               )}
             </ha-button-menu>`
         : html`
@@ -70,6 +71,8 @@ export class HaIconOverflowMenu extends LitElement {
             ${this.items.map((item) =>
               item.narrowOnly
                 ? ""
+                : item.divider
+                ? html`<li divider role="separator"></li>`
                 : html`<div>
                     ${item.tooltip
                       ? html`<paper-tooltip animation-delay="0" position="left">
@@ -113,6 +116,9 @@ export class HaIconOverflowMenu extends LitElement {
         :host {
           display: flex;
           justify-content: flex-end;
+        }
+        li[role="separator"] {
+          border-bottom-color: var(--divider-color);
         }
       `,
     ];

--- a/src/components/ha-icon-overflow-menu.ts
+++ b/src/components/ha-icon-overflow-menu.ts
@@ -72,7 +72,7 @@ export class HaIconOverflowMenu extends LitElement {
               item.narrowOnly
                 ? ""
                 : item.divider
-                ? html`<li divider role="separator"></li>`
+                ? html`<div role="separator"></div>`
                 : html`<div>
                     ${item.tooltip
                       ? html`<paper-tooltip animation-delay="0" position="left">
@@ -119,6 +119,10 @@ export class HaIconOverflowMenu extends LitElement {
         }
         li[role="separator"] {
           border-bottom-color: var(--divider-color);
+        }
+        div[role="separator"] {
+          border-right: 1px solid var(--divider-color);
+          width: 1px;
         }
       `,
     ];

--- a/src/components/ha-icon-overflow-menu.ts
+++ b/src/components/ha-icon-overflow-menu.ts
@@ -72,20 +72,20 @@ export class HaIconOverflowMenu extends LitElement {
               item.narrowOnly
                 ? ""
                 : item.divider
-                  ? html`<li divider role="separator"></li>`
-                  : html`<div>
-                      ${item.tooltip
-                        ? html`<paper-tooltip animation-delay="0" position="left">
-                            ${item.tooltip}
-                          </paper-tooltip>`
-                        : ""}
-                      <ha-icon-button
-                        @click=${item.action}
-                        .label=${item.label}
-                        .path=${item.path}
-                        .disabled=${item.disabled}
-                      ></ha-icon-button>
-                    </div> `
+                ? html`<li divider role="separator"></li>`
+                : html`<div>
+                    ${item.tooltip
+                      ? html`<paper-tooltip animation-delay="0" position="left">
+                          ${item.tooltip}
+                        </paper-tooltip>`
+                      : ""}
+                    <ha-icon-button
+                      @click=${item.action}
+                      .label=${item.label}
+                      .path=${item.path}
+                      .disabled=${item.disabled}
+                    ></ha-icon-button>
+                  </div> `
             )}
           `}
     `;

--- a/src/components/ha-icon-overflow-menu.ts
+++ b/src/components/ha-icon-overflow-menu.ts
@@ -72,20 +72,20 @@ export class HaIconOverflowMenu extends LitElement {
               item.narrowOnly
                 ? ""
                 : item.divider
-                ? html`<li divider role="separator"></li>`
-                : html`<div>
-                    ${item.tooltip
-                      ? html`<paper-tooltip animation-delay="0" position="left">
-                          ${item.tooltip}
-                        </paper-tooltip>`
-                      : ""}
-                    <ha-icon-button
-                      @click=${item.action}
-                      .label=${item.label}
-                      .path=${item.path}
-                      .disabled=${item.disabled}
-                    ></ha-icon-button>
-                  </div> `
+                  ? html`<li divider role="separator"></li>`
+                  : html`<div>
+                      ${item.tooltip
+                        ? html`<paper-tooltip animation-delay="0" position="left">
+                            ${item.tooltip}
+                          </paper-tooltip>`
+                        : ""}
+                      <ha-icon-button
+                        @click=${item.action}
+                        .label=${item.label}
+                        .path=${item.path}
+                        .disabled=${item.disabled}
+                      ></ha-icon-button>
+                    </div> `
             )}
           `}
     `;

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -213,6 +213,9 @@ class HaAutomationPicker extends LitElement {
                   action: () => this._showTrace(automation),
                 },
                 {
+                  divider: true,
+                },
+                {
                   path: mdiContentDuplicate,
                   label: this.hass.localize(
                     "ui.panel.config.automation.picker.duplicate"

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -158,6 +158,9 @@ class HaSceneDashboard extends LitElement {
                   action: () => this._activateScene(scene),
                 },
                 {
+                  divider: true,
+                },
+                {
                   path: mdiContentDuplicate,
                   label: this.hass.localize(
                     "ui.panel.config.scene.picker.duplicate"

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -156,6 +156,9 @@ class HaScriptPicker extends LitElement {
                 action: () => this._showTrace(script),
               },
               {
+                divider: true,
+              },
+              {
                 path: mdiContentDuplicate,
                 label: this.hass.localize(
                   "ui.panel.config.script.picker.duplicate"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Added the option to insert a divider / separator to the `ha-icon-overflow-menu` which ensures that the menu can now look the same as the overflow menus in the automation, script, scene editor.

Non-narrow variant now also covered thanks to Bram :)

![image](https://user-images.githubusercontent.com/114137/188893105-451fa501-9e61-4986-a1bc-e00bbfa17cfe.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
