### PR TITLE
Fix zero for a slider in a blueprint

### DIFF
--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -184,7 +184,7 @@ export class HaBlueprintAutomationEditor extends LitElement {
     ev.stopPropagation();
     const target = ev.target as any;
     const key = target.key;
-    const value = ev.detail?.value || target.value;
+    const value = !isNaN(ev.detail?.value) ? ev.detail?.value : target.value;
     if (
       (this.config.use_blueprint.input &&
         this.config.use_blueprint.input[key] === value) ||

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -184,7 +184,7 @@ export class HaBlueprintAutomationEditor extends LitElement {
     ev.stopPropagation();
     const target = ev.target as any;
     const key = target.key;
-    const value = !isNaN(ev.detail?.value) ? ev.detail?.value : target.value;
+    const value = ev.detail?.value ?? target.value;
     if (
       (this.config.use_blueprint.input &&
         this.config.use_blueprint.input[key] === value) ||


### PR DESCRIPTION
## Proposed change

Zero was being treated as `false` for a slider input. This now checks if the input is a number, instead of falsey.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

For simplicity, I replaced the "no motion wait" slider in the demo `motion_light.yaml` blueprint with:
```yaml
    no_motion_wait:
      name: Test
      description: Test percent
      selector:
        number:
          min: 0
          max: 100
          unit_of_measurement: "%"
          mode: slider
```

## Additional information

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/frontend/issues/13867
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.