### PR TITLE
Enable compression for development

### DIFF
--- a/build-scripts/webpack.js
+++ b/build-scripts/webpack.js
@@ -2,6 +2,7 @@ const webpack = require("webpack");
 const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
 const { WebpackManifestPlugin } = require("webpack-manifest-plugin");
+const CompressionWebpackPlugin = require("compression-webpack-plugin");
 const log = require("fancy-log");
 const WebpackBar = require("webpackbar");
 const paths = require("./paths.js");
@@ -75,6 +76,7 @@ const createWebpackConfig = ({
       chunkIds: isProdBuild && !isStatsBuild ? "deterministic" : "named",
     },
     plugins: [
+      new CompressionWebpackPlugin(),
       !isStatsBuild && new WebpackBar({ fancy: !isProdBuild }),
       new WebpackManifestPlugin({
         // Only include the JS of entrypoints

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "app-datepicker": "^5.1.0",
     "chart.js": "^3.3.2",
     "comlink": "^4.4.1",
+    "compression-webpack-plugin": "^10.0.0",
     "core-js": "^3.28.0",
     "cropperjs": "^1.5.13",
     "date-fns": "^2.29.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6860,6 +6860,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compression-webpack-plugin@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "compression-webpack-plugin@npm:10.0.0"
+  dependencies:
+    schema-utils: ^4.0.0
+    serialize-javascript: ^6.0.0
+  peerDependencies:
+    webpack: ^5.1.0
+  checksum: 2ac9079b7ab87141639c62ddbb2820a06f105198e27ef4c3860da3186bdbefc00d1e206969833ce7a4b7b26161ddbec7b8d20d30f9f9c1d494818b9b86f0d5cc
+  languageName: node
+  linkType: hard
+
 "compression@npm:1.7.3":
   version: 1.7.3
   resolution: "compression@npm:1.7.3"
@@ -9626,6 +9638,7 @@ fsevents@~2.3.2:
     chai: ^4.3.7
     chart.js: ^3.3.2
     comlink: ^4.4.1
+    compression-webpack-plugin: ^10.0.0
     core-js: ^3.28.0
     cropperjs: ^1.5.13
     date-fns: ^2.29.3


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Enable compression for development.

We generate gzip files when we create the final package, but not when running in dev mode.  Ideally dev mode simulates production as much as possible.

Need to make sure this won't cause any conflicts with packaging the whl

While working in dev mode on a remote machine with slower connection it was taking minutes to load the UI. I realized it was downloading `app.js` as a 4MiB file uncompressed.  To do testing I'm developing on a remote with > 150ms latency to see how the UI will perform on mobile.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
