### PR TITLE
Update import blueprint dialog

### DIFF
--- a/src/panels/config/blueprint/dialog-import-blueprint.ts
+++ b/src/panels/config/blueprint/dialog-import-blueprint.ts
@@ -1,4 +1,5 @@
 import "@material/mwc-button";
+import { mdiOpenInNew } from "@mdi/js";
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
@@ -105,50 +106,61 @@ class DialogImportBlueprint extends LitElement {
                 >
                   <pre>${this._result.raw_data}</pre>
                 </ha-expansion-panel>`
-            : html`${this.hass.localize(
-                  "ui.panel.config.blueprint.add.import_introduction_link",
-                  "community_link",
-                  html`<a
-                    href="https://www.home-assistant.io/get-blueprints"
-                    target="_blank"
-                    rel="noreferrer noopener"
-                    >${this.hass.localize(
-                      "ui.panel.config.blueprint.add.community_forums"
-                    )}</a
-                  >`
-                )}<ha-textfield
+            : html`
+                <p>
+                  ${this.hass.localize(
+                    "ui.panel.config.blueprint.add.import_introduction"
+                  )}
+                </p>
+                <a
+                  href="https://www.home-assistant.io/get-blueprints"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  ${this.hass.localize(
+                    "ui.panel.config.blueprint.add.community_forums"
+                  )}
+                  <ha-svg-icon .path=${mdiOpenInNew}></ha-svg-icon>
+                </a>
+                <ha-textfield
                   id="input"
                   .label=${this.hass.localize(
                     "ui.panel.config.blueprint.add.url"
                   )}
                   .value=${this._url || ""}
                   dialogInitialFocus
-                ></ha-textfield>`}
+                ></ha-textfield>
+              `}
         </div>
+        <mwc-button
+          slot="primaryAction"
+          @click=${this.closeDialog}
+          .disabled=${this._saving}
+        >
+          ${this.hass.localize("ui.common.cancel")}
+        </mwc-button>
         ${!this._result
-          ? html`<mwc-button
-              slot="primaryAction"
-              @click=${this._import}
-              .disabled=${this._importing}
-            >
-              ${this._importing
-                ? html`<ha-circular-progress
-                    active
-                    size="small"
-                    .title=${this.hass.localize(
-                      "ui.panel.config.blueprint.add.importing"
-                    )}
-                  ></ha-circular-progress>`
-                : ""}
-              ${this.hass.localize("ui.panel.config.blueprint.add.import_btn")}
-            </mwc-button>`
-          : html`<mwc-button
-                slot="secondaryAction"
-                @click=${this.closeDialog}
-                .disabled=${this._saving}
+          ? html`
+              <mwc-button
+                slot="primaryAction"
+                @click=${this._import}
+                .disabled=${this._importing}
               >
-                ${this.hass.localize("ui.common.cancel")}
+                ${this._importing
+                  ? html`<ha-circular-progress
+                      active
+                      size="small"
+                      .title=${this.hass.localize(
+                        "ui.panel.config.blueprint.add.importing"
+                      )}
+                    ></ha-circular-progress>`
+                  : ""}
+                ${this.hass.localize(
+                  "ui.panel.config.blueprint.add.import_btn"
+                )}
               </mwc-button>
+            `
+          : html`
               <mwc-button
                 slot="primaryAction"
                 @click=${this._save}
@@ -164,7 +176,8 @@ class DialogImportBlueprint extends LitElement {
                     ></ha-circular-progress>`
                   : ""}
                 ${this.hass.localize("ui.panel.config.blueprint.add.save_btn")}
-              </mwc-button>`}
+              </mwc-button>
+            `}
       </ha-dialog>
     `;
   }
@@ -215,9 +228,19 @@ class DialogImportBlueprint extends LitElement {
   static styles = [
     haStyleDialog,
     css`
+      p {
+        margin-top: 0;
+        margin-bottom: 8px;
+      }
       ha-textfield {
         display: block;
-        margin-top: 8px;
+        margin-top: 24px;
+      }
+      a {
+        text-decoration: none;
+      }
+      a ha-svg-icon {
+        --mdc-icon-size: 16px;
       }
     `,
   ];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2257,15 +2257,15 @@
           "add": {
             "header": "Import a blueprint",
             "import_header": "Blueprint ''{name}''",
-            "import_introduction_link": "You can import blueprints of other users from Github and the {community_link}. Enter the URL of the blueprint below.",
-            "community_forums": "community forums",
-            "url": "URL of the blueprint",
+            "import_introduction": "Import blueprints of other users from GitHub and the community forums by pasting the address below.",
+            "community_forums": "View blueprints on the community forums",
+            "url": "Blueprint address",
             "raw_blueprint": "Blueprint content",
             "importing": "Loading blueprint…",
-            "import_btn": "Preview blueprint",
+            "import_btn": "Preview",
             "saving": "Importing blueprint…",
             "save_btn": "Import blueprint",
-            "error_no_url": "Please enter the URL of the blueprint.",
+            "error_no_url": "Please enter the blueprint address.",
             "unsupported_blueprint": "This blueprint is not supported",
             "file_name": "Blueprint Path"
           }


### PR DESCRIPTION
## Proposed change

<img width="621" alt="image" src="https://user-images.githubusercontent.com/5878303/191580926-e9a2fa28-8227-40ee-a91b-f251109ba27a.png">

On mobile, the dialog is different than your proposal @matthiasdebaat. We need a global redesign for this.

<img width="381" alt="image" src="https://user-images.githubusercontent.com/5878303/191581131-b4848046-706b-4e6e-ae70-92c0ec0a3e9a.png">

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13105
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
