### PR TITLE
Fix onboarding create new user password checks

### DIFF
--- a/src/onboarding/onboarding-create-user.ts
+++ b/src/onboarding/onboarding-create-user.ts
@@ -91,7 +91,7 @@ class OnboardingCreateUser extends LitElement {
         this._newUser.username &&
         this._newUser.password &&
         this._newUser.password_confirm &&
-        this._newUser.password == this._newUser.password_confirm
+        this._newUser.password === this._newUser.password_confirm
       ) {
         this._submitForm(ev);
       }

--- a/src/onboarding/onboarding-create-user.ts
+++ b/src/onboarding/onboarding-create-user.ts
@@ -72,7 +72,9 @@ class OnboardingCreateUser extends LitElement {
         .disabled=${this._loading ||
         !this._newUser.name ||
         !this._newUser.username ||
-        !this._newUser.password}
+        !this._newUser.password ||
+        !this._newUser.password_confirm ||
+        this._newUser.password != this._newUser.password_confirm}
       >
         ${this.localize("ui.panel.page-onboarding.user.create_account")}
       </mwc-button>
@@ -88,7 +90,8 @@ class OnboardingCreateUser extends LitElement {
         this._newUser.name &&
         this._newUser.username &&
         this._newUser.password &&
-        this._newUser.password_confirm
+        this._newUser.password_confirm &&
+        this._newUser.password == this._newUser.password_confirm
       ) {
         this._submitForm(ev);
       }

--- a/src/onboarding/onboarding-create-user.ts
+++ b/src/onboarding/onboarding-create-user.ts
@@ -74,7 +74,7 @@ class OnboardingCreateUser extends LitElement {
         !this._newUser.username ||
         !this._newUser.password ||
         !this._newUser.password_confirm ||
-        this._newUser.password != this._newUser.password_confirm}
+        this._newUser.password !== this._newUser.password_confirm}
       >
         ${this.localize("ui.panel.page-onboarding.user.create_account")}
       </mwc-button>


### PR DESCRIPTION
## Proposed change

During the onboarding process, the first step is to create a new user. `name`, `username`, `password` and `confirm password` are required fields. 

`confirm password` is marked as a required field, and shows an error message to the user if it did not match the password field. However, the user could still submit the form, without putting any text into the confirm password field. Further, even if the user entered text into the `confirm password`, the form could still be submitted if the passwords did not match.

This PR fixes this logic and prevents the user from submitting the form if the passwords do not match.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.