### PR TITLE
Added automatic expansible dialog in order to fit the text of the Titles of the Tab Bar

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -43,6 +43,8 @@ export class MoreInfoDialog extends LitElement {
 
   @property({ type: Boolean, reflect: true }) public large = false;
 
+  @property({ type: Boolean, reflect: true }) public extended = false;
+
   @state() private _entityId?: string | null;
 
   @state() private _currTab: Tab = "info";
@@ -55,6 +57,7 @@ export class MoreInfoDialog extends LitElement {
     }
     this._currTab = params.tab || "info";
     this.large = false;
+    this.extended = false;
   }
 
   public closeDialog() {
@@ -92,6 +95,9 @@ export class MoreInfoDialog extends LitElement {
     const domain = computeDomain(entityId);
     const name = (stateObj && computeStateName(stateObj)) || entityId;
     const tabs = this._getTabs(entityId, this.hass.user!.is_admin);
+    if (tabs.length > 3) {
+      this.extended = true;
+    }
 
     return html`
       <ha-dialog
@@ -306,6 +312,18 @@ export class MoreInfoDialog extends LitElement {
             --mdc-dialog-max-height: calc(100% - 72px);
           }
 
+          :host([extended]) ha-dialog {
+            --mdc-dialog-min-width: 560px;
+            --mdc-dialog-max-width: 85vw;
+            --dialog-surface-margin-top: 40px;
+            --mdc-dialog-max-height: calc(100% - 72px);
+          }
+
+          :host([extended]) .content {
+            min-width: 100%;
+            max-width: fit-content;
+          }
+
           .main-title {
             overflow: hidden;
             text-overflow: ellipsis;
@@ -314,8 +332,8 @@ export class MoreInfoDialog extends LitElement {
 
           :host([large]) ha-dialog,
           ha-dialog[data-domain="camera"] {
-            --mdc-dialog-min-width: 90vw;
-            --mdc-dialog-max-width: 90vw;
+            --mdc-dialog-min-width: 90vw !important;
+            --mdc-dialog-max-width: 90vw !important;
           }
         }
 


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

In plain English language the Dialogs looks good and everything fits, but not in other langs. Specifically the titles of the Tab Bar of the Dialog get so big that it overcomes the Dialog element and you will have to scroll horizontally to see the rest of the Tabs (it's a forced feature of the Tab Bar component of Material Design).

So what I did is under those circumstances (having 4 tabs or more) let the Dialog element resize with a dynamic width based on the size available on the screen so that it will **take the minimum needed** to not have to scroll.

It is supposed to not change anything under English language, only in the cases where the translations exceeds the available space.
In order to test this I have tested it in _Nederlands_ and _Español (Latin America)_

This issue was already mentioned here: #14042 

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Simply trying by changing language to either _Nederlands_ or _Español (Latin America)_ and then going to any entity that has more than 3 tabs in the "more info" Dialog.
Then to see that the Dialog is resized to fit all the tittles if there is enough space available
(The maximum allowed to take is `85vw` of the screen)

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14042 
- This PR is related to issue or discussion: #13084 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
