### PR TITLE
Add "show_names" option to history graphs

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -26,7 +26,7 @@ class StateHistoryChartLine extends LitElement {
 
   @property() public identifier?: string;
 
-  @property({ type: Boolean }) public isSingleDevice = false;
+  @property({ type: Boolean }) public showNames = true;
 
   @property({ attribute: false }) public endTime!: Date;
 
@@ -101,7 +101,7 @@ class StateHistoryChartLine extends LitElement {
             propagate: true,
           },
           legend: {
-            display: !this.isSingleDevice,
+            display: this.showNames,
             labels: {
               usePointStyle: true,
             },

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -83,7 +83,7 @@ export class StateHistoryChartTimeline extends LitElement {
 
   @property() public identifier?: string;
 
-  @property({ type: Boolean }) public isSingleDevice = false;
+  @property({ type: Boolean }) public showNames = true;
 
   @property({ type: Boolean }) public chunked = false;
 
@@ -175,8 +175,7 @@ export class StateHistoryChartTimeline extends LitElement {
             drawTicks: false,
           },
           ticks: {
-            display:
-              this.chunked || !this.isSingleDevice || this.data.length !== 1,
+            display: this.chunked || this.showNames,
           },
           afterSetDimensions: (y) => {
             y.maxWidth = y.chart.width * 0.18;

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -48,7 +48,7 @@ class StateHistoryCharts extends LitElement {
 
   @property({ type: Boolean, attribute: "up-to-now" }) public upToNow = false;
 
-  @property({ type: Boolean, attribute: "no-single" }) public noSingle = false;
+  @property({ type: Boolean }) public showNames = true;
 
   @property({ type: Boolean }) public isLoadingData = false;
 
@@ -128,8 +128,7 @@ class StateHistoryCharts extends LitElement {
           .unit=${item.unit}
           .data=${item.data}
           .identifier=${item.identifier}
-          .isSingleDevice=${!this.noSingle &&
-          this.historyData.line?.length === 1}
+          .showNames=${this.showNames}
           .endTime=${this._computedEndTime}
           .names=${this.names}
         ></state-history-chart-line>
@@ -141,8 +140,7 @@ class StateHistoryCharts extends LitElement {
         .data=${item}
         .startTime=${this._computedStartTime}
         .endTime=${this._computedEndTime}
-        .isSingleDevice=${!this.noSingle &&
-        this.historyData.timeline?.length === 1}
+        .showNames=${this.showNames}
         .names=${this.names}
         .narrow=${this.narrow}
         .chunked=${this.virtualize}

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -67,12 +67,14 @@ export class MoreInfoHistory extends LitElement {
                 .statTypes=${statTypes}
                 .names=${this._statNames}
                 hideLegend
+                .showNames=${false}
               ></statistics-chart>`
             : html`<state-history-charts
                 up-to-now
                 .hass=${this.hass}
                 .historyData=${this._stateHistory}
                 .isLoadingData=${!this._stateHistory}
+                .showNames=${false}
               ></state-history-charts>`}`
       : ""}`;
   }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -163,7 +163,6 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
                   .hass=${this.hass}
                   .historyData=${this._stateHistory}
                   .endTime=${this._endDate}
-                  no-single
                 >
                 </state-history-charts>
               `}

--- a/src/panels/lovelace/cards/hui-history-graph-card.ts
+++ b/src/panels/lovelace/cards/hui-history-graph-card.ts
@@ -144,7 +144,7 @@ export class HuiHistoryGraphCard extends LitElement implements LovelaceCard {
             .historyData=${this._stateHistory}
             .names=${this._names}
             up-to-now
-            no-single
+            .showNames=${this._config.show_names}
           ></state-history-charts>
         </div>
       </ha-card>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -300,6 +300,7 @@ export interface HistoryGraphCardConfig extends LovelaceCardConfig {
   hours_to_show?: number;
   refresh_interval?: number;
   title?: string;
+  show_names?: boolean;
 }
 
 export interface StatisticsGraphCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
@@ -4,6 +4,7 @@ import { customElement, property, state } from "lit/decorators";
 import {
   array,
   assert,
+  boolean,
   number,
   object,
   optional,
@@ -28,6 +29,7 @@ const cardConfigStruct = assign(
     title: optional(string()),
     hours_to_show: optional(number()),
     refresh_interval: optional(number()),
+    show_names: optional(boolean()),
   })
 );
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Add the optional parameter "show_names" to history graph card to hide the names. This solves the use cases described in the linked issue. At the same time I removed the confusing "no-single" / "isSingleDevice" logic for a cleaner "showNames" approach. There was no longer any usage where looking at the amount of timelines to determine what to show made sense since via "no-single" usage that was anyway practically disabled.

The timeline in the more-info of course still hides the timeline name since here it is clear from the context what is shown (similar to the use cases described in the linked issue).

The default is still that names are always shown, so this is **not** a breaking change.

Note: Doc update will follow once we are aligned that we will merge in this new option.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #12860
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25157

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
