### PR TITLE
Rerun layoutOptions when input_select options change

### DIFF
--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -1,6 +1,6 @@
 import "@material/mwc-list/mwc-list-item";
 import { css, html, LitElement, PropertyValues, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, state, query } from "lit/decorators";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import "../../../components/ha-select";
@@ -16,12 +16,15 @@ import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { LovelaceRow } from "./types";
+import type { HaSelect } from "../../../components/ha-select";
 
 @customElement("hui-input-select-entity-row")
 class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: EntitiesCardEntityConfig;
+
+  @query("ha-select", true) private _haSelect!: HaSelect;
 
   public setConfig(config: EntitiesCardEntityConfig): void {
     if (!config || !config.entity) {
@@ -33,6 +36,22 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     return hasConfigOrEntityChanged(this, changedProps);
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+    if (changedProps.has("hass")) {
+      const oldHass = changedProps.get("hass");
+      if (
+        this.hass &&
+        oldHass &&
+        this._config?.entity &&
+        this.hass.states[this._config.entity].attributes.options !==
+          oldHass.states[this._config.entity].attributes.options
+      ) {
+        this._haSelect.layoutOptions();
+      }
+    }
   }
 
   protected render(): TemplateResult {
@@ -62,7 +81,7 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
           .label=${this._config.name || computeStateName(stateObj)}
           .value=${stateObj.state}
           .disabled=${
-            stateObj.state === UNAVAILABLE /* UNKNWON state is allowed */
+            stateObj.state === UNAVAILABLE /* UNKNOWN state is allowed */
           }
           naturalMenuWidth
           @selected=${this._selectedChanged}

--- a/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-input-select-entity-row.ts
@@ -24,7 +24,7 @@ class HuiInputSelectEntityRow extends LitElement implements LovelaceRow {
 
   @state() private _config?: EntitiesCardEntityConfig;
 
-  @query("ha-select", true) private _haSelect!: HaSelect;
+  @query("ha-select") private _haSelect!: HaSelect;
 
   public setConfig(config: EntitiesCardEntityConfig): void {
     if (!config || !config.entity) {

--- a/src/state-summary/state-card-input_select.ts
+++ b/src/state-summary/state-card-input_select.ts
@@ -1,19 +1,42 @@
 import "@material/mwc-list/mwc-list-item";
 import "../components/ha-select";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators";
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  TemplateResult,
+  PropertyValues,
+} from "lit";
+import { customElement, property, query } from "lit/decorators";
 import { stopPropagation } from "../common/dom/stop_propagation";
 import { computeStateName } from "../common/entity/compute_state_name";
 import "../components/entity/state-badge";
 import { UNAVAILABLE } from "../data/entity";
 import { InputSelectEntity, setInputSelectOption } from "../data/input_select";
 import type { HomeAssistant } from "../types";
+import type { HaSelect } from "../components/ha-select";
 
 @customElement("state-card-input_select")
 class StateCardInputSelect extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property() public stateObj!: InputSelectEntity;
+
+  @query("ha-select", true) private _haSelect!: HaSelect;
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+    if (changedProps.has("stateObj")) {
+      const oldState = changedProps.get("stateObj");
+      if (
+        oldState &&
+        this.stateObj.attributes.options !== oldState.attributes.options
+      ) {
+        this._haSelect.layoutOptions();
+      }
+    }
+  }
 
   protected render(): TemplateResult {
     return html`
@@ -22,7 +45,7 @@ class StateCardInputSelect extends LitElement {
         .label=${computeStateName(this.stateObj)}
         .value=${this.stateObj.state}
         .disabled=${
-          this.stateObj.state === UNAVAILABLE /* UNKNWON state is allowed */
+          this.stateObj.state === UNAVAILABLE /* UNKNOWN state is allowed */
         }
         naturalMenuWidth
         fixedMenuPosition


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This change calls layoutOptions() on mwc-select when an input_select entity options change in input-select-entity-row and state-card-input_select.

When service input_select.set_options is called, if the current value of the input_select is not one of the new legal options, the value of input_select is reset to the 0th item of the new select options. Currently when this happens, if the old selected item was also item 0, the input_select box selected text still renders the old value, even though the entity value is now something different. The only way to fix this stale value is to select a different option. 

See screen clip. After changing the options of the input_select with a service call, the value in the textbox is stuck on "aaa", even though the value of the entity has changed to "xxx". 



![input_select_new_options](https://user-images.githubusercontent.com/32912880/215555039-fc6ce136-3482-42f8-acd9-199be1cc1df6.gif)


According to mwc documentation, layoutOptions should be called if the value of the selected text is changed. 

> layoutOptions() => Promise<void> | Synchronizes the list of options with the model of the component and  updates the selected text. Call this if the selected item is  dynamically updated in value or text.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13456
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
