### PR TITLE
Ensure correct color dialog is shown if light is off

### DIFF
--- a/src/dialogs/more-info/components/lights/ha-more-info-view-light-color-picker.ts
+++ b/src/dialogs/more-info/components/lights/ha-more-info-view-light-color-picker.ts
@@ -264,18 +264,10 @@ class MoreInfoViewLightColorPicker extends LitElement {
       }
 
       this._modes = modes;
-      // If we have an active color mode, use it to determine what to render.
-      // Otherwise (e. g. light is off) fallback to the supported modes instead.
-      this._mode = this.stateObj!.attributes.color_mode
-        ? this.stateObj!.attributes.color_mode === LightColorMode.COLOR_TEMP
+      this._mode =
+        this.stateObj!.attributes.color_mode === LightColorMode.COLOR_TEMP
           ? LightColorMode.COLOR_TEMP
-          : "color"
-        : this.stateObj!.attributes.supported_color_modes &&
-          this.stateObj!.attributes.supported_color_modes.indexOf(
-            LightColorMode.COLOR_TEMP
-          ) >= 0
-        ? LightColorMode.COLOR_TEMP
-        : "color";
+          : this._modes[0];
     }
 
     this._updateSliderValues();

--- a/src/dialogs/more-info/components/lights/ha-more-info-view-light-color-picker.ts
+++ b/src/dialogs/more-info/components/lights/ha-more-info-view-light-color-picker.ts
@@ -264,10 +264,18 @@ class MoreInfoViewLightColorPicker extends LitElement {
       }
 
       this._modes = modes;
-      this._mode =
-        this.stateObj!.attributes.color_mode === LightColorMode.COLOR_TEMP
+      // If we have an active color mode, use it to determine what to render.
+      // Otherwise (e. g. light is off) fallback to the supported modes instead.
+      this._mode = this.stateObj!.attributes.color_mode
+        ? this.stateObj!.attributes.color_mode === LightColorMode.COLOR_TEMP
           ? LightColorMode.COLOR_TEMP
-          : "color";
+          : "color"
+        : this.stateObj!.attributes.supported_color_modes &&
+          this.stateObj!.attributes.supported_color_modes.indexOf(
+            LightColorMode.COLOR_TEMP
+          ) >= 0
+        ? LightColorMode.COLOR_TEMP
+        : "color";
     }
 
     this._updateSliderValues();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

If you have a light that only supports `color_temp` but is off, it would show the color picker rather than the temperature slider.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
