### PR TITLE
Add dark_mode options for image elements in picture-element-card

### DIFF
--- a/src/panels/lovelace/elements/hui-image-element.ts
+++ b/src/panels/lovelace/elements/hui-image-element.ts
@@ -46,6 +46,8 @@ export class HuiImageElement extends LitElement implements LovelaceElement {
         .stateFilter=${this._config.state_filter}
         .title=${computeTooltip(this.hass, this._config)}
         .aspectRatio=${this._config.aspect_ratio}
+        .darkModeImage=${this._config.dark_mode_image}
+        .darkModeFilter=${this._config.dark_mode_filter}
         @action=${this._handleAction}
         .actionHandler=${actionHandler({
           hasHold: hasAction(this._config!.hold_action),

--- a/src/panels/lovelace/elements/types.ts
+++ b/src/panels/lovelace/elements/types.ts
@@ -43,6 +43,8 @@ export interface ImageElementConfig extends LovelaceElementConfigBase {
   image?: string;
   state_image?: string;
   camera_image?: string;
+  dark_mode_image?: string;
+  dark_mode_filter?: string;
   filter?: string;
   state_filter?: string;
   aspect_ratio?: string;


### PR DESCRIPTION
Allow the possible options `darkModeFilter` and `darkModeImage` from the image component also for image elements in the picture elements card. Allows for more advanced dark mode picture elements cards.

## Proposed change

Allow more options for dark mode in the image element of the picture elements card. I wanted to create a dark mode 3D Floorplan with the picture elements and while the image component allows for dark_mode_image and dark_mode_filter the image element sadly doesn't (even though it's possible because the same component is used). By passing those options you are able to create image elements for dark and light mode themes.

https://user-images.githubusercontent.com/22478441/211223280-a92afc32-ecb2-42be-8c27-4d00dd0fde7f.mp4



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
type: picture-elements
image: /local/plan/home_basic.png
dark_mode_image: /local/plan/dark/home_basic.jpg
elements:
  - type: conditional
    conditions:
      - entity: light.livingroom
        state: 'on'
    elements:
      - type: image
        image: local/plan/livingroom_on.png
        dark_mode_image: local/plan/dark/livingroom_on.png
        style:
          top: 50%
          left: 50%
          width: 100%
```

## Additional information


## Checklist


- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
will be added once merged (this is my first PR – if I'm expected to add this beforehand or what to do as best practice I'm willing to learn)

[docs-repository]: https://github.com/home-assistant/home-assistant.io
