### PR TITLE
Fix map card not loading in sidebar view

### DIFF
--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -92,25 +92,6 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     this._cleanupHistory();
   }
 
-  private _computePadding(): void {
-    const root = this.shadowRoot!.getElementById("root");
-    if (!this._config || this.isPanel || !root) {
-      return;
-    }
-
-    if (!this._config.aspect_ratio) {
-      root.style.paddingBottom = "100%";
-      return;
-    }
-
-    const ratio = parseAspectRatio(this._config.aspect_ratio);
-
-    root.style.paddingBottom =
-      ratio && ratio.w > 0 && ratio.h > 0
-        ? `${((100 * ratio.h) / ratio.w).toFixed(2)}%`
-        : (root.style.paddingBottom = "100%");
-  }
-
   public getCardSize(): number {
     if (!this._config?.aspect_ratio) {
       return 7;
@@ -216,6 +197,25 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     if (changedProps.has("_config")) {
       this._computePadding();
     }
+  }
+
+  private _computePadding(): void {
+    const root = this.shadowRoot!.getElementById("root");
+    if (!this._config || this.isPanel || !root) {
+      return;
+    }
+
+    if (!this._config.aspect_ratio) {
+      root.style.paddingBottom = "100%";
+      return;
+    }
+
+    const ratio = parseAspectRatio(this._config.aspect_ratio);
+
+    root.style.paddingBottom =
+      ratio && ratio.w > 0 && ratio.h > 0
+        ? `${((100 * ratio.h) / ratio.w).toFixed(2)}%`
+        : (root.style.paddingBottom = "100%");
   }
 
   private _fitMap() {

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -92,6 +92,25 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     this._cleanupHistory();
   }
 
+  private _computePadding(): void {
+    const root = this.shadowRoot!.getElementById("root");
+    if (!this._config || this.isPanel || !root) {
+      return;
+    }
+
+    if (!this._config.aspect_ratio) {
+      root.style.paddingBottom = "100%";
+      return;
+    }
+
+    const ratio = parseAspectRatio(this._config.aspect_ratio);
+
+    root.style.paddingBottom =
+      ratio && ratio.w > 0 && ratio.h > 0
+        ? `${((100 * ratio.h) / ratio.w).toFixed(2)}%`
+        : (root.style.paddingBottom = "100%");
+  }
+
   public getCardSize(): number {
     if (!this._config?.aspect_ratio) {
       return 7;
@@ -102,6 +121,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       ratio && ratio.w > 0 && ratio.h > 0
         ? `${((100 * ratio.h) / ratio.w).toFixed(2)}`
         : "100";
+
     return 1 + Math.floor(Number(ar) / 25) || 3;
   }
 
@@ -185,27 +205,6 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     return false;
   }
 
-  protected firstUpdated(changedProps: PropertyValues): void {
-    super.firstUpdated(changedProps);
-    const root = this.shadowRoot!.getElementById("root");
-
-    if (!this._config || this.isPanel || !root) {
-      return;
-    }
-
-    if (!this._config.aspect_ratio) {
-      root.style.paddingBottom = "100%";
-      return;
-    }
-
-    const ratio = parseAspectRatio(this._config.aspect_ratio);
-
-    root.style.paddingBottom =
-      ratio && ratio.w > 0 && ratio.h > 0
-        ? `${((100 * ratio.h) / ratio.w).toFixed(2)}%`
-        : (root.style.paddingBottom = "100%");
-  }
-
   protected updated(changedProps: PropertyValues): void {
     if (this._config?.hours_to_show && this._configEntities?.length) {
       if (changedProps.has("_config")) {
@@ -213,6 +212,9 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       } else if (Date.now() - this._date!.getTime() >= MINUTE) {
         this._getHistory();
       }
+    }
+    if (changedProps.has("_config")) {
+      this._computePadding();
     }
   }
 


### PR DESCRIPTION
## Proposed change

Current map card seems to expect setConfig to be called before firstUpdated, and then during firstUpdated, it uses the aspect ratio from _config to pad out the size of the map card needed to fit the desired aspect ratio. 

However in sidebar view, the majority of time these steps seem to happen out of order. firstUpdate seems to be called before setConfig. So in firstUpdate when the aspect ratio is processed, there is no config and no aspect ratio, so the necessary paddingBottom is not applied, and the card is rendered at 0 pixels height. 

Instead of assuming that _config is ready during first update, this change fixes map card to watch for changes to _config, and update the padding when change to _config is detected. 


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #12023
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
