### PR TITLE
Prevent optional time fields in ha-service-control from auto-enabling

### DIFF
--- a/src/components/ha-time-input.ts
+++ b/src/components/ha-time-input.ts
@@ -58,20 +58,32 @@ export class HaTimeInput extends LitElement {
     const eventValue = ev.detail.value;
 
     const useAMPM = useAmPm(this.locale);
-    let hours = eventValue.hours || 0;
-    if (eventValue && useAMPM) {
-      if (eventValue.amPm === "PM" && hours < 12) {
-        hours += 12;
+    let value;
+
+    if (
+      !isNaN(eventValue.hours) ||
+      !isNaN(eventValue.minutes) ||
+      !isNaN(eventValue.seconds)
+    ) {
+      let hours = eventValue.hours || 0;
+      if (eventValue && useAMPM) {
+        if (eventValue.amPm === "PM" && hours < 12) {
+          hours += 12;
+        }
+        if (eventValue.amPm === "AM" && hours === 12) {
+          hours = 0;
+        }
       }
-      if (eventValue.amPm === "AM" && hours === 12) {
-        hours = 0;
-      }
+      value = `${hours.toString().padStart(2, "0")}:${
+        eventValue.minutes
+          ? eventValue.minutes.toString().padStart(2, "0")
+          : "00"
+      }:${
+        eventValue.seconds
+          ? eventValue.seconds.toString().padStart(2, "0")
+          : "00"
+      }`;
     }
-    const value = `${hours.toString().padStart(2, "0")}:${
-      eventValue.minutes ? eventValue.minutes.toString().padStart(2, "0") : "00"
-    }:${
-      eventValue.seconds ? eventValue.seconds.toString().padStart(2, "0") : "00"
-    }`;
 
     if (value === this.value) {
       return;

--- a/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
@@ -102,6 +102,7 @@ class HuiSelectEntityRow extends LitElement implements LovelaceRow {
       }
       ha-select {
         width: 100%;
+        --ha-select-min-width: 0;
       }
     `;
   }

--- a/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-select-entity-row.ts
@@ -102,7 +102,6 @@ class HuiSelectEntityRow extends LitElement implements LovelaceRow {
       }
       ha-select {
         width: 100%;
-        --ha-select-min-width: 0;
       }
     `;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Services with an optional time parameter (using ha-selector-time) do not behave correctly, in that every time the service is loaded in the UI editor, the time parameter is always set to enabled. Other optional parameters are always disabled by default. 

This means that every time an automation is loaded in the UI, a `time: "00:00:00"` will be added to a service that has an optional time parameter, even if user does not desire that parameter to be defined. Deleting it, and refreshing the page, will bring it right back again. 

This occurs because when time is initialized (undefined by default), if localization requires an am/pm selector, it will instance the selector, default to AM, and then fire a "valueChanged" event with the value:

```
hours: NaN
minutes: NaN
seconds: NaN
ampm: "AM"
```

When ha-time-input gets this event, it coerces it into a value of "00:00:00" and itself fires a value changed up to its parent selector and service control. This event tricks the service control into thinking the time parameter exists with a value of 12am, and sets that parameter to enabled.

Suggest fix this in ha-time-input by treating valueChanged events with hours, minutes, and seconds as NaN as an undefined value, instead of "00:00:00". Then the time key remains correctly undefined after initialization, if the value is not already present in the yaml. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15117
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
