### PR TITLE
Bug Fix, can't create schedule on Sunday

### DIFF
--- a/src/panels/config/helpers/forms/ha-schedule-form.ts
+++ b/src/panels/config/helpers/forms/ha-schedule-form.ts
@@ -206,6 +206,7 @@ class HaScheduleForm extends LitElement {
   private get _events() {
     const events: any[] = [];
     const currentDay = new Date().getDay();
+    const baseDay = currentDay === 0 ? 7 : currentDay;
 
     for (const [i, day] of weekdays.entries()) {
       if (!this[`_${day}`].length) {
@@ -214,7 +215,7 @@ class HaScheduleForm extends LitElement {
 
       this[`_${day}`].forEach((item: ScheduleDay, index: number) => {
         // Add 7 to 0 because we start the calendar on Monday
-        const distance = i - currentDay + (i === 0 ? 7 : 0);
+        const distance = i - baseDay + (i === 0 ? 7 : 0);
 
         const start = new Date();
         start.setDate(start.getDate() + distance);


### PR DESCRIPTION

## Proposed change

This fixes a weird bug hard to find. Users can't create new scheduler on Sunday because the calculation of the distance fails. There is a discussion here:

https://github.com/home-assistant/frontend/issues/13865#issuecomment-1257278514

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Tested on Sunday and on Monday, the change is simple to understand once you see it.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
