### PR TITLE
Clarified meaning with slider in Network Settings

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5041,8 +5041,8 @@
           "container": "Container",
           "disabled": "Disabled",
           "header": "Network",
-          "show_disabled": "Show disabled ports",
-          "introduction": "Change the ports on your host that are exposed by the add-on"
+          "show_disabled": "Configure exposed add-on ports",
+          "introduction": "Add or change the ports on your host that are exposed by the add-on. Maps an exposed port to an addon port"
         }
       },
       "dashboard": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
No
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Update translation for frontend. For someone that reads the original text in an addon -> Network options for the first time it's very unclear what the slider in Network Ports actually should do. Also when enabled there is no indication that something should be added in the configuration field.
 
![image](https://user-images.githubusercontent.com/32157341/209231552-b1237923-65f2-4eff-8c0a-e5b6f7174fb1.png)

So I have proposed that the text is changed from 
- Show disabled ports
 to
- Configure exposed add-on ports
instead.
It will be clearer that when disabled the add-on has no exposed ports configured. And that it needs to be enabled to configure exposed ports for the add-on. 

The description text has also been updated to indicate that it both a add and change option that is valid. Add when nothing has been configured since before and change when it's already configured.

I've been spending long time trying to expose a port from the add-on, also created an issue that was answered fast and the lead me to the correct settings. So to save time from the next person, this is a good and small update.
https://github.com/hassio-addons/addon-nut/issues/261

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```
As the change is only in the UI, the easiest is to install an add-on that have ports to expose, I used Network UPS Tools
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
