### PR TITLE
Add swipe action on mobile to switch between dashboard views

### DIFF
--- a/src/layouts/hass-tabs-subpage.ts
+++ b/src/layouts/hass-tabs-subpage.ts
@@ -189,7 +189,11 @@ class HassTabsSubpage extends LitElement {
 
     this._removeHorizontalSwipe =
       this._removeHorizontalSwipe ||
-      setupHorizontalSwipe(this._handleSwipeLeft, this._handleSwipeRight);
+      setupHorizontalSwipe(
+        this._handleSwipeLeft,
+        this._handleSwipeRight,
+        this.shadowRoot
+      );
   }
 
   protected render(): TemplateResult {

--- a/src/panels/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/developer-tools/ha-panel-developer-tools.ts
@@ -27,7 +27,8 @@ class PanelDeveloperTools extends LitElement {
     this.hass.loadBackendTranslation("title");
   }
 
-  protected updated() {
+  protected updated(changedProps) {
+    super.updated(changedProps);
     this._removeHorizontalSwipe =
       this._removeHorizontalSwipe ||
       setupHorizontalSwipe(this._handleSwipeLeft, this._handleSwipeRight);

--- a/src/panels/developer-tools/ha-panel-developer-tools.ts
+++ b/src/panels/developer-tools/ha-panel-developer-tools.ts
@@ -31,7 +31,11 @@ class PanelDeveloperTools extends LitElement {
     super.updated(changedProps);
     this._removeHorizontalSwipe =
       this._removeHorizontalSwipe ||
-      setupHorizontalSwipe(this._handleSwipeLeft, this._handleSwipeRight);
+      setupHorizontalSwipe(
+        this._handleSwipeLeft,
+        this._handleSwipeRight,
+        this.shadowRoot
+      );
   }
 
   protected render(): TemplateResult {

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -587,14 +587,32 @@ class HUIRoot extends LitElement {
   };
 
   private _handleSwipeLeft = () => {
-    if ((this._curView as number) < 1) return;
-    this._selectView((this._curView as number) - 1, false);
+    const prevVisibleView = this.config.views
+      .slice(0, this._curView as number)
+      .reverse()
+      .find(this._isVisible);
+
+    if (!prevVisibleView) return;
+
+    this._selectView(
+      this.config.views.findIndex((v) => v.path === prevVisibleView?.path),
+      false
+    );
+
     scrollTo(0, 0);
   };
 
   private _handleSwipeRight = () => {
-    if ((this._curView as number) + 1 >= this.config.views.length) return;
-    this._selectView((this._curView as number) + 1, false);
+    const nextVisibleView = this.config.views
+      .slice((this._curView as number) + 1)
+      .find(this._isVisible);
+
+    if (!nextVisibleView) return;
+
+    this._selectView(
+      this.config.views.findIndex((v) => v.path === nextVisibleView?.path),
+      false
+    );
     scrollTo(0, 0);
   };
 

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -257,10 +257,9 @@ class HUIRoot extends LitElement {
                           dir=${computeRTLDirection(this.hass!)}
                         >
                           ${views.map(
-                            (view, i) => html`
+                            (view) => html`
                               <paper-tab
                                 aria-label=${ifDefined(view.title)}
-                                id="paper-tab-${i}"
                                 class=${classMap({
                                   "hide-tab": Boolean(
                                     view.subview ||

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -583,7 +583,11 @@ class HUIRoot extends LitElement {
   private _setupViewScroll = () => {
     this._removeHorizontalSwipe =
       this._removeHorizontalSwipe ||
-      setupHorizontalSwipe(this._handleSwipeLeft, this._handleSwipeRight);
+      setupHorizontalSwipe(
+        this._handleSwipeLeft,
+        this._handleSwipeRight,
+        this.shadowRoot
+      );
   };
 
   private _handleSwipeLeft = () => {

--- a/src/util/swipe.ts
+++ b/src/util/swipe.ts
@@ -1,0 +1,24 @@
+import "hammerjs";
+
+export const setupHorizontalSwipe = (backwardsCallback, forwardsCallback) => {
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+  if (!isMobile) return () => {};
+
+  const mc = new Hammer.Manager(document.body);
+  mc.add(
+    new Hammer.Swipe({
+      threshold: 120,
+      velocity: 1,
+    })
+  );
+
+  mc.on("swipeleft", forwardsCallback);
+  mc.on("swiperight", backwardsCallback);
+
+  // Hammer.Swipe intercepts all touch events and prevents scrolls
+  // So we add it back with this line
+  document.body.style.touchAction = "pan-y";
+
+  return () => mc.destroy();
+};

--- a/src/util/swipe.ts
+++ b/src/util/swipe.ts
@@ -1,24 +1,27 @@
 import "hammerjs";
 
-export const setupHorizontalSwipe = (backwardsCallback, forwardsCallback) => {
-  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+export const setupHorizontalSwipe = (
+  backwardsCallback,
+  forwardsCallback,
+  element
+) => {
+  if (!element) return undefined;
 
-  if (!isMobile) return () => {};
+  const mc = new Hammer.Manager(element, {
+    touchAction: "auto",
+    inputClass: Hammer.TouchMouseInput,
+  });
 
-  const mc = new Hammer.Manager(document.body);
   mc.add(
     new Hammer.Swipe({
       threshold: 120,
       velocity: 1,
+      direction: Hammer.DIRECTION_HORIZONTAL,
     })
   );
 
   mc.on("swipeleft", forwardsCallback);
   mc.on("swiperight", backwardsCallback);
-
-  // Hammer.Swipe intercepts all touch events and prevents scrolls
-  // So we add it back with this line
-  document.body.style.touchAction = "pan-y";
 
   return () => mc.destroy();
 };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

As an iPhone user, I'm really used to navigating with gestures, so this PR adds the ability to swipe between views in a dashboard
It will only swipe if the swipe length is at least 30% of the view width and lasts at max 200ms, to prevent false positives


![WhatsApp-Video-2022-11-07-at-17 04 23](https://user-images.githubusercontent.com/25714552/200405141-99443ab7-5229-4547-bab1-8ea2a51606d8.gif)

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

No additional configuration needed

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
