### PR TITLE
Move re-order button at triggers/conditions/actions level.

### DIFF
--- a/src/components/ha-selector/ha-selector-action.ts
+++ b/src/components/ha-selector/ha-selector-action.ts
@@ -1,5 +1,5 @@
 import { css, CSSResultGroup, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { Action } from "../../data/script";
 import { ActionSelector } from "../../data/selector";
 import "../../panels/config/automation/action/ha-automation-action";
@@ -17,17 +17,55 @@ export class HaActionSelector extends LitElement {
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
+  @state()
+  public reOrderMode = false;
+
   protected render() {
-    return html`<ha-automation-action
-      .disabled=${this.disabled}
-      .actions=${this.value || []}
-      .hass=${this.hass}
-    ></ha-automation-action>`;
+    return html`
+      ${this.reOrderMode
+        ? html`
+            <ha-alert
+              alert-type="info"
+              .title=${this.hass.localize(
+                "ui.panel.config.automation.editor.re_order_mode.title"
+              )}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.re_order_mode.description_actions"
+              )}
+              <mwc-button slot="action" @click=${this._exitReOrderMode}>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.re_order_mode.exit"
+                )}
+              </mwc-button>
+            </ha-alert>
+          `
+        : null}
+      <ha-automation-action
+        .disabled=${this.disabled}
+        .actions=${this.value || []}
+        .hass=${this.hass}
+        @re-order=${this._enterReOrderMode}
+        .reOrderMode=${this.reOrderMode}
+      ></ha-automation-action>
+    `;
+  }
+
+  private _exitReOrderMode() {
+    this.reOrderMode = false;
+  }
+
+  private _enterReOrderMode() {
+    this.reOrderMode = true;
   }
 
   static get styles(): CSSResultGroup {
     return css`
       ha-automation-action {
+        display: block;
+        margin-bottom: 16px;
+      }
+      ha-alert {
         display: block;
         margin-bottom: 16px;
       }

--- a/src/components/ha-selector/ha-selector-action.ts
+++ b/src/components/ha-selector/ha-selector-action.ts
@@ -1,5 +1,5 @@
 import { css, CSSResultGroup, html, LitElement } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { Action } from "../../data/script";
 import { ActionSelector } from "../../data/selector";
 import "../../panels/config/automation/action/ha-automation-action";
@@ -17,55 +17,19 @@ export class HaActionSelector extends LitElement {
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
-  @state()
-  public reOrderMode = false;
-
   protected render() {
     return html`
-      ${this.reOrderMode
-        ? html`
-            <ha-alert
-              alert-type="info"
-              .title=${this.hass.localize(
-                "ui.panel.config.automation.editor.re_order_mode.title"
-              )}
-            >
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.re_order_mode.description_actions"
-              )}
-              <mwc-button slot="action" @click=${this._exitReOrderMode}>
-                ${this.hass.localize(
-                  "ui.panel.config.automation.editor.re_order_mode.exit"
-                )}
-              </mwc-button>
-            </ha-alert>
-          `
-        : null}
       <ha-automation-action
         .disabled=${this.disabled}
         .actions=${this.value || []}
         .hass=${this.hass}
-        @re-order=${this._enterReOrderMode}
-        .reOrderMode=${this.reOrderMode}
       ></ha-automation-action>
     `;
-  }
-
-  private _exitReOrderMode() {
-    this.reOrderMode = false;
-  }
-
-  private _enterReOrderMode() {
-    this.reOrderMode = true;
   }
 
   static get styles(): CSSResultGroup {
     return css`
       ha-automation-action {
-        display: block;
-        margin-bottom: 16px;
-      }
-      ha-alert {
         display: block;
         margin-bottom: 16px;
       }

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -9,6 +9,7 @@ import {
   mdiPlayCircleOutline,
   mdiRenameBox,
   mdiStopCircleOutline,
+  mdiSort,
 } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
@@ -192,6 +193,12 @@ export default class HaAutomationActionRow extends LitElement {
                   </mwc-list-item>
                   <mwc-list-item graphic="icon" .disabled=${this.disabled}>
                     ${this.hass.localize(
+                      "ui.panel.config.automation.editor.actions.re_order"
+                    )}
+                    <ha-svg-icon slot="graphic" .path=${mdiSort}></ha-svg-icon>
+                  </mwc-list-item>
+                  <mwc-list-item graphic="icon" .disabled=${this.disabled}>
+                    ${this.hass.localize(
                       "ui.panel.config.automation.editor.actions.duplicate"
                     )}
                     <ha-svg-icon
@@ -348,20 +355,23 @@ export default class HaAutomationActionRow extends LitElement {
         await this._renameAction();
         break;
       case 2:
-        fireEvent(this, "duplicate");
+        fireEvent(this, "re-order");
         break;
       case 3:
+        fireEvent(this, "duplicate");
+        break;
+      case 4:
         this._switchUiMode();
         this.expand();
         break;
-      case 4:
+      case 5:
         this._switchYamlMode();
         this.expand();
         break;
-      case 5:
+      case 6:
         this._onDisable();
         break;
-      case 6:
+      case 7:
         this._onDelete();
         break;
     }

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -46,6 +46,8 @@ export default class HaAutomationAction extends LitElement {
 
   @property({ type: Boolean }) public disabled = false;
 
+  @property({ type: Boolean }) public nested = false;
+
   @property() public actions!: Action[];
 
   @property({ type: Boolean }) public reOrderMode = false;
@@ -58,6 +60,25 @@ export default class HaAutomationAction extends LitElement {
 
   protected render() {
     return html`
+      ${this.reOrderMode && !this.nested
+        ? html`
+            <ha-alert
+              alert-type="info"
+              .title=${this.hass.localize(
+                "ui.panel.config.automation.editor.re_order_mode.title"
+              )}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.re_order_mode.description"
+              )}
+              <mwc-button slot="action" @click=${this._exitReOrderMode}>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.re_order_mode.exit"
+                )}
+              </mwc-button>
+            </ha-alert>
+          `
+        : null}
       <div class="actions">
         ${repeat(
           this.actions,
@@ -72,6 +93,7 @@ export default class HaAutomationAction extends LitElement {
               .reOrderMode=${this.reOrderMode}
               @duplicate=${this._duplicateAction}
               @value-changed=${this._actionChanged}
+              @re-order=${this._enterReOrderMode}
               .hass=${this.hass}
             >
               ${this.reOrderMode
@@ -153,6 +175,16 @@ export default class HaAutomationAction extends LitElement {
         row.focus();
       });
     }
+  }
+
+  private async _enterReOrderMode(ev: CustomEvent) {
+    if (this.nested) return;
+    ev.stopPropagation();
+    this.reOrderMode = true;
+  }
+
+  private async _exitReOrderMode() {
+    this.reOrderMode = false;
   }
 
   private async _createSortable() {
@@ -281,6 +313,12 @@ export default class HaAutomationAction extends LitElement {
         }
         ha-svg-icon {
           height: 20px;
+        }
+        ha-alert {
+          display: block;
+          margin-bottom: 16px;
+          border-radius: var(--ha-card-border-radius, 12px);
+          overflow: hidden;
         }
         .handle {
           cursor: move;

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -69,7 +69,7 @@ export default class HaAutomationAction extends LitElement {
               )}
             >
               ${this.hass.localize(
-                "ui.panel.config.automation.editor.re_order_mode.description"
+                "ui.panel.config.automation.editor.re_order_mode.description_actions"
               )}
               <mwc-button slot="action" @click=${this._exitReOrderMode}>
                 ${this.hass.localize(

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -317,7 +317,7 @@ export default class HaAutomationAction extends LitElement {
         ha-alert {
           display: block;
           margin-bottom: 16px;
-          border-radius: var(--ha-card-border-radius, 12px);
+          border-radius: var(--ha-card-border-radius, 16px);
           overflow: hidden;
         }
         .handle {

--- a/src/panels/config/automation/action/types/ha-automation-action-choose.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-choose.ts
@@ -55,6 +55,7 @@ export class HaChooseAction extends LitElement implements ActionElement {
               )}:
             </h3>
             <ha-automation-condition
+              nested
               .conditions=${ensureArray<string | Condition>(option.conditions)}
               .reOrderMode=${this.reOrderMode}
               .disabled=${this.disabled}
@@ -68,6 +69,7 @@ export class HaChooseAction extends LitElement implements ActionElement {
               )}:
             </h3>
             <ha-automation-action
+              nested
               .actions=${ensureArray(option.sequence) || []}
               .reOrderMode=${this.reOrderMode}
               .disabled=${this.disabled}
@@ -96,6 +98,7 @@ export class HaChooseAction extends LitElement implements ActionElement {
               )}:
             </h2>
             <ha-automation-action
+              nested
               .actions=${ensureArray(action.default) || []}
               .reOrderMode=${this.reOrderMode}
               .disabled=${this.disabled}

--- a/src/panels/config/automation/action/types/ha-automation-action-if.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-if.ts
@@ -38,6 +38,7 @@ export class HaIfAction extends LitElement implements ActionElement {
         )}*:
       </h3>
       <ha-automation-condition
+        nested
         .conditions=${action.if}
         .reOrderMode=${this.reOrderMode}
         .disabled=${this.disabled}
@@ -51,6 +52,7 @@ export class HaIfAction extends LitElement implements ActionElement {
         )}*:
       </h3>
       <ha-automation-action
+        nested
         .actions=${action.then}
         .reOrderMode=${this.reOrderMode}
         .disabled=${this.disabled}
@@ -65,6 +67,7 @@ export class HaIfAction extends LitElement implements ActionElement {
               )}:
             </h3>
             <ha-automation-action
+              nested
               .actions=${action.else || []}
               .reOrderMode=${this.reOrderMode}
               .disabled=${this.disabled}

--- a/src/panels/config/automation/action/types/ha-automation-action-parallel.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-parallel.ts
@@ -29,6 +29,7 @@ export class HaParallelAction extends LitElement implements ActionElement {
 
     return html`
       <ha-automation-action
+        nested
         .actions=${action.parallel}
         .reOrderMode=${this.reOrderMode}
         .disabled=${this.disabled}

--- a/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
@@ -77,6 +77,7 @@ export class HaRepeatAction extends LitElement implements ActionElement {
                 )}:
               </h3>
               <ha-automation-condition
+                nested
                 .conditions=${(action as WhileRepeat).while || []}
                 .hass=${this.hass}
                 .disabled=${this.disabled}
@@ -89,6 +90,7 @@ export class HaRepeatAction extends LitElement implements ActionElement {
                 )}:
               </h3>
               <ha-automation-condition
+                nested
                 .conditions=${(action as UntilRepeat).until || []}
                 .hass=${this.hass}
                 .disabled=${this.disabled}
@@ -102,6 +104,7 @@ export class HaRepeatAction extends LitElement implements ActionElement {
         )}:
       </h3>
       <ha-automation-action
+        nested
         .actions=${action.sequence}
         .reOrderMode=${this.reOrderMode}
         .disabled=${this.disabled}

--- a/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-wait_for_trigger.ts
@@ -23,6 +23,8 @@ export class HaWaitForTriggerAction
 
   @property({ type: Boolean }) public disabled = false;
 
+  @property({ type: Boolean }) public reOrderMode = false;
+
   public static get defaultConfig() {
     return { wait_for_trigger: [] };
   }
@@ -53,10 +55,12 @@ export class HaWaitForTriggerAction
         ></ha-switch>
       </ha-formfield>
       <ha-automation-trigger
+        nested
         .triggers=${ensureArray(this.action.wait_for_trigger)}
         .hass=${this.hass}
         .disabled=${this.disabled}
         .name=${"wait_for_trigger"}
+        .reOrderMode=${this.reOrderMode}
         @value-changed=${this._valueChanged}
       ></ha-automation-trigger>
     `;

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -8,6 +8,7 @@ import {
   mdiFlask,
   mdiPlayCircleOutline,
   mdiRenameBox,
+  mdiSort,
   mdiStopCircleOutline,
 } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement } from "lit";
@@ -142,6 +143,14 @@ export default class HaAutomationConditionRow extends LitElement {
                       .path=${mdiRenameBox}
                     ></ha-svg-icon>
                   </mwc-list-item>
+
+                  <mwc-list-item graphic="icon" .disabled=${this.disabled}>
+                    ${this.hass.localize(
+                      "ui.panel.config.automation.editor.conditions.re_order"
+                    )}
+                    <ha-svg-icon slot="graphic" .path=${mdiSort}></ha-svg-icon>
+                  </mwc-list-item>
+
                   <mwc-list-item graphic="icon" .disabled=${this.disabled}>
                     ${this.hass.localize(
                       "ui.panel.config.automation.editor.actions.duplicate"
@@ -294,20 +303,23 @@ export default class HaAutomationConditionRow extends LitElement {
         await this._renameCondition();
         break;
       case 2:
-        fireEvent(this, "duplicate");
+        fireEvent(this, "re-order");
         break;
       case 3:
+        fireEvent(this, "duplicate");
+        break;
+      case 4:
         this._switchUiMode();
         this.expand();
         break;
-      case 4:
+      case 5:
         this._switchYamlMode();
         this.expand();
         break;
-      case 5:
+      case 6:
         this._onDisable();
         break;
-      case 6:
+      case 7:
         this._onDelete();
         break;
     }

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -346,7 +346,7 @@ export default class HaAutomationCondition extends LitElement {
         ha-alert {
           display: block;
           margin-bottom: 16px;
-          border-radius: var(--ha-card-border-radius, 12px);
+          border-radius: var(--ha-card-border-radius, 16px);
           overflow: hidden;
         }
         .handle {

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -113,7 +113,7 @@ export default class HaAutomationCondition extends LitElement {
               )}
             >
               ${this.hass.localize(
-                "ui.panel.config.automation.editor.re_order_mode.description"
+                "ui.panel.config.automation.editor.re_order_mode.description_conditions"
               )}
               <mwc-button slot="action" @click=${this._exitReOrderMode}>
                 ${this.hass.localize(
@@ -342,6 +342,12 @@ export default class HaAutomationCondition extends LitElement {
         }
         ha-svg-icon {
           height: 20px;
+        }
+        ha-alert {
+          display: block;
+          margin-bottom: 16px;
+          border-radius: var(--ha-card-border-radius, 12px);
+          overflow: hidden;
         }
         .handle {
           cursor: move;

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -44,6 +44,8 @@ export default class HaAutomationCondition extends LitElement {
 
   @property({ type: Boolean }) public disabled = false;
 
+  @property({ type: Boolean }) public nested = false;
+
   @property({ type: Boolean }) public reOrderMode = false;
 
   private _focusLastConditionOnChange = false;
@@ -102,6 +104,25 @@ export default class HaAutomationCondition extends LitElement {
       return html``;
     }
     return html`
+      ${this.reOrderMode && !this.nested
+        ? html`
+            <ha-alert
+              alert-type="info"
+              .title=${this.hass.localize(
+                "ui.panel.config.automation.editor.re_order_mode.title"
+              )}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.re_order_mode.description"
+              )}
+              <mwc-button slot="action" @click=${this._exitReOrderMode}>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.re_order_mode.exit"
+                )}
+              </mwc-button>
+            </ha-alert>
+          `
+        : null}
       <div class="conditions">
         ${repeat(
           this.conditions,
@@ -117,6 +138,7 @@ export default class HaAutomationCondition extends LitElement {
               @duplicate=${this._duplicateCondition}
               @move-condition=${this._move}
               @value-changed=${this._conditionChanged}
+              @re-order=${this._enterReOrderMode}
               .hass=${this.hass}
             >
               ${this.reOrderMode
@@ -174,6 +196,16 @@ export default class HaAutomationCondition extends LitElement {
         )}
       </ha-button-menu>
     `;
+  }
+
+  private async _enterReOrderMode(ev: CustomEvent) {
+    if (this.nested) return;
+    ev.stopPropagation();
+    this.reOrderMode = true;
+  }
+
+  private async _exitReOrderMode() {
+    this.reOrderMode = false;
   }
 
   private async _createSortable() {

--- a/src/panels/config/automation/condition/types/ha-automation-condition-logical.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-logical.ts
@@ -25,6 +25,7 @@ export class HaLogicalCondition extends LitElement implements ConditionElement {
   protected render() {
     return html`
       <ha-automation-condition
+        nested
         .conditions=${this.condition.conditions || []}
         @value-changed=${this._valueChanged}
         .hass=${this.hass}

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -11,7 +11,6 @@ import {
   mdiPlay,
   mdiPlayCircleOutline,
   mdiRenameBox,
-  mdiSort,
   mdiStopCircleOutline,
   mdiTransitConnection,
 } from "@mdi/js";
@@ -43,9 +42,9 @@ import {
   AutomationConfig,
   AutomationEntity,
   deleteAutomation,
-  getAutomationStateConfig,
   fetchAutomationFileConfig,
   getAutomationEditorInitData,
+  getAutomationStateConfig,
   saveAutomationConfig,
   showAutomationEditor,
   triggerAutomationActions,
@@ -65,7 +64,6 @@ import { showAutomationModeDialog } from "./automation-mode-dialog/show-dialog-a
 import { showAutomationRenameDialog } from "./automation-rename-dialog/show-dialog-automation-rename";
 import "./blueprint-automation-editor";
 import "./manual-automation-editor";
-import type { HaManualAutomationEditor } from "./manual-automation-editor";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -111,9 +109,6 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
   @state() private _readOnly = false;
 
   @query("ha-yaml-editor", true) private _yamlEditor?: HaYamlEditor;
-
-  @query("manual-automation-editor")
-  private _manualEditor?: HaManualAutomationEditor;
 
   private _configSubscriptions: Record<
     string,
@@ -215,18 +210,6 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
                   ></ha-svg-icon>
                 </mwc-list-item>
               `
-            : ""}
-          ${this._config && !("use_blueprint" in this._config)
-            ? html`<mwc-list-item
-                graphic="icon"
-                @click=${this._toggleReOrderMode}
-                .disabled=${this._readOnly || this._mode === "yaml"}
-              >
-                ${this.hass.localize(
-                  "ui.panel.config.automation.editor.re_order"
-                )}
-                <ha-svg-icon slot="graphic" .path=${mdiSort}></ha-svg-icon>
-              </mwc-list-item>`
             : ""}
 
           <mwc-list-item
@@ -666,12 +649,6 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
 
   private _switchYamlMode() {
     this._mode = "yaml";
-  }
-
-  private _toggleReOrderMode() {
-    if (this._manualEditor) {
-      this._manualEditor.reOrderMode = !this._manualEditor.reOrderMode;
-    }
   }
 
   private async _promptAutomationAlias(): Promise<void> {

--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -79,6 +79,7 @@ declare global {
     };
     "ui-mode-not-available": Error;
     duplicate: undefined;
+    "re-order": undefined;
   }
 }
 

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -6,7 +6,6 @@ import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
-import "../../../components/ha-alert";
 import {
   Condition,
   ManualAutomationConfig,
@@ -34,9 +33,6 @@ export class HaManualAutomationEditor extends LitElement {
 
   @property({ attribute: false }) public stateObj?: HassEntity;
 
-  @property({ type: Boolean, reflect: true, attribute: "re-order-mode" })
-  public reOrderMode = false;
-
   protected render() {
     return html`
       ${this.disabled
@@ -56,25 +52,6 @@ export class HaManualAutomationEditor extends LitElement {
               <mwc-button slot="action" @click=${this._enable}>
                 ${this.hass.localize(
                   "ui.panel.config.automation.editor.enable"
-                )}
-              </mwc-button>
-            </ha-alert>
-          `
-        : ""}
-      ${this.reOrderMode
-        ? html`
-            <ha-alert
-              alert-type="info"
-              .title=${this.hass.localize(
-                "ui.panel.config.automation.editor.re_order_mode.title"
-              )}
-            >
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.re_order_mode.description"
-              )}
-              <mwc-button slot="action" @click=${this._exitReOrderMode}>
-                ${this.hass.localize(
-                  "ui.panel.config.automation.editor.re_order_mode.exit"
                 )}
               </mwc-button>
             </ha-alert>
@@ -114,8 +91,6 @@ export class HaManualAutomationEditor extends LitElement {
         @value-changed=${this._triggerChanged}
         .hass=${this.hass}
         .disabled=${this.disabled}
-        .reOrderMode=${this.reOrderMode}
-        @re-order=${this._enterReOrderMode}
       ></ha-automation-trigger>
 
       <div class="header">
@@ -145,8 +120,6 @@ export class HaManualAutomationEditor extends LitElement {
         @value-changed=${this._conditionChanged}
         .hass=${this.hass}
         .disabled=${this.disabled}
-        .reOrderMode=${this.reOrderMode}
-        @re-order=${this._enterReOrderMode}
       ></ha-automation-condition>
 
       <div class="header">
@@ -179,18 +152,8 @@ export class HaManualAutomationEditor extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .disabled=${this.disabled}
-        .reOrderMode=${this.reOrderMode}
-        @re-order=${this._enterReOrderMode}
       ></ha-automation-action>
     `;
-  }
-
-  private _exitReOrderMode() {
-    this.reOrderMode = false;
-  }
-
-  private _enterReOrderMode() {
-    this.reOrderMode = true;
   }
 
   private _triggerChanged(ev: CustomEvent): void {
@@ -260,10 +223,6 @@ export class HaManualAutomationEditor extends LitElement {
         }
         .header a {
           color: var(--secondary-text-color);
-        }
-        ha-alert {
-          display: block;
-          margin-bottom: 16px;
         }
       `,
     ];

--- a/src/panels/config/automation/manual-automation-editor.ts
+++ b/src/panels/config/automation/manual-automation-editor.ts
@@ -113,8 +113,9 @@ export class HaManualAutomationEditor extends LitElement {
         .triggers=${this.config.trigger}
         @value-changed=${this._triggerChanged}
         .hass=${this.hass}
-        .reOrderMode=${this.reOrderMode}
         .disabled=${this.disabled}
+        .reOrderMode=${this.reOrderMode}
+        @re-order=${this._enterReOrderMode}
       ></ha-automation-trigger>
 
       <div class="header">
@@ -143,8 +144,9 @@ export class HaManualAutomationEditor extends LitElement {
         .conditions=${this.config.condition || []}
         @value-changed=${this._conditionChanged}
         .hass=${this.hass}
-        .reOrderMode=${this.reOrderMode}
         .disabled=${this.disabled}
+        .reOrderMode=${this.reOrderMode}
+        @re-order=${this._enterReOrderMode}
       ></ha-automation-condition>
 
       <div class="header">
@@ -176,14 +178,19 @@ export class HaManualAutomationEditor extends LitElement {
         @value-changed=${this._actionChanged}
         .hass=${this.hass}
         .narrow=${this.narrow}
-        .reOrderMode=${this.reOrderMode}
         .disabled=${this.disabled}
+        .reOrderMode=${this.reOrderMode}
+        @re-order=${this._enterReOrderMode}
       ></ha-automation-action>
     `;
   }
 
   private _exitReOrderMode() {
-    this.reOrderMode = !this.reOrderMode;
+    this.reOrderMode = false;
+  }
+
+  private _enterReOrderMode() {
+    this.reOrderMode = true;
   }
 
   private _triggerChanged(ev: CustomEvent): void {

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -8,6 +8,7 @@ import {
   mdiIdentifier,
   mdiPlayCircleOutline,
   mdiRenameBox,
+  mdiSort,
   mdiStopCircleOutline,
 } from "@mdi/js";
 import type { UnsubscribeFunc } from "home-assistant-js-websocket";
@@ -159,9 +160,17 @@ export default class HaAutomationTriggerRow extends LitElement {
                       .path=${mdiRenameBox}
                     ></ha-svg-icon>
                   </mwc-list-item>
+
                   <mwc-list-item graphic="icon" .disabled=${this.disabled}>
                     ${this.hass.localize(
-                      "ui.panel.config.automation.editor.actions.duplicate"
+                      "ui.panel.config.automation.editor.triggers.re_order"
+                    )}
+                    <ha-svg-icon slot="graphic" .path=${mdiSort}></ha-svg-icon>
+                  </mwc-list-item>
+
+                  <mwc-list-item graphic="icon" .disabled=${this.disabled}>
+                    ${this.hass.localize(
+                      "ui.panel.config.automation.editor.triggers.duplicate"
                     )}
                     <ha-svg-icon
                       slot="graphic"
@@ -417,24 +426,27 @@ export default class HaAutomationTriggerRow extends LitElement {
         await this._renameTrigger();
         break;
       case 1:
-        fireEvent(this, "duplicate");
+        fireEvent(this, "re-order");
         break;
       case 2:
+        fireEvent(this, "duplicate");
+        break;
+      case 3:
         this._requestShowId = true;
         this.expand();
         break;
-      case 3:
+      case 4:
         this._switchUiMode();
         this.expand();
         break;
-      case 4:
+      case 5:
         this._switchYamlMode();
         this.expand();
         break;
-      case 5:
+      case 6:
         this._onDisable();
         break;
-      case 6:
+      case 7:
         this._onDelete();
         break;
     }

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -67,7 +67,7 @@ export default class HaAutomationTrigger extends LitElement {
                 )}
               >
                 ${this.hass.localize(
-                  "ui.panel.config.automation.editor.re_order_mode.description_actions"
+                  "ui.panel.config.automation.editor.re_order_mode.description_triggers"
                 )}
                 <mwc-button slot="action" @click=${this._exitReOrderMode}>
                   ${this.hass.localize(

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -43,9 +43,11 @@ export default class HaAutomationTrigger extends LitElement {
 
   @property() public triggers!: Trigger[];
 
-  @property({ type: Boolean }) public reOrderMode = false;
-
   @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public nested = false;
+
+  @property({ type: Boolean }) public reOrderMode = false;
 
   private _focusLastTriggerOnChange = false;
 
@@ -55,6 +57,27 @@ export default class HaAutomationTrigger extends LitElement {
 
   protected render() {
     return html`
+      ${
+        this.reOrderMode && !this.nested
+          ? html`
+              <ha-alert
+                alert-type="info"
+                .title=${this.hass.localize(
+                  "ui.panel.config.automation.editor.re_order_mode.title"
+                )}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.re_order_mode.description_actions"
+                )}
+                <mwc-button slot="action" @click=${this._exitReOrderMode}>
+                  ${this.hass.localize(
+                    "ui.panel.config.automation.editor.re_order_mode.exit"
+                  )}
+                </mwc-button>
+              </ha-alert>
+            `
+          : null
+      }
       <div class="triggers">
         ${repeat(
           this.triggers,
@@ -68,6 +91,7 @@ export default class HaAutomationTrigger extends LitElement {
               @value-changed=${this._triggerChanged}
               .hass=${this.hass}
               .disabled=${this.disabled}
+              @re-order=${this._enterReOrderMode}
             >
               ${this.reOrderMode
                 ? html`
@@ -146,6 +170,16 @@ export default class HaAutomationTrigger extends LitElement {
         row.focus();
       });
     }
+  }
+
+  private async _enterReOrderMode(ev: CustomEvent) {
+    if (this.nested) return;
+    ev.stopPropagation();
+    this.reOrderMode = true;
+  }
+
+  private async _exitReOrderMode() {
+    this.reOrderMode = false;
   }
 
   private async _createSortable() {
@@ -282,6 +316,12 @@ export default class HaAutomationTrigger extends LitElement {
         }
         ha-svg-icon {
           height: 20px;
+        }
+        ha-alert {
+          display: block;
+          margin-bottom: 16px;
+          border-radius: var(--ha-card-border-radius, 16px);
+          overflow: hidden;
         }
         .handle {
           cursor: move;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -62,7 +62,6 @@ import { showToast } from "../../../util/toast";
 import { HaDeviceAction } from "../automation/action/types/ha-automation-action-device_id";
 import "./blueprint-script-editor";
 import "./manual-script-editor";
-import type { HaManualScriptEditor } from "./manual-script-editor";
 
 export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -92,9 +91,6 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
   @state() private _readOnly = false;
 
   @query("ha-yaml-editor", true) private _yamlEditor?: HaYamlEditor;
-
-  @query("manual-script-editor")
-  private _manualEditor?: HaManualScriptEditor;
 
   private _schema = memoizeOne(
     (

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -7,7 +7,6 @@ import {
   mdiDotsVertical,
   mdiInformationOutline,
   mdiPlay,
-  mdiSort,
   mdiTransitConnection,
 } from "@mdi/js";
 import "@polymer/app-layout/app-header/app-header";
@@ -237,23 +236,6 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
                     ></ha-svg-icon>
                   </mwc-list-item>
                 </a>
-              `
-            : ""}
-          ${this._config && !("use_blueprint" in this._config)
-            ? html`
-                <mwc-list-item
-                  aria-label=${this.hass.localize(
-                    "ui.panel.config.automation.editor.re_order"
-                  )}
-                  graphic="icon"
-                  .disabled=${this._readOnly || this._mode !== "gui"}
-                  @click=${this._toggleReOrderMode}
-                >
-                  ${this.hass.localize(
-                    "ui.panel.config.automation.editor.re_order"
-                  )}
-                  <ha-svg-icon slot="graphic" .path=${mdiSort}></ha-svg-icon>
-                </mwc-list-item>
               `
             : ""}
 
@@ -800,12 +782,6 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
   private _switchYamlMode() {
     this._mode = "yaml";
-  }
-
-  private _toggleReOrderMode() {
-    if (this._manualEditor) {
-      this._manualEditor.reOrderMode = !this._manualEditor.reOrderMode;
-    }
   }
 
   private async _saveScript(): Promise<void> {

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -84,6 +84,7 @@ export class HaManualScriptEditor extends LitElement {
         .narrow=${this.narrow}
         .disabled=${this.disabled}
         .reOrderMode=${this.reOrderMode}
+        @re-order=${this._enterReOrderMode}
       ></ha-automation-action>
     `;
   }
@@ -96,7 +97,11 @@ export class HaManualScriptEditor extends LitElement {
   }
 
   private _exitReOrderMode() {
-    this.reOrderMode = !this.reOrderMode;
+    this.reOrderMode = false;
+  }
+
+  private _enterReOrderMode() {
+    this.reOrderMode = true;
   }
 
   private _duplicate() {

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -3,7 +3,6 @@ import { mdiHelpCircle } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
-import "../../../components/ha-alert";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
 import { Action, ScriptConfig } from "../../../data/script";
@@ -24,9 +23,6 @@ export class HaManualScriptEditor extends LitElement {
 
   @property({ attribute: false }) public config!: ScriptConfig;
 
-  @property({ type: Boolean, reflect: true, attribute: "re-order-mode" })
-  public reOrderMode = false;
-
   protected render() {
     return html`
       ${this.disabled
@@ -37,26 +33,6 @@ export class HaManualScriptEditor extends LitElement {
             </mwc-button>
           </ha-alert>`
         : ""}
-      ${this.reOrderMode
-        ? html`
-            <ha-alert
-              alert-type="info"
-              .title=${this.hass.localize(
-                "ui.panel.config.automation.editor.re_order_mode.title"
-              )}
-            >
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.re_order_mode.description"
-              )}
-              <mwc-button slot="action" @click=${this._exitReOrderMode}>
-                ${this.hass.localize(
-                  "ui.panel.config.automation.editor.re_order_mode.exit"
-                )}
-              </mwc-button>
-            </ha-alert>
-          `
-        : ""}
-
       <div class="header">
         <h2 id="sequence-heading" class="name">
           ${this.hass.localize("ui.panel.config.script.editor.sequence")}
@@ -83,8 +59,6 @@ export class HaManualScriptEditor extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .disabled=${this.disabled}
-        .reOrderMode=${this.reOrderMode}
-        @re-order=${this._enterReOrderMode}
       ></ha-automation-action>
     `;
   }
@@ -94,14 +68,6 @@ export class HaManualScriptEditor extends LitElement {
     fireEvent(this, "value-changed", {
       value: { ...this.config!, sequence: ev.detail.value as Action[] },
     });
-  }
-
-  private _exitReOrderMode() {
-    this.reOrderMode = false;
-  }
-
-  private _enterReOrderMode() {
-    this.reOrderMode = true;
   }
 
   private _duplicate() {
@@ -138,10 +104,6 @@ export class HaManualScriptEditor extends LitElement {
         }
         .header a {
           color: var(--secondary-text-color);
-        }
-        ha-alert {
-          display: block;
-          margin-bottom: 16px;
         }
       `,
     ];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1884,6 +1884,7 @@
             "re_order_mode": {
               "title": "Re-order mode",
               "description": "You are in re-order mode, you can re-order your triggers, conditions and actions.",
+              "description_actions": "You are in re-order mode, you can re-order your actions.",
               "exit": "Exit"
             },
             "description": {
@@ -1921,6 +1922,7 @@
               "id": "Trigger ID",
               "edit_id": "Edit ID",
               "duplicate": "[%key:ui::common::duplicate%]",
+              "re_order": "Re-order",
               "rename": "Rename",
               "change_alias": "Rename trigger",
               "alias": "Trigger name",
@@ -2042,6 +2044,7 @@
               "invalid_condition": "Invalid condition configuration",
               "test_failed": "Error occurred while testing condition",
               "duplicate": "[%key:ui::common::duplicate%]",
+              "re-order": "[%key:ui::panel::config::automation::editor::triggers::re_order%]",
               "rename": "[%key:ui::panel::config::automation::editor::triggers::rename%]",
               "change_alias": "Rename condition",
               "alias": "Condition name",
@@ -2134,6 +2137,7 @@
               "run_action_error": "Error running action",
               "run_action_success": "Action run successfully",
               "duplicate": "[%key:ui::common::duplicate%]",
+              "re_order": "[%key:ui::panel::config::automation::editor::triggers::re_order%]",
               "rename": "[%key:ui::panel::config::automation::editor::triggers::rename%]",
               "change_alias": "Rename action",
               "alias": "Action name",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1883,7 +1883,8 @@
             "re_order": "Re-order",
             "re_order_mode": {
               "title": "Re-order mode",
-              "description": "You are in re-order mode, you can re-order your triggers, conditions and actions.",
+              "description_triggers": "You are in re-order mode, you can re-order your triggers.",
+              "description_conditions": "You are in re-order mode, you can re-order your conditions.",
               "description_actions": "You are in re-order mode, you can re-order your actions.",
               "exit": "Exit"
             },
@@ -2044,7 +2045,7 @@
               "invalid_condition": "Invalid condition configuration",
               "test_failed": "Error occurred while testing condition",
               "duplicate": "[%key:ui::common::duplicate%]",
-              "re-order": "[%key:ui::panel::config::automation::editor::triggers::re_order%]",
+              "re_order": "[%key:ui::panel::config::automation::editor::triggers::re_order%]",
               "rename": "[%key:ui::panel::config::automation::editor::triggers::rename%]",
               "change_alias": "Rename condition",
               "alias": "Condition name",


### PR DESCRIPTION
## Breaking change

Re-order button and alert message is now at the triggers/conditions/actions level. 

## Proposed change

Remove re-order button from script/automation overflow menu.
Add re-order button to triggers/conditions/actions overflow menu. 

Blueprint actions re-order has been added too.

### Removed from overflow menu
![Capture d’écran 2022-10-26 à 09 59 18](https://user-images.githubusercontent.com/5878303/197968797-c017e545-a961-441a-8fb9-122634ec2cc9.png)

### Added to row overflow menu
![Capture d’écran 2022-10-26 à 09 59 26](https://user-images.githubusercontent.com/5878303/197968789-154bb424-7e68-4dbe-90a8-b649d1c09c25.png)


### Blueprint demo
https://user-images.githubusercontent.com/5878303/197766931-ebb94cdd-7e82-40a6-a373-e222fb75c71d.mp4

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13679 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
