### PR TITLE
Add filter options to entity and device selectors

### DIFF
--- a/src/common/array/ensure-array.ts
+++ b/src/common/array/ensure-array.ts
@@ -1,7 +1,9 @@
 type NonUndefined<T> = T extends undefined ? never : T;
 
 export function ensureArray(value: undefined): undefined;
-export function ensureArray<T>(value: T | T[]): NonUndefined<T>[];
+export function ensureArray<T>(
+  value: T | T[] | readonly T[]
+): NonUndefined<T>[];
 export function ensureArray(value) {
   if (value === undefined || Array.isArray(value)) {
     return value;

--- a/src/common/array/ensure-array.ts
+++ b/src/common/array/ensure-array.ts
@@ -1,9 +1,8 @@
 type NonUndefined<T> = T extends undefined ? never : T;
 
 export function ensureArray(value: undefined): undefined;
-export function ensureArray<T>(
-  value: T | T[] | readonly T[]
-): NonUndefined<T>[];
+export function ensureArray<T>(value: T | T[]): NonUndefined<T>[];
+export function ensureArray<T>(value: T | readonly T[]): NonUndefined<T>[];
 export function ensureArray(value) {
   if (value === undefined || Array.isArray(value)) {
     return value;

--- a/src/components/device/ha-device-picker.ts
+++ b/src/components/device/ha-device-picker.ts
@@ -1,5 +1,5 @@
 import "@material/mwc-list/mwc-list-item";
-import { UnsubscribeFunc } from "home-assistant-js-websocket";
+import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { ComboBoxLitRenderer } from "@vaadin/combo-box/lit";
 import { customElement, property, query, state } from "lit/decorators";
@@ -36,6 +36,8 @@ interface Device {
 export type HaDevicePickerDeviceFilterFunc = (
   device: DeviceRegistryEntry
 ) => boolean;
+
+export type HaDevicePickerEntityFilterFunc = (entity: HassEntity) => boolean;
 
 const rowRenderer: ComboBoxLitRenderer<Device> = (item) => html`<mwc-list-item
   .twoline=${!!item.area}
@@ -94,6 +96,8 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
 
   @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
 
+  @property() public entityFilter?: HaDevicePickerEntityFilterFunc;
+
   @property({ type: Boolean }) public disabled?: boolean;
 
   @property({ type: Boolean }) public required?: boolean;
@@ -113,6 +117,7 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
       excludeDomains: this["excludeDomains"],
       includeDeviceClasses: this["includeDeviceClasses"],
       deviceFilter: this["deviceFilter"],
+      entityFilter: this["entityFilter"],
       excludeDevices: this["excludeDevices"]
     ): Device[] => {
       if (!devices.length) {
@@ -127,7 +132,12 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
 
       const deviceEntityLookup: DeviceEntityLookup = {};
 
-      if (includeDomains || excludeDomains || includeDeviceClasses) {
+      if (
+        includeDomains ||
+        excludeDomains ||
+        includeDeviceClasses ||
+        entityFilter
+      ) {
         for (const entity of entities) {
           if (!entity.device_id) {
             continue;
@@ -194,6 +204,22 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
               stateObj.attributes.device_class &&
               includeDeviceClasses.includes(stateObj.attributes.device_class)
             );
+          });
+        });
+      }
+
+      if (entityFilter) {
+        inputDevices = inputDevices.filter((device) => {
+          const devEntities = deviceEntityLookup[device.id];
+          if (!devEntities || !devEntities.length) {
+            return false;
+          }
+          return deviceEntityLookup[device.id].some((entity) => {
+            const stateObj = this.hass.states[entity.entity_id];
+            if (!stateObj) {
+              return false;
+            }
+            return entityFilter(stateObj);
           });
         });
       }
@@ -274,6 +300,7 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
         this.excludeDomains,
         this.includeDeviceClasses,
         this.deviceFilter,
+        this.entityFilter,
         this.excludeDevices
       );
     }

--- a/src/components/ha-area-picker.ts
+++ b/src/components/ha-area-picker.ts
@@ -1,4 +1,6 @@
+import "@material/mwc-list/mwc-list-item";
 import { ComboBoxLitRenderer } from "@vaadin/combo-box/lit";
+import { HassEntity } from "home-assistant-js-websocket";
 import { html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
@@ -83,7 +85,7 @@ export class HaAreaPicker extends LitElement {
 
   @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
 
-  @property() public entityFilter?: (entity: EntityRegistryEntry) => boolean;
+  @property() public entityFilter?: (entity: HassEntity) => boolean;
 
   @property({ type: Boolean }) public disabled?: boolean;
 
@@ -218,9 +220,10 @@ export class HaAreaPicker extends LitElement {
       }
 
       if (entityFilter) {
-        inputEntities = inputEntities!.filter((entity) =>
-          entityFilter!(entity)
-        );
+        inputEntities = inputEntities!.filter((entity) => {
+          const stateObj = this.hass.states[entity.entity_id];
+          return entityFilter!(stateObj);
+        });
       }
 
       let outputAreas = areas;

--- a/src/components/ha-areas-picker.ts
+++ b/src/components/ha-areas-picker.ts
@@ -1,7 +1,7 @@
+import { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
-import type { EntityRegistryEntry } from "../data/entity_registry";
 import { SubscribeMixin } from "../mixins/subscribe-mixin";
 import type { HomeAssistant } from "../types";
 import type { HaDevicePickerDeviceFilterFunc } from "./device/ha-device-picker";
@@ -48,7 +48,7 @@ export class HaAreasPicker extends SubscribeMixin(LitElement) {
 
   @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
 
-  @property() public entityFilter?: (entity: EntityRegistryEntry) => boolean;
+  @property() public entityFilter?: (entity: HassEntity) => boolean;
 
   @property({ attribute: "picked-area-label" })
   public pickedAreaLabel?: string;

--- a/src/components/ha-selector/ha-selector-area.ts
+++ b/src/components/ha-selector/ha-selector-area.ts
@@ -53,15 +53,17 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
     ];
   }
 
+  private _hasIntegration(selector: AreaSelector) {
+    return (
+      ensureArray(selector.area?.entity).some((filter) => filter.integration) ||
+      ensureArray(selector.area?.device).some((device) => device.integration)
+    );
+  }
+
   protected updated(changedProperties: PropertyValues): void {
     if (
       changedProperties.has("selector") &&
-      (ensureArray(this.selector.area?.device).some(
-        (device) => device.integration
-      ) ||
-        ensureArray(this.selector.area?.entity).some(
-          (entity) => entity.integration
-        )) &&
+      this._hasIntegration(this.selector) &&
       !this._entitySources
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
@@ -71,15 +73,7 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
   }
 
   protected render(): TemplateResult {
-    if (
-      (ensureArray(this.selector.area?.device).some(
-        (device) => device.integration
-      ) ||
-        ensureArray(this.selector.area?.entity).some(
-          (entity) => entity.integration
-        )) &&
-      !this._entitySources
-    ) {
+    if (this._hasIntegration(this.selector) && !this._entitySources) {
       return html``;
     }
 

--- a/src/components/ha-selector/ha-selector-area.ts
+++ b/src/components/ha-selector/ha-selector-area.ts
@@ -56,7 +56,9 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
   protected updated(changedProperties: PropertyValues): void {
     if (
       changedProperties.has("selector") &&
-      (this.selector.area?.device?.integration ||
+      (ensureArray(this.selector.area?.device).some(
+        (device) => device.integration
+      ) ||
         ensureArray(this.selector.area?.entity).some(
           (entity) => entity.integration
         )) &&
@@ -70,7 +72,9 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
 
   protected render(): TemplateResult {
     if (
-      (this.selector.area?.device?.integration ||
+      (ensureArray(this.selector.area?.device).some(
+        (device) => device.integration
+      ) ||
         ensureArray(this.selector.area?.entity).some(
           (entity) => entity.integration
         )) &&
@@ -130,10 +134,8 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
         ? this._deviceIntegrationLookup(this._entitySources, this._entities)
         : undefined;
 
-    return filterSelectorDevices(
-      this.selector.area.device,
-      device,
-      deviceIntegrations
+    return ensureArray(this.selector.area.device).some((filter) =>
+      filterSelectorDevices(filter, device, deviceIntegrations)
     );
   };
 }

--- a/src/components/ha-selector/ha-selector-area.ts
+++ b/src/components/ha-selector/ha-selector-area.ts
@@ -55,8 +55,12 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
 
   private _hasIntegration(selector: AreaSelector) {
     return (
-      ensureArray(selector.area?.entity).some((filter) => filter.integration) ||
-      ensureArray(selector.area?.device).some((device) => device.integration)
+      (selector.area?.entity &&
+        ensureArray(selector.area.entity).some(
+          (filter) => filter.integration
+        )) ||
+      (selector.area?.device &&
+        ensureArray(selector.area.device).some((device) => device.integration))
     );
   }
 

--- a/src/components/ha-selector/ha-selector-area.ts
+++ b/src/components/ha-selector/ha-selector-area.ts
@@ -2,6 +2,7 @@ import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { ensureArray } from "../../common/array/ensure-array";
 import type { DeviceRegistryEntry } from "../../data/device_registry";
 import { getDeviceIntegrationLookup } from "../../data/device_registry";
 import {
@@ -56,7 +57,9 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
     if (
       changedProperties.has("selector") &&
       (this.selector.area?.device?.integration ||
-        this.selector.area?.entity?.integration) &&
+        ensureArray(this.selector.area?.entity).some(
+          (entity) => entity.integration
+        )) &&
       !this._entitySources
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
@@ -68,7 +71,9 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
   protected render(): TemplateResult {
     if (
       (this.selector.area?.device?.integration ||
-        this.selector.area?.entity?.integration) &&
+        ensureArray(this.selector.area?.entity).some(
+          (entity) => entity.integration
+        )) &&
       !this._entitySources
     ) {
       return html``;
@@ -110,10 +115,8 @@ export class HaAreaSelector extends SubscribeMixin(LitElement) {
       return true;
     }
 
-    return filterSelectorEntities(
-      this.selector.area.entity,
-      entity,
-      this._entitySources
+    return ensureArray(this.selector.area.entity).some((filter) =>
+      filterSelectorEntities(filter, entity, this._entitySources)
     );
   };
 

--- a/src/components/ha-selector/ha-selector-device.ts
+++ b/src/components/ha-selector/ha-selector-device.ts
@@ -55,10 +55,14 @@ export class HaDeviceSelector extends SubscribeMixin(LitElement) {
 
   private _hasIntegration(selector: DeviceSelector) {
     return (
-      ensureArray(selector.device?.filter).some(
-        (filter) => filter.integration
-      ) ||
-      ensureArray(selector.device?.entity).some((device) => device.integration)
+      (selector.device?.filter &&
+        ensureArray(selector.device.filter).some(
+          (filter) => filter.integration
+        )) ||
+      (selector.device?.entity &&
+        ensureArray(selector.device.entity).some(
+          (device) => device.integration
+        ))
     );
   }
 

--- a/src/components/ha-selector/ha-selector-device.ts
+++ b/src/components/ha-selector/ha-selector-device.ts
@@ -92,6 +92,7 @@ export class HaDeviceSelector extends SubscribeMixin(LitElement) {
           .label=${this.label}
           .helper=${this.helper}
           .deviceFilter=${this._filterDevices}
+          .entityFilter=${this._filterEntities}
           .disabled=${this.disabled}
           .required=${this.required}
           allow-custom-entity

--- a/src/components/ha-selector/ha-selector-device.ts
+++ b/src/components/ha-selector/ha-selector-device.ts
@@ -101,13 +101,18 @@ export class HaDeviceSelector extends SubscribeMixin(LitElement) {
   }
 
   private _filterDevices = (device: DeviceRegistryEntry): boolean => {
+    if (!this.selector.device) {
+      return true;
+    }
     const deviceIntegrations =
       this._entitySources && this._entities
         ? this._deviceIntegrationLookup(this._entitySources, this._entities)
         : undefined;
 
-    if (!this.selector.device) {
-      return true;
+    if (this.selector.device.filter) {
+      return ensureArray(this.selector.device.filter).some((filter) =>
+        filterSelectorDevices(filter, device, deviceIntegrations)
+      );
     }
     return filterSelectorDevices(
       this.selector.device,

--- a/src/components/ha-selector/ha-selector-device.ts
+++ b/src/components/ha-selector/ha-selector-device.ts
@@ -53,11 +53,20 @@ export class HaDeviceSelector extends SubscribeMixin(LitElement) {
     ];
   }
 
+  private _hasIntegration(selector: DeviceSelector) {
+    return (
+      ensureArray(selector.device?.filter).some(
+        (filter) => filter.integration
+      ) ||
+      ensureArray(selector.device?.entity).some((device) => device.integration)
+    );
+  }
+
   protected updated(changedProperties): void {
     super.updated(changedProperties);
     if (
       changedProperties.has("selector") &&
-      this.selector.device?.integration &&
+      this._hasIntegration(this.selector) &&
       !this._entitySources
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
@@ -67,7 +76,7 @@ export class HaDeviceSelector extends SubscribeMixin(LitElement) {
   }
 
   protected render() {
-    if (this.selector.device?.integration && !this._entitySources) {
+    if (this._hasIntegration(this.selector) && !this._entitySources) {
       return html``;
     }
 
@@ -101,7 +110,7 @@ export class HaDeviceSelector extends SubscribeMixin(LitElement) {
   }
 
   private _filterDevices = (device: DeviceRegistryEntry): boolean => {
-    if (!this.selector.device) {
+    if (!this.selector.device?.filter) {
       return true;
     }
     const deviceIntegrations =
@@ -109,15 +118,8 @@ export class HaDeviceSelector extends SubscribeMixin(LitElement) {
         ? this._deviceIntegrationLookup(this._entitySources, this._entities)
         : undefined;
 
-    if (this.selector.device.filter) {
-      return ensureArray(this.selector.device.filter).some((filter) =>
-        filterSelectorDevices(filter, device, deviceIntegrations)
-      );
-    }
-    return filterSelectorDevices(
-      this.selector.device,
-      device,
-      deviceIntegrations
+    return ensureArray(this.selector.device.filter).some((filter) =>
+      filterSelectorDevices(filter, device, deviceIntegrations)
     );
   };
 

--- a/src/components/ha-selector/ha-selector-entity.ts
+++ b/src/components/ha-selector/ha-selector-entity.ts
@@ -31,8 +31,9 @@ export class HaEntitySelector extends LitElement {
   @property({ type: Boolean }) public required = true;
 
   private _hasIntegration(selector: EntitySelector) {
-    return ensureArray(selector.entity?.filter).some(
-      (filter) => filter.integration
+    return (
+      selector.entity?.filter &&
+      ensureArray(selector.entity.filter).some((filter) => filter.integration)
     );
   }
 

--- a/src/components/ha-selector/ha-selector-entity.ts
+++ b/src/components/ha-selector/ha-selector-entity.ts
@@ -30,7 +30,17 @@ export class HaEntitySelector extends LitElement {
 
   @property({ type: Boolean }) public required = true;
 
+  private _hasIntegration(selector: EntitySelector) {
+    return ensureArray(selector.entity?.filter).some(
+      (filter) => filter.integration
+    );
+  }
+
   protected render() {
+    if (this._hasIntegration(this.selector) && !this._entitySources) {
+      return html``;
+    }
+
     if (!this.selector.entity?.multiple) {
       return html`<ha-entity-picker
         .hass=${this.hass}
@@ -65,9 +75,7 @@ export class HaEntitySelector extends LitElement {
     super.updated(changedProps);
     if (
       changedProps.has("selector") &&
-      ensureArray(this.selector.entity?.filter).some(
-        (filter) => filter.integration
-      ) &&
+      this._hasIntegration(this.selector) &&
       !this._entitySources
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {

--- a/src/components/ha-selector/ha-selector-entity.ts
+++ b/src/components/ha-selector/ha-selector-entity.ts
@@ -65,7 +65,9 @@ export class HaEntitySelector extends LitElement {
     super.updated(changedProps);
     if (
       changedProps.has("selector") &&
-      this.selector.entity?.integration &&
+      ensureArray(this.selector.entity?.filter).some(
+        (filter) => filter.integration
+      ) &&
       !this._entitySources
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
@@ -75,18 +77,11 @@ export class HaEntitySelector extends LitElement {
   }
 
   private _filterEntities = (entity: HassEntity): boolean => {
-    if (!this.selector?.entity) {
+    if (!this.selector?.entity?.filter) {
       return true;
     }
-    if (this.selector.entity.filter) {
-      return ensureArray(this.selector.entity.filter).some((filter) =>
-        filterSelectorEntities(filter, entity, this._entitySources)
-      );
-    }
-    return filterSelectorEntities(
-      this.selector.entity,
-      entity,
-      this._entitySources
+    return ensureArray(this.selector.entity.filter).some((filter) =>
+      filterSelectorEntities(filter, entity, this._entitySources)
     );
   };
 }

--- a/src/components/ha-selector/ha-selector-entity.ts
+++ b/src/components/ha-selector/ha-selector-entity.ts
@@ -1,6 +1,7 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { ensureArray } from "../../common/array/ensure-array";
 import {
   EntitySources,
   fetchEntitySourcesWithCache,
@@ -76,6 +77,11 @@ export class HaEntitySelector extends LitElement {
   private _filterEntities = (entity: HassEntity): boolean => {
     if (!this.selector?.entity) {
       return true;
+    }
+    if (this.selector.entity.filter) {
+      return ensureArray(this.selector.entity.filter).some((filter) =>
+        filterSelectorEntities(filter, entity, this._entitySources)
+      );
     }
     return filterSelectorEntities(
       this.selector.entity,

--- a/src/components/ha-selector/ha-selector-target.ts
+++ b/src/components/ha-selector/ha-selector-target.ts
@@ -48,7 +48,9 @@ export class HaTargetSelector extends LitElement {
     super.updated(changedProperties);
     if (
       changedProperties.has("selector") &&
-      (this.selector.target?.device?.integration ||
+      (ensureArray(this.selector.target?.device).some(
+        (device) => device.integration
+      ) ||
         ensureArray(this.selector.target?.entity).some(
           (entity) => entity.integration
         )) &&
@@ -62,7 +64,9 @@ export class HaTargetSelector extends LitElement {
 
   protected render(): TemplateResult {
     if (
-      (this.selector.target?.device?.integration ||
+      (ensureArray(this.selector.target?.device).some(
+        (device) => device.integration
+      ) ||
         ensureArray(this.selector.target?.entity).some(
           (entity) => entity.integration
         )) &&
@@ -103,10 +107,8 @@ export class HaTargetSelector extends LitElement {
         )
       : undefined;
 
-    return filterSelectorDevices(
-      this.selector.target.device,
-      device,
-      deviceIntegrations
+    return ensureArray(this.selector.target.device).some((filter) =>
+      filterSelectorDevices(filter, device, deviceIntegrations)
     );
   };
 

--- a/src/components/ha-selector/ha-selector-target.ts
+++ b/src/components/ha-selector/ha-selector-target.ts
@@ -44,16 +44,20 @@ export class HaTargetSelector extends LitElement {
 
   private _deviceIntegrationLookup = memoizeOne(getDeviceIntegrationLookup);
 
+  private _hasIntegration(selector: TargetSelector) {
+    return (
+      ensureArray(selector.target?.entity).some(
+        (filter) => filter.integration
+      ) ||
+      ensureArray(selector.target?.device).some((device) => device.integration)
+    );
+  }
+
   protected updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
     if (
       changedProperties.has("selector") &&
-      (ensureArray(this.selector.target?.device).some(
-        (device) => device.integration
-      ) ||
-        ensureArray(this.selector.target?.entity).some(
-          (entity) => entity.integration
-        )) &&
+      this._hasIntegration(this.selector) &&
       !this._entitySources
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
@@ -63,15 +67,7 @@ export class HaTargetSelector extends LitElement {
   }
 
   protected render(): TemplateResult {
-    if (
-      (ensureArray(this.selector.target?.device).some(
-        (device) => device.integration
-      ) ||
-        ensureArray(this.selector.target?.entity).some(
-          (entity) => entity.integration
-        )) &&
-      !this._entitySources
-    ) {
+    if (this._hasIntegration(this.selector) && !this._entitySources) {
       return html``;
     }
 

--- a/src/components/ha-selector/ha-selector-target.ts
+++ b/src/components/ha-selector/ha-selector-target.ts
@@ -14,7 +14,6 @@ import {
   DeviceRegistryEntry,
   getDeviceIntegrationLookup,
 } from "../../data/device_registry";
-import { EntityRegistryEntry } from "../../data/entity_registry";
 import {
   EntitySources,
   fetchEntitySourcesWithCache,
@@ -50,7 +49,9 @@ export class HaTargetSelector extends LitElement {
     if (
       changedProperties.has("selector") &&
       (this.selector.target?.device?.integration ||
-        this.selector.target?.entity?.integration) &&
+        ensureArray(this.selector.target?.entity).some(
+          (entity) => entity.integration
+        )) &&
       !this._entitySources
     ) {
       fetchEntitySourcesWithCache(this.hass).then((sources) => {
@@ -62,7 +63,9 @@ export class HaTargetSelector extends LitElement {
   protected render(): TemplateResult {
     if (
       (this.selector.target?.device?.integration ||
-        this.selector.target?.entity?.integration) &&
+        ensureArray(this.selector.target?.entity).some(
+          (entity) => entity.integration
+        )) &&
       !this._entitySources
     ) {
       return html``;
@@ -73,37 +76,19 @@ export class HaTargetSelector extends LitElement {
       .value=${this.value}
       .helper=${this.helper}
       .deviceFilter=${this._filterDevices}
-      .entityFilter=${this._filterStates}
-      .entityRegFilter=${this._filterRegEntities}
-      .includeDeviceClasses=${this.selector.target?.entity?.device_class
-        ? [this.selector.target?.entity.device_class]
-        : undefined}
-      .includeDomains=${this.selector.target?.entity?.domain
-        ? ensureArray(this.selector.target.entity.domain as string | string[])
-        : undefined}
+      .entityFilter=${this._filterEntities}
       .disabled=${this.disabled}
     ></ha-target-picker>`;
   }
 
-  private _filterStates = (entity: HassEntity): boolean => {
+  private _filterEntities = (entity: HassEntity): boolean => {
     if (!this.selector.target?.entity) {
       return true;
     }
 
-    return filterSelectorEntities(
-      this.selector.target.entity,
-      entity,
-      this._entitySources
+    return ensureArray(this.selector.target.entity).some((filter) =>
+      filterSelectorEntities(filter, entity, this._entitySources)
     );
-  };
-
-  private _filterRegEntities = (entity: EntityRegistryEntry): boolean => {
-    if (this.selector.target?.entity?.integration) {
-      if (entity.platform !== this.selector.target.entity.integration) {
-        return false;
-      }
-    }
-    return true;
   };
 
   private _filterDevices = (device: DeviceRegistryEntry): boolean => {

--- a/src/components/ha-selector/ha-selector-target.ts
+++ b/src/components/ha-selector/ha-selector-target.ts
@@ -46,10 +46,14 @@ export class HaTargetSelector extends LitElement {
 
   private _hasIntegration(selector: TargetSelector) {
     return (
-      ensureArray(selector.target?.entity).some(
-        (filter) => filter.integration
-      ) ||
-      ensureArray(selector.target?.device).some((device) => device.integration)
+      (selector.target?.entity &&
+        ensureArray(selector.target.entity).some(
+          (filter) => filter.integration
+        )) ||
+      (selector.target?.device &&
+        ensureArray(selector.target.device).some(
+          (device) => device.integration
+        ))
     );
   }
 

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -1,7 +1,8 @@
 import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
+import memoizeOne from "memoize-one";
 import { dynamicElement } from "../../common/dom/dynamic-element-directive";
-import type { Selector } from "../../data/selector";
+import { Selector, handleLegacyEntitySelector } from "../../data/selector";
 import type { HomeAssistant } from "../../types";
 
 const LOAD_ELEMENTS = {
@@ -75,12 +76,19 @@ export class HaSelector extends LitElement {
     }
   }
 
+  private _handleLegacySelector = memoizeOne((selector: Selector) => {
+    if ("entity" in selector) {
+      return handleLegacyEntitySelector(selector);
+    }
+    return selector;
+  });
+
   protected render() {
     return html`
       ${dynamicElement(`ha-selector-${this._type}`, {
         hass: this.hass,
         name: this.name,
-        selector: this.selector,
+        selector: this._handleLegacySelector(this.selector),
         value: this.value,
         label: this.label,
         placeholder: this.placeholder,

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -2,7 +2,11 @@ import { html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { dynamicElement } from "../../common/dom/dynamic-element-directive";
-import { Selector, handleLegacyEntitySelector } from "../../data/selector";
+import {
+  Selector,
+  handleLegacyEntitySelector,
+  handleLegacyDeviceSelector,
+} from "../../data/selector";
 import type { HomeAssistant } from "../../types";
 
 const LOAD_ELEMENTS = {
@@ -79,6 +83,9 @@ export class HaSelector extends LitElement {
   private _handleLegacySelector = memoizeOne((selector: Selector) => {
     if ("entity" in selector) {
       return handleLegacyEntitySelector(selector);
+    }
+    if ("device" in selector) {
+      return handleLegacyDeviceSelector(selector);
     }
     return selector;
   });

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -342,7 +342,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
             )}
             no-add
             .deviceFilter=${this.deviceFilter}
-            .entityFilter=${this.entityRegFilter}
+            .entityFilter=${this.entityFilter}
             .includeDeviceClasses=${this.includeDeviceClasses}
             .includeDomains=${this.includeDomains}
             .excludeAreas=${ensureArray(this.value?.area_id)}

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -357,6 +357,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
               "ui.components.target-picker.add_device_id"
             )}
             .deviceFilter=${this.deviceFilter}
+            .entityFilter=${this.entityFilter}
             .includeDeviceClasses=${this.includeDeviceClasses}
             .includeDomains=${this.includeDomains}
             .excludeDevices=${ensureArray(this.value?.device_id)}

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -9,32 +9,19 @@ import {
   mdiUnfoldMoreVertical,
 } from "@mdi/js";
 import "@polymer/paper-tooltip/paper-tooltip";
-import {
-  HassEntity,
-  HassServiceTarget,
-  UnsubscribeFunc,
-} from "home-assistant-js-websocket";
+import { HassEntity, HassServiceTarget } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, unsafeCSS } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
-import { fireEvent } from "../common/dom/fire_event";
 import { ensureArray } from "../common/array/ensure-array";
+import { fireEvent } from "../common/dom/fire_event";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateName } from "../common/entity/compute_state_name";
 import {
-  AreaRegistryEntry,
-  subscribeAreaRegistry,
-} from "../data/area_registry";
-import {
   computeDeviceName,
   DeviceRegistryEntry,
-  subscribeDeviceRegistry,
 } from "../data/device_registry";
-import {
-  EntityRegistryEntry,
-  subscribeEntityRegistry,
-} from "../data/entity_registry";
-import { SubscribeMixin } from "../mixins/subscribe-mixin";
+import { EntityRegistryEntry } from "../data/entity_registry";
 import { HomeAssistant } from "../types";
 import "./device/ha-device-picker";
 import type { HaDevicePickerDeviceFilterFunc } from "./device/ha-device-picker";
@@ -46,7 +33,7 @@ import "./ha-input-helper-text";
 import "./ha-svg-icon";
 
 @customElement("ha-target-picker")
-export class HaTargetPicker extends SubscribeMixin(LitElement) {
+export class HaTargetPicker extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public value?: HassServiceTarget;
@@ -79,44 +66,11 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   @property({ type: Boolean }) public horizontal = false;
 
-  @state() private _areas?: { [areaId: string]: AreaRegistryEntry };
-
-  @state() private _devices?: {
-    [deviceId: string]: DeviceRegistryEntry;
-  };
-
-  @state() private _entities?: EntityRegistryEntry[];
-
   @state() private _addMode?: "area_id" | "entity_id" | "device_id";
 
   @query("#input") private _inputElement?;
 
-  public hassSubscribe(): UnsubscribeFunc[] {
-    return [
-      subscribeAreaRegistry(this.hass.connection!, (areas) => {
-        const areaLookup: { [areaId: string]: AreaRegistryEntry } = {};
-        for (const area of areas) {
-          areaLookup[area.area_id] = area;
-        }
-        this._areas = areaLookup;
-      }),
-      subscribeDeviceRegistry(this.hass.connection!, (devices) => {
-        const deviceLookup: { [deviceId: string]: DeviceRegistryEntry } = {};
-        for (const device of devices) {
-          deviceLookup[device.id] = device;
-        }
-        this._devices = deviceLookup;
-      }),
-      subscribeEntityRegistry(this.hass.connection!, (entities) => {
-        this._entities = entities;
-      }),
-    ];
-  }
-
   protected render() {
-    if (!this._areas || !this._devices || !this._entities) {
-      return html``;
-    }
     return html`
       ${this.horizontal
         ? html`
@@ -139,7 +93,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       <div class="mdc-chip-set items">
         ${this.value?.area_id
           ? ensureArray(this.value.area_id).map((area_id) => {
-              const area = this._areas![area_id];
+              const area = this.hass.devices![area_id];
               return this._renderChip(
                 "area_id",
                 area_id,
@@ -151,7 +105,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
           : ""}
         ${this.value?.device_id
           ? ensureArray(this.value.device_id).map((device_id) => {
-              const device = this._devices![device_id];
+              const device = this.hass.devices![device_id];
               return this._renderChip(
                 "device_id",
                 device_id,
@@ -418,7 +372,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     const newDevices: string[] = [];
     const newEntities: string[] = [];
     if (target.type === "area_id") {
-      Object.values(this._devices!).forEach((device) => {
+      Object.values(this.hass.devices).forEach((device) => {
         if (
           device.area_id === target.id &&
           !this.value!.device_id?.includes(device.id) &&
@@ -427,7 +381,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
           newDevices.push(device.id);
         }
       });
-      this._entities!.forEach((entity) => {
+      Object.values(this.hass.entities).forEach((entity) => {
         if (
           entity.area_id === target.id &&
           !this.value!.entity_id?.includes(entity.entity_id) &&
@@ -437,7 +391,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
         }
       });
     } else if (target.type === "device_id") {
-      this._entities!.forEach((entity) => {
+      Object.values(this.hass.entities).forEach((entity) => {
         if (
           entity.device_id === target.id &&
           !this.value!.entity_id?.includes(entity.entity_id) &&
@@ -501,9 +455,10 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
   }
 
   private _deviceMeetsFilter(device: DeviceRegistryEntry): boolean {
-    const devEntities = this._entities?.filter(
+    const devEntities = Object.values(this.hass.entities).filter(
       (entity) => entity.device_id === device.id
     );
+
     if (this.includeDomains) {
       if (!devEntities || !devEntities.length) {
         return false;
@@ -540,7 +495,23 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     }
 
     if (this.deviceFilter) {
-      return this.deviceFilter(device);
+      if (!this.deviceFilter(device)) {
+        return false;
+      }
+    }
+
+    if (this.entityFilter) {
+      if (
+        !devEntities.some((entity) => {
+          const stateObj = this.hass.states[entity.entity_id];
+          if (!stateObj) {
+            return false;
+          }
+          return this.entityFilter!(stateObj);
+        })
+      ) {
+        return false;
+      }
     }
     return true;
   }
@@ -549,6 +520,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
     if (entity.entity_category) {
       return false;
     }
+
     if (
       this.includeDomains &&
       !this.includeDomains.includes(computeDomain(entity.entity_id))
@@ -564,6 +536,16 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
         !stateObj.attributes.device_class ||
         !this.includeDeviceClasses!.includes(stateObj.attributes.device_class)
       ) {
+        return false;
+      }
+    }
+
+    if (this.entityFilter) {
+      const stateObj = this.hass.states[entity.entity_id];
+      if (!stateObj) {
+        return false;
+      }
+      if (!this.entityFilter!(stateObj)) {
         return false;
       }
     }

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -73,8 +73,6 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   @property() public deviceFilter?: HaDevicePickerDeviceFilterFunc;
 
-  @property() public entityRegFilter?: (entity: EntityRegistryEntry) => boolean;
-
   @property() public entityFilter?: HaEntityPickerEntityFilterFunc;
 
   @property({ type: Boolean, reflect: true }) public disabled = false;
@@ -567,9 +565,6 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
       ) {
         return false;
       }
-    }
-    if (this.entityRegFilter) {
-      return this.entityRegFilter(entity);
     }
     return true;
   }

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -48,16 +48,10 @@ export interface AddonSelector {
   } | null;
 }
 
-export interface SelectorDevice {
-  integration?: NonNullable<DeviceSelector["device"]>["integration"];
-  manufacturer?: NonNullable<DeviceSelector["device"]>["manufacturer"];
-  model?: NonNullable<DeviceSelector["device"]>["model"];
-}
-
 export interface AreaSelector {
   area: {
     entity?: EntitySelectorFilter | EntitySelectorFilter[];
-    device?: SelectorDevice;
+    device?: DeviceSelectorFilter | DeviceSelectorFilter[];
     multiple?: boolean;
   } | null;
 }
@@ -102,13 +96,29 @@ export interface DateTimeSelector {
   datetime: {} | null;
 }
 
+interface DeviceSelectorFilter {
+  integration?: string;
+  manufacturer?: string;
+  model?: string;
+}
+
 export interface DeviceSelector {
   device: {
-    integration?: string;
-    manufacturer?: string;
-    model?: string;
+    filter?: DeviceSelectorFilter | DeviceSelectorFilter[];
     entity?: EntitySelectorFilter | EntitySelectorFilter[];
     multiple?: boolean;
+    /**
+     * @deprecated Backward compatibility, use filter instead
+     */
+    integration?: DeviceSelectorFilter["integration"];
+    /**
+     * @deprecated Backward compatibility, use filter instead
+     */
+    manufacturer?: DeviceSelectorFilter["manufacturer"];
+    /**
+     * @deprecated Backward compatibility, use filter instead
+     */
+    model?: DeviceSelectorFilter["model"];
   } | null;
 }
 
@@ -261,7 +271,7 @@ export interface StringSelector {
 export interface TargetSelector {
   target: {
     entity?: EntitySelectorFilter | EntitySelectorFilter[];
-    device?: SelectorDevice;
+    device?: DeviceSelectorFilter | DeviceSelectorFilter[];
   } | null;
 }
 
@@ -291,7 +301,7 @@ export interface UiColorSelector {
 }
 
 export const filterSelectorDevices = (
-  filterDevice: SelectorDevice,
+  filterDevice: DeviceSelectorFilter,
   device: DeviceRegistryEntry,
   deviceIntegrationLookup: Record<string, string[]> | undefined
 ): boolean => {

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -56,7 +56,7 @@ export interface SelectorDevice {
 
 export interface AreaSelector {
   area: {
-    entity?: EntitySelectorFilter;
+    entity?: EntitySelectorFilter | EntitySelectorFilter[];
     device?: SelectorDevice;
     multiple?: boolean;
   } | null;

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -107,7 +107,7 @@ export interface DeviceSelector {
     integration?: string;
     manufacturer?: string;
     model?: string;
-    entity?: EntitySelectorFilter;
+    entity?: EntitySelectorFilter | EntitySelectorFilter[];
     multiple?: boolean;
   } | null;
 }

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -50,8 +50,8 @@ export interface AddonSelector {
 
 export interface AreaSelector {
   area: {
-    entity?: EntitySelectorFilter | EntitySelectorFilter[];
-    device?: DeviceSelectorFilter | DeviceSelectorFilter[];
+    entity?: EntitySelectorFilter | readonly EntitySelectorFilter[];
+    device?: DeviceSelectorFilter | readonly DeviceSelectorFilter[];
     multiple?: boolean;
   } | null;
 }
@@ -104,8 +104,8 @@ interface DeviceSelectorFilter {
 
 export interface DeviceSelector {
   device: {
-    filter?: DeviceSelectorFilter | DeviceSelectorFilter[];
-    entity?: EntitySelectorFilter | EntitySelectorFilter[];
+    filter?: DeviceSelectorFilter | readonly DeviceSelectorFilter[];
+    entity?: EntitySelectorFilter | readonly EntitySelectorFilter[];
     multiple?: boolean;
     /**
      * @deprecated Backward compatibility, use filter instead
@@ -139,7 +139,7 @@ export interface EntitySelector {
     multiple?: boolean;
     include_entities?: string[];
     exclude_entities?: string[];
-    filter?: EntitySelectorFilter | EntitySelectorFilter[];
+    filter?: EntitySelectorFilter | readonly EntitySelectorFilter[];
     /**
      * @deprecated Backward compatibility, use filter instead
      */
@@ -270,8 +270,8 @@ export interface StringSelector {
 
 export interface TargetSelector {
   target: {
-    entity?: EntitySelectorFilter | EntitySelectorFilter[];
-    device?: DeviceSelectorFilter | DeviceSelectorFilter[];
+    entity?: EntitySelectorFilter | readonly EntitySelectorFilter[];
+    device?: DeviceSelectorFilter | readonly DeviceSelectorFilter[];
   } | null;
 }
 

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -54,15 +54,9 @@ export interface SelectorDevice {
   model?: NonNullable<DeviceSelector["device"]>["model"];
 }
 
-export interface SelectorEntity {
-  integration?: NonNullable<EntitySelector["entity"]>["integration"];
-  domain?: NonNullable<EntitySelector["entity"]>["domain"];
-  device_class?: NonNullable<EntitySelector["entity"]>["device_class"];
-}
-
 export interface AreaSelector {
   area: {
-    entity?: SelectorEntity;
+    entity?: EntitySelectorFilter;
     device?: SelectorDevice;
     multiple?: boolean;
   } | null;
@@ -113,7 +107,7 @@ export interface DeviceSelector {
     integration?: string;
     manufacturer?: string;
     model?: string;
-    entity?: SelectorEntity;
+    entity?: EntitySelectorFilter;
     multiple?: boolean;
   } | null;
 }
@@ -124,14 +118,30 @@ export interface DurationSelector {
   } | null;
 }
 
+interface EntitySelectorFilter {
+  integration?: string;
+  domain?: string | readonly string[];
+  device_class?: string;
+}
+
 export interface EntitySelector {
   entity: {
-    integration?: string;
-    domain?: string | readonly string[];
-    device_class?: string;
     multiple?: boolean;
     include_entities?: string[];
     exclude_entities?: string[];
+    filter?: EntitySelectorFilter | EntitySelectorFilter[];
+    /**
+     * @deprecated Backward compatibility, use filter instead
+     */
+    integration?: EntitySelectorFilter["integration"];
+    /**
+     * @deprecated Backward compatibility, use filter instead
+     */
+    domain?: EntitySelectorFilter["domain"];
+    /**
+     * @deprecated Backward compatibility, use filter instead
+     */
+    device_class?: EntitySelectorFilter["device_class"];
   } | null;
 }
 
@@ -250,7 +260,7 @@ export interface StringSelector {
 
 export interface TargetSelector {
   target: {
-    entity?: SelectorEntity;
+    entity?: EntitySelectorFilter;
     device?: SelectorDevice;
   } | null;
 }
@@ -308,7 +318,7 @@ export const filterSelectorDevices = (
 };
 
 export const filterSelectorEntities = (
-  filterEntity: SelectorEntity,
+  filterEntity: EntitySelectorFilter,
   entity: HassEntity,
   entitySources?: EntitySources
 ): boolean => {

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -260,7 +260,7 @@ export interface StringSelector {
 
 export interface TargetSelector {
   target: {
-    entity?: EntitySelectorFilter;
+    entity?: EntitySelectorFilter | EntitySelectorFilter[];
     device?: SelectorDevice;
   } | null;
 }

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -115,8 +115,17 @@ export interface DeviceSelector {
 export interface LegacyDeviceSelector {
   device:
     | DeviceSelector["device"] & {
+        /**
+         * @deprecated Use filter instead
+         */
         integration?: DeviceSelectorFilter["integration"];
+        /**
+         * @deprecated Use filter instead
+         */
         manufacturer?: DeviceSelectorFilter["manufacturer"];
+        /**
+         * @deprecated Use filter instead
+         */
         model?: DeviceSelectorFilter["model"];
       };
 }
@@ -145,8 +154,17 @@ export interface EntitySelector {
 export interface LegacyEntitySelector {
   entity:
     | EntitySelector["entity"] & {
+        /**
+         * @deprecated Use filter instead
+         */
         integration?: EntitySelectorFilter["integration"];
+        /**
+         * @deprecated Use filter instead
+         */
         domain?: EntitySelectorFilter["domain"];
+        /**
+         * @deprecated Use filter instead
+         */
         device_class?: EntitySelectorFilter["device_class"];
       };
 }

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -130,8 +130,8 @@ export interface DurationSelector {
 
 interface EntitySelectorFilter {
   integration?: string;
-  domain?: string | string[];
-  device_class?: string | string[];
+  domain?: string | readonly string[];
+  device_class?: string | readonly string[];
 }
 
 export interface EntitySelector {

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -130,8 +130,8 @@ export interface DurationSelector {
 
 interface EntitySelectorFilter {
   integration?: string;
-  domain?: string | readonly string[];
-  device_class?: string;
+  domain?: string | string[];
+  device_class?: string | string[];
 }
 
 export interface EntitySelector {
@@ -349,11 +349,15 @@ export const filterSelectorEntities = (
     }
   }
 
-  if (
-    filterDeviceClass &&
-    entity.attributes.device_class !== filterDeviceClass
-  ) {
-    return false;
+  if (filterDeviceClass) {
+    const entityDeviceClass = entity.attributes.device_class;
+    if (
+      entityDeviceClass && Array.isArray(filterDeviceClass)
+        ? !filterDeviceClass.includes(entityDeviceClass)
+        : entityDeviceClass !== filterDeviceClass
+    ) {
+      return false;
+    }
   }
 
   if (


### PR DESCRIPTION
## Breaking changes

Entity filters are now inside `filter` property but we can add backward compatibility.

## Proposed change

- Add `filter` config for entity selector to allow array of filter.
- Add `filter` config for device selector to allow array of filter.
- Allow `device_class` list for entity filter config

It fixes somes issues :
- Include `input_datetime` domain and sensor domain with `timestamp` device class : https://github.com/home-assistant/frontend/pull/15292
- Add multiple manufacturer and model for device if we extend this to devices : https://github.com/home-assistant/frontend/pull/15104

### New schemas

```ts
interface EntitySelectorFilter {
  integration?: string;
  domain?: string | string[];
  device_class?: string | string[];
}

interface DeviceSelectorFilter {
  integration?: string;
  manufacturer?: string;
  model?: string;
}

export interface DeviceSelector {
  device: {
    filter?: DeviceSelectorFilter | DeviceSelectorFilter[];
    entity?: EntitySelectorFilter | EntitySelectorFilter[];
    multiple?: boolean;
     /** For backward compatilibity **/
    integration?: DeviceSelectorFilter["integration"];
    manufacturer?: DeviceSelectorFilter["manufacturer"];
    model?: DeviceSelectorFilter["model"];
  } | null;
}

export interface EntitySelector {
  entity: {
    multiple?: boolean;
    include_entities?: string[];
    exclude_entities?: string[];
    filter?: EntitySelectorFilter | EntitySelectorFilter[];
    /** For backward compatilibity **/
    integration?: EntitySelectorFilter["integration"];
    domain?: EntitySelectorFilter["domain"];
    device_class?: EntitySelectorFilter["device_class"];
  } | null;
}

```
### Example

```ts
{
  entity: {
    filter: [
      { domain: "input_datetime" },
      { domain: "sensor", device_class: "timestamp" },
    ]
  }
}
```
## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26145

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
