### PR TITLE
Add `my` support for brands

### DIFF
--- a/src/panels/config/integrations/dialog-add-integration.ts
+++ b/src/panels/config/integrations/dialog-add-integration.ts
@@ -38,6 +38,7 @@ import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import "./ha-domain-integrations";
 import "./ha-integration-list-item";
+import { AddIntegrationDialogParams } from "./show-add-integration-dialog";
 
 export interface IntegrationListItem {
   name: string;
@@ -78,8 +79,9 @@ class AddIntegrationDialog extends LitElement {
 
   private _height?: number;
 
-  public showDialog(params): void {
+  public showDialog(params: AddIntegrationDialogParams): void {
     this._open = true;
+    this._pickedBrand = params.brand;
     this._initialFilter = params.initialFilter;
     this._narrow = matchMedia(
       "all and (max-width: 450px), all and (max-height: 500px)"

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -678,8 +678,16 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
   }
 
   private async _handleAdd(localizePromise: Promise<LocalizeFunc>) {
+    const brand = extractSearchParam("brand");
     const domain = extractSearchParam("domain");
     navigate("/config/integrations", { replace: true });
+
+    if (brand) {
+      showAddIntegrationDialog(this, {
+        brand,
+      });
+      return;
+    }
     if (!domain) {
       return;
     }
@@ -714,14 +722,14 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
 
     // Supported brand exists, so we can just create a flow
     if (Object.keys(supportedBrandsIntegrations).includes(domain)) {
-      const brand = supportedBrandsIntegrations[domain];
-      const slug = brand.supported_flows![0];
+      const supBrand = supportedBrandsIntegrations[domain];
+      const slug = supBrand.supported_flows![0];
 
       showConfirmationDialog(this, {
         text: this.hass.localize(
           "ui.panel.config.integrations.config_flow.supported_brand_flow",
           {
-            supported_brand: brand.name,
+            supported_brand: supBrand.name,
             flow_domain_name: domainToName(this.hass.localize, slug),
           }
         ),

--- a/src/panels/config/integrations/show-add-integration-dialog.ts
+++ b/src/panels/config/integrations/show-add-integration-dialog.ts
@@ -1,8 +1,13 @@
 import { fireEvent } from "../../../common/dom/fire_event";
 
+export interface AddIntegrationDialogParams {
+  brand?: string;
+  initialFilter?: string;
+}
+
 export const showAddIntegrationDialog = (
   element: HTMLElement,
-  dialogParams?: any
+  dialogParams?: AddIntegrationDialogParams
 ): void => {
   fireEvent(element, "show-dialog", {
     dialogTag: "dialog-add-integration",

--- a/src/panels/my/ha-panel-my.ts
+++ b/src/panels/my/ha-panel-my.ts
@@ -53,6 +53,12 @@ export const getMyRedirects = (hasSupervisor: boolean): Redirects => ({
       domain: "string",
     },
   },
+  brand: {
+    redirect: "/config/integrations/add",
+    params: {
+      brand: "string",
+    },
+  },
   integrations: {
     redirect: "/config/integrations",
   },


### PR DESCRIPTION
## Proposed change

Adds support for my.home-assistant.io to link to a specific brand.
https://github.com/home-assistant/my.home-assistant.io/pull/288

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
