### PR TITLE
ha-entities-picker should exclude selected items from dropdowns

### DIFF
--- a/src/components/entity/ha-entities-picker.ts
+++ b/src/components/entity/ha-entities-picker.ts
@@ -92,7 +92,10 @@ class HaEntitiesPickerLight extends LitElement {
               .includeDomains=${this.includeDomains}
               .excludeDomains=${this.excludeDomains}
               .includeEntities=${this.includeEntities}
-              .excludeEntities=${this.excludeEntities}
+              .excludeEntities=${[
+                ...(this.excludeEntities || []),
+                ...(this._currentEntities.filter((e) => e !== entityId) || []),
+              ]}
               .includeDeviceClasses=${this.includeDeviceClasses}
               .includeUnitOfMeasurement=${this.includeUnitOfMeasurement}
               .entityFilter=${this._entityFilter}
@@ -111,7 +114,10 @@ class HaEntitiesPickerLight extends LitElement {
           .includeDomains=${this.includeDomains}
           .excludeDomains=${this.excludeDomains}
           .includeEntities=${this.includeEntities}
-          .excludeEntities=${this.excludeEntities}
+          .excludeEntities=${[
+            ...(this.excludeEntities || []),
+            ...(this._currentEntities || []),
+          ]}
           .includeDeviceClasses=${this.includeDeviceClasses}
           .includeUnitOfMeasurement=${this.includeUnitOfMeasurement}
           .entityFilter=${this._entityFilter}


### PR DESCRIPTION
## Proposed change

The ha-entities-picker should exclude currently selected items from dropdowns, to prevent them from being selected a second time. We already reject the addition if an entity is already in the list, and this just goes one step further by removing the selected items from the visible list of items to be selected. 

This really helps for things like creating a group, where you want to add all entities of a certain type to a group. Otherwise it's very hard to track that you've got everything added, and you may end up accidentally selecting certain items twice. 

There maybe seems to already be an attempt to do this via the entityFilter function, but it does not really seem to work. When `ha-entities-picker.value` changes, the individual ha-entity-pickers do not rerun their _getStates algorithm, so they all basically filter against the static list of states the `ha-entities-picker` had when it was first created, not the current list of values in `ha-entities-picker`.   Fixing that code path may be an alternative way to fix this, but I didn't really identify an obvious way to fix it that way. 

![entities-picker](https://user-images.githubusercontent.com/32912880/211159633-fea10226-d92c-4124-8415-590c5f4af3da.gif)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
