### PR TITLE
Add alarm commands feature to tile card

### DIFF
--- a/src/panels/lovelace/create-element/create-tile-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-tile-feature-element.ts
@@ -3,12 +3,14 @@ import {
   createLovelaceElement,
   getLovelaceElementClass,
 } from "./create-element-base";
+import "../tile-features/hui-alarm-commands-tile-feature";
 import "../tile-features/hui-cover-open-close-tile-feature";
 import "../tile-features/hui-cover-tilt-tile-feature";
 import "../tile-features/hui-light-brightness-tile-feature";
 import "../tile-features/hui-vacuum-commands-tile-feature";
 
 const TYPES: Set<LovelaceTileFeatureConfig["type"]> = new Set([
+  "alarm-commands",
   "cover-open-close",
   "cover-tilt",
   "light-brightness",

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-commands-tile-feature-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-commands-tile-feature-editor.ts
@@ -1,0 +1,90 @@
+import { html, LitElement, TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../common/translations/localize";
+import "../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../components/ha-form/types";
+import type { HomeAssistant } from "../../../../types";
+import {
+  AlarmCommandsTileFeatureConfig,
+  ALARM_COMMANDS,
+} from "../../tile-features/types";
+import type { LovelaceTileFeatureEditor } from "../../types";
+
+@customElement("hui-alarm-commands-tile-feature-editor")
+export class HuiAlarmCommandsTileFeatureEditor
+  extends LitElement
+  implements LovelaceTileFeatureEditor
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _config?: AlarmCommandsTileFeatureConfig;
+
+  public setConfig(config: AlarmCommandsTileFeatureConfig): void {
+    this._config = config;
+  }
+
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        {
+          name: "commands",
+          selector: {
+            select: {
+              multiple: true,
+              options: ALARM_COMMANDS.map((command) => ({
+                value: command,
+                label: localize(
+                  `ui.panel.lovelace.editor.card.tile.features.types.alarm-commands.commands_list.${command}`
+                ),
+              })),
+            },
+          },
+        },
+      ] as const
+  );
+
+  protected render(): TemplateResult {
+    if (!this.hass || !this._config) {
+      return html``;
+    }
+
+    const schema = this._schema(this.hass.localize);
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${schema}
+        .computeLabel=${this._computeLabelCallback}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ) => {
+    switch (schema.name) {
+      case "commands":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.tile.features.types.alarm-commands.${schema.name}`
+        );
+      default:
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.generic.${schema.name}`
+        );
+    }
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-alarm-commands-tile-feature-editor": HuiAlarmCommandsTileFeatureEditor;
+  }
+}

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
@@ -30,6 +30,7 @@ import {
 import { LovelaceTileFeatureConfig } from "../../tile-features/types";
 
 const FEATURES_TYPE: LovelaceTileFeatureConfig["type"][] = [
+  "alarm-commands",
   "cover-open-close",
   "cover-tilt",
   "light-brightness",

--- a/src/panels/lovelace/tile-features/hui-alarm-commands-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-alarm-commands-tile-feature.ts
@@ -1,0 +1,171 @@
+import {
+  mdiShieldAirplaneOutline,
+  mdiShieldHalfFull,
+  mdiShieldHomeOutline,
+  mdiShieldLockOutline,
+  mdiShieldMoonOutline,
+  mdiShieldOffOutline,
+} from "@mdi/js";
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import "../../../components/tile/ha-tile-button";
+import { UNAVAILABLE } from "../../../data/entity";
+import { HomeAssistant } from "../../../types";
+import { LovelaceTileFeature, LovelaceTileFeatureEditor } from "../types";
+import { AlarmCommand, AlarmCommandsTileFeatureConfig } from "./types";
+
+interface AlarmButton {
+  translationKey: string;
+  icon: string;
+  serviceName: AlarmCommand;
+}
+
+export const armAlarmCommand = (
+  stateObj: HassEntity,
+  button: AlarmButton
+): boolean => {
+  if (stateObj.state !== "disarmed" && button.serviceName !== "alarm_disarm") {
+    return false;
+  }
+  return true;
+};
+
+export const ALARM_COMMANDS_BUTTONS: AlarmButton[] = [
+  {
+    translationKey: "disarm",
+    icon: mdiShieldOffOutline,
+    serviceName: "alarm_disarm",
+  },
+  {
+    translationKey: "arm_away",
+    icon: mdiShieldLockOutline,
+    serviceName: "alarm_arm_away",
+  },
+  {
+    translationKey: "arm_home",
+    icon: mdiShieldHomeOutline,
+    serviceName: "alarm_arm_home",
+  },
+  {
+    translationKey: "arm_night",
+    icon: mdiShieldMoonOutline,
+    serviceName: "alarm_arm_night",
+  },
+  {
+    translationKey: "arm_vacation",
+    icon: mdiShieldAirplaneOutline,
+    serviceName: "alarm_arm_vacation",
+  },
+  {
+    translationKey: "arm_custom_bypass",
+    icon: mdiShieldHalfFull,
+    serviceName: "alarm_arm_custom_bypass",
+  },
+];
+
+@customElement("hui-alarm-commands-tile-feature")
+class HuiVacuumCommandTileFeature
+  extends LitElement
+  implements LovelaceTileFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state() private _config?: AlarmCommandsTileFeatureConfig;
+
+  static getStubConfig(): AlarmCommandsTileFeatureConfig {
+    return {
+      type: "alarm-commands",
+      commands: [
+        "alarm_arm_away",
+        "alarm_arm_home",
+        "alarm_arm_night",
+        "alarm_arm_vacation",
+        "alarm_arm_custom_bypass",
+        "alarm_disarm",
+      ],
+    };
+  }
+
+  public static async getConfigElement(): Promise<LovelaceTileFeatureEditor> {
+    await import(
+      "../editor/config-elements/hui-alarm-commands-tile-feature-editor"
+    );
+    return document.createElement("hui-alarm-commands-tile-feature-editor");
+  }
+
+  public setConfig(config: AlarmCommandsTileFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  private _onCommandTap(ev): void {
+    ev.stopPropagation();
+    const entry = (ev.target! as any).entry as AlarmButton;
+    this.hass!.callService("alarm_control_panel", entry.serviceName, {
+      entity_id: this.stateObj!.entity_id,
+    });
+  }
+
+  protected render(): TemplateResult {
+    if (!this._config || !this.hass || !this.stateObj) {
+      return html``;
+    }
+
+    const stateObj = this.stateObj;
+
+    return html`
+      <div class="container">
+        ${ALARM_COMMANDS_BUTTONS.filter(
+          (button) =>
+            armAlarmCommand(stateObj, button) &&
+            this._config?.commands?.includes(button.serviceName)
+        ).map(
+          (button) => html`
+            <ha-tile-button
+              .entry=${button}
+              .label=${this.hass!.localize(
+                // @ts-ignore
+                `ui.dialogs.more_info_control.alarm.${button.translationKey}`
+              )}
+              @click=${this._onCommandTap}
+              .disabled=${this.stateObj?.state === UNAVAILABLE}
+            >
+              <ha-svg-icon .path=${button.icon}></ha-svg-icon>
+            </ha-tile-button>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .container {
+        display: flex;
+        flex-direction: row;
+        padding: 0 12px 12px 12px;
+        width: auto;
+      }
+      ha-tile-button {
+        flex: 1;
+      }
+      ha-tile-button:not(:last-child) {
+        margin-right: 12px;
+        margin-inline-end: 12px;
+        margin-inline-start: initial;
+        direction: var(--direction);
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-alarm-commands-tile-feature": HuiVacuumCommandTileFeature;
+  }
+}

--- a/src/panels/lovelace/tile-features/tile-features.ts
+++ b/src/panels/lovelace/tile-features/tile-features.ts
@@ -10,6 +10,8 @@ type TileFeatureType = LovelaceTileFeatureConfig["type"];
 export type SupportsTileFeature = (stateObj: HassEntity) => boolean;
 
 const TILE_FEATURES_SUPPORT: Record<TileFeatureType, SupportsTileFeature> = {
+  "alarm-commands": (stateObj) =>
+    computeDomain(stateObj.entity_id) === "alarm_control_panel",
   "cover-open-close": (stateObj) =>
     computeDomain(stateObj.entity_id) === "cover" &&
     (supportsFeature(stateObj, CoverEntityFeature.OPEN) ||
@@ -27,6 +29,7 @@ const TILE_FEATURES_SUPPORT: Record<TileFeatureType, SupportsTileFeature> = {
 };
 
 const TILE_FEATURE_EDITABLE: Set<TileFeatureType> = new Set([
+  "alarm-commands",
   "vacuum-commands",
 ]);
 

--- a/src/panels/lovelace/tile-features/types.ts
+++ b/src/panels/lovelace/tile-features/types.ts
@@ -25,7 +25,24 @@ export interface VacuumCommandsTileFeatureConfig {
   commands?: VacuumCommand[];
 }
 
+export const ALARM_COMMANDS = [
+  "alarm_arm_away",
+  "alarm_arm_home",
+  "alarm_arm_night",
+  "alarm_arm_vacation",
+  "alarm_arm_custom_bypass",
+  "alarm_disarm",
+] as const;
+
+export type AlarmCommand = typeof ALARM_COMMANDS[number];
+
+export interface AlarmCommandsTileFeatureConfig {
+  type: "alarm-commands";
+  commands?: AlarmCommand[];
+}
+
 export type LovelaceTileFeatureConfig =
+  | AlarmCommandsTileFeatureConfig
   | CoverOpenCloseTileFeatureConfig
   | CoverTiltTileFeatureConfig
   | LightBrightnessTileFeatureConfig

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4304,6 +4304,19 @@
                 "edit": "Edit feature",
                 "remove": "Remove feature",
                 "types": {
+                  "alarm-commands": {
+                    "label": "Alarm commands",
+                    "commands": "Commands",
+                    "commands_helper": "Only compatible commands will be displayed on the card",
+                    "commands_list": {
+                      "arm_away": "[%key:ui::card::alarm_control_panel::arm_away%]",
+                      "arm_home": "[%key:ui::card::alarm_control_panel::arm_home%]",
+                      "arm_night": "[%key:ui::card::alarm_control_panel::arm_night%]",
+                      "arm_vacation": "[%key:ui::card::alarm_control_panel::arm_vacation%]",
+                      "arm_custom_bypass": "[%key:ui::card::alarm_control_panel::arm_custom_bypass%]",
+                      "disarm": "[%key:ui::card::alarm_control_panel::disarm%]"
+                    }
+                  },
                   "cover-open-close": {
                     "label": "Cover open/close"
                   },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
With this PR I want to add command features to the alarm integration:
<img src="https://user-images.githubusercontent.com/1368405/208244246-e0c584cf-44c3-4a2b-9153-769bc0045daa.png" width="300"/>
<img src="https://user-images.githubusercontent.com/1368405/208244261-a45310af-373a-4109-bcb7-55e31b4e8c66.png" width="300"/>
<img src="https://user-images.githubusercontent.com/1368405/208244292-af588cc0-1ea6-4421-849c-4a8ec7c16cef.png" width="300"/>

The only thing that does not work yet is the feature selection. It currently looks like this:
<img src="https://user-images.githubusercontent.com/1368405/208244316-64be66a0-1c37-4f0c-b578-c1af09390698.png" width="300"/>

And I want it to look like this:
<img src="https://user-images.githubusercontent.com/1368405/208244362-76142ab6-a961-4c01-a3be-9d586d05e140.png" width="300"/>

I tried to find the issue for quite some time now, but did not manage to do so. Maybe someone could give me a hint here?
Would really appreciate it!

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
