### PR TITLE
Either show range or fix target temperature control in climate more-info

### DIFF
--- a/src/dialogs/more-info/controls/more-info-climate.ts
+++ b/src/dialogs/more-info/controls/more-info-climate.ts
@@ -98,7 +98,8 @@ class MoreInfoClimate extends LitElement {
                   </div>
                 `
               : ""}
-            ${stateObj.attributes.temperature !== undefined &&
+            ${!supportTargetTemperatureRange &&
+            stateObj.attributes.temperature !== undefined &&
             stateObj.attributes.temperature !== null
               ? html`
                   <ha-climate-control
@@ -112,10 +113,11 @@ class MoreInfoClimate extends LitElement {
                   ></ha-climate-control>
                 `
               : ""}
-            ${(stateObj.attributes.target_temp_low !== undefined &&
+            ${supportTargetTemperatureRange &&
+            ((stateObj.attributes.target_temp_low !== undefined &&
               stateObj.attributes.target_temp_low !== null) ||
-            (stateObj.attributes.target_temp_high !== undefined &&
-              stateObj.attributes.target_temp_high !== null)
+              (stateObj.attributes.target_temp_high !== undefined &&
+                stateObj.attributes.target_temp_high !== null))
               ? html`
                   <ha-climate-control
                     .hass=${this.hass}

--- a/src/dialogs/more-info/controls/more-info-climate.ts
+++ b/src/dialogs/more-info/controls/more-info-climate.ts
@@ -98,7 +98,8 @@ class MoreInfoClimate extends LitElement {
                   </div>
                 `
               : ""}
-            ${!supportTargetTemperatureRange &&
+            ${supportTargetTemperature &&
+            !supportTargetTemperatureRange &&
             stateObj.attributes.temperature !== undefined &&
             stateObj.attributes.temperature !== null
               ? html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Some (many?) climate entity integrations seem to report via the support flags that both a fixed target temperature as as well as temperature are allowed. That results then in the climate more-info dialog showing three value inputs.

Now we check whether a range is flagged as supported and then only show the range inputs and not the fixed one (rather than blindly relying on what attributes the entity has).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13450
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
