### PR TITLE
Prevent re-creation of custom panel when content was not changed

### DIFF
--- a/src/data/entity_registry.ts
+++ b/src/data/entity_registry.ts
@@ -61,7 +61,7 @@ export interface EntityRegistryEntryUpdateParams {
   hidden_by: string | null;
   new_entity_id?: string;
   options_domain?: string;
-  options?: SensorEntityOptions | WeatherEntityOptions;
+  options?: SensorEntityOptions | NumberEntityOptions | WeatherEntityOptions;
 }
 
 export const findBatteryEntity = (

--- a/src/panels/custom/ha-panel-custom.ts
+++ b/src/panels/custom/ha-panel-custom.ts
@@ -1,6 +1,7 @@
 import { PropertyValues, ReactiveElement } from "lit";
 import { property } from "lit/decorators";
 import { navigate, NavigateOptions } from "../../common/navigate";
+import { deepEqual } from "../../common/util/deep-equal";
 import { CustomPanelInfo } from "../../data/panel_custom";
 import { HomeAssistant, Route } from "../../types";
 import { createCustomPanelElement } from "../../util/custom-panel/create-custom-panel-element";
@@ -54,12 +55,15 @@ export class HaPanelCustom extends ReactiveElement {
   protected update(changedProps: PropertyValues) {
     super.update(changedProps);
     if (changedProps.has("panel")) {
-      // Clean up old things if we had a panel
-      if (changedProps.get("panel")) {
-        this._cleanupPanel();
+      // Clean up old things if we had a panel and the new one is different.
+      const oldPanel = changedProps.get("panel") as CustomPanelInfo | undefined;
+      if (!deepEqual(oldPanel, this.panel)) {
+        if (oldPanel) {
+          this._cleanupPanel();
+        }
+        this._createPanel(this.panel);
+        return;
       }
-      this._createPanel(this.panel);
-      return;
     }
     if (!this._setProperties) {
       return;


### PR DESCRIPTION


## Proposed change

When we would re-connect, the panels would be refetched, causing custom panel to do a complete rebuild, even if the content of the panel would not be changed.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
