### PR TITLE
Prevent config menu jump when cloud info loads

### DIFF
--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -137,16 +137,17 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
     total: 0,
   };
 
-  private _pages = memoizeOne((clouStatus, isLoaded) => {
+  private _pages = memoizeOne((cloudStatus, isCloudLoaded) => {
     const pages: PageNavigation[] = [];
-    if (clouStatus && isLoaded) {
+    if (isCloudLoaded) {
       pages.push({
         component: "cloud",
         path: "/config/cloud",
         name: "Home Assistant Cloud",
-        info: this.cloudStatus,
+        info: cloudStatus,
         iconPath: mdiCloudLock,
         iconColor: "#3B808E",
+        translationKey: "cloud",
       });
     }
     return [...pages, ...configSections.dashboard];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1395,6 +1395,9 @@
           "about": {
             "main": "About",
             "secondary": "Version information, credits and more"
+          },
+          "cloud": {
+            "secondary": "Loading..."
           }
         },
         "common": {


### PR DESCRIPTION


## Proposed change

The cloud item would only be shown when the cloud info was loaded, causing a jump the config menu. Now it will always show and be updated when cloud info is loaded.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
