### PR TITLE
Fix errors in duration data processing in Automation UI Editor

### DIFF
--- a/src/common/datetime/create_duration_data.ts
+++ b/src/common/datetime/create_duration_data.ts
@@ -10,11 +10,19 @@ export const createDurationData = (
   if (typeof duration !== "object") {
     if (typeof duration === "string" || isNaN(duration)) {
       const parts = duration?.toString().split(":") || [];
+      if (parts.length === 1) {
+        return { seconds: Number(parts[0]) };
+      }
+      if (parts.length > 3) {
+        return undefined;
+      }
+      const seconds = Number(parts[2]) || 0;
+      const seconds_whole = Math.floor(seconds);
       return {
         hours: Number(parts[0]) || 0,
         minutes: Number(parts[1]) || 0,
-        seconds: Number(parts[2]) || 0,
-        milliseconds: Number(parts[3]) || 0,
+        seconds: seconds_whole,
+        milliseconds: Math.floor((seconds - seconds_whole) * 1000),
       };
     }
     return { seconds: duration };

--- a/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-state.ts
@@ -5,6 +5,7 @@ import {
   assert,
   boolean,
   literal,
+  number,
   object,
   optional,
   string,
@@ -25,7 +26,7 @@ const stateConditionStruct = object({
   entity_id: optional(string()),
   attribute: optional(string()),
   state: optional(string()),
-  for: optional(union([string(), forDictStruct])),
+  for: optional(union([number(), string(), forDictStruct])),
   enabled: optional(boolean()),
 });
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-state.ts
@@ -5,6 +5,7 @@ import {
   assert,
   assign,
   literal,
+  number,
   object,
   optional,
   string,
@@ -31,7 +32,7 @@ const stateTriggerStruct = assign(
     attribute: optional(string()),
     from: optional(string()),
     to: optional(string()),
-    for: optional(union([string(), forDictStruct])),
+    for: optional(union([number(), string(), forDictStruct])),
   })
 );
 


### PR DESCRIPTION
## Proposed change

The UI automation editor has two small errors in handling duration strings (delay: / for: / timeout: )

1. If a string containing a single number is encountered, the UI editor assumes this is hours. However the automation processor in core interprets this as seconds. Change UI editor to also understand that this is seconds. 

2. The UI editor assumes a string of format "hh:mm:ss:mmm" is hours, minutes, seconds, and milliseconds. This string format is actually illegal and will cause an error in core automation processor. The only legal duration string formats are "ss", "hh:mm", "hh:mm:ss", and "hh:mm:ss.mmm". Change UI editor to reject "hh:mm:ss:mmm", and correctly parse "hh:mm:ss.mmm" as hours, minutes, seconds, and milliseconds. 


Also this change adds number type as legal option for `for:` in state trigger and condition, which matches core. A bare number is a number of seconds. Previously the UI editor would fallback to yaml when encountered. This was inconsistent with other triggers/actions which correctly interpreted the bare number. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15409
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
