### PR TITLE
Fix zwave automations not handling 0 values in the visual editor

### DIFF
--- a/src/components/ha-selector/ha-selector-select.ts
+++ b/src/components/ha-selector/ha-selector-select.ts
@@ -190,8 +190,7 @@ export class HaSelectSelector extends LitElement {
   private _valueChanged(ev) {
     ev.stopPropagation();
     const value = ev.detail?.value || ev.target.value;
-    const validValue = value || (typeof value === "number" && value === 0);
-    if (this.disabled || !validValue) {
+    if (this.disabled || value === undefined) {
       return;
     }
     fireEvent(this, "value-changed", {

--- a/src/components/ha-selector/ha-selector-select.ts
+++ b/src/components/ha-selector/ha-selector-select.ts
@@ -190,7 +190,8 @@ export class HaSelectSelector extends LitElement {
   private _valueChanged(ev) {
     ev.stopPropagation();
     const value = ev.detail?.value || ev.target.value;
-    if (this.disabled || !value) {
+    const validValue = value || (typeof value === "number" && value === 0);
+    if (this.disabled || !validValue) {
       return;
     }
     fireEvent(this, "value-changed", {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Users editing zwavejs based automations in the visual editor have raised many issue reports about the visual editor not working correctly when selecting zwave configuration radio buttons associated with the parameter value "0". Clicking the value associated with the 0 entry is ignored by the visual editor and treated as if nothing was clicked on, and when writing the automation it will complain about the missing value. 

Users were forced to go into yaml mode and add `value: 0` line manually. 

Debugged in the frontend why this was occuring and I believe it was from this line in ha-selector-select. This `valueChanged` function rejected all falsey type values and would not fire a changed event when a radio button with the value '0' was selected. 

I am not fully sure what the implications of changing this are, but if I make a change to allow '0' to be propogated, but still reject all other falsey values, the problems with the visual automation editor were resolved. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
fixes #13729 
fixes #14307 
fixes #14279 
fixes https://github.com/home-assistant/core/issues/82690
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
