### PR TITLE
Use CSS colors for tile components

### DIFF
--- a/gallery/src/pages/components/ha-bar-slider.ts
+++ b/gallery/src/pages/components/ha-bar-slider.ts
@@ -142,7 +142,8 @@ export class DemoHaBarSlider extends LitElement {
       }
       .custom {
         --slider-bar-color: #ffcf4c;
-        --slider-bar-background: #ffcf4c64;
+        --slider-bar-background: #ffcf4c;
+        --slider-bar-background-opacity: 0.2;
         --slider-bar-thickness: 100px;
         --slider-bar-border-radius: 24px;
       }

--- a/gallery/src/pages/components/ha-bar-switch.ts
+++ b/gallery/src/pages/components/ha-bar-switch.ts
@@ -115,8 +115,8 @@ export class DemoHaBarSwitch extends LitElement {
         font-weight: 600;
       }
       .custom {
-        --switch-bar-color-on: var(--rgb-green-color);
-        --switch-bar-color-off: var(--rgb-red-color);
+        --switch-bar-color-on: rgb(var(--rgb-green-color));
+        --switch-bar-color-off: rgb(var(--rgb-red-color));
         --switch-bar-thickness: 100px;
         --switch-bar-border-radius: 24px;
         --switch-bar-padding: 6px;

--- a/gallery/src/pages/components/ha-bar-switch.ts
+++ b/gallery/src/pages/components/ha-bar-switch.ts
@@ -115,8 +115,8 @@ export class DemoHaBarSwitch extends LitElement {
         font-weight: 600;
       }
       .custom {
-        --switch-bar-color-on: rgb(var(--rgb-green-color));
-        --switch-bar-color-off: rgb(var(--rgb-red-color));
+        --switch-bar-on-color: rgb(var(--rgb-green-color));
+        --switch-bar-off-color: rgb(var(--rgb-red-color));
         --switch-bar-thickness: 100px;
         --switch-bar-border-radius: 24px;
         --switch-bar-padding: 6px;

--- a/src/common/color/compute-color.ts
+++ b/src/common/color/compute-color.ts
@@ -1,5 +1,3 @@
-import { hex2rgb } from "./convert-color";
-
 export const THEME_COLORS = new Set([
   "primary",
   "accent",
@@ -27,16 +25,9 @@ export const THEME_COLORS = new Set([
   "white",
 ]);
 
-export function computeRgbColor(color: string): string {
+export function computeCssColor(color: string): string {
   if (THEME_COLORS.has(color)) {
-    return `var(--rgb-${color}-color)`;
-  }
-  if (color.startsWith("#")) {
-    try {
-      return hex2rgb(color).join(", ");
-    } catch (err) {
-      return "";
-    }
+    return `rgb(var(--rgb-${color}-color))`;
   }
   return color;
 }

--- a/src/components/ha-bar-slider.ts
+++ b/src/components/ha-bar-slider.ts
@@ -272,7 +272,8 @@ export class HaBarSlider extends LitElement {
       :host {
         display: block;
         --slider-bar-color: rgb(var(--rgb-primary-color));
-        --slider-bar-background: rgba(var(--rgb-disabled-color), 0.2);
+        --slider-bar-background: rgb(var(--rgb-disabled-color));
+        --slider-bar-background-opacity: 0.2;
         --slider-bar-thickness: 40px;
         --slider-bar-border-radius: 10px;
         height: var(--slider-bar-thickness);
@@ -301,6 +302,7 @@ export class HaBarSlider extends LitElement {
         height: 100%;
         width: 100%;
         background: var(--slider-bar-background);
+        opacity: var(--slider-bar-background-opacity);
       }
       .slider .slider-track-bar {
         --border-radius: var(--slider-bar-border-radius);

--- a/src/components/ha-bar-switch.ts
+++ b/src/components/ha-bar-switch.ts
@@ -74,6 +74,7 @@ export class HaBarSwitch extends LitElement {
   protected render(): TemplateResult {
     return html`
       <div class="switch">
+        <div class="background"></div>
         <div class="button" aria-hidden="true">
           ${this.checked
             ? this.pathOn
@@ -91,8 +92,9 @@ export class HaBarSwitch extends LitElement {
     return css`
       :host {
         display: block;
-        --switch-bar-color-on: var(--rgb-primary-color);
-        --switch-bar-color-off: var(--rgb-disabled-color);
+        --switch-bar-on-color: rgb(var(--rgb-primary-color));
+        --switch-bar-off-color: rgb(var(--rgb-disabled-color));
+        --switch-bar-background-opacity: 0.2;
         --switch-bar-thickness: 40px;
         --switch-bar-border-radius: 12px;
         --switch-bar-padding: 4px;
@@ -109,10 +111,19 @@ export class HaBarSwitch extends LitElement {
         height: 100%;
         width: 100%;
         border-radius: var(--switch-bar-border-radius);
-        background-color: rgba(var(--switch-bar-color-off), 0.3);
+        overflow: hidden;
         padding: var(--switch-bar-padding);
-        transition: background-color 180ms ease-in-out;
         display: flex;
+      }
+      .switch .background {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        background-color: var(--switch-bar-off-color);
+        transition: background-color 180ms ease-in-out;
+        opacity: var(--switch-bar-background-opacity);
       }
       .switch .button {
         width: 50%;
@@ -123,18 +134,18 @@ export class HaBarSwitch extends LitElement {
         );
         transition: transform 180ms ease-in-out,
           background-color 180ms ease-in-out;
-        background-color: rgb(var(--switch-bar-color-off));
+        background-color: var(--switch-bar-off-color);
         color: white;
         display: flex;
         align-items: center;
         justify-content: center;
       }
-      :host([checked]) .switch {
-        background-color: rgba(var(--switch-bar-color-on), 0.3);
+      :host([checked]) .switch .background {
+        background-color: var(--switch-bar-on-color);
       }
       :host([checked]) .switch .button {
         transform: translateX(100%);
-        background-color: rgb(var(--switch-bar-color-on));
+        background-color: var(--switch-bar-on-color);
       }
       :host([reversed]) .switch {
         flex-direction: row-reverse;

--- a/src/components/tile/ha-tile-button.ts
+++ b/src/components/tile/ha-tile-button.ts
@@ -41,7 +41,9 @@ export class HaTileButton extends LitElement {
         @touchcancel=${this.handleRippleDeactivate}
       >
         <slot></slot>
-        ${this._shouldRenderRipple ? html`<mwc-ripple></mwc-ripple>` : ""}
+        ${this._shouldRenderRipple && !this.disabled
+          ? html`<mwc-ripple></mwc-ripple>`
+          : ""}
       </button>
     `;
   }
@@ -79,9 +81,10 @@ export class HaTileButton extends LitElement {
   static get styles(): CSSResultGroup {
     return css`
       :host {
-        --icon-color: rgb(var(--color, var(--rgb-primary-text-color)));
-        --bg-color: rgba(var(--color, var(--rgb-disabled-color)), 0.2);
-        --mdc-ripple-color: rgba(var(--color, var(--rgb-disabled-color)));
+        --tile-button-icon-color: var(--primary-text-color);
+        --tile-button-background-color: rgb(var(--rgb-disabled-color));
+        --tile-button-background-opacity: 0.2;
+        --mdc-ripple-color: var(--tile-button-background-color);
         width: 40px;
         height: 40px;
         -webkit-tap-highlight-color: transparent;
@@ -97,25 +100,37 @@ export class HaTileButton extends LitElement {
         height: 100%;
         border-radius: 10px;
         border: none;
-        background-color: var(--bg-color);
-        transition: background-color 280ms ease-in-out, transform 180ms ease-out;
         margin: 0;
         padding: 0;
         box-sizing: border-box;
         line-height: 0;
         outline: none;
+        overflow: hidden;
+        background: none;
+      }
+      .button::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        background-color: var(--tile-button-background-color);
+        transition: background-color 180ms ease-in-out,
+          opacity 180ms ease-in-out;
+        opacity: var(--tile-button-background-opacity);
       }
       .button ::slotted(*) {
         --mdc-icon-size: 20px;
-        color: var(--icon-color);
+        transition: color 180ms ease-in-out;
+        color: var(--tile-button-icon-color);
         pointer-events: none;
       }
       .button:disabled {
         cursor: not-allowed;
-        background-color: rgba(var(--rgb-disabled-color), 0.2);
-      }
-      .button:disabled ::slotted(*) {
-        color: rgb(var(--rgb-disabled-color));
+        --tile-button-background-color: rgb(var(--rgb-disabled-color));
+        --tile-button-icon-color: var(--disabled-text-color);
+        --tile-button-background-opacity: 0.2;
       }
     `;
   }

--- a/src/components/tile/ha-tile-icon.ts
+++ b/src/components/tile/ha-tile-icon.ts
@@ -22,9 +22,19 @@ export class HaTileIcon extends LitElement {
   static get styles(): CSSResultGroup {
     return css`
       :host {
-        --icon-color: rgb(var(--color));
-        --shape-color: rgba(var(--color), 0.2);
+        --tile-icon-color: rgb(var(--rgb-disabled-color));
         --mdc-icon-size: 24px;
+      }
+      .shape::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        background-color: var(--tile-icon-color);
+        transition: background-color 180ms ease-in-out;
+        opacity: 0.2;
       }
       .shape {
         position: relative;
@@ -34,13 +44,13 @@ export class HaTileIcon extends LitElement {
         display: flex;
         align-items: center;
         justify-content: center;
-        background-color: var(--shape-color);
-        transition: background-color 180ms ease-in-out, color 180ms ease-in-out;
+        transition: color 180ms ease-in-out;
+        overflow: hidden;
       }
       .shape ha-icon,
       .shape ha-svg-icon {
         display: flex;
-        color: var(--icon-color);
+        color: var(--tile-icon-color);
         transition: color 180ms ease-in-out;
       }
     `;

--- a/src/components/tile/ha-tile-slider.ts
+++ b/src/components/tile/ha-tile-slider.ts
@@ -48,12 +48,16 @@ export class HaTileSlider extends LitElement {
     return css`
       ha-bar-slider {
         --slider-bar-color: var(
-          --tile-slider-bar-color,
+          --tile-slider-color,
           rgb(var(--rgb-primary-color))
         );
         --slider-bar-background: var(
-          --tile-slider-bar-background,
-          rgba(var(--rgb-disabled-color), 0.2)
+          --tile-slider-background,
+          rgb(var(--rgb-disabled-color))
+        );
+        --slider-bar-background-opacity: var(
+          --tile-slider-background-opacity,
+          0.2
         );
         --slider-bar-thickness: 40px;
         --slider-bar-border-radius: 10px;

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -243,6 +243,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
               ></ha-tile-badge>
             </div>
             <ha-tile-info
+              class="info"
               .primary=${entityId}
               secondary=${this.hass.localize("ui.card.tile.not_found")}
             ></ha-tile-info>
@@ -311,6 +312,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
               : null}
           </div>
           <ha-tile-info
+            class="info"
             .primary=${name}
             .secondary=${stateDisplay}
             role="button"
@@ -394,8 +396,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
         transition: transform 180ms ease-in-out;
       }
       .icon-container .icon {
-        --icon-color: rgb(var(--tile-color));
-        --shape-color: rgba(var(--tile-color), 0.2);
+        --tile-icon-color: rgb(var(--tile-color));
       }
       .icon-container .badge {
         position: absolute;
@@ -406,16 +407,28 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       .icon-container[role="button"]:active {
         transform: scale(1.2);
       }
-      ha-tile-info {
+      .info {
+        position: relative;
         padding: var(--tile-tap-padding);
         flex: 1;
         min-width: 0;
         min-height: 40px;
-        border-radius: calc(var(--ha-card-border-radius, 10px) - 2px);
         transition: background-color 180ms ease-in-out;
       }
-      ha-tile-info:focus-visible {
-        background-color: rgba(var(--tile-color), 0.1);
+      .info::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        border-radius: calc(var(--ha-card-border-radius, 10px) - 2px);
+        background-color: transparent;
+        opacity: 0.1;
+        transition: background-color ease-in-out 180ms;
+      }
+      .info:focus-visible::before {
+        background-color: rgb(var(--tile-color));
       }
     `;
   }

--- a/src/panels/lovelace/components/hui-color-picker.ts
+++ b/src/panels/lovelace/components/hui-color-picker.ts
@@ -3,7 +3,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
 import {
-  computeRgbColor,
+  computeCssColor,
   THEME_COLORS,
 } from "../../../common/color/compute-color";
 import { fireEvent } from "../../../common/dom/fire_event";
@@ -76,7 +76,7 @@ export class HuiColorPicker extends LitElement {
       <span
         class="circle-color"
         style=${styleMap({
-          "--circle-color": computeRgbColor(color),
+          "--circle-color": computeCssColor(color),
         })}
       ></span>
     `;
@@ -86,7 +86,7 @@ export class HuiColorPicker extends LitElement {
     return css`
       .circle-color {
         display: block;
-        background-color: rgb(var(--circle-color));
+        background-color: var(--circle-color);
         border-radius: 10px;
         width: 20px;
         height: 20px;

--- a/src/panels/lovelace/tile-features/hui-light-brightness-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-light-brightness-tile-feature.ts
@@ -73,8 +73,9 @@ class HuiLightBrightnessTileFeature
   static get styles() {
     return css`
       ha-tile-slider {
-        --tile-slider-bar-color: rgb(var(--tile-color));
-        --tile-slider-bar-background: rgba(var(--tile-color), 0.2);
+        --tile-slider-color: rgb(var(--tile-color));
+        --tile-slider-background: rgb(var(--tile-color));
+        --tile-slider-background-opacity: 0.2;
       }
       .container {
         padding: 0 12px 12px 12px;

--- a/src/panels/lovelace/tile-features/hui-light-brightness-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-light-brightness-tile-feature.ts
@@ -73,8 +73,8 @@ class HuiLightBrightnessTileFeature
   static get styles() {
     return css`
       ha-tile-slider {
-        --tile-slider-color: rgb(var(--tile-color));
-        --tile-slider-background: rgb(var(--tile-color));
+        --tile-slider-color: var(--tile-color);
+        --tile-slider-background: var(--tile-color);
         --tile-slider-background-opacity: 0.2;
       }
       .container {


### PR DESCRIPTION
## Proposed change

Tile components now use css color instead of RGB ones like any other components. It's just internal code. No impact for the end user.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
