### PR TITLE
Add slight hysteresis to chart height to prevent scrollbar juddering

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -41,6 +41,8 @@ export default class HaChartBase extends LitElement {
 
   @state() private _chartHeight?: number;
 
+  @state() private _hysteresisHeight?: number;
+
   @state() private _tooltip?: Tooltip;
 
   @state() private _hiddenDatasets: Set<number> = new Set();
@@ -103,6 +105,12 @@ export default class HaChartBase extends LitElement {
   }
 
   protected render() {
+    const newheight = this.height ?? this._chartHeight ?? 0;
+    const change = newheight - (this._hysteresisHeight ?? 0);
+    if (!this._hysteresisHeight || change > 0 || change < -12) {
+      this._hysteresisHeight = newheight;
+    }
+
     return html`
       ${this.options?.plugins?.legend?.display === true
         ? html`<div class="chartLegend">
@@ -132,7 +140,7 @@ export default class HaChartBase extends LitElement {
       <div
         class="chartContainer"
         style=${styleMap({
-          height: `${this.height ?? this._chartHeight}px`,
+          height: `${this._hysteresisHeight}px`,
           overflow: this._chartHeight ? "initial" : "hidden",
           "padding-left": `${computeRTL(this.hass) ? 0 : this.paddingYAxis}px`,
           "padding-right": `${computeRTL(this.hass) ? this.paddingYAxis : 0}px`,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If a window with a chart is sized just right, and the width is changed, it can spawn an endless loop of juddering where:

* The width of the chart decreases to fit the window width
* The height of the chart decreases to scale with the reduced width
* The height of the page decreases enough to not need a scrollbar, and it is removed
* The removal of the scrollbar gives extra room in the window width
* The extra room in the window induces the chart to get slightly wider
* The height of the chart increases to scale with the increased width
* The increased height means the page now needs a scrollbar again, and it is added
* The new scrollbar takes up some room on the page, which reduces the usable width of the page
* Repeat loop forever

This change adds a slight amount of hysteresis or "stickiness" when decreasing the chart height, which breaks this endless loop. It is visible as just a couple extra pixels of blank space inside the chart card below the chart. In just example testing I see the height toggling by 9 pixels in this loop, so I settled on 12 pixels of hysteresis to cover this and add a bit of a buffer for unknown changes. I can't be confident that this fixes every possible case of juddering, but I can't trigger it anymore in my test cases. 

The one thing that puzzles me is that I can't seem to trigger this with other cards that scale their height with their width (like map card). I would have assumed a window with map card would be exposed to the same problem, but I couldn't trigger it. Maybe it solves it in a different way, I'm not sure. 

Example of the problem:

![chart_judder](https://user-images.githubusercontent.com/32912880/216405163-bda88d40-5a96-47ab-bd92-5254f9e1894d.gif)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
