### PR TITLE
Add retain switch for MQTT publish

### DIFF
--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-config-panel.ts
@@ -1,6 +1,7 @@
 import "@material/mwc-button";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { LocalStorage } from "../../../../../common/decorators/local-storage";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-code-editor";
 import { getConfigEntries } from "../../../../../data/config_entries";
@@ -18,26 +19,17 @@ class HaPanelDevMqtt extends LitElement {
 
   @property({ type: Boolean }) public narrow!: boolean;
 
-  @state() private topic = "";
+  @state()
+  @LocalStorage("panel-dev-mqtt-topic-ls", true, false)
+  private topic = "";
 
-  @state() private payload = "";
+  @state()
+  @LocalStorage("panel-dev-mqtt-payload-ls", true, false)
+  private payload = "";
 
-  @state() private qos = "0";
-
-  private inited = false;
-
-  protected firstUpdated() {
-    if (localStorage && localStorage["panel-dev-mqtt-topic"]) {
-      this.topic = localStorage["panel-dev-mqtt-topic"];
-    }
-    if (localStorage && localStorage["panel-dev-mqtt-payload"]) {
-      this.payload = localStorage["panel-dev-mqtt-payload"];
-    }
-    if (localStorage && localStorage["panel-dev-mqtt-qos"]) {
-      this.qos = localStorage["panel-dev-mqtt-qos"];
-    }
-    this.inited = true;
-  }
+  @state()
+  @LocalStorage("panel-dev-mqtt-qos-ls", true, false)
+  private qos = "0";
 
   protected render(): TemplateResult {
     return html`
@@ -99,23 +91,16 @@ class HaPanelDevMqtt extends LitElement {
 
   private _handleTopic(ev: CustomEvent) {
     this.topic = (ev.target! as any).value;
-    if (localStorage && this.inited) {
-      localStorage["panel-dev-mqtt-topic"] = this.topic;
-    }
   }
 
   private _handlePayload(ev: CustomEvent) {
     this.payload = ev.detail.value;
-    if (localStorage && this.inited) {
-      localStorage["panel-dev-mqtt-payload"] = this.payload;
-    }
   }
 
   private _handleQos(ev: CustomEvent) {
     const newValue = (ev.target! as any).value;
-    if (newValue >= 0 && newValue !== this.qos && localStorage && this.inited) {
+    if (newValue >= 0 && newValue !== this.qos) {
       this.qos = newValue;
-      localStorage["panel-dev-mqtt-qos"] = this.qos;
     }
   }
 

--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-config-panel.ts
@@ -1,9 +1,11 @@
 import "@material/mwc-button";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { LocalStorage } from "../../../../../common/decorators/local-storage";
 import "../../../../../components/ha-card";
 import "../../../../../components/ha-code-editor";
+import "../../../../../components/ha-formfield";
+import "../../../../../components/ha-switch";
 import { getConfigEntries } from "../../../../../data/config_entries";
 import { showOptionsFlowDialog } from "../../../../../dialogs/config-flow/show-dialog-options-flow";
 import "../../../../../layouts/hass-subpage";
@@ -19,17 +21,17 @@ class HaPanelDevMqtt extends LitElement {
 
   @property({ type: Boolean }) public narrow!: boolean;
 
-  @state()
   @LocalStorage("panel-dev-mqtt-topic-ls", true, false)
   private topic = "";
 
-  @state()
   @LocalStorage("panel-dev-mqtt-payload-ls", true, false)
   private payload = "";
 
-  @state()
   @LocalStorage("panel-dev-mqtt-qos-ls", true, false)
   private qos = "0";
+
+  @LocalStorage("panel-dev-mqtt-retain-ls", true, false)
+  private retain = false;
 
   protected render(): TemplateResult {
     return html`
@@ -62,7 +64,14 @@ class HaPanelDevMqtt extends LitElement {
                     html`<mwc-list-item .value=${qos}>${qos}</mwc-list-item>`
                 )}
               </ha-select>
-
+              <ha-formfield
+                label=${this.hass!.localize("ui.panel.config.mqtt.retain")}
+              >
+                <ha-switch
+                  @change=${this._handleRetain}
+                  .checked=${this.retain}
+                ></ha-switch>
+              </ha-formfield>
               <p>${this.hass.localize("ui.panel.config.mqtt.payload")}</p>
               <ha-code-editor
                 mode="jinja2"
@@ -104,6 +113,10 @@ class HaPanelDevMqtt extends LitElement {
     }
   }
 
+  private _handleRetain(ev: CustomEvent) {
+    this.retain = (ev.target! as any).checked;
+  }
+
   private _publish(): void {
     if (!this.hass) {
       return;
@@ -112,6 +125,7 @@ class HaPanelDevMqtt extends LitElement {
       topic: this.topic,
       payload_template: this.payload,
       qos: parseInt(this.qos),
+      retain: this.retain,
     });
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3234,7 +3234,8 @@
           "start_listening": "Start listening",
           "stop_listening": "Stop listening",
           "message_received": "Message {id} received on {topic} at {time}:",
-          "qos": "QoS"
+          "qos": "QoS",
+          "retain": "Retain"
         },
         "zha": {
           "common": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add retain switch for MQTT publish function at the MQTT config entry page.
The @LocalStorage decorator has been implemented now. (Changed the keys to avoid cache conflicts).

This is a follow up PR on https://github.com/home-assistant/frontend/pull/14559

See also: https://github.com/home-assistant/frontend/pull/14565

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
