### PR TITLE
Fix timezone problem for "Today" in the Date Picker.

### DIFF
--- a/src/components/ha-dialog-date-picker.ts
+++ b/src/components/ha-dialog-date-picker.ts
@@ -56,7 +56,7 @@ export class HaDialogDatePicker extends LitElement {
   }
 
   private _setToday() {
-    this._value = new Date().toISOString().split("T")[0];
+    this._value = new Date().toLocaleDateString("en-CA");
   }
 
   private _setValue() {

--- a/src/components/ha-dialog-date-picker.ts
+++ b/src/components/ha-dialog-date-picker.ts
@@ -56,6 +56,7 @@ export class HaDialogDatePicker extends LitElement {
   }
 
   private _setToday() {
+    // en-CA locale used for date format YYYY-MM-DD
     this._value = new Date().toLocaleDateString("en-CA");
   }
 


### PR DESCRIPTION
## Proposed change

Fixes the `Today` button actually resetting to the current date, based on the users browser date. 

Currently, the date string `YYYY-MM-DD` that is passed to the `date picker` app gets an ISO 8601, which is based on Zulu time, or GMT. However, for users on in a different timezone than GMT, could have the date be set either forward, in the case of users in a `GMT-#` timezone, or backwards in the case of users in a `GMT+#`.

The new date string is format `YYYY-MM-DD` will reflect the actual date in the users local timezone/browser time.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/frontend/issues/13573
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

