### PR TITLE
Clean up the ZHA pairing UI

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
@@ -190,12 +190,19 @@ class ZHAAddDevicesPage extends LitElement {
     }
   }
 
+  private _deactivate(): void {
+    this._active = false;
+    if (this._addDevicesTimeoutHandle) {
+      clearTimeout(this._addDevicesTimeoutHandle);
+    }
+  }
+
   private _subscribe(): void {
     if (!this.hass) {
       return;
     }
     this._active = true;
-    const data: any = { type: "zha/devices/permit" };
+    const data: any = { type: "zha/devices/permit", duration: 254 };
     if (this._ieeeAddress) {
       data.ieee = this._ieeeAddress;
     }
@@ -204,8 +211,8 @@ class ZHAAddDevicesPage extends LitElement {
       data
     );
     this._addDevicesTimeoutHandle = setTimeout(
-      () => this._unsubscribe(),
-      120000
+      () => this._deactivate(),
+      254000
     );
   }
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -73,9 +73,9 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
     );
 
     return html`
-      <ha-card .header=${this.device.user_given_name || this.device.name}>
+      <ha-card>
         <div class="card-content">
-          <div class="info">
+          <div>
             <div class="model">${this.device.model}</div>
             <div class="manuf">
               ${this.hass.localize(
@@ -87,15 +87,17 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
           </div>
 
           <div class="device-entities">
-            ${entities.map(
-              (entity) => html`
-                <state-badge
-                  @click=${this._openMoreInfo}
-                  .title=${entity.stateName!}
-                  .stateObj=${this.hass!.states[entity.entity_id]}
-                  slot="item-icon"
-                ></state-badge>
-              `
+            ${entities.map((entity) =>
+              !entity.disabled_by
+                ? html`
+                    <state-badge
+                      @click=${this._openMoreInfo}
+                      .title=${entity.stateName!}
+                      .stateObj=${this.hass!.states[entity.entity_id]}
+                      slot="item-icon"
+                    ></state-badge>
+                  `
+                : ""
             )}
           </div>
           <paper-input
@@ -225,6 +227,10 @@ class ZHADeviceCard extends SubscribeMixin(LitElement) {
         }
         state-badge {
           cursor: pointer;
+        }
+
+        ha-card {
+          border: none;
         }
       `,
     ];

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -109,6 +109,8 @@ class ZHADevicePairingStatusCard extends LitElement {
           padding: 8px;
           text-align: center;
           margin-bottom: 20px;
+          border-top-left-radius: var(--ha-card-border-radius, 12px);
+          border-top-right-radius: var(--ha-card-border-radius, 12px);
         }
         .discovered.initialized .header {
           background: var(--success-color);

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -109,8 +109,13 @@ class ZHADevicePairingStatusCard extends LitElement {
           padding: 8px;
           text-align: center;
           margin-bottom: 20px;
-          border-top-left-radius: var(--ha-card-border-radius, 12px);
-          border-top-right-radius: var(--ha-card-border-radius, 12px);
+          /* Padding is subtracted for nested elements with border radiuses */
+          border-top-left-radius: calc(
+            var(--ha-card-border-radius, 12px) - 2px
+          );
+          border-top-right-radius: calc(
+            var(--ha-card-border-radius, 12px) - 2px
+          );
         }
         .discovered.initialized .header {
           background: var(--success-color);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
No
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR cleans up the ZHA pairing UI. 

- fix CSS
- remove the device name from the top of the card. It was on the screen 3x 
- extend the default pairing time to the maximum of 254 seconds. 
- The event subscription semantics have been updated to avoid a race condition for devices that join the network late. The subscription timeout has been modified to only stop the spinner so that devices that join at the end of the window will continue to update in the UI. The subscription for events will be terminated when the page is left. 
- remove disabled entities from the UI as the exclamation icon caused user confusion / concern

Before: 
<img width="556" alt="before" src="https://user-images.githubusercontent.com/1335687/199981793-da26e520-c768-48f0-b167-00b319b08261.png">

After:
<img width="507" alt="after" src="https://user-images.githubusercontent.com/1335687/199981838-58063641-8a8a-4f0f-9d22-ef58bf6106c3.png">

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
