### PR TITLE
Add UI support for entities in numeric_state above/below conditions &…

### DIFF
--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../../common/translations/localize";
@@ -15,6 +15,10 @@ export default class HaNumericStateCondition extends LitElement {
   @property({ attribute: false }) public condition!: NumericStateCondition;
 
   @property({ type: Boolean }) public disabled = false;
+
+  @state() private _inputAboveIsEntity?: boolean;
+
+  @state() private _inputBelowIsEntity?: boolean;
 
   public static get defaultConfig() {
     return {
@@ -122,20 +126,28 @@ export default class HaNumericStateCondition extends LitElement {
             ],
           ],
         },
-
-        {
-          name: "above",
-          selector: inputAboveIsEntity
-            ? { entity: { domain: ["input_number", "number", "sensor"] } }
-            : {
-                number: {
-                  mode: "box",
-                  min: Number.MIN_SAFE_INTEGER,
-                  max: Number.MAX_SAFE_INTEGER,
-                  step: 0.1,
+        ...(inputAboveIsEntity
+          ? ([
+              {
+                name: "above",
+                selector: {
+                  entity: { domain: ["input_number", "number", "sensor"] },
                 },
               },
-        },
+            ] as const)
+          : ([
+              {
+                name: "above",
+                selector: {
+                  number: {
+                    mode: "box",
+                    min: Number.MIN_SAFE_INTEGER,
+                    max: Number.MAX_SAFE_INTEGER,
+                    step: 0.1,
+                  },
+                },
+              },
+            ] as const)),
         {
           name: "mode_below",
           type: "select",
@@ -155,19 +167,28 @@ export default class HaNumericStateCondition extends LitElement {
             ],
           ],
         },
-        {
-          name: "below",
-          selector: inputBelowIsEntity
-            ? { entity: { domain: ["input_number", "number", "sensor"] } }
-            : {
-                number: {
-                  mode: "box",
-                  min: Number.MIN_SAFE_INTEGER,
-                  max: Number.MAX_SAFE_INTEGER,
-                  step: 0.1,
+        ...(inputBelowIsEntity
+          ? ([
+              {
+                name: "below",
+                selector: {
+                  entity: { domain: ["input_number", "number", "sensor"] },
                 },
               },
-        },
+            ] as const)
+          : ([
+              {
+                name: "below",
+                selector: {
+                  number: {
+                    mode: "box",
+                    min: Number.MIN_SAFE_INTEGER,
+                    max: Number.MAX_SAFE_INTEGER,
+                    step: 0.1,
+                  },
+                },
+              },
+            ] as const)),
         {
           name: "value_template",
           selector: { template: {} },
@@ -179,15 +200,15 @@ export default class HaNumericStateCondition extends LitElement {
     const inputAboveIsEntity =
       this._inputAboveIsEntity ??
       (typeof this.condition.above === "string" &&
-        (this.condition.above?.startsWith("input_number.") ||
-          this.condition.above?.startsWith("number.") ||
-          this.condition.above?.startsWith("sensor.")));
+        ((this.condition.above as string).startsWith("input_number.") ||
+          (this.condition.above as string).startsWith("number.") ||
+          (this.condition.above as string).startsWith("sensor.")));
     const inputBelowIsEntity =
       this._inputBelowIsEntity ??
       (typeof this.condition.below === "string" &&
-        (this.condition.below?.startsWith("input_number.") ||
-          this.condition.below?.startsWith("number.") ||
-          this.condition.below?.startsWith("sensor.")));
+        ((this.condition.below as string).startsWith("input_number.") ||
+          (this.condition.below as string).startsWith("number.") ||
+          (this.condition.below as string).startsWith("sensor.")));
 
     const schema = this._schema(
       this.hass.localize,

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -1,5 +1,5 @@
 import { html, LitElement, PropertyValues } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 import { fireEvent } from "../../../../../common/dom/fire_event";
@@ -17,6 +17,10 @@ export class HaNumericStateTrigger extends LitElement {
   @property({ attribute: false }) public trigger!: NumericStateTrigger;
 
   @property({ type: Boolean }) public disabled = false;
+
+  @state() private _inputAboveIsEntity?: boolean;
+
+  @state() private _inputBelowIsEntity?: boolean;
 
   private _schema = memoizeOne(
     (
@@ -118,20 +122,28 @@ export class HaNumericStateTrigger extends LitElement {
             ],
           ],
         },
-
-        {
-          name: "above",
-          selector: inputAboveIsEntity
-            ? { entity: { domain: ["input_number", "number", "sensor"] } }
-            : {
-                number: {
-                  mode: "box",
-                  min: Number.MIN_SAFE_INTEGER,
-                  max: Number.MAX_SAFE_INTEGER,
-                  step: 0.1,
+        ...(inputAboveIsEntity
+          ? ([
+              {
+                name: "above",
+                selector: {
+                  entity: { domain: ["input_number", "number", "sensor"] },
                 },
               },
-        },
+            ] as const)
+          : ([
+              {
+                name: "above",
+                selector: {
+                  number: {
+                    mode: "box",
+                    min: Number.MIN_SAFE_INTEGER,
+                    max: Number.MAX_SAFE_INTEGER,
+                    step: 0.1,
+                  },
+                },
+              },
+            ] as const)),
         {
           name: "mode_below",
           type: "select",
@@ -151,19 +163,28 @@ export class HaNumericStateTrigger extends LitElement {
             ],
           ],
         },
-        {
-          name: "below",
-          selector: inputBelowIsEntity
-            ? { entity: { domain: ["input_number", "number", "sensor"] } }
-            : {
-                number: {
-                  mode: "box",
-                  min: Number.MIN_SAFE_INTEGER,
-                  max: Number.MAX_SAFE_INTEGER,
-                  step: 0.1,
+        ...(inputBelowIsEntity
+          ? ([
+              {
+                name: "below",
+                selector: {
+                  entity: { domain: ["input_number", "number", "sensor"] },
                 },
               },
-        },
+            ] as const)
+          : ([
+              {
+                name: "below",
+                selector: {
+                  number: {
+                    mode: "box",
+                    min: Number.MIN_SAFE_INTEGER,
+                    max: Number.MAX_SAFE_INTEGER,
+                    step: 0.1,
+                  },
+                },
+              },
+            ] as const)),
         {
           name: "value_template",
           selector: { template: {} },
@@ -198,15 +219,15 @@ export class HaNumericStateTrigger extends LitElement {
     const inputAboveIsEntity =
       this._inputAboveIsEntity ??
       (typeof this.trigger.above === "string" &&
-        (this.trigger.above?.startsWith("input_number.") ||
-          this.trigger.above?.startsWith("number.") ||
-          this.trigger.above?.startsWith("sensor.")));
+        ((this.trigger.above as string).startsWith("input_number.") ||
+          (this.trigger.above as string).startsWith("number.") ||
+          (this.trigger.above as string).startsWith("sensor.")));
     const inputBelowIsEntity =
       this._inputBelowIsEntity ??
       (typeof this.trigger.below === "string" &&
-        (this.trigger.below?.startsWith("input_number.") ||
-          this.trigger.below?.startsWith("number.") ||
-          this.trigger.below?.startsWith("sensor.")));
+        ((this.trigger.below as string).startsWith("input_number.") ||
+          (this.trigger.below as string).startsWith("number.") ||
+          (this.trigger.below as string).startsWith("sensor.")));
 
     const schema = this._schema(
       this.hass.localize,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2095,7 +2095,11 @@
                   "label": "Numeric state",
                   "above": "Above",
                   "below": "Below",
-                  "value_template": "Value template"
+                  "mode_above": "Above mode",
+                  "mode_below": "Below mode",
+                  "value_template": "Value template",
+                  "type_value": "Fixed number",
+                  "type_input": "Numeric value of another entity"
                 },
                 "sun": {
                   "label": "Sun",
@@ -2178,9 +2182,13 @@
                   "label": "Not"
                 },
                 "numeric_state": {
+                  "type_value": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::type_value%]",
+                  "type_input": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::type_input%]",
                   "label": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::label%]",
                   "above": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::above%]",
                   "below": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::below%]",
+                  "mode_above": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::mode_above%]",
+                  "mode_below": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::mode_below%]",
                   "value_template": "[%key:ui::panel::config::automation::editor::triggers::type::numeric_state::value_template%]"
                 },
                 "or": {


### PR DESCRIPTION
… triggers

## Proposed change

Add support for using entities as numeric_state above/below condition in automation triggers and conditions. Currently, the UI only supports fixed numbers. Style copied from how the time trigger/condition supports a fixed time or helper. 

Example:
![numeric_state_condition](https://user-images.githubusercontent.com/32912880/210279341-5d7ec37b-54c1-431c-85b0-48f10eede6bd.PNG)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration



## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14958
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
