### PR TITLE
Implement forecast types for Weather

### DIFF
--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -24,6 +24,7 @@ import {
 } from "home-assistant-js-websocket";
 import { css, html, svg, SVGTemplateResult, TemplateResult } from "lit";
 import { styleMap } from "lit/directives/style-map";
+import { supportsFeature } from "../common/entity/supports-feature";
 import { formatNumber } from "../common/number/format_number";
 import "../components/ha-svg-icon";
 import type { HomeAssistant } from "../types";
@@ -631,3 +632,16 @@ export const subscribeForecast = (
     forecast_type,
     entity_id,
   });
+
+export const getDefaultForecastType = (stateObj: HassEntityBase) => {
+  if (supportsFeature(stateObj, WeatherEntityFeature.FORECAST_DAILY)) {
+    return "daily";
+  }
+  if (supportsFeature(stateObj, WeatherEntityFeature.FORECAST_HOURLY)) {
+    return "hourly";
+  }
+  if (supportsFeature(stateObj, WeatherEntityFeature.FORECAST_TWICE_DAILY)) {
+    return "twice_daily";
+  }
+  return undefined;
+};

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -36,7 +36,7 @@ interface ForecastAttribute {
   precipitation_probability?: number;
   humidity?: number;
   condition?: string;
-  daytime?: boolean;
+  is_daytime?: boolean;
   pressure?: number;
   wind_speed?: string;
 }

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -545,60 +545,48 @@ export const getWeatherConvertibleUnits = (
     type: "weather/convertible_units",
   });
 
-export const Forecast_type = (
+export const getForecast = (
   forecast?: ForecastAttribute[],
-  forecast_daily?: ForecastAttribute[],
-  forecast_hourly?: ForecastAttribute[],
-  forecast_twice_daily?: ForecastAttribute[],
-  forecast_type?: string
+  forecastDaily?: ForecastAttribute[],
+  forecastHourly?: ForecastAttribute[],
+  forecastTwiceDaily?: ForecastAttribute[],
+  forecastType?: string | undefined
 ): ForecastAttribute[] | undefined => {
   if (
-    forecast_type === "daily" &&
-    forecast_daily?.length &&
-    forecast_daily?.length > 2
+    forecastType === "daily" &&
+    forecastDaily?.length &&
+    forecastDaily?.length > 2
   ) {
-    return forecast_daily;
+    return forecastDaily;
   }
   if (
-    forecast_type === "hourly" &&
-    forecast_hourly?.length &&
-    forecast_hourly?.length > 2
+    forecastType === "hourly" &&
+    forecastHourly?.length &&
+    forecastHourly?.length > 2
   ) {
-    return forecast_hourly;
+    return forecastHourly;
   }
   if (
-    forecast_type === "twice_daily" &&
-    forecast_twice_daily?.length &&
-    forecast_twice_daily?.length > 2
+    forecastType === "twice_daily" &&
+    forecastTwiceDaily?.length &&
+    forecastTwiceDaily?.length > 2
   ) {
-    return forecast_twice_daily;
+    return forecastTwiceDaily;
   }
-  if (
-    (forecast_type === "legacy" || forecast_type === undefined) &&
-    forecast?.length &&
-    forecast?.length > 2
-  ) {
+  if (forecastType === "legacy" && forecast?.length && forecast?.length > 2) {
     return forecast;
+  }
+  if (forecastType === undefined) {
+    if (forecastDaily?.length && forecastDaily?.length > 2) {
+      return forecastDaily;
+    }
+    if (forecastHourly?.length && forecastHourly?.length > 2) {
+      return forecastHourly;
+    }
+    if (forecastTwiceDaily?.length && forecastTwiceDaily?.length > 2) {
+      return forecastTwiceDaily;
+    }
   }
 
   return undefined;
-};
-
-export const Forecast_type_undefined = (
-  forecast?: ForecastAttribute[],
-  forecast_daily?: ForecastAttribute[],
-  forecast_hourly?: ForecastAttribute[],
-  forecast_twice_daily?: ForecastAttribute[]
-): ForecastAttribute[] | undefined => {
-  if (forecast_daily?.length && forecast_daily?.length > 2) {
-    return forecast_daily;
-  }
-  if (forecast_hourly?.length && forecast_hourly?.length > 2) {
-    return forecast_hourly;
-  }
-  if (forecast_twice_daily?.length && forecast_twice_daily?.length > 2) {
-    return forecast_twice_daily;
-  }
-
-  return forecast;
 };

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -571,7 +571,11 @@ export const Forecast_type = (
   ) {
     return forecast_twice_daily;
   }
-  if (forecast_type === undefined && forecast?.length && forecast?.length > 2) {
+  if (
+    (forecast_type === "legacy" || forecast_type === undefined) &&
+    forecast?.length &&
+    forecast?.length > 2
+  ) {
     return forecast;
   }
 

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -45,6 +45,10 @@ interface WeatherEntityAttributes extends HassEntityAttributeBase {
   attribution?: string;
   humidity?: number;
   forecast?: ForecastAttribute[];
+  forecast_daily?: ForecastAttribute[];
+  forecast_hourly?: ForecastAttribute[];
+  forecast_twice_daily?: ForecastAttribute[];
+  is_daytime?: boolean;
   pressure?: number;
   temperature?: number;
   visibility?: number;
@@ -538,3 +542,38 @@ export const getWeatherConvertibleUnits = (
   hass.callWS({
     type: "weather/convertible_units",
   });
+
+export const Forecast_type = (
+  forecast?: ForecastAttribute[],
+  forecast_daily?: ForecastAttribute[],
+  forecast_hourly?: ForecastAttribute[],
+  forecast_twice_daily?: ForecastAttribute[],
+  forecast_type?: string
+): ForecastAttribute[] | undefined => {
+  if (
+    forecast_type === "daily" &&
+    forecast_daily?.length &&
+    forecast_daily?.length > 2
+  ) {
+    return forecast_daily;
+  }
+  if (
+    forecast_type === "hourly" &&
+    forecast_hourly?.length &&
+    forecast_hourly?.length > 2
+  ) {
+    return forecast_hourly;
+  }
+  if (
+    forecast_type === "twice_daily" &&
+    forecast_twice_daily?.length &&
+    forecast_twice_daily?.length > 2
+  ) {
+    return forecast_twice_daily;
+  }
+  if (forecast_type === undefined && forecast?.length && forecast?.length > 2) {
+    return forecast;
+  }
+
+  return undefined;
+};

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -229,9 +229,10 @@ export const getWeatherUnit = (
 
 export const getSecondaryWeatherAttribute = (
   hass: HomeAssistant,
-  stateObj: WeatherEntity
+  stateObj: WeatherEntity,
+  forecast: ForecastAttribute[]
 ): TemplateResult | undefined => {
-  const extrema = getWeatherExtrema(hass, stateObj);
+  const extrema = getWeatherExtrema(hass, stateObj, forecast);
 
   if (extrema) {
     return extrema;
@@ -241,11 +242,11 @@ export const getSecondaryWeatherAttribute = (
   let attribute: string;
 
   if (
-    stateObj.attributes.forecast?.length &&
-    stateObj.attributes.forecast[0].precipitation !== undefined &&
-    stateObj.attributes.forecast[0].precipitation !== null
+    forecast?.length &&
+    forecast[0].precipitation !== undefined &&
+    forecast[0].precipitation !== null
   ) {
-    value = stateObj.attributes.forecast[0].precipitation!;
+    value = forecast[0].precipitation!;
     attribute = "precipitation";
   } else if ("humidity" in stateObj.attributes) {
     value = stateObj.attributes.humidity!;
@@ -269,9 +270,10 @@ export const getSecondaryWeatherAttribute = (
 
 const getWeatherExtrema = (
   hass: HomeAssistant,
-  stateObj: WeatherEntity
+  stateObj: WeatherEntity,
+  forecast: ForecastAttribute[]
 ): TemplateResult | undefined => {
-  if (!stateObj.attributes.forecast?.length) {
+  if (!forecast?.length) {
     return undefined;
   }
 
@@ -279,18 +281,18 @@ const getWeatherExtrema = (
   let tempHigh: number | undefined;
   const today = new Date().getDate();
 
-  for (const forecast of stateObj.attributes.forecast!) {
-    if (new Date(forecast.datetime).getDate() !== today) {
+  for (const fc of forecast!) {
+    if (new Date(fc.datetime).getDate() !== today) {
       break;
     }
-    if (!tempHigh || forecast.temperature > tempHigh) {
-      tempHigh = forecast.temperature;
+    if (!tempHigh || fc.temperature > tempHigh) {
+      tempHigh = fc.temperature;
     }
-    if (!tempLow || (forecast.templow && forecast.templow < tempLow)) {
-      tempLow = forecast.templow;
+    if (!tempLow || (fc.templow && fc.templow < tempLow)) {
+      tempLow = fc.templow;
     }
-    if (!forecast.templow && (!tempLow || forecast.temperature < tempLow)) {
-      tempLow = forecast.temperature;
+    if (!fc.templow && (!tempLow || fc.temperature < tempLow)) {
+      tempLow = fc.temperature;
     }
   }
 
@@ -580,4 +582,23 @@ export const Forecast_type = (
   }
 
   return undefined;
+};
+
+export const Forecast_type_undefined = (
+  forecast?: ForecastAttribute[],
+  forecast_daily?: ForecastAttribute[],
+  forecast_hourly?: ForecastAttribute[],
+  forecast_twice_daily?: ForecastAttribute[]
+): ForecastAttribute[] | undefined => {
+  if (forecast_daily?.length && forecast_daily?.length > 2) {
+    return forecast_daily;
+  }
+  if (forecast_hourly?.length && forecast_hourly?.length > 2) {
+    return forecast_hourly;
+  }
+  if (forecast_twice_daily?.length && forecast_twice_daily?.length > 2) {
+    return forecast_twice_daily;
+  }
+
+  return forecast;
 };

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -616,21 +616,21 @@ export const getForecast = (
       forecast_event?.type === "daily" &&
       forecast_event?.forecast &&
       forecast_event?.forecast?.length > 2
-      ) {
+    ) {
       return { forecast: forecast_event.forecast, type: "daily" };
     }
     if (
       forecast_event?.type === "hourly" &&
       forecast_event?.forecast &&
       forecast_event?.forecast?.length > 2
-      ) {
+    ) {
       return { forecast: forecast_event.forecast, type: "hourly" };
     }
     if (
       forecast_event?.type === "twice_daily" &&
       forecast_event?.forecast &&
       forecast_event?.forecast?.length > 2
-      ) {
+    ) {
       return {
         forecast: forecast_event.forecast,
         type: "twice_daily",
@@ -662,12 +662,11 @@ export const getForecast = (
   return undefined;
 };
 
-
 export const subscribeForecast = (
   hass: HomeAssistant,
   entity_id: string,
   forecast_type: "daily" | "hourly" | "twice_daily",
-  callback: (forecastevent: ForecastEvent) => void,
+  callback: (forecastevent: ForecastEvent) => void
 ) =>
   hass.connection.subscribeMessage<ForecastEvent>(callback, {
     type: "weather/subscribe_forecast",

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -567,7 +567,7 @@ export const getForecast = (
   | undefined => {
   if (
     forecast_type === "daily" &&
-    forecast_event?.type == "daily" &&
+    forecast_event?.type === "daily" &&
     forecast_event?.forecast &&
     forecast_event?.forecast?.length > 2
   ) {
@@ -575,7 +575,7 @@ export const getForecast = (
   }
   if (
     forecast_type === "hourly" &&
-    forecast_event?.type == "hourly" &&
+    forecast_event?.type === "hourly" &&
     forecast_event?.forecast &&
     forecast_event?.forecast?.length > 2
   ) {
@@ -583,7 +583,7 @@ export const getForecast = (
   }
   if (
     forecast_type === "twice_daily" &&
-    forecast_event?.type == "twice_daily" &&
+    forecast_event?.type === "twice_daily" &&
     forecast_event?.forecast &&
     forecast_event?.forecast?.length > 2
   ) {
@@ -613,21 +613,21 @@ export const getForecast = (
   }
   if (forecast_type === undefined) {
     if (
-      forecast_event?.type == "daily" &&
+      forecast_event?.type === "daily" &&
       forecast_event?.forecast &&
       forecast_event?.forecast?.length > 2
       ) {
       return { forecast: forecast_event.forecast, type: "daily" };
     }
     if (
-      forecast_event?.type == "hourly" &&
+      forecast_event?.type === "hourly" &&
       forecast_event?.forecast &&
       forecast_event?.forecast?.length > 2
       ) {
       return { forecast: forecast_event.forecast, type: "hourly" };
     }
     if (
-      forecast_event?.type == "twice_daily" &&
+      forecast_event?.type === "twice_daily" &&
       forecast_event?.forecast &&
       forecast_event?.forecast?.length > 2
       ) {

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -43,19 +43,13 @@ class MoreInfoWeather extends LitElement {
   @state() private _subscribed?: Promise<() => void>;
 
   private _needForecastSubscription() {
-    return (
-      supportsFeature(
-        this.stateObj as HassEntityBase,
-        WeatherEntityFeature.FORECAST_DAILY
-      ) ||
-      supportsFeature(
-        this.stateObj as HassEntityBase,
-        WeatherEntityFeature.FORECAST_HOURLY
-      ) ||
-      supportsFeature(
-        this.stateObj as HassEntityBase,
+    return supportsFeature(
+      this.stateObj as HassEntityBase,
+      // eslint-disable-next-line no-bitwise
+      WeatherEntityFeature.FORECAST_DAILY |
+        // eslint-disable-next-line no-bitwise
+        WeatherEntityFeature.FORECAST_HOURLY |
         WeatherEntityFeature.FORECAST_TWICE_DAILY
-      )
     );
   }
 

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -40,7 +40,7 @@ class MoreInfoWeather extends LitElement {
 
   @state() private _forecastEvent?: ForecastEvent;
 
-  @state() private _subscribed?: () => void;
+  @state() private _subscribed?: Promise<() => void>;
 
   private _needForecastSubscription() {
     return (
@@ -93,12 +93,12 @@ class MoreInfoWeather extends LitElement {
 
   private async _subscribeForecastEvents() {
     if (this._subscribed) {
-      this._subscribed();
+      this._subscribed.then((unsub) => unsub());
       this._subscribed = undefined;
     }
     const forecastType = this._forecastType();
     if (forecastType) {
-      this._subscribed = await subscribeForecast(
+      this._subscribed = subscribeForecast(
         this.hass!,
         this.stateObj!.entity_id,
         forecastType,
@@ -110,7 +110,7 @@ class MoreInfoWeather extends LitElement {
   public disconnectedCallback(): void {
     super.disconnectedCallback();
     if (this._subscribed) {
-      this._subscribed();
+      this._subscribed.then((unsub) => unsub());
       this._subscribed = undefined;
     }
   }

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -56,8 +56,8 @@ class MoreInfoWeather extends LitElement {
     }
 
     const forecastData = getForecast(this.stateObj.attributes);
-    const forecast = forecastData?.[0];
-    const hourly = forecastData?.[1] === "hourly";
+    const forecast = forecastData?.forecast;
+    const hourly = forecastData?.type === "hourly";
 
     return html`
       ${this._showValue(this.stateObj.attributes.temperature)

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -22,7 +22,6 @@ import {
   getForecast,
   getWeatherUnit,
   getWind,
-  isForecastHourly,
   WeatherEntity,
   weatherIcons,
 } from "../../../data/weather";
@@ -56,14 +55,9 @@ class MoreInfoWeather extends LitElement {
       return nothing;
     }
 
-    const forecast = getForecast(
-      this.stateObj.attributes.forecast,
-      this.stateObj.attributes.forecast_daily,
-      this.stateObj.attributes.forecast_hourly,
-      this.stateObj.attributes.forecast_twice_daily
-    );
-
-    const hourly = isForecastHourly(forecast);
+    const forecastData = getForecast(this.stateObj.attributes);
+    const forecast = forecastData?.[0];
+    const hourly = forecastData?.[1] === "hourly";
 
     return html`
       ${this._showValue(this.stateObj.attributes.temperature)
@@ -184,7 +178,7 @@ class MoreInfoWeather extends LitElement {
                               this.hass.locale,
                               this.hass.config
                             )}
-                            ${item.is_daytime === undefined || item.is_daytime
+                            ${item.is_daytime !== false
                               ? this.hass!.localize("ui.card.weather.day")
                               : this.hass!.localize("ui.card.weather.night")}
                           </div>

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -205,6 +205,149 @@ class MoreInfoWeather extends LitElement {
             )}
           `
         : ""}
+      ${this.stateObj.attributes.forecast_daily
+        ? html`
+            <div class="section">
+              ${this.hass.localize("ui.card.weather.forecast_daily")}:
+            </div>
+            ${this.stateObj.attributes.forecast_daily.map((item) =>
+              this._showValue(item.templow) || this._showValue(item.temperature)
+                ? html`<div class="flex">
+                    ${item.condition
+                      ? html`
+                          <ha-svg-icon
+                            .path=${weatherIcons[item.condition]}
+                          ></ha-svg-icon>
+                          <div class="main">
+                            ${formatDateWeekdayDay(
+                              new Date(item.datetime),
+                              this.hass.locale
+                            )}
+                          </div>
+                        `
+                      : ""}
+                    <div class="templow">
+                      ${this._showValue(item.templow)
+                        ? `${formatNumber(item.templow!, this.hass.locale)}
+                          ${getWeatherUnit(
+                            this.hass,
+                            this.stateObj!,
+                            "temperature"
+                          )}`
+                        : "—"}
+                    </div>
+                    <div class="temp">
+                      ${this._showValue(item.temperature)
+                        ? `${formatNumber(item.temperature!, this.hass.locale)}
+                        ${getWeatherUnit(
+                          this.hass,
+                          this.stateObj!,
+                          "temperature"
+                        )}`
+                        : "—"}
+                    </div>
+                  </div>`
+                : ""
+            )}
+          `
+        : ""}
+      ${this.stateObj.attributes.forecast_hourly
+        ? html`
+            <div class="section">
+              ${this.hass.localize("ui.card.weather.forecast_hourly")}:
+            </div>
+            ${this.stateObj.attributes.forecast_hourly.map((item) =>
+              this._showValue(item.templow) || this._showValue(item.temperature)
+                ? html`<div class="flex">
+                    ${item.condition
+                      ? html`
+                          <ha-svg-icon
+                            .path=${weatherIcons[item.condition]}
+                          ></ha-svg-icon>
+                          <div class="main">
+                            ${formatTimeWeekday(
+                              new Date(item.datetime),
+                              this.hass.locale
+                            )}
+                          </div>
+                        `
+                      : ""}
+                    <div class="templow">
+                      ${this._showValue(item.templow)
+                        ? `${formatNumber(item.templow!, this.hass.locale)}
+                          ${getWeatherUnit(
+                            this.hass,
+                            this.stateObj!,
+                            "temperature"
+                          )}`
+                        : ""}
+                    </div>
+                    <div class="temp">
+                      ${this._showValue(item.temperature)
+                        ? `${formatNumber(item.temperature!, this.hass.locale)}
+                        ${getWeatherUnit(
+                          this.hass,
+                          this.stateObj!,
+                          "temperature"
+                        )}`
+                        : "—"}
+                    </div>
+                  </div>`
+                : ""
+            )}
+          `
+        : ""}
+      ${this.stateObj.attributes.forecast_twice_daily
+        ? html`
+            <div class="section">
+              ${this.hass.localize("ui.card.weather.forecast_twice_daily")}:
+            </div>
+            ${this.stateObj.attributes.forecast_twice_daily.map((item) =>
+              this._showValue(item.templow) || this._showValue(item.temperature)
+                ? html`<div class="flex">
+                    ${item.condition
+                      ? html`
+                          <ha-svg-icon
+                            .path=${weatherIcons[item.condition]}
+                          ></ha-svg-icon>
+                          <div class="main">
+                            ${formatDateWeekdayDay(
+                              new Date(item.datetime),
+                              this.hass.locale
+                            )}
+                            ${item.is_daytime === undefined || item.is_daytime
+                              ? this.hass!.localize("ui.card.weather.day")
+                              : this.hass!.localize("ui.card.weather.night")}
+                          </div>
+                        `
+                      : ""}
+                    <div class="templow">
+                      ${this._showValue(item.templow)
+                        ? `${formatNumber(item.templow!, this.hass.locale)}
+                          ${getWeatherUnit(
+                            this.hass,
+                            this.stateObj!,
+                            "temperature"
+                          )}`
+                        : hourly
+                        ? ""
+                        : "—"}
+                    </div>
+                    <div class="temp">
+                      ${this._showValue(item.temperature)
+                        ? `${formatNumber(item.temperature!, this.hass.locale)}
+                        ${getWeatherUnit(
+                          this.hass,
+                          this.stateObj!,
+                          "temperature"
+                        )}`
+                        : "—"}
+                    </div>
+                  </div>`
+                : ""
+            )}
+          `
+        : ""}
       ${this.stateObj.attributes.attribution
         ? html`
             <div class="attribution">

--- a/src/dialogs/more-info/controls/more-info-weather.ts
+++ b/src/dialogs/more-info/controls/more-info-weather.ts
@@ -19,6 +19,7 @@ import { formatTimeWeekday } from "../../../common/datetime/format_time";
 import { formatNumber } from "../../../common/number/format_number";
 import "../../../components/ha-svg-icon";
 import {
+  getForecast,
   getWeatherUnit,
   getWind,
   isForecastHourly,
@@ -55,7 +56,14 @@ class MoreInfoWeather extends LitElement {
       return nothing;
     }
 
-    const hourly = isForecastHourly(this.stateObj.attributes.forecast);
+    const forecast = getForecast(
+      this.stateObj.attributes.forecast,
+      this.stateObj.attributes.forecast_daily,
+      this.stateObj.attributes.forecast_hourly,
+      this.stateObj.attributes.forecast_twice_daily
+    );
+
+    const hourly = isForecastHourly(forecast);
 
     return html`
       ${this._showValue(this.stateObj.attributes.temperature)
@@ -144,12 +152,12 @@ class MoreInfoWeather extends LitElement {
             </div>
           `
         : ""}
-      ${this.stateObj.attributes.forecast
+      ${forecast
         ? html`
             <div class="section">
               ${this.hass.localize("ui.card.weather.forecast")}:
             </div>
-            ${this.stateObj.attributes.forecast.map((item) =>
+            ${forecast.map((item) =>
               this._showValue(item.templow) || this._showValue(item.temperature)
                 ? html`<div class="flex">
                     ${item.condition
@@ -176,151 +184,11 @@ class MoreInfoWeather extends LitElement {
                               this.hass.locale,
                               this.hass.config
                             )}
-                          </div>
-                        `}
-                    <div class="templow">
-                      ${this._showValue(item.templow)
-                        ? `${formatNumber(item.templow!, this.hass.locale)}
-                          ${getWeatherUnit(
-                            this.hass,
-                            this.stateObj!,
-                            "temperature"
-                          )}`
-                        : hourly
-                        ? ""
-                        : "—"}
-                    </div>
-                    <div class="temp">
-                      ${this._showValue(item.temperature)
-                        ? `${formatNumber(item.temperature!, this.hass.locale)}
-                        ${getWeatherUnit(
-                          this.hass,
-                          this.stateObj!,
-                          "temperature"
-                        )}`
-                        : "—"}
-                    </div>
-                  </div>`
-                : ""
-            )}
-          `
-        : ""}
-      ${this.stateObj.attributes.forecast_daily
-        ? html`
-            <div class="section">
-              ${this.hass.localize("ui.card.weather.forecast_daily")}:
-            </div>
-            ${this.stateObj.attributes.forecast_daily.map((item) =>
-              this._showValue(item.templow) || this._showValue(item.temperature)
-                ? html`<div class="flex">
-                    ${item.condition
-                      ? html`
-                          <ha-svg-icon
-                            .path=${weatherIcons[item.condition]}
-                          ></ha-svg-icon>
-                          <div class="main">
-                            ${formatDateWeekdayDay(
-                              new Date(item.datetime),
-                              this.hass.locale
-                            )}
-                          </div>
-                        `
-                      : ""}
-                    <div class="templow">
-                      ${this._showValue(item.templow)
-                        ? `${formatNumber(item.templow!, this.hass.locale)}
-                          ${getWeatherUnit(
-                            this.hass,
-                            this.stateObj!,
-                            "temperature"
-                          )}`
-                        : "—"}
-                    </div>
-                    <div class="temp">
-                      ${this._showValue(item.temperature)
-                        ? `${formatNumber(item.temperature!, this.hass.locale)}
-                        ${getWeatherUnit(
-                          this.hass,
-                          this.stateObj!,
-                          "temperature"
-                        )}`
-                        : "—"}
-                    </div>
-                  </div>`
-                : ""
-            )}
-          `
-        : ""}
-      ${this.stateObj.attributes.forecast_hourly
-        ? html`
-            <div class="section">
-              ${this.hass.localize("ui.card.weather.forecast_hourly")}:
-            </div>
-            ${this.stateObj.attributes.forecast_hourly.map((item) =>
-              this._showValue(item.templow) || this._showValue(item.temperature)
-                ? html`<div class="flex">
-                    ${item.condition
-                      ? html`
-                          <ha-svg-icon
-                            .path=${weatherIcons[item.condition]}
-                          ></ha-svg-icon>
-                          <div class="main">
-                            ${formatTimeWeekday(
-                              new Date(item.datetime),
-                              this.hass.locale
-                            )}
-                          </div>
-                        `
-                      : ""}
-                    <div class="templow">
-                      ${this._showValue(item.templow)
-                        ? `${formatNumber(item.templow!, this.hass.locale)}
-                          ${getWeatherUnit(
-                            this.hass,
-                            this.stateObj!,
-                            "temperature"
-                          )}`
-                        : ""}
-                    </div>
-                    <div class="temp">
-                      ${this._showValue(item.temperature)
-                        ? `${formatNumber(item.temperature!, this.hass.locale)}
-                        ${getWeatherUnit(
-                          this.hass,
-                          this.stateObj!,
-                          "temperature"
-                        )}`
-                        : "—"}
-                    </div>
-                  </div>`
-                : ""
-            )}
-          `
-        : ""}
-      ${this.stateObj.attributes.forecast_twice_daily
-        ? html`
-            <div class="section">
-              ${this.hass.localize("ui.card.weather.forecast_twice_daily")}:
-            </div>
-            ${this.stateObj.attributes.forecast_twice_daily.map((item) =>
-              this._showValue(item.templow) || this._showValue(item.temperature)
-                ? html`<div class="flex">
-                    ${item.condition
-                      ? html`
-                          <ha-svg-icon
-                            .path=${weatherIcons[item.condition]}
-                          ></ha-svg-icon>
-                          <div class="main">
-                            ${formatDateWeekdayDay(
-                              new Date(item.datetime),
-                              this.hass.locale
-                            )}
                             ${item.is_daytime === undefined || item.is_daytime
                               ? this.hass!.localize("ui.card.weather.day")
                               : this.hass!.localize("ui.card.weather.night")}
                           </div>
-                        `
-                      : ""}
+                        `}
                     <div class="templow">
                       ${this._showValue(item.templow)
                         ? `${formatNumber(item.templow!, this.hass.locale)}

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -74,7 +74,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
   @state() private _forecastEvent?: ForecastEvent;
 
-  @state() private _subscribed?: () => void;
+  @state() private _subscribed?: Promise<() => void>;
 
   @property({ type: Boolean, reflect: true, attribute: "veryverynarrow" })
   private _veryVeryNarrow = false;
@@ -93,14 +93,14 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
 
   private async _subscribeForecastEvents() {
     if (this._subscribed) {
-      this._subscribed();
+      this._subscribed.then((unsub) => unsub());
       this._subscribed = undefined;
     }
     if (
       this._config!.forecast_type &&
       this._config!.forecast_type !== "legacy"
     ) {
-      this._subscribed = await subscribeForecast(
+      this._subscribed = subscribeForecast(
         this.hass!,
         this._config!.entity,
         this._config!.forecast_type,
@@ -119,7 +119,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       this._resizeObserver.disconnect();
     }
     if (this._subscribed) {
-      this._subscribed();
+      this._subscribed.then((unsub) => unsub());
       this._subscribed = undefined;
     }
   }

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -20,7 +20,7 @@ import "../../../components/ha-svg-icon";
 import { UNAVAILABLE } from "../../../data/entity";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import {
-  Forecast_type,
+  getForecast,
   getSecondaryWeatherAttribute,
   getWeatherStateIcon,
   getWeatherUnit,
@@ -173,7 +173,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       `;
     }
 
-    const forecast_type = Forecast_type(
+    const forecastType = getForecast(
       stateObj.attributes.forecast,
       stateObj.attributes.forecast_daily,
       stateObj.attributes.forecast_hourly,
@@ -181,8 +181,8 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       this._config?.forecast_type
     );
     const forecast =
-      this._config?.show_forecast !== false && forecast_type?.length
-        ? forecast_type.slice(0, this._veryVeryNarrow ? 3 : 5)
+      this._config?.show_forecast !== false && forecastType?.length
+        ? forecastType.slice(0, this._veryVeryNarrow ? 3 : 5)
         : undefined;
     const weather = !forecast || this._config?.show_current !== false;
 
@@ -198,7 +198,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
     }
 
     const twice_daily =
-      this._config?.forecast_type === "twice_daily" ? true : undefined;
+      this._config?.forecastType === "twice_daily" ? true : undefined;
     if (twice_daily) {
       dayNight = true;
     }

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -175,13 +175,13 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       this._config?.forecast_type
     );
     const forecast =
-      this._config?.show_forecast !== false && forecastData?.[0]?.length
-        ? forecastData[0].slice(0, this._veryVeryNarrow ? 3 : 5)
+      this._config?.show_forecast !== false && forecastData?.forecast?.length
+        ? forecastData.forecast.slice(0, this._veryVeryNarrow ? 3 : 5)
         : undefined;
     const weather = !forecast || this._config?.show_current !== false;
 
-    const hourly = forecastData?.[1];
-    const dayNight = forecastData?.[2];
+    const hourly = forecastData?.type === "hourly";
+    const dayNight = forecastData?.type === "twice_daily";
 
     const weatherStateIcon = getWeatherStateIcon(stateObj.state, this);
     const name = this._config.name ?? computeStateName(stateObj);

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -73,6 +73,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   @state() private _config?: WeatherForecastCardConfig;
 
   @state() private _forecastEvent?: ForecastEvent;
+
   @state() private _subscribed?: () => void;
 
   @property({ type: Boolean, reflect: true, attribute: "veryverynarrow" })
@@ -91,7 +92,7 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
     }
     if (
       this._config!.forecast_type &&
-      this._config!.forecast_type != "legacy"
+      this._config!.forecast_type !== "legacy"
     ) {
       this._subscribed = await subscribeForecast(
         this.hass!,

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -111,6 +111,10 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
     if (this._resizeObserver) {
       this._resizeObserver.disconnect();
     }
+    if (this._subscribed) {
+      this._subscribed();
+      this._subscribed = undefined;
+    }
   }
 
   public getCardSize(): number {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -298,7 +298,11 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                                   )}
                                 `}
                           `
-                        : getSecondaryWeatherAttribute(this.hass, stateObj)}
+                        : getSecondaryWeatherAttribute(
+                            this.hass,
+                            stateObj,
+                            forecast!
+                          )}
                     </div>
                   </div>
                 </div>

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -20,6 +20,7 @@ import "../../../components/ha-svg-icon";
 import { UNAVAILABLE } from "../../../data/entity";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import {
+  Forecast_type,
   getSecondaryWeatherAttribute,
   getWeatherStateIcon,
   getWeatherUnit,
@@ -172,10 +173,16 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       `;
     }
 
+    const forecast_type = Forecast_type(
+      stateObj.attributes.forecast,
+      stateObj.attributes.forecast_daily,
+      stateObj.attributes.forecast_hourly,
+      stateObj.attributes.forecast_twice_daily,
+      this._config?.forecast_type
+    );
     const forecast =
-      this._config?.show_forecast !== false &&
-      stateObj.attributes.forecast?.length
-        ? stateObj.attributes.forecast.slice(0, this._veryVeryNarrow ? 3 : 5)
+      this._config?.show_forecast !== false && forecast_type?.length
+        ? forecast_type.slice(0, this._veryVeryNarrow ? 3 : 5)
         : undefined;
     const weather = !forecast || this._config?.show_current !== false;
 

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -141,7 +141,10 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
-    return hasConfigOrEntityChanged(this, changedProps) || changedProps.has("forecastEvent");
+    return (
+      hasConfigOrEntityChanged(this, changedProps) ||
+      changedProps.has("forecastEvent")
+    );
   }
 
   public willUpdate(): void {

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -197,6 +197,12 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       dayNight = dayDiff > DAY_IN_MILLISECONDS;
     }
 
+    const twice_daily =
+      this._config?.forecast_type === "twice_daily" ? true : undefined;
+    if (twice_daily) {
+      dayNight = true;
+    }
+
     const weatherStateIcon = getWeatherStateIcon(stateObj.state, this);
     const name = this._config.name ?? computeStateName(stateObj);
 
@@ -315,7 +321,8 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                                     { weekday: "short" }
                                   )}
                                   <div class="daynight">
-                                    ${item.daytime === undefined || item.daytime
+                                    ${item.is_daytime === undefined ||
+                                    item.is_daytime
                                       ? this.hass!.localize(
                                           "ui.card.weather.day"
                                         )
@@ -347,7 +354,8 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
                                     item.condition!,
                                     this,
                                     !(
-                                      item.daytime || item.daytime === undefined
+                                      item.is_daytime ||
+                                      item.is_daytime === undefined
                                     )
                                   )}
                                 </div>

--- a/src/panels/lovelace/cards/hui-weather-forecast-card.ts
+++ b/src/panels/lovelace/cards/hui-weather-forecast-card.ts
@@ -85,6 +85,12 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
     this._forecastEvent = forecastEvent;
   }
 
+  private _needForecastSubscription() {
+    return (
+      this._config!.forecast_type && this._config!.forecast_type !== "legacy"
+    );
+  }
+
   private async _subscribeForecastEvents() {
     if (this._subscribed) {
       this._subscribed();
@@ -163,7 +169,10 @@ class HuiWeatherForecastCard extends LitElement implements LovelaceCard {
       return;
     }
 
-    if (changedProps.has("_config")) {
+    if (
+      this._needForecastSubscription() &&
+      (changedProps.has("_config") || !this._subscribed)
+    ) {
       this._subscribeForecastEvents();
     }
 

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -444,6 +444,7 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
   name?: string;
   show_current?: boolean;
   show_forecast?: boolean;
+  forecast_type?: string;
   secondary_info_attribute?: keyof TranslationDict["ui"]["card"]["weather"]["attributes"];
   theme?: string;
   tap_action?: ActionConfig;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -12,6 +12,7 @@ import {
 import { LovelaceHeaderFooterConfig } from "../header-footer/types";
 import { HaDurationData } from "../../../components/ha-duration-input";
 import { LovelaceTileFeatureConfig } from "../tile-features/types";
+import { ForecastType } from "../../../data/weather";
 
 export interface AlarmPanelCardConfig extends LovelaceCardConfig {
   entity: string;
@@ -444,7 +445,7 @@ export interface WeatherForecastCardConfig extends LovelaceCardConfig {
   name?: string;
   show_current?: boolean;
   show_forecast?: boolean;
-  forecast_type?: string;
+  forecast_type?: ForecastType;
   secondary_info_attribute?: keyof TranslationDict["ui"]["card"]["weather"]["attributes"];
   theme?: string;
   tap_action?: ActionConfig;

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -101,22 +101,19 @@ export class HuiWeatherForecastCardEditor
     if (forecastType === "daily") {
       return !!(
         stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features &
-          WeatherEntityFeature.FORECAST_DAILY
+        stateObj.attributes.supported_features === WeatherEntityFeature.FORECAST_DAILY
       );
     }
     if (forecastType === "hourly") {
       return !!(
         stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features &
-          WeatherEntityFeature.FORECAST_HOURLY
+        stateObj.attributes.supported_features === WeatherEntityFeature.FORECAST_HOURLY
       );
     }
     if (forecastType === "twice_daily") {
       return !!(
         stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features &
-          WeatherEntityFeature.FORECAST_TWICE_DAILY
+        stateObj.attributes.supported_features === WeatherEntityFeature.FORECAST_TWICE_DAILY
       );
     }
     return false

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -22,6 +22,7 @@ const cardConfigStruct = assign(
     theme: optional(string()),
     show_current: optional(boolean()),
     show_forecast: optional(boolean()),
+    forecast_type: optional(string()),
     secondary_info_attribute: optional(string()),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
@@ -59,7 +60,12 @@ export class HuiWeatherForecastCardEditor
     if (this.hass && this._config) {
       const stateObj = this.hass.states[this._config.entity] as WeatherEntity;
       if (stateObj && stateObj.state !== UNAVAILABLE) {
-        return !!stateObj.attributes.forecast?.length;
+        return !!(
+          stateObj.attributes.forecast?.length ||
+          stateObj.attributes.forecast_daily?.length ||
+          stateObj.attributes.forecast_hourly?.length ||
+          stateObj.attributes.forecast_twice_daily?.length
+        );
       }
     }
     return undefined;
@@ -86,35 +92,41 @@ export class HuiWeatherForecastCardEditor
             { name: "theme", selector: { theme: {} } },
           ],
         },
-        {
-          name: "forecast_type",
-          selector: {
-            select: {
-              options: [
-                {
-                  value: "daily",
-                  label: localize(
-                    "ui.panel.lovelace.editor.card.weather-forecast.daily"
-                  ),
-                },
-                {
-                  value: "hourly",
-                  label: localize(
-                    "ui.panel.lovelace.editor.card.weather-forecast.hourly"
-                  ),
-                },
-                {
-                  value: "twice_daily",
-                  label: localize(
-                    "ui.panel.lovelace.editor.card.weather-forecast.twice_daily"
-                  ),
-                },
-              ],
-            },
-          },
-        },
         ...(hasForecast
           ? ([
+              {
+                name: "forecast_type",
+                selector: {
+                  select: {
+                    options: [
+                      {
+                        value: "legacy",
+                        label: localize(
+                          "ui.panel.lovelace.editor.card.weather-forecast.no_type"
+                        ),
+                      },
+                      {
+                        value: "daily",
+                        label: localize(
+                          "ui.panel.lovelace.editor.card.weather-forecast.daily"
+                        ),
+                      },
+                      {
+                        value: "hourly",
+                        label: localize(
+                          "ui.panel.lovelace.editor.card.weather-forecast.hourly"
+                        ),
+                      },
+                      {
+                        value: "twice_daily",
+                        label: localize(
+                          "ui.panel.lovelace.editor.card.weather-forecast.twice_daily"
+                        ),
+                      },
+                    ],
+                  },
+                },
+              },
               {
                 name: "forecast",
                 selector: {

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -212,6 +212,10 @@ export class HuiWeatherForecastCardEditor
                   },
                 },
               },
+            ] as const)
+          : []),
+        ...(hasForecast
+          ? ([
               {
                 name: "forecast",
                 selector: {

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -61,10 +61,10 @@ export class HuiWeatherForecastCardEditor
       let forecastType: string | undefined;
       if (this._forecastSupported("daily")) {
         forecastType = "daily";
-      } else if (this._forecastSupported("twice_daily")) {
-        forecastType = "twice_daily";
       } else if (this._forecastSupported("hourly")) {
         forecastType = "hourly";
+      } else if (this._forecastSupported("twice_daily")) {
+        forecastType = "twice_daily";
       } else if (this._forecastSupported("legacy")) {
         forecastType = "legacy";
       }

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -143,30 +143,46 @@ export class HuiWeatherForecastCardEditor
                 selector: {
                   select: {
                     options: [
-                      {
-                        value: "legacy",
-                        label: localize(
-                          "ui.panel.lovelace.editor.card.weather-forecast.no_type"
-                        ),
-                      },
-                      {
-                        value: "daily",
-                        label: localize(
-                          "ui.panel.lovelace.editor.card.weather-forecast.daily"
-                        ),
-                      },
-                      {
-                        value: "hourly",
-                        label: localize(
-                          "ui.panel.lovelace.editor.card.weather-forecast.hourly"
-                        ),
-                      },
-                      {
-                        value: "twice_daily",
-                        label: localize(
-                          "ui.panel.lovelace.editor.card.weather-forecast.twice_daily"
-                        ),
-                      },
+                      ...(hasForecastLegacy
+                        ? ([
+                            {
+                              value: "legacy",
+                              label: localize(
+                                "ui.panel.lovelace.editor.card.weather-forecast.no_type"
+                              ),
+                            },
+                          ] as const)
+                        : []),
+                      ...(hasForecastDaily
+                        ? ([
+                            {
+                              value: "daily",
+                              label: localize(
+                                "ui.panel.lovelace.editor.card.weather-forecast.daily"
+                              ),
+                            },
+                          ] as const)
+                        : []),
+                      ...(hasForecastHourly
+                        ? ([
+                            {
+                              value: "hourly",
+                              label: localize(
+                                "ui.panel.lovelace.editor.card.weather-forecast.hourly"
+                              ),
+                            },
+                          ] as const)
+                        : []),
+                      ...(hasForecastTwiceDaily
+                        ? ([
+                            {
+                              value: "twice_daily",
+                              label: localize(
+                                "ui.panel.lovelace.editor.card.weather-forecast.twice_daily"
+                              ),
+                            },
+                          ] as const)
+                        : []),
                     ],
                   },
                 },

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -54,7 +54,10 @@ export class HuiWeatherForecastCardEditor
         config: { ...config, show_current: true, show_forecast: false },
       });
     }
-    if (!config.forecast_type) {
+    if (
+      !config.forecast_type ||
+      !this._forecastSupported(config.forecast_type)
+    ) {
       let forecastType = "legacy";
       if (this._forecastTwiceDaily === true) {
         forecastType = "twice_daily";
@@ -87,6 +90,23 @@ export class HuiWeatherForecastCardEditor
         stateObj.attributes.forecast_hourly?.length ||
         stateObj.attributes.forecast_twice_daily?.length
       );
+    }
+    return undefined;
+  }
+
+  private _forecastSupported(forecastType: string): boolean | undefined {
+    const stateObj = this._stateObj as WeatherEntity;
+    if (forecastType === "legacy") {
+      return !!stateObj.attributes.forecast?.length;
+    }
+    if (forecastType === "twice_daily") {
+      return !!stateObj.attributes.forecast_twice_daily?.length;
+    }
+    if (forecastType === "hourly") {
+      return !!stateObj.attributes.forecast_hourly?.length;
+    }
+    if (forecastType === "daily") {
+      return !!stateObj.attributes.forecast_daily?.length;
     }
     return undefined;
   }

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -54,6 +54,21 @@ export class HuiWeatherForecastCardEditor
         config: { ...config, show_current: true, show_forecast: false },
       });
     }
+    if (!config.forecast_type) {
+      let _forecast_type = "legacy";
+      if (this._forecast_twice_daily === true) {
+        _forecast_type = "twice_daily";
+      }
+      if (this._forecast_hourly === true) {
+        _forecast_type = "hourly";
+      }
+      if (this._forecast_daily === true) {
+        _forecast_type = "daily";
+      }
+      fireEvent(this, "config-changed", {
+        config: { ...config, forecast_type: _forecast_type },
+      });
+    }
   }
 
   get _stateObj(): WeatherEntity | undefined {

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -101,22 +101,25 @@ export class HuiWeatherForecastCardEditor
     if (forecastType === "daily") {
       return !!(
         stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features === WeatherEntityFeature.FORECAST_DAILY
+        stateObj.attributes.supported_features ===
+          WeatherEntityFeature.FORECAST_DAILY
       );
     }
     if (forecastType === "hourly") {
       return !!(
         stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features === WeatherEntityFeature.FORECAST_HOURLY
+        stateObj.attributes.supported_features ===
+          WeatherEntityFeature.FORECAST_HOURLY
       );
     }
     if (forecastType === "twice_daily") {
       return !!(
         stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features === WeatherEntityFeature.FORECAST_TWICE_DAILY
+        stateObj.attributes.supported_features ===
+          WeatherEntityFeature.FORECAST_TWICE_DAILY
       );
     }
-    return false
+    return false;
   }
 
   private _schema = memoizeOne(

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -8,6 +8,7 @@ import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import { UNAVAILABLE } from "../../../../data/entity";
 import type { ForecastType, WeatherEntity } from "../../../../data/weather";
+import { WeatherEntityFeature } from "../../../../data/weather";
 import type { HomeAssistant } from "../../../../types";
 import type { WeatherForecastCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
@@ -86,9 +87,7 @@ export class HuiWeatherForecastCardEditor
     if (stateObj && stateObj.state !== UNAVAILABLE) {
       return !!(
         stateObj.attributes.forecast?.length ||
-        stateObj.attributes.forecast_daily?.length ||
-        stateObj.attributes.forecast_hourly?.length ||
-        stateObj.attributes.forecast_twice_daily?.length
+        stateObj.attributes.supported_features
       );
     }
     return undefined;
@@ -99,7 +98,28 @@ export class HuiWeatherForecastCardEditor
     if (forecastType === "legacy") {
       return !!stateObj.attributes.forecast?.length;
     }
-    return !!stateObj?.attributes[`forecast_${forecastType}`]?.length;
+    if (forecastType === "daily") {
+      return !!(
+        stateObj.attributes.supported_features &&
+        stateObj.attributes.supported_features &
+          WeatherEntityFeature.FORECAST_DAILY
+      );
+    }
+    if (forecastType === "hourly") {
+      return !!(
+        stateObj.attributes.supported_features &&
+        stateObj.attributes.supported_features &
+          WeatherEntityFeature.FORECAST_HOURLY
+      );
+    }
+    if (forecastType === "twice_daily") {
+      return !!(
+        stateObj.attributes.supported_features &&
+        stateObj.attributes.supported_features &
+          WeatherEntityFeature.FORECAST_TWICE_DAILY
+      );
+    }
+    return false
   }
 
   private _schema = memoizeOne(

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -14,6 +14,7 @@ import type { WeatherForecastCardConfig } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
 import { actionConfigStruct } from "../structs/action-struct";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
+import { supportsFeature } from "../../../../common/entity/supports-feature";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -99,24 +100,15 @@ export class HuiWeatherForecastCardEditor
       return !!stateObj.attributes.forecast?.length;
     }
     if (forecastType === "daily") {
-      return !!(
-        stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features ===
-          WeatherEntityFeature.FORECAST_DAILY
-      );
+      return supportsFeature(stateObj, WeatherEntityFeature.FORECAST_DAILY);
     }
     if (forecastType === "hourly") {
-      return !!(
-        stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features ===
-          WeatherEntityFeature.FORECAST_HOURLY
-      );
+      return supportsFeature(stateObj, WeatherEntityFeature.FORECAST_HOURLY);
     }
     if (forecastType === "twice_daily") {
-      return !!(
-        stateObj.attributes.supported_features &&
-        stateObj.attributes.supported_features ===
-          WeatherEntityFeature.FORECAST_TWICE_DAILY
+      return supportsFeature(
+        stateObj,
+        WeatherEntityFeature.FORECAST_TWICE_DAILY
       );
     }
     return false;

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -56,23 +56,67 @@ export class HuiWeatherForecastCardEditor
     }
   }
 
-  get _has_forecast(): boolean | undefined {
+  get _stateObj(): WeatherEntity | undefined {
     if (this.hass && this._config) {
-      const stateObj = this.hass.states[this._config.entity] as WeatherEntity;
-      if (stateObj && stateObj.state !== UNAVAILABLE) {
-        return !!(
-          stateObj.attributes.forecast?.length ||
-          stateObj.attributes.forecast_daily?.length ||
-          stateObj.attributes.forecast_hourly?.length ||
-          stateObj.attributes.forecast_twice_daily?.length
-        );
-      }
+      return this.hass.states[this._config.entity] as WeatherEntity;
+    }
+    return undefined;
+  }
+
+  get _has_forecast(): boolean | undefined {
+    const stateObj = this._stateObj as WeatherEntity;
+    if (stateObj && stateObj.state !== UNAVAILABLE) {
+      return !!(
+        stateObj.attributes.forecast?.length ||
+        stateObj.attributes.forecast_daily?.length ||
+        stateObj.attributes.forecast_hourly?.length ||
+        stateObj.attributes.forecast_twice_daily?.length
+      );
+    }
+    return undefined;
+  }
+
+  get _forecast_legacy(): boolean | undefined {
+    const stateObj = this._stateObj as WeatherEntity;
+    if (stateObj && stateObj.state !== UNAVAILABLE) {
+      return !!stateObj.attributes.forecast?.length;
+    }
+    return undefined;
+  }
+
+  get _forecast_daily(): boolean | undefined {
+    const stateObj = this._stateObj as WeatherEntity;
+    if (stateObj && stateObj.state !== UNAVAILABLE) {
+      return !!stateObj.attributes.forecast_daily?.length;
+    }
+    return undefined;
+  }
+
+  get _forecast_hourly(): boolean | undefined {
+    const stateObj = this._stateObj as WeatherEntity;
+    if (stateObj && stateObj.state !== UNAVAILABLE) {
+      return !!stateObj.attributes.forecast_hourly?.length;
+    }
+    return undefined;
+  }
+
+  get _forecast_twice_daily(): boolean | undefined {
+    const stateObj = this._stateObj as WeatherEntity;
+    if (stateObj && stateObj.state !== UNAVAILABLE) {
+      return !!stateObj.attributes.forecast_twice_daily?.length;
     }
     return undefined;
   }
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc, hasForecast?: boolean) =>
+    (
+      localize: LocalizeFunc,
+      hasForecast?: boolean,
+      hasForecastLegacy?: boolean,
+      hasForecastDaily?: boolean,
+      hasForecastHourly?: boolean,
+      hasForecastTwiceDaily?: boolean
+    ) =>
       [
         {
           name: "entity",
@@ -164,7 +208,14 @@ export class HuiWeatherForecastCardEditor
       return nothing;
     }
 
-    const schema = this._schema(this.hass.localize, this._has_forecast);
+    const schema = this._schema(
+      this.hass.localize,
+      this._has_forecast,
+      this._forecast_legacy,
+      this._forecast_daily,
+      this._forecast_hourly,
+      this._forecast_twice_daily
+    );
 
     const data: WeatherForecastCardConfig = {
       show_current: true,

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -45,7 +45,7 @@ export class HuiWeatherForecastCardEditor
 
     if (
       /* cannot show forecast in case it is unavailable on the entity */
-      (config.show_forecast === true && this._has_forecast === false) ||
+      (config.show_forecast === true && this._hasForecast === false) ||
       /* cannot hide both weather and forecast, need one of them */
       (config.show_current === false && config.show_forecast === false)
     ) {
@@ -55,30 +55,30 @@ export class HuiWeatherForecastCardEditor
       });
     }
     if (!config.forecast_type) {
-      let _forecast_type = "legacy";
-      if (this._forecast_twice_daily === true) {
-        _forecast_type = "twice_daily";
+      let forecastType = "legacy";
+      if (this._forecastTwiceDaily === true) {
+        forecastType = "twice_daily";
       }
-      if (this._forecast_hourly === true) {
-        _forecast_type = "hourly";
+      if (this.__forecastHourly === true) {
+        forecastType = "hourly";
       }
-      if (this._forecast_daily === true) {
-        _forecast_type = "daily";
+      if (this._forecastDaily === true) {
+        forecastType = "daily";
       }
       fireEvent(this, "config-changed", {
-        config: { ...config, forecast_type: _forecast_type },
+        config: { ...config, forecast_type: forecastType },
       });
     }
   }
 
-  get _stateObj(): WeatherEntity | undefined {
+  private get _stateObj(): WeatherEntity | undefined {
     if (this.hass && this._config) {
       return this.hass.states[this._config.entity] as WeatherEntity;
     }
     return undefined;
   }
 
-  get _has_forecast(): boolean | undefined {
+  private get _hasForecast(): boolean | undefined {
     const stateObj = this._stateObj as WeatherEntity;
     if (stateObj && stateObj.state !== UNAVAILABLE) {
       return !!(
@@ -91,7 +91,7 @@ export class HuiWeatherForecastCardEditor
     return undefined;
   }
 
-  get _forecast_legacy(): boolean | undefined {
+  private get _forecastLegacy(): boolean | undefined {
     const stateObj = this._stateObj as WeatherEntity;
     if (stateObj && stateObj.state !== UNAVAILABLE) {
       return !!stateObj.attributes.forecast?.length;
@@ -99,7 +99,7 @@ export class HuiWeatherForecastCardEditor
     return undefined;
   }
 
-  get _forecast_daily(): boolean | undefined {
+  private get _forecastDaily(): boolean | undefined {
     const stateObj = this._stateObj as WeatherEntity;
     if (stateObj && stateObj.state !== UNAVAILABLE) {
       return !!stateObj.attributes.forecast_daily?.length;
@@ -107,7 +107,7 @@ export class HuiWeatherForecastCardEditor
     return undefined;
   }
 
-  get _forecast_hourly(): boolean | undefined {
+  private get __forecastHourly(): boolean | undefined {
     const stateObj = this._stateObj as WeatherEntity;
     if (stateObj && stateObj.state !== UNAVAILABLE) {
       return !!stateObj.attributes.forecast_hourly?.length;
@@ -115,7 +115,7 @@ export class HuiWeatherForecastCardEditor
     return undefined;
   }
 
-  get _forecast_twice_daily(): boolean | undefined {
+  private get _forecastTwiceDaily(): boolean | undefined {
     const stateObj = this._stateObj as WeatherEntity;
     if (stateObj && stateObj.state !== UNAVAILABLE) {
       return !!stateObj.attributes.forecast_twice_daily?.length;
@@ -151,7 +151,7 @@ export class HuiWeatherForecastCardEditor
             { name: "theme", selector: { theme: {} } },
           ],
         },
-        ...(hasForecast
+        ...(hasForecast && hasForecastLegacy === false
           ? ([
               {
                 name: "forecast_type",
@@ -241,16 +241,16 @@ export class HuiWeatherForecastCardEditor
 
     const schema = this._schema(
       this.hass.localize,
-      this._has_forecast,
-      this._forecast_legacy,
-      this._forecast_daily,
-      this._forecast_hourly,
-      this._forecast_twice_daily
+      this._hasForecast,
+      this._forecastLegacy,
+      this._forecastDaily,
+      this.__forecastHourly,
+      this._forecastTwiceDaily
     );
 
     const data: WeatherForecastCardConfig = {
       show_current: true,
-      show_forecast: this._has_forecast,
+      show_forecast: this._hasForecast,
       ...this._config,
     };
 

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -158,16 +158,6 @@ export class HuiWeatherForecastCardEditor
                 selector: {
                   select: {
                     options: [
-                      ...(hasForecastLegacy
-                        ? ([
-                            {
-                              value: "legacy",
-                              label: localize(
-                                "ui.panel.lovelace.editor.card.weather-forecast.no_type"
-                              ),
-                            },
-                          ] as const)
-                        : []),
                       ...(hasForecastDaily
                         ? ([
                             {

--- a/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-weather-forecast-card-editor.ts
@@ -86,6 +86,33 @@ export class HuiWeatherForecastCardEditor
             { name: "theme", selector: { theme: {} } },
           ],
         },
+        {
+          name: "forecast_type",
+          selector: {
+            select: {
+              options: [
+                {
+                  value: "daily",
+                  label: localize(
+                    "ui.panel.lovelace.editor.card.weather-forecast.daily"
+                  ),
+                },
+                {
+                  value: "hourly",
+                  label: localize(
+                    "ui.panel.lovelace.editor.card.weather-forecast.hourly"
+                  ),
+                },
+                {
+                  value: "twice_daily",
+                  label: localize(
+                    "ui.panel.lovelace.editor.card.weather-forecast.twice_daily"
+                  ),
+                },
+              ],
+            },
+          },
+        },
         ...(hasForecast
           ? ([
               {
@@ -184,6 +211,10 @@ export class HuiWeatherForecastCardEditor
         )} (${this.hass!.localize(
           "ui.panel.lovelace.editor.card.config.optional"
         )})`;
+      case "forecast_type":
+        return this.hass!.localize(
+          "ui.panel.lovelace.editor.card.weather-forecast.forecast_type"
+        );
       case "forecast":
         return this.hass!.localize(
           "ui.panel.lovelace.editor.card.weather-forecast.weather_to_show"

--- a/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
@@ -52,9 +52,14 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
     const stateObj = this.hass!.states[this._config!.entity];
     return (
       stateObj &&
-      (supportsFeature(stateObj, WeatherEntityFeature.FORECAST_DAILY) ||
-        supportsFeature(stateObj, WeatherEntityFeature.FORECAST_HOURLY) ||
-        supportsFeature(stateObj, WeatherEntityFeature.FORECAST_TWICE_DAILY))
+      supportsFeature(
+        stateObj,
+        // eslint-disable-next-line no-bitwise
+        WeatherEntityFeature.FORECAST_DAILY |
+          // eslint-disable-next-line no-bitwise
+          WeatherEntityFeature.FORECAST_HOURLY |
+          WeatherEntityFeature.FORECAST_TWICE_DAILY
+      )
     );
   }
 

--- a/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
@@ -46,7 +46,7 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
 
   @state() private _forecastEvent?: ForecastEvent;
 
-  @state() private _subscribed?: () => void;
+  @state() private _subscribed?: Promise<() => void>;
 
   private _needForecastSubscription() {
     const stateObj = this.hass!.states[this._config!.entity];
@@ -77,7 +77,7 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
 
   private async _subscribeForecastEvents() {
     if (this._subscribed) {
-      this._subscribed();
+      this._subscribed.then((unsub) => unsub());
       this._subscribed = undefined;
     }
     const stateObj = this.hass!.states[this._config!.entity];
@@ -86,7 +86,7 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
     }
     const forecastType = this._forecastType(stateObj);
     if (forecastType) {
-      this._subscribed = await subscribeForecast(
+      this._subscribed = subscribeForecast(
         this.hass!,
         stateObj.entity_id,
         forecastType,
@@ -98,7 +98,7 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
   public disconnectedCallback(): void {
     super.disconnectedCallback();
     if (this._subscribed) {
-      this._subscribed();
+      this._subscribed.then((unsub) => unsub());
       this._subscribed = undefined;
     }
   }

--- a/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
@@ -73,12 +73,8 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
     const hasSecondary = this._config.secondary_info;
     const weatherStateIcon = getWeatherStateIcon(stateObj.state, this);
 
-    const forecast = getForecast(
-      stateObj.attributes.forecast,
-      stateObj.attributes.forecast_daily,
-      stateObj.attributes.forecast_hourly,
-      stateObj.attributes.forecast_twice_daily
-    );
+    const forecastData = getForecast(stateObj.attributes);
+    const forecast = forecastData?.[0];
 
     return html`
       <div

--- a/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
@@ -16,7 +16,7 @@ import "../../../components/entity/state-badge";
 import { isUnavailableState } from "../../../data/entity";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import {
-  Forecast_type_undefined,
+  getForecast,
   getSecondaryWeatherAttribute,
   getWeatherStateIcon,
   getWeatherUnit,
@@ -73,7 +73,7 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
     const hasSecondary = this._config.secondary_info;
     const weatherStateIcon = getWeatherStateIcon(stateObj.state, this);
 
-    const forecast = Forecast_type_undefined(
+    const forecast = getForecast(
       stateObj.attributes.forecast,
       stateObj.attributes.forecast_daily,
       stateObj.attributes.forecast_hourly,

--- a/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-weather-entity-row.ts
@@ -16,6 +16,7 @@ import "../../../components/entity/state-badge";
 import { isUnavailableState } from "../../../data/entity";
 import { ActionHandlerEvent } from "../../../data/lovelace";
 import {
+  Forecast_type_undefined,
   getSecondaryWeatherAttribute,
   getWeatherStateIcon,
   getWeatherUnit,
@@ -71,6 +72,13 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
 
     const hasSecondary = this._config.secondary_info;
     const weatherStateIcon = getWeatherStateIcon(stateObj.state, this);
+
+    const forecast = Forecast_type_undefined(
+      stateObj.attributes.forecast,
+      stateObj.attributes.forecast_daily,
+      stateObj.attributes.forecast_hourly,
+      stateObj.attributes.forecast_twice_daily
+    );
 
     return html`
       <div
@@ -160,7 +168,7 @@ class HuiWeatherEntityRow extends LitElement implements LovelaceRow {
               `}
         </div>
         <div class="secondary">
-          ${getSecondaryWeatherAttribute(this.hass!, stateObj)}
+          ${getSecondaryWeatherAttribute(this.hass!, stateObj, forecast!)}
         </div>
       </div>
     `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4945,7 +4945,11 @@
               "weather_to_show": "Weather to Show",
               "show_both": "Show current Weather and Forecast",
               "show_only_current": "Show only current Weather",
-              "show_only_forecast": "Show only Forecast"
+              "show_only_forecast": "Show only Forecast",
+              "forecast_type": "Select forecast type",
+              "daily": "Daily",
+              "hourly": "Hourly",
+              "twice_daily": "Twice daily"
             }
           },
           "view": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4947,6 +4947,7 @@
               "show_only_current": "Show only current Weather",
               "show_only_forecast": "Show only Forecast",
               "forecast_type": "Select forecast type",
+              "no_type": "No type",
               "daily": "Daily",
               "hourly": "Hourly",
               "twice_daily": "Twice daily"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -251,6 +251,9 @@
         "day": "Day",
         "night": "Night",
         "forecast": "Forecast",
+        "forecast_daily": "Forecast daily",
+        "forecast_hourly": "Forecast hourly",
+        "forecast_twice_daily": "Forecast twice daily",
         "high": "High",
         "low": "Low"
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Frontend adjustments for architecture decision https://github.com/home-assistant/architecture/discussions/781
Core PR: https://github.com/home-assistant/core/pull/75219
Dev PR: https://github.com/home-assistant/developers.home-assistant/pull/1616
Blog: https://github.com/home-assistant/developers.home-assistant/pull/1809

When unconfigured or used in cards without configuration (entity-row, more-info) priority is daily, hourly, twice-daily

More-info card gives details about the forecast in order of priority: `daily`, `hourly` and `bi-daily`
![image](https://github.com/home-assistant/frontend/assets/62932417/6f694987-6ee8-48f5-add1-430959e75099)

### Weather card

Configuring `legacy` `weather` entities does not provide option to specify forecast. Only show the `legacy` (`forecast` for the `weather` entity)
![image](https://github.com/home-assistant/frontend/assets/62932417/99e8409d-dad5-4198-bdac-0c45d07b4e04)

Configuring `weather` entities with the new forecast attributes provide option to specify which forecast to show (`forecast_type`).
Priority is given in order of: `daily`, `hourly` and `bi-daily`
![image](https://github.com/home-assistant/frontend/assets/62932417/d602b74f-cd4a-4989-9c75-30c4479f1761)
![image](https://github.com/home-assistant/frontend/assets/62932417/67ff7595-b59f-4f57-a3bc-e0bc1a0e36c7)
![image](https://github.com/home-assistant/frontend/assets/62932417/601a8ed3-a9f3-4ee8-9a3f-df3446f36c08)
![image](https://github.com/home-assistant/frontend/assets/62932417/dde15bfd-49ee-47c1-82e0-2326e3fceeb7)

Configured with option `bi-daily`
![image](https://github.com/home-assistant/frontend/assets/62932417/fa2de872-a7d4-41c4-b829-bc5059013030)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
