### PR TITLE
Use entity based color for state history

### DIFF
--- a/src/common/entity/state_active.ts
+++ b/src/common/entity/state_active.ts
@@ -5,14 +5,14 @@ import { computeDomain } from "./compute_domain";
 const NORMAL_UNKNOWN_DOMAIN = ["button", "input_button", "scene"];
 const NORMAL_OFF_DOMAIN = ["script"];
 
-export function stateActive(stateObj: HassEntity): boolean {
+export function stateActive(stateObj: HassEntity, state?: string): boolean {
   const domain = computeDomain(stateObj.entity_id);
-  const state = stateObj.state;
+  const compareState = state !== undefined ? state : stateObj?.state;
 
   if (
-    OFF_STATES.includes(state) &&
-    !(NORMAL_UNKNOWN_DOMAIN.includes(domain) && state === "unknown") &&
-    !(NORMAL_OFF_DOMAIN.includes(domain) && state === "script")
+    OFF_STATES.includes(compareState) &&
+    !(NORMAL_UNKNOWN_DOMAIN.includes(domain) && compareState === "unknown") &&
+    !(NORMAL_OFF_DOMAIN.includes(domain) && compareState === "script")
   ) {
     return false;
   }
@@ -20,16 +20,16 @@ export function stateActive(stateObj: HassEntity): boolean {
   // Custom cases
   switch (domain) {
     case "cover":
-      return state === "open" || state === "opening";
+      return compareState === "open" || compareState === "opening";
     case "device_tracker":
     case "person":
-      return state !== "not_home";
+      return compareState !== "not_home";
     case "media-player":
-      return state !== "idle" && state !== "standby";
+      return compareState !== "idle" && compareState !== "standby";
     case "vacuum":
-      return state === "on" || state === "cleaning";
+      return compareState === "on" || compareState === "cleaning";
     case "plant":
-      return state === "problem";
+      return compareState === "problem";
     default:
       return true;
   }

--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -10,12 +10,12 @@ import { sensorColor } from "./color/sensor_color";
 import { computeDomain } from "./compute_domain";
 import { stateActive } from "./state_active";
 
-export const stateColorCss = (stateObj?: HassEntity) => {
-  if (!stateObj || !stateActive(stateObj)) {
+export const stateColorCss = (stateObj?: HassEntity, state?: string) => {
+  if (!stateObj || !stateActive(stateObj, state)) {
     return `var(--rgb-disabled-color)`;
   }
 
-  const color = stateColor(stateObj);
+  const color = stateColor(stateObj, state);
 
   if (color) {
     return `var(--rgb-state-${color}-color)`;
@@ -24,13 +24,13 @@ export const stateColorCss = (stateObj?: HassEntity) => {
   return `var(--rgb-primary-color)`;
 };
 
-export const stateColor = (stateObj: HassEntity) => {
-  const state = stateObj.state;
+export const stateColor = (stateObj: HassEntity, state?: string) => {
+  const compareState = state !== undefined ? state : stateObj?.state;
   const domain = computeDomain(stateObj.entity_id);
 
   switch (domain) {
     case "alarm_control_panel":
-      return alarmControlPanelColor(state);
+      return alarmControlPanelColor(compareState);
 
     case "binary_sensor":
       return binarySensorColor(stateObj);
@@ -39,10 +39,10 @@ export const stateColor = (stateObj: HassEntity) => {
       return coverColor(stateObj);
 
     case "climate":
-      return climateColor(state);
+      return climateColor(compareState);
 
     case "lock":
-      return lockColor(state);
+      return lockColor(compareState);
 
     case "light":
       return "light";
@@ -64,7 +64,7 @@ export const stateColor = (stateObj: HassEntity) => {
       return "vacuum";
 
     case "sun":
-      return state === "above_horizon" ? "sun-day" : "sun-night";
+      return compareState === "above_horizon" ? "sun-day" : "sun-night";
 
     case "update":
       return updateIsInstalling(stateObj as UpdateEntity)

--- a/src/dialogs/more-info/ha-more-info-logbook.ts
+++ b/src/dialogs/more-info/ha-more-info-logbook.ts
@@ -45,6 +45,7 @@ export class MoreInfoLogbook extends LitElement {
         narrow
         no-icon
         no-name
+        show-indicator
         relative-time
       ></ha-logbook>
     `;

--- a/src/panels/logbook/ha-logbook-renderer.ts
+++ b/src/panels/logbook/ha-logbook-renderer.ts
@@ -11,12 +11,15 @@ import {
 import type { HassEntity } from "home-assistant-js-websocket";
 import { customElement, eventOptions, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
+import { styleMap } from "lit/directives/style-map";
 import { formatDate } from "../../common/datetime/format_date";
 import { formatTimeWithSeconds } from "../../common/datetime/format_time";
 import { restoreScroll } from "../../common/decorators/restore-scroll";
 import { fireEvent } from "../../common/dom/fire_event";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
+import { stateActive } from "../../common/entity/state_active";
+import { stateColorCss } from "../../common/entity/state_color";
 import "../../components/entity/state-badge";
 import "../../components/ha-circular-progress";
 import "../../components/ha-relative-time";
@@ -66,6 +69,9 @@ class HaLogbookRenderer extends LitElement {
 
   @property({ type: Boolean, attribute: "virtualize", reflect: true })
   public virtualize = false;
+
+  @property({ type: Boolean, attribute: "show-indicator" })
+  public showIndicator = false;
 
   @property({ type: Boolean, attribute: "no-icon" })
   public noIcon = false;
@@ -132,7 +138,7 @@ class HaLogbookRenderer extends LitElement {
     if (!item || index === undefined) {
       return html``;
     }
-    const previous = this.entries[index - 1];
+    const previous = this.entries[index - 1] as LogbookEntry | undefined;
     const seenEntityIds: string[] = [];
     const currentStateObj = item.entity_id
       ? this.hass.states[item.entity_id]
@@ -199,6 +205,7 @@ class HaLogbookRenderer extends LitElement {
                   ></state-badge>
                 `
               : ""}
+            ${this.showIndicator ? this._renderIndicator(item) : ""}
             <div class="message-relative_time">
               <div class="message">
                 ${!this.noName // Used for more-info panel (single entity case)
@@ -251,6 +258,23 @@ class HaLogbookRenderer extends LitElement {
     fireEvent(this, "hass-logbook-live", {
       enable: e.first === 0,
     });
+  }
+
+  private _renderIndicator(item: LogbookEntry) {
+    const stateObj = this.hass.states[item.entity_id!] as
+      | HassEntity
+      | undefined;
+
+    const color =
+      stateObj && stateActive(stateObj, item.state)
+        ? stateColorCss(stateObj, item.state)
+        : undefined;
+
+    const style = {
+      "--indicator-color": color,
+    };
+
+    return html` <div class="indicator" style=${styleMap(style)}></div> `;
   }
 
   private _renderMessage(
@@ -541,6 +565,7 @@ class HaLogbookRenderer extends LitElement {
         }
 
         .entry {
+          position: relative;
           display: flex;
           width: 100%;
           line-height: 2em;
@@ -549,6 +574,20 @@ class HaLogbookRenderer extends LitElement {
           border-top: 1px solid var(--divider-color);
           justify-content: space-between;
           align-items: center;
+        }
+
+        .indicator {
+          background-color: rgb(
+            var(--indicator-color, var(--rgb-disabled-color))
+          );
+          height: 8px;
+          width: 8px;
+          border-radius: 4px;
+          flex-shrink: 0;
+          margin-right: 12px;
+          margin-inline-start: initial;
+          margin-inline-end: 12px;
+          direction: var(--direction);
         }
 
         ha-icon-next {

--- a/src/panels/logbook/ha-logbook.ts
+++ b/src/panels/logbook/ha-logbook.ts
@@ -65,6 +65,9 @@ export class HaLogbook extends LitElement {
   @property({ type: Boolean, attribute: "no-name" })
   public noName = false;
 
+  @property({ type: Boolean, attribute: "show-indicator" })
+  public showIndicator = false;
+
   @property({ type: Boolean, attribute: "relative-time" })
   public relativeTime = false;
 
@@ -126,6 +129,7 @@ export class HaLogbook extends LitElement {
         .virtualize=${this.virtualize}
         .noIcon=${this.noIcon}
         .noName=${this.noName}
+        .showIndicator=${this.showIndicator}
         .relativeTime=${this.relativeTime}
         .entries=${this._logbookEntries}
         .traceContexts=${this._traceContexts}


### PR DESCRIPTION
## Proposed change

### State History

Following https://github.com/home-assistant/frontend/pull/14128, the same colors are now used in state-history-chart instead of random colors. If no color is defined for a given state, we default to the previous logic.

![image](https://user-images.githubusercontent.com/5878303/200536889-ea6c2e0c-a027-44cc-8ae5-9a2b9fd286bb.png)

### Logbook

Add state color in the more info logbook to better understand state changes.

![Capture d’écran 2022-11-08 à 14 31 36](https://user-images.githubusercontent.com/5878303/200581968-f1c8bce0-0f36-47be-aae3-b48506b8dbd4.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
