### PR TITLE
Theme color fixes

### DIFF
--- a/src/common/color/compute-color.ts
+++ b/src/common/color/compute-color.ts
@@ -4,6 +4,7 @@ export const THEME_COLORS = new Set([
   "primary",
   "accent",
   "disabled",
+  "inactive",
   "red",
   "pink",
   "purple",

--- a/src/common/entity/color/sensor_color.ts
+++ b/src/common/entity/color/sensor_color.ts
@@ -3,12 +3,12 @@ import { batteryStateColor } from "./battery_color";
 
 export const sensorColor = (
   stateObj: HassEntity,
-  compareState: string
+  state: string
 ): string | undefined => {
   const deviceClass = stateObj?.attributes.device_class;
 
   if (deviceClass === "battery") {
-    return batteryStateColor(compareState);
+    return batteryStateColor(state);
   }
 
   return undefined;

--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -38,7 +38,7 @@ export const stateColorCss = (stateObj: HassEntity, state?: string) => {
   }
 
   if (!stateActive(stateObj, state)) {
-    return `var(--rgb-state-off-color)`;
+    return `var(--rgb-state-inactive-color)`;
   }
 
   const domainColor = stateColor(stateObj, state);
@@ -47,7 +47,7 @@ export const stateColorCss = (stateObj: HassEntity, state?: string) => {
     return `var(--rgb-state-${domainColor}-color)`;
   }
 
-  return `var(--rgb-state-default-color)`;
+  return undefined;
 };
 
 export const stateColor = (stateObj: HassEntity, state?: string) => {

--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -1,5 +1,6 @@
 /** Return an color representing a state. */
 import { HassEntity } from "home-assistant-js-websocket";
+import { UNAVAILABLE } from "../../data/entity";
 import { UpdateEntity, updateIsInstalling } from "../../data/update";
 import { alarmControlPanelColor } from "./color/alarm_control_panel_color";
 import { binarySensorColor } from "./color/binary_sensor_color";
@@ -30,15 +31,20 @@ const STATIC_COLORED_DOMAIN = new Set([
   "vacuum",
 ]);
 
-export const stateColorCss = (stateObj?: HassEntity, state?: string) => {
-  if (!stateObj || !stateActive(stateObj, state)) {
-    return `var(--rgb-disabled-color)`;
+export const stateColorCss = (stateObj: HassEntity, state?: string) => {
+  const compareState = state !== undefined ? state : stateObj?.state;
+  if (compareState === UNAVAILABLE) {
+    return `var(--rgb-state-unavailable-color)`;
   }
 
-  const color = stateColor(stateObj, state);
+  if (!stateActive(stateObj, state)) {
+    return `var(--rgb-state-off-color)`;
+  }
 
-  if (color) {
-    return `var(--rgb-state-${color}-color)`;
+  const domainColor = stateColor(stateObj, state);
+
+  if (domainColor) {
+    return `var(--rgb-state-${domainColor}-color)`;
   }
 
   return `var(--rgb-state-default-color)`;

--- a/src/common/style/icon_color_css.ts
+++ b/src/common/style/icon_color_css.ts
@@ -21,6 +21,6 @@ export const iconColorCSS = css`
 
   /* Color the icon if unavailable */
   ha-state-icon[data-state="unavailable"] {
-    color: var(--state-unavailable-color);
+    color: rgb(var(--rgb-state-unavailable-color));
   }
 `;

--- a/src/components/chart/timeline-chart/timeline-color.ts
+++ b/src/components/chart/timeline-chart/timeline-color.ts
@@ -5,6 +5,7 @@ import { labBrighten } from "../../../common/color/lab";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { stateActive } from "../../../common/entity/state_active";
 import { stateColor } from "../../../common/entity/state_color";
+import { UNAVAILABLE } from "../../../data/entity";
 
 const DOMAIN_STATE_SHADES: Record<string, Record<string, number>> = {
   media_player: {
@@ -49,11 +50,18 @@ function computeTimelineStateColor(
   computedStyles: CSSStyleDeclaration,
   stateObj?: HassEntity
 ): string | undefined {
-  if (!stateObj || !stateActive(stateObj, state)) {
-    const rgb = cssToRgb("--rgb-disabled-color", computedStyles);
+  if (!stateObj || state === UNAVAILABLE) {
+    const rgb = cssToRgb("--rgb-state-unavailable-color", computedStyles);
     if (!rgb) return undefined;
     return rgb2hex(rgb);
   }
+
+  if (!stateActive(stateObj, state)) {
+    const rgb = cssToRgb("--rgb-state-off-color", computedStyles);
+    if (!rgb) return undefined;
+    return rgb2hex(rgb);
+  }
+
   const color = stateColor(stateObj, state);
 
   if (!color) return undefined;

--- a/src/components/chart/timeline-chart/timeline-color.ts
+++ b/src/components/chart/timeline-chart/timeline-color.ts
@@ -57,7 +57,7 @@ function computeTimelineStateColor(
   }
 
   if (!stateActive(stateObj, state)) {
-    const rgb = cssToRgb("--rgb-state-off-color", computedStyles);
+    const rgb = cssToRgb("--rgb-state-inactive-color", computedStyles);
     if (!rgb) return undefined;
     return rgb2hex(rgb);
   }

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -14,7 +14,7 @@ import { styleMap } from "lit/directives/style-map";
 import { computeDomain } from "../../common/entity/compute_domain";
 import { computeStateDomain } from "../../common/entity/compute_state_domain";
 import { stateActive } from "../../common/entity/state_active";
-import { stateColor } from "../../common/entity/state_color";
+import { stateColorCss } from "../../common/entity/state_color";
 import { iconColorCSS } from "../../common/style/icon_color_css";
 import { cameraUrlWithWidthHeight } from "../../data/camera";
 import type { HomeAssistant } from "../../types";
@@ -107,24 +107,24 @@ export class StateBadge extends LitElement {
         }
         hostStyle.backgroundImage = `url(${imageUrl})`;
         this._showIcon = false;
-      } else if (stateActive(stateObj) && this._stateColor) {
-        const iconColor = stateColor(stateObj);
-        if (stateObj.attributes.rgb_color) {
-          iconStyle.color = `rgb(${stateObj.attributes.rgb_color.join(",")})`;
-        } else if (iconColor) {
-          iconStyle.color = `rgb(var(--rgb-state-${iconColor}-color))`;
-        }
-        if (stateObj.attributes.brightness) {
-          const brightness = stateObj.attributes.brightness;
-          if (typeof brightness !== "number") {
-            const errorMessage = `Type error: state-badge expected number, but type of ${
-              stateObj.entity_id
-            }.attributes.brightness is ${typeof brightness} (${brightness})`;
-            // eslint-disable-next-line
-            console.warn(errorMessage);
+      } else if (this._stateColor) {
+        iconStyle.color = `rgb(${stateColorCss(stateObj)})`;
+        if (stateActive(stateObj)) {
+          if (stateObj.attributes.rgb_color) {
+            iconStyle.color = `rgb(${stateObj.attributes.rgb_color.join(",")})`;
           }
-          // lowest brightness will be around 50% (that's pretty dark)
-          iconStyle.filter = `brightness(${(brightness + 245) / 5}%)`;
+          if (stateObj.attributes.brightness) {
+            const brightness = stateObj.attributes.brightness;
+            if (typeof brightness !== "number") {
+              const errorMessage = `Type error: state-badge expected number, but type of ${
+                stateObj.entity_id
+              }.attributes.brightness is ${typeof brightness} (${brightness})`;
+              // eslint-disable-next-line
+              console.warn(errorMessage);
+            }
+            // lowest brightness will be around 50% (that's pretty dark)
+            iconStyle.filter = `brightness(${(brightness + 245) / 5}%)`;
+          }
         }
       }
     } else if (this.overrideImage) {

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -108,7 +108,10 @@ export class StateBadge extends LitElement {
         hostStyle.backgroundImage = `url(${imageUrl})`;
         this._showIcon = false;
       } else if (this._stateColor) {
-        iconStyle.color = `rgb(${stateColorCss(stateObj)})`;
+        const color = stateColorCss(stateObj);
+        if (color) {
+          iconStyle.color = `rgb(${color})`;
+        }
         if (stateActive(stateObj)) {
           if (stateObj.attributes.rgb_color) {
             iconStyle.color = `rgb(${stateObj.attributes.rgb_color.join(",")})`;

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -26,7 +26,7 @@ import { computeStateDisplay } from "../../../common/entity/compute_state_displa
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { stateActive } from "../../../common/entity/state_active";
-import { stateColor } from "../../../common/entity/state_color";
+import { stateColorCss } from "../../../common/entity/state_color";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import { iconColorCSS } from "../../../common/style/icon_color_css";
 import "../../../components/ha-card";
@@ -78,6 +78,15 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   @queryAsync("mwc-ripple") private _ripple!: Promise<Ripple | null>;
 
   @state() private _shouldRenderRipple = false;
+
+  private getStateColor(stateObj: HassEntity, config: ButtonCardConfig) {
+    const domain = stateObj ? computeStateDomain(stateObj) : undefined;
+    return (
+      config &&
+      (config.state_color ||
+        (domain === "light" && config.state_color !== false))
+    );
+  }
 
   public getCardSize(): number {
     return (
@@ -146,13 +155,9 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
     const name = this._config.show_name
       ? this._config.name || (stateObj ? computeStateName(stateObj) : "")
       : "";
-    const domain = stateObj ? computeStateDomain(stateObj) : undefined;
 
-    const active =
-      (this._config.state_color ||
-        (domain === "light" && this._config.state_color !== false)) &&
-      stateObj &&
-      stateActive(stateObj);
+    const colored = stateObj && this.getStateColor(stateObj, this._config);
+    const active = stateObj && colored && stateActive(stateObj);
 
     return html`
       <ha-card
@@ -187,9 +192,8 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
                 .icon=${this._config.icon}
                 .state=${stateObj}
                 style=${styleMap({
-                  color: stateObj && active ? this._computeColor(stateObj) : "",
-                  filter:
-                    stateObj && active ? this._computeBrightness(stateObj) : "",
+                  color: colored ? this._computeColor(stateObj) : "",
+                  filter: colored ? this._computeBrightness(stateObj) : "",
                   height: this._config.icon_height
                     ? this._config.icon_height
                     : "",
@@ -305,7 +309,7 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   private _computeBrightness(stateObj: HassEntity | LightEntity): string {
-    if (!stateObj.attributes.brightness) {
+    if (!stateObj.attributes.brightness && stateActive(stateObj)) {
       const brightness = stateObj.attributes.brightness;
       return `brightness(${(brightness + 245) / 5}%)`;
     }
@@ -313,14 +317,10 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   private _computeColor(stateObj: HassEntity | LightEntity): string {
-    if (stateObj.attributes.rgb_color) {
+    if (stateObj.attributes.rgb_color && stateActive(stateObj)) {
       return `rgb(${stateObj.attributes.rgb_color.join(",")})`;
     }
-    const iconColor = stateColor(stateObj);
-    if (iconColor) {
-      return `rgb(var(--rgb-state-${iconColor}-color))`;
-    }
-    return "";
+    return `rgb(${stateColorCss(stateObj)})`;
   }
 
   private _handleAction(ev: ActionHandlerEvent) {

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -320,7 +320,11 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
     if (stateObj.attributes.rgb_color && stateActive(stateObj)) {
       return `rgb(${stateObj.attributes.rgb_color.join(",")})`;
     }
-    return `rgb(${stateColorCss(stateObj)})`;
+    const iconColor = stateColorCss(stateObj);
+    if (iconColor) {
+      return `rgb(${iconColor})`;
+    }
+    return "";
   }
 
   private _handleAction(ev: ActionHandlerEvent) {

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -16,7 +16,7 @@ import { computeStateDisplay } from "../../../common/entity/compute_state_displa
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { stateActive } from "../../../common/entity/state_active";
-import { stateColor } from "../../../common/entity/state_color";
+import { stateColorCss } from "../../../common/entity/state_color";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import {
   formatNumber,
@@ -76,6 +76,15 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
 
   private _footerElement?: HuiErrorCard | LovelaceHeaderFooter;
 
+  private getStateColor(stateObj: HassEntity, config: EntityCardConfig) {
+    const domain = stateObj ? computeStateDomain(stateObj) : undefined;
+    return (
+      config &&
+      (config.state_color ||
+        (domain === "light" && config.state_color !== false))
+    );
+  }
+
   public setConfig(config: EntityCardConfig): void {
     if (!config.entity) {
       throw new Error("Entity must be specified");
@@ -124,10 +133,8 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
 
     const name = this._config.name || computeStateName(stateObj);
 
-    const active =
-      (this._config.state_color ||
-        (domain === "light" && this._config.state_color !== false)) &&
-      stateActive(stateObj);
+    const colored = stateObj && this.getStateColor(stateObj, this._config);
+    const active = stateObj && colored && stateActive(stateObj);
 
     return html`
       <ha-card @click=${this._handleClick} tabindex="0">
@@ -141,7 +148,7 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
               data-domain=${ifDefined(domain)}
               data-state=${stateObj.state}
               style=${styleMap({
-                color: active ? this._computeColor(stateObj) : "",
+                color: colored ? this._computeColor(stateObj) : undefined,
                 height: this._config.icon_height
                   ? this._config.icon_height
                   : "",
@@ -192,14 +199,13 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
       !(
         this._config?.state_color ||
         (domain === "light" && this._config?.state_color !== false)
-      ) ||
-      !stateActive(stateObj)
+      )
     ) {
       return "";
     }
-    const iconColor = stateColor(stateObj);
+    const iconColor = stateColorCss(stateObj);
     if (iconColor) {
-      return `rgb(var(--rgb-state-${iconColor}-color))`;
+      return `rgb(${iconColor})`;
     }
     return "";
   }

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -194,15 +194,6 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
   }
 
   private _computeColor(stateObj: HassEntity | LightEntity): string {
-    const domain = computeStateDomain(stateObj);
-    if (
-      !(
-        this._config?.state_color ||
-        (domain === "light" && this._config?.state_color !== false)
-      )
-    ) {
-      return "";
-    }
     const iconColor = stateColorCss(stateObj);
     if (iconColor) {
       return `rgb(${iconColor})`;

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -161,7 +161,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     }
 
     // Fallback to state color
-    return stateColorCss(entity);
+    return stateColorCss(entity) ?? "var(--rgb-state-default-color)";
   });
 
   private _computeStateDisplay(stateObj: HassEntity): TemplateResult | string {

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -9,7 +9,6 @@ import { hsv2rgb, rgb2hsv } from "../../../common/color/convert-color";
 import { DOMAINS_TOGGLE } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { computeStateDisplay } from "../../../common/entity/compute_state_display";
-import { stateActive } from "../../../common/entity/state_active";
 import { stateColorCss } from "../../../common/entity/state_color";
 import { stateIconPath } from "../../../common/entity/state_icon_path";
 import { blankBeforePercent } from "../../../common/translations/blank_before_percent";
@@ -129,8 +128,9 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
   }
 
   private _computeStateColor = memoize((entity: HassEntity, color?: string) => {
-    if (UNAVAILABLE_STATES.includes(entity.state)) {
-      return undefined;
+    // Use custom color
+    if (color) {
+      return computeRgbColor(color);
     }
 
     // Use default color for person/device_tracker because color is on the badge
@@ -141,16 +141,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       return "var(--rgb-state-default-color)";
     }
 
-    if (!stateActive(entity)) {
-      return undefined;
-    }
-
-    if (color) {
-      return computeRgbColor(color);
-    }
-
-    let stateColor = stateColorCss(entity);
-
+    // Use light color if the light support rgb
     if (
       computeDomain(entity.entity_id) === "light" &&
       entity.attributes.rgb_color
@@ -166,10 +157,11 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
           hsvColor[1] = 0.4;
         }
       }
-      stateColor = hsv2rgb(hsvColor).join(",");
+      return hsv2rgb(hsvColor).join(",");
     }
 
-    return stateColor;
+    // Fallback to state color
+    return stateColorCss(entity);
   });
 
   private _computeStateDisplay(stateObj: HassEntity): TemplateResult | string {
@@ -360,7 +352,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
   static get styles(): CSSResultGroup {
     return css`
       :host {
-        --tile-color: var(--rgb-disabled-color);
+        --tile-color: var(--rgb-state-default-color);
         --tile-tap-padding: 6px;
         -webkit-tap-highlight-color: transparent;
       }
@@ -368,7 +360,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
         height: 100%;
       }
       ha-card.disabled {
-        background: rgba(var(--rgb-disabled-color), 0.1);
+        background: rgba(var(--rgb-state-unavailable-color), 0.1);
       }
       [role="button"] {
         cursor: pointer;

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -107,7 +107,7 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-primary-color: 3, 169, 244;
       --rgb-accent-color: 255, 152, 0;
       --rgb-disabled-color: 189, 189, 189;
-      --rgb-off-color: 114, 114, 114;
+      --rgb-inactive-color: 114, 114, 114;
       --rgb-primary-text-color: 33, 33, 33;
       --rgb-secondary-text-color: 114, 114, 114;
       --rgb-text-primary-color: 255, 255, 255;
@@ -137,7 +137,7 @@ documentContainer.innerHTML = `<custom-style>
       /* rgb state color */
       --rgb-state-default-color: var(--rgb-dark-primary-color, 68, 115, 158);
       --rgb-state-unavailable-color: var(--rgb-disabled-color);
-      --rgb-state-off-color: var(--rgb-off-color);
+      --rgb-state-inactive-color: var(--rgb-inactive-color);
 
       /* rgb state color */
       --rgb-state-alarm-armed-color: var(--rgb-red-color);

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -107,6 +107,7 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-primary-color: 3, 169, 244;
       --rgb-accent-color: 255, 152, 0;
       --rgb-disabled-color: 189, 189, 189;
+      --rgb-off-color: 114, 114, 114;
       --rgb-primary-text-color: 33, 33, 33;
       --rgb-secondary-text-color: 114, 114, 114;
       --rgb-text-primary-color: 255, 255, 255;
@@ -134,7 +135,11 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-white-color: 255, 255, 255;
 
       /* rgb state color */
-      --rgb-state-default-color: 68, 115, 158;
+      --rgb-state-default-color: var(--rgb-dark-primary-color, 68, 115, 158);
+      --rgb-state-unavailable-color: var(--rgb-disabled-color);
+      --rgb-state-off-color: var(--rgb-off-color);
+
+      /* rgb state color */
       --rgb-state-alarm-armed-color: var(--rgb-red-color);
       --rgb-state-alarm-arming-color: var(--rgb-orange-color);
       --rgb-state-alarm-pending-color: var(--rgb-orange-color);
@@ -151,7 +156,7 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-state-climate-fan-only-color: var(--rgb-cyan-color);
       --rgb-state-climate-heat-color: var(--rgb-deep-orange-color);
       --rgb-state-climate-heat-cool-color: var(--rgb-amber-color);
-      --rgb-state-climate-idle-color: var(--rgb-disabled-color);
+      --rgb-state-climate-idle-color: var(--rgb-off-color);
       --rgb-state-cover-color: var(--rgb-purple-color);
       --rgb-state-fan-color: var(--rgb-cyan-color);
       --rgb-state-group-color: var(--rgb-amber-color);
@@ -169,7 +174,7 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-state-sensor-battery-high-color: var(--rgb-green-color);
       --rgb-state-sensor-battery-low-color: var(--rgb-red-color);
       --rgb-state-sensor-battery-medium-color: var(--rgb-orange-color);
-      --rgb-state-sensor-battery-unknown-color: var(--rgb-disabled-color);
+      --rgb-state-sensor-battery-unknown-color: var(--rgb-off-color);
       --rgb-state-siren-color: var(--rgb-red-color);
       --rgb-state-sun-day-color: var(--rgb-amber-color);
       --rgb-state-sun-night-color: var(--rgb-deep-purple-color);

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -147,9 +147,9 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-state-alert-color: var(--rgb-red-color);
       --rgb-state-automation-color: var(--rgb-amber-color);
       --rgb-state-binary-sensor-alerting-color: var(--rgb-red-color);
-      --rgb-state-binary-sensor-color: var(--rgb-blue-color);
-      --rgb-state-calendar-color: var(--rgb-blue-color);
-      --rgb-state-camera-color: var(--rgb-blue-color);
+      --rgb-state-binary-sensor-color: var(--rgb-amber-color);
+      --rgb-state-calendar-color: var(--rgb-amber-color);
+      --rgb-state-camera-color: var(--rgb-amber-color);
       --rgb-state-climate-auto-color: var(--rgb-green-color);
       --rgb-state-climate-cool-color: var(--rgb-blue-color);
       --rgb-state-climate-dry-color: var(--rgb-orange-color);
@@ -169,7 +169,7 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-state-media-player-color: var(--rgb-indigo-color);
       --rgb-state-person-home-color: var(--rgb-green-color);
       --rgb-state-person-zone-color: var(--rgb-blue-color);
-      --rgb-state-remote-color: var(--rgb-blue-color);
+      --rgb-state-remote-color: var(--rgb-amber-color);
       --rgb-state-script-color: var(--rgb-amber-color);
       --rgb-state-sensor-battery-high-color: var(--rgb-green-color);
       --rgb-state-sensor-battery-low-color: var(--rgb-red-color);

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -48,7 +48,8 @@ export const darkStyles = {
   "energy-grid-return-color": "#a280db",
   "map-filter":
     "invert(.9) hue-rotate(170deg) brightness(1.5) contrast(1.2) saturate(.3)",
-  "rgb-disabled-color": "111, 111, 111",
+  "rgb-disabled-color": "70, 70, 70",
+  "rgb-off-color": "141, 141, 141",
 };
 
 export const derivedStyles = {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -49,7 +49,7 @@ export const darkStyles = {
   "map-filter":
     "invert(.9) hue-rotate(170deg) brightness(1.5) contrast(1.2) saturate(.3)",
   "rgb-disabled-color": "70, 70, 70",
-  "rgb-off-color": "141, 141, 141",
+  "rgb-inactive-color": "141, 141, 141",
 };
 
 export const derivedStyles = {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4349,6 +4349,7 @@
               "primary": "Primary",
               "accent": "Accent",
               "disabled": "Disabled",
+              "inactive": "Inactive",
               "red": "Red",
               "pink": "Pink",
               "purple": "Purple",


### PR DESCRIPTION
## Proposed change

- Use yellow color by default for `binary_sensor`.
- Introduce two colors for inactive and unavailable : `--rgb-state-unavailable-color` and `--rgb-state-inactive-color`.
- Changes have been applied to entities card, button card, entity card, glance card, tile card, history, logbook, more-info state

## Examples

**Tile card**

![CleanShot 2022-12-09 at 14 47 03](https://user-images.githubusercontent.com/5878303/206716532-4fcc2c0d-c005-4ceb-baf9-2f6f71919acd.png)
 
**Button card with `state_color` option (active, inactive, unavailable)**

![CleanShot 2022-12-09 at 14 33 54](https://user-images.githubusercontent.com/5878303/206714266-d5685819-aa39-4804-ae8b-040f7c7e9a16.png)

**Button card without `state_color` option (active, inactive, unavailable)**

![CleanShot 2022-12-09 at 14 34 00](https://user-images.githubusercontent.com/5878303/206714239-8854f025-e0d1-4773-86d2-9f5b4b4f93e3.png)

**Button card with binary sensor color (alerting active, normal active, inactive)**

![CleanShot 2022-12-09 at 14 37 28](https://user-images.githubusercontent.com/5878303/206714527-a800499b-c56a-4daf-96ab-968cbc842b15.png)

**Entities card with `state_color` option**

![CleanShot 2022-12-09 at 14 54 32](https://user-images.githubusercontent.com/5878303/206718076-2001790d-fc35-4315-a46d-4be700f64acd.png)

**Entities card without `state_color` option**

![CleanShot 2022-12-09 at 14 54 46](https://user-images.githubusercontent.com/5878303/206718103-6b1df2ba-bbf4-4922-b304-0ed38ce0a655.png)

**History**

![CleanShot 2022-12-09 at 14 40 31](https://user-images.githubusercontent.com/5878303/206715076-1c18b23d-f3bf-459b-8ece-42d4cabcebc9.png)

**Logbook**

![CleanShot 2022-12-09 at 14 49 15](https://user-images.githubusercontent.com/5878303/206716871-2c7687f1-429b-45b6-b250-2d33392210cf.png)

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14619
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
