### PR TITLE
Move hvac_action to extra line

### DIFF
--- a/src/components/ha-climate-state.ts
+++ b/src/components/ha-climate-state.ts
@@ -33,7 +33,9 @@ class HaClimateState extends LitElement {
 
       ${currentStatus && !UNAVAILABLE_STATES.includes(this.stateObj.state)
         ? html`<div class="current">
-            ${this.hass.localize("ui.card.climate.currently")}:
+            ${this.stateObj.attributes.hvac_action
+              ? this._localizeAction()
+              : this.hass.localize("ui.card.climate.currently")}
             <div class="unit">${currentStatus}</div>
           </div>`
         : ""}`;
@@ -113,15 +115,15 @@ class HaClimateState extends LitElement {
       return this.hass.localize(`state.default.${this.stateObj.state}`);
     }
 
-    const stateString = this.hass.localize(
+    return this.hass.localize(
       `component.climate.state._.${this.stateObj.state}`
     );
+  }
 
-    return this.stateObj.attributes.hvac_action
-      ? `${this.hass.localize(
-          `state_attributes.climate.hvac_action.${this.stateObj.attributes.hvac_action}`
-        )} (${stateString})`
-      : stateString;
+  private _localizeAction(): string {
+    return this.hass.localize(
+      `state_attributes.climate.hvac_action.${this.stateObj.attributes.hvac_action}`
+    );
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

 - Move hvac action to second row instead of the text "Current"

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<img width="597" alt="image" src="https://user-images.githubusercontent.com/482976/200947301-dbe2e6ea-14a7-4e7a-a2a9-0b36e39a3a3e.png">


## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
