### PR TITLE
Color adjustments for entity state

### DIFF
--- a/gallery/src/pages/misc/entity-state.ts
+++ b/gallery/src/pages/misc/entity-state.ts
@@ -4,14 +4,12 @@ import {
 } from "home-assistant-js-websocket";
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
-import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
 import { computeDomain } from "../../../../src/common/entity/compute_domain";
 import { computeStateDisplay } from "../../../../src/common/entity/compute_state_display";
-import { stateColorCss } from "../../../../src/common/entity/state_color";
-import { stateIconPath } from "../../../../src/common/entity/state_icon_path";
 import "../../../../src/components/data-table/ha-data-table";
 import type { DataTableColumnContainer } from "../../../../src/components/data-table/ha-data-table";
+import "../../../../src/components/entity/state-badge";
 import "../../../../src/components/ha-chip";
 import { provideHass } from "../../../../src/fake_data/provide_hass";
 import { HomeAssistant } from "../../../../src/types";
@@ -105,6 +103,12 @@ const ENTITIES: HassEntity[] = [
   createEntity("alarm_control_panel.arming", "arming"),
   createEntity("alarm_control_panel.disarming", "disarming"),
   createEntity("alarm_control_panel.triggered", "triggered"),
+  // Alert
+  createEntity("alert.off", "off"),
+  createEntity("alert.on", "on"),
+  // Automation
+  createEntity("automation.off", "off"),
+  createEntity("automation.on", "on"),
   // Binary Sensor
   ...BINARY_SENSOR_DEVICE_CLASSES.map((dc) =>
     createEntity(`binary_sensor.${dc}`, "on", dc)
@@ -113,8 +117,11 @@ const ENTITIES: HassEntity[] = [
   createEntity("button.restart", "unknown", "restart"),
   createEntity("button.update", "unknown", "update"),
   // Calendar
-  createEntity("calendar.on", "on"),
   createEntity("calendar.off", "off"),
+  createEntity("calendar.on", "on"),
+  // Camera
+  createEntity("camera.off", "off"),
+  createEntity("camera.on", "on"),
   // Climate
   createEntity("climate.off", "off"),
   createEntity("climate.heat", "heat"),
@@ -124,10 +131,10 @@ const ENTITIES: HassEntity[] = [
   createEntity("climate.dry", "dry"),
   createEntity("climate.fan_only", "fan_only"),
   // Cover
-  createEntity("cover.opening", "opening"),
-  createEntity("cover.open", "open"),
   createEntity("cover.closing", "closing"),
   createEntity("cover.closed", "closed"),
+  createEntity("cover.opening", "opening"),
+  createEntity("cover.open", "open"),
   createEntity("cover.awning", "open", "awning"),
   createEntity("cover.blind", "open", "blind"),
   createEntity("cover.curtain", "open", "curtain"),
@@ -139,24 +146,30 @@ const ENTITIES: HassEntity[] = [
   createEntity("cover.shutter", "open", "shutter"),
   createEntity("cover.window", "open", "window"),
   // Device tracker/person
-  createEntity("device_tracker.home", "home"),
   createEntity("device_tracker.not_home", "not_home"),
+  createEntity("device_tracker.home", "home"),
   createEntity("device_tracker.work", "work"),
   createEntity("person.home", "home"),
   createEntity("person.not_home", "not_home"),
   createEntity("person.work", "work"),
   // Fan
-  createEntity("fan.on", "on"),
   createEntity("fan.off", "off"),
+  createEntity("fan.on", "on"),
+  // Timer
+  createEntity("timer.off", "off"),
+  createEntity("timer.on", "on"),
   // Humidifier
-  createEntity("humidifier.on", "on"),
   createEntity("humidifier.off", "off"),
+  createEntity("humidifier.on", "on"),
+  // Helpers
+  createEntity("input_boolean.off", "off"),
+  createEntity("input_boolean.on", "on"),
   // Light
-  createEntity("light.on", "on"),
   createEntity("light.off", "off"),
+  createEntity("light.on", "on"),
   // Locks
-  createEntity("lock.locked", "locked"),
   createEntity("lock.unlocked", "unlocked"),
+  createEntity("lock.locked", "locked"),
   createEntity("lock.locking", "locking"),
   createEntity("lock.unlocking", "unlocking"),
   createEntity("lock.jammed", "jammed"),
@@ -180,6 +193,12 @@ const ENTITIES: HassEntity[] = [
   createEntity("media_player.speaker_playing", "playing", "speaker"),
   createEntity("media_player.speaker_paused", "paused", "speaker"),
   createEntity("media_player.speaker_standby", "standby", "speaker"),
+  // Remote
+  createEntity("remote.off", "off"),
+  createEntity("remote.on", "on"),
+  // Script
+  createEntity("script.off", "off"),
+  createEntity("script.on", "on"),
   // Sensor
   ...SENSOR_DEVICE_CLASSES.map((dc) => createEntity(`sensor.${dc}`, "10", dc)),
   // Battery sensor
@@ -196,9 +215,12 @@ const ENTITIES: HassEntity[] = [
   createEntity("switch.outlet_on", "on", "outlet"),
   createEntity("switch.switch_off", "off", "switch"),
   createEntity("switch.switch_on", "on", "switch"),
+  // Timer
+  createEntity("timer.off", "off"),
+  createEntity("timer.on", "on"),
   // Vacuum
-  createEntity("vacuum.cleaning", "cleaning"),
   createEntity("vacuum.docked", "docked"),
+  createEntity("vacuum.cleaning", "cleaning"),
   createEntity("vacuum.paused", "paused"),
   createEntity("vacuum.idle", "idle"),
   createEntity("vacuum.returning", "returning"),
@@ -280,18 +302,12 @@ export class DemoEntityState extends LitElement {
       const columns: DataTableColumnContainer<EntityRowData> = {
         icon: {
           title: "Icon",
-          template: (_, entry) => {
-            const cssColor = stateColorCss(entry.stateObj);
-            return html`
-              <ha-svg-icon
-                style=${styleMap({
-                  color: `rgb(${cssColor})`,
-                })}
-                .path=${stateIconPath(entry.stateObj)}
-              >
-              </ha-svg-icon>
-            `;
-          },
+          template: (_, entry) => html`
+            <state-badge
+              .stateObj=${entry.stateObj}
+              .stateColor=${true}
+            ></state-badge>
+          `,
         },
         entity_id: {
           title: "Entity id",

--- a/gallery/src/pages/misc/entity-state.ts
+++ b/gallery/src/pages/misc/entity-state.ts
@@ -155,9 +155,6 @@ const ENTITIES: HassEntity[] = [
   // Fan
   createEntity("fan.off", "off"),
   createEntity("fan.on", "on"),
-  // Timer
-  createEntity("timer.off", "off"),
-  createEntity("timer.on", "on"),
   // Humidifier
   createEntity("humidifier.off", "off"),
   createEntity("humidifier.on", "on"),

--- a/src/common/entity/color/person_color.ts
+++ b/src/common/entity/color/person_color.ts
@@ -1,0 +1,10 @@
+import { HassEntity } from "home-assistant-js-websocket";
+
+export const personColor = (stateObj: HassEntity): string | undefined => {
+  switch (stateObj.state) {
+    case "home":
+      return "person-home";
+    default:
+      return "person-zone";
+  }
+};

--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -29,6 +29,9 @@ export const stateColor = (stateObj: HassEntity, state?: string) => {
   const domain = computeDomain(stateObj.entity_id);
 
   switch (domain) {
+    case "automation":
+      return "automation";
+
     case "alarm_control_panel":
       return alarmControlPanelColor(compareState);
 
@@ -73,13 +76,12 @@ export const stateColor = (stateObj: HassEntity, state?: string) => {
       return compareState === "above_horizon" ? "sun-day" : "sun-night";
 
     case "switch":
+    case "input_boolean":
       return "switch";
 
     case "alert":
       return "alert";
 
-    case "input_boolean":
-    case "automation":
     case "calendar":
     case "camera":
     case "remote":

--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -5,6 +5,7 @@ import { alarmControlPanelColor } from "./color/alarm_control_panel_color";
 import { binarySensorColor } from "./color/binary_sensor_color";
 import { climateColor } from "./color/climate_color";
 import { lockColor } from "./color/lock_color";
+import { personColor } from "./color/person_color";
 import { sensorColor } from "./color/sensor_color";
 import { computeDomain } from "./compute_domain";
 import { stateActive } from "./state_active";
@@ -55,6 +56,10 @@ export const stateColor = (stateObj: HassEntity, state?: string) => {
     case "media_player":
       return "media-player";
 
+    case "person":
+    case "device_tracker":
+      return personColor(stateObj);
+
     case "sensor":
       return sensorColor(stateObj);
 
@@ -69,6 +74,19 @@ export const stateColor = (stateObj: HassEntity, state?: string) => {
 
     case "switch":
       return "switch";
+
+    case "alert":
+      return "alert";
+
+    case "input_boolean":
+    case "automation":
+    case "calendar":
+    case "camera":
+    case "remote":
+    case "script":
+    case "timer":
+    case "group":
+      return "active";
 
     case "update":
       return updateIsInstalling(stateObj as UpdateEntity)

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -1,29 +1,6 @@
 import { css } from "lit";
 
 export const iconColorCSS = css`
-  ha-state-icon[data-active][data-domain="alert"],
-  ha-state-icon[data-active][data-domain="automation"],
-  ha-state-icon[data-active][data-domain="binary_sensor"],
-  ha-state-icon[data-active][data-domain="calendar"],
-  ha-state-icon[data-active][data-domain="camera"],
-  ha-state-icon[data-active][data-domain="cover"],
-  ha-state-icon[data-active][data-domain="device_tracker"],
-  ha-state-icon[data-active][data-domain="fan"],
-  ha-state-icon[data-active][data-domain="humidifier"],
-  ha-state-icon[data-active][data-domain="light"],
-  ha-state-icon[data-active][data-domain="input_boolean"],
-  ha-state-icon[data-active][data-domain="lock"],
-  ha-state-icon[data-active][data-domain="media_player"],
-  ha-state-icon[data-active][data-domain="remote"],
-  ha-state-icon[data-active][data-domain="script"],
-  ha-state-icon[data-active][data-domain="sun"],
-  ha-state-icon[data-active][data-domain="switch"],
-  ha-state-icon[data-active][data-domain="timer"],
-  ha-state-icon[data-active][data-domain="vacuum"],
-  ha-state-icon[data-active][data-domain="group"] {
-    color: var(--paper-item-icon-active-color, #fdd835);
-  }
-
   ha-state-icon[data-active][data-domain="alarm_control_panel"][data-state="pending"],
   ha-state-icon[data-active][data-domain="alarm_control_panel"][data-state="arming"],
   ha-state-icon[data-active][data-domain="alarm_control_panel"][data-state="triggered"] {

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -128,6 +128,18 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
   }
 
   private _computeStateColor = memoize((entity: HassEntity, color?: string) => {
+    if (UNAVAILABLE_STATES.includes(entity.state)) {
+      return undefined;
+    }
+
+    // Use default color for person/device_tracker because color is on the badge
+    if (
+      computeDomain(entity.entity_id) === "person" ||
+      computeDomain(entity.entity_id) === "device_tracker"
+    ) {
+      return "var(--rgb-state-default-color)";
+    }
+
     if (!stateActive(entity)) {
       return undefined;
     }

--- a/src/panels/lovelace/cards/tile/badges/tile-badge-person.ts
+++ b/src/panels/lovelace/cards/tile/badges/tile-badge-person.ts
@@ -1,6 +1,5 @@
-import { mdiHelp, mdiHome, mdiHomeExportOutline } from "@mdi/js";
+import { mdiHome, mdiHomeExportOutline } from "@mdi/js";
 import { HassEntity } from "home-assistant-js-websocket";
-import { UNAVAILABLE_STATES } from "../../../../../data/entity";
 import { HomeAssistant } from "../../../../../types";
 import { ComputeBadgeFunction } from "./tile-badge";
 
@@ -17,20 +16,18 @@ function getZone(entity: HassEntity, hass: HomeAssistant) {
 
 function personBadgeIcon(entity: HassEntity) {
   const state = entity.state;
-  if (UNAVAILABLE_STATES.includes(state)) {
-    return mdiHelp;
-  }
   return state === "not_home" ? mdiHomeExportOutline : mdiHome;
 }
 
-function personBadgeColor(entity: HassEntity, inZone?: boolean) {
-  if (inZone) {
-    return "var(--rgb-state-person-zone-color)";
+function personBadgeColor(entity: HassEntity) {
+  switch (entity.state) {
+    case "home":
+      return "var(--rgb-badge-person-home-color)";
+    case "not_home":
+      return "var(--rgb-badge-person-not-home-color)";
+    default:
+      return "var(--rgb-badge-person-zone-color)";
   }
-  const state = entity.state;
-  return state === "not_home"
-    ? "var(--rgb-state-person-not-home-color)"
-    : "var(--rgb-state-person-home-color)";
 }
 
 export const computePersonBadge: ComputeBadgeFunction = (stateObj, hass) => {
@@ -39,6 +36,6 @@ export const computePersonBadge: ComputeBadgeFunction = (stateObj, hass) => {
   return {
     iconPath: personBadgeIcon(stateObj),
     icon: zone?.attributes.icon,
-    color: personBadgeColor(stateObj, Boolean(zone)),
+    color: personBadgeColor(stateObj),
   };
 };

--- a/src/panels/lovelace/cards/tile/badges/tile-badge.ts
+++ b/src/panels/lovelace/cards/tile/badges/tile-badge.ts
@@ -1,5 +1,6 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { computeDomain } from "../../../../../common/entity/compute_domain";
+import { UNAVAILABLE_STATES } from "../../../../../data/entity";
 import { HomeAssistant } from "../../../../../types";
 import { computeClimateBadge } from "./tile-badge-climate";
 import { computePersonBadge } from "./tile-badge-person";
@@ -16,6 +17,9 @@ export type ComputeBadgeFunction = (
 ) => TileBadge | undefined;
 
 export const computeTileBadge: ComputeBadgeFunction = (stateObj, hass) => {
+  if (UNAVAILABLE_STATES.includes(stateObj.state)) {
+    return undefined;
+  }
   const domain = computeDomain(stateObj.entity_id);
   switch (domain) {
     case "person":

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -137,12 +137,13 @@ documentContainer.innerHTML = `<custom-style>
 
       /* rgb state color */
       --rgb-state-default-color: 68, 115, 158;
-      --rgb-state-active-color: var(--rgb-amber-color);
+      --rgb-state-active-color: var(--rgb-primary-color);
       --rgb-state-alarm-armed-color: var(--rgb-red-color);
       --rgb-state-alarm-pending-color: var(--rgb-orange-color);
       --rgb-state-alarm-arming-color: var(--rgb-orange-color);
       --rgb-state-alarm-triggered-color: var(--rgb-red-color);
       --rgb-state-alert-color: var(--rgb-red-color);
+      --rgb-state-automation-color: var(--rgb-amber-color);
       --rgb-state-binary-sensor-color: var(--rgb-primary-color);
       --rgb-state-binary-sensor-alerting-color: var(--rgb-red-color);
       --rgb-state-cover-color: var(--rgb-purple-color);

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -137,10 +137,12 @@ documentContainer.innerHTML = `<custom-style>
 
       /* rgb state color */
       --rgb-state-default-color: 68, 115, 158;
+      --rgb-state-active-color: var(--rgb-amber-color);
       --rgb-state-alarm-armed-color: var(--rgb-red-color);
       --rgb-state-alarm-pending-color: var(--rgb-orange-color);
       --rgb-state-alarm-arming-color: var(--rgb-orange-color);
       --rgb-state-alarm-triggered-color: var(--rgb-red-color);
+      --rgb-state-alert-color: var(--rgb-red-color);
       --rgb-state-binary-sensor-color: var(--rgb-primary-color);
       --rgb-state-binary-sensor-alerting-color: var(--rgb-red-color);
       --rgb-state-cover-color: var(--rgb-purple-color);
@@ -152,7 +154,6 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-state-lock-pending-color: var(--rgb-orange-color);
       --rgb-state-media-player-color: var(--rgb-indigo-color);
       --rgb-state-person-home-color: var(--rgb-green-color);
-      --rgb-state-person-not-home-color: var(--rgb-red-color);
       --rgb-state-person-zone-color: var(--rgb-blue-color);
       --rgb-state-sensor-battery-high-color: var(--rgb-green-color);
       --rgb-state-sensor-battery-low-color: var(--rgb-red-color);
@@ -172,6 +173,11 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-state-climate-heat-color: var(--rgb-deep-orange-color);
       --rgb-state-climate-heat-cool-color: var(--rgb-state-default-color);
       --rgb-state-climate-idle-color: var(--rgb-disabled-color);
+
+      /* rgb state badge color */
+      --rgb-badge-person-home-color: var(--rgb-state-person-home-color);
+      --rgb-badge-person-zone-color: var(--rgb-state-person-zone-color);
+      --rgb-badge-person-not-home-color: var(--rgb-red-color);
 
       /* input components */
       --input-idle-line-color: rgba(0, 0, 0, 0.42);


### PR DESCRIPTION
## Breaking change

Default color for active state on `state-badge` is now `--rgb-state-active-color` (primary blue color) instead of `--paper-item-icon-active-color`.

## Proposed change

### Default active color

Use same color as binary sensor (primary blue color). For example, `remote`, `calendar`, `timer` use this color.

![CleanShot 2022-12-05 at 16 19 53](https://user-images.githubusercontent.com/5878303/205674005-eba42090-2df6-44b6-bd92-5df6e4d9dc0d.png)![CleanShot 2022-12-05 at 16 17 13](https://user-images.githubusercontent.com/5878303/205674016-e70d01b9-d769-491a-8b44-cbcb2378a525.png)![CleanShot 2022-12-05 at 16 17 03](https://user-images.githubusercontent.com/5878303/205674023-84617abb-02bb-415f-a927-551b364e357a.png)

### Input boolean and automation

Use same color as switch

![CleanShot 2022-12-05 at 16 16 31](https://user-images.githubusercontent.com/5878303/205673236-1b8073cc-c09e-4be7-8e55-d9ac8e787976.png)

### Person and device tracker

Improve color rules for `person` and `device_tracker` entities.

#### In entities card
![CleanShot 2022-12-05 at 14 11 14](https://user-images.githubusercontent.com/5878303/205671158-1ca2a46a-fb48-4099-bb0c-84a4928699f3.png)

#### In tile card
Icon is not colored but the badge is because person often use entity picture.

![CleanShot 2022-12-05 at 14 11 19](https://user-images.githubusercontent.com/5878303/205671167-2eb643a4-80e4-4ac4-936e-5a991ffe08fb.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
