### PR TITLE
Widen history panel entity picker

### DIFF
--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -367,6 +367,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       case "entity_id":
         return html`
           <ha-entity-picker
+            class=${this.horizontal ? "horizontal-entity-picker" : ""}
             .hass=${this.hass}
             id="input"
             .type=${"entity_id"}
@@ -656,6 +657,10 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       :host([disabled]) .mdc-chip {
         opacity: var(--light-disabled-opacity);
         pointer-events: none;
+      }
+      .horizontal-entity-picker {
+        flex-basis: 400px;
+        max-width: 400px;
       }
     `;
   }

--- a/src/panels/history/ha-panel-history.ts
+++ b/src/panels/history/ha-panel-history.ts
@@ -130,7 +130,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
         </app-header>
 
         <div class="flex content">
-          <div class="filters flex layout horizontal narrow-wrap">
+          <div class="filters flex layout horizontal wrap">
             <ha-date-range-picker
               .hass=${this.hass}
               ?disabled=${this._isLoading}
@@ -445,7 +445,7 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
           height: 100%;
         }
 
-        :host([narrow]) .narrow-wrap {
+        :host .wrap {
           flex-wrap: wrap;
         }
 
@@ -493,15 +493,9 @@ class HaPanelHistory extends SubscribeMixin(LitElement) {
           transform: translate(-50%, -50%);
         }
 
-        ha-entity-picker {
-          display: inline-block;
-          flex-grow: 1;
-          max-width: 400px;
-        }
-
-        :host([narrow]) ha-entity-picker {
-          max-width: none;
-          width: 100%;
+        ha-target-picker {
+          flex: 1;
+          flex-basis: 400px;
         }
 
         .start-search {


### PR DESCRIPTION
## Proposed change

The current history panel entity picker gets several complaints for being too narrow. It is by default around 230 pixels, and any medium to long entity names get cut off and are hard to distinguish. 
Also, at around 900 pixels in width the whole picker squishes up against the right side and is cut in half. 

**Current behavior:** 
![old_entity_width](https://user-images.githubusercontent.com/32912880/210146239-6b9ac319-4316-4ca8-b7ec-de76232f8dda.gif)

This change tweaks the wrapping behavior in the history panel, and tries to fix the entity picker at 400 pixels, which aligns nicely width the width of the 3 picker chips, and should allow for seeing much more of entity names. And it lets the whole picker wrap more instead of squishing up against the right edge. 

**Proposed behavior:**
![new_entity_width](https://user-images.githubusercontent.com/32912880/210147043-4f7679d1-a5f3-4d60-bd84-4a5a01a73db8.gif)


ha-target-pickers instanced by ha-selector-targets on other panels are unchanged, they don't seem to have this problem.

Area and Devices picker are unchanged, their names are not nearly as long, so don't seem to have this problem.



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
fixes #13671 
fixes #14897 
- This PR is related to issue or discussion:
https://github.com/home-assistant/frontend/discussions/13648
https://community.home-assistant.io/t/increase-the-width-of-the-search-bar-on-new-history-browser/437439

- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
