### PR TITLE
Some fixes for low carbon display

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-carbon-consumed-gauge-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-carbon-consumed-gauge-card.ts
@@ -85,10 +85,6 @@ class HuiEnergyCarbonGaugeCard
 
     let value: number | undefined;
 
-    if (totalGridConsumption === 0) {
-      value = 100;
-    }
-
     if (this._data.fossilEnergyConsumption && totalGridConsumption) {
       const highCarbonEnergy = this._data.fossilEnergyConsumption
         ? Object.values(this._data.fossilEnergyConsumption).reduce(
@@ -141,12 +137,12 @@ class HuiEnergyCarbonGaugeCard
               ></ha-gauge>
               <div class="name">
                 ${this.hass.localize(
-                  "ui.panel.lovelace.cards.energy.carbon_consumed_gauge.non_fossil_energy_consumed"
+                  "ui.panel.lovelace.cards.energy.carbon_consumed_gauge.low_carbon_energy_consumed"
                 )}
               </div>
             `
           : html`${this.hass.localize(
-              "ui.panel.lovelace.cards.energy.carbon_consumed_gauge.non_fossil_energy_not_calculated"
+              "ui.panel.lovelace.cards.energy.carbon_consumed_gauge.low_carbon_energy_not_calculated"
             )}`}
       </ha-card>
     `;

--- a/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-distribution-card.ts
@@ -262,7 +262,7 @@ class HuiEnergyDistrubutionCard
                   : html`<div class="circle-container low-carbon">
                       <span class="label"
                         >${this.hass.localize(
-                          "ui.panel.lovelace.cards.energy.energy_distribution.non_fossil"
+                          "ui.panel.lovelace.cards.energy.energy_distribution.low_carbon"
                         )}</span
                       >
                       <a
@@ -272,11 +272,9 @@ class HuiEnergyDistrubutionCard
                         rel="noopener no referrer"
                       >
                         <ha-svg-icon .path=${mdiLeaf}></ha-svg-icon>
-                        ${lowCarbonEnergy
-                          ? formatNumber(lowCarbonEnergy, this.hass.locale, {
-                              maximumFractionDigits: 1,
-                            })
-                          : "—"}
+                        ${formatNumber(lowCarbonEnergy || 0, this.hass.locale, {
+                          maximumFractionDigits: 1,
+                        })}
                         kWh
                       </a>
                       <svg width="80" height="30">

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3691,7 +3691,7 @@
               "grid": "Grid",
               "gas": "Gas",
               "solar": "Solar",
-              "non_fossil": "Non-fossil",
+              "low_carbon": "Low-carbon",
               "home": "Home",
               "battery": "Battery",
               "go_to_energy_dashboard": "Go to the energy dashboard"
@@ -3702,8 +3702,8 @@
             },
             "carbon_consumed_gauge": {
               "card_indicates_energy_used": "This card indicates how much of the energy consumed by your home was generated using non-fossil fuels like solar, wind and nuclear. The higher, the better!",
-              "non_fossil_energy_consumed": "Non-fossil energy consumed",
-              "non_fossil_energy_not_calculated": "Consumed non-fossil energy couldn't be calculated"
+              "low_carbon_energy_consumed": "Low-carbon energy consumed",
+              "low_carbon_energy_not_calculated": "Consumed low-carbon energy couldn't be calculated"
             }
           }
         },


### PR DESCRIPTION
## Proposed change

- [x] Replace "non-fossil" by "low-carbon"
- [x] Do not show 100% low carbon energy if there is no consumption
- [x] Show `0` instead of `-` in the circle when no low carbon energy (to be consistent with other circles)
 
## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
