### PR TITLE
Fix overzealous loading of ha-service-control default values

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -363,7 +363,7 @@ export class HaServiceControl extends LitElement {
         this._value?.service,
         this.hass.services
       )?.fields.find((field) => field.key === key)?.default;
-      if (defaultValue || defaultValue === 0) {
+      if (defaultValue != null) {
         data = {
           ...this._value?.data,
           [key]: defaultValue,

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -346,6 +346,7 @@ export class HaServiceControl extends LitElement {
                     .value=${this._value?.data
                       ? this._value.data[dataField.key]
                       : undefined}
+                    .placeholder=${dataField.default}
                   ></ha-selector>
                 </ha-settings-row>`
               : "";

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -136,6 +136,7 @@ export class HaServiceControl extends LitElement {
     if (oldValue?.service !== this.value?.service) {
       let updatedDefaultValue = false;
       if (this._value && serviceData) {
+        const loadDefaults = this.value && !("data" in this.value);
         // Set mandatory bools without a default value to false
         if (!this._value.data) {
           this._value.data = {};
@@ -152,6 +153,7 @@ export class HaServiceControl extends LitElement {
             this._value!.data![field.key] = false;
           }
           if (
+            loadDefaults &&
             field.selector &&
             field.default !== undefined &&
             this._value!.data![field.key] === undefined
@@ -341,10 +343,9 @@ export class HaServiceControl extends LitElement {
                     .selector=${dataField.selector}
                     .key=${dataField.key}
                     @value-changed=${this._serviceDataChanged}
-                    .value=${this._value?.data &&
-                    this._value.data[dataField.key] !== undefined
+                    .value=${this._value?.data
                       ? this._value.data[dataField.key]
-                      : dataField.default}
+                      : undefined}
                   ></ha-selector>
                 </ha-settings-row>`
               : "";
@@ -362,7 +363,7 @@ export class HaServiceControl extends LitElement {
         this._value?.service,
         this.hass.services
       )?.fields.find((field) => field.key === key)?.default;
-      if (defaultValue) {
+      if (defaultValue || defaultValue === 0) {
         data = {
           ...this._value?.data,
           [key]: defaultValue,

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -57,7 +57,9 @@ export class HuiActionEditor extends LitElement {
   private _serviceAction = memoizeOne(
     (config: CallServiceActionConfig): ServiceAction => ({
       service: this._service,
-      data: config.data ?? config.service_data,
+      ...(config.data || config.service_data
+        ? { data: config.data ?? config.service_data }
+        : null),
       target: config.target,
     })
   );
@@ -196,9 +198,12 @@ export class HuiActionEditor extends LitElement {
     const value = {
       ...this.config!,
       service: ev.detail.value.service || "",
-      data: ev.detail.value.data || {},
+      data: ev.detail.value.data,
       target: ev.detail.value.target || {},
     };
+    if (!ev.detail.value.data) {
+      delete value.data;
+    }
     // "service_data" is allowed for backwards compatibility but replaced with "data" on write
     if ("service_data" in value) {
       delete value.service_data;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Services which have default values are not behaving as I believe they are intended. Currently, anytime a ha-service-control is loaded, if it sees an optional parameter without a value, it populates it with its default value from services.yaml. 

For example in automation editor, if you add a new action and select call service, after choosing a service it will be populated with the defaults (good). But then if you deselect some of the optional parameters and save the automation, next time you return it will automatically populate them again (bad). Or even without saving, anytime you toggle to yaml mode, and back to visual mode, it will populate all the defaults again (bad). 

This change changes the behavior of ha-service-control to only load default values if no data key is already present for the service. This means defaults are loaded anytime a new service is selected, but not when an existing service is loaded in the visual editor. 

I found three places that use ha-service-control:
* automation action editor
* developer tools service calls
* hui-action-editor for cards (e.g. tap action for a button card). 

I tested this change in all three places, and only the hui-action-editor needed a change to not pass `data: {}` to the ha-service-control on the first time a service is selected. Other than that this seems to work correctly in all three places. 


This change is somewhat adjacent to my previous change #14949. I think this behavior started appearing after that change, but I don't want to revert that, because prior to that change the service defaults were even more broken in some cases. 


Also found one minor place in ha-service-control where defaults of `0` were not being honored properly, so fixed that as well, but that's not related to the main change. 


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
  fixes #15706 
  fixes #15349 
  fixes #15634
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
