### PR TITLE
Fix UNTIL values to be inclusive of last event and bug in populating recurrence rules when editing calendar events

### DIFF
--- a/src/panels/calendar/ha-recurrence-rule-editor.ts
+++ b/src/panels/calendar/ha-recurrence-rule-editor.ts
@@ -489,12 +489,12 @@ export class RecurrenceRuleEditor extends LitElement {
 
   // Formats a date in browser display timezone
   private _formatDate(date: Date): string {
-    return formatInTimeZone(date, this.timezone, "yyyy-MM-dd");
+    return formatInTimeZone(date, this.timezone!, "yyyy-MM-dd");
   }
 
   // Formats a time in browser display timezone
   private _formatTime(date: Date): string {
-    return formatInTimeZone(date, this.timezone, "HH:mm:ss");
+    return formatInTimeZone(date, this.timezone!, "HH:mm:ss");
   }
 
   static styles = css`

--- a/src/panels/calendar/ha-recurrence-rule-editor.ts
+++ b/src/panels/calendar/ha-recurrence-rule-editor.ts
@@ -97,15 +97,16 @@ export class RecurrenceRuleEditor extends LitElement {
     }
 
     if (
-      changedProps.has("timezone") ||
-      changedProps.has("_freq") ||
-      changedProps.has("_interval") ||
-      changedProps.has("_weekday") ||
-      changedProps.has("_monthlyRepeatWeekday") ||
-      changedProps.has("_monthday") ||
-      changedProps.has("_end") ||
-      changedProps.has("_count") ||
-      changedProps.has("_until")
+      !changedProps.has("value") &&
+      (changedProps.has("timezone") ||
+        changedProps.has("_freq") ||
+        changedProps.has("_interval") ||
+        changedProps.has("_weekday") ||
+        changedProps.has("_monthlyRepeatWeekday") ||
+        changedProps.has("_monthday") ||
+        changedProps.has("_end") ||
+        changedProps.has("_count") ||
+        changedProps.has("_until"))
     ) {
       this._updateRule();
       return;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fix a bug in the calendar event editor when populating recurrence rules.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/85222 https://github.com/home-assistant/core/issues/85126
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
