### PR TITLE
Fix recurrence rule generation for UNTIL rules

### DIFF
--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -189,6 +189,7 @@ class DialogCalendarEventEditor extends LitElement {
           </div>
           <ha-recurrence-rule-editor
             .locale=${this.hass.locale}
+            .timezone=${this.hass.config.time_zone}
             .value=${this._rrule || ""}
             @value-changed=${this._handleRRuleChanged}
           >

--- a/src/panels/calendar/ha-recurrence-rule-editor.ts
+++ b/src/panels/calendar/ha-recurrence-rule-editor.ts
@@ -34,6 +34,8 @@ export class RecurrenceRuleEditor extends LitElement {
 
   @property({ attribute: false }) public locale!: HomeAssistant["locale"];
 
+  @property() public timezone?: string;
+
   @state() private _computedRRule = "";
 
   @state() private _freq?: RepeatFrequency = "none";
@@ -292,6 +294,7 @@ export class RecurrenceRuleEditor extends LitElement {
       byweekday: ruleByWeekDay(this._weekday),
       count: this._count,
       until: this._until,
+      tzid: this.timezone,
     };
     const contentline = RRule.optionsToString(options);
     return contentline.slice(6); // Strip "RRULE:" prefix


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Ensure that the `UNTIL` value is set in a local timezone as it much match the value in `dtstart`. This is enforced by the validation in the `ical` library, and also fails in the google calendar API.

The approach is to set the `tzid` field in `rrule.js`. This has the effect of just dropping the `Z` from the UNTIL value.

Fixes this error:
```
2022-12-03 13:49:06.888 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [139652348842144] Error handling message: Unknown error (unknown_error) from 10.10.38.91 (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36)
Traceback (most recent call last):
  File "/home/allen/home-assistant-core/homeassistant/components/websocket_api/decorators.py", line 27, in _handle_async_response
    await func(hass, connection, msg)
  File "/home/allen/home-assistant-core/homeassistant/components/calendar/__init__.py", line 403, in handle_calendar_event_create
    await entity.async_create_event(**msg[CONF_EVENT])
  File "/home/allen/home-assistant-core/homeassistant/components/local_calendar/calendar.py", line 114, in async_create_event
    event.rrule = Recur.from_rrule(rrule)
  File "pydantic/main.py", line 398, in pydantic.main.BaseModel.__setattr__
pydantic.error_wrappers.ValidationError: 1 validation error for Event
__root__
  DTSTART is date local but UNTIL was not (type=value_error)
```

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/83098
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
