### PR TITLE
fix: add previous repeat action configuration on change

### DIFF
--- a/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
@@ -115,6 +115,7 @@ export class HaRepeatAction extends LitElement implements ActionElement {
 
     fireEvent(this, "value-changed", {
       value: {
+        ...this.action,
         repeat: { [type]: value, sequence: this.action.repeat.sequence },
       },
     });
@@ -125,6 +126,7 @@ export class HaRepeatAction extends LitElement implements ActionElement {
     const value = ev.detail.value as Condition[];
     fireEvent(this, "value-changed", {
       value: {
+        ...this.action,
         repeat: {
           ...this.action.repeat,
           [getType(this.action.repeat)!]: value,
@@ -138,6 +140,7 @@ export class HaRepeatAction extends LitElement implements ActionElement {
     const value = ev.detail.value as Action[];
     fireEvent(this, "value-changed", {
       value: {
+        ...this.action,
         repeat: {
           ...this.action.repeat,
           sequence: value,
@@ -153,6 +156,7 @@ export class HaRepeatAction extends LitElement implements ActionElement {
     }
     fireEvent(this, "value-changed", {
       value: {
+        ...this.action,
         repeat: {
           ...this.action.repeat,
           count: newVal,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Repeat action alias is rewritten each time its type, condition or action is changed. The previous state has been added on change callbacks.

**Before:**

https://user-images.githubusercontent.com/397503/189927470-818a625e-40c8-4662-b056-cc0731a10eaa.mp4

**After:**

https://user-images.githubusercontent.com/397503/189927528-6ee33254-1a67-458a-8c7e-b3c2edf053ac.mp4




## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
