### PR TITLE
Add better focus style for tile card when theme use box-shadow

### DIFF
--- a/src/components/ha-bar-slider.ts
+++ b/src/components/ha-bar-slider.ts
@@ -280,6 +280,7 @@ export class HaBarSlider extends LitElement {
         width: 100%;
         border-radius: var(--slider-bar-border-radius);
         outline: none;
+        transition: box-shadow 180ms ease-in-out;
       }
       :host(:focus-visible) {
         box-shadow: 0 0 0 2px var(--slider-bar-color);

--- a/src/components/ha-bar-switch.ts
+++ b/src/components/ha-bar-switch.ts
@@ -106,6 +106,7 @@ export class HaBarSwitch extends LitElement {
         cursor: pointer;
         border-radius: var(--switch-bar-border-radius);
         outline: none;
+        transition: box-shadow 180ms ease-in-out;
       }
       :host(:focus-visible) {
         box-shadow: 0 0 0 2px var(--switch-bar-off-color);

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -422,14 +422,17 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
         -webkit-tap-highlight-color: transparent;
       }
       ha-card:has(.background:focus-visible) {
+        --shadow-default: var(--ha-card-box-shadow, 0 0 0 0 transparent);
+        --shadow-focus: 0 0 0 1px var(--tile-color);
         border-color: var(--tile-color);
-        box-shadow: 0 0 0 1px var(--tile-color);
+        box-shadow: var(--shadow-default), var(--shadow-focus);
       }
       ha-card {
         --mdc-ripple-color: var(--tile-color);
         height: 100%;
         z-index: 0;
         overflow: hidden;
+        transition: box-shadow 180ms ease-in-out, border-color 180ms ease-in-out;
       }
       ha-card.active {
         --tile-color: var(--state-icon-color);


### PR DESCRIPTION
## Proposed change

Combine theme box shadow and focus style for tile card
Add animations for focus style

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
