### PR TITLE
Highlight focus on show/hide password toggle

### DIFF
--- a/src/components/ha-selector/ha-selector-text.ts
+++ b/src/components/ha-selector/ha-selector-text.ts
@@ -98,13 +98,13 @@ export class HaTextSelector extends LitElement {
       }
       ha-icon-button {
         position: absolute;
-        top: 16px;
-        right: 16px;
-        --mdc-icon-button-size: 24px;
+        top: 10px;
+        right: 10px;
+        --mdc-icon-button-size: 36px;
         --mdc-icon-size: 20px;
         color: var(--secondary-text-color);
         inset-inline-start: initial;
-        inset-inline-end: 16px;
+        inset-inline-end: 10px;
         direction: var(--direction);
       }
     `;


### PR DESCRIPTION
## Proposed change

Follow-up to https://github.com/home-assistant/frontend/pull/13954#issuecomment-1266581760. This is a visual change only.

The toggle for show/hide has the focus circle around it relatively small compared to the icon size. While filling out the form, the eye was sometimes not drawn to it. I personally experienced this, thinking my "tabbing" had gone off screen somewhere because of a bug.

Increasing the radius of the focus circle will help capture the eyes attention, indicating where the focus has gone.
I felt 36px for the radius was more visually appealing/eye-drawing. Below are account creating screen comparisons for the original (24px), and as I'm suggesting (36px).

<img width="250" alt="Screen Shot 2022-10-04 at 6 27 36 PM" src="https://user-images.githubusercontent.com/68717336/193942556-5c9ca863-31a4-4662-bfcd-9ec05e11c0b8.png"> <img width="250" alt="Screen Shot 2022-10-04 at 6 26 12 PM" src="https://user-images.githubusercontent.com/68717336/193942537-8cce8a5b-ca35-4096-afb1-90c939d6f25f.png">

## Type of change


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: This could be classified as "WTH".
- Link to documentation pull request:


For reference, I've included a visual comparison below for the differences between 32px (left), 36px as proposed (center) and 40px (right).
<img width="250" alt="Screen Shot 2022-10-04 at 6 26 22 PM" src="https://user-images.githubusercontent.com/68717336/193942547-a9f397fb-8822-4531-b1cb-e8e784a663f3.png">  <img width="250" alt="Screen Shot 2022-10-04 at 6 26 12 PM" src="https://user-images.githubusercontent.com/68717336/193942537-8cce8a5b-ca35-4096-afb1-90c939d6f25f.png"> <img width="250" alt="Screen Shot 2022-10-04 at 6 41 57 PM" src="https://user-images.githubusercontent.com/68717336/193943980-5a492017-58d8-4573-b913-b536c63b54a8.png">

## Checklist


- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.