### PR TITLE
Use ripple effect for tile card

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -254,14 +254,6 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     this._rippleHandlers.endHover();
   }
 
-  private handleRippleFocus() {
-    this._rippleHandlers.startFocus();
-  }
-
-  private handleRippleBlur() {
-    this._rippleHandlers.endFocus();
-  }
-
   protected render(): TemplateResult {
     if (!this._config || !this.hass) {
       return html``;
@@ -361,8 +353,6 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             .actionHandler=${actionHandler()}
             role="button"
             tabindex="0"
-            @focus=${this.handleRippleFocus}
-            @blur=${this.handleRippleBlur}
             @mousedown=${this.handleRippleActivate}
             @mouseup=${this.handleRippleDeactivate}
             @mouseenter=${this.handleRippleMouseEnter}
@@ -419,6 +409,10 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       :host {
         --tile-color: rgb(var(--rgb-state-inactive-color));
         -webkit-tap-highlight-color: transparent;
+      }
+      ha-card:has(ha-tile-info:focus-visible) {
+        border-color: var(--tile-color);
+        box-shadow: 0 0 0 1px var(--tile-color);
       }
       ha-card {
         --mdc-ripple-color: var(--tile-color);


### PR DESCRIPTION
## Proposed change

Add ripple effect on hover/tap and border color on keyboard focus.

https://user-images.githubusercontent.com/5878303/211334082-852c110c-3b00-4a99-84de-66730735a13b.mp4

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
