### PR TITLE
Fix statistics-picker filter when no entity selected

### DIFF
--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -75,20 +75,6 @@ class HaStatisticsPicker extends LitElement {
       ? undefined
       : this.statisticTypes;
 
-    const ignoreRestrictionLastPicker =
-      this.ignoreRestrictionsOnFirstStatistic &&
-      this._currentStatistics.length === 0;
-
-    const includeStatisticsUnitCurrentLastPicker = ignoreRestrictionLastPicker
-      ? undefined
-      : this.includeStatisticsUnitOfMeasurement;
-    const includeUnitClassCurrentLastPicker = ignoreRestrictionLastPicker
-      ? undefined
-      : this.includeUnitClass;
-    const includeStatisticTypesCurrentLastPicker = ignoreRestrictionLastPicker
-      ? undefined
-      : this.statisticTypes;
-
     return html`
       ${this._currentStatistics.map(
         (statisticId) => html`
@@ -110,10 +96,11 @@ class HaStatisticsPicker extends LitElement {
       <div>
         <ha-statistic-picker
           .hass=${this.hass}
-          .includeStatisticsUnitOfMeasurement=${includeStatisticsUnitCurrentLastPicker}
-          .includeUnitClass=${includeUnitClassCurrentLastPicker}
+          .includeStatisticsUnitOfMeasurement=${this
+            .includeStatisticsUnitOfMeasurement}
+          .includeUnitClass=${this.includeUnitClass}
           .includeDeviceClass=${this.includeDeviceClass}
-          .statisticTypes=${includeStatisticTypesCurrentLastPicker}
+          .statisticTypes=${this.statisticTypes}
           .statisticIds=${this.statisticIds}
           .label=${this.pickStatisticLabel}
           @value-changed=${this._addStatistic}

--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -75,6 +75,20 @@ class HaStatisticsPicker extends LitElement {
       ? undefined
       : this.statisticTypes;
 
+    const ignoreRestrictionLastPicker =
+      this.ignoreRestrictionsOnFirstStatistic &&
+      this._currentStatistics.length === 0;
+
+    const includeStatisticsUnitCurrentLastPicker = ignoreRestrictionLastPicker
+      ? undefined
+      : this.includeStatisticsUnitOfMeasurement;
+    const includeUnitClassCurrentLastPicker = ignoreRestrictionLastPicker
+      ? undefined
+      : this.includeUnitClass;
+    const includeStatisticTypesCurrentLastPicker = ignoreRestrictionLastPicker
+      ? undefined
+      : this.statisticTypes;
+
     return html`
       ${this._currentStatistics.map(
         (statisticId) => html`
@@ -96,11 +110,10 @@ class HaStatisticsPicker extends LitElement {
       <div>
         <ha-statistic-picker
           .hass=${this.hass}
-          .includeStatisticsUnitOfMeasurement=${this
-            .includeStatisticsUnitOfMeasurement}
-          .includeUnitClass=${this.includeUnitClass}
+          .includeStatisticsUnitOfMeasurement=${includeStatisticsUnitCurrentLastPicker}
+          .includeUnitClass=${includeUnitClassCurrentLastPicker}
           .includeDeviceClass=${this.includeDeviceClass}
-          .statisticTypes=${this.statisticTypes}
+          .statisticTypes=${includeStatisticTypesCurrentLastPicker}
           .statisticIds=${this.statisticIds}
           .label=${this.pickStatisticLabel}
           @value-changed=${this._addStatistic}

--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -71,6 +71,9 @@ class HaStatisticsPicker extends LitElement {
     const includeUnitClassCurrent = ignoreRestriction
       ? undefined
       : this.includeUnitClass;
+    const includeDeviceClassCurrent = ignoreRestriction
+      ? undefined
+      : this.includeDeviceClass;
     const includeStatisticTypesCurrent = ignoreRestriction
       ? undefined
       : this.statisticTypes;
@@ -84,6 +87,7 @@ class HaStatisticsPicker extends LitElement {
               .hass=${this.hass}
               .includeStatisticsUnitOfMeasurement=${includeStatisticsUnitCurrent}
               .includeUnitClass=${includeUnitClassCurrent}
+              .includeDeviceClass=${includeDeviceClassCurrent}
               .value=${statisticId}
               .statisticTypes=${includeStatisticTypesCurrent}
               .statisticIds=${this.statisticIds}

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -121,7 +121,9 @@ export class HuiStatisticsGraphCardEditor
       !deepEqual(this._configEntities, changedProps.get("_configEntities"))
     ) {
       this._metaDatas = undefined;
-      this._getStatisticsMetaData(this._configEntities);
+      if (this._configEntities && this._configEntities.length > 0) {
+        this._getStatisticsMetaData(this._configEntities);
+      }
     }
   }
 

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -121,7 +121,7 @@ export class HuiStatisticsGraphCardEditor
       !deepEqual(this._configEntities, changedProps.get("_configEntities"))
     ) {
       this._metaDatas = undefined;
-      if (this._configEntities && this._configEntities.length > 0) {
+      if (this._configEntities?.length) {
         this._getStatisticsMetaData(this._configEntities);
       }
     }


### PR DESCRIPTION

## Proposed change

Allow statistics-picker to implement ignoreRestrictionOnFirstStatistic behavior when no entities are selected. Only applies to stastics graph card. 

Additional description in #15583

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15583
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
