### PR TITLE
Re-add target option to zwave-js firmware upload

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -757,10 +757,14 @@ export const fetchZwaveNodeFirmwareUpdateCapabilities = (
 export const uploadFirmwareAndBeginUpdate = async (
   hass: HomeAssistant,
   device_id: string,
-  file: File
+  file: File,
+  target?: number
 ) => {
   const fd = new FormData();
   fd.append("file", file);
+  if (target !== undefined) {
+    fd.append("target", target.toString());
+  }
   const resp = await hass.fetchWithAuth(
     `/api/zwave_js/firmware/upload/${device_id}`,
     {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
@@ -36,13 +36,15 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../../../dialogs/generic/show-dialog-box";
-import { HaFormIntegerSchema } from "../../../../../components/ha-form/types";
+import { HaFormSchema } from "../../../../../components/ha-form/types";
 
-const firmwareTargetSchema: HaFormIntegerSchema = {
-  name: "firmware_target",
-  type: "integer",
-  valueMin: 0,
-};
+const firmwareTargetSchema: HaFormSchema[] = [
+  {
+    name: "firmware_target",
+    type: "integer",
+    valueMin: 0,
+  },
+];
 
 @customElement("dialog-zwave_js-update-firmware-node")
 class DialogZWaveJSUpdateFirmwareNode extends LitElement {
@@ -122,7 +124,7 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
       <ha-form
         .hass=${this.hass}
         .data=${{ firmware_target: this._firmwareTarget }}
-        .schema=${[firmwareTargetSchema]}
+        .schema=${firmwareTargetSchema}
         @value-changed=${this._firmwareTargetChanged}
       ></ha-form>
       <mwc-button

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
@@ -38,6 +38,12 @@ import {
 } from "../../../../../dialogs/generic/show-dialog-box";
 import { HaFormIntegerSchema } from "../../../../../components/ha-form/types";
 
+const firmwareTargetSchema: HaFormIntegerSchema = {
+  name: "firmware_target",
+  type: "integer",
+  valueMin: 0,
+};
+
 @customElement("dialog-zwave_js-update-firmware-node")
 class DialogZWaveJSUpdateFirmwareNode extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -98,12 +104,6 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
       return html``;
     }
 
-    const schema: HaFormIntegerSchema = {
-      name: "firmware_target",
-      type: "integer",
-      valueMin: 0,
-    };
-
     const beginFirmwareUpdateHTML = html`<ha-file-upload
         .hass=${this.hass}
         .uploading=${this._uploading}
@@ -122,7 +122,7 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
       <ha-form
         .hass=${this.hass}
         .data=${{ firmware_target: this._firmwareTarget }}
-        .schema=${[schema]}
+        .schema=${[firmwareTargetSchema]}
         @value-changed=${this._firmwareTargetChanged}
       ></ha-form>
       <mwc-button

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-update-firmware-node.ts
@@ -116,17 +116,19 @@ class DialogZWaveJSUpdateFirmwareNode extends LitElement {
         )}
         @file-picked=${this._uploadFile}
       ></ha-file-upload>
-      <p>
-        ${this.hass.localize(
-          "ui.panel.config.zwave_js.update_firmware.firmware_target_intro"
-        )}
-      </p>
-      <ha-form
-        .hass=${this.hass}
-        .data=${{ firmware_target: this._firmwareTarget }}
-        .schema=${firmwareTargetSchema}
-        @value-changed=${this._firmwareTargetChanged}
-      ></ha-form>
+      ${this._nodeStatus.is_controller_node
+        ? html``
+        : html`<p>
+              ${this.hass.localize(
+                "ui.panel.config.zwave_js.update_firmware.firmware_target_intro"
+              )}
+            </p>
+            <ha-form
+              .hass=${this.hass}
+              .data=${{ firmware_target: this._firmwareTarget }}
+              .schema=${firmwareTargetSchema}
+              @value-changed=${this._firmwareTargetChanged}
+            ></ha-form>`}
       <mwc-button
         slot="primaryAction"
         @click=${this._beginFirmwareUpdate}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3691,6 +3691,8 @@
             "warning_controller": "WARNING: Firmware updates can brick your controller if you do not use the right firmware files, or if you attempt to stop the firmware update before it completes. The Home Assistant and Z-Wave JS teams do not take any responsibility for any damages to your controller as a result of the firmware update and will not be able to help you if you brick your controller. Would you still like to continue?",
             "introduction": "Select the firmware file you would like to use to update {device}.",
             "introduction_controller": "Select the firmware file you would like to use to update {device}. Note that once you start a firmware update, you MUST wait for the update to complete.",
+            "firmware_target_intro": "Select the firmware target (0 for the Z-Wave chip, ≥1 for other chips if they exist) for this update.",
+            "firmware_target": "Firmware Target (chip)",
             "upload_firmware": "Upload Firmware",
             "upload_failed": "Upload Failed",
             "begin_update": "Begin Firmware Update",


### PR DESCRIPTION
## Proposed change
This PR was a mistake: https://github.com/home-assistant/frontend/pull/15425

We should have never removed this option but I misunderstood the implications of a new zwave-js release and learned about this issue recently so it's been readded everywhere else upstream, including in core here: https://github.com/home-assistant/core/pull/88523

I made some slight modifications to the things I removed in the original PR. Mainly I changed the intro text because it was not accurate, and the target is now undefined by default. This means that if the user doesn't make a change, we send undefined upstream to the zwave-js-server and let zwave-js decide how to handle it.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
