### PR TITLE
Fix All Day recurring events that end on a specific date

### DIFF
--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -250,6 +250,7 @@ class DialogCalendarEventEditor extends LitElement {
           <ha-recurrence-rule-editor
             .hass=${this.hass}
             .dtstart=${this._dtstart}
+            .allDay=${this._allDay}
             .locale=${this.hass.locale}
             .timezone=${this.hass.config.time_zone}
             .value=${this._rrule || ""}

--- a/src/panels/calendar/ha-recurrence-rule-editor.ts
+++ b/src/panels/calendar/ha-recurrence-rule-editor.ts
@@ -41,7 +41,7 @@ export class RecurrenceRuleEditor extends LitElement {
 
   @property() public dtstart?: Date;
 
-  @property() public allDay?: Boolean;
+  @property() public allDay?: boolean;
 
   @property({ attribute: false }) public locale!: HomeAssistant["locale"];
 

--- a/src/panels/calendar/ha-recurrence-rule-editor.ts
+++ b/src/panels/calendar/ha-recurrence-rule-editor.ts
@@ -41,6 +41,8 @@ export class RecurrenceRuleEditor extends LitElement {
 
   @property() public dtstart?: Date;
 
+  @property() public allDay?: bool;
+
   @property({ attribute: false }) public locale!: HomeAssistant["locale"];
 
   @property() public timezone?: string;
@@ -402,7 +404,14 @@ export class RecurrenceRuleEditor extends LitElement {
       byweekday: byweekday,
       bymonthday: bymonthday,
     };
-    const contentline = RRule.optionsToString(options);
+    let contentline = RRule.optionsToString(options);
+    if (this._until && this.allDay) {
+      // rrule.js only computes UNTIL values as DATE-TIME however rfc5545 says
+      // The value of the UNTIL rule part MUST have the same value type as the
+      // "DTSTART" property. If needed, strip off any time values as a workaround
+      // This converts "UNTIL=20220512T060000" to "UNTIL=20220512"
+      contentline = contentline.replace(/(UNTIL=\d{8})T\d{6}Z?/, "$1");
+    }
     return contentline.slice(6); // Strip "RRULE:" prefix
   }
 

--- a/src/panels/calendar/ha-recurrence-rule-editor.ts
+++ b/src/panels/calendar/ha-recurrence-rule-editor.ts
@@ -41,7 +41,7 @@ export class RecurrenceRuleEditor extends LitElement {
 
   @property() public dtstart?: Date;
 
-  @property() public allDay?: bool;
+  @property() public allDay?: Boolean;
 
   @property({ attribute: false }) public locale!: HomeAssistant["locale"];
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fix All Day recurring events that end on a specific date. This is a workaround for the `rrule.js` behavior that only allows `UNTIL` values to be `DATE-TIME` type. The rfc states that `UNTIL` and `DTSTART` values must be of the same type, enforced by `ical`, so this is changed when setting the rule in the frontend.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/84042
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
