### PR TITLE
Format entity & sensor card with manual units; fix param comment typo

### DIFF
--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -34,7 +34,7 @@ export const numberFormatToLocale = (
  * Formats a number based on the user's preference with thousands separator(s) and decimal character for better legibility.
  *
  * @param num The number to format
- * @param locale The user-selected language and number format, from `hass.locale`
+ * @param localeOptions The user-selected language and formatting, from `hass.locale`
  * @param options Intl.NumberFormatOptions to use
  */
 export const formatNumber = (

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -146,8 +146,7 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
                     stateObj.attributes[this._config.attribute!]
                   )
                 : this.hass.localize("state.default.unknown")
-              : isNumericState(stateObj) ||
-                (!isNaN(Number(stateObj.state)) && this._config.unit)
+              : isNumericState(stateObj) || this._config.unit
               ? formatNumber(stateObj.state, this.hass.locale)
               : computeStateDisplay(
                   this.hass.localize,

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -146,7 +146,8 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
                     stateObj.attributes[this._config.attribute!]
                   )
                 : this.hass.localize("state.default.unknown")
-              : isNumericState(stateObj)
+              : isNumericState(stateObj) ||
+                (!isNaN(Number(stateObj.state)) && this._config.unit)
               ? formatNumber(stateObj.state, this.hass.locale)
               : computeStateDisplay(
                   this.hass.localize,


### PR DESCRIPTION
## Proposed change

This adds number formatting to Entity and Sensor cards when the selected `sensor` does not have a `unit_of_measurement` or `state_class` but the lovelace card has something entered in the "Unit" field. If the `sensor` value is numeric and a unit is specified, we can assume this is a value that should have formatting applied.

Without units specified in the lovelace card configuration:
![Screen Shot 2022-10-13 at 3 16 33 PM](https://user-images.githubusercontent.com/1522068/195721139-ca52512e-b931-48cf-8e33-ec9b57c1fc5f.png)

With units specified in the lovelace card configuration:
![Screen Shot 2022-10-13 at 3 17 19 PM](https://user-images.githubusercontent.com/1522068/195721169-1f9c863f-1c78-417f-8c42-da469fbaf167.png)

This also fixes a minor typo in the `formatNumber` params.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Create a sensor that has no `unit_of_measurement` or `state_class`, add it to an Entity or Sensor card, and manually enter something in the Units field for the card. It should now display as a formatted number with thousands separator and decimal per the user-selected number formatting.

```yaml
template:
  - sensor:
      - name: "No Unit or State Class Sensor"
        state: 1234.567
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
