### PR TITLE
Add logic to find best device domain match + show correct brand logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "roboto-fontface": "^0.10.0",
     "rrule": "^2.7.1",
     "sortablejs": "^1.14.0",
+    "string-similarity": "4.0.4",
     "superstruct": "^0.15.2",
     "tinykeys": "^1.1.3",
     "tsparticles": "^1.34.0",

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -1,5 +1,6 @@
 import { Connection, createCollection } from "home-assistant-js-websocket";
 import type { Store } from "home-assistant-js-websocket/dist/store";
+import { findBestMatch } from "string-similarity";
 import { computeStateName } from "../common/entity/compute_state_name";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
 import { debounce } from "../common/util/debounce";
@@ -162,4 +163,25 @@ export const getDeviceIntegrationLookup = (
     deviceIntegrations[entity.device_id!].push(source.domain);
   }
   return deviceIntegrations;
+};
+
+export const findBestDeviceDomainMatch = (
+  manufacturer: string,
+  domains: string[],
+  integrations?: string[]
+): string => {
+  const { bestMatch: bestMatchDomain, bestMatchIndex: bestDomainIndex } =
+    findBestMatch(manufacturer, domains);
+  if (!integrations) {
+    return domains[bestDomainIndex];
+  }
+
+  const {
+    bestMatch: bestMatchIntegration,
+    bestMatchIndex: bestIntegrationIndex,
+  } = findBestMatch(manufacturer, integrations);
+
+  return bestMatchDomain.rating > bestMatchIntegration.rating
+    ? domains[bestDomainIndex]
+    : domains[bestIntegrationIndex];
 };

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -38,6 +38,7 @@ import {
 import {
   computeDeviceName,
   DeviceRegistryEntry,
+  findBestDeviceDomainMatch,
   removeConfigEntryFromDevice,
   updateDeviceRegistryEntry,
 } from "../../../data/device_registry";
@@ -210,6 +211,11 @@ export class HaConfigDevicePage extends LitElement {
   private _batteryChargingEntity = memoizeOne(
     (entities: EntityRegistryEntry[]): EntityRegistryEntry | undefined =>
       findBatteryChargingEntity(this.hass, entities)
+  );
+
+  private _brandsDomain = memoizeOne(
+    (manufacturer: string, domains: string[]): string =>
+      findBestDeviceDomainMatch(manufacturer, domains)
   );
 
   public willUpdate(changedProps) {
@@ -611,15 +617,12 @@ export class HaConfigDevicePage extends LitElement {
         .narrow=${this.narrow}
         .header=${deviceName}
       >
-
-                <ha-icon-button
-                  slot="toolbar-icon"
-                  .path=${mdiPencil}
-                  @click=${this._showSettings}
-                  .label=${this.hass.localize(
-                    "ui.panel.config.devices.edit_settings"
-                  )}
-                ></ha-icon-button>
+        <ha-icon-button
+          slot="toolbar-icon"
+          .path=${mdiPencil}
+          @click=${this._showSettings}
+          .label=${this.hass.localize("ui.panel.config.devices.edit_settings")}
+        ></ha-icon-button>
         <div class="container">
           <div class="header fullwidth">
             ${
@@ -659,7 +662,12 @@ export class HaConfigDevicePage extends LitElement {
                       ? html`
                           <img
                             src=${brandsUrl({
-                              domain: integrations[0].domain,
+                              domain: device.manufacturer
+                                ? this._brandsDomain(
+                                    device.manufacturer,
+                                    Array.from(integrations, (i) => i.domain)
+                                  )
+                                : integrations[0].domain,
                               type: "logo",
                               darkOptimized: this.hass.themes?.darkMode,
                             })}

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -215,7 +215,9 @@ export class HaConfigDevicePage extends LitElement {
 
   private _brandsDomain = memoizeOne(
     (manufacturer: string, domains: string[]): string =>
-      findBestDeviceDomainMatch(manufacturer, domains)
+      domains.length > 1
+        ? findBestDeviceDomainMatch(manufacturer, domains)
+        : domains[0]
   );
 
   public willUpdate(changedProps) {

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -26,6 +26,7 @@ import {
   computeDeviceName,
   DeviceEntityLookup,
   DeviceRegistryEntry,
+  findBestDeviceDomainMatch,
 } from "../../../data/device_registry";
 import {
   EntityRegistryEntry,
@@ -46,6 +47,7 @@ interface DeviceRowData extends DeviceRegistryEntry {
   device?: DeviceRowData;
   area?: string;
   integration?: string;
+  domains?: string[];
   battery_entity?: [string | undefined, string | undefined];
 }
 
@@ -250,7 +252,11 @@ export class HaConfigDeviceDashboard extends LitElement {
                   alt=""
                   referrerpolicy="no-referrer"
                   src=${brandsUrl({
-                    domain: device.domains[0],
+                    domain: findBestDeviceDomainMatch(
+                      device.manufacturer,
+                      device.domains,
+                      device.integration.split(",")
+                    ),
                     type: "icon",
                     darkOptimized: this.hass.themes?.darkMode,
                   })}

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -252,11 +252,14 @@ export class HaConfigDeviceDashboard extends LitElement {
                   alt=""
                   referrerpolicy="no-referrer"
                   src=${brandsUrl({
-                    domain: findBestDeviceDomainMatch(
-                      device.manufacturer,
-                      device.domains,
-                      device.integration.split(",")
-                    ),
+                    domain:
+                      device.domains.length > 1
+                        ? findBestDeviceDomainMatch(
+                            device.manufacturer,
+                            device.domains,
+                            device.integration.split(",")
+                          )
+                        : device.domains[0],
                     type: "icon",
                     darkOptimized: this.hass.themes?.darkMode,
                   })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9441,6 +9441,7 @@ fsevents@^1.2.7:
     sinon: ^11.0.0
     sortablejs: ^1.14.0
     source-map-url: ^0.4.0
+    string-similarity: 4.0.4
     superstruct: ^0.15.2
     systemjs: ^6.3.2
     tar: ^6.1.11
@@ -14596,6 +14597,13 @@ fsevents@^1.2.7:
   version: 0.3.1
   resolution: "string-argv@npm:0.3.1"
   checksum: efbd0289b599bee808ce80820dfe49c9635610715429c6b7cc50750f0437e3c2f697c81e5c390208c13b5d5d12d904a1546172a88579f6ee5cbaaaa4dc9ec5cf
+  languageName: node
+  linkType: hard
+
+"string-similarity@npm:4.0.4":
+  version: 4.0.4
+  resolution: "string-similarity@npm:4.0.4"
+  checksum: 797b41b24e1eb6b3b0ab896950b58c295a19a82933479c75f7b5279ffb63e0b456a8c8d10329c02f607ca1a50370e961e83d552aa468ff3b0fa15809abc9eff7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Try to determine the "most correct" domain that should therefore be used to display the brands icon.

Both domain and integration names are used, since the manufacturer name does not necessarily match directly the domain, but it might the more user friendly name.

On the device page, we do not yet have the integration names available, although I could of course add a look-up here as well, so we have exactly the same logic int he device dashboard and the device info page.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14620
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
