### PR TITLE
Fix webpack source maps

### DIFF
--- a/build-scripts/bundle.js
+++ b/build-scripts/bundle.js
@@ -3,9 +3,13 @@ const env = require("./env.js");
 const paths = require("./paths.js");
 
 // GitHub base URL to use for production source maps
-// Assumes there is a tag that matches the version
-module.exports.sourceMapURL = () =>
-  `https://raw.githubusercontent.com/home-assistant/frontend/${env.version()}`;
+// Nightly builds use the commit SHA, otherwise assumes there is a tag that matches the version
+module.exports.sourceMapURL = () => {
+  const ref = env.version().endsWith("dev")
+    ? process.env.GITHUB_SHA || "dev"
+    : env.version();
+  return `https://raw.githubusercontent.com/home-assistant/frontend/${ref}`;
+};
 
 // Files from NPM Packages that should not be imported
 // eslint-disable-next-line unused-imports/no-unused-vars

--- a/build-scripts/bundle.js
+++ b/build-scripts/bundle.js
@@ -2,6 +2,11 @@ const path = require("path");
 const env = require("./env.js");
 const paths = require("./paths.js");
 
+// GitHub base URL to use for production source maps
+// Assumes there is a tag that matches the version
+module.exports.sourceMapURL = () =>
+  `https://raw.githubusercontent.com/home-assistant/frontend/${env.version()}`;
+
 // Files from NPM Packages that should not be imported
 // eslint-disable-next-line unused-imports/no-unused-vars
 module.exports.ignorePackages = ({ latestBuild }) => [

--- a/build-scripts/env.js
+++ b/build-scripts/env.js
@@ -17,7 +17,7 @@ module.exports = {
   isStatsBuild() {
     return process.env.STATS === "1";
   },
-  isTest() {
+  isTestBuild() {
     return process.env.IS_TEST === "true";
   },
   isNetlify() {

--- a/build-scripts/gulp/app.js
+++ b/build-scripts/gulp/app.js
@@ -1,8 +1,7 @@
 // Run HA develop mode
+
 const gulp = require("gulp");
-
 const env = require("../env");
-
 require("./clean.js");
 require("./translations.js");
 require("./locale-data.js");
@@ -50,7 +49,7 @@ gulp.task(
     "copy-static-app",
     env.useRollup() ? "rollup-prod-app" : "webpack-prod-app",
     // Don't compress running tests
-    ...(env.isTest() ? [] : ["compress-app"]),
+    ...(env.isTestBuild() ? [] : ["compress-app"]),
     gulp.parallel(
       "gen-pages-prod",
       "gen-index-app-prod",

--- a/build-scripts/gulp/hassio.js
+++ b/build-scripts/gulp/hassio.js
@@ -1,7 +1,5 @@
 const gulp = require("gulp");
-
 const env = require("../env");
-
 require("./clean.js");
 require("./gen-icons-json.js");
 require("./webpack.js");
@@ -43,6 +41,6 @@ gulp.task(
     env.useRollup() ? "rollup-prod-hassio" : "webpack-prod-hassio",
     "gen-index-hassio-prod",
     ...// Don't compress running tests
-    (env.isTest() ? [] : ["compress-hassio"])
+    (env.isTestBuild() ? [] : ["compress-hassio"])
   )
 );

--- a/build-scripts/gulp/webpack.js
+++ b/build-scripts/gulp/webpack.js
@@ -5,6 +5,7 @@ const webpack = require("webpack");
 const WebpackDevServer = require("webpack-dev-server");
 const log = require("fancy-log");
 const path = require("path");
+const env = require("../env");
 const paths = require("../paths");
 const {
   createAppConfig,
@@ -104,6 +105,8 @@ gulp.task("webpack-prod-app", () =>
   prodBuild(
     bothBuilds(createAppConfig, {
       isProdBuild: true,
+      isStatsBuild: env.isStatsBuild(),
+      isTestBuild: env.isTestBuild(),
     })
   )
 );
@@ -161,6 +164,8 @@ gulp.task("webpack-prod-hassio", () =>
   prodBuild(
     bothBuilds(createHassioConfig, {
       isProdBuild: true,
+      isStatsBuild: env.isStatsBuild(),
+      isTestBuild: env.isTestBuild(),
     })
   )
 );

--- a/build-scripts/rollup.js
+++ b/build-scripts/rollup.js
@@ -76,7 +76,7 @@ const createRollupConfig = ({
         }),
       !isWDS && worker(),
       !isWDS && dontHashPlugin({ dontHash }),
-      !isWDS && isProdBuild && terser(bundle.terserOptions(latestBuild)),
+      !isWDS && isProdBuild && terser(bundle.terserOptions({ latestBuild })),
       !isWDS &&
         isStatsBuild &&
         visualizer({

--- a/build-scripts/webpack.js
+++ b/build-scripts/webpack.js
@@ -22,6 +22,7 @@ class LogStartCompilePlugin {
 }
 
 const createWebpackConfig = ({
+  name,
   entry,
   outputPath,
   publicPath,
@@ -29,6 +30,7 @@ const createWebpackConfig = ({
   isProdBuild,
   latestBuild,
   isStatsBuild,
+  isTestBuild,
   isHassioBuild,
   dontHash,
 }) => {
@@ -37,10 +39,16 @@ const createWebpackConfig = ({
   }
   const ignorePackages = bundle.ignorePackages({ latestBuild });
   return {
+    name,
     mode: isProdBuild ? "production" : "development",
     target: ["web", latestBuild ? "es2017" : "es5"],
-    devtool: isProdBuild
-      ? "cheap-module-source-map"
+    // For tests/CI, source maps are skipped to gain build speed
+    // For production, generate source maps for accurate stack traces without source code
+    // For development, generate "cheap" versions that can map to original line numbers
+    devtool: isTestBuild
+      ? false
+      : isProdBuild
+      ? "nosources-source-map"
       : "eval-cheap-module-source-map",
     entry,
     node: false,
@@ -51,7 +59,7 @@ const createWebpackConfig = ({
           use: {
             loader: "babel-loader",
             options: {
-              ...bundle.babelOptions({ latestBuild, isProdBuild }),
+              ...bundle.babelOptions({ latestBuild, isProdBuild, isTestBuild }),
               cacheDirectory: !isProdBuild,
               cacheCompression: false,
             },
@@ -68,7 +76,7 @@ const createWebpackConfig = ({
         new TerserPlugin({
           parallel: true,
           extractComments: true,
-          terserOptions: bundle.terserOptions(latestBuild),
+          terserOptions: bundle.terserOptions({ latestBuild, isTestBuild }),
         }),
       ],
       moduleIds: isProdBuild && !isStatsBuild ? "deterministic" : "named",
@@ -160,9 +168,14 @@ const createWebpackConfig = ({
   };
 };
 
-const createAppConfig = ({ isProdBuild, latestBuild, isStatsBuild }) =>
+const createAppConfig = ({
+  isProdBuild,
+  latestBuild,
+  isStatsBuild,
+  isTestBuild,
+}) =>
   createWebpackConfig(
-    bundle.config.app({ isProdBuild, latestBuild, isStatsBuild })
+    bundle.config.app({ isProdBuild, latestBuild, isStatsBuild, isTestBuild })
   );
 
 const createDemoConfig = ({ isProdBuild, latestBuild, isStatsBuild }) =>
@@ -173,8 +186,20 @@ const createDemoConfig = ({ isProdBuild, latestBuild, isStatsBuild }) =>
 const createCastConfig = ({ isProdBuild, latestBuild }) =>
   createWebpackConfig(bundle.config.cast({ isProdBuild, latestBuild }));
 
-const createHassioConfig = ({ isProdBuild, latestBuild }) =>
-  createWebpackConfig(bundle.config.hassio({ isProdBuild, latestBuild }));
+const createHassioConfig = ({
+  isProdBuild,
+  latestBuild,
+  isStatsBuild,
+  isTestBuild,
+}) =>
+  createWebpackConfig(
+    bundle.config.hassio({
+      isProdBuild,
+      latestBuild,
+      isStatsBuild,
+      isTestBuild,
+    })
+  );
 
 const createGalleryConfig = ({ isProdBuild, latestBuild }) =>
   createWebpackConfig(bundle.config.gallery({ isProdBuild, latestBuild }));

--- a/build-scripts/webpack.js
+++ b/build-scripts/webpack.js
@@ -161,6 +161,22 @@ const createWebpackConfig = ({
       publicPath,
       // To silence warning in worker plugin
       globalObject: "self",
+      // Since production source maps don't include sources, we need to point to them elsewhere
+      // For dependencies, just provide the path (no source in browser)
+      // Otherwise, point to the raw code on GitHub for browser to load
+      devtoolModuleFilenameTemplate:
+        !isTestBuild && isProdBuild
+          ? (info) => {
+              const sourcePath = info.resourcePath.replace(/^\.\//, "");
+              if (
+                sourcePath.startsWith("node_modules") ||
+                sourcePath.startsWith("webpack")
+              ) {
+                return `no-source/${sourcePath}`;
+              }
+              return `${bundle.sourceMapURL()}/${sourcePath}`;
+            }
+          : undefined,
     },
     experiments: {
       topLevelAwait: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,12 @@
+/* eslint-disable import/extensions */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 const { createAppConfig } = require("./build-scripts/webpack.js");
-const { isProdBuild, isStatsBuild } = require("./build-scripts/env.js");
+const {
+  isProdBuild,
+  isStatsBuild,
+  isTestBuild,
+} = require("./build-scripts/env.js");
 
 // This file exists because we haven't migrated the stats script yet
 
@@ -7,6 +14,7 @@ const configs = [
   createAppConfig({
     isProdBuild: isProdBuild(),
     isStatsBuild: isStatsBuild(),
+    isTestBuild: isTestBuild(),
     latestBuild: true,
   }),
 ];
@@ -16,6 +24,7 @@ if (isProdBuild && !isStatsBuild) {
     createAppConfig({
       isProdBuild: isProdBuild(),
       isStatsBuild: isStatsBuild(),
+      isTestBuild: isTestBuild(),
       latestBuild: false,
     })
   );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change overhauls Webpack's generation of source maps, which are controlled by the [`devtool` configuration](https://webpack.js.org/configuration/devtool/).  The primary change is to produce useful source maps to distribute in production.

### 1. Development
For development, it's currently set to `"eval-cheap-module-source-map"` for build speed.  This is perfectly fine since minification is turned off in this scenario.  It maps errors back to original source line numbers.  However, the "module" part will use the source maps from loaders, but they aren't turned on for Babel.  This change fixes that.

### 2. Production
For production, it's currently set to `"cheap-module-source-map"`.  Since the code is minified, this is effectively useless.  See the explanations on the [Terser plugin page](https://webpack.js.org/plugins/terser-webpack-plugin/) and the `devtool` page.  Furthermore, source maps are also not turned on for Terser.  The bottom line is that when users paste stack traces to issues, they are difficult to try to map back to original source.

The option that I think makes the most sense for HA is `"nosources-source-map"`, which will allow stack traces back to original line and column numbers.  This produces a separate map for each JS file, but doesn't bloat it by including the original source (so clicking on it in the browser won't work.... yet).  Of course it's readily available on GH anyway.

#### Questions & next steps
- I ran a [nightly on this branch](https://github.com/home-assistant/frontend/actions/runs/4307315904) - wheels went from 36 to 46 MB.  Is that a problem?
- If so, I did not add the maps to compression since I wasn't sure if the server could handle it.  Should I?
- The wheels also currently includes both compressed and uncompressed JS.  Size could be cut in half by knocking off the former.
- I think I can make the browser pull directly from GH to show sources.  Next PR...

### 3. Testing/CI
For test builds that will be thrown away, IMO it doesn't make sense to incur the cost of generating maps.  From my tests, they add about 20-25% to latest builds.  This change turns them off in this scenario.

### Other small change
I also added a `name` to all the configs.  This helps when running via CLI and distinguishing log output.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
