### PR TITLE
Format currency per unit values like USD/kWh

### DIFF
--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -62,6 +62,24 @@ export const formatNumber = (
     Intl
   ) {
     try {
+      // If currency per unit (e.g. 99 USD/kWh), format the currency while
+      // retaining the unit (e.g. U$99.00/kWh)
+      if (options?.style === "currency" && options.currency) {
+        const parts = options.currency.split("/");
+        if (parts.length === 2) {
+          const currency = parts[0];
+          const unit = parts[1];
+          return `${formatNumber(
+            num,
+            localeOptions,
+            getDefaultFormatOptions(num, {
+              ...options,
+              currency,
+            })
+          )}/${unit}`;
+        }
+      }
+
       return new Intl.NumberFormat(
         locale,
         getDefaultFormatOptions(num, options)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

N/A

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

I started to play with energy measurement in my home recently, and since then I realized a few stack traces being printed in my browser console. Tracking down the issue, it seems that the unit of measurement that I used was not supported.

Specifically, I have RESTful sensor that collects the tariff from the energy provider. And the proper unit of measurement for the tariff is money per kilowatt hour.

So, this adds proper format for currencies with unit as unit of measurement, like USD/kWh.

Some demos, English:

![chrome_9dUMqgeXV2](https://user-images.githubusercontent.com/29582865/209578789-56b7cd10-9820-4921-b936-fb0e8438c7b4.png)

Portuguese BR:

![chrome_akBxeAMzQ9](https://user-images.githubusercontent.com/29582865/209578790-61dc7d9e-d153-4855-b720-50cb2f23a55b.png)

Previously they would all render as `99BRL/kWh`, and an error would be printed in the browser console that `BRL/kWh` isn't a supported currency.

Additionally, I spent some time improving the devcontainer experience.

Also, the debugger configuration wasn't working for me. I suppose something changed in the VSCode/the debugger/webpack since then. After spending some time on it, I realized that the default configuration for `webRoot` works while the one previously set here doesn't, so I simply removed it. Renamed `pwa-chrome` to `chrome` as the former was deprecated. I did not test the debug configuration for anything but Frontend (because the build task wasn't working for me and I didn't want to spend more time on it).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
template:
  - sensor:
      - name: "Total cost"
        state: "99"
        device_class: monetary
        unit_of_measurement: "BRL"
        unique_id: total_cost
      - name: "Cost per kWh"
        state: "1"
        device_class: monetary
        unit_of_measurement: "BRL/kWh"
        unique_id: cost_per_kwh
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
