### PR TITLE
Improve voice dialog

### DIFF
--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -156,11 +156,7 @@ export class HaVoiceCommandDialog extends LitElement {
             id="message-input"
             @keyup=${this._handleKeyUp}
             @input=${this._handleInput}
-            .label=${this.hass.localize(
-              `ui.dialogs.voice_command.${
-                SpeechRecognition ? "label_voice" : "label"
-              }`
-            )}
+            .label=${this.hass.localize(`ui.dialogs.voice_command.input_label`)}
             dialogInitialFocus
             iconTrailing
           >

--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -56,7 +56,7 @@ export class HaVoiceCommandDialog extends LitElement {
 
   @state() private _agentInfo?: AgentInfo;
 
-  @query("ha-dialog", true) private _dialog!: HaDialog;
+  @query("ha-dialog") private _dialog!: HaDialog;
 
   private recognition!: SpeechRecognition;
 
@@ -65,6 +65,7 @@ export class HaVoiceCommandDialog extends LitElement {
   public async showDialog(): Promise<void> {
     this._opened = true;
     this._agentInfo = await getAgentInfo(this.hass);
+    this._scrollMessagesBottom();
   }
 
   public async closeDialog(): Promise<void> {
@@ -84,6 +85,7 @@ export class HaVoiceCommandDialog extends LitElement {
         open
         @closed=${this.closeDialog}
         .heading=${this.hass.localize("ui.dialogs.voice_command.title")}
+        flexContent
       >
         <div slot="heading">
           <ha-header-bar>
@@ -98,7 +100,7 @@ export class HaVoiceCommandDialog extends LitElement {
             ></ha-icon-button>
           </ha-header-bar>
         </div>
-        <div>
+        <div class="messages">
           ${this._agentInfo && this._agentInfo.onboarding
             ? html`
                 <div class="onboarding">
@@ -379,6 +381,8 @@ export class HaVoiceCommandDialog extends LitElement {
           --primary-action-button-flex: 1;
           --secondary-action-button-flex: 0;
           --mdc-dialog-max-width: 450px;
+          --mdc-dialog-max-height: 550px;
+          --dialog-content-padding: 0;
         }
         ha-header-bar {
           display: none;
@@ -415,6 +419,10 @@ export class HaVoiceCommandDialog extends LitElement {
         }
         .attribution {
           color: var(--secondary-text-color);
+        }
+        .messages {
+          padding: 24px;
+          display: block;
         }
         .message {
           font-size: 18px;

--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -56,7 +56,7 @@ export class HaVoiceCommandDialog extends LitElement {
 
   @state() private _agentInfo?: AgentInfo;
 
-  @query("ha-dialog") private _dialog!: HaDialog;
+  @query("[data-scroll-container]") private _scrollContainer!: HaDialog;
 
   private recognition!: SpeechRecognition;
 
@@ -101,46 +101,51 @@ export class HaVoiceCommandDialog extends LitElement {
           </ha-header-bar>
         </div>
         <div class="messages">
-          ${this._agentInfo && this._agentInfo.onboarding
-            ? html`
-                <div class="onboarding">
-                  ${this._agentInfo.onboarding.text}
-                  <div class="side-by-side" @click=${this._completeOnboarding}>
-                    <a
-                      class="button"
-                      href=${this._agentInfo.onboarding.url}
-                      target="_blank"
-                      rel="noreferrer"
-                      ><mwc-button unelevated
-                        >${this.hass.localize("ui.common.yes")}!</mwc-button
-                      ></a
+          <div class="messages-container" data-scroll-container>
+            ${this._agentInfo && this._agentInfo.onboarding
+              ? html`
+                  <div class="onboarding">
+                    ${this._agentInfo.onboarding.text}
+                    <div
+                      class="side-by-side"
+                      @click=${this._completeOnboarding}
                     >
-                    <mwc-button outlined
-                      >${this.hass.localize("ui.common.no")}</mwc-button
-                    >
+                      <a
+                        class="button"
+                        href=${this._agentInfo.onboarding.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        ><mwc-button unelevated
+                          >${this.hass.localize("ui.common.yes")}!</mwc-button
+                        ></a
+                      >
+                      <mwc-button outlined
+                        >${this.hass.localize("ui.common.no")}</mwc-button
+                      >
+                    </div>
                   </div>
+                `
+              : ""}
+            ${this._conversation.map(
+              (message) => html`
+                <div class=${this._computeMessageClasses(message)}>
+                  ${message.text}
                 </div>
               `
-            : ""}
-          ${this._conversation.map(
-            (message) => html`
-              <div class=${this._computeMessageClasses(message)}>
-                ${message.text}
-              </div>
-            `
-          )}
-          ${this.results
-            ? html`
-                <div class="message user">
-                  <span
-                    class=${classMap({
-                      interimTranscript: !this.results.final,
-                    })}
-                    >${this.results.transcript}</span
-                  >${!this.results.final ? "…" : ""}
-                </div>
-              `
-            : ""}
+            )}
+            ${this.results
+              ? html`
+                  <div class="message user">
+                    <span
+                      class=${classMap({
+                        interimTranscript: !this.results.final,
+                      })}
+                      >${this.results.transcript}</span
+                    >${!this.results.final ? "…" : ""}
+                  </div>
+                `
+              : ""}
+          </div>
         </div>
         <div class="input" slot="primaryAction">
           <ha-textfield
@@ -354,7 +359,7 @@ export class HaVoiceCommandDialog extends LitElement {
   }
 
   private _scrollMessagesBottom() {
-    this._dialog.scrollToPos(0, 99999);
+    this._scrollContainer.scrollTo(0, 99999);
   }
 
   private _computeMessageClasses(message: Message) {
@@ -381,19 +386,14 @@ export class HaVoiceCommandDialog extends LitElement {
           --primary-action-button-flex: 1;
           --secondary-action-button-flex: 0;
           --mdc-dialog-max-width: 450px;
-          --mdc-dialog-max-height: 550px;
+          --mdc-dialog-max-height: 500px;
           --dialog-content-padding: 0;
         }
         ha-header-bar {
-          display: none;
-        }
-        @media all and (max-width: 450px), all and (max-height: 500px) {
-          ha-header-bar {
-            --mdc-theme-on-primary: var(--primary-text-color);
-            --mdc-theme-primary: var(--mdc-theme-surface);
-            display: flex;
-            flex-shrink: 0;
-          }
+          --mdc-theme-on-primary: var(--primary-text-color);
+          --mdc-theme-primary: var(--mdc-theme-surface);
+          display: flex;
+          flex-shrink: 0;
         }
 
         ha-textfield {
@@ -421,8 +421,23 @@ export class HaVoiceCommandDialog extends LitElement {
           color: var(--secondary-text-color);
         }
         .messages {
-          padding: 24px;
           display: block;
+          height: 300px;
+          box-sizing: border-box;
+        }
+        @media all and (max-width: 450px), all and (max-height: 500px) {
+          .messages {
+            height: 100%;
+          }
+        }
+        .messages-container {
+          position: absolute;
+          bottom: 0px;
+          right: 0px;
+          left: 0px;
+          padding: 24px;
+          overflow-y: auto;
+          max-height: 100%;
         }
         .message {
           font-size: 18px;

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -3,13 +3,13 @@ import "@material/mwc-list/mwc-list-item";
 import type { RequestSelectedDetail } from "@material/mwc-list/mwc-list-item";
 import {
   mdiCodeBraces,
+  mdiCommentProcessingOutline,
   mdiDotsVertical,
   mdiFileMultiple,
   mdiFormatListBulletedTriangle,
   mdiHelp,
   mdiHelpCircle,
   mdiMagnify,
-  mdiMicrophone,
   mdiPencil,
   mdiPlus,
   mdiRefresh,
@@ -302,9 +302,9 @@ class HUIRoot extends LitElement {
                     ? html`
                         <ha-icon-button
                           .label=${this.hass!.localize(
-                            "ui.panel.lovelace.menu.start_conversation"
+                            "ui.panel.lovelace.menu.assist"
                           )}
-                          .path=${mdiMicrophone}
+                          .path=${mdiCommentProcessingOutline}
                           @click=${this._showVoiceCommandDialog}
                         ></ha-icon-button>
                       `
@@ -324,7 +324,7 @@ class HUIRoot extends LitElement {
                             ? html`
                                 <mwc-list-item
                                   graphic="icon"
-                                  @request-selected=${this._showQuickBar}
+                                  @request-selected=${this._handleShowQuickBar}
                                 >
                                   ${this.hass!.localize(
                                     "ui.panel.lovelace.menu.search"
@@ -343,15 +343,15 @@ class HUIRoot extends LitElement {
                                 <mwc-list-item
                                   graphic="icon"
                                   @request-selected=${this
-                                    ._showVoiceCommandDialog}
+                                    ._handleShowVoiceCommandDialog}
                                 >
                                   ${this.hass!.localize(
-                                    "ui.panel.lovelace.menu.start_conversation"
+                                    "ui.panel.lovelace.menu.assist"
                                   )}
 
                                   <ha-svg-icon
                                     slot="graphic"
-                                    .path=${mdiMicrophone}
+                                    .path=${mdiCommentProcessingOutline}
                                   ></ha-svg-icon>
                                 </mwc-list-item>
                               `
@@ -711,6 +711,13 @@ class HUIRoot extends LitElement {
     });
   }
 
+  private _handleShowQuickBar(ev: CustomEvent<RequestSelectedDetail>): void {
+    if (!shouldHandleRequestSelectedEvent(ev)) {
+      return;
+    }
+    this._showQuickBar();
+  }
+
   private _showQuickBar(): void {
     showQuickBar(this, {
       commandMode: false,
@@ -760,6 +767,15 @@ class HUIRoot extends LitElement {
       return;
     }
     navigate(`${this.route?.prefix}/hass-unused-entities`);
+  }
+
+  private _handleShowVoiceCommandDialog(
+    ev: CustomEvent<RequestSelectedDetail>
+  ): void {
+    if (!shouldHandleRequestSelectedEvent(ev)) {
+      return;
+    }
+    this._showVoiceCommandDialog();
   }
 
   private _showVoiceCommandDialog(): void {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -803,6 +803,7 @@
         "nothing_found": "Nothing found!"
       },
       "voice_command": {
+        "title": "Assistant",
         "did_not_hear": "Home Assistant did not hear anything",
         "did_not_understand": "Didn't quite get that",
         "found": "I found the following for you:",
@@ -3916,7 +3917,7 @@
           "configure_ui": "Edit Dashboard",
           "help": "Help",
           "search": "Search",
-          "start_conversation": "Start conversation",
+          "assist": "Assist",
           "reload_resources": "Reload resources",
           "exit_edit_mode": "Done",
           "close": "Close"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -810,7 +810,9 @@
         "error": "Oops, an error has occurred",
         "how_can_i_help": "How can I help?",
         "label": "Type a question and press 'Enter'",
-        "label_voice": "Type and press 'Enter' or tap the microphone to speak"
+        "label_voice": "Type and press 'Enter' or tap the microphone to speak",
+        "send_text": "Send text",
+        "start_listening": "Start listening"
       },
       "generic": {
         "cancel": "Cancel",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -809,8 +809,7 @@
         "found": "I found the following for you:",
         "error": "Oops, an error has occurred",
         "how_can_i_help": "How can I help?",
-        "label": "Type a question and press 'Enter'",
-        "label_voice": "Type and press 'Enter' or tap the microphone to speak",
+        "input_label": "Enter a request",
         "send_text": "Send text",
         "start_listening": "Start listening"
       },


### PR DESCRIPTION
## Proposed change

- Change icon
- Rename button to "Assist"
- Do not start speech recognition on dialog open
- Align messages to bottom to keep messages visible when keyboard is open on mobile app
- Transform microphone icon to send button if text is entered
- Fixes close button on mobile
- Fixes overflow menu issue (several dialogs could open at the same time)

https://user-images.githubusercontent.com/5878303/212057489-d992b5da-fbd6-4901-9ce7-0a9138faac7d.mp4

### Mobile
![CleanShot 2023-01-12 at 09 54 18](https://user-images.githubusercontent.com/5878303/212022216-29f29cbc-ff03-4c49-8ed1-3e0316d52e8b.png)

### Desktop
![CleanShot 2023-01-12 at 09 53 53](https://user-images.githubusercontent.com/5878303/212022231-3f9e4bff-4934-4237-b8d6-2eda5fb57021.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
