### PR TITLE
Add loading info text to hardware config page

### DIFF
--- a/src/panels/config/hardware/ha-config-hardware.ts
+++ b/src/panels/config/hardware/ha-config-hardware.ts
@@ -75,6 +75,8 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
 
   private _cpuEntries: { x: number; y: number | null }[] = [];
 
+  private _hardwareComponentLoaded = false;
+
   public hassSubscribe(): Array<UnsubscribeFunc | Promise<UnsubscribeFunc>> {
     const subs = [
       subscribeConfigEntries(
@@ -140,6 +142,7 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
           }
         )
       );
+      this._hardwareComponentLoaded = true;
     }
 
     return subs;
@@ -439,7 +442,8 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
                     ></ha-chart-base>
                   </div>
                 </ha-card>`
-            : html`<ha-card outlined>
+            : this._hardwareComponentLoaded
+            ? html`<ha-card outlined>
                 <div class="card-content">
                   <div class="value">
                     ${this.hass.localize(
@@ -447,7 +451,8 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
                     )}
                   </div>
                 </div>
-              </ha-card>`}
+              </ha-card>`
+            : ""}
         </div>
       </hass-subpage>
     `;

--- a/src/panels/config/hardware/ha-config-hardware.ts
+++ b/src/panels/config/hardware/ha-config-hardware.ts
@@ -75,8 +75,6 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
 
   private _cpuEntries: { x: number; y: number | null }[] = [];
 
-  private _hardwareComponentLoaded = false;
-
   public hassSubscribe(): Array<UnsubscribeFunc | Promise<UnsubscribeFunc>> {
     const subs = [
       subscribeConfigEntries(
@@ -142,7 +140,6 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
           }
         )
       );
-      this._hardwareComponentLoaded = true;
     }
 
     return subs;
@@ -442,7 +439,7 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
                     ></ha-chart-base>
                   </div>
                 </ha-card>`
-            : this._hardwareComponentLoaded
+            : isComponentLoaded(this.hass, "hardware")
             ? html`<ha-card outlined>
                 <div class="card-content">
                   <div class="value">

--- a/src/panels/config/hardware/ha-config-hardware.ts
+++ b/src/panels/config/hardware/ha-config-hardware.ts
@@ -357,7 +357,7 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
               `
             : ""}
           ${dongles?.length
-            ? html`<ha-card>
+            ? html`<ha-card outlined>
                 ${dongles.map((dongle) => {
                   const configEntry = dongle.config_entries
                     .map((id) => this._configEntries?.[id])
@@ -439,7 +439,15 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
                     ></ha-chart-base>
                   </div>
                 </ha-card>`
-            : ""}
+            : html`<ha-card outlined>
+                <div class="card-content">
+                  <div class="value">
+                    ${this.hass.localize(
+                      "ui.panel.config.hardware.loading_system_data"
+                    )}
+                  </div>
+                </div>
+              </ha-card>`}
         </div>
       </hass-subpage>
     `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1805,7 +1805,8 @@
           "documentation": "Documentation",
           "configure": "Configure",
           "documentation_description": "Find extra information about your device",
-          "restart_homeassistant": "[%key:ui::panel::config::system_dashboard::restart_homeassistant%]"
+          "restart_homeassistant": "[%key:ui::panel::config::system_dashboard::restart_homeassistant%]",
+          "loading_system_data": "Loading process and memory data..."
         },
         "info": {
           "caption": "About",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1806,7 +1806,7 @@
           "configure": "Configure",
           "documentation_description": "Find extra information about your device",
           "restart_homeassistant": "[%key:ui::panel::config::system_dashboard::restart_homeassistant%]",
-          "loading_system_data": "Loading process and memory data..."
+          "loading_system_data": "Loading processor and memory data..."
         },
         "info": {
           "caption": "About",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The rendering of processor and memory information takes a few seconds before the data is available and the charts appear. 

Now we show an info that data is being loaded, Otherwise it looks weird if nothing is shown on the page (if you do not have a detected board or dongle; and even if you do nothing indicates that you need to wait a bit to see more data).

![image](https://user-images.githubusercontent.com/114137/221581826-3cdeb703-035f-44ac-95f3-a72ce2aae355.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
