### PR TITLE
Fixes state history colors edge cases

### DIFF
--- a/src/common/entity/color/battery_color.ts
+++ b/src/common/entity/color/battery_color.ts
@@ -1,7 +1,5 @@
-import { HassEntity } from "home-assistant-js-websocket";
-
-export const batteryStateColor = (stateObj: HassEntity) => {
-  const value = Number(stateObj.state);
+export const batteryStateColor = (state: string) => {
+  const value = Number(state);
   if (isNaN(value)) {
     return "sensor-battery-unknown";
   }

--- a/src/common/entity/color/person_color.ts
+++ b/src/common/entity/color/person_color.ts
@@ -1,7 +1,5 @@
-import { HassEntity } from "home-assistant-js-websocket";
-
-export const personColor = (stateObj: HassEntity): string | undefined => {
-  switch (stateObj.state) {
+export const personColor = (state: string): string | undefined => {
+  switch (state) {
     case "home":
       return "person-home";
     default:

--- a/src/common/entity/color/sensor_color.ts
+++ b/src/common/entity/color/sensor_color.ts
@@ -1,11 +1,14 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { batteryStateColor } from "./battery_color";
 
-export const sensorColor = (stateObj: HassEntity): string | undefined => {
+export const sensorColor = (
+  stateObj: HassEntity,
+  compareState: string
+): string | undefined => {
   const deviceClass = stateObj?.attributes.device_class;
 
   if (deviceClass === "battery") {
-    return batteryStateColor(stateObj);
+    return batteryStateColor(compareState);
   }
 
   return undefined;

--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -67,10 +67,10 @@ export const stateColor = (stateObj: HassEntity, state?: string) => {
 
     case "person":
     case "device_tracker":
-      return personColor(stateObj);
+      return personColor(compareState);
 
     case "sensor":
-      return sensorColor(stateObj);
+      return sensorColor(stateObj, compareState);
 
     case "sun":
       return compareState === "above_horizon" ? "sun-day" : "sun-night";


### PR DESCRIPTION
## Proposed change

The last state was taken for history timeline because we used `stateObj.state` instead of `compareState`.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14627
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
