### PR TITLE
Fix map sizing in grids and h-stacks

### DIFF
--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -255,13 +255,12 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       return;
     }
 
-    // Fix sizing issues in grid and h-stack, frontend issue #14298
-    root.style.height = "0";
-
     if (!this._config.aspect_ratio) {
       root.style.paddingBottom = "100%";
       return;
     }
+
+    root.style.height = "auto";
 
     const ratio = parseAspectRatio(this._config.aspect_ratio);
 
@@ -376,6 +375,8 @@ class HuiMapCard extends LitElement implements LovelaceCard {
         overflow: hidden;
         width: 100%;
         height: 100%;
+        display: flex;
+        flex-direction: column;
       }
 
       ha-map {

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -255,6 +255,9 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       return;
     }
 
+    // Fix sizing issues in grid and h-stack, frontend issue #14298
+    root.style.height = "0";
+
     if (!this._config.aspect_ratio) {
       root.style.paddingBottom = "100%";
       return;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This change attempts to fix some of the issues when using hui-map-card inside of grids and horizontal stacks. The basic issues are: 

* Maps do not center around the correct point.
* Aspect ratio is not respected. 
* Copyright notices in bottom right are often missing/off-screen.

I am not fully confident in what the correct behavior of cards inside stack elements should be, so perhaps this can start a discussion, but I have one fix which seems to resolve the issues as I see them.

First, some examples of problems:

Here is a 2x2 grid card of maps. All are titled with their aspect ratio, except the 4th which has no title, and an AR of 1:1. All maps are displaying only the zone.home, so they should all center on the orange circle. Notice all of the maps are the same size despite their different defined aspect ratios, and none of them center about the correct point. The 2:3 map is so far off that the center of the map is not even visible. 

![image](https://user-images.githubusercontent.com/32912880/215805502-c50712c0-fa14-4444-bba4-94cc5f6c2e77.png)


Another smaller grid of maps, with various wide and short maps. Notice that as aspect ratio approaches large positive numbers the map starts to center correctly, but again AR is ignored.

![image](https://user-images.githubusercontent.com/32912880/215805899-c5998547-7792-484c-a770-4236d73d1d05.png)

Similar issues in a horizontal stack:

![image](https://user-images.githubusercontent.com/32912880/215806181-517a3651-34bd-4556-b2bc-998b80c5bbba.png)


Maps in vertical stacks, and hui-map-cards directly on the panel outside of a stack render correctly. I notice this problem seems to occur because the basic map card is coded to size itself entirely by using padding-bottom to set the size of the card, and the map renders inside of this. But when a map card is in a grid or h-stack, it seems to inherit some non-zero height field from somewhere, and then when the computed padding-bottom is added to that, it becomes much larger than the space alloted in the stack. See this example where this 1:1 ratio map is highlighted inside of a grid. The map itself thinks it is much larger than what is displayed. And the off centering comes because the map is centering based on what it thinks its total height is, not what is actually displayed. 

![image](https://user-images.githubusercontent.com/32912880/215806937-f013d2fb-3e03-4b3a-a2c0-b4b2947b1bbe.png)



To fix this, I noticed that if I just manually set root.height = 0 inside the map card, everything seems to work closer to what I would expect. The same examples again:

The fixed 2x2 grid. Aspect ratio is now respected, so some of the maps are smaller than their grid. I am not sure if this is desirable or not, but it doesn't seem like an unreasonable approach to me. All maps now correctly centered and showing the leaflet copyright notice.

![image](https://user-images.githubusercontent.com/32912880/215807474-827c68e0-5163-4f9f-862c-dd915bab08b8.png)

The fixed 3x2 grid. Notice it looks bad for most, but that's only because it is respecting the extreme aspect ratios. The 1:1 map looks correct now. 

![image](https://user-images.githubusercontent.com/32912880/215807846-8dcb04e4-4621-4688-b6d7-6775e580afa2.png)

The fixed h-stack:

![image](https://user-images.githubusercontent.com/32912880/215808069-a8c9be91-c0c4-44c1-80cd-053809407276.png)


Also tested maps in sidebar views, panel views, and map sidebar, all work as expected still. 

I guess the primary question should be, should the maps in stacks respect the requested aspect ratio, or should they ignore it and just fill the stack? If the answer is the latter than this fix may not be desired, but I'm not sure what expected behavior should be. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
  - theme: Backend-selected
    title: many maps
    path: selector
    badges: []
    cards:
      - square: true
        columns: 2
        type: grid
        cards:
          - type: map
            entities:
              - entity: zone.home
            title: Map 1:1
          - type: map
            entities:
              - entity: zone.home
            aspect_ratio: '2:1'
            title: Map 2:1
          - type: map
            entities:
              - entity: zone.home
            title: Map 2:3
            aspect_ratio: '2:3'
          - type: map
            entities:
              - entity: zone.home
      - type: grid
        cards:
          - type: markdown
            content: |-
              Small 2x3 grid maps
              1:1, 4:1, 6:1, 8:1, 10:1
          - type: map
            entities:
              - entity: zone.home
          - type: map
            entities:
              - entity: zone.home
            aspect_ratio: '4:1'
          - type: map
            entities:
              - entity: zone.home
            aspect_ratio: '6:1'
          - type: map
            entities:
              - entity: zone.home
            aspect_ratio: '8:1'
          - type: map
            entities:
              - entity: zone.home
            aspect_ratio: '10:1'
      - type: horizontal-stack
        cards:
          - type: map
            entities:
              - entity: zone.home
            title: H Stack (1:1)
          - type: map
            entities:
              - entity: zone.home
            title: H Stack (2:1)
            aspect_ratio: '2:1'
          - type: map
            entities:
              - entity: zone.home
            title: H Stack (2:3)
            aspect_ratio: '2:3'
      - type: vertical-stack
        cards:
          - type: map
            entities:
              - entity: zone.home
            title: V Stack Maps (1:1)
            aspect_ratio: '1:1'
          - type: map
            entities:
              - entity: zone.home
            title: (2:3)
            aspect_ratio: '2:3'
          - type: map
            entities:
              - entity: zone.home
            title: (2:1)
            aspect_ratio: '2:1'
      - type: map
        entities:
          - entity: zone.home
        title: Map Card (2:3)
        aspect_ratio: '2:3'
      - type: map
        entities:
          - entity: zone.home
        title: Map Card 1:1
        aspect_ratio: '1:1'
      - type: map
        entities:
          - entity: zone.home
        aspect_ratio: '2:1'
        title: Map Card (2:1)
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14298
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
