### PR TITLE
Disable sidebar edit mode on drawer close

### DIFF
--- a/src/layouts/home-assistant-main.ts
+++ b/src/layouts/home-assistant-main.ts
@@ -87,6 +87,7 @@ export class HomeAssistantMain extends LitElement {
           .swipeOpen=${!disableSwipe}
           .persistent=${!this.narrow &&
           this.hass.dockedSidebar !== "always_hidden"}
+          @app-drawer-transitioned=${this._drawerTransitioned}
         >
           <ha-sidebar
             .hass=${hass}
@@ -185,6 +186,13 @@ export class HomeAssistantMain extends LitElement {
     // Make app-drawer adjust to a potential LTR/RTL change
     if (oldHass && oldHass.language !== this.hass!.language) {
       this.drawer._resetPosition();
+    }
+  }
+
+  private _drawerTransitioned(ev: CustomEvent) {
+    const drawer = ev.currentTarget as AppDrawerElement;
+    if (!drawer.opened) {
+      this._sidebarEditMode = false;
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Issue related: https://github.com/home-assistant/frontend/issues/14168

While on desktop small screen mode and app the drawer won't open if it was previously closed while on edit mode.
I added a listener on app-drawer transition and made sure that, when it's on closed event, it will disable drawer edit mode.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

No special configuration needed
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14168

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
