### PR TITLE
Improve video user experience by loading camera thumbnail as initial video background image

### DIFF
--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -140,7 +140,7 @@ class HaCameraStream extends LitElement {
   private async _getPosterUrl(): Promise<void> {
     try {
       this._posterUrl = await fetchThumbnailUrlWithCache(
-        this.hass,
+        this.hass!,
         this.stateObj!.entity_id,
         this.clientWidth,
         this.clientHeight

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -15,6 +15,7 @@ import {
   CAMERA_SUPPORT_STREAM,
   computeMJPEGStreamUrl,
   fetchStreamUrl,
+  fetchThumbnailUrlWithCache,
   STREAM_TYPE_HLS,
   STREAM_TYPE_WEB_RTC,
 } from "../data/camera";
@@ -37,6 +38,9 @@ class HaCameraStream extends LitElement {
   @property({ type: Boolean, attribute: "allow-exoplayer" })
   public allowExoPlayer = false;
 
+  // Video background image before its loaded
+  @state() private _posterUrl: string;
+
   // We keep track if we should force MJPEG if there was a failure
   // to get the HLS stream url. This is reset if we change entities.
   @state() private _forceMJPEG?: string;
@@ -51,12 +55,15 @@ class HaCameraStream extends LitElement {
       !this._shouldRenderMJPEG &&
       this.stateObj &&
       (changedProps.get("stateObj") as CameraEntity | undefined)?.entity_id !==
-        this.stateObj.entity_id &&
-      this.stateObj!.attributes.frontend_stream_type === STREAM_TYPE_HLS
+        this.stateObj.entity_id
     ) {
-      this._forceMJPEG = undefined;
-      this._url = undefined;
-      this._getStreamUrl();
+      this._posterUrl = undefined;
+      this._getPosterUrl();
+      if (this.stateObj!.attributes.frontend_stream_type === STREAM_TYPE_HLS) {
+        this._forceMJPEG = undefined;
+        this._url = undefined;
+        this._getStreamUrl();
+      }
     }
   }
 
@@ -94,6 +101,7 @@ class HaCameraStream extends LitElement {
             .controls=${this.controls}
             .hass=${this.hass}
             .url=${this._url}
+            .posterUrl=${this._posterUrl}
           ></ha-hls-player>`
         : html``;
     }
@@ -105,6 +113,7 @@ class HaCameraStream extends LitElement {
         .controls=${this.controls}
         .hass=${this.hass}
         .entityid=${this.stateObj.entity_id}
+        .posterUrl=${this._posterUrl}
       ></ha-web-rtc-player>`;
     }
     return html``;
@@ -127,6 +136,15 @@ class HaCameraStream extends LitElement {
     }
     // Server side stream component required for HLS
     return !isComponentLoaded(this.hass!, "stream");
+  }
+
+  private async _getPosterUrl(): Promise<void> {
+    this._posterUrl = await fetchThumbnailUrlWithCache(
+      this.hass,
+      this.stateObj!.entity_id,
+      this.clientWidth,
+      this.clientHeight
+    );
   }
 
   private async _getStreamUrl(): Promise<void> {

--- a/src/components/ha-camera-stream.ts
+++ b/src/components/ha-camera-stream.ts
@@ -39,7 +39,7 @@ class HaCameraStream extends LitElement {
   public allowExoPlayer = false;
 
   // Video background image before its loaded
-  @state() private _posterUrl: string;
+  @state() private _posterUrl?: string;
 
   // We keep track if we should force MJPEG if there was a failure
   // to get the HLS stream url. This is reset if we change entities.
@@ -57,7 +57,6 @@ class HaCameraStream extends LitElement {
       (changedProps.get("stateObj") as CameraEntity | undefined)?.entity_id !==
         this.stateObj.entity_id
     ) {
-      this._posterUrl = undefined;
       this._getPosterUrl();
       if (this.stateObj!.attributes.frontend_stream_type === STREAM_TYPE_HLS) {
         this._forceMJPEG = undefined;
@@ -139,12 +138,17 @@ class HaCameraStream extends LitElement {
   }
 
   private async _getPosterUrl(): Promise<void> {
-    this._posterUrl = await fetchThumbnailUrlWithCache(
-      this.hass,
-      this.stateObj!.entity_id,
-      this.clientWidth,
-      this.clientHeight
-    );
+    try {
+      this._posterUrl = await fetchThumbnailUrlWithCache(
+        this.hass,
+        this.stateObj!.entity_id,
+        this.clientWidth,
+        this.clientHeight
+      );
+    } catch (err: any) {
+      // poster url is optional
+      this._posterUrl = undefined;
+    }
   }
 
   private async _getStreamUrl(): Promise<void> {

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -23,6 +23,8 @@ class HaHLSPlayer extends LitElement {
 
   @property() public url!: string;
 
+  @property() public posterUrl!: string;
+
   @property({ type: Boolean, attribute: "controls" })
   public controls = false;
 
@@ -78,6 +80,7 @@ class HaHLSPlayer extends LitElement {
         : ""}
       ${!this._errorIsFatal
         ? html`<video
+            poster=${this.posterUrl}
             ?autoplay=${this.autoPlay}
             .muted=${this.muted}
             ?playsinline=${this.playsInline}

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -80,7 +80,7 @@ class HaHLSPlayer extends LitElement {
         : ""}
       ${!this._errorIsFatal
         ? html`<video
-            poster=${this.posterUrl}
+            .poster=${this.posterUrl}
             ?autoplay=${this.autoPlay}
             .muted=${this.muted}
             ?playsinline=${this.playsInline}

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -34,6 +34,8 @@ class HaWebRtcPlayer extends LitElement {
   @property({ type: Boolean, attribute: "playsinline" })
   public playsInline = false;
 
+  @property() public posterUrl!: string;
+
   @state() private _error?: string;
 
   // don't cache this, as we remove it on disconnects
@@ -54,6 +56,7 @@ class HaWebRtcPlayer extends LitElement {
         .muted=${this.muted}
         ?playsinline=${this.playsInline}
         ?controls=${this.controls}
+        poster=${this.posterUrl}
       ></video>
     `;
   }

--- a/src/components/ha-web-rtc-player.ts
+++ b/src/components/ha-web-rtc-player.ts
@@ -56,7 +56,7 @@ class HaWebRtcPlayer extends LitElement {
         .muted=${this.muted}
         ?playsinline=${this.playsInline}
         ?controls=${this.controls}
-        poster=${this.posterUrl}
+        .poster=${this.posterUrl}
       ></video>
     `;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Set a poster image for a stream (a default background for a video while it is loading) based on the camera snapshot. This improves the video experience, especially on mobile android where the default background image looks like a broken video.  This is from an idea of the post at https://www.reddit.com/r/homeassistant/comments/vu0ep7/my_strategy_for_camera_feeds_to_appear_to_load/ flagged by @AngellusMortis as a good feature to add.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
