### PR TITLE
Support displaying relative change in statistics graph cards

### DIFF
--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -38,6 +38,7 @@ export const statTypeMap: Record<ExtendedStatisticType, StatisticType> = {
   max: "max",
   sum: "sum",
   sum_rel: "sum",
+  state: "sum",
 };
 @customElement("statistics-chart")
 class StatisticsChart extends LitElement {

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -30,14 +30,13 @@ import {
 import type { HomeAssistant } from "../../types";
 import "./ha-chart-base";
 
-export type ExtendedStatisticType = StatisticType | "state" | "sum_rel";
+export type ExtendedStatisticType = StatisticType | "state";
 
 export const statTypeMap: Record<ExtendedStatisticType, StatisticType> = {
   mean: "mean",
   min: "min",
   max: "max",
   sum: "sum",
-  sum_rel: "sum",
   state: "sum",
 };
 @customElement("statistics-chart")
@@ -345,14 +344,7 @@ class StatisticsChart extends LitElement {
 
       let prevDate: Date | null = null;
       // Process chart data.
-      const initVal: Record<"sum" | "sum_rel", number | null> = {
-        sum: null,
-        sum_rel: null,
-      };
-      const prevSum: Record<"sum" | "sum_rel", number | null> = {
-        sum: null,
-        sum_rel: null,
-      };
+      let prevSum: number | null = null;
       stats.forEach((stat) => {
         const date = new Date(stat.start);
         if (prevDate === date) {
@@ -362,12 +354,12 @@ class StatisticsChart extends LitElement {
         const dataValues: Array<number | null> = [];
         statTypes.forEach((type) => {
           let val: number | null;
-          if (type === "sum" || type === "sum_rel") {
-            if (initVal[type] === null) {
-              initVal[type] = val = type === "sum_rel" ? 0 : stat.sum || 0;
-              prevSum[type] = stat.sum;
+          if (type === "sum") {
+            if (prevSum === null) {
+              val = 0;
+              prevSum = stat.sum;
             } else {
-              val = initVal[type]! + ((stat.sum || 0) - prevSum[type]!);
+              val = (stat.sum || 0) - prevSum;
             }
           } else {
             val = stat[type];

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -346,9 +346,9 @@ class StatisticsChart extends LitElement {
         const dataValues: Array<number | null> = [];
         statTypes.forEach((type) => {
           let val: number | null;
-          if (type === "sum") {
+          if (type === "sum" || type === "sum_rel") {
             if (initVal === null) {
-              initVal = val = stat.state || 0;
+              initVal = val = type === "sum_rel" ? 0 : stat.sum || 0;
               prevSum = stat.sum;
             } else {
               val = initVal + ((stat.sum || 0) - prevSum!);

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -1,7 +1,7 @@
 import { computeStateName } from "../common/entity/compute_state_name";
 import { HomeAssistant } from "../types";
 
-export type StatisticType = "sum" | "min" | "max" | "mean";
+export type StatisticType = "state" | "sum" | "min" | "max" | "mean";
 
 export interface Statistics {
   [statisticId: string]: StatisticValue[];

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -1,7 +1,7 @@
 import { computeStateName } from "../common/entity/compute_state_name";
 import { HomeAssistant } from "../types";
 
-export type StatisticType = "sum" | "sum_rel" | "min" | "max" | "mean";
+export type StatisticType = "sum" | "min" | "max" | "mean";
 
 export interface Statistics {
   [statisticId: string]: StatisticValue[];
@@ -201,13 +201,10 @@ export const calculateStatisticsSumGrowth = (
 export const statisticsHaveType = (
   stats: StatisticValue[],
   type: StatisticType
-) => {
-  type = type === "sum_rel" ? "sum" : type;
-  return stats.some((stat) => stat[type] !== null);
-};
+) => stats.some((stat) => stat[type] !== null);
 
 const mean_stat_types: readonly StatisticType[] = ["mean", "min", "max"];
-const sum_stat_types: readonly StatisticType[] = ["sum", "sum_rel"];
+const sum_stat_types: readonly StatisticType[] = ["sum"];
 
 export const statisticsMetaHasType = (
   metadata: StatisticsMetaData,

--- a/src/data/recorder.ts
+++ b/src/data/recorder.ts
@@ -1,7 +1,7 @@
 import { computeStateName } from "../common/entity/compute_state_name";
 import { HomeAssistant } from "../types";
 
-export type StatisticType = "sum" | "min" | "max" | "mean";
+export type StatisticType = "sum" | "sum_rel" | "min" | "max" | "mean";
 
 export interface Statistics {
   [statisticId: string]: StatisticValue[];
@@ -201,10 +201,13 @@ export const calculateStatisticsSumGrowth = (
 export const statisticsHaveType = (
   stats: StatisticValue[],
   type: StatisticType
-) => stats.some((stat) => stat[type] !== null);
+) => {
+  type = type === "sum_rel" ? "sum" : type;
+  return stats.some((stat) => stat[type] !== null);
+};
 
 const mean_stat_types: readonly StatisticType[] = ["mean", "min", "max"];
-const sum_stat_types: readonly StatisticType[] = ["sum"];
+const sum_stat_types: readonly StatisticType[] = ["sum", "sum_rel"];
 
 export const statisticsMetaHasType = (
   metadata: StatisticsMetaData,

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -38,8 +38,6 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
 
   private _names: Record<string, string> = {};
 
-  private _fetching = false;
-
   private _interval?: number;
 
   public disconnectedCallback() {
@@ -156,15 +154,11 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
   }
 
   private async _getStatistics(): Promise<void> {
-    if (this._fetching) {
-      return;
-    }
     const startDate = new Date();
     startDate.setTime(
       startDate.getTime() -
         1000 * 60 * 60 * (24 * (this._config!.days_to_show || 30) + 1)
     );
-    this._fetching = true;
     try {
       this._statistics = await fetchStatistics(
         this.hass!,
@@ -173,8 +167,8 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
         this._entities,
         this._config!.period
       );
-    } finally {
-      this._fetching = false;
+    } catch (err) {
+      this._statistics = undefined;
     }
   }
 

--- a/src/panels/lovelace/cards/hui-statistics-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-statistics-graph-card.ts
@@ -90,7 +90,10 @@ export class HuiStatisticsGraphCard extends LitElement implements LovelaceCard {
     if (typeof config.stat_types === "string") {
       this._config = { ...config, stat_types: [config.stat_types] };
     } else if (!config.stat_types) {
-      this._config = { ...config, stat_types: ["sum", "min", "max", "mean"] };
+      this._config = {
+        ...config,
+        stat_types: ["state", "sum", "min", "max", "mean"],
+      };
     } else {
       this._config = config;
     }

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -39,6 +39,7 @@ import { deepEqual } from "../../../../common/util/deep-equal";
 import { statTypeMap } from "../../../../components/chart/statistics-chart";
 
 const statTypeStruct = union([
+  literal("state"),
   literal("sum"),
   literal("sum_rel"),
   literal("min"),
@@ -66,7 +67,7 @@ const cardConfigStruct = assign(
 );
 
 const periods = ["5minute", "hour", "day", "month"] as const;
-const stat_types = ["mean", "min", "max", "sum", "sum_rel"] as const;
+const stat_types = ["mean", "min", "max", "sum", "sum_rel", "state"] as const;
 
 @customElement("hui-statistics-graph-card-editor")
 export class HuiStatisticsGraphCardEditor

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -94,6 +94,12 @@ export class HuiStatisticsGraphCardEditor
       this.hass!,
       statisticIds || []
     );
+    if (statisticIds?.some((statistic_id) => statistic_id.includes(":"))) {
+      const { period, ...config } = this._config!;
+      fireEvent(this, "config-changed", {
+        config: config,
+      });
+    }
   };
 
   public willUpdate(changedProps: PropertyValues) {

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -36,6 +36,7 @@ import {
   statisticsMetaHasType,
 } from "../../../../data/recorder";
 import { deepEqual } from "../../../../common/util/deep-equal";
+import { statTypeMap } from "../../../../components/chart/statistics-chart";
 
 const statTypeStruct = union([
   literal("sum"),
@@ -157,7 +158,7 @@ export class HuiStatisticsGraphCardEditor
                     disabled:
                       !metaDatas ||
                       !metaDatas?.every((metaData) =>
-                        statisticsMetaHasType(metaData, stat_type)
+                        statisticsMetaHasType(metaData, statTypeMap[stat_type])
                       ),
                   })),
                 },

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -41,7 +41,6 @@ import { statTypeMap } from "../../../../components/chart/statistics-chart";
 const statTypeStruct = union([
   literal("state"),
   literal("sum"),
-  literal("sum_rel"),
   literal("min"),
   literal("max"),
   literal("mean"),
@@ -67,7 +66,7 @@ const cardConfigStruct = assign(
 );
 
 const periods = ["5minute", "hour", "day", "month"] as const;
-const stat_types = ["mean", "min", "max", "sum", "sum_rel", "state"] as const;
+const stat_types = ["mean", "min", "max", "sum", "state"] as const;
 
 @customElement("hui-statistics-graph-card-editor")
 export class HuiStatisticsGraphCardEditor

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -94,12 +94,6 @@ export class HuiStatisticsGraphCardEditor
       this.hass!,
       statisticIds || []
     );
-    if (statisticIds?.some((statistic_id) => statistic_id.includes(":"))) {
-      const { period, ...config } = this._config!;
-      fireEvent(this, "config-changed", {
-        config: config,
-      });
-    }
   };
 
   public willUpdate(changedProps: PropertyValues) {
@@ -239,8 +233,15 @@ export class HuiStatisticsGraphCardEditor
   }
 
   private _entitiesChanged(ev: CustomEvent): void {
+    const config = { ...this._config!, entities: ev.detail.value };
+    if (
+      config.entities?.some((statistic_id) => statistic_id.includes(":")) &&
+      config.period === "5minute"
+    ) {
+      delete config.period;
+    }
     fireEvent(this, "config-changed", {
-      config: { ...this._config!, entities: ev.detail.value },
+      config,
     });
   }
 

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -39,6 +39,7 @@ import { deepEqual } from "../../../../common/util/deep-equal";
 
 const statTypeStruct = union([
   literal("sum"),
+  literal("sum_rel"),
   literal("min"),
   literal("max"),
   literal("mean"),
@@ -64,7 +65,7 @@ const cardConfigStruct = assign(
 );
 
 const periods = ["5minute", "hour", "day", "month"] as const;
-const stat_types = ["mean", "min", "max", "sum"] as const;
+const stat_types = ["mean", "min", "max", "sum", "sum_rel"] as const;
 
 @customElement("hui-statistics-graph-card-editor")
 export class HuiStatisticsGraphCardEditor

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -518,8 +518,7 @@
           "max": "max",
           "mean": "mean",
           "state": "state",
-          "sum": "sum",
-          "sum_rel": "change"
+          "sum": "sum"
         }
       },
       "service-picker": {
@@ -3972,8 +3971,7 @@
                 "min": "Min",
                 "max": "Max",
                 "state": "State",
-                "sum": "Sum (absolute)",
-                "sum_rel": "Change"
+                "sum": "Sum (change during period)"
               },
               "chart_type": "Chart type",
               "periods": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -517,6 +517,7 @@
           "min": "min",
           "max": "max",
           "mean": "mean",
+          "state": "state",
           "sum": "sum",
           "sum_rel": "change"
         }
@@ -3970,6 +3971,7 @@
                 "mean": "Mean",
                 "min": "Min",
                 "max": "Max",
+                "state": "State",
                 "sum": "Sum (absolute)",
                 "sum_rel": "Change"
               },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -517,7 +517,8 @@
           "min": "min",
           "max": "max",
           "mean": "mean",
-          "sum": "sum"
+          "sum": "sum",
+          "sum_rel": "change"
         }
       },
       "service-picker": {
@@ -3969,7 +3970,8 @@
                 "mean": "Mean",
                 "min": "Min",
                 "max": "Max",
-                "sum": "Sum"
+                "sum": "Sum (absolute)",
+                "sum_rel": "Change"
               },
               "chart_type": "Chart type",
               "periods": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Support displaying relative change in statistics graph cards

Absolute value (already supported, but will use the `state` instead of the `sum` with this PR):
![image](https://user-images.githubusercontent.com/14281572/191474493-8a66badb-d6f2-4789-8c63-6ad3df3ede1a.png)

Relative change during a period (added by this PR):
![image](https://user-images.githubusercontent.com/14281572/191474563-e8c8f7a8-1b83-4baa-98f2-63bf3375cc53.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
