### PR TITLE
Fix current_humidity no shown on climate state card if also current_temperature is set

### DIFF
--- a/src/components/ha-climate-state.ts
+++ b/src/components/ha-climate-state.ts
@@ -1,9 +1,6 @@
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
-import {
-  computeAttributeNameDisplay,
-  computeAttributeValueDisplay,
-} from "../common/entity/compute_attribute_display";
+import { computeAttributeValueDisplay } from "../common/entity/compute_attribute_display";
 import { computeStateDisplay } from "../common/entity/compute_state_display";
 import { formatNumber } from "../common/number/format_number";
 import { ClimateEntity, CLIMATE_PRESET_NONE } from "../data/climate";
@@ -18,7 +15,6 @@ class HaClimateState extends LitElement {
 
   protected render(): TemplateResult {
     const currentStatus = this._computeCurrentStatus();
-    const currentHumidityStatus = this._computeCurrentHumidityStatus();
 
     return html`<div class="target">
         ${!isUnavailableState(this.stateObj.state)
@@ -44,23 +40,25 @@ class HaClimateState extends LitElement {
             ${this.hass.localize("ui.card.climate.currently")}:
             <div class="unit">${currentStatus}</div>
           </div>`
-        : ""}
-      ${currentHumidityStatus && !isUnavailableState(this.stateObj.state)
-        ? html`<div class="current">
-            ${computeAttributeNameDisplay(
-              this.hass.localize,
-              this.stateObj,
-              this.hass.entities,
-              "current_humidity"
-            )}:
-            <div class="unit">${currentHumidityStatus}</div>
-          </div>`
         : ""}`;
   }
 
   private _computeCurrentStatus(): string | undefined {
     if (!this.hass || !this.stateObj) {
       return undefined;
+    }
+    if (
+      this.stateObj.attributes.current_temperature != null &&
+      this.stateObj.attributes.current_humidity != null
+    ) {
+      return `${formatNumber(
+        this.stateObj.attributes.current_temperature,
+        this.hass.locale
+      )} ${this.hass.config.unit_system.temperature}/
+      ${formatNumber(
+        this.stateObj.attributes.current_humidity,
+        this.hass.locale
+      )} %`;
     }
 
     if (this.stateObj.attributes.current_temperature != null) {
@@ -71,20 +69,6 @@ class HaClimateState extends LitElement {
     }
 
     if (this.stateObj.attributes.current_humidity != null) {
-      return `${formatNumber(
-        this.stateObj.attributes.current_humidity,
-        this.hass.locale
-      )} %`;
-    }
-
-    return undefined;
-  }
-
-  private _computeCurrentHumidityStatus(): string | undefined {
-    if (
-      this.stateObj.attributes.current_temperature != null &&
-      this.stateObj.attributes.current_humidity != null
-    ) {
       return `${formatNumber(
         this.stateObj.attributes.current_humidity,
         this.hass.locale

--- a/src/components/ha-climate-state.ts
+++ b/src/components/ha-climate-state.ts
@@ -1,6 +1,9 @@
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
-import { computeAttributeValueDisplay } from "../common/entity/compute_attribute_display";
+import {
+  computeAttributeNameDisplay,
+  computeAttributeValueDisplay,
+} from "../common/entity/compute_attribute_display";
 import { computeStateDisplay } from "../common/entity/compute_state_display";
 import { formatNumber } from "../common/number/format_number";
 import { ClimateEntity, CLIMATE_PRESET_NONE } from "../data/climate";
@@ -15,6 +18,7 @@ class HaClimateState extends LitElement {
 
   protected render(): TemplateResult {
     const currentStatus = this._computeCurrentStatus();
+    const currentHumidityStatus = this._computeCurrentHumidityStatus();
 
     return html`<div class="target">
         ${!isUnavailableState(this.stateObj.state)
@@ -40,6 +44,17 @@ class HaClimateState extends LitElement {
             ${this.hass.localize("ui.card.climate.currently")}:
             <div class="unit">${currentStatus}</div>
           </div>`
+        : ""}
+      ${currentHumidityStatus && !isUnavailableState(this.stateObj.state)
+        ? html`<div class="current">
+            ${computeAttributeNameDisplay(
+              this.hass.localize,
+              this.stateObj,
+              this.hass.entities,
+              "current_humidity"
+            )}:
+            <div class="unit">${currentHumidityStatus}</div>
+          </div>`
         : ""}`;
   }
 
@@ -56,6 +71,20 @@ class HaClimateState extends LitElement {
     }
 
     if (this.stateObj.attributes.current_humidity != null) {
+      return `${formatNumber(
+        this.stateObj.attributes.current_humidity,
+        this.hass.locale
+      )} %`;
+    }
+
+    return undefined;
+  }
+
+  private _computeCurrentHumidityStatus(): string | undefined {
+    if (
+      this.stateObj.attributes.current_temperature != null &&
+      this.stateObj.attributes.current_humidity != null
+    ) {
       return `${formatNumber(
         this.stateObj.attributes.current_humidity,
         this.hass.locale

--- a/src/components/ha-climate-state.ts
+++ b/src/components/ha-climate-state.ts
@@ -58,7 +58,7 @@ class HaClimateState extends LitElement {
       ${formatNumber(
         this.stateObj.attributes.current_humidity,
         this.hass.locale
-      )} %`;
+      )}${blankBeforePercent(this.hass.locale)}%`;
     }
 
     if (this.stateObj.attributes.current_temperature != null) {

--- a/src/components/ha-climate-state.ts
+++ b/src/components/ha-climate-state.ts
@@ -3,6 +3,7 @@ import { customElement, property } from "lit/decorators";
 import { computeAttributeValueDisplay } from "../common/entity/compute_attribute_display";
 import { computeStateDisplay } from "../common/entity/compute_state_display";
 import { formatNumber } from "../common/number/format_number";
+import { blankBeforePercent } from "../common/translations/blank_before_percent";
 import { ClimateEntity, CLIMATE_PRESET_NONE } from "../data/climate";
 import { isUnavailableState } from "../data/entity";
 import type { HomeAssistant } from "../types";
@@ -72,7 +73,7 @@ class HaClimateState extends LitElement {
       return `${formatNumber(
         this.stateObj.attributes.current_humidity,
         this.hass.locale
-      )} %`;
+      )}${blankBeforePercent(this.hass.locale)}%`;
     }
 
     return undefined;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Also show `current_humidity` on climate if a `current_temperature` is available on the climate details card. Current behaviour is that humidity is only shown when there is no `current_temperature`.

Only `current_humidity`:
![afbeelding](https://user-images.githubusercontent.com/7188918/210617529-56f59eb4-52af-4421-8d29-ad0c8e461047.png)

Only `current_temperature`:
![afbeelding](https://user-images.githubusercontent.com/7188918/210618472-4e86435a-5a05-416e-ad83-6ceb46a7e4f7.png)

This PR enables to show both if they are both available.
![afbeelding](https://user-images.githubusercontent.com/7188918/214353456-cc6236e6-b94a-4cef-a509-84fb8979f729.png)

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
