### PR TITLE
Fix calendar card list view

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-calendar-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-calendar-card-editor.ts
@@ -31,7 +31,7 @@ const cardConfigStruct = assign(
   })
 );
 
-const views = ["dayGridMonth", "dayGridDay", "listWeek"] as const;
+const views = ["dayGridMonth", "dayGridDay", "list"] as const;
 
 @customElement("hui-calendar-card-editor")
 export class HuiCalendarCardEditor

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3893,7 +3893,7 @@
               "views": {
                 "dayGridMonth": "Month",
                 "dayGridDay": "Day",
-                "listWeek": "List"
+                "list": "List"
               }
             },
             "conditional": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fixes #13999
The Calendar Card Configuration was storing `listWeek` instead of `list`. `list` is a custom view [defined here](https://github.com/home-assistant/frontend/blob/88983806ae4bb02d2446f03270b579bf253d93ba/src/panels/calendar/ha-full-calendar.ts#L67-L71) and was actually used by the [card here](https://github.com/home-assistant/frontend/blob/88983806ae4bb02d2446f03270b579bf253d93ba/src/panels/lovelace/cards/hui-calendar-card.ts#L119-L120). It was just not used by the configuration for initial load.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

Note: I do not have a lokalise account, so I was not able to run `script/translations_download`. Please advise on whether this is needed to be run by me.

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13999
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
