### PR TITLE
Show climate and media player entities in Area card

### DIFF
--- a/src/panels/lovelace/cards/hui-area-card.ts
+++ b/src/panels/lovelace/cards/hui-area-card.ts
@@ -62,7 +62,7 @@ const ALERT_DOMAINS = ["binary_sensor"];
 
 const TOGGLE_DOMAINS = ["light", "switch", "fan"];
 
-const OTHER_DOMAINS = ["camera", "climate", "media_player"];
+const OTHER_DOMAINS = ["camera"];
 
 const DEVICE_CLASSES = {
   sensor: ["temperature", "humidity"],
@@ -115,6 +115,7 @@ export class HuiAreaCard
       areaId: string,
       devicesInArea: Set<string>,
       registryEntities: EntityRegistryEntry[],
+      extraDomains: Array<string> | undefined,
       states: HomeAssistant["states"]
     ) => {
       const entitiesInArea = registryEntities
@@ -136,7 +137,9 @@ export class HuiAreaCard
           !TOGGLE_DOMAINS.includes(domain) &&
           !SENSOR_DOMAINS.includes(domain) &&
           !ALERT_DOMAINS.includes(domain) &&
-          !OTHER_DOMAINS.includes(domain)
+          !OTHER_DOMAINS.includes(domain) &&
+          extraDomains &&
+          !extraDomains.includes(domain)
         ) {
           continue;
         }
@@ -170,6 +173,7 @@ export class HuiAreaCard
       this._config!.area,
       this._devicesInArea(this._config!.area, this._devices!),
       this._entities!,
+      this._config!.show_extra_domains,
       this.hass.states
     )[domain];
     if (!entities) {
@@ -193,6 +197,7 @@ export class HuiAreaCard
       this._config!.area,
       this._devicesInArea(this._config!.area, this._devices!),
       this._entities!,
+      this._config!.show_extra_domains,
       this.hass.states
     )[domain].filter((entity) =>
       deviceClass ? entity.attributes.device_class === deviceClass : true
@@ -307,6 +312,7 @@ export class HuiAreaCard
       this._config.area,
       this._devicesInArea(this._config.area, this._devices),
       this._entities,
+      this._config!.show_extra_domains,
       this.hass.states
     );
 
@@ -336,6 +342,7 @@ export class HuiAreaCard
       this._config.area,
       this._devicesInArea(this._config.area, this._devices),
       this._entities,
+      this._config!.show_extra_domains,
       this.hass.states
     );
     const area = this._area(this._config.area, this._areas);
@@ -438,31 +445,33 @@ export class HuiAreaCard
                     `
                   : "";
               })}
-              ${OTHER_DOMAINS.map((domain) => {
-                if (domain === "camera") {
-                  return "";
-                }
+              ${this._config!.show_extra_domains
+                ? this._config!.show_extra_domains.map((domain) => {
+                    if (domain === "camera") {
+                      return "";
+                    }
 
-                if (!(domain in entitiesByDomain)) {
-                  return "";
-                }
+                    if (!(domain in entitiesByDomain)) {
+                      return "";
+                    }
 
-                return entitiesByDomain[domain].map((entity) => {
-                  const on = !STATES_OFF.includes(entity.state);
-                  const icon = domainIcon(domain, entity);
+                    return entitiesByDomain[domain].map((entity) => {
+                      const on = !STATES_OFF.includes(entity.state);
+                      const icon = domainIcon(domain, entity);
 
-                  return html`
-                    <ha-icon-button
-                      class=${on ? "on" : "off"}
-                      .path=${icon}
-                      .domain=${domain}
-                      .entity=${entity.entity_id}
-                      @click=${this._handleAction}
-                    >
-                    </ha-icon-button>
-                  `;
-                });
-              })}
+                      return html`
+                        <ha-icon-button
+                          class=${on ? "on" : "off"}
+                          .path=${icon}
+                          .domain=${domain}
+                          .entity=${entity.entity_id}
+                          @click=${this._handleAction}
+                        >
+                        </ha-icon-button>
+                      `;
+                    });
+                  })
+                : ""}
             </div>
           </div>
         </div>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -82,6 +82,7 @@ export interface AreaCardConfig extends LovelaceCardConfig {
   area: string;
   navigation_path?: string;
   show_camera?: boolean;
+  show_extra_domains?: Array<string>;
 }
 
 export interface ButtonCardConfig extends LovelaceCardConfig {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3883,7 +3883,8 @@
             "area": {
               "name": "Area",
               "description": "The Area card automatically displays entities of a specific area.",
-              "show_camera": "Show camera feed instead of area picture"
+              "show_camera": "Show camera feed instead of area picture",
+              "show_extra_domains": "Show entities of additional domains from this list"
             },
             "calendar": {
               "name": "Calendar",


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This adds "climate" and "media_player" entities to the area card. These entities are shown as buttons in the card, but unlike "toggle" entities, clicking on the button will open the more-info dialog for the corresponding entity.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

Before (media player):

![2022-10-02-135828_999x570_scrot](https://user-images.githubusercontent.com/117643/193456631-8bc2b098-8377-48a0-b8e1-e343dbc0bcef.png)

After (media player):

![2022-10-02-140300_995x575_scrot](https://user-images.githubusercontent.com/117643/193456648-dfaa669d-e6e5-4286-8534-d788f26ff20c.png)

Before (climate):

![2022-10-02-135847_1004x574_scrot](https://user-images.githubusercontent.com/117643/193456655-06631620-d915-4659-a66e-bfa78ef6aff9.png)

After (climate, off):

![2022-10-02-140307_1002x569_scrot](https://user-images.githubusercontent.com/117643/193456665-eaed3879-2644-4abf-9c0b-d7b2ea439f1c.png)

After (climate, on):

![2022-10-02-142548_1006x571_scrot](https://user-images.githubusercontent.com/117643/193456676-d28f417c-72f8-4502-8f7b-6be856bb3cf9.png)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
