### PR TITLE
Fix translation of Duplicate label in automation and script editors

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1861,6 +1861,7 @@
             "disabled": "Automation is disabled",
             "read_only": "This automation can not be edited from the UI, because it is not stored in the automations.yaml file, or doesn't have an ID.",
             "migrate": "Migrate",
+            "duplicate": "[%key:ui::common::duplicate%]",
             "run": "[%key:ui::panel::config::automation::editor::actions::run%]",
             "rename": "[%key:ui::panel::config::automation::editor::triggers::rename%]",
             "show_trace": "Traces",
@@ -2337,7 +2338,7 @@
             "show_info": "[%key:ui::panel::config::automation::editor::show_info%]",
             "read_only": "This script can not be edited from the UI, because it is not stored in the ''scripts.yaml'' file.",
             "migrate": "Migrate",
-            "duplicate": "Duplicate",
+            "duplicate": "[%key:ui::common::duplicate%]",
             "header": "Script: {name}",
             "default_name": "New Script",
             "modes": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The automation editor overflow menu refers to a non-existent translation key (`ui.panel.config.automation.editor.duplicate`) for the Duplicate label, resulting in the missing label that I reported in https://github.com/home-assistant/frontend/issues/14004:

![image](https://user-images.githubusercontent.com/18428022/196739129-9b86818d-1181-44a5-ae34-d32f0848f6a9.png)

This PR addresses that issue by updating the base translation keys in `src/translations/en.json` to add the missing translation key to the automation editor and also replaces the static "Duplicate" translation key in the script editor with `[%key:ui::common::duplicate%]`.

Tested locally, and works with English language, but further localization work may be needed for other language translations. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # [14004](https://github.com/home-assistant/frontend/issues/14004)
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
