### PR TITLE
Add QoS option for MQTT subscribe

### DIFF
--- a/src/data/mqtt.ts
+++ b/src/data/mqtt.ts
@@ -37,8 +37,8 @@ export interface MQTTDeviceDebugInfo {
 export const subscribeMQTTTopic = (
   hass: HomeAssistant,
   topic: string,
-  qos?: number,
-  callback: (message: MQTTMessage) => void
+  callback: (message: MQTTMessage) => void,
+  qos?: number
 ) =>
   hass.connection.subscribeMessage<MQTTMessage>(callback, {
     type: "mqtt/subscribe",

--- a/src/data/mqtt.ts
+++ b/src/data/mqtt.ts
@@ -37,11 +37,13 @@ export interface MQTTDeviceDebugInfo {
 export const subscribeMQTTTopic = (
   hass: HomeAssistant,
   topic: string,
+  qos: number,
   callback: (message: MQTTMessage) => void
 ) =>
   hass.connection.subscribeMessage<MQTTMessage>(callback, {
     type: "mqtt/subscribe",
     topic,
+    qos,
   });
 
 export const fetchMQTTDebugInfo = (

--- a/src/data/mqtt.ts
+++ b/src/data/mqtt.ts
@@ -37,7 +37,7 @@ export interface MQTTDeviceDebugInfo {
 export const subscribeMQTTTopic = (
   hass: HomeAssistant,
   topic: string,
-  qos: number,
+  qos?: number,
   callback: (message: MQTTMessage) => void
 ) =>
   hass.connection.subscribeMessage<MQTTMessage>(callback, {

--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
@@ -100,8 +100,8 @@ class MqttSubscribeCard extends LitElement {
     `;
   }
 
-  private _handleTopic(ev: CustomEvent): void {
-    this._topic = (ev.target! as any).value;
+  private _handleTopic(ev): void {
+    this._topic = ev.target.value;
   }
 
   private _handleQos(ev: CustomEvent): void {

--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
@@ -1,15 +1,14 @@
 import "@material/mwc-button";
-import "@polymer/paper-input/paper-input";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-select";
+import "../../../../../components/ha-textfield";
 import { formatTime } from "../../../../../common/datetime/format_time";
 import { MQTTMessage, subscribeMQTTTopic } from "../../../../../data/mqtt";
 import { HomeAssistant } from "../../../../../types";
 import "@material/mwc-list/mwc-list-item";
 import { LocalStorage } from "../../../../../common/decorators/local-storage";
-import "../../../../../components/ha-textfield";
 
 const qosLevel = ["0", "1", "2"];
 
@@ -151,10 +150,6 @@ class MqttSubscribeCard extends LitElement {
       form {
         display: block;
         padding: 16px;
-      }
-      paper-input {
-        display: inline-block;
-        width: 200px;
       }
       .events {
         margin: -16px 0;

--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
@@ -119,8 +119,8 @@ class MqttSubscribeCard extends LitElement {
       this._subscribed = await subscribeMQTTTopic(
         this.hass!,
         this._topic,
-        parseInt(this._qos),
-        (message) => this._handleMessage(message)
+        (message) => this._handleMessage(message),
+        parseInt(this._qos)
       );
     }
   }

--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-subscribe-card.ts
@@ -8,6 +8,8 @@ import { formatTime } from "../../../../../common/datetime/format_time";
 import { MQTTMessage, subscribeMQTTTopic } from "../../../../../data/mqtt";
 import { HomeAssistant } from "../../../../../types";
 import "@material/mwc-list/mwc-list-item";
+import { LocalStorage } from "../../../../../common/decorators/local-storage";
+import "../../../../../components/ha-textfield";
 
 const qosLevel = ["0", "1", "2"];
 
@@ -15,9 +17,11 @@ const qosLevel = ["0", "1", "2"];
 class MqttSubscribeCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @state() private _topic = "";
+  @LocalStorage("panel-dev-mqtt-topic-subscribe", true, false)
+  private _topic = "";
 
-  @state() private _qos = "0";
+  @LocalStorage("panel-dev-mqtt-qos-subscribe", true, false)
+  private _qos = "0";
 
   @state() private _subscribed?: () => void;
 
@@ -44,14 +48,14 @@ class MqttSubscribeCard extends LitElement {
         header=${this.hass.localize("ui.panel.config.mqtt.description_listen")}
       >
         <form>
-          <paper-input
+          <ha-textfield
             .label=${this._subscribed
               ? this.hass.localize("ui.panel.config.mqtt.listening_to")
               : this.hass.localize("ui.panel.config.mqtt.subscribe_to")}
             .disabled=${this._subscribed !== undefined}
             .value=${this._topic}
-            @value-changed=${this._valueChanged}
-          ></paper-input>
+            @change=${this._handleTopic}
+          ></ha-textfield>
           <ha-select
             .label=${this.hass.localize("ui.panel.config.mqtt.qos")}
             .disabled=${this._subscribed !== undefined}
@@ -97,8 +101,8 @@ class MqttSubscribeCard extends LitElement {
     `;
   }
 
-  private _valueChanged(ev: CustomEvent): void {
-    this._topic = ev.detail.value;
+  private _handleTopic(ev: CustomEvent): void {
+    this._topic = (ev.target! as any).value;
   }
 
   private _handleQos(ev: CustomEvent): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Add QoS option for MQTT subscribe:
- Add QoS option for MQTT subscribe section.
- Implement the @LocalStorage decorator on topic and new QoS field.
- Adjust the style of the topic subscribe field with with style used at the MQTT publish section.

Depends on https://github.com/home-assistant/core/pull/83241 (Merged) for the support of subscribing with additional `qos` parameter.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
