### PR TITLE
Fix logbook reporting unknown states as unavailable

### DIFF
--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -10,7 +10,7 @@ import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { LocalizeFunc } from "../common/translations/localize";
 import { HaEntityPickerEntityFilterFunc } from "../components/entity/ha-entity-picker";
 import { HomeAssistant } from "../types";
-import { UNAVAILABLE_STATES, UNKNOWN } from "./entity";
+import { UNAVAILABLE, UNKNOWN } from "./entity";
 
 const LOGBOOK_LOCALIZE_PATH = "ui.components.logbook.messages";
 export const CONTINUOUS_DOMAINS = ["counter", "proximity", "sensor", "zone"];

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -10,7 +10,7 @@ import { computeStateDomain } from "../common/entity/compute_state_domain";
 import { LocalizeFunc } from "../common/translations/localize";
 import { HaEntityPickerEntityFilterFunc } from "../components/entity/ha-entity-picker";
 import { HomeAssistant } from "../types";
-import { UNAVAILABLE_STATES } from "./entity";
+import { UNAVAILABLE_STATES, UNKNOWN } from "./entity";
 
 const LOGBOOK_LOCALIZE_PATH = "ui.components.logbook.messages";
 export const CONTINUOUS_DOMAINS = ["counter", "proximity", "sensor", "zone"];
@@ -413,6 +413,10 @@ export const localizeStateMessage = (
 
   if (state === BINARY_STATE_OFF) {
     return localize(`${LOGBOOK_LOCALIZE_PATH}.turned_off`);
+  }
+
+  if (state === UNKNOWN) {
+    return localize(`${LOGBOOK_LOCALIZE_PATH}.became_unknown`);
   }
 
   if (UNAVAILABLE_STATES.includes(state)) {

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -419,7 +419,7 @@ export const localizeStateMessage = (
     return localize(`${LOGBOOK_LOCALIZE_PATH}.became_unknown`);
   }
 
-  if (UNAVAILABLE_STATES.includes(state)) {
+  if (state === UNAVAILABLE) {
     return localize(`${LOGBOOK_LOCALIZE_PATH}.became_unavailable`);
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -388,6 +388,7 @@
           "turned_on": "turned on",
           "changed_to_state": "changed to {state}",
           "became_unavailable": "became unavailable",
+          "became_unknown": "became unknown",
           "detected_tampering": "detected tampering",
           "cleared_tampering": "cleared tampering"
         }


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
After spending a few hours [debugging a lock](https://github.com/home-assistant/core/issues/81887) because I thought it was going unavailable, it turns out logbook was reporting unknown as unavailable.
## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
