### PR TITLE
Fix a hang in history graph card editor

### DIFF
--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -143,7 +143,10 @@ export class StateHistoryChartTimeline extends LitElement {
             }
           },
           afterUpdate: (y) => {
-            if (this._yWidth !== Math.floor(y.width)) {
+            if (
+              this._yWidth !== Math.floor(y.width) &&
+              y.ticks.length === this.data.length
+            ) {
               this._yWidth = Math.floor(y.width);
               fireEvent(this, "y-width-changed", {
                 value: this._yWidth,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Fix the browser hang described in #15620. 

I'm not fully understanding what's happening here, but when adding a new entity to an existing timeline graph, the animation flickers between rendering and not rendering the new y-axis label. This cause the y-axis width tracker to seem to get stuck in an infinite loop, since every time the graph renders it toggles between rendering the new label or not, and the y axis thinks it continually needs to update and rerender because the width changes.

This change causes the y-width updates to be suppressed when the timeline chart is rendering less y-axes than the datasets in the chart, which seems to only occur in the brief transition period when an entity is being added. 

It seems to fix the issue of getting stuck in an infinite loop in my testing. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15620
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
