### PR TITLE
Add new light temperature control on tile card

### DIFF
--- a/src/panels/lovelace/create-element/create-tile-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-tile-feature-element.ts
@@ -6,12 +6,14 @@ import {
 import "../tile-features/hui-cover-open-close-tile-feature";
 import "../tile-features/hui-cover-tilt-tile-feature";
 import "../tile-features/hui-light-brightness-tile-feature";
+import "../tile-features/hui-light-temperature-tile-feature";
 import "../tile-features/hui-vacuum-commands-tile-feature";
 
 const TYPES: Set<LovelaceTileFeatureConfig["type"]> = new Set([
   "cover-open-close",
   "cover-tilt",
   "light-brightness",
+  "light-temperature",
   "vacuum-commands",
 ]);
 

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
@@ -33,6 +33,7 @@ const FEATURES_TYPE: LovelaceTileFeatureConfig["type"][] = [
   "cover-open-close",
   "cover-tilt",
   "light-brightness",
+  "light-temperature",
   "vacuum-commands",
 ];
 

--- a/src/panels/lovelace/tile-features/hui-light-temperature-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-light-temperature-tile-feature.ts
@@ -1,0 +1,91 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { UNAVAILABLE } from "../../../data/entity";
+import { HomeAssistant } from "../../../types";
+import { LovelaceTileFeature } from "../types";
+import { LightTemperatureTileFeatureConfig } from "./types";
+import "../../../components/tile/ha-tile-slider";
+
+@customElement("hui-light-temperature-tile-feature")
+class HuiLightTemperatureTileFeature
+  extends LitElement
+  implements LovelaceTileFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state() private _config?: LightTemperatureTileFeatureConfig;
+
+  static getStubConfig(): LightTemperatureTileFeatureConfig {
+    return {
+      type: "light-temperature",
+    };
+  }
+
+  public setConfig(config: LightTemperatureTileFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render(): TemplateResult {
+    if (!this._config || !this.hass || !this.stateObj) {
+      return html``;
+    }
+
+    const position =
+      this.stateObj.attributes.color_temp_kelvin != null
+        ? this.stateObj.attributes.color_temp_kelvin
+        : undefined;
+
+    return html`
+      <div class="container">
+        <ha-tile-slider
+          .value=${position}
+          min=${this.stateObj.attributes.min_color_temp_kelvin}
+          max=${this.stateObj.attributes.max_color_temp_kelvin}
+          .disabled=${this.stateObj!.state === UNAVAILABLE}
+          @value-changed=${this._valueChanged}
+          .label=${this.hass.localize("ui.card.light.brightness")}
+          mode="cursor"
+        ></ha-tile-slider>
+      </div>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const value = ev.detail.value;
+
+    this.hass!.callService("light", "turn_on", {
+      entity_id: this.stateObj!.entity_id,
+      kelvin: value,
+    });
+  }
+
+  static get styles() {
+    return css`
+      ha-tile-slider {
+        --tile-slider-bar-background: -webkit-linear-gradient(
+          var(--float-end),
+          rgb(166, 209, 255) 0%,
+          white 50%,
+          rgb(255, 160, 0) 100%
+        );
+      }
+      .container {
+        padding: 0 12px 12px 12px;
+        width: auto;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-light-temperature-tile-feature": HuiLightTemperatureTileFeature;
+  }
+}

--- a/src/panels/lovelace/tile-features/tile-features.ts
+++ b/src/panels/lovelace/tile-features/tile-features.ts
@@ -2,7 +2,11 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { computeDomain } from "../../../common/entity/compute_domain";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import { CoverEntityFeature } from "../../../data/cover";
-import { lightSupportsBrightness } from "../../../data/light";
+import {
+  LightColorMode,
+  lightSupportsBrightness,
+  lightSupportsColorMode,
+} from "../../../data/light";
 import { supportsVacuumCommand } from "./hui-vacuum-commands-tile-feature";
 import { LovelaceTileFeatureConfig, VACUUM_COMMANDS } from "./types";
 
@@ -21,6 +25,9 @@ const TILE_FEATURES_SUPPORT: Record<TileFeatureType, SupportsTileFeature> = {
   "light-brightness": (stateObj) =>
     computeDomain(stateObj.entity_id) === "light" &&
     lightSupportsBrightness(stateObj),
+  "light-temperature": (stateObj) =>
+    computeDomain(stateObj.entity_id) === "light" &&
+    lightSupportsColorMode(stateObj, LightColorMode.COLOR_TEMP),
   "vacuum-commands": (stateObj) =>
     computeDomain(stateObj.entity_id) === "vacuum" &&
     VACUUM_COMMANDS.some((c) => supportsVacuumCommand(stateObj, c)),

--- a/src/panels/lovelace/tile-features/types.ts
+++ b/src/panels/lovelace/tile-features/types.ts
@@ -10,6 +10,10 @@ export interface LightBrightnessTileFeatureConfig {
   type: "light-brightness";
 }
 
+export interface LightTemperatureTileFeatureConfig {
+  type: "light-temperature";
+}
+
 export const VACUUM_COMMANDS = [
   "start_pause",
   "stop",
@@ -29,6 +33,7 @@ export type LovelaceTileFeatureConfig =
   | CoverOpenCloseTileFeatureConfig
   | CoverTiltTileFeatureConfig
   | LightBrightnessTileFeatureConfig
+  | LightTemperatureTileFeatureConfig
   | VacuumCommandsTileFeatureConfig;
 
 export type LovelaceTileFeatureContext = {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4311,6 +4311,9 @@
                   "light-brightness": {
                     "label": "Light brightness"
                   },
+                  "light-temperature": {
+                    "label": "Light temperature"
+                  },
                   "vacuum-commands": {
                     "label": "Vacuum commands",
                     "commands": "Commands",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This PR adds a feature to change the color temperature on a tile card.

![image](https://user-images.githubusercontent.com/33957974/206874385-eb9c8391-24d6-442c-9aaf-f4066cec247e.png)

In the future we could also have tile features to change the hue or saturation of a light.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
entity: light.bed_light
name: Bed Light
features:
  - type: light-temperature
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/25231

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
