### PR TITLE
Prevent duplicate entities from being chosen in the target picker

### DIFF
--- a/src/components/device/ha-device-picker.ts
+++ b/src/components/device/ha-device-picker.ts
@@ -84,6 +84,14 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
   @property({ type: Array, attribute: "include-device-classes" })
   public includeDeviceClasses?: string[];
 
+  /**
+   * List of devices to be excluded.
+   * @type {Array}
+   * @attr exclude-devices
+   */
+  @property({ type: Array, attribute: "exclude-devices" })
+  public excludeDevices?: string[];
+
   @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
 
   @property({ type: Boolean }) public disabled?: boolean;
@@ -104,7 +112,8 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
       includeDomains: this["includeDomains"],
       excludeDomains: this["excludeDomains"],
       includeDeviceClasses: this["includeDeviceClasses"],
-      deviceFilter: this["deviceFilter"]
+      deviceFilter: this["deviceFilter"],
+      excludeDevices: this["excludeDevices"]
     ): Device[] => {
       if (!devices.length) {
         return [
@@ -162,6 +171,12 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
               !excludeDomains.includes(computeDomain(entity.entity_id))
           );
         });
+      }
+
+      if (excludeDevices) {
+        inputDevices = inputDevices.filter(
+          (device) => !excludeDevices!.includes(device.id)
+        );
       }
 
       if (includeDeviceClasses) {
@@ -258,7 +273,8 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
         this.includeDomains,
         this.excludeDomains,
         this.includeDeviceClasses,
-        this.deviceFilter
+        this.deviceFilter,
+        this.excludeDevices
       );
     }
   }

--- a/src/components/ha-area-picker.ts
+++ b/src/components/ha-area-picker.ts
@@ -279,7 +279,7 @@ export class HaAreaPicker extends LitElement {
       (this._init && changedProps.has("_opened") && this._opened)
     ) {
       this._init = true;
-      (this.comboBox as any).items = this._getAreas(
+      const areas = this._getAreas(
         Object.values(this.hass.areas),
         Object.values(this.hass.devices),
         Object.values(this.hass.entities),
@@ -291,6 +291,8 @@ export class HaAreaPicker extends LitElement {
         this.noAdd,
         this.excludeAreas
       );
+      (this.comboBox as any).items = areas;
+      (this.comboBox as any).filteredItems = areas;
     }
   }
 

--- a/src/components/ha-area-picker.ts
+++ b/src/components/ha-area-picker.ts
@@ -73,6 +73,14 @@ export class HaAreaPicker extends LitElement {
   @property({ type: Array, attribute: "include-device-classes" })
   public includeDeviceClasses?: string[];
 
+  /**
+   * List of areas to be excluded.
+   * @type {Array}
+   * @attr exclude-areas
+   */
+  @property({ type: Array, attribute: "exclude-areas" })
+  public excludeAreas?: string[];
+
   @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
 
   @property() public entityFilter?: (entity: EntityRegistryEntry) => boolean;
@@ -109,7 +117,8 @@ export class HaAreaPicker extends LitElement {
       includeDeviceClasses: this["includeDeviceClasses"],
       deviceFilter: this["deviceFilter"],
       entityFilter: this["entityFilter"],
-      noAdd: this["noAdd"]
+      noAdd: this["noAdd"],
+      excludeAreas: this["excludeAreas"]
     ): AreaRegistryEntry[] => {
       if (!areas.length) {
         return [
@@ -235,6 +244,12 @@ export class HaAreaPicker extends LitElement {
         outputAreas = areas.filter((area) => areaIds!.includes(area.area_id));
       }
 
+      if (excludeAreas) {
+        outputAreas = outputAreas.filter(
+          (area) => !excludeAreas!.includes(area.area_id)
+        );
+      }
+
       if (!outputAreas.length) {
         outputAreas = [
           {
@@ -273,7 +288,8 @@ export class HaAreaPicker extends LitElement {
         this.includeDeviceClasses,
         this.deviceFilter,
         this.entityFilter,
-        this.noAdd
+        this.noAdd,
+        this.excludeAreas
       );
     }
   }
@@ -384,7 +400,8 @@ export class HaAreaPicker extends LitElement {
             this.includeDeviceClasses,
             this.deviceFilter,
             this.entityFilter,
-            this.noAdd
+            this.noAdd,
+            this.excludeAreas
           );
           await this.updateComplete;
           await this.comboBox.updateComplete;

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -55,6 +55,8 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   @property() public helper?: string;
 
+  @property({ type: Boolean }) public filterDuplicates;
+
   /**
    * Show only targets with entities from specific domains.
    * @type {Array}
@@ -345,6 +347,9 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
             .entityFilter=${this.entityRegFilter}
             .includeDeviceClasses=${this.includeDeviceClasses}
             .includeDomains=${this.includeDomains}
+            .excludeAreas=${this.filterDuplicates && this.value
+              ? this.value.area_id
+              : undefined}
             @value-changed=${this._targetPicked}
           ></ha-area-picker>
         `;
@@ -361,6 +366,9 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
             .entityFilter=${this.entityRegFilter}
             .includeDeviceClasses=${this.includeDeviceClasses}
             .includeDomains=${this.includeDomains}
+            .excludeDevices=${this.filterDuplicates && this.value
+              ? this.value.device_id
+              : undefined}
             @value-changed=${this._targetPicked}
           ></ha-device-picker>
         `;
@@ -376,6 +384,9 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
             .entityFilter=${this.entityFilter}
             .includeDeviceClasses=${this.includeDeviceClasses}
             .includeDomains=${this.includeDomains}
+            .excludeEntities=${this.filterDuplicates && this.value
+              ? this.value.entity_id
+              : undefined}
             @value-changed=${this._targetPicked}
             allow-custom-entity
           ></ha-entity-picker>
@@ -393,6 +404,14 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     const target = ev.currentTarget;
     target.value = "";
     this._addMode = undefined;
+    if (
+      this.filterDuplicates &&
+      this.value &&
+      this.value[target.type] &&
+      this.value[target.type].includes(value)
+    ) {
+      return;
+    }
     fireEvent(this, "value-changed", {
       value: this.value
         ? {

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -399,7 +399,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     if (
       this.value &&
       this.value[target.type] &&
-      this.value[target.type].includes(value)
+      ensureArray(this.value[target.type]).includes(value)
     ) {
       return;
     }

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -55,8 +55,6 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   @property() public helper?: string;
 
-  @property({ type: Boolean }) public filterDuplicates;
-
   /**
    * Show only targets with entities from specific domains.
    * @type {Array}
@@ -347,9 +345,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
             .entityFilter=${this.entityRegFilter}
             .includeDeviceClasses=${this.includeDeviceClasses}
             .includeDomains=${this.includeDomains}
-            .excludeAreas=${this.filterDuplicates && this.value
-              ? this.value.area_id
-              : undefined}
+            .excludeAreas=${ensureArray(this.value?.area_id)}
             @value-changed=${this._targetPicked}
           ></ha-area-picker>
         `;
@@ -366,9 +362,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
             .entityFilter=${this.entityRegFilter}
             .includeDeviceClasses=${this.includeDeviceClasses}
             .includeDomains=${this.includeDomains}
-            .excludeDevices=${this.filterDuplicates && this.value
-              ? this.value.device_id
-              : undefined}
+            .excludeDevices=${ensureArray(this.value?.device_id)}
             @value-changed=${this._targetPicked}
           ></ha-device-picker>
         `;
@@ -384,9 +378,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
             .entityFilter=${this.entityFilter}
             .includeDeviceClasses=${this.includeDeviceClasses}
             .includeDomains=${this.includeDomains}
-            .excludeEntities=${this.filterDuplicates && this.value
-              ? this.value.entity_id
-              : undefined}
+            .excludeEntities=${ensureArray(this.value?.entity_id)}
             @value-changed=${this._targetPicked}
             allow-custom-entity
           ></ha-entity-picker>
@@ -405,7 +397,6 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     target.value = "";
     this._addMode = undefined;
     if (
-      this.filterDuplicates &&
       this.value &&
       this.value[target.type] &&
       this.value[target.type].includes(value)

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -143,6 +143,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
               .hass=${this.hass}
               .value=${this._targetPickerValue}
               .disabled=${this._isLoading}
+              filterDuplicates
               horizontal
               @value-changed=${this._targetsChanged}
             ></ha-target-picker>

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -143,7 +143,6 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
               .hass=${this.hass}
               .value=${this._targetPickerValue}
               .disabled=${this._isLoading}
-              filterDuplicates
               horizontal
               @value-changed=${this._targetsChanged}
             ></ha-target-picker>


### PR DESCRIPTION
## Proposed change

The target picker used e.g. in history panel currently allows for selecting areas, devices, and entities to display the history. 

Currently it does not prevent the user from selecting the same area/device/entity two or more times. This creates a bit of a visual bug where a chip for that item appears multiple times in the list of active items (see linked issue). It is not actually added to the graph multiple times, and clicking X on any item removes that item and all duplicates, which is not the behavior a user would expect. 

With this change, the picker dropdown list will filter out any already selected items, so they cannot be selected twice. If a user manually types the item twice, it will be ignored. This should prevent duplicate chips from being displayed. Removing an item by clicking the 'x' on its chip adds it back into the dropdown list, or "expanding" a chip (area -> devices, or device -> entities) adds the expanded device back into its dropdown list. 

I considered if this change should apply to all instances of ha-target-picker, but since I am not sure all the areas it is used, I limited this behavior currently to the history panel only. If appropriate it could be the default behavior for all ha-target-pickers. 


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14875 fixes #11879
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
