### PR TITLE
Allow negative values in gauge severity config GUI

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -98,15 +98,15 @@ export class HuiGaugeCardEditor
                 schema: [
                   {
                     name: "green",
-                    selector: { number: { min: 0, mode: "box" } },
+                    selector: { number: { mode: "box" } },
                   },
                   {
                     name: "yellow",
-                    selector: { number: { min: 0, mode: "box" } },
+                    selector: { number: { mode: "box" } },
                   },
                   {
                     name: "red",
-                    selector: { number: { min: 0, mode: "box" } },
+                    selector: { number: { mode: "box" } },
                   },
                 ],
               },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
>I was going to write a issue about this, but it's so simple I used the GH file search to guess-find the correct source code and, hopefully, edited it at the right spot :pray: 

Summary:
This works wonders on the gauge:
```yaml
type: gauge
needle: true
[...]
severity:
  green: -15
  yellow: -17.5
  red: -25
```

But currently, severity shows empty on the GUI, because the field renders as `<input min=0/>`.
![image](https://user-images.githubusercontent.com/532299/196587389-ffa63f4f-0efa-4f1c-b65c-58005b0517d4.png)


<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: gauge
entity: «numeric sensor»
min: -25
max: -10
needle: true
name: Negative needle gauge test
severity:
  green: -15
  yellow: -17.5
  red: -25
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- ~This PR fixes or closes issue: fixes #~
- ~This PR is related to issue or discussion:~
- ~Link to documentation pull request:~

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->
Honestly, I have no clue how to start testing such a simple change. If no one is able to test the change and the PR will be closed because of it, I guess I'll just open an issue instead :man_shrugging: 

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
