### PR TITLE
Improve pluralization in automation descriptions

### DIFF
--- a/src/common/datetime/format_duration.ts
+++ b/src/common/datetime/format_duration.ts
@@ -10,7 +10,7 @@ export const formatDuration = (duration: HaDurationData) => {
   const ms = duration.milliseconds || 0;
 
   if (d > 0) {
-    return `${d} days ${h}:${leftPad(m)}:${leftPad(s)}`;
+    return `${d} day${d === 1 ? "" : "s"} ${h}:${leftPad(m)}:${leftPad(s)}`;
   }
   if (h > 0) {
     return `${h}:${leftPad(m)}:${leftPad(s)}`;
@@ -19,10 +19,10 @@ export const formatDuration = (duration: HaDurationData) => {
     return `${m}:${leftPad(s)}`;
   }
   if (s > 0) {
-    return `${s} seconds`;
+    return `${s} second${s === 1 ? "" : "s"}`;
   }
   if (ms > 0) {
-    return `${ms} milliseconds`;
+    return `${ms} millisecond${ms === 1 ? "" : "s"}`;
   }
   return null;
 };

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -398,7 +398,8 @@ export const describeCondition = (
 
     if (!conditions || conditions.length === 0) {
       return "Test if no condition matches";
-    } if (conditions.length === 1) {
+    }
+    if (conditions.length === 1) {
       return "Test if 1 condition does not match";
     }
     return `Test if none of ${conditions.length} conditions match`;

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -374,35 +374,34 @@ export const describeCondition = (
   if (condition.condition === "or") {
     const conditions = ensureArray(condition.conditions);
 
-    let count = "condition";
-
     if (conditions && conditions.length > 0) {
-      count = `of ${conditions.length} conditions`;
+      return "Test if any condition matches";
     }
-
-    return `Test if any ${count} matches`;
+    const count = conditions.length;
+    return `Test if any of ${count} condition${count === 1 ? "" : "s"} matches`;
   }
 
   if (condition.condition === "and") {
     const conditions = ensureArray(condition.conditions);
 
-    const count =
-      conditions && conditions.length > 0
-        ? `${conditions.length} `
-        : "multiple";
-
-    return `Test if ${count} conditions match`;
+    if (!conditions || conditions.length === 0) {
+      return "Test if multiple conditions match";
+    }
+    const count = conditions.length;
+    return `Test if ${count} condition${count === 1 ? "" : "s"} match${
+      count === 1 ? "es" : ""
+    }`;
   }
 
   if (condition.condition === "not") {
     const conditions = ensureArray(condition.conditions);
 
-    const what =
-      conditions && conditions.length > 0
-        ? `none of ${conditions.length} conditions match`
-        : "no condition matches";
-
-    return `Test if ${what}`;
+    if (!conditions || conditions.length === 0) {
+      return "Test if no condition matches";
+    } if (conditions.length === 1) {
+      return "Test if 1 condition does not match";
+    }
+    return `Test if none of ${conditions.length} conditions match`;
   }
 
   // State Condition

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -374,7 +374,7 @@ export const describeCondition = (
   if (condition.condition === "or") {
     const conditions = ensureArray(condition.conditions);
 
-    if (conditions && conditions.length > 0) {
+    if (!conditions || conditions.length === 0) {
       return "Test if any condition matches";
     }
     const count = conditions.length;

--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -185,7 +185,7 @@ interface BaseRepeat extends BaseAction {
 }
 
 export interface CountRepeat extends BaseRepeat {
-  count: number;
+  count: number | string;
 }
 
 export interface WhileRepeat extends BaseRepeat {

--- a/src/data/script_i18n.ts
+++ b/src/data/script_i18n.ts
@@ -247,7 +247,7 @@ export const describeAction = <T extends ActionType>(
     let base = "Repeat an action";
     if ("count" in config.repeat) {
       const count = config.repeat.count;
-      base += ` ${count} time${count === "1" || count === 1 ? "" : "s"}`;
+      base += ` ${count} time${Number(count) === 1 ? "" : "s"}`;
     } else if ("while" in config.repeat) {
       base += ` while ${ensureArray(config.repeat.while)
         .map((condition) => describeCondition(condition, hass))

--- a/src/data/script_i18n.ts
+++ b/src/data/script_i18n.ts
@@ -231,32 +231,37 @@ export const describeAction = <T extends ActionType>(
 
   if (actionType === "choose") {
     const config = action as ChooseAction;
-    return config.choose
-      ? `Choose between ${
-          ensureArray(config.choose).length + (config.default ? 1 : 0)
-        } actions`
-      : "Choose an action";
+    if (config.choose) {
+      const numActions =
+        ensureArray(config.choose).length + (config.default ? 1 : 0);
+      return `Choose between ${numActions} action${
+        numActions === 1 ? "" : "s"
+      }`;
+    }
+    return "Choose an action";
   }
 
   if (actionType === "repeat") {
     const config = action as RepeatAction;
-    return `Repeat an action ${
-      "count" in config.repeat ? `${config.repeat.count} times` : ""
-    }${
-      "while" in config.repeat
-        ? `while ${ensureArray(config.repeat.while)
-            .map((condition) => describeCondition(condition, hass))
-            .join(", ")} is true`
-        : "until" in config.repeat
-        ? `until ${ensureArray(config.repeat.until)
-            .map((condition) => describeCondition(condition, hass))
-            .join(", ")} is true`
-        : "for_each" in config.repeat
-        ? `for every item: ${ensureArray(config.repeat.for_each)
-            .map((item) => JSON.stringify(item))
-            .join(", ")}`
-        : ""
-    }`;
+
+    let base = "Repeat an action";
+    if ("count" in config.repeat) {
+      const count = config.repeat.count;
+      base += ` ${count} time${count === "1" || count === 1 ? "" : "s"}`;
+    } else if ("while" in config.repeat) {
+      base += ` while ${ensureArray(config.repeat.while)
+        .map((condition) => describeCondition(condition, hass))
+        .join(", ")} is true`;
+    } else if ("until" in config.repeat) {
+      base += ` until ${ensureArray(config.repeat.until)
+        .map((condition) => describeCondition(condition, hass))
+        .join(", ")} is true`;
+    } else if ("for_each" in config.repeat) {
+      base += ` for every item: ${ensureArray(config.repeat.for_each)
+        .map((item) => JSON.stringify(item))
+        .join(", ")}`;
+    }
+    return base;
   }
 
   if (actionType === "check_condition") {
@@ -280,7 +285,8 @@ export const describeAction = <T extends ActionType>(
 
   if (actionType === "parallel") {
     const config = action as ParallelAction;
-    return `Run  ${ensureArray(config.parallel).length} actions in parallel`;
+    const numActions = ensureArray(config.parallel).length;
+    return `Run ${numActions} action${numActions === 1 ? "" : "s"} in parallel`;
   }
 
   return actionType;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Improve the pluralization when generating the descriptions for conditions and actions.
 - `Test if any of 1 conditions matches` -> `Test if any of 1 condition matches`
 - `Test if 1 conditions match` -> `Test if 1 condition matches`
 - `Test if none of 1 conditions match` -> `Test if 1 condition does not match`
 - `Choose between 1 actions` -> `Choose between 1 action`
 - `Run 1 actions in parallel` -> `Run 1 action in parallel`
 - `Delay for 1 seconds` -> `Delay for 1 second`
 - `Delay for 1 days 0:00:00` -> `Delay for 1 day 0:00:00`
 - `Repeat an action 1 times` -> `Repeat an action 1 time`

I also fixed an issue with the type definition of `CountRepeat`. The count can be a number or a string since it accepts a template.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
