### PR TITLE
Do not close aliases dialog on enter

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -1,11 +1,13 @@
 import { DialogBase } from "@material/mwc-dialog/mwc-dialog-base";
 import { styles } from "@material/mwc-dialog/mwc-dialog.css";
 import { mdiClose } from "@mdi/js";
-import { css, html, PropertyValues, TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators";
+import { css, html, TemplateResult } from "lit";
+import { customElement } from "lit/decorators";
 import { FOCUS_TARGET } from "../dialogs/make-dialog-manager";
 import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
+
+const SUPPRESS_DEFAULT_PRESS_SELECTOR = ["button"];
 
 export const createCloseHeading = (
   hass: HomeAssistant,
@@ -32,15 +34,12 @@ export class HaDialog extends DialogBase {
     return html`<slot name="heading"> ${super.renderHeading()} </slot>`;
   }
 
-  @property({ type: Boolean }) public disableEnterKeySubmit?: boolean;
-
-  override updated(changedProperties: PropertyValues) {
-    super.updated(changedProperties);
-    if (changedProperties.has("disableEnterKeySubmit")) {
-      this.mdcFoundation.setSuppressDefaultPressSelector(
-        this.disableEnterKeySubmit ? "*" : ""
-      );
-    }
+  protected firstUpdated(): void {
+    super.firstUpdated();
+    this.suppressDefaultPressSelector = [
+      this.suppressDefaultPressSelector,
+      SUPPRESS_DEFAULT_PRESS_SELECTOR,
+    ].join(", ");
   }
 
   static override styles = [

--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -1,10 +1,10 @@
 import { DialogBase } from "@material/mwc-dialog/mwc-dialog-base";
 import { styles } from "@material/mwc-dialog/mwc-dialog.css";
 import { mdiClose } from "@mdi/js";
-import { css, html, TemplateResult } from "lit";
-import { customElement } from "lit/decorators";
-import type { HomeAssistant } from "../types";
+import { css, html, PropertyValues, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators";
 import { FOCUS_TARGET } from "../dialogs/make-dialog-manager";
+import type { HomeAssistant } from "../types";
 import "./ha-icon-button";
 
 export const createCloseHeading = (
@@ -30,6 +30,17 @@ export class HaDialog extends DialogBase {
 
   protected renderHeading() {
     return html`<slot name="heading"> ${super.renderHeading()} </slot>`;
+  }
+
+  @property({ type: Boolean }) public disableEnterKeySubmit?: boolean;
+
+  override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties);
+    if (changedProperties.has("disableEnterKeySubmit")) {
+      this.mdcFoundation.setSuppressDefaultPressSelector(
+        this.disableEnterKeySubmit ? "*" : ""
+      );
+    }
   }
 
   static override styles = [

--- a/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
+++ b/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
@@ -54,12 +54,12 @@ class DialogEntityAliases extends LitElement {
     return html`
       <ha-dialog
         open
-        hideActions
         @closed=${this.closeDialog}
         .heading=${this.hass.localize(
           "ui.dialogs.entity_registry.editor.aliases.heading",
           { name }
         )}
+        disableEnterKeySubmit
       >
         <div>
           ${this._error
@@ -79,7 +79,7 @@ class DialogEntityAliases extends LitElement {
                     )}
                     .value=${alias}
                     ?data-last=${index === this._aliases.length - 1}
-                    @input=${this._editAlias}
+                    @change=${this._editAlias}
                     @keydown=${this._keyDownAlias}
                   ></ha-textfield>
                   <ha-icon-button
@@ -105,16 +105,22 @@ class DialogEntityAliases extends LitElement {
             </div>
           </div>
         </div>
-        <div class="buttons">
-          <mwc-button @click=${this.closeDialog} .disabled=${this._submitting}>
-            ${this.hass.localize("ui.common.cancel")}
-          </mwc-button>
-          <mwc-button @click=${this._updateEntry} .disabled=${this._submitting}>
-            ${this.hass.localize(
-              "ui.dialogs.entity_registry.editor.aliases.save"
-            )}
-          </mwc-button>
-        </div>
+        <mwc-button
+          slot="secondaryAction"
+          @click=${this.closeDialog}
+          .disabled=${this._submitting}
+        >
+          ${this.hass.localize("ui.common.cancel")}
+        </mwc-button>
+        <mwc-button
+          slot="primaryAction"
+          @click=${this._updateEntry}
+          .disabled=${this._submitting}
+        >
+          ${this.hass.localize(
+            "ui.dialogs.entity_registry.editor.aliases.save"
+          )}
+        </mwc-button>
       </ha-dialog>
     `;
   }
@@ -182,9 +188,6 @@ class DialogEntityAliases extends LitElement {
         ha-icon-button {
           display: block;
         }
-        ha-dialog {
-          --dialog-content-padding: 0;
-        }
         mwc-button {
           margin-left: 8px;
         }
@@ -196,21 +199,6 @@ class DialogEntityAliases extends LitElement {
           border-radius: 4px;
           margin-top: 4px;
           --mdc-icon-button-size: 24px;
-        }
-        .form {
-          padding: 20px 24px;
-        }
-        .buttons {
-          box-sizing: border-box;
-          display: flex;
-          padding: 20px 24px;
-          padding-top: 16px;
-          justify-content: space-between;
-          padding-bottom: max(env(safe-area-inset-bottom), 20px);
-          background-color: var(--mdc-theme-surface, #fff);
-          border-top: 1px solid var(--divider-color);
-          position: sticky;
-          bottom: 0px;
         }
       `,
     ];

--- a/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
+++ b/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
@@ -54,6 +54,7 @@ class DialogEntityAliases extends LitElement {
     return html`
       <ha-dialog
         open
+        hideActions
         @closed=${this.closeDialog}
         .heading=${this.hass.localize(
           "ui.dialogs.entity_registry.editor.aliases.heading",
@@ -64,7 +65,7 @@ class DialogEntityAliases extends LitElement {
           ${this._error
             ? html`<ha-alert alert-type="error">${this._error}</ha-alert> `
             : ""}
-          <div class="form" @keydown=${this._ignoreKeydown}>
+          <div class="form">
             ${this._aliases.map(
               (alias, index) => html`
                 <div class="layout horizontal center-center row">
@@ -78,7 +79,7 @@ class DialogEntityAliases extends LitElement {
                     )}
                     .value=${alias}
                     ?data-last=${index === this._aliases.length - 1}
-                    @change=${this._editAlias}
+                    @input=${this._editAlias}
                     @keydown=${this._keyDownAlias}
                   ></ha-textfield>
                   <ha-icon-button
@@ -104,28 +105,18 @@ class DialogEntityAliases extends LitElement {
             </div>
           </div>
         </div>
-        <mwc-button
-          slot="secondaryAction"
-          @click=${this.closeDialog}
-          .disabled=${this._submitting}
-        >
-          ${this.hass.localize("ui.common.cancel")}
-        </mwc-button>
-        <mwc-button
-          slot="primaryAction"
-          @click=${this._updateEntry}
-          .disabled=${this._submitting}
-        >
-          ${this.hass.localize(
-            "ui.dialogs.entity_registry.editor.aliases.save"
-          )}
-        </mwc-button>
+        <div class="buttons">
+          <mwc-button @click=${this.closeDialog} .disabled=${this._submitting}>
+            ${this.hass.localize("ui.common.cancel")}
+          </mwc-button>
+          <mwc-button @click=${this._updateEntry} .disabled=${this._submitting}>
+            ${this.hass.localize(
+              "ui.dialogs.entity_registry.editor.aliases.save"
+            )}
+          </mwc-button>
+        </div>
       </ha-dialog>
     `;
-  }
-
-  private _ignoreKeydown(ev: KeyboardEvent) {
-    ev.stopPropagation();
   }
 
   private async _addAlias() {
@@ -191,6 +182,9 @@ class DialogEntityAliases extends LitElement {
         ha-icon-button {
           display: block;
         }
+        ha-dialog {
+          --dialog-content-padding: 0;
+        }
         mwc-button {
           margin-left: 8px;
         }
@@ -202,6 +196,21 @@ class DialogEntityAliases extends LitElement {
           border-radius: 4px;
           margin-top: 4px;
           --mdc-icon-button-size: 24px;
+        }
+        .form {
+          padding: 20px 24px;
+        }
+        .buttons {
+          box-sizing: border-box;
+          display: flex;
+          padding: 20px 24px;
+          padding-top: 16px;
+          justify-content: space-between;
+          padding-bottom: max(env(safe-area-inset-bottom), 20px);
+          background-color: var(--mdc-theme-surface, #fff);
+          border-top: 1px solid var(--divider-color);
+          position: sticky;
+          bottom: 0px;
         }
       `,
     ];

--- a/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
+++ b/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
@@ -59,7 +59,6 @@ class DialogEntityAliases extends LitElement {
           "ui.dialogs.entity_registry.editor.aliases.heading",
           { name }
         )}
-        .suppressDefaultPressSelector=${"input"}
       >
         <div>
           ${this._error
@@ -141,6 +140,7 @@ class DialogEntityAliases extends LitElement {
 
   private async _keyDownAlias(ev: KeyboardEvent) {
     if (ev.key === "Enter") {
+      ev.stopPropagation();
       this._addAlias();
     }
   }

--- a/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
+++ b/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
@@ -59,7 +59,7 @@ class DialogEntityAliases extends LitElement {
           "ui.dialogs.entity_registry.editor.aliases.heading",
           { name }
         )}
-        disableEnterKeySubmit
+        .suppressDefaultPressSelector=${"input"}
       >
         <div>
           ${this._error

--- a/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
+++ b/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
@@ -79,7 +79,7 @@ class DialogEntityAliases extends LitElement {
                     )}
                     .value=${alias}
                     ?data-last=${index === this._aliases.length - 1}
-                    @change=${this._editAlias}
+                    @input=${this._editAlias}
                     @keydown=${this._keyDownAlias}
                   ></ha-textfield>
                   <ha-icon-button

--- a/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
+++ b/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
@@ -64,7 +64,7 @@ class DialogEntityAliases extends LitElement {
           ${this._error
             ? html`<ha-alert alert-type="error">${this._error}</ha-alert> `
             : ""}
-          <div class="form">
+          <div class="form" @keydown=${this._ignoreKeydown}>
             ${this._aliases.map(
               (alias, index) => html`
                 <div class="layout horizontal center-center row">
@@ -72,16 +72,21 @@ class DialogEntityAliases extends LitElement {
                     dialogInitialFocus=${index}
                     .index=${index}
                     class="flex-auto"
-                    label="Alias"
+                    label=${this.hass!.localize(
+                      "ui.dialogs.entity_registry.editor.aliases.input_label",
+                      { number: index + 1 }
+                    )}
                     .value=${alias}
                     ?data-last=${index === this._aliases.length - 1}
                     @change=${this._editAlias}
+                    @keydown=${this._keyDownAlias}
                   ></ha-textfield>
                   <ha-icon-button
                     .index=${index}
                     slot="navigationIcon"
                     label=${this.hass!.localize(
-                      "ui.dialogs.entity_registry.editor.aliases.remove_alias"
+                      "ui.dialogs.entity_registry.editor.aliases.remove_alias",
+                      { number: index + 1 }
                     )}
                     @click=${this._removeAlias}
                     .path=${mdiDeleteOutline}
@@ -119,6 +124,10 @@ class DialogEntityAliases extends LitElement {
     `;
   }
 
+  private _ignoreKeydown(ev: KeyboardEvent) {
+    ev.stopPropagation();
+  }
+
   private async _addAlias() {
     this._aliases = [...this._aliases, ""];
     await this.updateComplete;
@@ -131,6 +140,12 @@ class DialogEntityAliases extends LitElement {
   private async _editAlias(ev: Event) {
     const index = (ev.target as any).index;
     this._aliases[index] = (ev.target as any).value;
+  }
+
+  private async _keyDownAlias(ev: KeyboardEvent) {
+    if (ev.key === "Enter") {
+      this._addAlias();
+    }
   }
 
   private async _removeAlias(ev: Event) {

--- a/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
+++ b/src/panels/config/entities/entity-aliases/dialog-entity-aliases.ts
@@ -73,7 +73,7 @@ class DialogEntityAliases extends LitElement {
                     dialogInitialFocus=${index}
                     .index=${index}
                     class="flex-auto"
-                    label=${this.hass!.localize(
+                    .label=${this.hass!.localize(
                       "ui.dialogs.entity_registry.editor.aliases.input_label",
                       { number: index + 1 }
                     )}

--- a/src/panels/config/entities/entity-registry-basic-editor.ts
+++ b/src/panels/config/entities/entity-registry-basic-editor.ts
@@ -49,7 +49,8 @@ export class HaEntityRegistryBasicEditor extends SubscribeMixin(LitElement) {
 
   @state() private _submitting = false;
 
-  private _openAliasesSettings() {
+  private _handleAliasesClicked(ev: CustomEvent) {
+    if (ev.detail.index !== 0) return;
     showEntityAliasesDialog(this, {
       entity: this.entry!,
       updateEntry: async (updates) => {
@@ -272,12 +273,8 @@ export class HaEntityRegistryBasicEditor extends SubscribeMixin(LitElement) {
             "ui.dialogs.entity_registry.editor.aliases_section"
           )}
         </div>
-        <mwc-list class="aliases">
-          <mwc-list-item
-            .twoline=${this.entry.aliases.length > 0}
-            hasMeta
-            @click=${this._openAliasesSettings}
-          >
+        <mwc-list class="aliases" @action=${this._handleAliasesClicked}>
+          <mwc-list-item .twoline=${this.entry.aliases.length > 0} hasMeta>
             <span>
               ${this.entry.aliases.length > 0
                 ? this.hass.localize(

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -771,12 +771,8 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
               "ui.dialogs.entity_registry.editor.aliases_section"
             )}
           </div>
-          <mwc-list class="aliases">
-            <mwc-list-item
-              .twoline=${this.entry.aliases.length > 0}
-              hasMeta
-              @click=${this._openAliasesSettings}
-            >
+          <mwc-list class="aliases" @action=${this._handleAliasesClicked}>
+            <mwc-list-item .twoline=${this.entry.aliases.length > 0} hasMeta>
               <span>
                 ${this.entry.aliases.length > 0
                   ? this.hass.localize(
@@ -979,7 +975,8 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
     });
   }
 
-  private _openAliasesSettings() {
+  private _handleAliasesClicked(ev: CustomEvent) {
+    if (ev.detail.index !== 0) return;
     showEntityAliasesDialog(this, {
       entity: this.entry!,
       updateEntry: async (updates) => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -976,7 +976,8 @@
           "aliases": {
             "heading": "{name} aliases",
             "description": "Aliases are alternative names used in voice assistants to refer to this entity.",
-            "remove_alias": "Remove alias",
+            "remove_alias": "Remove alias {number}",
+            "input_label": "Alias {number}",
             "save": "Save",
             "add_alias": "Add alias",
             "no_aliases": "No aliases have been added yet",


### PR DESCRIPTION
## Proposed change

When hitting enter, a new alias textfield is added instead of closing the dialog.
Translations have been improved too.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14907
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
