### PR TITLE
Add icon for receiver deviceclass

### DIFF
--- a/src/common/entity/domain_icon.ts
+++ b/src/common/entity/domain_icon.ts
@@ -25,6 +25,8 @@ import {
   mdiPackageUp,
   mdiPowerPlug,
   mdiPowerPlugOff,
+  mdiAudioVideo,
+  mdiAudioVideoOff,
   mdiRestart,
   mdiSpeaker,
   mdiSpeakerOff,
@@ -158,6 +160,13 @@ export const domainIconWithoutDefault = (
               return mdiTelevisionOff;
             default:
               return mdiTelevision;
+          }
+        case "receiver":
+          switch (compareState) {
+            case "off":
+              return mdiAudioVideoOff;
+            default:
+              return mdiAudioVideo;
           }
         default:
           switch (compareState) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Mediaplayer did not have a specific icon when deviceclass of the media_player is "receiver", so added an icon for that as the different icons for device classes help to identify the mediaplayers.

MDI currently has icons for on and off, but there is an [open request](https://github.com/Templarian/MaterialDesign/issues/6722) for more states which can be added to frontend later.

Looks like this:
![image](https://user-images.githubusercontent.com/732514/197340082-a4581506-d672-47a8-b048-763f0b4d2893.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->
You can use the following integrations if you have a suitable device which support receiver device class: `anthemav`, `directv`, `google_assistant`, `lookin`, `roku` and `yamaha_ynca` (custom integration), there might be more.

or use the developer tools to set the device_class on any media_player to receiver like below.
```yaml
device_class: receiver
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
