### PR TITLE
Support fractional hours_to_show for history-graph-card

### DIFF
--- a/src/data/cached-history.ts
+++ b/src/data/cached-history.ts
@@ -106,7 +106,14 @@ export const getRecentWithCache = (
   const fullCacheKey = cacheKey + `_${cacheConfig.hoursToShow}`;
   const endTime = new Date();
   const startTime = new Date(endTime);
-  startTime.setHours(startTime.getHours() - cacheConfig.hoursToShow);
+  const hoursToShow = Math.trunc(cacheConfig.hoursToShow);
+  const minutesToShow = Math.round(
+    (cacheConfig.hoursToShow - hoursToShow) * 60
+  );
+  startTime.setHours(
+    startTime.getHours() - hoursToShow,
+    startTime.getMinutes() - minutesToShow
+  );
   let toFetchStartTime = startTime;
   let appendingToCache = false;
 

--- a/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-history-graph-card-editor.ts
@@ -39,7 +39,10 @@ const SCHEMA = [
     name: "",
     type: "grid",
     schema: [
-      { name: "hours_to_show", selector: { number: { min: 1, mode: "box" } } },
+      {
+        name: "hours_to_show",
+        selector: { number: { min: 0.01, mode: "box", step: 0.01 } },
+      },
       {
         name: "refresh_interval",
         selector: { number: { min: 1, mode: "box" } },


### PR DESCRIPTION
## Proposed change

This change proposes to add support for fractional hours_to_show when configuring a history-graph-card. Currently only integer number of hours is allowed, and any decimal part of hours is rounded up to the next hour (entering "0.25" shows 1 hour). 

I have occasionally tried to create a 15 or 30 minute history graph, and felt it was somewhat arbitrary that I was not able to do so. 

This change would take a non-integer value from hours_to_show and convert it to a number of hours and minutes, instead of just hours. This means that the minimum graph length would be 1 minute. That's probably too small to be actually useful, but I don't see a reason to put a further arbitrary restriction on it. 1-minute graphs work fine in my testing. 

If this change is acceptible, please let me know and I can add an additional linked documentation change. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
