### PR TITLE
Support typing negative values for ha-form-float

### DIFF
--- a/src/components/ha-form/ha-form-float.ts
+++ b/src/components/ha-form/ha-form-float.ts
@@ -26,6 +26,7 @@ export class HaFormFloat extends LitElement implements HaFormElement {
   protected render(): TemplateResult {
     return html`
       <ha-textfield
+        type="numeric"
         inputMode="decimal"
         .label=${this.label}
         .value=${this.data !== undefined ? this.data : ""}
@@ -52,6 +53,11 @@ export class HaFormFloat extends LitElement implements HaFormElement {
     let value: number | undefined;
 
     if (rawValue.endsWith(".")) {
+      return;
+    }
+
+    // Allow user to start typing a negative value
+    if (rawValue === "-") {
       return;
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixes https://github.com/home-assistant/frontend/issues/13493 and allows users to type negative values into the input field.

Also adds the `type="numeric"` to match other numeric input fields in HA.

If a user started to type in a negative number, the `-` would fail validation and reject the input because `-` alone is not a number. A workaround involved manually editing the `automation.yaml`. _OR_, after a user has input a number (e.g. `2`) into the field, they could prefix their number with a `-`, creating `-2` in the input field.

So we check if the entire input is exactly `-`, we allow the input _for now_. (and so you can't go typing `--` or `-2-`

The behavior to `return` follows the same behavior as if a user were to input `.` and try to save. 

![image](https://user-images.githubusercontent.com/3487107/193415071-b544cbce-23bb-438d-8f10-37248236afcd.png)

![image](https://user-images.githubusercontent.com/3487107/193415098-6f43ca63-cbdb-4d80-bd64-bf5b21a3caad.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

in the `automation.yaml`, I've set up an automation against the `sensor.outside_temperature` from the pre-built demo config.

From here, one can go to the automations tab and play around with updating the `below` attribute with negative values.

```yaml
- id: '1664632521018'
  alias: Test automation
  description: ''
  trigger:
  - type: temperature
    platform: device
    device_id: dcf2cb8bfafacd1b7711f5337b0944b5
    entity_id: sensor.outside_temperature
    domain: sensor
    below: -1
  condition: []
  action:
  - delay:
      hours: 0
      minutes: 0
      seconds: 3
      milliseconds: 0
  mode: single
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [#13493](https://github.com/home-assistant/frontend/issues/13493)
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
