### PR TITLE
Limit description width on zwave_js device configuration page

### DIFF
--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -471,7 +471,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
         }
 
         :host(:not([narrow])) ha-settings-row ha-textfield {
-          width: 30%;
+          width: 100px;
           text-align: right;
         }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The current device configuration page for zwave_js is unusable for fields in which the field description is too long. The textbox where the field can be changed overflows out of the parent, and is left as a small runt box in which you cannot see the current value nor see what you are typing. Supposedly you can type and hit enter, but you can't see it and no indication that it is working. 

![zwave1](https://user-images.githubusercontent.com/32912880/207647799-f70a2668-9877-4a8f-8a19-a0fb2693ef25.png)

This change replaces width 30% with a fixed width of 100px, which fixes the issue. I wish I understood enough CSS to figure out how to make it work and keep the relative 30%, but I could not figure it out. That said the current form is completely broken, so I think this change is a big improvement, even if not perfect, given that it has been reported broken for >6 months. 

![zwave_fix](https://user-images.githubusercontent.com/32912880/207647447-b2d752bd-671a-40ce-9de6-f7de90bc6ee0.png)



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #12747, fixes #14422
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
