### PR TITLE
Add subview option to dashboard views

### DIFF
--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -93,6 +93,8 @@ export interface LovelaceViewConfig {
   panel?: boolean;
   background?: string;
   visible?: boolean | ShowViewConfig[];
+  child_view?: boolean;
+  back_path?: string;
 }
 
 export interface LovelaceViewElement extends HTMLElement {

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -93,7 +93,7 @@ export interface LovelaceViewConfig {
   panel?: boolean;
   background?: string;
   visible?: boolean | ShowViewConfig[];
-  child_view?: boolean;
+  subview?: boolean;
   back_path?: string;
 }
 

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -73,7 +73,7 @@ export class HuiViewEditor extends LitElement {
           ? [
               {
                 name: "back_path",
-                selector: { text: {} },
+                selector: { navigation: {} },
               },
             ]
           : []),

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -64,7 +64,7 @@ export class HuiViewEditor extends LitElement {
           },
         },
         {
-          name: "child_view",
+          name: "subview",
           selector: {
             boolean: {},
           },
@@ -105,7 +105,7 @@ export class HuiViewEditor extends LitElement {
 
     const schema = this._schema(
       this.hass.localize,
-      this._config.child_view ?? false
+      this._config.subview ?? false
     );
     const data = {
       theme: "Backend-selected",
@@ -130,7 +130,7 @@ export class HuiViewEditor extends LitElement {
     if (config.type === "masonry") {
       delete config.type;
     }
-    if (!config.child_view) {
+    if (!config.subview) {
       delete config.back_path;
     }
 
@@ -155,10 +155,8 @@ export class HuiViewEditor extends LitElement {
         return this.hass!.localize("ui.panel.lovelace.editor.card.generic.url");
       case "type":
         return this.hass.localize("ui.panel.lovelace.editor.edit_view.type");
-      case "child_view":
-        return this.hass.localize(
-          "ui.panel.lovelace.editor.edit_view.child_view"
-        );
+      case "subview":
+        return this.hass.localize("ui.panel.lovelace.editor.edit_view.subview");
       case "back_path":
         return this.hass.localize(
           "ui.panel.lovelace.editor.edit_view.back_path"

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -33,7 +33,7 @@ export class HuiViewEditor extends LitElement {
   private _suggestedPath = false;
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc, subview: boolean) =>
+    (localize: LocalizeFunc, subview: boolean, showAdvanced: boolean) =>
       [
         { name: "title", selector: { text: {} } },
         {
@@ -69,7 +69,7 @@ export class HuiViewEditor extends LitElement {
             boolean: {},
           },
         },
-        ...(subview
+        ...(subview && showAdvanced
           ? [
               {
                 name: "back_path",
@@ -100,8 +100,10 @@ export class HuiViewEditor extends LitElement {
 
     const schema = this._schema(
       this.hass.localize,
-      this._config.subview ?? false
+      this._config.subview ?? false,
+      this.hass.userData?.showAdvanced ?? false
     );
+
     const data = {
       theme: "Backend-selected",
       ...this._config,

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -1,10 +1,10 @@
-import "../../../../components/ha-form/ha-form";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { slugify } from "../../../../common/string/slugify";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
+import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { LovelaceViewConfig } from "../../../../data/lovelace";
 import type { HomeAssistant } from "../../../../types";
@@ -74,11 +74,6 @@ export class HuiViewEditor extends LitElement {
               {
                 name: "back_path",
                 selector: { text: {} },
-
-                description: {
-                  suggested_value:
-                    "Back path only apply when the view is a child view",
-                },
               },
             ]
           : []),
@@ -118,7 +113,8 @@ export class HuiViewEditor extends LitElement {
         .hass=${this.hass}
         .data=${data}
         .schema=${schema}
-        .computeLabel=${this._computeLabelCallback}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
         @value-changed=${this._valueChanged}
       ></ha-form>
     `;
@@ -147,7 +143,7 @@ export class HuiViewEditor extends LitElement {
     fireEvent(this, "view-config-changed", { config });
   }
 
-  private _computeLabelCallback = (
+  private _computeLabel = (
     schema: SchemaUnion<ReturnType<typeof this._schema>>
   ) => {
     switch (schema.name) {
@@ -165,6 +161,23 @@ export class HuiViewEditor extends LitElement {
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.generic.${schema.name}`
         );
+    }
+  };
+
+  private _computeHelper = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "subview":
+        return this.hass.localize(
+          "ui.panel.lovelace.editor.edit_view.subview_helper"
+        );
+      case "back_path":
+        return this.hass.localize(
+          "ui.panel.lovelace.editor.edit_view.back_path_helper"
+        );
+      default:
+        return undefined;
     }
   };
 }

--- a/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-view-editor.ts
@@ -33,7 +33,7 @@ export class HuiViewEditor extends LitElement {
   private _suggestedPath = false;
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc, childView: boolean) =>
+    (localize: LocalizeFunc, subview: boolean) =>
       [
         { name: "title", selector: { text: {} } },
         {
@@ -69,7 +69,7 @@ export class HuiViewEditor extends LitElement {
             boolean: {},
           },
         },
-        ...(childView
+        ...(subview
           ? [
               {
                 name: "back_path",

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -2,7 +2,6 @@ import "@material/mwc-button";
 import "@material/mwc-list/mwc-list-item";
 import type { RequestSelectedDetail } from "@material/mwc-list/mwc-list-item";
 import {
-  mdiArrowLeft,
   mdiCodeBraces,
   mdiDotsVertical,
   mdiFileMultiple,
@@ -237,10 +236,9 @@ class HUIRoot extends LitElement {
                 <app-toolbar>
                   ${curViewConfig?.subview
                     ? html`
-                        <ha-icon-button
-                          .path=${mdiArrowLeft}
+                        <ha-icon-button-arrow-prev
                           @click=${this._goBack}
-                        ></ha-icon-button>
+                        ></ha-icon-button-arrow-prev>
                       `
                     : html`
                         <ha-menu-button

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -235,7 +235,7 @@ class HUIRoot extends LitElement {
               `
             : html`
                 <app-toolbar>
-                  ${curViewConfig?.child_view
+                  ${curViewConfig?.subview
                     ? html`
                         <ha-icon-button
                           .path=${mdiArrowLeft}
@@ -248,9 +248,9 @@ class HUIRoot extends LitElement {
                           .narrow=${this.narrow}
                         ></ha-menu-button>
                       `}
-                  ${curViewConfig?.child_view
+                  ${curViewConfig?.subview
                     ? html`<div main-title>${curViewConfig.title}</div>`
-                    : views.filter((view) => !view.child_view).length > 1
+                    : views.filter((view) => !view.subview).length > 1
                     ? html`
                         <ha-tabs
                           scrollable
@@ -264,7 +264,7 @@ class HUIRoot extends LitElement {
                                 aria-label=${ifDefined(view.title)}
                                 class=${classMap({
                                   "hide-tab": Boolean(
-                                    view.child_view ||
+                                    view.subview ||
                                       (view.visible !== undefined &&
                                         ((Array.isArray(view.visible) &&
                                           !view.visible.some(
@@ -525,7 +525,7 @@ class HUIRoot extends LitElement {
                             ? html`
                                 <ha-icon
                                   class=${classMap({
-                                    "child-view-icon": Boolean(view.child_view),
+                                    "child-view-icon": Boolean(view.subview),
                                   })}
                                   title=${ifDefined(view.title)}
                                   .icon=${view.icon}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3741,7 +3741,7 @@
               "sidebar": "Sidebar",
               "panel": "Panel (1 card)"
             },
-            "child_view": "Child view (do not appear in tabs)",
+            "subview": "Subview (do not appear in tabs)",
             "back_path": "Back path (go to previous page if empty)"
           },
           "edit_badges": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3742,9 +3742,9 @@
               "panel": "Panel (1 card)"
             },
             "subview": "Subview",
-            "subview_helper": "Subviews don't appear in tabs and have a back button",
+            "subview_helper": "Subviews don't appear in tabs and have a back button.",
             "back_path": "Back path (optional)",
-            "back_path_helper": "If empty, it will go to the previous page"
+            "back_path_helper": "Only for subviews. If empty, clicking on back button will go to the previous page."
           },
           "edit_badges": {
             "view_no_badges": "Badges are not be supported by the current view type."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3741,8 +3741,10 @@
               "sidebar": "Sidebar",
               "panel": "Panel (1 card)"
             },
-            "subview": "Subview (do not appear in tabs)",
-            "back_path": "Back path (go to previous page if empty)"
+            "subview": "Subview",
+            "subview_helper": "Subviews don't appear in tabs and have a back button",
+            "back_path": "Back path (optional)",
+            "back_path_helper": "If empty, it will go to the previous page"
           },
           "edit_badges": {
             "view_no_badges": "Badges are not be supported by the current view type."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3740,7 +3740,9 @@
               "masonry": "Masonry (default)",
               "sidebar": "Sidebar",
               "panel": "Panel (1 card)"
-            }
+            },
+            "child_view": "Child view (do not appear in tabs)",
+            "back_path": "Back path (go to previous page if empty)"
           },
           "edit_badges": {
             "view_no_badges": "Badges are not be supported by the current view type."


### PR DESCRIPTION
## Proposed change

This PR add a new view configuration option to tag a view as "subview". 

It allow user to easily create room oriented dashboard.

When a subview is displayed, the tab bar is replaced by the view name and the menu icon by a back icon.
By default the back icon go to the previous page but the `back_path` option allow user to define a custom back path (always go back to the home view for example)

### YAML example
```yaml
title: Bathroom
path: bathroom
icon: mdi:shower
subview: true
back_path: /lovelace/home
```

### Editor

Back path option is only displayed when `subview` is `true`.

![image](https://user-images.githubusercontent.com/5878303/191509109-68d10563-739c-4dd0-91af-b209ca303059.png)

### Updated tab bar

The subviews doesn't appear in the tab bar and are greyed out in edit mode.

![image](https://user-images.githubusercontent.com/5878303/191217968-4c6db23e-8fb0-4ba9-a355-a3aa79c3800c.png)

![image](https://user-images.githubusercontent.com/5878303/191217822-7632804a-a0df-4520-b934-81fcde187d4a.png)

### Demo time

https://user-images.githubusercontent.com/5878303/191218073-b3ba3bff-c75d-4544-bec9-3417b7941ddc.mp4

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
