### PR TITLE
Update automation auto-generated explanations

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -33,9 +33,7 @@ export const describeTrigger = (
         } else if (index === trigger.event_type.length - 1) {
           // Last item in the list
           eventTypes += ` ${
-            trigger.event_type.length > 1
-              ? "or"
-              : ""
+            trigger.event_type.length > 1 ? "or" : ""
           } ${state}`;
         } else {
           // Middle item in the list
@@ -116,11 +114,9 @@ export const describeTrigger = (
             entities += `${computeStateName(states[entity]) || entity}`;
           } else if (index === trigger.entity_id.length - 1) {
             // Last item in the list
-            entities += ` ${
-              trigger.entity_id.length > 1
-                ? "or"
-                : ""
-            } ${computeStateName(states[entity]) || entity}`;
+            entities += ` ${trigger.entity_id.length > 1 ? "or" : ""} ${
+              computeStateName(states[entity]) || entity
+            }`;
           } else {
             // Middle item in the list
             entities += `, ${computeStateName(states[entity]) || entity}`;
@@ -149,11 +145,7 @@ export const describeTrigger = (
             from += `${state}`;
           } else if (index === trigger.from.length - 1) {
             // Last item in the list
-            from += ` ${
-              trigger.from.length > 1
-                ? "or"
-                : ""
-            } ${state}`;
+            from += ` ${trigger.from.length > 1 ? "or" : ""} ${state}`;
           } else {
             // Middle item in the list
             from += `, ${state}`;
@@ -174,11 +166,7 @@ export const describeTrigger = (
             to += `${state}`;
           } else if (index === trigger.to.length - 1) {
             // Last item in the list
-            to += ` ${
-              trigger.to.length > 1
-                ? "or"
-                : ""
-            } ${state}`;
+            to += ` ${trigger.to.length > 1 ? "or" : ""} ${state}`;
           } else {
             // Middle item in the list
             to += `, ${state}`;
@@ -271,11 +259,9 @@ export const describeTrigger = (
             entities += `${computeStateName(states[entity]) || entity}`;
           } else if (index === trigger.entity_id.length - 1) {
             // Last item in the list
-            entities += ` ${
-              trigger.entity_id.length > 1
-                ? "or"
-                : ""
-            } ${computeStateName(states[entity]) || entity}`;
+            entities += ` ${trigger.entity_id.length > 1 ? "or" : ""} ${
+              computeStateName(states[entity]) || entity
+            }`;
           } else {
             // Middle item in the list
             entities += `, ${computeStateName(states[entity]) || entity}`;
@@ -300,11 +286,9 @@ export const describeTrigger = (
             zones += `${computeStateName(states[zone]) || zone}`;
           } else if (index === trigger.zone.length - 1) {
             // Last item in the list
-            zones += ` ${
-              trigger.zone.length > 1
-                ? "or"
-                : ""
-            } ${computeStateName(states[zone]) || zone}`;
+            zones += ` ${trigger.zone.length > 1 ? "or" : ""} ${
+              computeStateName(states[zone]) || zone
+            }`;
           } else {
             // Middle item in the list
             zones += `, ${computeStateName(states[zone]) || zone}`;
@@ -336,11 +320,7 @@ export const describeTrigger = (
           sources += `${source}`;
         } else if (index === trigger.source.length - 1) {
           // Last item in the list
-          sources += ` ${
-            trigger.source.length > 1
-              ? "or"
-              : ""
-          } ${source}`;
+          sources += ` ${trigger.source.length > 1 ? "or" : ""} ${source}`;
         } else {
           // Middle item in the list
           sources += `, ${source}`;
@@ -362,11 +342,9 @@ export const describeTrigger = (
             zones += `${computeStateName(states[zone]) || zone}`;
           } else if (index === trigger.zone.length - 1) {
             // Last item in the list
-            zones += ` ${
-              trigger.zone.length > 1
-                ? "or"
-                : ""
-            } ${computeStateName(states[zone]) || zone}`;
+            zones += ` ${trigger.zone.length > 1 ? "or" : ""} ${
+              computeStateName(states[zone]) || zone
+            }`;
           } else {
             // Middle item in the list
             zones += `, ${computeStateName(states[zone]) || zone}`;
@@ -499,11 +477,7 @@ export const describeCondition = (
           states += `${state}`;
         } else if (index === condition.state.length - 1) {
           // Last item in the list
-          states += ` ${
-            condition.state.length > 1
-              ? "or"
-              : ""
-          } ${state}`;
+          states += ` ${condition.state.length > 1 ? "or" : ""} ${state}`;
         } else {
           // Middle item in the list
           states += `, ${state}`;
@@ -620,11 +594,9 @@ export const describeCondition = (
             entities += `${computeStateName(states[entity]) || entity}`;
           } else if (index === condition.entity_id.length - 1) {
             // Last item in the list
-            entities += ` ${
-              condition.entity_id.length > 1
-                ? "or"
-                : ""
-            } ${computeStateName(states[entity]) || entity}`;
+            entities += ` ${condition.entity_id.length > 1 ? "or" : ""} ${
+              computeStateName(states[entity]) || entity
+            }`;
           } else {
             // Middle item in the list
             entities += `, ${computeStateName(states[entity]) || entity}`;
@@ -649,11 +621,9 @@ export const describeCondition = (
             zones += `${computeStateName(states[zone]) || zone}`;
           } else if (index === condition.zone.length - 1) {
             // Last item in the list
-            zones += ` ${
-              condition.zone.length > 1
-                ? "or"
-                : ""
-            } ${computeStateName(states[zone]) || zone}`;
+            zones += ` ${condition.zone.length > 1 ? "or" : ""} ${
+              computeStateName(states[zone]) || zone
+            }`;
           } else {
             // Middle item in the list
             zones += `, ${computeStateName(states[zone]) || zone}`;

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -27,12 +27,20 @@ export const describeTrigger = (
 
     if (Array.isArray(trigger.event_type)) {
       for (const [index, state] of trigger.event_type.entries()) {
-        eventTypes += `${index > 0 ? "," : ""} ${
-          trigger.event_type.length > 1 &&
-          index === trigger.event_type.length - 1
-            ? "or"
-            : ""
-        } ${state}`;
+        if (index === 0) {
+          // First item in the list
+          eventTypes += `${state}`;
+        } else if (index === trigger.event_type.length - 1) {
+          // Last item in the list
+          eventTypes += ` ${
+            trigger.event_type.length > 1
+              ? "or"
+              : ""
+          } ${state}`;
+        } else {
+          // Middle item in the list
+          eventTypes += `, ${state}`;
+        }
       }
     } else {
       eventTypes = trigger.event_type.toString();
@@ -103,12 +111,20 @@ export const describeTrigger = (
     if (Array.isArray(trigger.entity_id)) {
       for (const [index, entity] of trigger.entity_id.entries()) {
         if (states[entity]) {
-          entities += `${index > 0 ? "," : ""} ${
-            trigger.entity_id.length > 1 &&
-            index === trigger.entity_id.length - 1
-              ? "or"
-              : ""
-          } ${computeStateName(states[entity]) || entity}`;
+          if (index === 0) {
+            // First item in the list
+            entities += `${computeStateName(states[entity]) || entity}`;
+          } else if (index === trigger.entity_id.length - 1) {
+            // Last item in the list
+            entities += ` ${
+              trigger.entity_id.length > 1
+                ? "or"
+                : ""
+            } ${computeStateName(states[entity]) || entity}`;
+          } else {
+            // Middle item in the list
+            entities += `, ${computeStateName(states[entity]) || entity}`;
+          }
         }
       }
     } else if (trigger.entity_id) {
@@ -128,11 +144,20 @@ export const describeTrigger = (
       let from = "";
       if (Array.isArray(trigger.from)) {
         for (const [index, state] of trigger.from.entries()) {
-          from += `${index > 0 ? "," : ""} ${
-            trigger.from.length > 1 && index === trigger.from.length - 1
-              ? "or"
-              : ""
-          } ${state}`;
+          if (index === 0) {
+            // First item in the list
+            from += `${state}`;
+          } else if (index === trigger.from.length - 1) {
+            // Last item in the list
+            from += ` ${
+              trigger.from.length > 1
+                ? "or"
+                : ""
+            } ${state}`;
+          } else {
+            // Middle item in the list
+            from += `, ${state}`;
+          }
         }
       } else {
         from = trigger.from.toString();
@@ -144,9 +169,20 @@ export const describeTrigger = (
       let to = "";
       if (Array.isArray(trigger.to)) {
         for (const [index, state] of trigger.to.entries()) {
-          to += `${index > 0 ? "," : ""} ${
-            trigger.to.length > 1 && index === trigger.to.length - 1 ? "or" : ""
-          } ${state}`;
+          if (index === 0) {
+            // First item in the list
+            to += `${state}`;
+          } else if (index === trigger.to.length - 1) {
+            // Last item in the list
+            to += ` ${
+              trigger.to.length > 1
+                ? "or"
+                : ""
+            } ${state}`;
+          } else {
+            // Middle item in the list
+            to += `, ${state}`;
+          }
         }
       } else if (trigger.to) {
         to = trigger.to.toString();
@@ -230,12 +266,20 @@ export const describeTrigger = (
     if (Array.isArray(trigger.entity_id)) {
       for (const [index, entity] of trigger.entity_id.entries()) {
         if (states[entity]) {
-          entities += `${index > 0 ? "," : ""} ${
-            trigger.entity_id.length > 1 &&
-            index === trigger.entity_id.length - 1
-              ? "or"
-              : ""
-          } ${computeStateName(states[entity]) || entity}`;
+          if (index === 0) {
+            // First item in the list
+            entities += `${computeStateName(states[entity]) || entity}`;
+          } else if (index === trigger.entity_id.length - 1) {
+            // Last item in the list
+            entities += ` ${
+              trigger.entity_id.length > 1
+                ? "or"
+                : ""
+            } ${computeStateName(states[entity]) || entity}`;
+          } else {
+            // Middle item in the list
+            entities += `, ${computeStateName(states[entity]) || entity}`;
+          }
         }
       }
     } else {
@@ -251,11 +295,20 @@ export const describeTrigger = (
 
       for (const [index, zone] of trigger.zone.entries()) {
         if (states[zone]) {
-          zones += `${index > 0 ? "," : ""} ${
-            trigger.zone.length > 1 && index === trigger.zone.length - 1
-              ? "or"
-              : ""
-          } ${computeStateName(states[zone]) || zone}`;
+          if (index === 0) {
+            // First item in the list
+            zones += `${computeStateName(states[zone]) || zone}`;
+          } else if (index === trigger.zone.length - 1) {
+            // Last item in the list
+            zones += ` ${
+              trigger.zone.length > 1
+                ? "or"
+                : ""
+            } ${computeStateName(states[zone]) || zone}`;
+          } else {
+            // Middle item in the list
+            zones += `, ${computeStateName(states[zone]) || zone}`;
+          }
         }
       }
     } else {
@@ -278,11 +331,20 @@ export const describeTrigger = (
 
     if (Array.isArray(trigger.source)) {
       for (const [index, source] of trigger.source.entries()) {
-        sources += `${index > 0 ? "," : ""} ${
-          trigger.source.length > 1 && index === trigger.source.length - 1
-            ? "or"
-            : ""
-        } ${source}`;
+        if (index === 0) {
+          // First item in the list
+          sources += `${source}`;
+        } else if (index === trigger.source.length - 1) {
+          // Last item in the list
+          sources += ` ${
+            trigger.source.length > 1
+              ? "or"
+              : ""
+          } ${source}`;
+        } else {
+          // Middle item in the list
+          sources += `, ${source}`;
+        }
       }
     } else {
       sources = trigger.source;
@@ -295,11 +357,20 @@ export const describeTrigger = (
 
       for (const [index, zone] of trigger.zone.entries()) {
         if (states[zone]) {
-          zones += `${index > 0 ? "," : ""} ${
-            trigger.zone.length > 1 && index === trigger.zone.length - 1
-              ? "or"
-              : ""
-          } ${computeStateName(states[zone]) || zone}`;
+          if (index === 0) {
+            // First item in the list
+            zones += `${computeStateName(states[zone]) || zone}`;
+          } else if (index === trigger.zone.length - 1) {
+            // Last item in the list
+            zones += ` ${
+              trigger.zone.length > 1
+                ? "or"
+                : ""
+            } ${computeStateName(states[zone]) || zone}`;
+          } else {
+            // Middle item in the list
+            zones += `, ${computeStateName(states[zone]) || zone}`;
+          }
         }
       }
     } else {
@@ -423,11 +494,20 @@ export const describeCondition = (
 
     if (Array.isArray(condition.state)) {
       for (const [index, state] of condition.state.entries()) {
-        states += `${index > 0 ? "," : ""} ${
-          condition.state.length > 1 && index === condition.state.length - 1
-            ? "or"
-            : ""
-        } ${state}`;
+        if (index === 0) {
+          // First item in the list
+          states += `${state}`;
+        } else if (index === condition.state.length - 1) {
+          // Last item in the list
+          states += ` ${
+            condition.state.length > 1
+              ? "or"
+              : ""
+          } ${state}`;
+        } else {
+          // Middle item in the list
+          states += `, ${state}`;
+        }
       }
     } else if (condition.state) {
       states = condition.state.toString();
@@ -535,12 +615,20 @@ export const describeCondition = (
       }
       for (const [index, entity] of condition.entity_id.entries()) {
         if (states[entity]) {
-          entities += `${index > 0 ? "," : ""} ${
-            condition.entity_id.length > 1 &&
-            index === condition.entity_id.length - 1
-              ? "or"
-              : ""
-          } ${computeStateName(states[entity]) || entity}`;
+          if (index === 0) {
+            // First item in the list
+            entities += `${computeStateName(states[entity]) || entity}`;
+          } else if (index === condition.entity_id.length - 1) {
+            // Last item in the list
+            entities += ` ${
+              condition.entity_id.length > 1
+                ? "or"
+                : ""
+            } ${computeStateName(states[entity]) || entity}`;
+          } else {
+            // Middle item in the list
+            entities += `, ${computeStateName(states[entity]) || entity}`;
+          }
         }
       }
     } else {
@@ -556,11 +644,20 @@ export const describeCondition = (
 
       for (const [index, zone] of condition.zone.entries()) {
         if (states[zone]) {
-          zones += `${index > 0 ? "," : ""} ${
-            condition.zone.length > 1 && index === condition.zone.length - 1
-              ? "or"
-              : ""
-          } ${computeStateName(states[zone]) || zone}`;
+          if (index === 0) {
+            // First item in the list
+            zones += `${computeStateName(states[zone]) || zone}`;
+          } else if (index === condition.zone.length - 1) {
+            // Last item in the list
+            zones += ` ${
+              condition.zone.length > 1
+                ? "or"
+                : ""
+            } ${computeStateName(states[zone]) || zone}`;
+          } else {
+            // Middle item in the list
+            zones += `, ${computeStateName(states[zone]) || zone}`;
+          }
         }
       }
     } else {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently, if a state trigger or state condition references two entities or two states, the automatically-generated explanation in the automation editor includes a superfluous comma between the two entities or states.

This PR tweaks how automation natural language explanations are generated for triggers and conditions with multiple entities and/or states to achieve proper punctuation (e.g., no comma between multiple entities or multiple states when there are only two entities or states).  See examples below.

### Existing Auto-Generated Explanations

**State Trigger with Two Entities:**

![image](https://user-images.githubusercontent.com/18428022/206029713-baf54c2e-1067-4d35-b8cc-728f0b22a70c.png)

**State Condition with Two States:**

![image](https://user-images.githubusercontent.com/18428022/206029786-5764dcac-5b6a-4dae-9726-ee078181ea77.png)

### Post-PR Auto-Generated Explanations

**State Trigger with Two Entities:**

![image](https://user-images.githubusercontent.com/18428022/206030121-88f7c2fe-cd3c-40d3-9bb9-76c9438ea5e6.png)

**State Trigger with Three Entities:**

![image](https://user-images.githubusercontent.com/18428022/206030279-fed923b2-628c-4efc-a9b3-85f112af4330.png)

**State Condition with Two States:**

![image](https://user-images.githubusercontent.com/18428022/206030649-b013314a-d0a0-4522-ab37-acab1329c6be.png)

**State Condition with Three States:**

![image](https://user-images.githubusercontent.com/18428022/206030915-81f24a13-dc76-4ac2-8d5a-7541d330c110.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
