### PR TITLE
Updated wrong translation in Energy Dashboard

### DIFF
--- a/translations/frontend/it.json
+++ b/translations/frontend/it.json
@@ -4241,7 +4241,7 @@
                             "gas": "Gas",
                             "go_to_energy_dashboard": "Vai alla plancia energia",
                             "grid": "Rete",
-                            "home": "Home",
+                            "home": "Casa",
                             "non_fossil": "Non fossile",
                             "solar": "Solare",
                             "title_today": "Distribuzione dell'energia oggi"


### PR DESCRIPTION
While looking at my home energy dashboard, I noticed the energy dashboard displays "Home" instead of "Casa" (which is the translation of "home" in italian). I see a commit from a few days ago to this repo, so I assume we should fix this here.

![Screenshot 2022-10-12 at 16 16 49](https://user-images.githubusercontent.com/25389602/195368589-c8334d83-c3ab-40cc-9e59-f5097cb8cc2e.png)


## Proposed change

Fixed translation of "Home" to "Casa".
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

N/A
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

## Additional information

N/A
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:
-->

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

<!--
If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
