### PR TITLE
More alarm arming options in more-info dialog

### DIFF
--- a/src/data/alarm_control_panel.ts
+++ b/src/data/alarm_control_panel.ts
@@ -3,6 +3,15 @@ import { HomeAssistant } from "../types";
 export const FORMAT_TEXT = "text";
 export const FORMAT_NUMBER = "number";
 
+export const enum AlarmControlPanelEntityFeature {
+  ARM_HOME = 1,
+  ARM_AWAY = 2,
+  ARM_NIGHT = 4,
+  TRIGGER = 8,
+  ARM_CUSTOM_BYPASS = 16,
+  ARM_VACATION = 32,
+}
+
 export const callAlarmAction = (
   hass: HomeAssistant,
   entity: string,

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
@@ -22,7 +22,7 @@ export class MoreInfoAlarmControlPanel extends LitElement {
 
   @property({ attribute: false }) public stateObj?: HassEntity;
 
-  @state() private _armActions!: string[];
+  @state() private _armActions?: string[];
 
   @query("#alarmCode") private _input?: HaTextField;
 
@@ -116,7 +116,7 @@ export class MoreInfoAlarmControlPanel extends LitElement {
           `}
       <div class="actions">
         ${(this.stateObj.state === "disarmed"
-          ? this._armActions
+          ? this._armActions ?? []
           : DISARM_ACTIONS
         ).map(
           (stateAction) => html`

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
@@ -22,7 +22,7 @@ export class MoreInfoAlarmControlPanel extends LitElement {
 
   @property({ attribute: false }) public stateObj?: HassEntity;
 
-  @state() private _armActions?: string[];
+  @state() private _armActions: string[] = [];
 
   @query("#alarmCode") private _input?: HaTextField;
 

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
@@ -116,7 +116,7 @@ export class MoreInfoAlarmControlPanel extends LitElement {
           `}
       <div class="actions">
         ${(this.stateObj.state === "disarmed"
-          ? this._armActions ?? []
+          ? this._armActions
           : DISARM_ACTIONS
         ).map(
           (stateAction) => html`

--- a/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
+++ b/src/dialogs/more-info/controls/more-info-alarm_control_panel.ts
@@ -1,18 +1,19 @@
 import "@material/mwc-button";
 import type { HassEntity } from "home-assistant-js-websocket";
-import { css, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, query } from "lit/decorators";
+import { css, html, LitElement, PropertyValues, TemplateResult } from "lit";
+import { customElement, property, state, query } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import "../../../components/ha-textfield";
+import { supportsFeature } from "../../../common/entity/supports-feature";
 import type { HaTextField } from "../../../components/ha-textfield";
 import {
   callAlarmAction,
   FORMAT_NUMBER,
+  AlarmControlPanelEntityFeature,
 } from "../../../data/alarm_control_panel";
 import type { HomeAssistant } from "../../../types";
 
 const BUTTONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "clear"];
-const ARM_ACTIONS = ["arm_home", "arm_away"];
 const DISARM_ACTIONS = ["disarm"];
 
 @customElement("more-info-alarm_control_panel")
@@ -21,7 +22,50 @@ export class MoreInfoAlarmControlPanel extends LitElement {
 
   @property({ attribute: false }) public stateObj?: HassEntity;
 
+  @state() private _armActions!: string[];
+
   @query("#alarmCode") private _input?: HaTextField;
+
+  public willUpdate(changedProps: PropertyValues<this>) {
+    super.willUpdate(changedProps);
+
+    if (!this.stateObj || !changedProps.has("stateObj")) {
+      return;
+    }
+
+    this._armActions = [];
+    if (
+      supportsFeature(this.stateObj, AlarmControlPanelEntityFeature.ARM_HOME)
+    ) {
+      this._armActions.push("arm_home");
+    }
+    if (
+      supportsFeature(this.stateObj, AlarmControlPanelEntityFeature.ARM_AWAY)
+    ) {
+      this._armActions.push("arm_away");
+    }
+    if (
+      supportsFeature(this.stateObj, AlarmControlPanelEntityFeature.ARM_NIGHT)
+    ) {
+      this._armActions.push("arm_night");
+    }
+    if (
+      supportsFeature(
+        this.stateObj,
+        AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+      )
+    ) {
+      this._armActions.push("arm_custom_bypass");
+    }
+    if (
+      supportsFeature(
+        this.stateObj,
+        AlarmControlPanelEntityFeature.ARM_VACATION
+      )
+    ) {
+      this._armActions.push("arm_vacation");
+    }
+  }
 
   protected render(): TemplateResult {
     if (!this.hass || !this.stateObj) {
@@ -72,7 +116,7 @@ export class MoreInfoAlarmControlPanel extends LitElement {
           `}
       <div class="actions">
         ${(this.stateObj.state === "disarmed"
-          ? ARM_ACTIONS
+          ? this._armActions
           : DISARM_ACTIONS
         ).map(
           (stateAction) => html`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add additional buttons to the alarm_control_panel more-info dialog, based on what the entity supports. Previously only supported arm_home and arm_away. Gives feature parity with the dashboard card, which supports the 5 arming options. 

![image](https://user-images.githubusercontent.com/32912880/218877351-166c0ed8-6011-45c6-9cff-befb212f8fe2.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
fixes #15351 
fixes #15289

- This PR is related to issue or discussion: 
#11287 
#11309
https://community.home-assistant.io/t/add-arm-night-to-alarm-control-panel-entity-badge/216372

- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
