### PR TITLE
Fix camera dialog

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -294,6 +294,10 @@ export class MoreInfoDialog extends LitElement {
             var(--mdc-dialog-scroll-divider-color, rgba(0, 0, 0, 0.12));
         }
 
+        :host([tab="info"]) ha-dialog[data-domain="camera"] {
+          --mdc-dialog-max-width: auto;
+        }
+
         :host([tab="settings"]) ha-dialog {
           --dialog-content-padding: 0px;
         }

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -316,8 +316,8 @@ export class MoreInfoDialog extends LitElement {
             cursor: default;
           }
 
-          :host([large]) ha-dialog,
-          :host([tab="info"]) ha-dialog[data-domain="camera"] {
+          :host([large]):not([data-domain="camera"]) ha-dialog,
+          :host([tab="info"][large]) ha-dialog[data-domain="camera"] {
             --mdc-dialog-min-width: 90vw;
             --mdc-dialog-max-width: 90vw;
           }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Issue being resolved

Following [Combine more info and entity registry editor #13416](https://github.com/home-assistant/frontend/pull/13416), where `ha-more-info-dialog.ts` (specifically lines [294-300](https://github.com/home-assistant/frontend/blob/9e445115425b27097697c9f85575eec54ad9887b/src/dialogs/more-info/ha-more-info-dialog.ts#L294-L300) and [312-316](https://github.com/home-assistant/frontend/blob/9e445115425b27097697c9f85575eec54ad9887b/src/dialogs/more-info/ha-more-info-dialog.ts#L312-L316)) was modified in an effort to standardize some of the frontend, camera dialogs are a bit buggy.

Prior to that commit, you could click the header text ("Patio Camera" below) to resize it and toggle between "normal" and "larger" sizes.
(normal)
![image](https://user-images.githubusercontent.com/34781835/197616113-0e41b91b-a427-4360-a41c-0c9915f9a612.png)
(larger)
![image](https://user-images.githubusercontent.com/34781835/197615888-f51d3414-e432-410a-984f-c1b99937f31c.png)

That ability is now gone, and we're presented a permanently large view of the camera.
![image](https://user-images.githubusercontent.com/34781835/197621640-27d6c4c9-c6a9-4da6-8d9f-9b38b70adb43.png)

Related previous rules:
```css
@media all and (min-width: 451px) and (min-height: 501px) {
  /* Restricts all dialogs to a max-width of 90vw */
  ha-dialog {
    --mdc-dialog-max-width: 90vw;
  }

  /* Allows the camera dialog to automatically fill the viewport width, up to the height of wide screens */
  ha-dialog[data-domain="camera"] .content,
  ha-dialog[data-domain="camera"] ha-header-bar {
    width: auto;
  }

  /* Resizes the width of camera dialogs from auto to 90vw when expanded (large) */
  :host([large]) ha-dialog[data-domain="camera"] .content,
  :host([large]) ha-header-bar {
    width: 90vw;
  }
}
```

Related new rules:
```css
@media all and (min-width: 600px) and (min-height: 501px) {
  /* Sizes all dialogs to a width of 560px */
  ha-dialog {
    --mdc-dialog-min-width: 560px;
    --mdc-dialog-max-width: 560px;
    --dialog-surface-position: fixed;
    --dialog-surface-top: 40px;
    --mdc-dialog-max-height: calc(100% - 72px);
  }

  /* Sizes expanded dialogs and all camera dialogs (both expanded and not) to a width of 90vw */
  :host([large]) ha-dialog,
  ha-dialog[data-domain="camera"] {
    --mdc-dialog-min-width: 90vw;
    --mdc-dialog-max-width: 90vw;
  }
}
```

These new rules have two issues with regards to camera dialogs:
1. They *force* all camera dialogs, regardless of whether you clicked the title's text to expand them, to a min- and max-width of `90vw`. This breaks the ability to resize camera dialogs as the CSS still applies when the `large` HTML attribute is absent.
2. They don't allow camera dialogs to auto-expand vertically, nicely filling the screen, as the min-width is set to `560px` instead of `auto` as it used to be. After fixing the ability to resize the camera dialog by clicking the title text, this results in a tiny camera dialog at the top of the page which, while similar to every other entity, is different than the previously working behavior and just feels too small for a camera dialog.
![image](https://user-images.githubusercontent.com/34781835/197666829-32a2e8c9-1b77-4b73-b004-91487b9c7cd3.png)

I also found [Only change dialog for camera in info tab #14130](https://github.com/home-assistant/frontend/pull/14130) which attempts to address the "settings" and "related" tabs being sized to `90vw` and having no padding. This PR, however, did not fully achieve that goal as there are two selectors and the first selector (`:host([large]) ha-dialog`) still matches, resulting in the dialog's min- and max-width still being set to `90vw`.

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The following stylesheet adjustments resolve both #13581 and #14130:
```css
/* Set camera dialogs on the "info" tab to a max-width of `auto`, allowing them to auto-expand vertically as they did before */
:host([tab="info"]) ha-dialog[data-domain="camera"] {
  --mdc-dialog-max-width: auto;
}

@media all and (min-width: 600px) and (min-height: 501px) {
  /* Resize camera dialogs only if they're on the "info" tab and expanded */
  :host([large]):not([data-domain="camera"]) ha-dialog,
  :host([tab="info"][large]) ha-dialog[data-domain="camera"] {
    --mdc-dialog-min-width: 90vw;
    --mdc-dialog-max-width: 90vw;
  }
}

/* Remove padding only on the "info" tab of camera dialogs */
:host([tab="info"]) ha-dialog[data-domain="camera"] {
  --dialog-content-padding: 0;
}
```

These adjustments:
- Set camera dialogs on the info tab to a width of `90vw` when expanded, resulting in the restoration of the old "toggle" behavior.
- Set camera dialogs on the info tab to a max-width of `auto`, allowing them to grow and fill the full width of the viewport, or the height of wide screens.
- Set camera dialogs to have tab-specific padding when appropriate.
- Do not modify anything else not specifically related to camera dialogs.

![image](https://user-images.githubusercontent.com/34781835/197621441-fba0f3e9-a511-4c1f-97ec-bb51c57bd8dc.png)

What I have yet to address is the bottom of the camera image being clipped, a result of the addition of the toolbar button row (the "info", "settings", and "related" tabs) which, of course, can be addressed at a later time.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - Fixes issue #13581
  - Expands on #14130
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
