### PR TITLE
Format numeric entities with integer value and step as integer instead of float

### DIFF
--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -9,7 +9,11 @@ import { formatDuration, UNIT_TO_SECOND_CONVERT } from "../datetime/duration";
 import { formatDate } from "../datetime/format_date";
 import { formatDateTime } from "../datetime/format_date_time";
 import { formatTime } from "../datetime/format_time";
-import { formatNumber, isNumericFromAttributes } from "../number/format_number";
+import {
+  formatNumber,
+  getMaxDigits,
+  isNumericFromAttributes,
+} from "../number/format_number";
 import { blankBeforePercent } from "../translations/blank_before_percent";
 import { LocalizeFunc } from "../translations/localize";
 import { computeDomain } from "./compute_domain";
@@ -70,7 +74,11 @@ export const computeStateDisplayFromEntityAttributes = (
       : attributes.unit_of_measurement === "%"
       ? blankBeforePercent(locale) + "%"
       : ` ${attributes.unit_of_measurement}`;
-    return `${formatNumber(state, locale)}${unit}`;
+    return `${formatNumber(
+      state,
+      locale,
+      getMaxDigits({ state, attributes } as HassEntity)
+    )}${unit}`;
   }
 
   const domain = computeDomain(entityId);
@@ -143,7 +151,12 @@ export const computeStateDisplayFromEntityAttributes = (
     domain === "number" ||
     domain === "input_number"
   ) {
-    return formatNumber(state, locale);
+    // Format as an integer if the value and step are integers
+    return formatNumber(
+      state,
+      locale,
+      getMaxDigits({ state, attributes } as HassEntity)
+    );
   }
 
   // state of button is a timestamp

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -11,7 +11,7 @@ import { formatDateTime } from "../datetime/format_date_time";
 import { formatTime } from "../datetime/format_time";
 import {
   formatNumber,
-  getMaxDigits,
+  getNumberFormatOptions,
   isNumericFromAttributes,
 } from "../number/format_number";
 import { blankBeforePercent } from "../translations/blank_before_percent";
@@ -77,7 +77,7 @@ export const computeStateDisplayFromEntityAttributes = (
     return `${formatNumber(
       state,
       locale,
-      getMaxDigits({ state, attributes } as HassEntity)
+      getNumberFormatOptions({ state, attributes } as HassEntity)
     )}${unit}`;
   }
 
@@ -155,7 +155,7 @@ export const computeStateDisplayFromEntityAttributes = (
     return formatNumber(
       state,
       locale,
-      getMaxDigits({ state, attributes } as HassEntity)
+      getNumberFormatOptions({ state, attributes } as HassEntity)
     );
   }
 

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -89,7 +89,7 @@ export const formatNumber = (
  * @param entityState The state object of the entity
  * @returns An `Intl.NumberFormatOptions` object with `maximumFractionDigits` set to 0, or `undefined`
  */
-export const getMaxDigits = (
+export const getNumberFormatOptions = (
   entityState: HassEntity
 ): Intl.NumberFormatOptions | undefined => {
   if (

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -85,6 +85,23 @@ export const formatNumber = (
 };
 
 /**
+ * Checks if the current entity state should be formatted as an integer based on the `state` and `step` attribute and returns the appropriate `Intl.NumberFormatOptions` object with `maximumFractionDigits` set
+ * @param entityState The state object of the entity
+ * @returns An `Intl.NumberFormatOptions` object with `maximumFractionDigits` set to 0, or `undefined`
+ */
+export const getMaxDigits = (
+  entityState: HassEntity
+): Intl.NumberFormatOptions | undefined => {
+  if (
+    Number.isInteger(Number(entityState.attributes?.step)) &&
+    Number.isInteger(Number(entityState.state))
+  ) {
+    return { maximumFractionDigits: 0 };
+  }
+  return undefined;
+};
+
+/**
  * Generates default options for Intl.NumberFormat
  * @param num The number to be formatted
  * @param options The Intl.NumberFormatOptions that should be included in the returned options

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -1,4 +1,7 @@
-import { HassEntity } from "home-assistant-js-websocket";
+import {
+  HassEntity,
+  HassEntityAttributeBase,
+} from "home-assistant-js-websocket";
 import { FrontendLocaleData, NumberFormat } from "../../data/translation";
 import { round } from "./round";
 
@@ -9,9 +12,9 @@ import { round } from "./round";
 export const isNumericState = (stateObj: HassEntity): boolean =>
   isNumericFromAttributes(stateObj.attributes);
 
-export const isNumericFromAttributes = (attributes: {
-  [key: string]: any;
-}): boolean => !!attributes.unit_of_measurement || !!attributes.state_class;
+export const isNumericFromAttributes = (
+  attributes: HassEntityAttributeBase
+): boolean => !!attributes.unit_of_measurement || !!attributes.state_class;
 
 export const numberFormatToLocale = (
   localeOptions: FrontendLocaleData

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -106,7 +106,7 @@ export const getMaxDigits = (
  * @param num The number to be formatted
  * @param options The Intl.NumberFormatOptions that should be included in the returned options
  */
-const getDefaultFormatOptions = (
+export const getDefaultFormatOptions = (
   num: string | number,
   options?: Intl.NumberFormatOptions
 ): Intl.NumberFormatOptions => {

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -102,7 +102,8 @@ const getDefaultFormatOptions = (
   // Keep decimal trailing zeros if they are present in a string numeric value
   if (
     !options ||
-    (!options.minimumFractionDigits && !options.maximumFractionDigits)
+    (options.minimumFractionDigits === undefined &&
+      options.maximumFractionDigits === undefined)
   ) {
     const digits = num.indexOf(".") > -1 ? num.split(".")[1].length : 0;
     defaultOptions.minimumFractionDigits = digits;

--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -16,6 +16,7 @@ import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { computeStateName } from "../../common/entity/compute_state_name";
 import {
   formatNumber,
+  getMaxDigits,
   isNumericState,
 } from "../../common/number/format_number";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity";
@@ -149,7 +150,11 @@ export class HaStateLabelBadge extends LitElement {
           entityState.state === UNAVAILABLE
           ? "—"
           : isNumericState(entityState)
-          ? formatNumber(entityState.state, this.hass!.locale)
+          ? formatNumber(
+              entityState.state,
+              this.hass!.locale,
+              getMaxDigits(entityState)
+            )
           : computeStateDisplay(
               this.hass!.localize,
               entityState,

--- a/src/components/entity/ha-state-label-badge.ts
+++ b/src/components/entity/ha-state-label-badge.ts
@@ -16,7 +16,7 @@ import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { computeStateName } from "../../common/entity/compute_state_name";
 import {
   formatNumber,
-  getMaxDigits,
+  getNumberFormatOptions,
   isNumericState,
 } from "../../common/number/format_number";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity";
@@ -153,7 +153,7 @@ export class HaStateLabelBadge extends LitElement {
           ? formatNumber(
               entityState.state,
               this.hass!.locale,
-              getMaxDigits(entityState)
+              getNumberFormatOptions(entityState)
             )
           : computeStateDisplay(
               this.hass!.localize,

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -17,6 +17,7 @@ import { computeStateName } from "../../../common/entity/compute_state_name";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import {
   formatNumber,
+  getMaxDigits,
   isNumericState,
 } from "../../../common/number/format_number";
 import { iconColorCSS } from "../../../common/style/icon_color_css";
@@ -147,7 +148,11 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
                   )
                 : this.hass.localize("state.default.unknown")
               : isNumericState(stateObj) || this._config.unit
-              ? formatNumber(stateObj.state, this.hass.locale)
+              ? formatNumber(
+                  stateObj.state,
+                  this.hass.locale,
+                  getMaxDigits(stateObj)
+                )
               : computeStateDisplay(
                   this.hass.localize,
                   stateObj,

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -17,7 +17,7 @@ import { computeStateName } from "../../../common/entity/compute_state_name";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import {
   formatNumber,
-  getMaxDigits,
+  getNumberFormatOptions,
   isNumericState,
 } from "../../../common/number/format_number";
 import { iconColorCSS } from "../../../common/style/icon_color_css";
@@ -151,7 +151,7 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
               ? formatNumber(
                   stateObj.state,
                   this.hass.locale,
-                  getMaxDigits(stateObj)
+                  getNumberFormatOptions(stateObj)
                 )
               : computeStateDisplay(
                   this.hass.localize,

--- a/test/common/string/format_number.ts
+++ b/test/common/string/format_number.ts
@@ -4,7 +4,7 @@ import { HassEntity } from "home-assistant-js-websocket";
 import {
   formatNumber,
   getDefaultFormatOptions,
-  getMaxDigits,
+  getNumberFormatOptions,
 } from "../../../src/common/number/format_number";
 import {
   FrontendLocaleData,
@@ -111,7 +111,7 @@ describe("formatNumber", () => {
 
   it("Sets maximumFractionDigits to '0' when the state value and step are integers", () => {
     assert.deepEqual(
-      getMaxDigits({
+      getNumberFormatOptions({
         state: "3.0",
         attributes: { step: 1 },
       } as unknown as HassEntity),
@@ -123,7 +123,7 @@ describe("formatNumber", () => {
 
   it("Does not set any Intl.NumberFormatOptions when the step is not an integer", () => {
     assert.strictEqual(
-      getMaxDigits({
+      getNumberFormatOptions({
         state: "3.0",
         attributes: { step: 0.5 },
       } as unknown as HassEntity),
@@ -133,14 +133,14 @@ describe("formatNumber", () => {
 
   it("Does not set any Intl.NumberFormatOptions when the state value is not an integer", () => {
     assert.strictEqual(
-      getMaxDigits({ state: "3.5" } as unknown as HassEntity),
+      getNumberFormatOptions({ state: "3.5" } as unknown as HassEntity),
       undefined
     );
   });
 
   it("Does not set any Intl.NumberFormatOptions when there is no step attribute", () => {
     assert.strictEqual(
-      getMaxDigits({ state: "3.0" } as unknown as HassEntity),
+      getNumberFormatOptions({ state: "3.0" } as unknown as HassEntity),
       undefined
     );
   });

--- a/test/common/string/format_number.ts
+++ b/test/common/string/format_number.ts
@@ -1,6 +1,11 @@
 import { assert } from "chai";
+import { HassEntity } from "home-assistant-js-websocket";
 
-import { formatNumber } from "../../../src/common/number/format_number";
+import {
+  formatNumber,
+  getDefaultFormatOptions,
+  getMaxDigits,
+} from "../../../src/common/number/format_number";
 import {
   FrontendLocaleData,
   NumberFormat,
@@ -61,6 +66,82 @@ describe("formatNumber", () => {
         minimumFractionDigits: 2,
       }),
       "1,234.50"
+    );
+  });
+
+  it("Sets only the maximumFractionDigits format option when none are provided for a number value", () => {
+    assert.deepEqual(getDefaultFormatOptions(1234.5), {
+      maximumFractionDigits: 2,
+    });
+  });
+
+  it("Sets minimumFractionDigits and maximumFractionDigits to '2' when none are provided for a string numeric value with two decimal places", () => {
+    assert.deepEqual(getDefaultFormatOptions("1234.50"), {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  });
+
+  it("Merges default format options (minimumFractionDigits and maximumFractionDigits) and non-default format options for a string numeric value with two decimal places", () => {
+    assert.deepEqual(getDefaultFormatOptions("1234.50", { currency: "USD" }), {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+      currency: "USD",
+    });
+  });
+
+  it("Sets maximumFractionDigits when that is the only format option provided", () => {
+    assert.deepEqual(
+      getDefaultFormatOptions("1234.50", { maximumFractionDigits: 0 }),
+      {
+        maximumFractionDigits: 0,
+      }
+    );
+  });
+
+  it("Sets maximumFractionDigits to '2' and minimumFractionDigits to the provided value when only minimumFractionDigits is provided", () => {
+    assert.deepEqual(
+      getDefaultFormatOptions("1234.50", { minimumFractionDigits: 1 }),
+      {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 2,
+      }
+    );
+  });
+
+  it("Sets maximumFractionDigits to '0' when the state value and step are integers", () => {
+    assert.deepEqual(
+      getMaxDigits({
+        state: "3.0",
+        attributes: { step: 1 },
+      } as unknown as HassEntity),
+      {
+        maximumFractionDigits: 0,
+      }
+    );
+  });
+
+  it("Does not set any Intl.NumberFormatOptions when the step is not an integer", () => {
+    assert.strictEqual(
+      getMaxDigits({
+        state: "3.0",
+        attributes: { step: 0.5 },
+      } as unknown as HassEntity),
+      undefined
+    );
+  });
+
+  it("Does not set any Intl.NumberFormatOptions when the state value is not an integer", () => {
+    assert.strictEqual(
+      getMaxDigits({ state: "3.5" } as unknown as HassEntity),
+      undefined
+    );
+  });
+
+  it("Does not set any Intl.NumberFormatOptions when there is no step attribute", () => {
+    assert.strictEqual(
+      getMaxDigits({ state: "3.0" } as unknown as HassEntity),
+      undefined
     );
   });
 });


### PR DESCRIPTION
## Proposed change

This updates how numeric entities with a `step` attribute are formatted. If the `state` of the entity is an integer (e.g. "1.0") and the `step` attribute is also an integer (e.g. "1"), the state is formatted as an integer with no trailing zero decimal place. Currently the number is formatted as a float with a trailing zero (e.g. "1.0") as this is how the state is stored by Home Assistant. See https://github.com/home-assistant/frontend/issues/9224

This also fixes a potential bug when setting formatting options and adds some additional tests to check for that bug and a new `getMaxDigits()` function.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Create an `input_number` helper with a `step` value of "1" and add it to Lovelace in an Entity or Entities card or as a Badge. The number should be formatted as an integer instead of a float with a trailing zero.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/frontend/issues/9224
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
