### PR TITLE
Provide an option to disable icon colouring based on light RGB state

### DIFF
--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -29,6 +29,8 @@ export class StateBadge extends LitElement {
 
   @property() public overrideImage?: string;
 
+  @property({ type: Boolean }) public lightColoring?: boolean;
+
   @property({ type: Boolean }) public stateColor?: boolean;
 
   @property() public color?: string;
@@ -76,6 +78,7 @@ export class StateBadge extends LitElement {
       !changedProps.has("stateObj") &&
       !changedProps.has("overrideImage") &&
       !changedProps.has("overrideIcon") &&
+      !changedProps.has("lightColoring") &&
       !changedProps.has("stateColor") &&
       !changedProps.has("color")
     ) {
@@ -109,28 +112,33 @@ export class StateBadge extends LitElement {
         hostStyle.backgroundImage = `url(${imageUrl})`;
         this._showIcon = false;
       } else if (this.color) {
-        // Externally provided overriding color wins over state color
+        // Externally provided overriding color wins over state color unless
+        // ignoreLightColor is set to true
         iconStyle.color = this.color;
       } else if (this._stateColor) {
         const color = stateColorCss(stateObj);
         if (color) {
           iconStyle.color = color;
         }
-        if (stateObj.attributes.rgb_color) {
-          iconStyle.color = `rgb(${stateObj.attributes.rgb_color.join(",")})`;
-        }
-        if (stateObj.attributes.brightness) {
-          const brightness = stateObj.attributes.brightness;
-          if (typeof brightness !== "number") {
-            const errorMessage = `Type error: state-badge expected number, but type of ${
-              stateObj.entity_id
-            }.attributes.brightness is ${typeof brightness} (${brightness})`;
-            // eslint-disable-next-line
-            console.warn(errorMessage);
+
+        if (this.lightColoring !== false) {
+          if (stateObj.attributes.rgb_color) {
+            iconStyle.color = `rgb(${stateObj.attributes.rgb_color.join(",")})`;
           }
-          // lowest brightness will be around 50% (that's pretty dark)
-          iconStyle.filter = `brightness(${(brightness + 245) / 5}%)`;
+          if (stateObj.attributes.brightness) {
+            const brightness = stateObj.attributes.brightness;
+            if (typeof brightness !== "number") {
+              const errorMessage = `Type error: state-badge expected number, but type of ${
+                stateObj.entity_id
+              }.attributes.brightness is ${typeof brightness} (${brightness})`;
+              // eslint-disable-next-line
+              console.warn(errorMessage);
+            }
+            // lowest brightness will be around 50% (that's pretty dark)
+            iconStyle.filter = `brightness(${(brightness + 245) / 5}%)`;
+          }
         }
+
         if (stateObj.attributes.hvac_action) {
           const hvacAction = stateObj.attributes.hvac_action;
           if (hvacAction in HVAC_ACTION_TO_MODE) {

--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -310,7 +310,8 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   private _computeBrightness(stateObj: HassEntity | LightEntity): string {
-    if (stateObj.attributes.brightness) {
+    const lightColoring = this._config?.light_coloring !== false;
+    if (lightColoring && stateObj.attributes.brightness) {
       const brightness = stateObj.attributes.brightness;
       return `brightness(${(brightness + 245) / 5}%)`;
     }
@@ -318,7 +319,8 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   private _computeColor(stateObj: HassEntity): string | undefined {
-    if (stateObj.attributes.rgb_color) {
+    const lightColoring = this._config?.light_coloring !== false;
+    if (lightColoring && stateObj.attributes.rgb_color) {
       return `rgb(${stateObj.attributes.rgb_color.join(",")})`;
     }
     if (stateObj.attributes.hvac_action) {

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -200,7 +200,8 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
       }
       return undefined;
     }
-    if (stateObj.attributes.rgb_color) {
+    const lightColoring = this._config?.light_coloring !== false;
+    if (lightColoring && stateObj.attributes.rgb_color) {
       return `rgb(${stateObj.attributes.rgb_color.join(",")})`;
     }
     const iconColor = stateColorCss(stateObj);
@@ -211,7 +212,8 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
   }
 
   private _computeBrightness(stateObj: HassEntity | LightEntity): string {
-    if (stateObj.attributes.brightness) {
+    const lightColoring = this._config?.light_coloring !== false;
+    if (lightColoring && stateObj.attributes.brightness) {
       const brightness = stateObj.attributes.brightness;
       return `brightness(${(brightness + 245) / 5}%)`;
     }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -43,6 +43,7 @@ export interface EntityCardConfig extends LovelaceCardConfig {
   unit?: string;
   theme?: string;
   state_color?: boolean;
+  light_coloring?: boolean;
 }
 
 export interface EntitiesCardEntityConfig extends EntityConfig {
@@ -65,6 +66,7 @@ export interface EntitiesCardEntityConfig extends EntityConfig {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
   state_color?: boolean;
+  light_coloring?: boolean;
   show_name?: boolean;
   show_icon?: boolean;
 }
@@ -99,6 +101,7 @@ export interface ButtonCardConfig extends LovelaceCardConfig {
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;
   state_color?: boolean;
+  light_coloring?: boolean;
   show_state?: boolean;
 }
 

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -76,6 +76,7 @@ class HuiGenericEntityRow extends LitElement {
         .stateObj=${stateObj}
         .overrideIcon=${this.config.icon}
         .overrideImage=${this.config.image}
+        .lightColoring=${this.config.light_coloring}
         .stateColor=${this.config.state_color}
         @action=${this._handleAction}
         .actionHandler=${actionHandler({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently, light icons for RGB lights are displayed in the colour of the actual light. This is a UX nightmare and [many people](https://community.home-assistant.io/t/disable-colouring-of-light-entities-icons/462611) want the ability to turn this off. Unfortunately, there was no way to do so until now, without resorting to CSS hacks (e.g. card-mod).

See screenshot with `light_coloring` both on and off:

![image](https://user-images.githubusercontent.com/296540/216734229-7ad60a3a-b0d2-416d-a833-469b112f84fc.png)

On the left hand side, the icon takes the colour of the bulb (green), on the right hand side, it uses the default colour for active light entities as defined in the theme.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
type: entities
entities:
  - entity: light.ceiling
    light_coloring: false
  - entity: light.floor_lamp
    light_coloring: false
  - entity: light.floor_lamp_2
    light_coloring: false
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/disable-colouring-of-light-entities-icons/462611
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26108

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
