### PR TITLE
Use unique id for script

### DIFF
--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -15,7 +15,6 @@ import {
   Describe,
   boolean,
 } from "superstruct";
-import { computeObjectId } from "../common/entity/compute_object_id";
 import { navigate } from "../common/navigate";
 import { HomeAssistant } from "../types";
 import {
@@ -278,9 +277,9 @@ export type ActionType = keyof ActionTypes;
 
 export const triggerScript = (
   hass: HomeAssistant,
-  entityId: string,
+  scriptId: string,
   variables?: Record<string, unknown>
-) => hass.callService("script", computeObjectId(entityId), variables);
+) => hass.callService("script", scriptId, variables);
 
 export const canRun = (state: ScriptEntity) => {
   if (state.state === "off") {

--- a/src/panels/config/script/ha-config-script.ts
+++ b/src/panels/config/script/ha-config-script.ts
@@ -88,8 +88,8 @@ class HaConfigScript extends HassRouterPage {
       this._currentPage !== "dashboard"
     ) {
       pageEl.creatingNew = undefined;
-      const scriptEntityId = this.routeTail.path.substr(1);
-      pageEl.scriptEntityId = scriptEntityId === "new" ? null : scriptEntityId;
+      const scriptId = this.routeTail.path.substr(1);
+      pageEl.scriptId = scriptId === "new" ? null : scriptId;
     }
   }
 }

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -40,7 +40,6 @@ import "../../../components/ha-icon-button";
 import "../../../components/ha-svg-icon";
 import "../../../components/ha-yaml-editor";
 import type { HaYamlEditor } from "../../../components/ha-yaml-editor";
-import { EntityRegistryEntry } from "../../../data/entity_registry";
 import {
   deleteScript,
   getScriptConfig,
@@ -68,7 +67,7 @@ import type { HaManualScriptEditor } from "./manual-script-editor";
 export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public scriptEntityId: string | null = null;
+  @property() public scriptId: string | null = null;
 
   @property({ attribute: false }) public route!: Route;
 
@@ -162,7 +161,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
     }
 
     const schema = this._schema(
-      !!this.scriptEntityId,
+      !!this.scriptId,
       "use_blueprint" in this._config,
       this._config.mode
     );
@@ -183,7 +182,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
         .backCallback=${this._backTapped}
         .header=${!this._config?.alias ? "" : this._config.alias}
       >
-        ${this.scriptEntityId && !this.narrow
+        ${this.scriptId && !this.narrow
           ? html`
               <mwc-button @click=${this._showTrace} slot="toolbar-icon">
                 ${this.hass.localize(
@@ -201,7 +200,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
           <mwc-list-item
             graphic="icon"
-            .disabled=${!this.scriptEntityId}
+            .disabled=${!this.scriptId}
             @click=${this._showInfo}
           >
             ${this.hass.localize("ui.panel.config.script.editor.show_info")}
@@ -213,16 +212,16 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
           <mwc-list-item
             graphic="icon"
-            .disabled=${!this.scriptEntityId}
+            .disabled=${!this.scriptId}
             @click=${this._runScript}
           >
             ${this.hass.localize("ui.panel.config.script.picker.run_script")}
             <ha-svg-icon slot="graphic" .path=${mdiPlay}></ha-svg-icon>
           </mwc-list-item>
 
-          ${this.scriptEntityId && this.narrow
+          ${this.scriptId && this.narrow
             ? html`
-                <a href="/config/script/trace/${this.scriptEntityId}">
+                <a href="/config/script/trace/${this.scriptId}">
                   <mwc-list-item graphic="icon">
                     ${this.hass.localize(
                       "ui.panel.config.script.editor.show_trace"
@@ -295,7 +294,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
           <li divider role="separator"></li>
 
           <mwc-list-item
-            .disabled=${!this.scriptEntityId}
+            .disabled=${!this.scriptId}
             .label=${this.hass.localize(
               "ui.panel.config.script.picker.duplicate"
             )}
@@ -310,17 +309,17 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
           </mwc-list-item>
 
           <mwc-list-item
-            .disabled=${!this.scriptEntityId}
+            .disabled=${!this.scriptId}
             aria-label=${this.hass.localize(
               "ui.panel.config.script.picker.delete"
             )}
-            class=${classMap({ warning: Boolean(this.scriptEntityId) })}
+            class=${classMap({ warning: Boolean(this.scriptId) })}
             graphic="icon"
             @click=${this._deleteConfirm}
           >
             ${this.hass.localize("ui.panel.config.script.picker.delete")}
             <ha-svg-icon
-              class=${classMap({ warning: Boolean(this.scriptEntityId) })}
+              class=${classMap({ warning: Boolean(this.scriptId) })}
               slot="graphic"
               .path=${mdiDelete}
             >
@@ -430,27 +429,15 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
   protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
 
-    const oldScript = changedProps.get("scriptEntityId");
+    const oldScript = changedProps.get("scriptId");
     if (
-      changedProps.has("scriptEntityId") &&
-      this.scriptEntityId &&
+      changedProps.has("scriptId") &&
+      this.scriptId &&
       this.hass &&
       // Only refresh config if we picked a new script. If same ID, don't fetch it.
-      (!oldScript || oldScript !== this.scriptEntityId)
+      (!oldScript || oldScript !== this.scriptId)
     ) {
-      const entry = this.hass.entities[this.scriptEntityId] as
-        | EntityRegistryEntry
-        | undefined;
-      if (!entry) {
-        alert(
-          this.hass.localize(
-            "ui.panel.config.script.editor.load_error_not_editable"
-          )
-        );
-        return;
-      }
-
-      getScriptConfig(this.hass, entry.unique_id).then(
+      getScriptConfig(this.hass, this.scriptId).then(
         (config) => {
           // Normalize data: ensure sequence is a list
           // Happens when people copy paste their scripts into the config
@@ -478,11 +465,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
       );
     }
 
-    if (
-      changedProps.has("scriptEntityId") &&
-      !this.scriptEntityId &&
-      this.hass
-    ) {
+    if (changedProps.has("scriptId") && !this.scriptId && this.hass) {
       const initData = getScriptEditorInitData();
       this._dirty = !!initData;
       const baseConfig: Partial<ScriptConfig> = {
@@ -542,25 +525,30 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
   };
 
   private async _showInfo() {
-    if (!this.scriptEntityId) {
+    if (!this.scriptId) {
       return;
     }
-    fireEvent(this, "hass-more-info", { entityId: this.scriptEntityId });
+    const entity = Object.values(this.hass.entities).find(
+      (entry) => entry.unique_id === this.scriptId
+    );
+    if (!entity) {
+      return;
+    }
+    fireEvent(this, "hass-more-info", { entityId: entity.entity_id });
   }
 
   private async _showTrace() {
-    if (this.scriptEntityId) {
+    if (this.scriptId) {
       const result = await this.confirmUnsavedChanged();
       if (result) {
-        navigate(`/config/script/trace/${this.scriptEntityId}`);
+        navigate(`/config/script/trace/${this.scriptId}`);
       }
     }
   }
 
   private async _runScript(ev: CustomEvent) {
     ev.stopPropagation();
-    const entry = this.hass.entities[this.scriptEntityId!];
-    await triggerScript(this.hass, entry.unique_id);
+    await triggerScript(this.hass, this.scriptId!);
     showToast(this, {
       message: this.hass.localize(
         "ui.notification_toast.triggered",
@@ -733,8 +721,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
   }
 
   private async _delete() {
-    const entry = this.hass.entities[this.scriptEntityId!];
-    await deleteScript(this.hass, entry.unique_id);
+    await deleteScript(this.hass, this.scriptId!);
     history.back();
   }
 
@@ -768,8 +755,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
       return;
     }
 
-    const entry = this.hass.entities[this.scriptEntityId!];
-    const id = entry ? entry.unique_id : this._entityId || Date.now();
+    const id = this.scriptId || this._entityId || Date.now();
     try {
       await this.hass!.callApi(
         "POST",
@@ -786,8 +772,8 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
     this._dirty = false;
 
-    if (!this.scriptEntityId) {
-      navigate(`/config/script/edit/script.${id}`, { replace: true });
+    if (!this.scriptId) {
+      navigate(`/config/script/edit/${id}`, { replace: true });
     }
   }
 

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -614,7 +614,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
       max: isMaxMode(values.mode) ? values.max : undefined,
     };
 
-    if (!this.scriptEntityId) {
+    if (!this.scriptId) {
       this.updateEntityId(values.id, values.alias);
     }
 

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -13,7 +13,6 @@ import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { formatDateTime } from "../../../common/datetime/format_date_time";
 import { fireEvent, HASSDomEvent } from "../../../common/dom/fire_event";
-import { computeObjectId } from "../../../common/entity/compute_object_id";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { navigate } from "../../../common/navigate";
 import { computeRTL } from "../../../common/util/compute_rtl";
@@ -26,6 +25,7 @@ import "../../../components/ha-fab";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-icon-overflow-menu";
 import "../../../components/ha-svg-icon";
+import { getExtendedEntityRegistryEntry } from "../../../data/entity_registry";
 import {
   deleteScript,
   getScriptConfig,
@@ -256,7 +256,11 @@ class HaScriptPicker extends LitElement {
   }
 
   private _runScript = async (script: any) => {
-    await triggerScript(this.hass, script.entity_id);
+    const entry = await getExtendedEntityRegistryEntry(
+      this.hass,
+      script.entity_id
+    );
+    await triggerScript(this.hass, entry.unique_id);
     showToast(this, {
       message: this.hass.localize(
         "ui.notification_toast.triggered",
@@ -294,10 +298,11 @@ class HaScriptPicker extends LitElement {
 
   private async _duplicate(script: any) {
     try {
-      const config = await getScriptConfig(
+      const entry = await getExtendedEntityRegistryEntry(
         this.hass,
-        computeObjectId(script.entity_id)
+        script.entity_id
       );
+      const config = await getScriptConfig(this.hass, entry.unique_id);
       showScriptEditor({
         ...config,
         alias: `${config?.alias} (${this.hass.localize(
@@ -338,7 +343,11 @@ class HaScriptPicker extends LitElement {
 
   private async _delete(script: any) {
     try {
-      await deleteScript(this.hass, computeObjectId(script.entity_id));
+      const entry = await getExtendedEntityRegistryEntry(
+        this.hass,
+        script.entity_id
+      );
+      await deleteScript(this.hass, entry.unique_id);
     } catch (err: any) {
       await showAlertDialog(this, {
         text:

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -251,7 +251,10 @@ class HaScriptPicker extends LitElement {
   }
 
   private _handleRowClicked(ev: HASSDomEvent<RowClickedEvent>) {
-    navigate(`/config/script/edit/${ev.detail.id}`);
+    const entry = this.hass.entities[ev.detail.id];
+    if (entry) {
+      navigate(`/config/script/edit/${entry.unique_id}`);
+    }
   }
 
   private _runScript = async (script: any) => {
@@ -271,7 +274,10 @@ class HaScriptPicker extends LitElement {
   }
 
   private _showTrace(script: any) {
-    navigate(`/config/script/trace/${script.entity_id}`);
+    const entry = this.hass.entities[script.entity_id];
+    if (entry) {
+      navigate(`/config/script/trace/${entry.unique_id}`);
+    }
   }
 
   private _showHelp() {

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -25,7 +25,6 @@ import "../../../components/ha-fab";
 import "../../../components/ha-icon-button";
 import "../../../components/ha-icon-overflow-menu";
 import "../../../components/ha-svg-icon";
-import { getExtendedEntityRegistryEntry } from "../../../data/entity_registry";
 import {
   deleteScript,
   getScriptConfig,
@@ -256,10 +255,7 @@ class HaScriptPicker extends LitElement {
   }
 
   private _runScript = async (script: any) => {
-    const entry = await getExtendedEntityRegistryEntry(
-      this.hass,
-      script.entity_id
-    );
+    const entry = this.hass.entities[script.entity_id];
     await triggerScript(this.hass, entry.unique_id);
     showToast(this, {
       message: this.hass.localize(
@@ -298,10 +294,7 @@ class HaScriptPicker extends LitElement {
 
   private async _duplicate(script: any) {
     try {
-      const entry = await getExtendedEntityRegistryEntry(
-        this.hass,
-        script.entity_id
-      );
+      const entry = this.hass.entities[script.entity_id];
       const config = await getScriptConfig(this.hass, entry.unique_id);
       showScriptEditor({
         ...config,
@@ -343,10 +336,7 @@ class HaScriptPicker extends LitElement {
 
   private async _delete(script: any) {
     try {
-      const entry = await getExtendedEntityRegistryEntry(
-        this.hass,
-        script.entity_id
-      );
+      const entry = this.hass.entities[script.entity_id];
       await deleteScript(this.hass, entry.unique_id);
     } catch (err: any) {
       await showAlertDialog(this, {

--- a/src/panels/config/script/ha-script-trace.ts
+++ b/src/panels/config/script/ha-script-trace.ts
@@ -326,7 +326,7 @@ export class HaScriptTrace extends LitElement {
   public willUpdate(changedProps) {
     super.willUpdate(changedProps);
 
-    // Only reset if scriptEntityId has changed and we had one before.
+    // Only reset if scriptId has changed and we had one before.
     if (changedProps.get("scriptId")) {
       this._traces = undefined;
       this._runId = undefined;

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -170,11 +170,7 @@ class HaLogbookRenderer extends LitElement {
       <div
         class="entry-container ${classMap({ clickable: hasTrace })}"
         .traceLink=${traceContext
-          ? `/config/${traceContext.domain}/trace/${
-              traceContext.domain === "script"
-                ? `script.${traceContext.item_id}`
-                : traceContext.item_id
-            }?run_id=${traceContext.run_id}`
+          ? `/config/${traceContext.domain}/trace/${traceContext.item_id}?run_id=${traceContext.run_id}`
           : undefined}
         @click=${this._handleClick}
       >


### PR DESCRIPTION
## Proposed change

Use unique id for script instead of entity id / computed object id

No more `script.` in the script editor/trace route. It use now the key (unique_id) defined is the yaml and used to fetch the config)

Script service call (run trigger) should work when https://github.com/home-assistant/core/pull/78765 is merged.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

Needs https://github.com/home-assistant/frontend/pull/13886

- This PR fixes or closes issue: fixes #13748
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
