### PR TITLE
Allow empty strings in config flow form values

### DIFF
--- a/src/components/ha-form/types.ts
+++ b/src/components/ha-form/types.ts
@@ -21,6 +21,7 @@ export interface HaFormBaseSchema {
   default?: HaFormData;
   required?: boolean;
   disabled?: boolean;
+  allow_none?: boolean;
   description?: {
     suffix?: string;
     // This value will be set initially when form is loaded

--- a/src/data/options_flow.ts
+++ b/src/data/options_flow.ts
@@ -25,8 +25,29 @@ export const handleOptionsFlowStep = (
   hass.callApi<DataEntryFlowStep>(
     "POST",
     `config/config_entries/options/flow/${flowId}`,
-    data
+    transformEmptiedFields(data)
   );
+
+/**
+ * If a field is undefined it was emptied by the user.
+ *
+ * Set those to null so they won't be overridden by voluptuous defaults in core
+ * @param data Data which is intended to be send as the OptionFlow payload
+ * @returns the same data where undefined fields are null instead
+ */
+function transformEmptiedFields<T>(
+  data: Record<string, T>
+): Record<string, T | null> {
+  // If a field is undefined it was emptied by the user
+  // Set it to null so it won't be overridden by voluptuous defaults in core
+  const toSendData: Record<string, T | null> = {};
+
+  for (const [key, value] of Object.entries(data)) {
+    toSendData[key] = value !== undefined ? value : null;
+  }
+
+  return toSendData;
+}
 
 export const deleteOptionsFlow = (hass: HomeAssistant, flowId: string) =>
   hass.callApi("DELETE", `config/config_entries/options/flow/${flowId}`);

--- a/src/data/options_flow.ts
+++ b/src/data/options_flow.ts
@@ -25,27 +25,8 @@ export const handleOptionsFlowStep = (
   hass.callApi<DataEntryFlowStep>(
     "POST",
     `config/config_entries/options/flow/${flowId}`,
-    transformEmptiedFields(data)
+    data
   );
-
-/**
- * If a field is undefined it was emptied by the user.
- *
- * Set those to null so they won't be overridden by voluptuous defaults in core
- * @param data Data which is intended to be send as the OptionFlow payload
- * @returns the same data where undefined fields are null instead
- */
-function transformEmptiedFields<T>(
-  data: Record<string, T>
-): Record<string, T | null> {
-  const toSendData: Record<string, T | null> = {};
-
-  for (const [key, value] of Object.entries(data)) {
-    toSendData[key] = value !== undefined ? value : null;
-  }
-
-  return toSendData;
-}
 
 export const deleteOptionsFlow = (hass: HomeAssistant, flowId: string) =>
   hass.callApi("DELETE", `config/config_entries/options/flow/${flowId}`);

--- a/src/data/options_flow.ts
+++ b/src/data/options_flow.ts
@@ -38,8 +38,6 @@ export const handleOptionsFlowStep = (
 function transformEmptiedFields<T>(
   data: Record<string, T>
 ): Record<string, T | null> {
-  // If a field is undefined it was emptied by the user
-  // Set it to null so it won't be overridden by voluptuous defaults in core
   const toSendData: Record<string, T | null> = {};
 
   for (const [key, value] of Object.entries(data)) {

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -130,9 +130,8 @@ class StepFlowForm extends LitElement {
     const toSendData = {};
     Object.keys(stepData).forEach((key) => {
       const value = stepData[key];
-      const isEmpty = [undefined, ""].includes(value);
 
-      if (!isEmpty) {
+      if (value !== undefined) {
         toSendData[key] = value;
       }
     });

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -127,11 +127,24 @@ class StepFlowForm extends LitElement {
 
     const flowId = this.step.flow_id;
 
+    // If a field is undefined it was unset by the user
+    // Set it to empty string so it won't be overridden by voluptuous defaults
+    const toSendData = {};
+    Object.keys(stepData).forEach((key) => {
+      const value = stepData[key];
+
+      if (value === undefined) {
+        toSendData[key] = "";
+      } else {
+        toSendData[key] = value;
+      }
+    });
+
     try {
       const step = await this.flowConfig.handleFlowStep(
         this.hass,
         this.step.flow_id,
-        stepData
+        toSendData
       );
 
       // make sure we're still showing the same step as when we

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -127,24 +127,11 @@ class StepFlowForm extends LitElement {
 
     const flowId = this.step.flow_id;
 
-    // If a field is undefined it was unset by the user
-    // Set it to empty string so it won't be overridden by voluptuous defaults
-    const toSendData = {};
-    Object.keys(stepData).forEach((key) => {
-      const value = stepData[key];
-
-      if (value === undefined) {
-        toSendData[key] = "";
-      } else {
-        toSendData[key] = value;
-      }
-    });
-
     try {
       const step = await this.flowConfig.handleFlowStep(
         this.hass,
         this.step.flow_id,
-        toSendData
+        stepData
       );
 
       // make sure we're still showing the same step as when we

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -127,20 +127,11 @@ class StepFlowForm extends LitElement {
 
     const flowId = this.step.flow_id;
 
-    const toSendData = {};
-    Object.keys(stepData).forEach((key) => {
-      const value = stepData[key];
-
-      if (value !== undefined) {
-        toSendData[key] = value;
-      }
-    });
-
     try {
       const step = await this.flowConfig.handleFlowStep(
         this.hass,
         this.step.flow_id,
-        toSendData
+        stepData
       );
 
       // make sure we're still showing the same step as when we


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

### What?

Allow empty strings as values in config flow step forms.

### Why?

The Waze Travel Time integration allows to filter the routes it supplies by strings which have to be part of the route or must not be part of the route. This is done via two string fields in the OptionsFlow.
We have an open issue https://github.com/home-assistant/core/issues/86946 that once set, these fields cannot be unset anymore.

Empty strings are filtered out and not included in the data structure send to the backend.
There the schema is applied to the data here https://github.com/home-assistant/core/blob/dev/homeassistant/data_entry_flow.py#L245

Because the fields are not part of the data received the default value is set for those fields. And this is the value of the field as it was before the OptionsFlow started.
The intention "empty the string again" is ignored.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/core/issues/86946 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
