### PR TITLE
Prevent service call error if preset_mode is null

### DIFF
--- a/src/dialogs/more-info/controls/more-info-climate.ts
+++ b/src/dialogs/more-info/controls/more-info-climate.ts
@@ -377,12 +377,14 @@ class MoreInfoClimate extends LitElement {
 
   private _handlePresetmodeChanged(ev) {
     const newVal = ev.target.value || null;
-    this._callServiceHelper(
-      this.stateObj!.attributes.preset_mode,
-      newVal,
-      "set_preset_mode",
-      { preset_mode: newVal }
-    );
+    if (newVal) {
+      this._callServiceHelper(
+        this.stateObj!.attributes.preset_mode,
+        newVal,
+        "set_preset_mode",
+        { preset_mode: newVal }
+      );
+    }
   }
 
   private async _callServiceHelper(
@@ -394,7 +396,7 @@ class MoreInfoClimate extends LitElement {
       [key: string]: unknown;
     }
   ) {
-    if (oldVal === newVal || !newVal) {
+    if (oldVal === newVal) {
       return;
     }
 

--- a/src/dialogs/more-info/controls/more-info-climate.ts
+++ b/src/dialogs/more-info/controls/more-info-climate.ts
@@ -394,7 +394,7 @@ class MoreInfoClimate extends LitElement {
       [key: string]: unknown;
     }
   ) {
-    if (oldVal === newVal) {
+    if (oldVal === newVal || !newVal) {
       return;
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
On the more-info-climate dialog, the preset_mode value can be null.  However, if it is null, it calls the set_preset_mode service with the preset_mode as null and causes an error.  

```
Failed to call service climate/set_preset_mode. String value is None for dictionary value @ data['preset_mode']
```
This minor change amends _handlePresetmodeChanged to prevent calling of the service is the preset_mode is null. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13801 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
