### PR TITLE
Fix days missing from ha-base-time-input _valueChanged

### DIFF
--- a/src/components/ha-base-time-input.ts
+++ b/src/components/ha-base-time-input.ts
@@ -261,12 +261,14 @@ export class HaBaseTimeInput extends LitElement {
     this[textField.name] =
       textField.name === "amPm" ? textField.value : Number(textField.value);
     const value: TimeChangedEvent = {
-      days: this.enableDay ? this.days : undefined,
       hours: this.hours,
       minutes: this.minutes,
       seconds: this.seconds,
       milliseconds: this.milliseconds,
     };
+    if (this.enableDay) {
+      value.days = this.days;
+    }
     if (this.format === 12) {
       value.amPm = this.amPm;
     }

--- a/src/components/ha-base-time-input.ts
+++ b/src/components/ha-base-time-input.ts
@@ -261,6 +261,7 @@ export class HaBaseTimeInput extends LitElement {
     this[textField.name] =
       textField.name === "amPm" ? textField.value : Number(textField.value);
     const value: TimeChangedEvent = {
+      days: this.enableDay ? this.days : undefined,
       hours: this.hours,
       minutes: this.minutes,
       seconds: this.seconds,


### PR DESCRIPTION

## Proposed change

The valueChanged method for ha-base-time-input is missing the days field. Cause a bug where changing the days in the selector would not send the proper event. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14906
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
