### PR TITLE
Prefer regex literals over constructors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,7 +60,6 @@
     "no-restricted-globals": [2, "event"],
     "prefer-promise-reject-errors": "off",
     "no-unsafe-optional-chaining": "warn",
-    "prefer-regex-literals": ["warn"],
     "import/prefer-default-export": "off",
     "import/no-default-export": "off",
     "import/no-unresolved": "off",

--- a/demo/src/stubs/history.ts
+++ b/demo/src/stubs/history.ts
@@ -66,7 +66,7 @@ const incrementalUnits = ["clients", "queries", "ads"];
 
 export const mockHistory = (mockHass: MockHomeAssistant) => {
   mockHass.mockAPI(
-    new RegExp("history/period/.+"),
+    /history\/period\/.+/,
     (hass, _method, path, _parameters) => {
       const params = parseQuery<HistoryQueryParams>(path.split("?")[1]);
       const entities = params.filter_entity_id.split(",");

--- a/src/common/string/has-template.ts
+++ b/src/common/string/has-template.ts
@@ -1,4 +1,4 @@
-const isTemplateRegex = new RegExp("{%|{{");
+const isTemplateRegex = /{%|{{/;
 
 export const isTemplate = (value: string): boolean =>
   isTemplateRegex.test(value);

--- a/src/entrypoints/service_worker.ts
+++ b/src/entrypoints/service_worker.ts
@@ -13,10 +13,8 @@ import {
   StaleWhileRevalidate,
 } from "workbox-strategies";
 
-const noFallBackRegEx = new RegExp(
-  "/(api|static|auth|frontend_latest|frontend_es5|local)/.*"
-);
-
+const noFallBackRegEx =
+  /\/(api|static|auth|frontend_latest|frontend_es5|local)\/.*/;
 // Clean up caches from older workboxes and old service workers.
 // Will help with cleaning up Workbox v4 stuff
 cleanupOutdatedCaches();
@@ -33,22 +31,22 @@ function initRouting() {
 
   // Cache static content (including translations) on first access.
   registerRoute(
-    new RegExp("/(static|frontend_latest|frontend_es5)/.+"),
+    /\/(static|frontend_latest|frontend_es5)\/.+/,
     new CacheFirst({ matchOptions: { ignoreSearch: true } })
   );
 
   // Get api from network.
-  registerRoute(new RegExp("/(api|auth)/.*"), new NetworkOnly());
+  registerRoute(/\/(api|auth)\/.*/, new NetworkOnly());
 
   // Get manifest, service worker, onboarding from network.
   registerRoute(
-    new RegExp("/(service_worker.js|manifest.json|onboarding.html)"),
+    /\/(service_worker.js|manifest.json|onboarding.html)/,
     new NetworkOnly()
   );
 
   // For the root "/" we ignore search
   registerRoute(
-    new RegExp(/\/(\?.*)?$/),
+    /\/(\?.*)?$/,
     new StaleWhileRevalidate({ matchOptions: { ignoreSearch: true } })
   );
 
@@ -57,7 +55,7 @@ function initRouting() {
   // First access might bring stale data from cache, but a single refresh will bring updated
   // file.
   registerRoute(
-    new RegExp(/\/.*/),
+    /\/.*/,
     new StaleWhileRevalidate({
       cacheName: "file-cache",
       plugins: [

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -116,7 +116,7 @@ export const provideHass = (
   }
 
   mockAPI(
-    new RegExp("states/.+"),
+    /states\/.+/,
     (
       // @ts-ignore
       method,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Prompted by a new ESLint rule in the Airbnb config, this change just converts several regex constructors to the literal form.  This is a small optimization as literals are evaluated on load while constructors are always evaluated at runtime.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
