### PR TITLE
Fixed spelling of _(un)subscribeBootstrapIntegrations()

### DIFF
--- a/src/state/disconnect-toast-mixin.ts
+++ b/src/state/disconnect-toast-mixin.ts
@@ -44,18 +44,18 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
             text:
               this.hass!.localize("ui.notification_toast.dismiss") || "Dismiss",
             action: () => {
-              this._unsubscribeBootstrapIntergrations();
+              this._unsubscribeBootstrapIntegrations();
             },
           },
         });
-        this._subscribeBootstrapIntergrations();
+        this._subscribeBootstrapIntegrations();
       } else if (
         oldHass?.config &&
         oldHass.config.state === STATE_NOT_RUNNING &&
         (this.hass!.config.state === STATE_STARTING ||
           this.hass!.config.state === STATE_RUNNING)
       ) {
-        this._unsubscribeBootstrapIntergrations();
+        this._unsubscribeBootstrapIntegrations();
         showToast(this, {
           message: this.hass!.localize("ui.notification_toast.started"),
           duration: 5000,
@@ -97,7 +97,7 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
             text:
               this.hass!.localize("ui.notification_toast.dismiss") || "Dismiss",
             action: () => {
-              this._unsubscribeBootstrapIntergrations();
+              this._unsubscribeBootstrapIntegrations();
             },
           },
         });
@@ -123,20 +123,20 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
           text:
             this.hass!.localize("ui.notification_toast.dismiss") || "Dismiss",
           action: () => {
-            this._unsubscribeBootstrapIntergrations();
+            this._unsubscribeBootstrapIntegrations();
           },
         },
       });
     }
 
-    private _unsubscribeBootstrapIntergrations() {
+    private _unsubscribeBootstrapIntegrations() {
       if (this._subscribedBootstrapIntegrations) {
         this._subscribedBootstrapIntegrations.then((unsub) => unsub());
         this._subscribedBootstrapIntegrations = undefined;
       }
     }
 
-    private _subscribeBootstrapIntergrations() {
+    private _subscribeBootstrapIntegrations() {
       if (!this.hass) {
         return;
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fixed spelling of private functions `_(un)subscribeBootstrapIntegrations()`
in `src/state/disconnect-toast-mixin.ts`. No issue was raised as there's no
actual bug to be fixed or functionality changed. Change is contained in
one class and file with no side effects.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
