### PR TITLE
Avoid tabbing onto show/hide password icon.

### DIFF
--- a/src/components/ha-selector/ha-selector-text.ts
+++ b/src/components/ha-selector/ha-selector-text.ts
@@ -66,6 +66,7 @@ export class HaTextSelector extends LitElement {
             .label=${`${this._unmaskedPassword ? "Hide" : "Show"} password`}
             @click=${this._toggleUnmaskedPassword}
             .path=${this._unmaskedPassword ? mdiEyeOff : mdiEye}
+            tabindex="-1"
           ></ha-icon-button>`
         : ""}`;
   }


### PR DESCRIPTION
## Breaking change

Users exclusively navigating the webgui using a keyboard may not be able to button for showing/hiding password fields.

I suggest that the impact of this would be low, as displaying passwords should be discouraged.

## Proposed change

When filling out a form, such as the initial onboarding/creation of a new user the password field is used. This password field currently has two "tab-selectable" items: the password input box, and the icon/button to toggle showing or hiding of the password.

Intuitively, when I am filling out the onboarding form, I will click on the "Name field", tab to the username field, and so-on through the password and confirm password field, finally using enter to submit.

However, when attempting to tab between the password and confirm password field, tabbing currently selects the icon first, confusing the user and causing them to press the tab button a second time to get to their actual desired field.

<img width="200" alt="Screen Shot 2022-10-02 at 3 25 56 PM" src="https://user-images.githubusercontent.com/68717336/193472550-6e4772dc-e941-40a8-ae01-dbff7b12ce3a.png"> **VS** <img width="206" alt="Screen Shot 2022-10-02 at 3 26 57 PM" src="https://user-images.githubusercontent.com/68717336/193472553-b043ee37-76fe-4a32-9b28-643acefc5a4e.png">

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

Reset Home Assistant to a default configuration, to trigger the onboarding process. Fill out the create user form, primarily using the keyboard to tab between fields.

## Additional information

While there is not a forum post, I believe this should be tagged as WTH.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.