### PR TITLE
Fix disabling a state condition in the visual automation editor

### DIFF
--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -1,7 +1,15 @@
 import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import { assert, literal, object, optional, string, union } from "superstruct";
+import {
+  assert,
+  boolean,
+  literal,
+  object,
+  optional,
+  string,
+  union,
+} from "superstruct";
 import { createDurationData } from "../../../../../common/datetime/create_duration_data";
 import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/ha-form/ha-form";
@@ -18,6 +26,7 @@ const stateConditionStruct = object({
   attribute: optional(string()),
   state: optional(string()),
   for: optional(union([string(), forDictStruct])),
+  enabled: optional(boolean()),
 });
 
 @customElement("ha-automation-condition-state")


### PR DESCRIPTION
## Proposed change
The schema for a `state` condition does not have `enabled` as a possible key. This causes the condition to not be editable in the visual editor when it gets disabled.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Add a state condition to an automation via the visual editor, then disable it.

## Additional information

- This PR fixes or closes issue: https://github.com/home-assistant/core/issues/79076#issuecomment-1374393182
**Note: does not fix the underlying issue #79076, just the issue reported in that comment.**

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
