### PR TITLE
Remove box shadow for ha-card

### DIFF
--- a/src/components/date-range-picker.ts
+++ b/src/components/date-range-picker.ts
@@ -111,7 +111,7 @@ class DateRangePickerElement extends WrappedElement {
           .daterangepicker {
             left: 0px !important;
             top: auto;
-            box-shadow: var(--ha-card-box-shadow, "none");
+            box-shadow: var(--ha-card-box-shadow, none);
             background-color: var(--card-background-color);
             border-radius: var(--ha-card-border-radius, 16px);
             border-width: var(--ha-card-border-width, 1px);

--- a/src/components/date-range-picker.ts
+++ b/src/components/date-range-picker.ts
@@ -112,13 +112,12 @@ class DateRangePickerElement extends WrappedElement {
             left: 0px !important;
             top: auto;
             background-color: var(--card-background-color);
-            border: none;
-            border-radius: var(--ha-card-border-radius, 4px);
-            box-shadow: var(
-              --ha-card-box-shadow,
-              0px 2px 1px -1px rgba(0, 0, 0, 0.2),
-              0px 1px 1px 0px rgba(0, 0, 0, 0.14),
-              0px 1px 3px 0px rgba(0, 0, 0, 0.12)
+            border-radius: var(--ha-card-border-radius, 16px);
+            border-width: var(--ha-card-border-width, 1px);
+            border-style: solid;
+            border-color: var(
+              --ha-card-border-color,
+              var(--divider-color, #e0e0e0)
             );
             color: var(--primary-text-color);
             min-width: initial !important;

--- a/src/components/date-range-picker.ts
+++ b/src/components/date-range-picker.ts
@@ -111,6 +111,7 @@ class DateRangePickerElement extends WrappedElement {
           .daterangepicker {
             left: 0px !important;
             top: auto;
+            box-shadow: var(--ha-card-box-shadow, "none");
             background-color: var(--card-background-color);
             border-radius: var(--ha-card-border-radius, 16px);
             border-width: var(--ha-card-border-width, 1px);

--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -5,6 +5,8 @@ import { customElement, property } from "lit/decorators";
 export class HaCard extends LitElement {
   @property() public header?: string;
 
+  @property({ type: Boolean, reflect: true }) public raised = false;
+
   static get styles(): CSSResultGroup {
     return css`
       :host {
@@ -23,6 +25,16 @@ export class HaCard extends LitElement {
         display: block;
         transition: all 0.3s ease-out;
         position: relative;
+      }
+
+      :host([raised]) {
+        border: none;
+        box-shadow: var(
+          --ha-card-box-shadow,
+          0px 2px 1px -1px rgba(0, 0, 0, 0.2),
+          0px 1px 1px 0px rgba(0, 0, 0, 0.14),
+          0px 1px 3px 0px rgba(0, 0, 0, 0.12)
+        );
       }
 
       .card-header,

--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -5,8 +5,6 @@ import { customElement, property } from "lit/decorators";
 export class HaCard extends LitElement {
   @property() public header?: string;
 
-  @property({ type: Boolean, reflect: true }) public outlined = false;
-
   static get styles(): CSSResultGroup {
     return css`
       :host {
@@ -14,27 +12,17 @@ export class HaCard extends LitElement {
           --ha-card-background,
           var(--card-background-color, white)
         );
-        border-radius: var(--ha-card-border-radius, 4px);
-        box-shadow: var(
-          --ha-card-box-shadow,
-          0px 2px 1px -1px rgba(0, 0, 0, 0.2),
-          0px 1px 1px 0px rgba(0, 0, 0, 0.14),
-          0px 1px 3px 0px rgba(0, 0, 0, 0.12)
-        );
-        color: var(--primary-text-color);
-        display: block;
-        transition: all 0.3s ease-out;
-        position: relative;
-      }
-
-      :host([outlined]) {
-        box-shadow: none;
+        border-radius: var(--ha-card-border-radius, 16px);
         border-width: var(--ha-card-border-width, 1px);
         border-style: solid;
         border-color: var(
           --ha-card-border-color,
           var(--divider-color, #e0e0e0)
         );
+        color: var(--primary-text-color);
+        display: block;
+        transition: all 0.3s ease-out;
+        position: relative;
       }
 
       .card-header,

--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -14,6 +14,7 @@ export class HaCard extends LitElement {
           --ha-card-background,
           var(--card-background-color, white)
         );
+        box-sizing: border-box;
         border-radius: var(--ha-card-border-radius, 16px);
         border-width: var(--ha-card-border-width, 1px);
         border-style: solid;

--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -14,7 +14,7 @@ export class HaCard extends LitElement {
           --ha-card-background,
           var(--card-background-color, white)
         );
-        box-shadow: var(--ha-card-box-shadow, "none");
+        box-shadow: var(--ha-card-box-shadow, none);
         box-sizing: border-box;
         border-radius: var(--ha-card-border-radius, 16px);
         border-width: var(--ha-card-border-width, 1px);

--- a/src/components/ha-card.ts
+++ b/src/components/ha-card.ts
@@ -14,6 +14,7 @@ export class HaCard extends LitElement {
           --ha-card-background,
           var(--card-background-color, white)
         );
+        box-shadow: var(--ha-card-box-shadow, "none");
         box-sizing: border-box;
         border-radius: var(--ha-card-border-radius, 16px);
         border-width: var(--ha-card-border-width, 1px);

--- a/src/html/onboarding.html.template
+++ b/src/html/onboarding.html.template
@@ -16,7 +16,7 @@
       .content {
         box-sizing: border-box;
         padding: 20px 16px;
-        border-radius: 4px;
+        border-radius: var(--ha-card-border-radius, 16px);
         max-width: 432px;
         margin: 64px auto 0;
         box-shadow: var(

--- a/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
+++ b/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
@@ -163,6 +163,7 @@ export class HuiUnusedEntities extends LitElement {
         height: 100%;
       }
       ha-card {
+        --ha-card-box-shadow: none;
         --ha-card-border-radius: 0;
       }
       hui-entity-picker-table {

--- a/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
+++ b/src/panels/lovelace/editor/unused-entities/hui-unused-entities.ts
@@ -163,7 +163,6 @@ export class HuiUnusedEntities extends LitElement {
         height: 100%;
       }
       ha-card {
-        --ha-card-box-shadow: none;
         --ha-card-border-radius: 0;
       }
       hui-entity-picker-table {


### PR DESCRIPTION

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

After discussing with @matthiasdebaat. We removed default box-shadow and increase default border radius for all `ha-card`. Another PR will follow to remove all the `outlined` properties as it's the default.

![image](https://user-images.githubusercontent.com/5878303/195108065-b7815b08-40ae-4db4-a5c8-ccaccbff65e1.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
