### PR TITLE
Add sort-by-state feature to entities card

### DIFF
--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -30,6 +30,7 @@ import {
   LovelaceHeaderFooter,
 } from "../types";
 import { EntitiesCardConfig, SortConfig } from "./types";
+import { hasConfigOrEntityChanged } from "../common/has-changed";
 
 @customElement("hui-entities-card")
 class HuiEntitiesCard extends LitElement implements LovelaceCard {
@@ -57,7 +58,7 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
   @state() private _config?: EntitiesCardConfig;
 
-  private _hass?: HomeAssistant;
+  @state() private _hass?: HomeAssistant;
 
   private _configEntities?: LovelaceRowConfig[];
 
@@ -72,8 +73,6 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   private _headerElement?: LovelaceHeaderFooter;
 
   private _footerElement?: LovelaceHeaderFooter;
-
-  private _requestUpdateInterval?: NodeJS.Timeout;
 
   set hass(hass: HomeAssistant) {
     this._hass = hass;
@@ -189,25 +188,11 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
     }
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-
-    if (this._enableSorting ?? false) {
-      this._requestUpdateInterval = setInterval(() => {
-        if (this._checkIfSortOrderChanged()) {
-          this.requestUpdate();
-        }
-      }, 1000);
-    }
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-
-    if (this._requestUpdateInterval !== undefined) {
-      clearInterval(this._requestUpdateInterval!);
-      this._requestUpdateInterval = undefined;
-    }
+  protected shouldUpdate(changedProps: PropertyValues) {
+    return (
+      hasConfigOrEntityChanged(this, changedProps) ||
+      this._checkIfSortOrderChanged()
+    );
   }
 
   private _checkIfSortOrderChanged(): boolean {

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -200,17 +200,14 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
   }
 
   private _checkIfSortOrderChanged(): boolean {
-    if (
+    return (
       this._lastUsedSortedEntities === undefined ||
       this._lastUsedSortedEntities.length !==
         this._sortedConfigEntities.length ||
       this._lastUsedSortedEntities.some(
         (oldEntity, index) => oldEntity !== this._sortedConfigEntities[index]
       )
-    ) {
-      return true;
-    }
-    return false;
+    );
   }
 
   get _sortedConfigEntities(): LovelaceRowConfig[] {

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -71,6 +71,8 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
 
   private _footerElement?: LovelaceHeaderFooter;
 
+  private _requestUpdateInterval?: NodeJS.Timeout;
+
   set hass(hass: HomeAssistant) {
     this._hass = hass;
     this.shadowRoot
@@ -182,6 +184,26 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
         (!oldConfig || oldConfig.theme !== this._config.theme))
     ) {
       applyThemesOnElement(this, this._hass.themes, this._config.theme);
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    if (this._enableSorting ?? false) {
+      this._requestUpdateInterval = setInterval(
+        () => this.requestUpdate(),
+        1000
+      );
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    if (this._requestUpdateInterval !== undefined) {
+      clearInterval(this._requestUpdateInterval!);
+      this._requestUpdateInterval = undefined;
     }
   }
 

--- a/src/panels/lovelace/cards/hui-entities-card.ts
+++ b/src/panels/lovelace/cards/hui-entities-card.ts
@@ -29,8 +29,12 @@ import {
   LovelaceCardEditor,
   LovelaceHeaderFooter,
 } from "../types";
-import { EntitiesCardConfig, SortConfig } from "./types";
+import { AlphaSortConfig, EntitiesCardConfig, SortConfig } from "./types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
+import {
+  stringCompare,
+  caseInsensitiveStringCompare,
+} from "../../../common/string/compare";
 
 @customElement("hui-entities-card")
 class HuiEntitiesCard extends LitElement implements LovelaceCard {
@@ -238,7 +242,8 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
       const stateB = entityB?.state;
 
       for (const sortConf of this._sortConfigs!) {
-        const reverseSortOrder = sortConf.reverse ? 1 : -1;
+        const reverseSortOrder =
+          sortConf.reverse !== undefined ? (sortConf.reverse ? 1 : -1) : -1;
         const aBeforeB = -1 * reverseSortOrder;
         const bBeforeA = -aBeforeB;
 
@@ -352,27 +357,9 @@ class HuiEntitiesCard extends LitElement implements LovelaceCard {
             );
           }
           case "alpha": {
-            const numValA = Number(stateA);
-            const numValB = Number(stateB);
-
-            /* eslint no-else-return: ["error", {allowElseIf: true}] */
-            if (!isNaN(numValA) && !isNaN(numValB)) {
-              continue;
-            } else if (!isNaN(numValA)) {
-              return bBeforeA;
-            } else if (!isNaN(numValB)) {
-              return aBeforeB;
-            }
-
-            return (
-              String(stateA!).localeCompare(
-                String(stateB!),
-                undefined,
-                sortConf.ignore_case !== undefined
-                  ? { ignorePunctuation: sortConf.ignore_case }
-                  : undefined
-              ) * reverseSortOrder
-            );
+            return (sortConf as AlphaSortConfig).ignore_case ?? false
+              ? caseInsensitiveStringCompare(String(stateA!), String(stateB!))
+              : stringCompare(String(stateA!), String(stateB!));
           }
         }
       }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -72,6 +72,8 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
 export interface EntitiesCardConfig extends LovelaceCardConfig {
   type: "entities";
   show_header_toggle?: boolean;
+  sort_by_state?: boolean;
+  reverse_sort_order?: boolean;
   title?: string;
   entities: Array<LovelaceRowConfig | string>;
   theme?: string;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -69,11 +69,46 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
   show_icon?: boolean;
 }
 
+export interface SortConfig {
+  type: string;
+  reverse?: boolean;
+  [key: string]: any;
+}
+
+export interface NumericSortConfig extends SortConfig {
+  type: "numeric";
+}
+
+export interface RandomSortConfig extends SortConfig {
+  type: "random";
+}
+
+export interface IPSortConfig extends SortConfig {
+  type: "ip";
+}
+
+export interface AlphaSortConfig extends SortConfig {
+  type: "alpha";
+  ignore_case?: boolean;
+}
+
+export interface LastChangedSortConfig extends SortConfig {
+  type: "last_changed";
+}
+
+export interface LastUpdatedSortConfig extends SortConfig {
+  type: "last_updated";
+}
+
+export interface LastTriggeredSortConfig extends SortConfig {
+  type: "last_triggered";
+}
+
 export interface EntitiesCardConfig extends LovelaceCardConfig {
   type: "entities";
   show_header_toggle?: boolean;
-  sort_by_state?: boolean;
-  reverse_sort_order?: boolean;
+  enable_sorting?: boolean;
+  sort_configs?: SortConfig[];
   title?: string;
   entities: Array<LovelaceRowConfig | string>;
   theme?: string;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -71,12 +71,12 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
 
 export interface SortConfig {
   type: string;
-  reverse?: boolean;
   [key: string]: any;
 }
 
 export interface NumericSortConfig extends SortConfig {
   type: "numeric";
+  reverse?: boolean;
 }
 
 export interface RandomSortConfig extends SortConfig {
@@ -85,6 +85,7 @@ export interface RandomSortConfig extends SortConfig {
 
 export interface IPSortConfig extends SortConfig {
   type: "ip";
+  reverse?: boolean;
 }
 
 export interface AlphaSortConfig extends SortConfig {
@@ -94,14 +95,17 @@ export interface AlphaSortConfig extends SortConfig {
 
 export interface LastChangedSortConfig extends SortConfig {
   type: "last_changed";
+  reverse?: boolean;
 }
 
 export interface LastUpdatedSortConfig extends SortConfig {
   type: "last_updated";
+  reverse?: boolean;
 }
 
 export interface LastTriggeredSortConfig extends SortConfig {
   type: "last_triggered";
+  reverse?: boolean;
 }
 
 export interface EntitiesCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/components/hui-sort-config-editor.ts
+++ b/src/panels/lovelace/components/hui-sort-config-editor.ts
@@ -13,7 +13,6 @@ import { SortableInstance } from "../../../resources/sortable";
 import { loadSortable } from "../../../resources/sortable.ondemand";
 import { sortableStyles } from "../../../resources/ha-sortable-style";
 import "./hui-sort-config-picker";
-import type { HuiSortConfigPicker } from "./hui-sort-config-picker";
 
 @customElement("hui-sort-config-editor")
 export class HuiSortConfigEditor extends LitElement {
@@ -106,15 +105,15 @@ export class HuiSortConfigEditor extends LitElement {
             </div>
           `
         )}
-        <hui-sort-config-picker
-          .label=${this.hass!.localize(
-            "ui.panel.lovelace.editor.sort-config-editor.new_config"
-          )}
-          .hass=${this.hass}
-          @value-changed=${this._sortConfigAdded}
-        >
-        </hui-sort-config-picker>
       </div>
+      <hui-sort-config-picker
+        .label=${this.hass!.localize(
+          "ui.panel.lovelace.editor.sort-config-editor.new_config"
+        )}
+        .hass=${this.hass}
+        @value-changed=${this._sortConfigAdded}
+      >
+      </hui-sort-config-picker>
     `;
   }
 
@@ -183,9 +182,6 @@ export class HuiSortConfigEditor extends LitElement {
     const newSortConfigs =
       this.config !== undefined ? this.config!.concat(value) : [value];
 
-    // TODO: This should remove the currently selected type, but it does not work yet
-    (ev.target as HuiSortConfigPicker).config = undefined;
-
     fireEvent(this, "value-changed", {
       value: newSortConfigs,
     });
@@ -195,10 +191,6 @@ export class HuiSortConfigEditor extends LitElement {
     return [
       sortableStyles,
       css`
-        hui-sort-config-picker {
-          margin-top: 8px;
-        }
-
         .sort-config {
           display: flex;
           align-items: center;
@@ -223,6 +215,10 @@ export class HuiSortConfigEditor extends LitElement {
         .remove-icon {
           --mdc-icon-button-size: 36px;
           color: var(--secondary-text-color);
+        }
+
+        .sort-configs {
+          margin-bottom: 8px;
         }
       `,
     ];

--- a/src/panels/lovelace/components/hui-sort-config-editor.ts
+++ b/src/panels/lovelace/components/hui-sort-config-editor.ts
@@ -1,13 +1,19 @@
 import { html, LitElement, TemplateResult, css, CSSResultGroup } from "lit";
 import { customElement, property } from "lit/decorators";
+import { SortableEvent } from "sortablejs";
+import { repeat } from "lit/directives/repeat";
+import { mdiClose, mdiDrag } from "@mdi/js";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-help-tooltip";
 import "../../../components/ha-service-control";
 import { HomeAssistant } from "../../../types";
-import { EditorTarget } from "../editor/types";
 import "../../../components/ha-navigation-picker";
 import { SortConfig } from "../cards/types";
+import { SortableInstance } from "../../../resources/sortable";
+import { loadSortable } from "../../../resources/sortable.ondemand";
+import { sortableStyles } from "../../../resources/ha-sortable-style";
 import "./hui-sort-config-picker";
+import type { HuiSortConfigPicker } from "./hui-sort-config-picker";
 
 @customElement("hui-sort-config-editor")
 export class HuiSortConfigEditor extends LitElement {
@@ -17,30 +23,128 @@ export class HuiSortConfigEditor extends LitElement {
 
   @property() protected hass?: HomeAssistant;
 
+  private _sortConfigKeys = new WeakMap<SortConfig, string>();
+
+  private _sortable?: SortableInstance;
+
+  public disconnectedCallback() {
+    this._destroySortable();
+  }
+
+  private _destroySortable() {
+    this._sortable?.destroy();
+    this._sortable = undefined;
+  }
+
+  private _getKey(action: SortConfig) {
+    if (!this._sortConfigKeys.has(action)) {
+      this._sortConfigKeys.set(action, Math.random().toString());
+    }
+
+    return this._sortConfigKeys.get(action)!;
+  }
+
+  private _sortConfigMoved(ev: SortableEvent): void {
+    if (ev.oldIndex === ev.newIndex) {
+      return;
+    }
+
+    const newConfig = this.config!.concat();
+
+    newConfig.splice(ev.newIndex!, 0, newConfig.splice(ev.oldIndex!, 1)[0]);
+
+    fireEvent(this, "value-changed", { value: newConfig });
+  }
+
+  private _sortConfigRemoved(ev: CustomEvent): void {
+    const index = (ev.currentTarget as any).index;
+    const newSortConfigs = this.config!.concat();
+
+    newSortConfigs.splice(index, 1);
+
+    fireEvent(this, "value-changed", { value: newSortConfigs });
+  }
+
   protected render(): TemplateResult {
     if (!this.hass) {
       return html``;
     }
 
     return html`
-      ${this.config?.map(
-        (sortConf: SortConfig, i: number) => html`
-          <hui-sort-config-picker
-            .hass=${this.hass}
-            .config=${sortConf}
-            .configValue=${i}
-            @value-changed=${this._sortConfigChanged}
-          >
-          </hui-sort-config-picker>
-        `
-      )}
-      <hui-sort-config-picker
-        .hass=${this.hass}
-        .configValue=${"add"}
-        @value-changed=${this._sortConfigChanged}
-      >
-      </hui-sort-config-picker>
+      <h3>
+        ${this.label ??
+        this.hass!.localize(
+          "ui.panel.lovelace.editor.sort-config-editor.title"
+        )}
+      </h3>
+
+      <div class="sort-configs">
+        ${repeat(
+          this.config ?? [],
+          (sortConf) => this._getKey(sortConf),
+          (sortConf, index) => html`
+            <div class="sort-config">
+              <div class="handle">
+                <ha-svg-icon .path=${mdiDrag}></ha-svg-icon>
+              </div>
+              <hui-sort-config-picker
+                .hass=${this.hass}
+                .config=${sortConf}
+                .index=${index}
+                @value-changed=${this._sortConfigChanged}
+              >
+              </hui-sort-config-picker>
+              <ha-icon-button
+                .label=${this.hass!.localize(
+                  "ui.components.entity.entity-picker.clear"
+                )}
+                .path=${mdiClose}
+                class="remove-icon"
+                .index=${index}
+                @click=${this._sortConfigRemoved}
+              ></ha-icon-button>
+            </div>
+          `
+        )}
+        <hui-sort-config-picker
+          .label=${this.hass!.localize(
+            "ui.panel.lovelace.editor.sort-config-editor.new_config"
+          )}
+          .hass=${this.hass}
+          @value-changed=${this._sortConfigAdded}
+        >
+        </hui-sort-config-picker>
+      </div>
     `;
+  }
+
+  protected firstUpdated(): void {
+    this._createSortable();
+  }
+
+  private async _createSortable() {
+    const Sortable = await loadSortable();
+    this._sortable = new Sortable(
+      this.shadowRoot!.querySelector(".sort-configs")!,
+      {
+        animation: 150,
+        fallbackClass: "sortable-fallback",
+        handle: ".handle",
+        onChoose: (evt: SortableEvent) => {
+          (evt.item as any).placeholder =
+            document.createComment("sort-placeholder");
+          evt.item.after((evt.item as any).placeholder);
+        },
+        onEnd: (evt: SortableEvent) => {
+          // put back in original location
+          if ((evt.item as any).placeholder) {
+            (evt.item as any).placeholder.replaceWith(evt.item);
+            delete (evt.item as any).placeholder;
+          }
+          this._sortConfigMoved(evt);
+        },
+      }
+    );
   }
 
   private _sortConfigChanged(ev): void {
@@ -49,44 +153,76 @@ export class HuiSortConfigEditor extends LitElement {
       return;
     }
 
-    const target = ev.target! as EditorTarget;
-    const sortConf = ev.detail.value as SortConfig;
+    const value = ev.detail.value;
+    const index = (ev.target as any).index;
+    const newSortConfigs =
+      this.config !== undefined ? this.config.concat() : [];
 
-    if (sortConf === undefined) {
-      return;
-    }
-
-    if (target.configValue === "add") {
-      fireEvent(this, "value-changed", {
-        value:
-          this.config !== undefined
-            ? this.config!.concat(sortConf)
-            : [sortConf],
-      });
-      return;
-    }
-
-    const changedConfigIndex = Number(target.configValue);
-    if (isNaN(changedConfigIndex)) {
-      return;
-    }
-
-    if (sortConf.type === "") {
-      delete this.config![changedConfigIndex];
+    if (value === "" || value === undefined) {
+      newSortConfigs.splice(index, 1);
     } else {
-      this.config![changedConfigIndex] = sortConf;
+      newSortConfigs[index] = value!;
     }
 
     fireEvent(this, "value-changed", {
-      value: this.config,
+      value: newSortConfigs,
+    });
+  }
+
+  private _sortConfigAdded(ev): void {
+    ev.stopPropagation();
+    if (!this.hass) {
+      return;
+    }
+
+    const value = ev.detail.value;
+    if (value === "") {
+      return;
+    }
+
+    const newSortConfigs =
+      this.config !== undefined ? this.config!.concat(value) : [value];
+
+    // TODO: This should remove the currently selected type, but it does not work yet
+    (ev.target as HuiSortConfigPicker).config = undefined;
+
+    fireEvent(this, "value-changed", {
+      value: newSortConfigs,
     });
   }
 
   static get styles(): CSSResultGroup {
     return [
+      sortableStyles,
       css`
-        :host {
-          display: block;
+        hui-sort-config-picker {
+          margin-top: 8px;
+        }
+
+        .sort-config {
+          display: flex;
+          align-items: center;
+        }
+
+        .sort-config .handle {
+          padding-right: 8px;
+          cursor: move;
+          padding-inline-end: 8px;
+          padding-inline-start: initial;
+          direction: var(--direction);
+        }
+
+        .sort-config .handle > * {
+          pointer-events: none;
+        }
+
+        .sort-config hui-sort-config-picker {
+          flex-grow: 1;
+        }
+
+        .remove-icon {
+          --mdc-icon-button-size: 36px;
+          color: var(--secondary-text-color);
         }
       `,
     ];

--- a/src/panels/lovelace/components/hui-sort-config-editor.ts
+++ b/src/panels/lovelace/components/hui-sort-config-editor.ts
@@ -13,6 +13,7 @@ import { SortableInstance } from "../../../resources/sortable";
 import { loadSortable } from "../../../resources/sortable.ondemand";
 import { sortableStyles } from "../../../resources/ha-sortable-style";
 import "./hui-sort-config-picker";
+import type { HuiSortConfigPicker } from "./hui-sort-config-picker";
 
 @customElement("hui-sort-config-editor")
 export class HuiSortConfigEditor extends LitElement {
@@ -181,6 +182,8 @@ export class HuiSortConfigEditor extends LitElement {
 
     const newSortConfigs =
       this.config !== undefined ? this.config!.concat(value) : [value];
+
+    (ev.target as HuiSortConfigPicker).config = undefined;
 
     fireEvent(this, "value-changed", {
       value: newSortConfigs,

--- a/src/panels/lovelace/components/hui-sort-config-editor.ts
+++ b/src/panels/lovelace/components/hui-sort-config-editor.ts
@@ -197,6 +197,7 @@ export class HuiSortConfigEditor extends LitElement {
         .sort-config {
           display: flex;
           align-items: center;
+          margin-bottom: 8px;
         }
 
         .sort-config .handle {
@@ -218,10 +219,6 @@ export class HuiSortConfigEditor extends LitElement {
         .remove-icon {
           --mdc-icon-button-size: 36px;
           color: var(--secondary-text-color);
-        }
-
-        .sort-configs {
-          margin-bottom: 8px;
         }
       `,
     ];

--- a/src/panels/lovelace/components/hui-sort-config-editor.ts
+++ b/src/panels/lovelace/components/hui-sort-config-editor.ts
@@ -1,0 +1,100 @@
+import { html, LitElement, TemplateResult, css, CSSResultGroup } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-help-tooltip";
+import "../../../components/ha-service-control";
+import { HomeAssistant } from "../../../types";
+import { EditorTarget } from "../editor/types";
+import "../../../components/ha-navigation-picker";
+import { SortConfig } from "../cards/types";
+import "./hui-sort-config-picker";
+
+@customElement("hui-sort-config-editor")
+export class HuiSortConfigEditor extends LitElement {
+  @property() public config?: SortConfig[];
+
+  @property() public label?: string;
+
+  @property() protected hass?: HomeAssistant;
+
+  protected render(): TemplateResult {
+    if (!this.hass) {
+      return html``;
+    }
+
+    return html`
+      ${this.config?.map(
+        (sortConf: SortConfig, i: number) => html`
+          <hui-sort-config-picker
+            .hass=${this.hass}
+            .config=${sortConf}
+            .configValue=${i}
+            @value-changed=${this._sortConfigChanged}
+          >
+          </hui-sort-config-picker>
+        `
+      )}
+      <hui-sort-config-picker
+        .hass=${this.hass}
+        .configValue=${"add"}
+        @value-changed=${this._sortConfigChanged}
+      >
+      </hui-sort-config-picker>
+    `;
+  }
+
+  private _sortConfigChanged(ev): void {
+    ev.stopPropagation();
+    if (!this.hass) {
+      return;
+    }
+
+    const target = ev.target! as EditorTarget;
+    const sortConf = ev.detail.value as SortConfig;
+
+    if (sortConf === undefined) {
+      return;
+    }
+
+    if (target.configValue === "add") {
+      fireEvent(this, "value-changed", {
+        value:
+          this.config !== undefined
+            ? this.config!.concat(sortConf)
+            : [sortConf],
+      });
+      return;
+    }
+
+    const changedConfigIndex = Number(target.configValue);
+    if (isNaN(changedConfigIndex)) {
+      return;
+    }
+
+    if (sortConf.type === "") {
+      delete this.config![changedConfigIndex];
+    } else {
+      this.config![changedConfigIndex] = sortConf;
+    }
+
+    fireEvent(this, "value-changed", {
+      value: this.config,
+    });
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      css`
+        :host {
+          display: block;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-sort-config-editor": HuiSortConfigEditor;
+  }
+}

--- a/src/panels/lovelace/components/hui-sort-config-picker.ts
+++ b/src/panels/lovelace/components/hui-sort-config-picker.ts
@@ -1,0 +1,150 @@
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../common/dom/fire_event";
+import { stopPropagation } from "../../../common/dom/stop_propagation";
+import "../../../components/ha-help-tooltip";
+import "../../../components/ha-service-control";
+import { HomeAssistant } from "../../../types";
+import { EditorTarget } from "../editor/types";
+import "../../../components/ha-navigation-picker";
+import { SortConfig, AlphaSortConfig } from "../cards/types";
+import { computeRTLDirection } from "../../../common/util/compute_rtl";
+
+// TODO: Get these programatically
+const POSSIBLE_SORT_CONFIG_TYPES: string[] = [
+  "numeric",
+  "alpha",
+  "ip",
+  "random",
+  "last_changed",
+  "last_triggered",
+  "last_updated",
+];
+
+@customElement("hui-sort-config-picker")
+export class HuiSortConfigPicker extends LitElement {
+  @property() public config?: SortConfig;
+
+  @property() protected hass?: HomeAssistant;
+
+  @property() public value?: string;
+
+  get _reverse(): boolean {
+    const config = this.config as SortConfig | undefined;
+    return config?.reverse || false;
+  }
+
+  get _ignore_case(): boolean {
+    const config = this.config as AlphaSortConfig | undefined;
+    return config?.ignore_case || false;
+  }
+
+  protected render(): TemplateResult {
+    if (!this.hass) {
+      return html``;
+    }
+
+    return html`
+      <ha-select
+        .label=${this.hass!.localize(
+          "ui.panel.lovelace.editor.sort-config-picker.title"
+        )}
+        .configValue=${"type"}
+        .value=${this.config?.type ?? ""}
+        @selected=${this._valueChanged}
+        @closed=${stopPropagation}
+        fixedMenuPosition
+        naturalMenuWidt
+      >
+        ${POSSIBLE_SORT_CONFIG_TYPES.map(
+          (config_type) => html`
+            <mwc-list-item .value=${config_type}>
+              ${this.hass!.localize(
+                `ui.panel.lovelace.editor.sort-config-picker.types.${config_type}`
+              )}
+            </mwc-list-item>
+          `
+        )}
+      </ha-select>
+
+      ${this.config?.type !== undefined
+        ? html`
+            <ha-formfield
+              .label=${this.hass.localize(
+                "ui.panel.lovelace.editor.sort-config-picker.reverse"
+              )}
+              .dir=${computeRTLDirection(this.hass)}
+            >
+              <ha-switch
+                .checked=${this.config?.reverse !== false}
+                .configValue=${"reverse"}
+                @change=${this._valueChanged}
+              ></ha-switch>
+            </ha-formfield>
+          `
+        : ""}
+      ${this.config?.type === "alpha"
+        ? html`
+            <ha-formfield
+              .label=${this.hass.localize(
+                "ui.panel.lovelace.editor.sort-config-picker.ignore_case"
+              )}
+              .dir=${computeRTLDirection(this.hass)}
+            >
+              <ha-switch
+                .checked=${this.config?.reverse !== false}
+                .configValue=${"ignore_case"}
+                @change=${this._valueChanged}
+              ></ha-switch>
+            </ha-formfield>
+          `
+        : ""}
+    `;
+  }
+
+  private _valueChanged(ev): void {
+    ev.stopPropagation();
+
+    if (!this.hass) {
+      return;
+    }
+
+    const target = ev.target! as EditorTarget;
+    const value =
+      target.checked !== undefined
+        ? target.checked
+        : target.value || ev.detail.config || ev.detail.value;
+
+    if (this[`_${target.configValue}`] === value) {
+      return;
+    }
+
+    if (target.configValue) {
+      fireEvent(this, "value-changed", {
+        value: {
+          ...(this.config !== undefined ? this.config! : {}),
+          [target.configValue!]: value,
+        },
+      });
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      css`
+        ha-select {
+          width: 100%;
+        }
+        ha-switch {
+          width: 100%;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-sort-config-picker": HuiSortConfigPicker;
+  }
+}

--- a/src/panels/lovelace/components/hui-sort-config-picker.ts
+++ b/src/panels/lovelace/components/hui-sort-config-picker.ts
@@ -73,7 +73,7 @@ export class HuiSortConfigPicker extends LitElement {
           )}
         </ha-select>
         <div class="sort-config-picker-options">
-          ${this.config?.type !== undefined
+          ${this.config?.type !== undefined && this.config?.type !== "random"
             ? html`
                 <ha-formfield
                   .label=${this.hass.localize(
@@ -130,7 +130,7 @@ export class HuiSortConfigPicker extends LitElement {
     }
 
     if (target.configValue === "type") {
-      this.config = { type: this._type, reverse: this._reverse };
+      this.config = { type: this._type };
     }
 
     fireEvent(this, "value-changed", {

--- a/src/panels/lovelace/components/hui-sort-config-picker.ts
+++ b/src/panels/lovelace/components/hui-sort-config-picker.ts
@@ -11,13 +11,13 @@ import { SortConfig, AlphaSortConfig } from "../cards/types";
 import { computeRTLDirection } from "../../../common/util/compute_rtl";
 
 const POSSIBLE_SORT_CONFIG_TYPES: string[] = [
-  "numeric",
   "alpha",
   "ip",
-  "random",
   "last_changed",
   "last_triggered",
   "last_updated",
+  "numeric",
+  "random",
 ];
 
 @customElement("hui-sort-config-picker")

--- a/src/panels/lovelace/components/hui-sort-config-picker.ts
+++ b/src/panels/lovelace/components/hui-sort-config-picker.ts
@@ -56,7 +56,7 @@ export class HuiSortConfigPicker extends LitElement {
             "ui.panel.lovelace.editor.sort-config-picker.title"
           )}
           .configValue=${"type"}
-          .value=${this.config?.type ?? ""}
+          .value=${this._type}
           @selected=${this._valueChanged}
           @closed=${stopPropagation}
           fixedMenuPosition
@@ -73,7 +73,7 @@ export class HuiSortConfigPicker extends LitElement {
           )}
         </ha-select>
         <div class="sort-config-picker-options">
-          ${this.config?.type !== undefined && this.config?.type !== "random"
+          ${this._type !== "" && this._type !== "random"
             ? html`
                 <ha-formfield
                   .label=${this.hass.localize(
@@ -82,14 +82,14 @@ export class HuiSortConfigPicker extends LitElement {
                   .dir=${computeRTLDirection(this.hass)}
                 >
                   <ha-switch
-                    .checked=${this.config.reverse ?? false}
+                    .checked=${this._reverse}
                     .configValue=${"reverse"}
                     @change=${this._valueChanged}
                   ></ha-switch>
                 </ha-formfield>
               `
             : ""}
-          ${this.config?.type === "alpha"
+          ${this._type === "alpha"
             ? html`
                 <ha-formfield
                   .label=${this.hass.localize(
@@ -98,7 +98,7 @@ export class HuiSortConfigPicker extends LitElement {
                   .dir=${computeRTLDirection(this.hass)}
                 >
                   <ha-switch
-                    .checked=${this.config?.ignore_case ?? false}
+                    .checked=${this._ignore_case}
                     .configValue=${"ignore_case"}
                     @change=${this._valueChanged}
                   ></ha-switch>

--- a/src/panels/lovelace/components/hui-sort-config-picker.ts
+++ b/src/panels/lovelace/components/hui-sort-config-picker.ts
@@ -155,7 +155,7 @@ export class HuiSortConfigPicker extends LitElement {
         }
 
         .sort-config-picker-options > * {
-          margin: 8px;
+          margin: 4px 8px;
         }
       `,
     ];

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -147,7 +147,6 @@ const numericSortConfig = object({
 
 const randomSortConfig = object({
   type: literal("random"),
-  reverse: optional(boolean()),
 });
 
 const ipSortConfig = object({

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -190,6 +190,8 @@ const cardConfigStruct = assign(
     theme: optional(string()),
     icon: optional(string()),
     show_header_toggle: optional(boolean()),
+    sort_by_state: optional(boolean()),
+    reverse_sort_order: optional(boolean()),
     state_color: optional(boolean()),
     entities: array(entitiesRowConfigStruct),
     header: optional(headerFooterConfigStructs),
@@ -286,6 +288,32 @@ export class HuiEntitiesCardEditor
             <ha-switch
               .checked=${this._config!.state_color}
               .configValue=${"state_color"}
+              @change=${this._valueChanged}
+            ></ha-switch>
+          </ha-formfield>
+        </div>
+        <div class="side-by-side">
+          <ha-formfield
+            .label=${this.hass.localize(
+              "ui.panel.lovelace.editor.card.entities.sort_by_state"
+            )}
+            .dir=${computeRTLDirection(this.hass)}
+          >
+            <ha-switch
+              .checked=${this._config!.sort_by_state !== false}
+              .configValue=${"sort_by_state"}
+              @change=${this._valueChanged}
+            ></ha-switch>
+          </ha-formfield>
+          <ha-formfield
+            .label=${this.hass.localize(
+              "ui.panel.lovelace.editor.card.entities.reverse_sort_order"
+            )}
+            .dir=${computeRTLDirection(this.hass)}
+          >
+            <ha-switch
+              .checked=${this._config!.reverse_sort_order !== false}
+              .configValue=${"reverse_sort_order"}
               @change=${this._valueChanged}
             ></ha-switch>
           </ha-formfield>

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -367,16 +367,16 @@ export class HuiEntitiesCardEditor
           .dir=${computeRTLDirection(this.hass)}
         >
           <ha-switch
-            .checked=${this._config!.enable_sorting !== false}
+            .checked=${this._config!.enable_sorting ?? false}
             .configValue=${"enable_sorting"}
             @change=${this._valueChanged}
           ></ha-switch>
         </ha-formfield>
-        ${this._config!.enable_sorting
+        ${this._config!.enable_sorting ?? false
           ? html`
               <hui-sort-config-editor
                 .hass=${this.hass}
-                .config=${this._config!.sort_configs}
+                .config=${this._config!.sort_configs ?? []}
                 @value-changed=${this._sortConfigChanged}
               ></hui-sort-config-editor>
             `
@@ -414,7 +414,9 @@ export class HuiEntitiesCardEditor
 
     this._config = { ...this._config!, sort_configs: ev.detail.value };
 
-    fireEvent(this, "config-changed", { config: this._config });
+    fireEvent(this, "config-changed", {
+      config: this._config,
+    });
   }
 
   private _valueChanged(ev: CustomEvent): void {

--- a/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-entities-card-editor.ts
@@ -201,8 +201,15 @@ const sortConfigsStruct = dynamic<any>((value: any) => {
       }
     }
   }
-  // No "type" property has been set. Return default (numeric).
-  return numericSortConfig;
+  return union([
+    numericSortConfig,
+    randomSortConfig,
+    ipSortConfig,
+    alphaSortConfig,
+    lastChangedConfig,
+    lastUpdatedConfig,
+    lastTriggeredConfig,
+  ]);
 });
 
 const entitiesRowConfigStruct = dynamic<any>((value) => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4055,6 +4055,20 @@
               "none": "No Action"
             }
           },
+          "sort-config-picker": {
+            "title": "Sort type",
+            "reverse": "Reverse sort order",
+            "ignore_case": "Ignore case",
+            "types": {
+              "numeric": "Numeric",
+              "alpha": "Alpha",
+              "random": "Random",
+              "ip": "IP-Adress",
+              "last_changed": "Last changed",
+              "last_updated": "Last updated",
+              "last_triggered": "Last triggered"
+            }
+          },
           "card": {
             "alarm-panel": {
               "name": "Alarm Panel",
@@ -4096,7 +4110,8 @@
             "entities": {
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
-              "sort_by_state": "Sort by state?",
+              "enable_sorting": "Enable sorting?",
+              "sort_configuration": "Sort configuration",
               "reverse_sort_order": "Reversed sort order?",
               "toggle": "Toggle entities.",
               "description": "The Entities card is the most common type of card. It groups items together into lists.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4055,6 +4055,10 @@
               "none": "No Action"
             }
           },
+          "sort-config-editor": {
+            "title": "Sort configurations",
+            "new_config": "New configuration"
+          },
           "sort-config-picker": {
             "title": "Sort type",
             "reverse": "Reverse sort order",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4096,6 +4096,8 @@
             "entities": {
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
+              "sort_by_state": "Sort by state?",
+              "reverse_sort_order": "Reversed sort order?",
               "toggle": "Toggle entities.",
               "description": "The Entities card is the most common type of card. It groups items together into lists.",
               "special_row": "special row",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4115,8 +4115,6 @@
               "name": "Entities",
               "show_header_toggle": "Show Header Toggle?",
               "enable_sorting": "Enable sorting?",
-              "sort_configuration": "Sort configuration",
-              "reverse_sort_order": "Reversed sort order?",
               "toggle": "Toggle entities.",
               "description": "The Entities card is the most common type of card. It groups items together into lists.",
               "special_row": "special row",


### PR DESCRIPTION
## Proposed change

Make the entities in the `Entities`-card sortable by state (like in the auto-entities card).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: entities
entities:
  - entity: sensor.bath_temperature
  - entity: sensor.bedroom_temperature
title: Temperature
enable_sorting: true
sort_configs:
  - type: numeric
  - type: alpha
    reverse: true
    ignore_case: true
```

## Additional information

There is no easy way to archive this yet (besides installing some custom components..e.g. auto-entities).

My plan is to make it possible to add multiple sort configurations (numeric, alpha, ip, etc.). If the first configuration-method can't sort two values, the next should be applied. Each configuration can have some additional options. In the alpha configuration it's for example possible to enable the ignore_case option.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
