### PR TITLE
Revert "Either show range or fix target temperature... #13638

### DIFF
--- a/src/dialogs/more-info/controls/more-info-climate.ts
+++ b/src/dialogs/more-info/controls/more-info-climate.ts
@@ -98,9 +98,7 @@ class MoreInfoClimate extends LitElement {
                   </div>
                 `
               : ""}
-            ${supportTargetTemperature &&
-            !supportTargetTemperatureRange &&
-            stateObj.attributes.temperature !== undefined &&
+            ${stateObj.attributes.temperature !== undefined &&
             stateObj.attributes.temperature !== null
               ? html`
                   <ha-climate-control
@@ -114,11 +112,10 @@ class MoreInfoClimate extends LitElement {
                   ></ha-climate-control>
                 `
               : ""}
-            ${supportTargetTemperatureRange &&
-            ((stateObj.attributes.target_temp_low !== undefined &&
+            ${(stateObj.attributes.target_temp_low !== undefined &&
               stateObj.attributes.target_temp_low !== null) ||
-              (stateObj.attributes.target_temp_high !== undefined &&
-                stateObj.attributes.target_temp_high !== null))
+            (stateObj.attributes.target_temp_high !== undefined &&
+              stateObj.attributes.target_temp_high !== null)
               ? html`
                   <ha-climate-control
                     .hass=${this.hass}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This reverts commit 7f82b90c25ca6b4da87413458d1ff2e3869fc4cf.

The change in above #13638 was a breaking change for a climate system that both support HEAT, COOL and HEAT_COOL modes. This change made it impossible to show any temperature when mode is HEAT or COOL. 

The `supported` flags are static and are not allowed to change based on a mode change. Thus UI should base presentation on what data is supplied, not based on what flags are present.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13649 and https://github.com/elupus/hass_nibe/issues/147

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
