### PR TITLE
Sort battery level column using numeric sort

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -200,7 +200,6 @@ export class HaDataTable extends LitElement {
       Object.values(clonedColumns).forEach(
         (column: ClonedDataTableColumnData) => {
           delete column.title;
-          delete column.type;
           delete column.template;
         }
       );

--- a/src/components/data-table/sort_filter_worker.ts
+++ b/src/components/data-table/sort_filter_worker.ts
@@ -55,11 +55,16 @@ const sortData = (
       ? b[column.valueColumn || sortColumn][column.filterKey]
       : b[column.valueColumn || sortColumn];
 
-    if (typeof valA === "string") {
-      valA = valA.toUpperCase();
-    }
-    if (typeof valB === "string") {
-      valB = valB.toUpperCase();
+    if (column.type === "numeric") {
+      valA = isNaN(valA) ? undefined : Number(valA);
+      valB = isNaN(valB) ? undefined : Number(valB);
+    } else {
+      if (typeof valA === "string") {
+        valA = valA.toUpperCase();
+      }
+      if (typeof valB === "string") {
+        valB = valB.toUpperCase();
+      }
     }
 
     // Ensure "undefined" is always sorted to the bottom


### PR DESCRIPTION
## Proposed change

The battery column in the devices table, despite tagged as numeric type, is still being sorted as strings (0 < 100 < 2).

This change adds support for numeric sort to the sorting worker, and sorts "numeric" type columns (currently only battery level) using a numeric sort. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
fixes #10973 
fixes #13986
- This PR is related to issue or discussion: 
https://community.home-assistant.io/t/device-page-sort-battery-on-numeric-value/415361
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
