### PR TITLE
Fix accidental date cross-overs in local cal event creation

### DIFF
--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -302,7 +302,11 @@ class DialogCalendarEventEditor extends LitElement {
     const duration = differenceInMilliseconds(this._dtend!, this._dtstart!);
 
     this._dtstart = new Date(
-      ev.detail.value + "T" + this._dtstart!.toISOString().split("T")[1]
+      ev.detail.value +
+        "T" +
+        this._dtstart!.toLocaleTimeString("en-GB", {
+          timeZone: this.hass.config.time_zone,
+        })
     );
 
     // Prevent that the end time can be before the start time. Try to keep the
@@ -326,7 +330,11 @@ class DialogCalendarEventEditor extends LitElement {
 
   private _endDateChanged(ev: CustomEvent) {
     this._dtend = new Date(
-      ev.detail.value + "T" + this._dtend!.toISOString().split("T")[1]
+      ev.detail.value +
+        "T" +
+        this._dtend!.toLocaleTimeString("en-GB", {
+          timeZone: this.hass.config.time_zone,
+        })
     );
   }
 
@@ -335,7 +343,11 @@ class DialogCalendarEventEditor extends LitElement {
     const duration = differenceInMilliseconds(this._dtend!, this._dtstart!);
 
     this._dtstart = new Date(
-      this._dtstart!.toISOString().split("T")[0] + "T" + ev.detail.value
+      this._dtstart!.toLocaleDateString("en-CA", {
+        timeZone: this.hass.config.time_zone,
+      }) +
+        "T" +
+        ev.detail.value
     );
 
     // Prevent that the end time can be before the start time. Try to keep the
@@ -357,7 +369,11 @@ class DialogCalendarEventEditor extends LitElement {
 
   private _endTimeChanged(ev: CustomEvent) {
     this._dtend = new Date(
-      this._dtend!.toISOString().split("T")[0] + "T" + ev.detail.value
+      this._dtend!.toLocaleDateString("en-CA", {
+        timeZone: this.hass.config.time_zone,
+      }) +
+        "T" +
+        ev.detail.value
     );
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The ISO conversion to UTC causes day cross-overs.

My scenario with timezone UTC+1 (Europe/Berlin):

- Set the start time to midnight 12:00 AM
- Date stays correct
- Set start time to 12:30 AM
- => The toISOString() returns now the date fromt he day before as it works with UTC so my previous local time of midnight is in UTC the day before at 11:00 PM
- => The resulting created new this._dtstart was wrong and the date selector changed to the day before.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
