### PR TITLE
Add re-order button for blueprint

### DIFF
--- a/src/components/ha-selector/ha-selector-action.ts
+++ b/src/components/ha-selector/ha-selector-action.ts
@@ -17,11 +17,16 @@ export class HaActionSelector extends LitElement {
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
+  @property({ attribute: false }) public context?: {
+    re_order_mode?: boolean;
+  };
+
   protected render() {
     return html`<ha-automation-action
       .disabled=${this.disabled}
       .actions=${this.value || []}
       .hass=${this.hass}
+      .reOrderMode=${this.context?.re_order_mode ?? false}
     ></ha-automation-action>`;
   }
 

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -63,6 +63,7 @@ import "../ha-config-section";
 import { showAutomationModeDialog } from "./automation-mode-dialog/show-dialog-automation-mode";
 import { showAutomationRenameDialog } from "./automation-rename-dialog/show-dialog-automation-rename";
 import "./blueprint-automation-editor";
+import type { HaBlueprintAutomationEditor } from "./blueprint-automation-editor";
 import "./manual-automation-editor";
 import type { HaManualAutomationEditor } from "./manual-automation-editor";
 
@@ -108,6 +109,9 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
 
   @query("manual-automation-editor")
   private _manualEditor?: HaManualAutomationEditor;
+
+  @query("blueprint-automation-editor")
+  private _blueprintEditor?: HaBlueprintAutomationEditor;
 
   private _configSubscriptions: Record<
     string,
@@ -216,19 +220,14 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
                 </mwc-list-item>
               `
             : ""}
-          ${this._config && !("use_blueprint" in this._config)
-            ? html`<mwc-list-item
-                graphic="icon"
-                @click=${this._toggleReOrderMode}
-                .disabled=${this._mode === "yaml"}
-              >
-                ${this.hass.localize(
-                  "ui.panel.config.automation.editor.re_order"
-                )}
-                <ha-svg-icon slot="graphic" .path=${mdiSort}></ha-svg-icon>
-              </mwc-list-item>`
-            : ""}
-
+          <mwc-list-item
+            graphic="icon"
+            @click=${this._toggleReOrderMode}
+            .disabled=${this._mode === "yaml"}
+          >
+            ${this.hass.localize("ui.panel.config.automation.editor.re_order")}
+            <ha-svg-icon slot="graphic" .path=${mdiSort}></ha-svg-icon>
+          </mwc-list-item>
           <mwc-list-item
             .disabled=${!this.automationId}
             graphic="icon"
@@ -604,6 +603,9 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
   private _toggleReOrderMode() {
     if (this._manualEditor) {
       this._manualEditor.reOrderMode = !this._manualEditor.reOrderMode;
+    }
+    if (this._blueprintEditor) {
+      this._blueprintEditor.reOrderMode = !this._blueprintEditor.reOrderMode;
     }
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1842,6 +1842,7 @@
             "re_order_mode": {
               "title": "Re-order mode",
               "description": "You are in re-order mode, you can re-order your triggers, conditions and actions.",
+              "description_blueprint": "You are in re-order mode, if you have actions in your blueprint, you can re-order them",
               "exit": "Exit"
             },
             "description": {


### PR DESCRIPTION
## Proposed change

Add re-order mode to automation blueprint editor

I'm not satisfied about the UX because most of blueprint doesn't have actions.
`ha-action-selector` can be used everywhere. May be the re-order mode should be inside the selector

![image](https://user-images.githubusercontent.com/5878303/189621170-0f810853-a53b-41b9-b2ca-b7cb34939810.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

- This PR fixes or closes issue: fixes #13679 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
