### PR TITLE
Fix calendar date display and parsing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "core-js": "^3.15.2",
     "cropperjs": "^1.5.12",
     "date-fns": "^2.23.0",
+    "date-fns-tz": "^1.3.7",
     "deep-clone-simple": "^1.1.1",
     "deep-freeze": "^0.0.1",
     "fuse.js": "^6.0.0",

--- a/src/panels/calendar/dialog-calendar-event-detail.ts
+++ b/src/panels/calendar/dialog-calendar-event-detail.ts
@@ -1,6 +1,7 @@
 import "@material/mwc-button";
 import { mdiCalendarClock, mdiClose } from "@mdi/js";
 import { addDays, isSameDay } from "date-fns/esm";
+import { toDate } from "date-fns-tz";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { property, state } from "lit/decorators";
 import { RRule, Weekday } from "rrule";
@@ -185,11 +186,12 @@ class DialogCalendarEventDetail extends LitElement {
   };
 
   private _formatDateRange() {
-    const start = new Date(this._data!.dtstart);
+    // Parse a dates in the browser timezone
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const start = toDate(this._data!.dtstart, { timeZone: timeZone });
+    const endValue = toDate(this._data!.dtend, { timeZone: timeZone });
     // All day events should be displayed as a day earlier
-    const end = isDate(this._data.dtend)
-      ? addDays(new Date(this._data!.dtend), -1)
-      : new Date(this._data!.dtend);
+    const end = isDate(this._data.dtend) ? addDays(endValue, -1) : endValue;
     // The range can be shortened when the start and end are on the same day.
     if (isSameDay(start, end)) {
       if (isDate(this._data.dtstart)) {

--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -78,7 +78,9 @@ class DialogCalendarEventEditor extends LitElement {
           computeStateDomain(stateObj) === "calendar" &&
           supportsFeature(stateObj, CalendarEntityFeature.CREATE_EVENT)
       )?.entity_id;
-    this._timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    this._timeZone =
+      Intl.DateTimeFormat().resolvedOptions().timeZone ||
+      this.hass.config.time_zone;
     if (params.entry) {
       const entry = params.entry!;
       this._allDay = isDate(entry.dtstart);
@@ -289,34 +291,28 @@ class DialogCalendarEventEditor extends LitElement {
   private _isEditableCalendar = (entityStateObj: HassEntity) =>
     supportsFeature(entityStateObj, CalendarEntityFeature.CREATE_EVENT);
 
-  private _getLocaleStrings = memoizeOne((startDate?: Date, endDate?: Date) => ({
-      startDate: this._formatDate(startDate),
-      startTime: this._formatTime(startDate),
-      endDate: this._formatDate(endDate),
-      endTime: this._formatTime(endDate),
-    }));
+  private _getLocaleStrings = memoizeOne(
+    (startDate?: Date, endDate?: Date) => ({
+      startDate: this._formatDate(startDate!),
+      startTime: this._formatTime(startDate!),
+      endDate: this._formatDate(endDate!),
+      endTime: this._formatTime(endDate!),
+    })
+  );
 
   // Formats a date in specified timezone, or defaulting to browser display timezone
-  private _formatDate(date: Date, timeZone?: string = this._timeZone): string {
-    return formatInTimeZone(
-      date,
-      timeZone,
-      "yyyy-MM-dd"
-    );
+  private _formatDate(date: Date, timeZone: string = this._timeZone!): string {
+    return formatInTimeZone(date, timeZone, "yyyy-MM-dd");
   }
 
   // Formats a time in specified timezone, or defaulting to browser display timezone
-  private _formatTime(date: Date, timeZone?: string): string {
-    return formatInTimeZone(
-      date,
-      timeZone || this.timeZone,
-      "HH:mm:ss"
-    ); // 24 hr
+  private _formatTime(date: Date, timeZone: string = this._timeZone!): string {
+    return formatInTimeZone(date, timeZone, "HH:mm:ss"); // 24 hr
   }
 
   // Parse a date in the browser timezone
   private _parseDate(dateStr: string): Date {
-    return toDate(dateStr, { timeZone: this.timeZone });
+    return toDate(dateStr, { timeZone: this._timeZone! });
   }
 
   private _clearInfo() {

--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -65,7 +65,7 @@ class DialogCalendarEventEditor extends LitElement {
   // which may be different from the Home Assistant timezone. When
   // events are persisted, they are relative to the Home Assistant
   // timezone, but floating without a timezone.
-  private _timeZone: string;
+  private _timeZone?: string;
 
   public showDialog(params: CalendarEventEditDialogParams): void {
     this._error = undefined;
@@ -297,10 +297,10 @@ class DialogCalendarEventEditor extends LitElement {
     }));
 
   // Formats a date in specified timezone, or defaulting to browser display timezone
-  private _formatDate(date: Date, timeZone?: string): string {
+  private _formatDate(date: Date, timeZone?: string = this._timeZone): string {
     return formatInTimeZone(
       date,
-      timeZone || this.timeZone,
+      timeZone,
       "yyyy-MM-dd"
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6993,6 +6993,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns-tz@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "date-fns-tz@npm:1.3.7"
+  peerDependencies:
+    date-fns: ">=2.0.0"
+  checksum: b749613669223056d5e6d715114c94bec57234b676d0cea0c72ca710626c81e9ea04df6441852a5fec74b42c5f27b2f076e13697ec43da360b67806a3042a10e
+  languageName: node
+  linkType: hard
+
 "date-fns@npm:^2.23.0":
   version: 2.23.0
   resolution: "date-fns@npm:2.23.0"
@@ -9427,6 +9436,7 @@ fsevents@^1.2.7:
     core-js: ^3.15.2
     cropperjs: ^1.5.12
     date-fns: ^2.23.0
+    date-fns-tz: ^1.3.7
     deep-clone-simple: ^1.1.1
     deep-freeze: ^0.0.1
     del: ^4.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Fix calendar date display and parsing issues. The primary change is to always display dates in the browsers display timezone, so that it is consistent with dates in other surfaces (e.g. the calendar display, logbook, etc). The date input controls will work in terms of the browser timezone, then convert to the home assistant timezone when persisting the event.

Note: Event date/times are created without a timezone, using floating dates relative to the core timezone.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14786 and fixes #14684
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
