### PR TITLE
Fix misleading error message

### DIFF
--- a/translations/frontend/en.json
+++ b/translations/frontend/en.json
@@ -3104,7 +3104,7 @@
                 "lovelace": {
                     "caption": "Dashboards",
                     "dashboards": {
-                        "cant_edit_default": "The default dashboard, Overview, cannot be edited from the UI. You can hide it by setting another dashboard as default.",
+                        "cant_edit_default": "Visibility settings for the default dashboard, Overview, cannot be edited from the UI. You can hide it by setting another dashboard as default.",
                         "cant_edit_yaml": "Dashboards created in YAML cannot be edited from the UI. Change them in configuration.yaml.",
                         "caption": "Dashboards",
                         "conf_mode": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The existing error message implies the default dashboard cannot be edited from the UI. That is not true, what the error really means is that the visibility settings (Admin only / Show in sidebar) cannot be edited from the UI. The default dashboard itself can be edited from the UI with no problem, if the user opens it and chooses "Edit Dashboard"

This PR was prompted by the outcome of https://community.home-assistant.io/t/editing-dashboards-from-ui-rules-keep-changing/449328

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/editing-dashboards-from-ui-rules-keep-changing/449328
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
