### PR TITLE
Fix alert padding inside more info dialog

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -274,6 +274,7 @@ export class MoreInfoDialog extends LitElement {
           --dialog-content-position: static;
           --vertical-align-dialog: flex-start;
           --dialog-content-padding: 0;
+          --content-padding: 24px;
         }
 
         ha-header-bar {
@@ -299,11 +300,17 @@ export class MoreInfoDialog extends LitElement {
         }
 
         ha-dialog .content {
-          padding: 24px;
+          padding: var(--content-padding);
         }
 
-        :host([tab="settings"]) ha-dialog .content {
-          padding: 0px;
+        :host([tab="settings"]) ha-dialog {
+          --content-padding: 0;
+        }
+
+        :host([tab="info"]) ha-dialog[data-domain="camera"] {
+          --content-padding: 0;
+          /* max height of the video is full screen, minus the height of the header of the dialog and the padding of the dialog (mdc-dialog-max-height: calc(100% - 72px)) */
+          --video-max-height: calc(100vh - 113px - 72px);
         }
 
         @media all and (min-width: 600px) and (min-height: 501px) {
@@ -324,12 +331,6 @@ export class MoreInfoDialog extends LitElement {
             --mdc-dialog-min-width: 90vw;
             --mdc-dialog-max-width: 90vw;
           }
-        }
-
-        :host([tab="info"]) ha-dialog[data-domain="camera"] .content {
-          padding: 0;
-          /* max height of the video is full screen, minus the height of the header of the dialog and the padding of the dialog (mdc-dialog-max-height: calc(100% - 72px)) */
-          --video-max-height: calc(100vh - 113px - 72px);
         }
       `,
     ];

--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -99,9 +99,9 @@ export class MoreInfoInfo extends LitElement {
 
       ha-alert {
         display: block;
-        margin: calc(-1 * var(--dialog-content-padding, 24px))
-          calc(-1 * var(--dialog-content-padding, 24px)) 16px
-          calc(-1 * var(--dialog-content-padding, 24px));
+        margin: calc(-1 * var(--content-padding, 24px))
+          calc(-1 * var(--content-padding, 24px)) 16px
+          calc(-1 * var(--content-padding, 24px));
       }
     `;
   }


### PR DESCRIPTION
## Proposed change

Following https://github.com/home-assistant/frontend/pull/15473. Alert used `dialog-content-padding` variable.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
