### PR TITLE
Update delete scene dialog

### DIFF
--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -279,7 +279,14 @@ class HaSceneDashboard extends LitElement {
 
   private _deleteConfirm(scene: SceneEntity): void {
     showConfirmationDialog(this, {
-      text: this.hass!.localize("ui.panel.config.scene.picker.delete_confirm"),
+      title: this.hass!.localize(
+        "ui.panel.config.scene.picker.delete_confirm_title"
+      ),
+      text: this.hass!.localize(
+        "ui.panel.config.scene.picker.delete_confirm_text",
+        "name",
+        computeStateName(scene)
+      ),
       confirmText: this.hass!.localize("ui.common.delete"),
       dismissText: this.hass!.localize("ui.common.cancel"),
       confirm: () => this._delete(scene),

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -268,11 +268,9 @@ class HaSceneDashboard extends LitElement {
   private _activateScene = async (scene: SceneEntity) => {
     await activateScene(this.hass, scene.entity_id);
     showToast(this, {
-      message: this.hass.localize(
-        "ui.panel.config.scene.activated",
-        "name",
-        computeStateName(scene)
-      ),
+      message: this.hass.localize("ui.panel.config.scene.activated", {
+        name: computeStateName(scene),
+      }),
     });
     forwardHaptic("light");
   };
@@ -284,8 +282,7 @@ class HaSceneDashboard extends LitElement {
       ),
       text: this.hass!.localize(
         "ui.panel.config.scene.picker.delete_confirm_text",
-        "name",
-        computeStateName(scene)
+        { name: computeStateName(scene) }
       ),
       confirmText: this.hass!.localize("ui.common.delete"),
       dismissText: this.hass!.localize("ui.common.cancel"),

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -785,10 +785,18 @@ export class HaSceneEditor extends SubscribeMixin(
 
   private _deleteTapped(): void {
     showConfirmationDialog(this, {
-      text: this.hass!.localize("ui.panel.config.scene.picker.delete_confirm"),
+      title: this.hass!.localize(
+        "ui.panel.config.scene.picker.delete_confirm_title"
+      ),
+      text: this.hass!.localize(
+        "ui.panel.config.scene.picker.delete_confirm_text",
+        "name",
+        this._config?.name
+      ),
       confirmText: this.hass!.localize("ui.common.delete"),
       dismissText: this.hass!.localize("ui.common.cancel"),
       confirm: () => this._delete(),
+      destructive: true,
     });
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2333,7 +2333,8 @@
             "activate": "Activate",
             "delete_scene": "Delete scene",
             "delete": "[%key:ui::common::delete%]",
-            "delete_confirm": "Are you sure you want to delete this scene?",
+            "delete_confirm_title": "Delete scene?",
+            "delete_confirm_text": "{name} will be permanently deleted.",
             "duplicate_scene": "Duplicate scene",
             "duplicate": "[%key:ui::common::duplicate%]",
             "headers": {


### PR DESCRIPTION
## Proposed change

![Capture d’écran 2022-09-15 à 13 46 41](https://user-images.githubusercontent.com/5878303/190399006-bf519f5c-fc24-4869-a167-5e50b29cd221.png)

> **Warning**
> Need https://github.com/home-assistant/frontend/pull/13761 for styling

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13091
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
