### PR TITLE
Consistent table style for calendar and scheduler

### DIFF
--- a/src/panels/calendar/ha-full-calendar.ts
+++ b/src/panels/calendar/ha-full-calendar.ts
@@ -380,7 +380,7 @@ export class HAFullCalendar extends LitElement {
         }
 
         a {
-          color: var(--primary-text-color);
+          color: var(--primary-color);
         }
 
         .controls {
@@ -449,9 +449,10 @@ export class HAFullCalendar extends LitElement {
         }
 
         th.fc-col-header-cell.fc-day {
-          color: var(--secondary-text-color);
+          background-color: var(--table-header-background-color);
+          color: var(--primary-text-color);
           font-size: 11px;
-          font-weight: 400;
+          font-weight: bold;
           text-transform: uppercase;
         }
 

--- a/src/panels/config/helpers/forms/ha-schedule-form.ts
+++ b/src/panels/config/helpers/forms/ha-schedule-form.ts
@@ -388,12 +388,26 @@ class HaScheduleForm extends LitElement {
           -webkit-user-select: none;
           -ms-user-select: none;
           user-select: none;
+          --fc-border-color: var(--divider-color);
+          --fc-event-border-color: var(--divider-color);
         }
         .fc-scroller {
           overflow-x: visible !important;
         }
         .fc-v-event .fc-event-time {
           white-space: inherit;
+        }
+
+        a {
+          color: inherit !important;
+        }
+
+        th.fc-col-header-cell.fc-day {
+          background-color: var(--table-header-background-color);
+          color: var(--primary-text-color);
+          font-size: 11px;
+          font-weight: bold;
+          text-transform: uppercase;
         }
       `,
     ];

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -75,6 +75,7 @@ export const derivedStyles = {
   "paper-listbox-background-color": "var(--card-background-color)",
   "paper-item-icon-color": "var(--state-icon-color)",
   "paper-item-icon-active-color": "var(--state-icon-active-color)",
+  "table-header-background-color": "var(--input-fill-color)",
   "table-row-background-color": "var(--primary-background-color)",
   "table-row-alternative-background-color": "var(--secondary-background-color)",
   "paper-slider-knob-color": "var(--slider-color)",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

I see three issues with the current styling:
1. In the calendar the header row does not stand out enough and therefore the whole table lacks some visual definition
2. The styling between the calendar and the scheduler were different. Especially the scheduler having blue text (which we usually reserve for interact-able elements) did not make sense to me.
3. The scheduler looked awful in dark mode.

This PR now introduces a new CSS var for the table header background color and applies consistent styling.

**Before** (next to some other dashboard elements, namely the input text field since that is where I took the color from):
![image](https://user-images.githubusercontent.com/114137/205443417-34af913a-bacb-434a-827c-af9ef5810aad.png)

**After:**
![image](https://user-images.githubusercontent.com/114137/205443426-a767e7ce-a9ef-4c9d-baa8-507b7c427780.png)
![image](https://user-images.githubusercontent.com/114137/205443432-526011d0-28fb-414b-9b11-dd56e7bd8c17.png)

**Before:**
![image](https://user-images.githubusercontent.com/114137/205443509-97485e72-1e71-4d9c-8b08-28c5cd559a91.png)

**After:**
![image](https://user-images.githubusercontent.com/114137/205443518-80459f6e-a5cf-41d5-8df2-260424c6e6eb.png)
![image](https://user-images.githubusercontent.com/114137/205443519-6a69b521-d27d-41cd-87e7-1889bf57e859.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
