### PR TITLE
Disable attribute validation on initial load of ha-selector-attribute (#15697)Co-authored-by: Bram Kragten <mail@bramkragten.nl>

### DIFF
--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -59,6 +59,7 @@ export class HaSelectorAttribute extends LitElement {
 
     if (
       !this.context ||
+      !oldContext ||
       oldContext?.filter_entity === this.context.filter_entity
     ) {
       return;

--- a/src/components/ha-selector/ha-selector-attribute.ts
+++ b/src/components/ha-selector/ha-selector-attribute.ts
@@ -60,7 +60,7 @@ export class HaSelectorAttribute extends LitElement {
     if (
       !this.context ||
       !oldContext ||
-      oldContext?.filter_entity === this.context.filter_entity
+      oldContext.filter_entity === this.context.filter_entity
     ) {
       return;
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Anytime the selected entity changes, a linked attribute selector will validate that its current attribute is valid for that entity, and clears itself if it is not. Normally I think this is a fine behavior when a user initiates the entity change from one to another. 

However this is not ideal on first load, since it is destructive to saved yaml automations. The example given in the linked issue is an automation that uses a light's brightness. If the light is off (and thus there is no brightness attribute) when the automation is edited, this behavior will cause visual editor to automatically delete the attribute, when it should be left alone. 

This change removes attribute validation when the linked entity changes from undefined (e.g. on initial load). 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15690
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
