### PR TITLE
Optionally update sensor units when unit system changes

### DIFF
--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -28,6 +28,7 @@ import type { HomeAssistant } from "../../../types";
 import "../../../components/ha-alert";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import type { HaCheckbox } from "../../../components/ha-checkbox";
+import "../../../components/ha-checkbox";
 
 @customElement("ha-config-section-general")
 class HaConfigSectionGeneral extends LitElement {

--- a/src/panels/config/core/ha-config-section-general.ts
+++ b/src/panels/config/core/ha-config-section-general.ts
@@ -195,7 +195,7 @@ class HaConfigSectionGeneral extends LitElement {
                       <div class="secondary">
                         ${this.hass.localize(
                           "ui.panel.config.core.section.core.core_config.update_units_text_1"
-                        )} <br /><br />
+                        )}
                         ${this.hass.localize(
                           "ui.panel.config.core.section.core.core_config.update_units_text_2"
                         )} <br /><br />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1702,11 +1702,11 @@
                 "currency": "Currency",
                 "edit_location": "Edit location",
                 "edit_location_description": "Location can be changed in zone settings",
-                "update_units_label": "Update unit of non temperature sensors",
+                "update_units_label": "Update the unit of all sensors",
                 "update_units_text_1": "The unit system has been changed, and the unit of some sensors like distance and speed can be updated.",
                 "update_units_text_2": "The unit of sensors where the unit has been edited from the UI or which can't be edited from the UI will not be updated.",
                 "update_units_text_3": "Note: The unit of temperature sensors is always updated.",
-                "update_units_confirm_title": "Unit of non temperature sensors will be updated",
+                "update_units_confirm_title": "The unit of sensors will be updated",
                 "update_units_confirm_text": "The unit system has been changed, and the unit of some sensors like distance and speed will be updated.",
                 "update_units_confirm_update": "Update"
               }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1701,7 +1701,14 @@
                 "save_button": "Save",
                 "currency": "Currency",
                 "edit_location": "Edit location",
-                "edit_location_description": "Location can be changed in zone settings"
+                "edit_location_description": "Location can be changed in zone settings",
+                "update_units_label": "Update unit of non temperature sensors",
+                "update_units_text_1": "The unit system has been changed, and the unit of some sensors like distance and speed can be updated.",
+                "update_units_text_2": "The unit of sensors where the unit has been edited from the UI or which can't be edited from the UI will not be updated.",
+                "update_units_text_3": "Note: The unit of temperature sensors is always updated.",
+                "update_units_confirm_title": "Unit of non temperature sensors will be updated",
+                "update_units_confirm_text": "The unit system has been changed, and the unit of some sensors like distance and speed will be updated.",
+                "update_units_confirm_update": "Update"
               }
             }
           }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Optionally update sensor units when unit system changes.

The user can control this via a checkbox which is only shown if the unit system is changed.

![image](https://user-images.githubusercontent.com/14281572/216631433-715d1468-8ad1-4b85-b504-28e4fa65a9d4.png)

![image](https://user-images.githubusercontent.com/14281572/216631513-dcfb4596-1f98-478a-ad60-5290e1e58183.png)


Needs core PR https://github.com/home-assistant/core/pull/83851

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
