### PR TITLE
Add climate temperature to tile features

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -29,6 +29,7 @@ import "../../../components/tile/ha-tile-icon";
 import "../../../components/tile/ha-tile-image";
 import "../../../components/tile/ha-tile-info";
 import { cameraUrlWithWidthHeight } from "../../../data/camera";
+import { ClimateEntity } from "../../../data/climate";
 import { CoverEntity } from "../../../data/cover";
 import { isUnavailableState, ON } from "../../../data/entity";
 import { FanEntity } from "../../../data/fan";
@@ -38,6 +39,7 @@ import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
 import { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { findEntities } from "../common/find-entities";
+import { formatNumber } from "../../../common/number/format_number";
 import { handleAction } from "../common/handle-action";
 import "../components/hui-timestamp-display";
 import { createTileFeatureElement } from "../create-element/create-tile-feature-element";
@@ -224,6 +226,12 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
           this.hass!.locale
         )}%`;
       }
+    }
+    if (domain === "climate") {
+      return `${stateDisplay} - ${formatNumber(
+        (stateObj as ClimateEntity).attributes.temperature,
+        this.hass!.locale
+      )}${this.hass!.config.unit_system.temperature}`;
     }
     return stateDisplay;
   }

--- a/src/panels/lovelace/create-element/create-tile-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-tile-feature-element.ts
@@ -3,12 +3,14 @@ import {
   createLovelaceElement,
   getLovelaceElementClass,
 } from "./create-element-base";
+import "../tile-features/hui-climate-temperature-tile-feature";
 import "../tile-features/hui-cover-open-close-tile-feature";
 import "../tile-features/hui-cover-tilt-tile-feature";
 import "../tile-features/hui-light-brightness-tile-feature";
 import "../tile-features/hui-vacuum-commands-tile-feature";
 
 const TYPES: Set<LovelaceTileFeatureConfig["type"]> = new Set([
+  "climate-temperature",
   "cover-open-close",
   "cover-tilt",
   "light-brightness",

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
@@ -31,6 +31,7 @@ import {
 import { LovelaceTileFeatureConfig } from "../../tile-features/types";
 
 const FEATURES_TYPE: LovelaceTileFeatureConfig["type"][] = [
+  "climate-temperature",
   "cover-open-close",
   "cover-tilt",
   "light-brightness",

--- a/src/panels/lovelace/tile-features/hui-climate-temperature-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-climate-temperature-tile-feature.ts
@@ -1,0 +1,115 @@
+import { mdiPlus, mdiMinus } from "@mdi/js";
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { supportsFeature } from "../../../common/entity/supports-feature";
+import "../../../components/tile/ha-tile-button";
+import { ClimateEntityFeature } from "../../../data/climate";
+import { HomeAssistant } from "../../../types";
+import { LovelaceTileFeature } from "../types";
+import { ClimateTemperatureTileFeatureConfig } from "./types";
+
+@customElement("hui-climate-temperature-tile-feature")
+class HuiClimateTemperatureTileFeature
+  extends LitElement
+  implements LovelaceTileFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state() private _config?: ClimateTemperatureTileFeatureConfig;
+
+  static getStubConfig(): ClimateTemperatureTileFeatureConfig {
+    return {
+      type: "climate-temperature",
+    };
+  }
+
+  public setConfig(config: ClimateTemperatureTileFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  private _onUp(ev): void {
+    ev.stopPropagation();
+    this.hass!.callService("climate", "set_temperature", {
+      entity_id: this.stateObj!.entity_id,
+      temperature:
+        this.stateObj!.attributes.temperature +
+        this.stateObj!.attributes.target_temp_step,
+    });
+  }
+
+  private _onDown(ev): void {
+    ev.stopPropagation();
+    this.hass!.callService("climate", "set_temperature", {
+      entity_id: this.stateObj!.entity_id,
+      temperature:
+        this.stateObj!.attributes.temperature -
+        this.stateObj!.attributes.target_temp_step,
+    });
+  }
+
+  protected render(): TemplateResult {
+    if (!this._config || !this.hass || !this.stateObj) {
+      return html``;
+    }
+
+    return html`
+      <div class="container">
+        ${supportsFeature(
+          this.stateObj,
+          ClimateEntityFeature.TARGET_TEMPERATURE
+        )
+          ? html`
+              <ha-tile-button
+                .label=${this.hass.localize(
+                  "ui.components.climate-control.temperature_up"
+                )}
+                @click=${this._onUp}
+              >
+                <ha-svg-icon .path=${mdiPlus}></ha-svg-icon>
+              </ha-tile-button>
+              <ha-tile-button
+                .label=${this.hass.localize(
+                  "ui.components.climate-control.temperature_down"
+                )}
+                @click=${this._onDown}
+              >
+                <ha-svg-icon .path=${mdiMinus}></ha-svg-icon>
+              </ha-tile-button>
+            `
+          : null}
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .container {
+        display: flex;
+        flex-direction: row;
+        padding: 0 12px 12px 12px;
+        width: auto;
+      }
+      ha-tile-button {
+        flex: 1;
+      }
+      ha-tile-button:not(:last-child) {
+        margin-right: 12px;
+        margin-inline-end: 12px;
+        margin-inline-start: initial;
+        direction: var(--direction);
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-climate-temperature-tile-feature": HuiClimateTemperatureTileFeature;
+  }
+}

--- a/src/panels/lovelace/tile-features/tile-features.ts
+++ b/src/panels/lovelace/tile-features/tile-features.ts
@@ -10,6 +10,8 @@ type TileFeatureType = LovelaceTileFeatureConfig["type"];
 export type SupportsTileFeature = (stateObj: HassEntity) => boolean;
 
 const TILE_FEATURES_SUPPORT: Record<TileFeatureType, SupportsTileFeature> = {
+  "climate-temperature": (stateObj) =>
+    computeDomain(stateObj.entity_id) === "climate",
   "cover-open-close": (stateObj) =>
     computeDomain(stateObj.entity_id) === "cover" &&
     (supportsFeature(stateObj, CoverEntityFeature.OPEN) ||

--- a/src/panels/lovelace/tile-features/types.ts
+++ b/src/panels/lovelace/tile-features/types.ts
@@ -2,6 +2,10 @@ export interface CoverOpenCloseTileFeatureConfig {
   type: "cover-open-close";
 }
 
+export interface ClimateTemperatureTileFeatureConfig {
+  type: "climate-temperature";
+}
+
 export interface CoverTiltTileFeatureConfig {
   type: "cover-tilt";
 }
@@ -26,6 +30,7 @@ export interface VacuumCommandsTileFeatureConfig {
 }
 
 export type LovelaceTileFeatureConfig =
+  | ClimateTemperatureTileFeatureConfig
   | CoverOpenCloseTileFeatureConfig
   | CoverTiltTileFeatureConfig
   | LightBrightnessTileFeatureConfig

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4298,6 +4298,9 @@
                 "edit": "Edit feature",
                 "remove": "Remove feature",
                 "types": {
+                  "climate-temperature": {
+                    "label": "Climate Temperature"
+                  },
                   "cover-open-close": {
                     "label": "Cover open/close"
                   },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This adds a Climate Temperature feature to the Tile card

![image](https://user-images.githubusercontent.com/9055503/218117427-a6934347-08fc-4db1-be8e-3edcb47edb1d.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
entity: climate.woonkamer
features:
  - type: climate-temperature
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/26200

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
