### PR TITLE
Update icons for shade device class

### DIFF
--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -12,8 +12,10 @@ import {
   mdiCircle,
   mdiWindowShutter,
   mdiWindowShutterOpen,
-  mdiBlinds,
-  mdiBlindsOpen,
+  mdiBlindsHorizontal,
+  mdiBlindsHorizontalClosed,
+  mdiRollerShade,
+  mdiRollerShadeClosed,
   mdiWindowClosed,
   mdiWindowOpen,
   mdiArrowExpandHorizontal,
@@ -79,6 +81,16 @@ export const coverIcon = (state?: string, stateObj?: HassEntity): string => {
           return mdiCurtains;
       }
     case "blind":
+      switch (state) {
+        case "opening":
+          return mdiArrowUpBox;
+        case "closing":
+          return mdiArrowDownBox;
+        case "closed":
+          return mdiBlindsHorizontalClosed;
+        default:
+          return mdiBlindsHorizontal;
+      }
     case "shade":
       switch (state) {
         case "opening":

--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -86,9 +86,9 @@ export const coverIcon = (state?: string, stateObj?: HassEntity): string => {
         case "closing":
           return mdiArrowDownBox;
         case "closed":
-          return mdiBlinds;
+          return mdiRollerShadeClosed;
         default:
-          return mdiBlindsOpen;
+          return mdiRollerShade;
       }
     case "window":
       switch (state) {


### PR DESCRIPTION
MDI v6.7.96 added icons for roller-shade and roller-shade-closed - this changes shade device class to match, rather than blinds/blinds-open.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

I don't believe this is a breaking change, unless someone is particularly attached to the blinds icons for shades.

## Proposed change

MDI v6.7.96 added icons for roller-shade and roller-shade-closed - this changes shade device class to match, rather than blinds/blinds-open.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
(will need new screenshot of device class icons, but simple enough if/when change approved)
<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
