### PR TITLE
Remove firmware target from zwave_js firmware upload UI

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -707,14 +707,10 @@ export const fetchZwaveNodeFirmwareUpdateCapabilities = (
 export const uploadFirmwareAndBeginUpdate = async (
   hass: HomeAssistant,
   device_id: string,
-  file: File,
-  target?: number
+  file: File
 ) => {
   const fd = new FormData();
   fd.append("file", file);
-  if (target !== undefined) {
-    fd.append("target", target.toString());
-  }
   const resp = await hass.fetchWithAuth(
     `/api/zwave_js/firmware/upload/${device_id}`,
     {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
@@ -34,7 +34,6 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../../../dialogs/generic/show-dialog-box";
-import { HaFormIntegerSchema } from "../../../../../components/ha-form/types";
 
 @customElement("dialog-zwave_js-update-firmware-node")
 class DialogZWaveJSUpdateFirmwareNode extends LitElement {
@@ -55,8 +54,6 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
   @state() private _firmwareFile?: File;
 
   @state() private _nodeStatus?: ZWaveJSNodeStatus;
-
-  @state() private _firmwareTarget? = 0;
 
   private _subscribedNodeStatus?: Promise<UnsubscribeFunc>;
 
@@ -80,7 +77,6 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
       this._firmwareFile =
       this._nodeStatus =
         undefined;
-    this._firmwareTarget = 0;
     this._uploading = this._updateInProgress = false;
 
     fireEvent(this, "dialog-closed", { dialog: this.localName });
@@ -95,12 +91,6 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
       return html``;
     }
 
-    const schema: HaFormIntegerSchema = {
-      name: "firmware_target",
-      type: "integer",
-      valueMin: 0,
-    };
-
     const beginFirmwareUpdateHTML = html`<ha-file-upload
         .hass=${this.hass}
         .uploading=${this._uploading}
@@ -111,17 +101,6 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
         )}
         @file-picked=${this._uploadFile}
       ></ha-file-upload>
-      <p>
-        ${this.hass.localize(
-          "ui.panel.config.zwave_js.update_firmware.firmware_target_intro"
-        )}
-      </p>
-      <ha-form
-        .hass=${this.hass}
-        .data=${{ firmware_target: this._firmwareTarget }}
-        .schema=${[schema]}
-        @value-changed=${this._firmwareTargetChanged}
-      ></ha-form>
       <mwc-button
         slot="primaryAction"
         @click=${this._beginFirmwareUpdate}
@@ -287,8 +266,7 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
       await uploadFirmwareAndBeginUpdate(
         this.hass,
         this.device!.id,
-        this._firmwareFile!,
-        this._firmwareTarget
+        this._firmwareFile!
       );
       this._updateInProgress = true;
       this._uploading = false;
@@ -390,10 +368,6 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
     }
     this._subscribedNodeFirmwareUpdate.then((unsub) => unsub());
     this._subscribedNodeFirmwareUpdate = undefined;
-  }
-
-  private async _firmwareTargetChanged(ev) {
-    this._firmwareTarget = ev.detail.value.firmware_target;
   }
 
   private async _uploadFile(ev) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3658,7 +3658,7 @@
               "Error_InvalidHeaderFormat": "Invalid Header Format",
               "Error_InsufficientMemory": "Insufficient Memory",
               "Error_InvalidHardwareVersion": "Invalid Hardware Version",
-              "OK_WaitingForActivation": "Waiting for Activiation",
+              "OK_WaitingForActivation": "Waiting for Activation",
               "OK_NoRestart": "No Restart",
               "OK_RestartPending": "Restart Pending"
             }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3633,8 +3633,6 @@
             "warning": "WARNING: Firmware updates can brick your device if you do not correctly follow the manufacturer's guidance. The Home Assistant and Z-Wave JS teams do not take any responsibility for any damages to your device as a result of the firmware update and will not be able to help you if you brick your device. Would you still like to continue?",
             "introduction": "Select the firmware file you would like to use to update {device}.",
             "upload_firmware": "Upload Firmware",
-            "firmware_target_intro": "Select the firmware target (0 for the Z-Wave chip, ≥1 for other chips if they exist) for this update, or uncheck the box to have the driver attempt to figure it out from the firmware file.",
-            "firmware_target": "Firmware Target (chip)",
             "upload_failed": "Upload Failed",
             "begin_update": "Begin Firmware Update",
             "queued": "The firmware update is ready to be sent to {device} but the device is asleep, wake the device to start the update.",


### PR DESCRIPTION
## Proposed change
At some point after we introduced firmware update entities for zwave_js, the zwave-js project changed the way that firmware updates were handled. Whereas before, we would potentially need to know the target for the firmware file, we no longer need it (in fact support was removed in core and in the upstream lib, so this functionality currently does nothing. We need to remove it so we don't confuse users.

References:
- https://github.com/zwave-js/node-zwave-js/pull/5121
- https://github.com/zwave-js/zwave-js-server/pull/765
- https://github.com/home-assistant-libs/zwave-js-server-python/pull/503
- https://github.com/home-assistant/core/pull/79342

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
