### PR TITLE
Update ZHA manage device dialog to use a form for cluster command arguments

### DIFF
--- a/src/components/buttons/ha-call-service-button.js
+++ b/src/components/buttons/ha-call-service-button.js
@@ -14,6 +14,7 @@ class HaCallServiceButton extends EventsMixin(PolymerElement) {
       <ha-progress-button
         id="progress"
         progress="[[progress]]"
+        disabled="[[disabled]]"
         on-click="buttonTapped"
         tabindex="0"
         ><slot></slot
@@ -47,6 +48,10 @@ class HaCallServiceButton extends EventsMixin(PolymerElement) {
 
       confirmation: {
         type: String,
+      },
+
+      disabled: {
+        type: Boolean,
       },
     };
   }

--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -106,6 +106,7 @@ export interface Command {
   name: string;
   id: number;
   type: string;
+  schema: HaFormSchema[];
 }
 
 export interface ReadAttributeServiceData {

--- a/src/panels/config/integrations/integration-panels/zha/types.ts
+++ b/src/panels/config/integrations/integration-panels/zha/types.ts
@@ -35,6 +35,7 @@ export interface IssueCommandServiceData {
   cluster_type: string;
   command: number;
   command_type: string;
+  data?: any;
 }
 
 export interface ZHADeviceSelectedParams {

--- a/src/panels/config/integrations/integration-panels/zha/types.ts
+++ b/src/panels/config/integrations/integration-panels/zha/types.ts
@@ -35,7 +35,7 @@ export interface IssueCommandServiceData {
   cluster_type: string;
   command: number;
   command_type: string;
-  args?: any;
+  params?: any;
 }
 
 export interface ZHADeviceSelectedParams {

--- a/src/panels/config/integrations/integration-panels/zha/types.ts
+++ b/src/panels/config/integrations/integration-panels/zha/types.ts
@@ -35,7 +35,7 @@ export interface IssueCommandServiceData {
   cluster_type: string;
   command: number;
   command_type: string;
-  data?: any;
+  args?: any;
 }
 
 export interface ZHADeviceSelectedParams {

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
@@ -170,13 +170,14 @@ export class ZHAClusterCommands extends LitElement {
       cluster_type: this.selectedCluster!.type,
       command: this._selectedCommandId!,
       command_type: selectedCommand!.type,
-      data: this._commandData,
+      args: this._commandData,
     };
   }
 
   private async _commandDataChanged(ev: CustomEvent): Promise<void> {
     this._commandData = ev.detail.value;
-    this._computeIssueClusterCommandServiceData();
+    this._issueClusterCommandServiceData =
+      this._computeIssueClusterCommandServiceData();
   }
 
   private _onManufacturerCodeOverrideChanged(value: ChangeEvent): void {

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
@@ -13,6 +13,7 @@ import { stopPropagation } from "../../../../../common/dom/stop_propagation";
 import "../../../../../components/buttons/ha-call-service-button";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-select";
+import "../../../../../components/ha-form/ha-form";
 import {
   Cluster,
   Command,
@@ -41,6 +42,12 @@ export class ZHAClusterCommands extends LitElement {
 
   @state()
   private _issueClusterCommandServiceData?: IssueCommandServiceData;
+
+  @state()
+  private _canIssueCommand = false;
+
+  @state()
+  private _commandData: Record<string, any> = {};
 
   protected updated(changedProperties: PropertyValues): void {
     if (changedProperties.has("selectedCluster")) {
@@ -93,12 +100,23 @@ export class ZHAClusterCommands extends LitElement {
                   )}
                 ></paper-input>
               </div>
+              <div class="command-form">
+                <ha-form
+                  .hass=${this.hass}
+                  .schema=${this._commands.find(
+                    (command) => command.id === this._selectedCommandId
+                  )!.schema}
+                  @value-changed=${this._commandDataChanged}
+                  .data=${this._commandData}
+                ></ha-form>
+              </div>
               <div class="card-actions">
                 <ha-call-service-button
                   .hass=${this.hass}
                   domain="zha"
                   service="issue_zigbee_cluster_command"
                   .serviceData=${this._issueClusterCommandServiceData}
+                  .disabled=${!this._canIssueCommand}
                 >
                   ${this.hass!.localize(
                     "ui.panel.config.zha.cluster_commands.issue_zigbee_command"
@@ -133,16 +151,32 @@ export class ZHAClusterCommands extends LitElement {
     if (!this.device || !this.selectedCluster || !this._commands) {
       return undefined;
     }
+    const selectedCommand = this._commands.find(
+      (command) => command.id === this._selectedCommandId
+    );
+
+    this._canIssueCommand =
+      this._commandData &&
+      selectedCommand!.schema.every(
+        (field) =>
+          !field.required ||
+          !["", undefined].includes(this._commandData![field.name])
+      );
+
     return {
       ieee: this.device!.ieee,
       endpoint_id: this.selectedCluster!.endpoint_id,
       cluster_id: this.selectedCluster!.id,
       cluster_type: this.selectedCluster!.type,
       command: this._selectedCommandId!,
-      command_type: this._commands.find(
-        (command) => command.id === this._selectedCommandId
-      )!.type,
+      command_type: selectedCommand!.type,
+      data: this._commandData,
     };
+  }
+
+  private async _commandDataChanged(ev: CustomEvent): Promise<void> {
+    this._commandData = ev.detail.value;
+    this._computeIssueClusterCommandServiceData();
   }
 
   private _onManufacturerCodeOverrideChanged(value: ChangeEvent): void {
@@ -180,6 +214,12 @@ export class ZHAClusterCommands extends LitElement {
         }
 
         .input-text {
+          padding-left: 28px;
+          padding-right: 28px;
+          padding-bottom: 10px;
+        }
+
+        .command-form {
           padding-left: 28px;
           padding-right: 28px;
           padding-bottom: 10px;

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
@@ -170,7 +170,7 @@ export class ZHAClusterCommands extends LitElement {
       cluster_type: this.selectedCluster!.type,
       command: this._selectedCommandId!,
       command_type: selectedCommand!.type,
-      args: this._commandData,
+      params: this._commandData,
     };
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR changes the cluster command card in the ZHA manage device dialog to use forms instead of a single field for command arguments.  ~~**REQUIRES** https://github.com/home-assistant/core/pull/79908~~ **BACKEND MERGED**

Fixes: #10633 

![](https://user-images.githubusercontent.com/1335687/194726187-21c92a75-2933-4b94-aad7-cc7eede4568a.png)

Form in action: 

https://share.icloud.com/photos/085jtifVaz58DQQmMnqQ03hhw


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
