### PR TITLE
Resync thermostat card setpoint values if service call fails

### DIFF
--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -90,6 +90,8 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
 
   @query("ha-card") private _card?: HaCard;
 
+  @state() private resyncSetpoint = false;
+
   public getCardSize(): number {
     return 7;
   }
@@ -120,11 +122,23 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
     const name =
       this._config!.name ||
       computeStateName(this.hass!.states[this._config!.entity]);
-    const targetTemp =
-      stateObj.attributes.temperature !== null &&
-      Number.isFinite(Number(stateObj.attributes.temperature))
-        ? stateObj.attributes.temperature
-        : stateObj.attributes.min_temp;
+    const targetTemp = this.resyncSetpoint
+      ? // If the user set position in the slider is out of sync with the entity
+        // value, then rerendering the slider with same $value a second time
+        // does not move the slider. Need to set it to a different dummy value
+        // for one update cycle to force it to rerender to the desired value.
+        stateObj.attributes.min_temp - 1
+      : stateObj.attributes.temperature !== null &&
+        Number.isFinite(Number(stateObj.attributes.temperature))
+      ? stateObj.attributes.temperature
+      : stateObj.attributes.min_temp;
+
+    const targetLow = this.resyncSetpoint
+      ? stateObj.attributes.min_temp - 1
+      : stateObj.attributes.target_temp_low;
+    const targetHigh = this.resyncSetpoint
+      ? stateObj.attributes.min_temp - 1
+      : stateObj.attributes.target_temp_high;
 
     const slider =
       stateObj.state === UNAVAILABLE
@@ -132,8 +146,8 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
         : html`
             <round-slider
               .value=${targetTemp}
-              .low=${stateObj.attributes.target_temp_low}
-              .high=${stateObj.attributes.target_temp_high}
+              .low=${targetLow}
+              .high=${targetHigh}
               .min=${stateObj.attributes.min_temp}
               .max=${stateObj.attributes.max_temp}
               .step=${this._stepSize}
@@ -289,7 +303,10 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
-    return hasConfigOrEntityChanged(this, changedProps);
+    return (
+      hasConfigOrEntityChanged(this, changedProps) ||
+      changedProps.has("resyncSetpoint")
+    );
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -328,7 +345,11 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
   }
 
   public willUpdate(changedProps: PropertyValues) {
-    if (!this.hass || !this._config || !changedProps.has("hass")) {
+    if (
+      !this.hass ||
+      !this._config ||
+      !(changedProps.has("hass") || changedProps.has("resyncSetpoint"))
+    ) {
       return;
     }
 
@@ -339,7 +360,11 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
 
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
 
-    if (!oldHass || oldHass.states[this._config.entity] !== stateObj) {
+    if (
+      !oldHass ||
+      oldHass.states[this._config.entity] !== stateObj ||
+      (changedProps.has("resyncSetpoint") && this.resyncSetpoint)
+    ) {
       this._setTemp = this._getSetTemp(stateObj);
     }
   }
@@ -410,22 +435,35 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
     const stateObj = this.hass!.states[this._config!.entity] as ClimateEntity;
 
     if (e.detail.low) {
-      this.hass!.callService("climate", "set_temperature", {
-        entity_id: this._config!.entity,
-        target_temp_low: e.detail.low,
-        target_temp_high: stateObj.attributes.target_temp_high,
-      });
+      const newVal = e.detail.low;
+      this._callServiceHelper(
+        stateObj.attributes.target_temp_low,
+        newVal,
+        "set_temperature",
+        {
+          target_temp_low: newVal,
+          target_temp_high: stateObj.attributes.target_temp_high,
+        }
+      );
     } else if (e.detail.high) {
-      this.hass!.callService("climate", "set_temperature", {
-        entity_id: this._config!.entity,
-        target_temp_low: stateObj.attributes.target_temp_low,
-        target_temp_high: e.detail.high,
-      });
+      const newVal = e.detail.high;
+      this._callServiceHelper(
+        stateObj.attributes.target_temp_high,
+        newVal,
+        "set_temperature",
+        {
+          target_temp_low: stateObj.attributes.target_temp_low,
+          target_temp_high: newVal,
+        }
+      );
     } else {
-      this.hass!.callService("climate", "set_temperature", {
-        entity_id: this._config!.entity,
-        temperature: e.detail.value,
-      });
+      const newVal = e.detail.value;
+      this._callServiceHelper(
+        stateObj!.attributes.temperature,
+        newVal,
+        "set_temperature",
+        { temperature: newVal }
+      );
     }
   }
 
@@ -457,6 +495,44 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
       entity_id: this._config!.entity,
       hvac_mode: (e.currentTarget as any).mode,
     });
+  }
+
+  private async _callServiceHelper(
+    oldVal: unknown,
+    newVal: unknown,
+    service: string,
+    data: {
+      entity_id?: string;
+      [key: string]: unknown;
+    }
+  ) {
+    if (oldVal === newVal) {
+      return;
+    }
+
+    data.entity_id = this._config!.entity;
+
+    await this.hass!.callService("climate", service, data);
+
+    // After updating temperature, wait 2s and check if the values
+    // from call service are reflected in the entity. If not, resync
+    // the slider to the entity values.
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const newState = this.hass!.states[this._config!.entity] as ClimateEntity;
+    delete data.entity_id;
+
+    if (
+      Object.entries(data).every(
+        ([key, value]) => newState.attributes[key] === value
+      )
+    ) {
+      return;
+    }
+
+    this.resyncSetpoint = true;
+    await this.updateComplete;
+    this.resyncSetpoint = false;
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If user uses thermostat card to update a thermostat setpoint, it optimistically assumes the setpoint value actually changes. If the call service fails for some reason and the entity setpoints never update, then the thermostat card remains out of sync with the entity, showing the wrong setpoints.

This change waits 2 seconds after the call service, and if the entity has not updated its setpoints within that time, it reverts the thermostat card to showing the current entity setpoints. 

This copies the same behavior as the thermostat more-info dialog, which already does this. 

![thermostat_setpoints_revert](https://user-images.githubusercontent.com/32912880/219957045-19bd0a7f-269d-4366-baaa-61d5a0f5c2b4.gif)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15483 maybe #14961, (needs more info)
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
