### PR TITLE
Show unit in numeric state trigger and condition

### DIFF
--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -29,9 +29,9 @@ export class HaNumberSelector extends LitElement {
   protected render() {
     const isBox = this.selector.number.mode === "box";
 
-    const fullLabel = `${this.label} ${
+    const fullLabel = `${this.label}${
       this.selector.number.unit_of_measurement
-        ? "(" + this.selector.number.unit_of_measurement + ")"
+        ? " (" + this.selector.number.unit_of_measurement + ")"
         : ""
     }`;
 

--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -29,13 +29,17 @@ export class HaNumberSelector extends LitElement {
   protected render() {
     const isBox = this.selector.number.mode === "box";
 
+    const fullLabel = `${this.label} ${
+      this.selector.number.unit_of_measurement
+        ? "(" + this.selector.number.unit_of_measurement + ")"
+        : ""
+    }`;
+
     return html`
       <div class="input">
         ${!isBox
           ? html`
-              ${this.label
-                ? html`${this.label}${this.required ? " *" : ""}`
-                : ""}
+              ${fullLabel ? html`${fullLabel}${this.required ? " *" : ""}` : ""}
               <ha-slider
                 .min=${this.selector.number.min}
                 .max=${this.selector.number.max}
@@ -53,7 +57,7 @@ export class HaNumberSelector extends LitElement {
         <ha-textfield
           inputMode="numeric"
           pattern="[0-9]+([\\.][0-9]+)?"
-          .label=${this.selector.number.mode !== "box" ? undefined : this.label}
+          .label=${this.selector.number.mode !== "box" ? undefined : fullLabel}
           .placeholder=${this.placeholder}
           class=${classMap({ single: this.selector.number.mode === "box" })}
           .min=${this.selector.number.min}

--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -20,7 +20,7 @@ export default class HaNumericStateCondition extends LitElement {
   }
 
   private _schema = memoizeOne(
-    (entityId) =>
+    (entityId, condition: NumericStateCondition) =>
       [
         { name: "entity_id", required: true, selector: { entity: {} } },
         {
@@ -103,6 +103,11 @@ export default class HaNumericStateCondition extends LitElement {
               min: Number.MIN_SAFE_INTEGER,
               max: Number.MAX_SAFE_INTEGER,
               step: 0.1,
+              // If we have an attribute selected, then the unit is not relevant and no input suffix should be shown
+              unit_of_measurement:
+                entityId && !condition.attribute
+                  ? this.hass.states[entityId].attributes.unit_of_measurement
+                  : undefined,
             },
           },
         },
@@ -114,6 +119,11 @@ export default class HaNumericStateCondition extends LitElement {
               min: Number.MIN_SAFE_INTEGER,
               max: Number.MAX_SAFE_INTEGER,
               step: 0.1,
+              // If we have an attribute selected, then the unit is not relevant and no input suffix should be shown
+              unit_of_measurement:
+                entityId && !condition.attribute
+                  ? this.hass.states[entityId].attributes.unit_of_measurement
+                  : undefined,
             },
           },
         },
@@ -125,7 +135,7 @@ export default class HaNumericStateCondition extends LitElement {
   );
 
   public render() {
-    const schema = this._schema(this.condition.entity_id);
+    const schema = this._schema(this.condition.entity_id, this.condition);
 
     return html`
       <ha-form

--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -20,7 +20,7 @@ export default class HaNumericStateCondition extends LitElement {
   }
 
   private _schema = memoizeOne(
-    (entityId, condition: NumericStateCondition) =>
+    (entityId, attribute) =>
       [
         { name: "entity_id", required: true, selector: { entity: {} } },
         {
@@ -105,7 +105,7 @@ export default class HaNumericStateCondition extends LitElement {
               step: 0.1,
               // If we have an attribute selected, then the unit is not relevant and no input suffix should be shown
               unit_of_measurement:
-                entityId && !condition.attribute
+                entityId && !attribute
                   ? this.hass.states[entityId].attributes.unit_of_measurement
                   : undefined,
             },
@@ -121,7 +121,7 @@ export default class HaNumericStateCondition extends LitElement {
               step: 0.1,
               // If we have an attribute selected, then the unit is not relevant and no input suffix should be shown
               unit_of_measurement:
-                entityId && !condition.attribute
+                entityId && !attribute
                   ? this.hass.states[entityId].attributes.unit_of_measurement
                   : undefined,
             },
@@ -135,7 +135,10 @@ export default class HaNumericStateCondition extends LitElement {
   );
 
   public render() {
-    const schema = this._schema(this.condition.entity_id, this.condition);
+    const schema = this._schema(
+      this.condition.entity_id,
+      this.condition.attribute
+    );
 
     return html`
       <ha-form

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -16,7 +16,7 @@ export class HaNumericStateTrigger extends LitElement {
   @property({ attribute: false }) public trigger!: NumericStateTrigger;
 
   private _schema = memoizeOne(
-    (entityId, trigger: NumericStateTrigger) =>
+    (entityId, attribute) =>
       [
         { name: "entity_id", required: true, selector: { entity: {} } },
         {
@@ -101,7 +101,7 @@ export class HaNumericStateTrigger extends LitElement {
               step: 0.1,
               // If we have an attribute selected, then the unit is not relevant and no input suffix should be shown
               unit_of_measurement:
-                entityId && !trigger.attribute
+                entityId && !attribute
                   ? this.hass.states[entityId].attributes.unit_of_measurement
                   : undefined,
             },
@@ -117,7 +117,7 @@ export class HaNumericStateTrigger extends LitElement {
               step: 0.1,
               // If we have an attribute selected, then the unit is not relevant and no input suffix should be shown
               unit_of_measurement:
-                entityId && !trigger.attribute
+                entityId && !attribute
                   ? this.hass.states[entityId].attributes.unit_of_measurement
                   : undefined,
             },
@@ -155,7 +155,7 @@ export class HaNumericStateTrigger extends LitElement {
     const trgFor = createDurationData(this.trigger.for);
 
     const data = { ...this.trigger, for: trgFor };
-    const schema = this._schema(this.trigger.entity_id, this.trigger);
+    const schema = this._schema(this.trigger.entity_id, this.trigger.attribute);
 
     return html`
       <ha-form

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -16,7 +16,7 @@ export class HaNumericStateTrigger extends LitElement {
   @property({ attribute: false }) public trigger!: NumericStateTrigger;
 
   private _schema = memoizeOne(
-    (entityId) =>
+    (entityId, trigger: NumericStateTrigger) =>
       [
         { name: "entity_id", required: true, selector: { entity: {} } },
         {
@@ -99,6 +99,11 @@ export class HaNumericStateTrigger extends LitElement {
               min: Number.MIN_SAFE_INTEGER,
               max: Number.MAX_SAFE_INTEGER,
               step: 0.1,
+              // If we have an attribute selected, then the unit is not relevant and no input suffix should be shown
+              unit_of_measurement:
+                entityId && !trigger.attribute
+                  ? this.hass.states[entityId].attributes.unit_of_measurement
+                  : undefined,
             },
           },
         },
@@ -110,6 +115,11 @@ export class HaNumericStateTrigger extends LitElement {
               min: Number.MIN_SAFE_INTEGER,
               max: Number.MAX_SAFE_INTEGER,
               step: 0.1,
+              // If we have an attribute selected, then the unit is not relevant and no input suffix should be shown
+              unit_of_measurement:
+                entityId && !trigger.attribute
+                  ? this.hass.states[entityId].attributes.unit_of_measurement
+                  : undefined,
             },
           },
         },
@@ -145,7 +155,7 @@ export class HaNumericStateTrigger extends LitElement {
     const trgFor = createDurationData(this.trigger.for);
 
     const data = { ...this.trigger, for: trgFor };
-    const schema = this._schema(this.trigger.entity_id);
+    const schema = this._schema(this.trigger.entity_id, this.trigger);
 
     return html`
       <ha-form


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

While working on #13628 I thought about the corresponding logic for the numeric state trigger and condition and the unit of measurement was completely ignored there so far. This PR now adds it in (as long as no attribute is selected, since then it makes no sense).

![image](https://user-images.githubusercontent.com/114137/188738672-03e35d99-4be2-4152-a2b6-81e2698e8e3a.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
