### PR TITLE
Remove default commission buttons on Matter config panel (#15304)Co-authored-by: Bram Kragten <mail@bramkragten.nl>

### DIFF
--- a/src/common/config/version.ts
+++ b/src/common/config/version.ts
@@ -22,3 +22,11 @@ export const atLeastVersion = (
       Number(haPatch) >= patch)
   );
 };
+
+export const isDevVersion = (version: string): boolean => {
+  if (__DEMO__) {
+    return false;
+  }
+
+  return version.includes("dev");
+};

--- a/src/panels/config/integrations/integration-panels/matter/matter-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/matter/matter-config-panel.ts
@@ -2,12 +2,7 @@ import "@material/mwc-button";
 import { css, html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../../../components/ha-card";
-import {
-  acceptSharedMatterDevice,
-  commissionMatterDevice,
-  matterSetThread,
-  matterSetWifi,
-} from "../../../../../data/matter";
+import { matterSetThread, matterSetWifi } from "../../../../../data/matter";
 import "../../../../../layouts/hass-subpage";
 import { haStyle } from "../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../types";
@@ -64,7 +59,9 @@ export class MatterConfigPanel extends LitElement {
               <mwc-button @click=${this._setWifi}
                 >Set WiFi Credentials</mwc-button
               >
-              <mwc-button @click=${this._setThread}>Set Thread Credentials</mwc-button>
+              <mwc-button @click=${this._setThread}
+                >Set Thread Credentials</mwc-button
+              >
             </div>
           </ha-card>
         </div>

--- a/src/panels/config/integrations/integration-panels/matter/matter-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/matter/matter-config-panel.ts
@@ -64,13 +64,7 @@ export class MatterConfigPanel extends LitElement {
               <mwc-button @click=${this._setWifi}
                 >Set WiFi Credentials</mwc-button
               >
-              <mwc-button @click=${this._setThread}>Set Thread</mwc-button>
-              <mwc-button @click=${this._commission}
-                >Commission device</mwc-button
-              >
-              <mwc-button @click=${this._acceptSharedDevice}
-                >Add shared device</mwc-button
-              >
+              <mwc-button @click=${this._setThread}>Set Thread Credentials</mwc-button>
             </div>
           </ha-card>
         </div>
@@ -129,44 +123,6 @@ export class MatterConfigPanel extends LitElement {
     }
     try {
       await matterSetWifi(this.hass, networkName, psk);
-    } catch (err: any) {
-      this._error = err.message;
-    }
-  }
-
-  private async _commission(): Promise<void> {
-    const code = await showPromptDialog(this, {
-      title: "Commission device",
-      inputLabel: "Code",
-      inputType: "string",
-      confirmText: "Commission",
-    });
-    if (!code) {
-      return;
-    }
-    this._error = undefined;
-    this._redirectOnNewDevice();
-    try {
-      await commissionMatterDevice(this.hass, code);
-    } catch (err: any) {
-      this._error = err.message;
-    }
-  }
-
-  private async _acceptSharedDevice(): Promise<void> {
-    const code = await showPromptDialog(this, {
-      title: "Add shared device",
-      inputLabel: "Pin",
-      inputType: "number",
-      confirmText: "Accept device",
-    });
-    if (!code) {
-      return;
-    }
-    this._error = undefined;
-    this._redirectOnNewDevice();
-    try {
-      await acceptSharedMatterDevice(this.hass, Number(code));
     } catch (err: any) {
       this._error = err.message;
     }


### PR DESCRIPTION

## Breaking change


## Proposed change

Remove the default commission buttons from the Matter config panel to avoid confusion. We want to steer people towards commissioning Matter device through the Companion apps. Using the direct commission command on the server requires bluetooth support on the Matter server and it breaks the builtin bluetooth integration, best to only use it for development with a manual call to the websocket.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
