### PR TITLE
Use display precision for number format none

### DIFF
--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -77,6 +77,24 @@ export const formatNumber = (
       ).format(Number(num));
     }
   }
+
+  if (
+    !Number.isNaN(Number(num)) &&
+    num !== "" &&
+    localeOptions?.number_format === NumberFormat.none &&
+    Intl
+  ) {
+    // If NumberFormat is none, just set the digits options for precision and use en-US format without grouping.
+    return new Intl.NumberFormat(
+      "en-US",
+      getDefaultFormatOptions(num, {
+        useGrouping: false,
+        maximumFractionDigits: options?.maximumFractionDigits,
+        minimumFractionDigits: options?.minimumFractionDigits,
+      })
+    ).format(Number(num));
+  }
+
   if (typeof num === "string") {
     return num;
   }

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -82,7 +82,8 @@ export const formatNumber = (
     !Number.isNaN(Number(num)) &&
     num !== "" &&
     localeOptions?.number_format === NumberFormat.none &&
-    Intl && (options?.maximumFractionDigits || options?.minimumFractionDigits)
+    Intl &&
+    (options?.maximumFractionDigits || options?.minimumFractionDigits)
   ) {
     // If NumberFormat is none, just set the digits options for precision and use en-US format without grouping.
     return new Intl.NumberFormat(

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -82,7 +82,7 @@ export const formatNumber = (
     !Number.isNaN(Number(num)) &&
     num !== "" &&
     localeOptions?.number_format === NumberFormat.none &&
-    Intl
+    Intl && (options?.maximumFractionDigits || options?.minimumFractionDigits)
   ) {
     // If NumberFormat is none, just set the digits options for precision and use en-US format without grouping.
     return new Intl.NumberFormat(

--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -83,7 +83,8 @@ export const formatNumber = (
     num !== "" &&
     localeOptions?.number_format === NumberFormat.none &&
     Intl &&
-    (options?.maximumFractionDigits || options?.minimumFractionDigits)
+    (options?.maximumFractionDigits != null ||
+      options?.minimumFractionDigits != null)
   ) {
     // If NumberFormat is none, just set the digits options for precision and use en-US format without grouping.
     return new Intl.NumberFormat(

--- a/src/panels/lovelace/common/has-changed.ts
+++ b/src/panels/lovelace/common/has-changed.ts
@@ -1,6 +1,6 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { PropertyValues } from "lit";
-import { EntityRegistryEntry } from "../../../data/entity_registry";
+import { EntityRegistryDisplayEntry } from "../../../data/entity_registry";
 import { HomeAssistant } from "../../../types";
 import { processConfigEntities } from "./process-config-entities";
 
@@ -37,24 +37,19 @@ function compareEntityState(
   return oldState !== newState;
 }
 
-function compareEntityEntryOptions(
+function compareEntityDisplayEntry(
   oldHass: HomeAssistant,
   newHass: HomeAssistant,
   entityId: string
 ) {
   const oldEntry = oldHass.entities[entityId] as
-    | EntityRegistryEntry
+    | EntityRegistryDisplayEntry
     | undefined;
   const newEntry = newHass.entities[entityId] as
-    | EntityRegistryEntry
+    | EntityRegistryDisplayEntry
     | undefined;
 
-  return (
-    oldEntry?.options?.sensor?.display_precision !==
-      newEntry?.options?.sensor?.display_precision ||
-    oldEntry?.options?.sensor?.suggested_display_precision !==
-      newEntry?.options?.sensor?.suggested_display_precision
-  );
+  return oldEntry?.display_precision !== newEntry?.display_precision;
 }
 
 // Check if config or Entity changed
@@ -71,7 +66,7 @@ export function hasConfigOrEntityChanged(
 
   return (
     compareEntityState(oldHass, newHass, element._config!.entity) ||
-    compareEntityEntryOptions(oldHass, newHass, element._config!.entity)
+    compareEntityDisplayEntry(oldHass, newHass, element._config!.entity)
   );
 }
 
@@ -96,7 +91,7 @@ export function hasConfigOrEntitiesChanged(
 
     return (
       compareEntityState(oldHass, newHass, entity.entity) ||
-      compareEntityEntryOptions(oldHass, newHass, entity.entity)
+      compareEntityDisplayEntry(oldHass, newHass, entity.entity)
     );
   });
 }

--- a/test/common/string/format_number.ts
+++ b/test/common/string/format_number.ts
@@ -69,6 +69,33 @@ describe("formatNumber", () => {
     );
   });
 
+  it("Formats number with fraction digits options if number format is none", () => {
+    assert.strictEqual(
+      formatNumber(
+        1234.5,
+        { ...defaultLocale, number_format: NumberFormat.none },
+        {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        }
+      ),
+      "1234.50"
+    );
+  });
+
+  it("Do not formats number with others options if number format is none", () => {
+    assert.strictEqual(
+      formatNumber(
+        1234.5,
+        { ...defaultLocale, number_format: NumberFormat.none },
+        {
+          useGrouping: true,
+        }
+      ),
+      "1234.5"
+    );
+  });
+
   it("Sets only the maximumFractionDigits format option when none are provided for a number value", () => {
     assert.deepEqual(getDefaultFormatOptions(1234.5), {
       maximumFractionDigits: 2,


### PR DESCRIPTION
## Proposed change

Use display precision for number format none.
I also added a fix for entity not updated when display precision changed.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15667
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
