### PR TITLE
Add any step for input number settings to match server-side validation

### DIFF
--- a/src/panels/config/helpers/forms/ha-input_number-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_number-form.ts
@@ -101,6 +101,7 @@ class HaInputNumberForm extends LitElement {
           .value=${this._min}
           .configValue=${"min"}
           type="number"
+          step="any"
           @input=${this._valueChanged}
           .label=${this.hass!.localize(
             "ui.dialogs.helper_settings.input_number.min"
@@ -110,6 +111,7 @@ class HaInputNumberForm extends LitElement {
           .value=${this._max}
           .configValue=${"max"}
           type="number"
+          step="any"
           @input=${this._valueChanged}
           .label=${this.hass!.localize(
             "ui.dialogs.helper_settings.input_number.max"
@@ -150,6 +152,7 @@ class HaInputNumberForm extends LitElement {
                 .value=${this._step}
                 .configValue=${"step"}
                 type="number"
+                step="any"
                 @input=${this._valueChanged}
                 .label=${this.hass!.localize(
                   "ui.dialogs.helper_settings.input_number.step"


### PR DESCRIPTION
## Proposed change

This adds `step="any"` to the min, max, and step fields for the `input_number` helper form. This allows the use of decimals for any of those fields. Currently those fields show as invalid if a decimal is entered, even thought a decimal is a valid value for those attributes of an `input_number` entity.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Create an `input_number` helper and enter a decimal value (for example 0.5) into the min, max, and step fields. Those fields should no longer show as invalid with a decimal value.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
