### PR TITLE
Adjust forecast solar data time offset to match

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-solar-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-solar-graph-card.ts
@@ -455,7 +455,7 @@ export class HuiEnergySolarGraphCard
               } else {
                 dateObj.setMinutes(0, 0, 0);
               }
-              const time = dateObj.getTime();
+              const time = dateObj.getTime()-3.6e6;
               if (time in forecastsData) {
                 forecastsData[time] += value;
               } else {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
No
## Proposed change
Current forecast data appears time shifted to solar production graph.  `forecast_solar` integration appears to generate correct data reported as hourly reset generation, at the end-of-hour. This matches well to actual hourly production values, but on the front-end card it appears shifted by 1h.

This correction is  removing a 1h delay (3.6e6 ms) so the plots align on the frontend. Not sure if this is the best location for the fix, as it will also add to the weekly/montly forecast (but in that case 1h delay is minimal on the graph).

Current output (frontend 20220907.2 - latest)
![image](https://user-images.githubusercontent.com/3289118/192122271-1e06e257-2d1c-4566-9baf-431064c2d45e.png)

With the PR applied:
![image](https://user-images.githubusercontent.com/3289118/192122278-490edb49-6712-4c78-9841-d4de50f61a18.png)

Diagnostics of solar forecast integration: 
[config_entry-forecast_solar-5bd412b4d71d1d33e198cbb1f43e3ab6.json (4).txt](https://github.com/home-assistant/frontend/files/9639753/config_entry-forecast_solar-5bd412b4d71d1d33e198cbb1f43e3ab6.json.4.txt)


Relevant links:

- https://www.home-assistant.io/integrations/forecast_solar 
- https://community.home-assistant.io/t/cant-get-forecast-solar-forecast-to-line-up-with-my-production/432205

## Type of change

<!--
  What type of change
[config_entry-forecast_solar-5bd412b4d71d1d33e198cbb1f43e3ab6.json (4).txt](https://github.com/home-assistant/frontend/files/9639751/config_entry-forecast_solar-5bd412b4d71d1d33e198cbb1f43e3ab6.json.4.txt)
 does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```
Requires solar to be setup in the energy dashboard, with forecast_solar also setup to generate forecast data. 
A live system makes it easier to correlate the data
```


## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/74375
- This PR is related to issue: potentially related to https://github.com/home-assistant/core/pull/77217
- This PR is related to issue or discussion: https://community.home-assistant.io/t/cant-get-forecast-solar-forecast-to-line-up-with-my-production/432205

- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally. 
- **Note tested only via chromium debugger, I have not found a good way to run a separate front-end for testing on my live system that contains usable data**
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
