### PR TITLE
Revert "Add initial field to the helper input_number in UI"

### DIFF
--- a/src/panels/config/helpers/forms/ha-input_number-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_number-form.ts
@@ -26,8 +26,6 @@ class HaInputNumberForm extends LitElement {
 
   @state() private _min?: number;
 
-  @state() private _initial?: number;
-
   @state() private _mode?: string;
 
   @state() private _step?: number;
@@ -44,7 +42,6 @@ class HaInputNumberForm extends LitElement {
       this._min = item.min ?? 0;
       this._mode = item.mode || "slider";
       this._step = item.step ?? 1;
-      this._initial = item.initial ?? 0;
       this._unit_of_measurement = item.unit_of_measurement;
     } else {
       this._item = {
@@ -57,7 +54,6 @@ class HaInputNumberForm extends LitElement {
       this._min = 0;
       this._mode = "slider";
       this._step = 1;
-      this._initial = 0;
     }
   }
 
@@ -115,15 +111,6 @@ class HaInputNumberForm extends LitElement {
           @input=${this._valueChanged}
           .label=${this.hass!.localize(
             "ui.dialogs.helper_settings.input_number.max"
-          )}
-        ></ha-textfield>
-        <ha-textfield
-          .value=${this._initial}
-          .configValue=${"initial"}
-          type="number"
-          @input=${this._valueChanged}
-          .label=${this.hass!.localize(
-            "ui.dialogs.helper_settings.input_number.initial"
           )}
         ></ha-textfield>
         ${this.hass.userData?.showAdvanced

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -924,7 +924,6 @@
           "pattern": "Regex pattern for client-side validation"
         },
         "input_number": {
-          "initial": "Initial value",
           "min": "Minimum value",
           "max": "Maximum value",
           "mode": "Display mode",


### PR DESCRIPTION
Reverts home-assistant/frontend#13378

The initial value for input_number is not intuitive.
Moreover, the PR introduced a bug where every input_number was forced to an initial value of 0.