### PR TITLE
Fix entity-filter handling of numeric states for == and != operators.

### DIFF
--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -2,10 +2,27 @@ import { HassEntity } from "home-assistant-js-websocket";
 
 export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
   const operator = filter.operator || "==";
-  const value = filter.value ?? filter;
-  const state = filter.attribute
+  let value = filter.value ?? filter;
+  let state = filter.attribute
     ? stateObj.attributes[filter.attribute]
     : stateObj.state;
+
+  if (operator === "==" || operator === "!=") {
+    const valueIsNumeric =
+      typeof value === "number" ||
+      (typeof value === "string" &&
+        !isNaN(+value) &&
+        value.trim().length !== 0);
+    const stateIsNumeric =
+      typeof state === "number" ||
+      (typeof state === "string" &&
+        !isNaN(+state) &&
+        state.trim().length !== 0);
+    if (valueIsNumeric && stateIsNumeric) {
+      value = +value;
+      state = +state;
+    }
+  }
 
   switch (operator) {
     case "==":

--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -10,14 +10,10 @@ export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
   if (operator === "==" || operator === "!=") {
     const valueIsNumeric =
       typeof value === "number" ||
-      (typeof value === "string" &&
-        !isNaN(+value) &&
-        value.trim().length !== 0);
+      (value.trim() && typeof value === "string" && !isNaN(Number(value)));
     const stateIsNumeric =
       typeof state === "number" ||
-      (typeof state === "string" &&
-        !isNaN(+state) &&
-        state.trim().length !== 0);
+      (state.trim() && typeof state === "string" && !isNaN(Number(state)));
     if (valueIsNumeric && stateIsNumeric) {
       value = Number(value);
       state = Number(state);

--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -10,10 +10,10 @@ export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
   if (operator === "==" || operator === "!=") {
     const valueIsNumeric =
       typeof value === "number" ||
-      (value.trim() && typeof value === "string" && !isNaN(Number(value)));
+      (typeof value === "string" && value.trim() && !isNaN(Number(value)));
     const stateIsNumeric =
       typeof state === "number" ||
-      (state.trim() && typeof state === "string" && !isNaN(Number(state)));
+      (typeof state === "string" && state.trim() && !isNaN(Number(state)));
     if (valueIsNumeric && stateIsNumeric) {
       value = Number(value);
       state = Number(state);

--- a/src/panels/lovelace/common/evaluate-filter.ts
+++ b/src/panels/lovelace/common/evaluate-filter.ts
@@ -19,8 +19,8 @@ export const evaluateFilter = (stateObj: HassEntity, filter: any): boolean => {
         !isNaN(+state) &&
         state.trim().length !== 0);
     if (valueIsNumeric && stateIsNumeric) {
-      value = +value;
-      state = +state;
+      value = Number(value);
+      state = Number(state);
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The current entity-filter card does not handle numeric states well when using == and != operators. 

See example for the following problems:

Comparing == with `value: '0'` matches states that are exactly '0', but it does not match numerically equivalent states like "0.0". For example an input number with value of 0 always stores its state as '0.0'. 
Comparing == with `value: 0` will never match any states, because all states are strings, and the `===` comparitor says that `0 === '0'` is false. 
Same problem for != operators.

The other numeric operators like <, <=, >, >= all already work as expected because those are not strict type checking like '===' and '!=='.

![entityfilterold](https://user-images.githubusercontent.com/32912880/207118287-c718bc7e-bf74-43eb-9641-1e73b8b720e3.PNG)

Same filters after fixing:

![entityfilterfixed](https://user-images.githubusercontent.com/32912880/207119251-12770e54-e966-447a-8db8-4e8cd670327e.PNG)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14692, partially #13343
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
