### PR TITLE
Handle "idle" state of alert entity

### DIFF
--- a/gallery/src/pages/misc/entity-state.ts
+++ b/gallery/src/pages/misc/entity-state.ts
@@ -106,6 +106,7 @@ const ENTITIES: HassEntity[] = [
   // Alert
   createEntity("alert.off", "off"),
   createEntity("alert.on", "on"),
+  createEntity("alert.idle", "idle"),
   // Automation
   createEntity("automation.off", "off"),
   createEntity("automation.on", "on"),

--- a/src/common/entity/color/alert_color.ts
+++ b/src/common/entity/color/alert_color.ts
@@ -1,0 +1,10 @@
+export const alertColor = (state?: string): string | undefined => {
+  switch (state) {
+    case "on":
+      return "alert";
+    case "off":
+      return "alert-off";
+    default:
+      return undefined;
+  }
+};

--- a/src/common/entity/state_active.ts
+++ b/src/common/entity/state_active.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { OFF_STATES, UNAVAILABLE } from "../../data/entity";
+import { UNAVAILABLE, UNAVAILABLE_STATES } from "../../data/entity";
 import { computeDomain } from "./compute_domain";
 
 export function stateActive(stateObj: HassEntity, state?: string): boolean {
@@ -10,7 +10,7 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
     return compareState !== UNAVAILABLE;
   }
 
-  if (OFF_STATES.includes(compareState)) {
+  if (UNAVAILABLE_STATES.includes(compareState)) {
     return false;
   }
 
@@ -19,7 +19,7 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
     case "alarm_control_panel":
       return compareState !== "disarmed";
     case "alert":
-      return compareState === "on";
+      return compareState !== "idle";
     case "cover":
       return !["closed", "closing"].includes(compareState);
     case "device_tracker":
@@ -39,7 +39,13 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
       return compareState === "active";
     case "camera":
       return compareState === "streaming";
-    default:
-      return true;
   }
+
+  // Needs to be after the switch statement since some domains such as "alert"
+  // do not consider "off" an inactive state (as there is "idle" for example).
+  if (compareState === "off") {
+    return false;
+  }
+
+  return true;
 }

--- a/src/common/entity/state_active.ts
+++ b/src/common/entity/state_active.ts
@@ -14,11 +14,20 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
     return false;
   }
 
+  // The "off" check is relevant for most domains, but there are exceptions
+  // such as "alert" where "off" is still a somewhat active state and
+  // therefore gets a custom color and "idle" is instead the state that
+  // matches what most other domains consider inactive.
+  if (compareState === OFF && domain !== "alert") {
+    return false;
+  }
+
   // Custom cases
   switch (domain) {
     case "alarm_control_panel":
       return compareState !== "disarmed";
     case "alert":
+      // "on" and "off" are active, as "off" just means alert was acknowledged but is still active
       return compareState !== "idle";
     case "cover":
       return !["closed", "closing"].includes(compareState);
@@ -39,12 +48,6 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
       return compareState === "active";
     case "camera":
       return compareState === "streaming";
-  }
-
-  // Needs to be after the switch statement since some domains such as "alert"
-  // do not consider "off" an inactive state (as there is "idle" for example).
-  if (compareState === OFF) {
-    return false;
   }
 
   return true;

--- a/src/common/entity/state_active.ts
+++ b/src/common/entity/state_active.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { UNAVAILABLE, UNAVAILABLE_STATES } from "../../data/entity";
+import { OFF, UNAVAILABLE, UNAVAILABLE_STATES } from "../../data/entity";
 import { computeDomain } from "./compute_domain";
 
 export function stateActive(stateObj: HassEntity, state?: string): boolean {
@@ -43,7 +43,7 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
 
   // Needs to be after the switch statement since some domains such as "alert"
   // do not consider "off" an inactive state (as there is "idle" for example).
-  if (compareState === "off") {
+  if (compareState === OFF) {
     return false;
   }
 

--- a/src/common/entity/state_active.ts
+++ b/src/common/entity/state_active.ts
@@ -18,6 +18,8 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
   switch (domain) {
     case "alarm_control_panel":
       return compareState !== "disarmed";
+    case "alert":
+      return compareState === "on";
     case "cover":
       return !["closed", "closing"].includes(compareState);
     case "device_tracker":

--- a/src/common/entity/state_color.ts
+++ b/src/common/entity/state_color.ts
@@ -2,6 +2,7 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { UNAVAILABLE } from "../../data/entity";
 import { alarmControlPanelColor } from "./color/alarm_control_panel_color";
+import { alertColor } from "./color/alert_color";
 import { binarySensorColor } from "./color/binary_sensor_color";
 import { climateColor } from "./color/climate_color";
 import { lockColor } from "./color/lock_color";
@@ -12,7 +13,6 @@ import { computeDomain } from "./compute_domain";
 import { stateActive } from "./state_active";
 
 const STATIC_ACTIVE_COLORED_DOMAIN = new Set([
-  "alert",
   "automation",
   "calendar",
   "camera",
@@ -64,6 +64,9 @@ export const stateColor = (stateObj: HassEntity, state?: string) => {
   switch (domain) {
     case "alarm_control_panel":
       return alarmControlPanelColor(compareState);
+
+    case "alert":
+      return alertColor(compareState);
 
     case "binary_sensor":
       return binarySensorColor(stateObj, compareState);

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -145,6 +145,7 @@ documentContainer.innerHTML = `<custom-style>
       --rgb-state-alarm-pending-color: var(--rgb-orange-color);
       --rgb-state-alarm-triggered-color: var(--rgb-red-color);
       --rgb-state-alert-color: var(--rgb-red-color);
+      --rgb-state-alert-off-color: var(--rgb-orange-color);
       --rgb-state-automation-color: var(--rgb-amber-color);
       --rgb-state-binary-sensor-alerting-color: var(--rgb-red-color);
       --rgb-state-binary-sensor-color: var(--rgb-amber-color);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Add "idle " state to gallery and ensure correct color (was automatically red before).

Backend translation strings are added via https://github.com/home-assistant/core/pull/83926.

![image](https://user-images.githubusercontent.com/114137/207664633-ea93a8af-16f2-4b8e-8b87-37811e2aedc3.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
