### PR TITLE
Handle optional state enum from sensor entities

### DIFF
--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -262,7 +262,7 @@ export const getStates = (
       }
       break;
     case "sensor":
-      if (!attribute && state.attributes.options) {
+      if (!attribute && state.attributes.device_class === "enum") {
         result.push(...state.attributes.options);
       }
       break;

--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -261,6 +261,11 @@ export const getStates = (
         result.push(...state.attributes.activity_list);
       }
       break;
+    case "sensor":
+      if (!attribute && state.attributes.options) {
+        result.push(...state.attributes.options);
+      }
+      break;
     case "vacuum":
       if (attribute === "fan_speed") {
         result.push(...state.attributes.fan_speed_list);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Small adjustment so the frontend can pick up the `options` attribute from `sensor` entities.

![image](https://user-images.githubusercontent.com/195327/203093421-d72a6bb2-448c-4e33-bf91-87a49b2b24d3.png)

Core PR: <https://github.com/home-assistant/core/pull/82489>

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
