### PR TITLE
Update delete person dialog

### DIFF
--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -233,10 +233,17 @@ class HaConfigPerson extends LitElement {
       removeEntry: async () => {
         if (
           !(await showConfirmationDialog(this, {
-            title: this.hass!.localize("ui.panel.config.person.confirm_delete"),
-            text: this.hass!.localize("ui.panel.config.person.confirm_delete2"),
+            title: this.hass!.localize(
+              "ui.panel.config.person.confirm_delete_title",
+              "name",
+              entry!.name
+            ),
+            text: this.hass!.localize(
+              "ui.panel.config.person.confirm_delete_text"
+            ),
             dismissText: this.hass!.localize("ui.common.cancel"),
             confirmText: this.hass!.localize("ui.common.delete"),
+            destructive: true,
           }))
         ) {
           return false;

--- a/src/panels/config/person/ha-config-person.ts
+++ b/src/panels/config/person/ha-config-person.ts
@@ -235,8 +235,7 @@ class HaConfigPerson extends LitElement {
           !(await showConfirmationDialog(this, {
             title: this.hass!.localize(
               "ui.panel.config.person.confirm_delete_title",
-              "name",
-              entry!.name
+              { name: entry!.name }
             ),
             text: this.hass!.localize(
               "ui.panel.config.person.confirm_delete_text"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2743,8 +2743,8 @@
           "no_persons_created_yet": "Looks like you have not added any people yet.",
           "create_person": "Create Person",
           "add_person": "Add Person",
-          "confirm_delete": "Are you sure you want to delete this person?",
-          "confirm_delete2": "All devices belonging to this person will become unassigned.",
+          "confirm_delete_title": "Delete {name}?",
+          "confirm_delete_text": "This person will be permanently deleted and all devices belonging to this person will become unassigned.",
           "person_not_found_title": "Person Not Found",
           "person_not_found": "We couldn't find the person you were trying to edit.",
           "detail": {


### PR DESCRIPTION
## Proposed change

![Capture d’écran 2022-09-15 à 16 30 48](https://user-images.githubusercontent.com/5878303/190430976-67d5f205-a5d1-489c-82d6-2d35467d8ea5.png)

> **Warning**
> Need https://github.com/home-assistant/frontend/pull/13761 for styling

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13114
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
