### PR TITLE
Remove aria-label and blur from list items

### DIFF
--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -144,7 +144,7 @@ export default class HaAutomationAction extends LitElement {
         </mwc-button>
         ${this._processedTypes(this.hass.localize).map(
           ([opt, label, icon]) => html`
-            <mwc-list-item .value=${opt} aria-label=${label} graphic="icon">
+            <mwc-list-item .value=${opt} graphic="icon">
               ${label}<ha-svg-icon slot="graphic" .path=${icon}></ha-svg-icon
             ></mwc-list-item>
           `

--- a/src/panels/config/automation/action/types/ha-automation-action-condition.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-condition.ts
@@ -38,7 +38,7 @@ export class HaConditionAction extends LitElement implements ActionElement {
       >
         ${this._processedTypes(this.hass.localize).map(
           ([opt, label, icon]) => html`
-            <mwc-list-item .value=${opt} aria-label=${label} graphic="icon">
+            <mwc-list-item .value=${opt} graphic="icon">
               ${label}<ha-svg-icon slot="graphic" .path=${icon}></ha-svg-icon
             ></mwc-list-item>
           `

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -189,7 +189,7 @@ export default class HaAutomationCondition extends LitElement {
         </mwc-button>
         ${this._processedTypes(this.hass.localize).map(
           ([opt, label, icon]) => html`
-            <mwc-list-item .value=${opt} aria-label=${label} graphic="icon">
+            <mwc-list-item .value=${opt} graphic="icon">
               ${label}<ha-svg-icon slot="graphic" .path=${icon}></ha-svg-icon
             ></mwc-list-item>
           `

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -137,7 +137,7 @@ export default class HaAutomationTrigger extends LitElement {
           </mwc-button>
           ${this._processedTypes(this.hass.localize).map(
             ([opt, label, icon]) => html`
-              <mwc-list-item .value=${opt} aria-label=${label} graphic="icon">
+              <mwc-list-item .value=${opt} graphic="icon">
                 ${label}<ha-svg-icon slot="graphic" .path=${icon}></ha-svg-icon
               ></mwc-list-item>
             `

--- a/src/panels/config/info/ha-config-info.ts
+++ b/src/panels/config/info/ha-config-info.ts
@@ -147,7 +147,6 @@ class HaConfigInfo extends LitElement {
                     graphic="avatar"
                     openNewTab
                     href=${documentationUrl(this.hass, page.path)}
-                    @click=${this._entryClicked}
                   >
                     <div
                       slot="graphic"
@@ -210,10 +209,6 @@ class HaConfigInfo extends LitElement {
 
     this._hassioInfo = hassioInfo;
     this._osInfo = osInfo;
-  }
-
-  private _entryClicked(ev) {
-    ev.currentTarget.blur();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/integrations/ha-integration-overflow-menu.ts
+++ b/src/panels/config/integrations/ha-integration-overflow-menu.ts
@@ -18,23 +18,13 @@ export class HaIntegrationOverflowMenu extends LitElement {
           .label=${this.hass.localize("ui.common.menu")}
           .path=${mdiDotsVertical}
         ></ha-icon-button>
-        <ha-clickable-list-item
-          @click=${this._entryClicked}
-          href="/config/application_credentials"
-          aria-label=${this.hass.localize(
-            "ui.panel.config.application_credentials.caption"
-          )}
-        >
+        <ha-clickable-list-item href="/config/application_credentials">
           ${this.hass.localize(
             "ui.panel.config.application_credentials.caption"
           )}
         </ha-clickable-list-item>
       </ha-button-menu>
     `;
-  }
-
-  private _entryClicked(ev) {
-    ev.currentTarget.blur();
   }
 }
 

--- a/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
+++ b/src/panels/config/lovelace/dashboards/ha-config-lovelace-dashboards.ts
@@ -277,13 +277,7 @@ export class HaConfigLovelaceDashboards extends LitElement {
                   .label=${this.hass.localize("ui.common.menu")}
                   .path=${mdiDotsVertical}
                 ></ha-icon-button>
-                <ha-clickable-list-item
-                  @click=${this._entryClicked}
-                  href="/config/lovelace/resources"
-                  aria-label=${this.hass.localize(
-                    "ui.panel.config.lovelace.resources.caption"
-                  )}
-                >
+                <ha-clickable-list-item href="/config/lovelace/resources">
                   ${this.hass.localize(
                     "ui.panel.config.lovelace.resources.caption"
                   )}
@@ -390,9 +384,5 @@ export class HaConfigLovelaceDashboards extends LitElement {
         }
       },
     });
-  }
-
-  private _entryClicked(ev) {
-    ev.currentTarget.blur();
   }
 }

--- a/src/panels/config/repairs/integrations-startup-time.ts
+++ b/src/panels/config/repairs/integrations-startup-time.ts
@@ -61,7 +61,6 @@ class IntegrationsStartupTime extends LitElement {
               twoline
               hasMeta
               openNewTab
-              @click=${this._entryClicked}
               href=${docLink}
             >
               <img
@@ -112,10 +111,6 @@ class IntegrationsStartupTime extends LitElement {
       }
       return b.seconds - a.seconds;
     });
-  }
-
-  private _entryClicked(ev) {
-    ev.currentTarget.blur();
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/config/scene/ha-scene-editor.ts
+++ b/src/panels/config/scene/ha-scene-editor.ts
@@ -239,13 +239,7 @@ export class HaSceneEditor extends SubscribeMixin(
             .path=${mdiDotsVertical}
           ></ha-icon-button>
 
-          <mwc-list-item
-            .disabled=${!this.sceneId}
-            aria-label=${this.hass.localize(
-              "ui.panel.config.scene.picker.duplicate_scene"
-            )}
-            graphic="icon"
-          >
+          <mwc-list-item .disabled=${!this.sceneId} graphic="icon">
             ${this.hass.localize(
               "ui.panel.config.scene.picker.duplicate_scene"
             )}
@@ -257,9 +251,6 @@ export class HaSceneEditor extends SubscribeMixin(
 
           <mwc-list-item
             .disabled=${!this.sceneId}
-            aria-label=${this.hass.localize(
-              "ui.panel.config.scene.picker.delete_scene"
-            )}
             class=${classMap({ warning: Boolean(this.sceneId) })}
             graphic="icon"
           >

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -236,13 +236,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
           <li divider role="separator"></li>
 
-          <mwc-list-item
-            aria-label=${this.hass.localize(
-              "ui.panel.config.automation.editor.edit_ui"
-            )}
-            graphic="icon"
-            @click=${this._switchUiMode}
-          >
+          <mwc-list-item graphic="icon" @click=${this._switchUiMode}>
             ${this.hass.localize("ui.panel.config.automation.editor.edit_ui")}
             ${this._mode === "gui"
               ? html`
@@ -254,13 +248,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
                 `
               : ``}
           </mwc-list-item>
-          <mwc-list-item
-            aria-label=${this.hass.localize(
-              "ui.panel.config.automation.editor.edit_yaml"
-            )}
-            graphic="icon"
-            @click=${this._switchYamlMode}
-          >
+          <mwc-list-item graphic="icon" @click=${this._switchYamlMode}>
             ${this.hass.localize("ui.panel.config.automation.editor.edit_yaml")}
             ${this._mode === "yaml"
               ? html`
@@ -277,11 +265,6 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
           <mwc-list-item
             .disabled=${!this._readOnly && !this.scriptId}
-            .label=${this.hass.localize(
-              this._readOnly
-                ? "ui.panel.config.script.editor.migrate"
-                : "ui.panel.config.script.editor.duplicate"
-            )}
             graphic="icon"
             @click=${this._duplicate}
           >
@@ -298,9 +281,6 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
           <mwc-list-item
             .disabled=${this._readOnly || !this.scriptId}
-            aria-label=${this.hass.localize(
-              "ui.panel.config.script.picker.delete"
-            )}
             class=${classMap({ warning: Boolean(this.scriptId) })}
             graphic="icon"
             @click=${this._deleteConfirm}

--- a/src/panels/lovelace/editor/hui-dialog-save-config.ts
+++ b/src/panels/lovelace/editor/hui-dialog-save-config.ts
@@ -122,17 +122,12 @@ export class HuiSaveConfig extends LitElement implements HassDialog {
         </div>
         ${this._params.mode === "storage"
           ? html`
-              <mwc-button
-                slot="primaryAction"
-                .label=${this.hass!.localize("ui.common.cancel")}
-                @click=${this.closeDialog}
-              ></mwc-button>
+              <mwc-button slot="primaryAction" @click=${this.closeDialog}>
+                ${this.hass!.localize("ui.common.cancel")}
+              </mwc-button>
               <mwc-button
                 slot="primaryAction"
                 ?disabled=${this._saving}
-                aria-label=${this.hass!.localize(
-                  "ui.panel.lovelace.editor.save_config.save"
-                )}
                 @click=${this._saveConfig}
               >
                 ${this._saving
@@ -148,13 +143,11 @@ export class HuiSaveConfig extends LitElement implements HassDialog {
               </mwc-button>
             `
           : html`
-              <mwc-button
-                slot="primaryAction"
-                .label=${this.hass!.localize(
+              <mwc-button slot="primaryAction" @click=${this.closeDialog}>
+                ${this.hass!.localize(
                   "ui.panel.lovelace.editor.save_config.close"
-                )}
-                @click=${this.closeDialog}
-              ></mwc-button>
+                )}</mwc-button
+              >
             `}
       </ha-dialog>
     `;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
I'm preparing to improve a11y for standalone instances of `mwc-list` and button menus which contain links.  This is some starter cleanup work:

- Removes remaining `aria-label` attributes from list items (again the contents provide the accessible name)
- Removes any `label` properties on list items as well (not a valid property)
- Removes calls to `blur()` for instances of `ha-clickable-list-item` (it's very unclear to me why these exist, but in general calls to `blur` are ticking off keyboard users 99% of the time)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
