### PR TITLE
Use _ prefix for local vars on MQTT config entry page

### DIFF
--- a/src/panels/config/integrations/integration-panels/mqtt/mqtt-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/mqtt/mqtt-config-panel.ts
@@ -22,16 +22,16 @@ class HaPanelDevMqtt extends LitElement {
   @property({ type: Boolean }) public narrow!: boolean;
 
   @LocalStorage("panel-dev-mqtt-topic-ls", true, false)
-  private topic = "";
+  private _topic = "";
 
   @LocalStorage("panel-dev-mqtt-payload-ls", true, false)
-  private payload = "";
+  private _payload = "";
 
   @LocalStorage("panel-dev-mqtt-qos-ls", true, false)
-  private qos = "0";
+  private _qos = "0";
 
   @LocalStorage("panel-dev-mqtt-retain-ls", true, false)
-  private retain = false;
+  private _retain = false;
 
   protected render(): TemplateResult {
     return html`
@@ -53,12 +53,12 @@ class HaPanelDevMqtt extends LitElement {
               <div class="panel-dev-mqtt-fields">
                 <ha-textfield
                   .label=${this.hass.localize("ui.panel.config.mqtt.topic")}
-                  .value=${this.topic}
+                  .value=${this._topic}
                   @change=${this._handleTopic}
                 ></ha-textfield>
                 <ha-select
                   .label=${this.hass.localize("ui.panel.config.mqtt.qos")}
-                  .value=${this.qos}
+                  .value=${this._qos}
                   @selected=${this._handleQos}
                   >${qosLevel.map(
                     (qos) =>
@@ -70,7 +70,7 @@ class HaPanelDevMqtt extends LitElement {
                 >
                   <ha-switch
                     @change=${this._handleRetain}
-                    .checked=${this.retain}
+                    .checked=${this._retain}
                   ></ha-switch>
                 </ha-formfield>
               </div>
@@ -80,7 +80,7 @@ class HaPanelDevMqtt extends LitElement {
                 autocomplete-entities
                 autocomplete-icons
                 .hass=${this.hass}
-                .value=${this.payload}
+                .value=${this._payload}
                 @value-changed=${this._handlePayload}
                 dir="ltr"
               ></ha-code-editor>
@@ -101,22 +101,22 @@ class HaPanelDevMqtt extends LitElement {
   }
 
   private _handleTopic(ev: CustomEvent) {
-    this.topic = (ev.target! as any).value;
+    this._topic = (ev.target! as any).value;
   }
 
   private _handlePayload(ev: CustomEvent) {
-    this.payload = ev.detail.value;
+    this._payload = ev.detail.value;
   }
 
   private _handleQos(ev: CustomEvent) {
     const newValue = (ev.target! as any).value;
-    if (newValue >= 0 && newValue !== this.qos) {
-      this.qos = newValue;
+    if (newValue >= 0 && newValue !== this._qos) {
+      this._qos = newValue;
     }
   }
 
   private _handleRetain(ev: CustomEvent) {
-    this.retain = (ev.target! as any).checked;
+    this._retain = (ev.target! as any).checked;
   }
 
   private _publish(): void {
@@ -124,10 +124,10 @@ class HaPanelDevMqtt extends LitElement {
       return;
     }
     this.hass.callService("mqtt", "publish", {
-      topic: this.topic,
-      payload_template: this.payload,
-      qos: parseInt(this.qos),
-      retain: this.retain,
+      topic: this._topic,
+      payload_template: this._payload,
+      qos: parseInt(this._qos),
+      retain: this._retain,
     });
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Use the `_` prefix for local variables `_topic`, `_payload`, `_qos` and `_retain` of the MQTT publish panel on the MQTT config entry dev panel.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
