### PR TITLE
Only show hover on clickable rows in data table

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -627,7 +627,7 @@ export class HaDataTable extends LitElement {
           border-top: 1px solid var(--divider-color);
         }
 
-        .mdc-data-table__row:not(.mdc-data-table__row--selected):hover {
+        .mdc-data-table__row:is(.clickable):not(.mdc-data-table__row--selected):hover {
           background-color: rgba(var(--rgb-primary-text-color), 0.04);
         }
 

--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -627,7 +627,7 @@ export class HaDataTable extends LitElement {
           border-top: 1px solid var(--divider-color);
         }
 
-        .mdc-data-table__row:is(.clickable):not(.mdc-data-table__row--selected):hover {
+        .mdc-data-table__row.clickable:not(.mdc-data-table__row--selected):hover {
           background-color: rgba(var(--rgb-primary-text-color), 0.04);
         }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

In data tables every row has a `:hover()` selector which indicates to a user that a row can be interacted with. However (IMHO) this should only be the case for actual, clickable rows. This would also show more clearly with what rows a user can actually interact with.

### Current behavior

**In _Automations_ I'm able to highlight with the last, empty row.**

![image](https://user-images.githubusercontent.com/5155694/200416351-d3f126da-c4bc-4c59-b532-e98a50d46cf9.png)

**Scenes lets me highlight _We couldn't find any scenes_ while doing nothing when I click on it**

![image](https://user-images.githubusercontent.com/5155694/200415884-19a701a8-9913-4a43-91c6-ebaab1810773.png)

**Blueprints let's me hover a row, but I cannot click on it.**

![image](https://user-images.githubusercontent.com/5155694/200416439-26f82b1e-4070-47ef-876d-8c72ad1f946a.png)

**However I can interact with the buttons, resulting in some sort of double `:hover()` effect**

![image](https://user-images.githubusercontent.com/5155694/200416586-451e6d85-1197-4322-8fae-34865bb64c3d.png)

**I can highlight _Discover more Blueprints_ row, but cannot interact with it.**

![image](https://user-images.githubusercontent.com/5155694/200416475-6f510d29-d6be-4aa5-8729-b8e741c0a73b.png)

**And again an empty row that I can highlight**

![image](https://user-images.githubusercontent.com/5155694/200416497-cc0d41f9-ff9e-4354-b0ee-8a6417c871e9.png)

### Proposed behavior

**No highlight when hovering over the last, empty row**

![image](https://user-images.githubusercontent.com/5155694/200418007-986d444b-9b8a-4c4d-b3be-a44f11d65dfc.png)

**Still highlighting interactable rows**

![image](https://user-images.githubusercontent.com/5155694/200418280-079b06e0-5a41-4777-a093-926af98b3187.png)

**Don't highlight a row we are unable to interact with**

![image](https://user-images.githubusercontent.com/5155694/200418541-a4d33bd8-906e-4bc2-aa8d-c46a8ef1736c.png)

**Don't highlight the row, but still highlight the button we can click on**

![image](https://user-images.githubusercontent.com/5155694/200418648-7e67cec5-e30e-4657-8533-3700328b760f.png)

![image](https://user-images.githubusercontent.com/5155694/200418698-7033b57e-2422-41ed-a8cb-f8deeb1b4ca6.png)

> _Note: I've included a stunt-cursor in some screenshots to show the proposed behavior more clearly._

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
