### PR TITLE
Set initial calendar event date based on active calendar view

### DIFF
--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -73,7 +73,15 @@ class DialogCalendarEventEditor extends LitElement {
       }
     } else {
       this._allDay = false;
-      this._dtstart = startOfHour(new Date());
+      // If we have been provided a selected date (e.g. based on the currently displayed
+      // day in a calendar view), use that as the starting value.
+      if (params.selectedDate) {
+        const startingDate = params.selectedDate;
+        startingDate.setHours(startOfHour(new Date()).getHours());
+        this._dtstart = startingDate;
+      } else {
+        this._dtstart = startOfHour(new Date());
+      }
       this._dtend = addHours(this._dtstart, 1);
     }
   }

--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -75,13 +75,9 @@ class DialogCalendarEventEditor extends LitElement {
       this._allDay = false;
       // If we have been provided a selected date (e.g. based on the currently displayed
       // day in a calendar view), use that as the starting value.
-      if (params.selectedDate) {
-        const startingDate = params.selectedDate;
-        startingDate.setHours(startOfHour(new Date()).getHours());
-        this._dtstart = startingDate;
-      } else {
-        this._dtstart = startOfHour(new Date());
-      }
+      this._dtstart = startOfHour(
+        params.selectedDate ? params.selectedDate : new Date()
+      );
       this._dtend = addHours(this._dtstart, 1);
     }
   }

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -276,11 +276,18 @@ export class HAFullCalendar extends LitElement {
   }
 
   private _createEvent(_info) {
+    // Logic for selectedDate: In week and day view, use the start of the week or the selected day.
+    // If we are in month view, we only use the start of the month, if we are not showing the
+    // current actual month, as for that one the current day is automatically highlighted and
+    // defaulting to a different day in the event creation dialog would be weird.
     showCalendarEventEditDialog(this, {
       calendars: this._mutableCalendars,
       selectedDate:
-        this._activeView === "dayGridWeek" || this._activeView === "dayGridDay"
-          ? this.calendar!.view.activeStart
+        this._activeView === "dayGridWeek" ||
+        this._activeView === "dayGridDay" ||
+        (this._activeView === "dayGridMonth" &&
+          this.calendar!.view.currentStart.getMonth() !== new Date().getMonth())
+          ? this.calendar!.view.currentStart
           : undefined,
       updated: () => {
         this._fireViewChanged();

--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -278,6 +278,10 @@ export class HAFullCalendar extends LitElement {
   private _createEvent(_info) {
     showCalendarEventEditDialog(this, {
       calendars: this._mutableCalendars,
+      selectedDate:
+        this._activeView === "dayGridWeek" || this._activeView === "dayGridDay"
+          ? this.calendar!.view.activeStart
+          : undefined,
       updated: () => {
         this._fireViewChanged();
       },

--- a/src/panels/calendar/show-dialog-calendar-event-detail.ts
+++ b/src/panels/calendar/show-dialog-calendar-event-detail.ts
@@ -2,7 +2,7 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { Calendar, CalendarEventData } from "../../data/calendar";
 
 export interface CalendarEventDetailDialogParams {
-  calendars: Calendar[]; // When creating new events, is the list of events that support creation
+  calendars: Calendar[]; // When creating new events, is the list of calendar entities that support creation
   calendarId?: string;
   entry?: CalendarEventData;
   canDelete?: boolean;

--- a/src/panels/calendar/show-dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/show-dialog-calendar-event-editor.ts
@@ -2,8 +2,9 @@ import { fireEvent } from "../../common/dom/fire_event";
 import { Calendar, CalendarEventData } from "../../data/calendar";
 
 export interface CalendarEventEditDialogParams {
-  calendars: Calendar[]; // When creating new events, is the list of events that support creation
+  calendars: Calendar[]; // When creating new events, is the list of calendar entities that support creation
   calendarId?: string;
+  selectedDate?: Date; // When provided is used as the pre-filled date for the event creation dialog
   entry?: CalendarEventData;
   canDelete?: boolean;
   updated: () => void;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

When calendar view is in week or day view and a new event is added, pre-fill the starting date appropriately.

Month view => Current date (logic unchanged)
Week view => First day of week
Day view => Displayed day is used

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
