### PR TITLE
Hide unit in state picker if attribute is set

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -19,14 +19,16 @@ export const computeStateDisplay = (
   localize: LocalizeFunc,
   stateObj: HassEntity,
   locale: FrontendLocaleData,
-  state?: string
+  state?: string,
+  hide_unit?: boolean
 ): string =>
   computeStateDisplayFromEntityAttributes(
     localize,
     locale,
     stateObj.entity_id,
     stateObj.attributes,
-    state !== undefined ? state : stateObj.state
+    state !== undefined ? state : stateObj.state,
+    hide_unit
   );
 
 export const computeStateDisplayFromEntityAttributes = (
@@ -34,7 +36,8 @@ export const computeStateDisplayFromEntityAttributes = (
   locale: FrontendLocaleData,
   entityId: string,
   attributes: any,
-  state: string
+  state: string,
+  hide_unit?: boolean
 ): string => {
   if (state === UNKNOWN || state === UNAVAILABLE) {
     return localize(`state.default.${state}`);
@@ -70,7 +73,7 @@ export const computeStateDisplayFromEntityAttributes = (
       : attributes.unit_of_measurement === "%"
       ? blankBeforePercent(locale) + "%"
       : ` ${attributes.unit_of_measurement}`;
-    return `${formatNumber(state, locale)}${unit}`;
+    return `${formatNumber(state, locale)}${hide_unit ? "" : unit}`;
   }
 
   const domain = computeDomain(entityId);

--- a/src/components/entity/ha-entity-state-picker.ts
+++ b/src/components/entity/ha-entity-state-picker.ts
@@ -54,6 +54,7 @@ class HaEntityStatePicker extends LitElement {
                     state,
                     this.hass.locale,
                     key,
+                    // If we have an attribute set, the unit is not relevant since it only applies to the entity state
                     !!this.attribute
                   )
                 : key,
@@ -77,6 +78,7 @@ class HaEntityStatePicker extends LitElement {
                 this.hass.states[this.entityId],
                 this.hass.locale,
                 this.value,
+                // If we have an attribute set, the unit is not relevant since it only applies to the entity state
                 !!this.attribute
               )
             : this.value

--- a/src/components/entity/ha-entity-state-picker.ts
+++ b/src/components/entity/ha-entity-state-picker.ts
@@ -53,7 +53,8 @@ class HaEntityStatePicker extends LitElement {
                     this.hass.localize,
                     state,
                     this.hass.locale,
-                    key
+                    key,
+                    !!this.attribute
                   )
                 : key,
             }))
@@ -75,7 +76,8 @@ class HaEntityStatePicker extends LitElement {
                 this.hass.localize,
                 this.hass.states[this.entityId],
                 this.hass.locale,
-                this.value
+                this.value,
+                !!this.attribute
               )
             : this.value
           : ""}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

If an attribute is selected, the unit does not make sense since it only applies tot he state of the entity itself. So in this case hide the unit.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13568 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
