### PR TITLE
Support entity reg id in device automations

### DIFF
--- a/gallery/src/pages/automation/describe-condition.ts
+++ b/gallery/src/pages/automation/describe-condition.ts
@@ -63,7 +63,7 @@ export class DemoAutomationDescribeCondition extends LitElement {
         <div class="condition">
           <span>
             ${this._condition
-              ? describeCondition(this._condition, this.hass)
+              ? describeCondition(this._condition, this.hass, [])
               : "<invalid YAML>"}
           </span>
           <ha-yaml-editor
@@ -76,7 +76,7 @@ export class DemoAutomationDescribeCondition extends LitElement {
         ${conditions.map(
           (conf) => html`
             <div class="condition">
-              <span>${describeCondition(conf as any, this.hass)}</span>
+              <span>${describeCondition(conf as any, this.hass, [])}</span>
               <pre>${dump(conf)}</pre>
             </div>
           `

--- a/gallery/src/pages/automation/describe-trigger.ts
+++ b/gallery/src/pages/automation/describe-trigger.ts
@@ -74,7 +74,7 @@ export class DemoAutomationDescribeTrigger extends LitElement {
         <div class="trigger">
           <span>
             ${this._trigger
-              ? describeTrigger(this._trigger, this.hass)
+              ? describeTrigger(this._trigger, this.hass, [])
               : "<invalid YAML>"}
           </span>
           <ha-yaml-editor
@@ -86,7 +86,7 @@ export class DemoAutomationDescribeTrigger extends LitElement {
         ${triggers.map(
           (conf) => html`
             <div class="trigger">
-              <span>${describeTrigger(conf as any, this.hass)}</span>
+              <span>${describeTrigger(conf as any, this.hass, [])}</span>
               <pre>${dump(conf)}</pre>
             </div>
           `

--- a/src/components/device/ha-device-automation-picker.ts
+++ b/src/components/device/ha-device-automation-picker.ts
@@ -75,7 +75,7 @@ export abstract class HaDeviceAutomationPicker<
     }
 
     const idx = this._automations.findIndex((automation) =>
-      deviceAutomationsEqual(automation, this.value!)
+      deviceAutomationsEqual(this.hass, automation, this.value!)
     );
 
     if (idx === -1) {
@@ -161,7 +161,10 @@ export abstract class HaDeviceAutomationPicker<
   }
 
   private _setValue(automation: T) {
-    if (this.value && deviceAutomationsEqual(automation, this.value)) {
+    if (
+      this.value &&
+      deviceAutomationsEqual(this.hass, automation, this.value)
+    ) {
       return;
     }
     const value = { ...automation };

--- a/src/components/device/ha-device-automation-picker.ts
+++ b/src/components/device/ha-device-automation-picker.ts
@@ -1,12 +1,15 @@
+import { consume } from "@lit-labs/context";
 import "@material/mwc-list/mwc-list-item";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
+import { fullEntitiesContext } from "../../data/context";
 import {
   DeviceAutomation,
   deviceAutomationsEqual,
   sortDeviceAutomations,
 } from "../../data/device_automation";
+import { EntityRegistryEntry } from "../../data/entity_registry";
 import { HomeAssistant } from "../../types";
 import "../ha-select";
 
@@ -30,6 +33,10 @@ export abstract class HaDeviceAutomationPicker<
   // paper-listbox does not like changing things around.
   @state() private _renderEmpty = false;
 
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
+
   protected get NO_AUTOMATION_TEXT() {
     return this.hass.localize(
       "ui.panel.config.devices.automation.actions.no_actions"
@@ -44,6 +51,7 @@ export abstract class HaDeviceAutomationPicker<
 
   private _localizeDeviceAutomation: (
     hass: HomeAssistant,
+    entityRegistry: EntityRegistryEntry[],
     automation: T
   ) => string;
 
@@ -75,7 +83,7 @@ export abstract class HaDeviceAutomationPicker<
     }
 
     const idx = this._automations.findIndex((automation) =>
-      deviceAutomationsEqual(this.hass, automation, this.value!)
+      deviceAutomationsEqual(this._entityReg, automation, this.value!)
     );
 
     if (idx === -1) {
@@ -110,7 +118,11 @@ export abstract class HaDeviceAutomationPicker<
         ${this._automations.map(
           (automation, idx) => html`
             <mwc-list-item .value=${`${automation.device_id}_${idx}`}>
-              ${this._localizeDeviceAutomation(this.hass, automation)}
+              ${this._localizeDeviceAutomation(
+                this.hass,
+                this._entityReg,
+                automation
+              )}
             </mwc-list-item>
           `
         )}
@@ -163,7 +175,7 @@ export abstract class HaDeviceAutomationPicker<
   private _setValue(automation: T) {
     if (
       this.value &&
-      deviceAutomationsEqual(this.hass, automation, this.value)
+      deviceAutomationsEqual(this._entityReg, automation, this.value)
     ) {
       return;
     }

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -15,6 +15,7 @@ import {
   computeAttributeValueDisplay,
 } from "../common/entity/compute_attribute_display";
 import { computeStateDisplay } from "../common/entity/compute_state_display";
+import { EntityRegistryEntry } from "./entity_registry";
 
 const describeDuration = (forTime: number | string | ForDict) => {
   let duration: string | null;
@@ -31,6 +32,7 @@ const describeDuration = (forTime: number | string | ForDict) => {
 export const describeTrigger = (
   trigger: Trigger,
   hass: HomeAssistant,
+  entityRegistry: EntityRegistryEntry[],
   ignoreAlias = false
 ) => {
   if (trigger.alias && !ignoreAlias) {
@@ -437,7 +439,11 @@ export const describeTrigger = (
       return "Device trigger";
     }
     const config = trigger as DeviceTrigger;
-    const localized = localizeDeviceAutomationTrigger(hass, config);
+    const localized = localizeDeviceAutomationTrigger(
+      hass,
+      entityRegistry,
+      config
+    );
     if (localized) {
       return localized;
     }
@@ -455,6 +461,7 @@ export const describeTrigger = (
 export const describeCondition = (
   condition: Condition,
   hass: HomeAssistant,
+  entityRegistry: EntityRegistryEntry[],
   ignoreAlias = false
 ) => {
   if (condition.alias && !ignoreAlias) {
@@ -749,7 +756,11 @@ export const describeCondition = (
       return "Device condition";
     }
     const config = condition as DeviceCondition;
-    const localized = localizeDeviceAutomationCondition(hass, config);
+    const localized = localizeDeviceAutomationCondition(
+      hass,
+      entityRegistry,
+      config
+    );
     if (localized) {
       return localized;
     }

--- a/src/data/context.ts
+++ b/src/data/context.ts
@@ -20,5 +20,5 @@ export const userDataContext =
   createContext<HomeAssistant["userData"]>("userData");
 export const panelsContext = createContext<HomeAssistant["panels"]>("panels");
 
-export const extendedEntitiesContext =
+export const fullEntitiesContext =
   createContext<EntityRegistryEntry[]>("extendedEntities");

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -133,69 +133,65 @@ const getEntityName = (
       return computeStateName(state);
     }
     return entityId;
-  } 
-    const entityReg = entityRegistryById(hass.entities)[entityId];
-    if (entityReg) {
-      return computeEntityRegistryName(hass, entityReg) || entityId;
-    }
-    return "<unknown entity>";
-  
+  }
+  const entityReg = entityRegistryById(hass.entities)[entityId];
+  if (entityReg) {
+    return computeEntityRegistryName(hass, entityReg) || entityId;
+  }
+  return "<unknown entity>";
 };
 
 export const localizeDeviceAutomationAction = (
   hass: HomeAssistant,
   action: DeviceAction
-): string => (
-    hass.localize(
-      `component.${action.domain}.device_automation.action_type.${action.type}`,
-      "entity_name",
-      getEntityName(hass, action.entity_id),
-      "subtype",
-      action.subtype
-        ? hass.localize(
-            `component.${action.domain}.device_automation.action_subtype.${action.subtype}`
-          ) || action.subtype
-        : ""
-    ) || (action.subtype ? `"${action.subtype}" ${action.type}` : action.type!)
-  );
+): string =>
+  hass.localize(
+    `component.${action.domain}.device_automation.action_type.${action.type}`,
+    "entity_name",
+    getEntityName(hass, action.entity_id),
+    "subtype",
+    action.subtype
+      ? hass.localize(
+          `component.${action.domain}.device_automation.action_subtype.${action.subtype}`
+        ) || action.subtype
+      : ""
+  ) || (action.subtype ? `"${action.subtype}" ${action.type}` : action.type!);
 
 export const localizeDeviceAutomationCondition = (
   hass: HomeAssistant,
   condition: DeviceCondition
-): string => (
-    hass.localize(
-      `component.${condition.domain}.device_automation.condition_type.${condition.type}`,
-      "entity_name",
-      getEntityName(hass, condition.entity_id),
-      "subtype",
-      condition.subtype
-        ? hass.localize(
-            `component.${condition.domain}.device_automation.condition_subtype.${condition.subtype}`
-          ) || condition.subtype
-        : ""
-    ) ||
-    (condition.subtype
-      ? `"${condition.subtype}" ${condition.type}`
-      : condition.type!)
-  );
+): string =>
+  hass.localize(
+    `component.${condition.domain}.device_automation.condition_type.${condition.type}`,
+    "entity_name",
+    getEntityName(hass, condition.entity_id),
+    "subtype",
+    condition.subtype
+      ? hass.localize(
+          `component.${condition.domain}.device_automation.condition_subtype.${condition.subtype}`
+        ) || condition.subtype
+      : ""
+  ) ||
+  (condition.subtype
+    ? `"${condition.subtype}" ${condition.type}`
+    : condition.type!);
 
 export const localizeDeviceAutomationTrigger = (
   hass: HomeAssistant,
   trigger: DeviceTrigger
-): string => (
-    hass.localize(
-      `component.${trigger.domain}.device_automation.trigger_type.${trigger.type}`,
-      "entity_name",
-      getEntityName(hass, trigger.entity_id),
-      "subtype",
-      trigger.subtype
-        ? hass.localize(
-            `component.${trigger.domain}.device_automation.trigger_subtype.${trigger.subtype}`
-          ) || trigger.subtype
-        : ""
-    ) ||
-    (trigger.subtype ? `"${trigger.subtype}" ${trigger.type}` : trigger.type!)
-  );
+): string =>
+  hass.localize(
+    `component.${trigger.domain}.device_automation.trigger_type.${trigger.type}`,
+    "entity_name",
+    getEntityName(hass, trigger.entity_id),
+    "subtype",
+    trigger.subtype
+      ? hass.localize(
+          `component.${trigger.domain}.device_automation.trigger_subtype.${trigger.subtype}`
+        ) || trigger.subtype
+      : ""
+  ) ||
+  (trigger.subtype ? `"${trigger.subtype}" ${trigger.type}` : trigger.type!);
 
 export const sortDeviceAutomations = (
   automationA: DeviceAutomation,

--- a/src/data/device_automation.ts
+++ b/src/data/device_automation.ts
@@ -93,6 +93,7 @@ const deviceAutomationIdentifiers = [
 ];
 
 export const deviceAutomationsEqual = (
+  hass: HomeAssistant,
   a: DeviceAutomation,
   b: DeviceAutomation
 ) => {
@@ -104,6 +105,16 @@ export const deviceAutomationsEqual = (
     if (!deviceAutomationIdentifiers.includes(property)) {
       continue;
     }
+    if (
+      property === "entity_id" &&
+      a[property]?.includes(".") !== b[property]?.includes(".")
+    ) {
+      // both entity_id and entity_reg_id could be used, we should compare the entity_reg_id
+      if (!compareEntityIdWithEntityRegId(hass, a[property], b[property])) {
+        return false;
+      }
+      continue;
+    }
     if (!Object.is(a[property], b[property])) {
       return false;
     }
@@ -112,12 +123,39 @@ export const deviceAutomationsEqual = (
     if (!deviceAutomationIdentifiers.includes(property)) {
       continue;
     }
+    if (
+      property === "entity_id" &&
+      a[property]?.includes(".") !== b[property]?.includes(".")
+    ) {
+      // both entity_id and entity_reg_id could be used, we should compare the entity_reg_id
+      if (!compareEntityIdWithEntityRegId(hass, a[property], b[property])) {
+        return false;
+      }
+      continue;
+    }
     if (!Object.is(a[property], b[property])) {
       return false;
     }
   }
 
   return true;
+};
+
+const compareEntityIdWithEntityRegId = (
+  hass: HomeAssistant,
+  entityIdA?: string,
+  entityIdB?: string
+) => {
+  if (!entityIdA || !entityIdB) {
+    return false;
+  }
+  if (entityIdA.includes(".")) {
+    entityIdA = hass.entities[entityIdA]?.id;
+  }
+  if (entityIdB.includes(".")) {
+    entityIdB = hass.entities[entityIdB]?.id;
+  }
+  return entityIdA === entityIdB;
 };
 
 const getEntityName = (

--- a/src/data/script_i18n.ts
+++ b/src/data/script_i18n.ts
@@ -186,7 +186,7 @@ export const describeAction = <T extends ActionType>(
       return "Wait for a trigger";
     }
     return `Wait for ${triggers
-      .map((trigger) => describeTrigger(trigger, hass))
+      .map((trigger) => describeTrigger(trigger, hass, entityRegistry))
       .join(", ")}`;
   }
 
@@ -208,7 +208,7 @@ export const describeAction = <T extends ActionType>(
   }
 
   if (actionType === "check_condition") {
-    return describeCondition(action as Condition, hass);
+    return describeCondition(action as Condition, hass, entityRegistry);
   }
 
   if (actionType === "stop") {
@@ -226,7 +226,7 @@ export const describeAction = <T extends ActionType>(
         : ensureArray(config.if).length > 1
         ? `${ensureArray(config.if).length} conditions`
         : ensureArray(config.if).length
-        ? describeCondition(ensureArray(config.if)[0], hass)
+        ? describeCondition(ensureArray(config.if)[0], hass, entityRegistry)
         : ""
     }${config.else ? " (or else!)" : ""}`;
   }
@@ -252,11 +252,11 @@ export const describeAction = <T extends ActionType>(
       base += ` ${count} time${Number(count) === 1 ? "" : "s"}`;
     } else if ("while" in config.repeat) {
       base += ` while ${ensureArray(config.repeat.while)
-        .map((condition) => describeCondition(condition, hass))
+        .map((condition) => describeCondition(condition, hass, entityRegistry))
         .join(", ")} is true`;
     } else if ("until" in config.repeat) {
       base += ` until ${ensureArray(config.repeat.until)
-        .map((condition) => describeCondition(condition, hass))
+        .map((condition) => describeCondition(condition, hass, entityRegistry))
         .join(", ")} is true`;
     } else if ("for_each" in config.repeat) {
       base += ` for every item: ${ensureArray(config.repeat.for_each)
@@ -267,7 +267,11 @@ export const describeAction = <T extends ActionType>(
   }
 
   if (actionType === "check_condition") {
-    return `Test ${describeCondition(action as Condition, hass)}`;
+    return `Test ${describeCondition(
+      action as Condition,
+      hass,
+      entityRegistry
+    )}`;
   }
 
   if (actionType === "device_action") {
@@ -275,7 +279,11 @@ export const describeAction = <T extends ActionType>(
     if (!config.device_id) {
       return "Device action";
     }
-    const localized = localizeDeviceAutomationAction(hass, config);
+    const localized = localizeDeviceAutomationAction(
+      hass,
+      entityRegistry,
+      config
+    );
     if (localized) {
       return localized;
     }

--- a/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
@@ -98,7 +98,10 @@ export class HaDeviceAction extends LitElement {
 
   protected updated(changedPros) {
     const prevAction = changedPros.get("action");
-    if (prevAction && !deviceAutomationsEqual(prevAction, this.action)) {
+    if (
+      prevAction &&
+      !deviceAutomationsEqual(this.hass, prevAction, this.action)
+    ) {
       this._deviceId = undefined;
       this._getCapabilities();
     }
@@ -123,7 +126,10 @@ export class HaDeviceAction extends LitElement {
   private _deviceActionPicked(ev) {
     ev.stopPropagation();
     let action = ev.detail.value;
-    if (this._origAction && deviceAutomationsEqual(this._origAction, action)) {
+    if (
+      this._origAction &&
+      deviceAutomationsEqual(this.hass, this._origAction, action)
+    ) {
       action = this._origAction;
     }
     fireEvent(this, "value-changed", { value: action });

--- a/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-device_id.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit-labs/context";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -5,12 +6,14 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/device/ha-device-action-picker";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/ha-form/ha-form";
+import { fullEntitiesContext } from "../../../../../data/context";
 import {
   DeviceAction,
   deviceAutomationsEqual,
   DeviceCapabilities,
   fetchDeviceActionCapabilities,
 } from "../../../../../data/device_automation";
+import { EntityRegistryEntry } from "../../../../../data/entity_registry";
 import { HomeAssistant } from "../../../../../types";
 
 @customElement("ha-automation-action-device_id")
@@ -24,6 +27,10 @@ export class HaDeviceAction extends LitElement {
   @state() private _deviceId?: string;
 
   @state() private _capabilities?: DeviceCapabilities;
+
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
 
   private _origAction?: DeviceAction;
 
@@ -100,7 +107,7 @@ export class HaDeviceAction extends LitElement {
     const prevAction = changedPros.get("action");
     if (
       prevAction &&
-      !deviceAutomationsEqual(this.hass, prevAction, this.action)
+      !deviceAutomationsEqual(this._entityReg, prevAction, this.action)
     ) {
       this._deviceId = undefined;
       this._getCapabilities();
@@ -128,7 +135,7 @@ export class HaDeviceAction extends LitElement {
     let action = ev.detail.value;
     if (
       this._origAction &&
-      deviceAutomationsEqual(this.hass, this._origAction, action)
+      deviceAutomationsEqual(this._entityReg, this._origAction, action)
     ) {
       action = this._origAction;
     }

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit-labs/context";
 import { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
 import "@material/mwc-list/mwc-list-item";
 import {
@@ -25,6 +26,8 @@ import { Condition, testCondition } from "../../../../data/automation";
 import { describeCondition } from "../../../../data/automation_i18n";
 import { CONDITION_TYPES } from "../../../../data/condition";
 import { validateConfig } from "../../../../data/config";
+import { fullEntitiesContext } from "../../../../data/context";
+import { EntityRegistryEntry } from "../../../../data/entity_registry";
 import {
   showAlertDialog,
   showConfirmationDialog,
@@ -85,6 +88,10 @@ export default class HaAutomationConditionRow extends LitElement {
 
   @state() private _testingResult?: boolean;
 
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
+
   protected render() {
     if (!this.condition) {
       return nothing;
@@ -106,7 +113,7 @@ export default class HaAutomationConditionRow extends LitElement {
               .path=${CONDITION_TYPES[this.condition.condition]}
             ></ha-svg-icon>
             ${capitalizeFirstLetter(
-              describeCondition(this.condition, this.hass)
+              describeCondition(this.condition, this.hass, this._entityReg)
             )}
           </h3>
 
@@ -423,7 +430,7 @@ export default class HaAutomationConditionRow extends LitElement {
       ),
       inputType: "string",
       placeholder: capitalizeFirstLetter(
-        describeCondition(this.condition, this.hass, true)
+        describeCondition(this.condition, this.hass, this._entityReg, true)
       ),
       defaultValue: this.condition.alias,
       confirmText: this.hass.localize("ui.common.submit"),

--- a/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
@@ -100,7 +100,7 @@ export class HaDeviceCondition extends LitElement {
     const prevCondition = changedPros.get("condition");
     if (
       prevCondition &&
-      !deviceAutomationsEqual(prevCondition, this.condition)
+      !deviceAutomationsEqual(this.hass, prevCondition, this.condition)
     ) {
       this._getCapabilities();
     }
@@ -129,7 +129,7 @@ export class HaDeviceCondition extends LitElement {
     let condition = ev.detail.value;
     if (
       this._origCondition &&
-      deviceAutomationsEqual(this._origCondition, condition)
+      deviceAutomationsEqual(this.hass, this._origCondition, condition)
     ) {
       condition = this._origCondition;
     }

--- a/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-device.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit-labs/context";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -5,12 +6,14 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/device/ha-device-condition-picker";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/ha-form/ha-form";
+import { fullEntitiesContext } from "../../../../../data/context";
 import {
   deviceAutomationsEqual,
   DeviceCapabilities,
   DeviceCondition,
   fetchDeviceConditionCapabilities,
 } from "../../../../../data/device_automation";
+import { EntityRegistryEntry } from "../../../../../data/entity_registry";
 import type { HomeAssistant } from "../../../../../types";
 
 @customElement("ha-automation-condition-device")
@@ -24,6 +27,10 @@ export class HaDeviceCondition extends LitElement {
   @state() private _deviceId?: string;
 
   @state() private _capabilities?: DeviceCapabilities;
+
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
 
   private _origCondition?: DeviceCondition;
 
@@ -100,7 +107,7 @@ export class HaDeviceCondition extends LitElement {
     const prevCondition = changedPros.get("condition");
     if (
       prevCondition &&
-      !deviceAutomationsEqual(this.hass, prevCondition, this.condition)
+      !deviceAutomationsEqual(this._entityReg, prevCondition, this.condition)
     ) {
       this._getCapabilities();
     }
@@ -129,7 +136,7 @@ export class HaDeviceCondition extends LitElement {
     let condition = ev.detail.value;
     if (
       this._origCondition &&
-      deviceAutomationsEqual(this.hass, this._origCondition, condition)
+      deviceAutomationsEqual(this._entityReg, this._origCondition, condition)
     ) {
       condition = this._origCondition;
     }

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit-labs/context";
 import { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
 import "@material/mwc-list/mwc-list-item";
 import {
@@ -30,6 +31,8 @@ import { HaYamlEditor } from "../../../../components/ha-yaml-editor";
 import { subscribeTrigger, Trigger } from "../../../../data/automation";
 import { describeTrigger } from "../../../../data/automation_i18n";
 import { validateConfig } from "../../../../data/config";
+import { fullEntitiesContext } from "../../../../data/context";
+import { EntityRegistryEntry } from "../../../../data/entity_registry";
 import { TRIGGER_TYPES } from "../../../../data/trigger";
 import {
   showAlertDialog,
@@ -104,6 +107,10 @@ export default class HaAutomationTriggerRow extends LitElement {
 
   @query("ha-yaml-editor") private _yamlEditor?: HaYamlEditor;
 
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
+
   private _triggerUnsub?: Promise<UnsubscribeFunc>;
 
   protected render() {
@@ -131,7 +138,9 @@ export default class HaAutomationTriggerRow extends LitElement {
               class="trigger-icon"
               .path=${TRIGGER_TYPES[this.trigger.platform]}
             ></ha-svg-icon>
-            ${capitalizeFirstLetter(describeTrigger(this.trigger, this.hass))}
+            ${capitalizeFirstLetter(
+              describeTrigger(this.trigger, this.hass, this._entityReg)
+            )}
           </h3>
 
           <slot name="icons" slot="icons"></slot>
@@ -534,7 +543,7 @@ export default class HaAutomationTriggerRow extends LitElement {
       ),
       inputType: "string",
       placeholder: capitalizeFirstLetter(
-        describeTrigger(this.trigger, this.hass, true)
+        describeTrigger(this.trigger, this.hass, this._entityReg, true)
       ),
       defaultValue: this.trigger.alias,
       confirmText: this.hass.localize("ui.common.submit"),

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -96,12 +96,15 @@ export class HaDeviceTrigger extends LitElement {
     }
   }
 
-  protected updated(changedPros) {
-    if (!changedPros.has("trigger")) {
+  protected updated(changedProps) {
+    if (!changedProps.has("trigger")) {
       return;
     }
-    const prevTrigger = changedPros.get("trigger");
-    if (prevTrigger && !deviceAutomationsEqual(prevTrigger, this.trigger)) {
+    const prevTrigger = changedProps.get("trigger");
+    if (
+      prevTrigger &&
+      !deviceAutomationsEqual(this.hass, prevTrigger, this.trigger)
+    ) {
       this._getCapabilities();
     }
   }
@@ -129,7 +132,7 @@ export class HaDeviceTrigger extends LitElement {
     let trigger = ev.detail.value;
     if (
       this._origTrigger &&
-      deviceAutomationsEqual(this._origTrigger, trigger)
+      deviceAutomationsEqual(this.hass, this._origTrigger, trigger)
     ) {
       trigger = this._origTrigger;
     }

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -56,7 +56,7 @@ export class HaDeviceTrigger extends LitElement {
         @value-changed=${this._devicePicked}
         .hass=${this.hass}
         .disabled=${this.disabled}
-        label=${this.hass.localize(
+        .label=${this.hass.localize(
           "ui.panel.config.automation.editor.triggers.type.device.label"
         )}
       ></ha-device-picker>
@@ -66,7 +66,7 @@ export class HaDeviceTrigger extends LitElement {
         @value-changed=${this._deviceTriggerPicked}
         .hass=${this.hass}
         .disabled=${this.disabled}
-        label=${this.hass.localize(
+        .label=${this.hass.localize(
           "ui.panel.config.automation.editor.triggers.type.device.trigger"
         )}
       ></ha-device-trigger-picker>

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-device.ts
@@ -1,3 +1,4 @@
+import { consume } from "@lit-labs/context";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
@@ -5,12 +6,14 @@ import { fireEvent } from "../../../../../common/dom/fire_event";
 import "../../../../../components/device/ha-device-picker";
 import "../../../../../components/device/ha-device-trigger-picker";
 import "../../../../../components/ha-form/ha-form";
+import { fullEntitiesContext } from "../../../../../data/context";
 import {
   deviceAutomationsEqual,
   DeviceCapabilities,
   DeviceTrigger,
   fetchDeviceTriggerCapabilities,
 } from "../../../../../data/device_automation";
+import { EntityRegistryEntry } from "../../../../../data/entity_registry";
 import { HomeAssistant } from "../../../../../types";
 
 @customElement("ha-automation-trigger-device")
@@ -24,6 +27,10 @@ export class HaDeviceTrigger extends LitElement {
   @state() private _deviceId?: string;
 
   @state() private _capabilities?: DeviceCapabilities;
+
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
 
   private _origTrigger?: DeviceTrigger;
 
@@ -103,7 +110,7 @@ export class HaDeviceTrigger extends LitElement {
     const prevTrigger = changedProps.get("trigger");
     if (
       prevTrigger &&
-      !deviceAutomationsEqual(this.hass, prevTrigger, this.trigger)
+      !deviceAutomationsEqual(this._entityReg, prevTrigger, this.trigger)
     ) {
       this._getCapabilities();
     }
@@ -132,7 +139,7 @@ export class HaDeviceTrigger extends LitElement {
     let trigger = ev.detail.value;
     if (
       this._origTrigger &&
-      deviceAutomationsEqual(this.hass, this._origTrigger, trigger)
+      deviceAutomationsEqual(this._entityReg, this._origTrigger, trigger)
     ) {
       trigger = this._origTrigger;
     }

--- a/src/panels/config/devices/device-detail/ha-device-automation-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-automation-card.ts
@@ -1,13 +1,16 @@
+import { consume } from "@lit-labs/context";
 import { css, html, LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-chip";
 import "../../../../components/ha-chip-set";
 import { showAutomationEditor } from "../../../../data/automation";
+import { fullEntitiesContext } from "../../../../data/context";
 import {
   DeviceAction,
   DeviceAutomation,
 } from "../../../../data/device_automation";
+import { EntityRegistryEntry } from "../../../../data/entity_registry";
 import { showScriptEditor } from "../../../../data/script";
 import { buttonLinkStyle } from "../../../../resources/styles";
 import { HomeAssistant } from "../../../../types";
@@ -31,12 +34,17 @@ export abstract class HaDeviceAutomationCard<
 
   @state() public _showSecondary = false;
 
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
+
   abstract headerKey: Parameters<typeof this.hass.localize>[0];
 
   abstract type: "action" | "condition" | "trigger";
 
   private _localizeDeviceAutomation: (
     hass: HomeAssistant,
+    entityRegistry: EntityRegistryEntry[],
     automation: T
   ) => string;
 
@@ -79,7 +87,11 @@ export abstract class HaDeviceAutomationCard<
                   @click=${this._handleAutomationClicked}
                   class=${automation.metadata?.secondary ? "secondary" : ""}
                 >
-                  ${this._localizeDeviceAutomation(this.hass, automation)}
+                  ${this._localizeDeviceAutomation(
+                    this.hass,
+                    this._entityReg,
+                    automation
+                  )}
                 </ha-chip>
               `
           )}

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -36,7 +36,11 @@ import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { listenMediaQuery } from "../../common/dom/media_query";
 import { CloudStatus, fetchCloudStatus } from "../../data/cloud";
 import { fullEntitiesContext } from "../../data/context";
-import { subscribeEntityRegistry } from "../../data/entity_registry";
+import {
+  entityRegistryByEntityId,
+  entityRegistryById,
+  subscribeEntityRegistry,
+} from "../../data/entity_registry";
 import "../../layouts/hass-loading-screen";
 import { HassRouterPage, RouterOptions } from "../../layouts/hass-router-page";
 import { PageNavigation } from "../../layouts/hass-tabs-subpage";
@@ -564,6 +568,8 @@ class HaPanelConfig extends SubscribeMixin(HassRouterPage) {
     while (this._listeners.length) {
       this._listeners.pop()!();
     }
+    entityRegistryByEntityId.clear();
+    entityRegistryById.clear();
   }
 
   protected firstUpdated(changedProps: PropertyValues) {

--- a/src/panels/config/script/ha-config-script.ts
+++ b/src/panels/config/script/ha-config-script.ts
@@ -1,19 +1,17 @@
-import { HassEntities, UnsubscribeFunc } from "home-assistant-js-websocket";
+import { consume } from "@lit-labs/context";
+import { HassEntities } from "home-assistant-js-websocket";
 import { PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { debounce } from "../../../common/util/debounce";
-import {
-  EntityRegistryEntry,
-  subscribeEntityRegistry,
-} from "../../../data/entity_registry";
+import { fullEntitiesContext } from "../../../data/context";
+import { EntityRegistryEntry } from "../../../data/entity_registry";
 import { ScriptEntity } from "../../../data/script";
 import {
   HassRouterPage,
   RouterOptions,
 } from "../../../layouts/hass-router-page";
-import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { HomeAssistant } from "../../../types";
 import "./ha-script-editor";
 import "./ha-script-picker";
@@ -26,7 +24,7 @@ const equal = (a: ScriptEntity[], b: ScriptEntity[]): boolean => {
 };
 
 @customElement("ha-config-script")
-class HaConfigScript extends SubscribeMixin(HassRouterPage) {
+class HaConfigScript extends HassRouterPage {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property() public narrow!: boolean;
@@ -37,15 +35,9 @@ class HaConfigScript extends SubscribeMixin(HassRouterPage) {
 
   @property() public scripts: ScriptEntity[] = [];
 
-  @state() private _entityReg: EntityRegistryEntry[] = [];
-
-  public hassSubscribe(): UnsubscribeFunc[] {
-    return [
-      subscribeEntityRegistry(this.hass.connection!, (entities) => {
-        this._entityReg = entities;
-      }),
-    ];
-  }
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
 
   protected routerOptions: RouterOptions = {
     defaultPage: "dashboard",


### PR DESCRIPTION

## Proposed change

This adds support for device automations to pass the entity registry id instead if the entity id.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
