### PR TITLE
Add sun domain to gallery entity states

### DIFF
--- a/gallery/src/pages/misc/entity-state.ts
+++ b/gallery/src/pages/misc/entity-state.ts
@@ -208,6 +208,11 @@ const ENTITIES: HassEntity[] = [
   // Siren
   createEntity("siren.off", "off"),
   createEntity("siren.on", "on"),
+  // Sun
+  createEntity("sun.below", "below_horizon"),
+  createEntity("sun.above", "above_horizon"),
+  createEntity("sun.unknown", "unknown"),
+  createEntity("sun.unavailable", "unavailable"),
   // Switch
   createEntity("switch.off", "off"),
   createEntity("switch.on", "on"),
@@ -311,7 +316,7 @@ export class DemoEntityState extends LitElement {
           `,
         },
         entity_id: {
-          title: "Entity id",
+          title: "Entity ID",
           width: "30%",
           filterable: true,
           sortable: true,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Currently looks like this, which I plan to propose a change for in a separate PR (unknown should not be default off color and purple does not make sense to me for the moon at night).

![image](https://user-images.githubusercontent.com/114137/207309690-01a46c83-b5ba-4b58-968a-375823fc9f0a.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
