### PR TITLE
Fix suffix not showing up

### DIFF
--- a/src/onboarding/onboarding-core-config.ts
+++ b/src/onboarding/onboarding-core-config.ts
@@ -156,13 +156,11 @@ class OnboardingCoreConfig extends LitElement {
           type="number"
           .disabled=${this._working}
           .value=${this._elevationValue}
+          .suffix=${this.hass.localize(
+            "ui.panel.config.core.section.core.core_config.elevation_meters"
+          )}
           @change=${this._handleChange}
         >
-          <span slot="suffix">
-            ${this.hass.localize(
-              "ui.panel.config.core.section.core.core_config.elevation_meters"
-            )}
-          </span>
         </ha-textfield>
       </div>
 

--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -118,13 +118,11 @@ class HaConfigSectionGeneral extends LitElement {
                 type="number"
                 .disabled=${disabled}
                 .value=${this._elevation}
+                .suffix=${this.hass.localize(
+                  "ui.panel.config.core.section.core.core_config.elevation_meters"
+                )}
                 @change=${this._handleChange}
               >
-                <span slot="suffix">
-                  ${this.hass.localize(
-                    "ui.panel.config.core.section.core.core_config.elevation_meters"
-                  )}
-                </span>
               </ha-textfield>
               <div>
                 <div>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

For some reason the slot suffix does not work how we expect it to work. I found out that suffix is a property we can fill and then the suffix works again.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests



## Additional information

I see more slot="suffix" in the code, but I can't properly say if they have the same issue since I can't don't have those integrations in my own hass setup. 

## Checklist



- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
