### PR TITLE
Update scene dashboard to use relative time for last_activated

### DIFF
--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -11,6 +11,7 @@ import "@polymer/paper-tooltip/paper-tooltip";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { differenceInDays } from "date-fns/esm";
 import { fireEvent, HASSDomEvent } from "../../../common/dom/fire_event";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { navigate } from "../../../common/navigate";
@@ -45,8 +46,6 @@ import { configSections } from "../ha-panel-config";
 import { formatShortDateTime } from "../../../common/datetime/format_date_time";
 import { relativeTime } from "../../../common/datetime/relative_time";
 import { UNAVAILABLE_STATES } from "../../../data/entity";
-
-const DAY_IN_MILLISECONDS = 86400000;
 
 @customElement("ha-scene-dashboard")
 class HaSceneDashboard extends LitElement {
@@ -115,13 +114,10 @@ class HaSceneDashboard extends LitElement {
           template: (last_activated) => {
             const date = new Date(last_activated);
             const now = new Date();
-
-            const diff = now.getTime() - date.getTime();
-            const dayDiff = diff / DAY_IN_MILLISECONDS;
-
+            const dayDifference = differenceInDays(now, date);
             return html`
               ${last_activated && !UNAVAILABLE_STATES.includes(last_activated)
-                ? dayDiff > 3
+                ? dayDifference > 3
                   ? formatShortDateTime(date, this.hass.locale)
                   : relativeTime(date, this.hass.locale)
                 : this.hass.localize("ui.components.relative_time.never")}

--- a/src/panels/config/scene/ha-scene-dashboard.ts
+++ b/src/panels/config/scene/ha-scene-dashboard.ts
@@ -42,8 +42,11 @@ import { HomeAssistant, Route } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
 import { configSections } from "../ha-panel-config";
-import { formatDateTime } from "../../../common/datetime/format_date_time";
+import { formatShortDateTime } from "../../../common/datetime/format_date_time";
+import { relativeTime } from "../../../common/datetime/relative_time";
 import { UNAVAILABLE_STATES } from "../../../data/entity";
+
+const DAY_IN_MILLISECONDS = 86400000;
 
 @customElement("ha-scene-dashboard")
 class HaSceneDashboard extends LitElement {
@@ -109,11 +112,21 @@ class HaSceneDashboard extends LitElement {
           ),
           sortable: true,
           width: "30%",
-          template: (last_activated) => html`
-            ${last_activated && !UNAVAILABLE_STATES.includes(last_activated)
-              ? formatDateTime(new Date(last_activated), this.hass.locale)
-              : this.hass.localize("ui.components.relative_time.never")}
-          `,
+          template: (last_activated) => {
+            const date = new Date(last_activated);
+            const now = new Date();
+
+            const diff = now.getTime() - date.getTime();
+            const dayDiff = diff / DAY_IN_MILLISECONDS;
+
+            return html`
+              ${last_activated && !UNAVAILABLE_STATES.includes(last_activated)
+                ? dayDiff > 3
+                  ? formatShortDateTime(date, this.hass.locale)
+                  : relativeTime(date, this.hass.locale)
+                : this.hass.localize("ui.components.relative_time.never")}
+            `;
+          },
         };
       }
       columns.only_editable = {


### PR DESCRIPTION
## Proposed change

The automation picker was recently updated to use relative time for `last_triggered`; this PR implements a similar change for `last_activated` in the scene dashboard for consistency.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
