### PR TITLE
Fix yaml editor behavior of statistics graph card

### DIFF
--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -30,6 +30,9 @@ export class HaStatisticPicker extends LitElement {
   @property({ attribute: "statistic-types" })
   public statisticTypes?: "mean" | "sum";
 
+  @property({ type: Boolean, attribute: "allow-custom-entity" })
+  public allowCustomEntity;
+
   @property({ type: Array }) public statisticIds?: StatisticsMetaData[];
 
   @property({ type: Boolean }) public disabled?: boolean;
@@ -245,6 +248,7 @@ export class HaStatisticPicker extends LitElement {
         .value=${this._value}
         .renderer=${this._rowRenderer}
         .disabled=${this.disabled}
+        .allowCustomValue=${this.allowCustomEntity}
         item-value-path="id"
         item-id-path="id"
         item-label-path="name"

--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -22,6 +22,9 @@ class HaStatisticsPicker extends LitElement {
   @property({ attribute: "pick-statistic-label" })
   public pickStatisticLabel?: string;
 
+  @property({ type: Boolean, attribute: "allow-custom-entity" })
+  public allowCustomEntity;
+
   /**
    * Show only statistics natively stored with these units of measurements.
    * @attr include-statistics-unit-of-measurement
@@ -88,6 +91,7 @@ class HaStatisticsPicker extends LitElement {
               .statisticTypes=${includeStatisticTypesCurrent}
               .statisticIds=${this.statisticIds}
               .label=${this.pickedStatisticLabel}
+              .allowCustomEntity=${this.allowCustomEntity}
               @value-changed=${this._statisticChanged}
             ></ha-statistic-picker>
           </div>
@@ -103,6 +107,7 @@ class HaStatisticsPicker extends LitElement {
           .statisticTypes=${this.statisticTypes}
           .statisticIds=${this.statisticIds}
           .label=${this.pickStatisticLabel}
+          .allowCustomEntity=${this.allowCustomEntity}
           @value-changed=${this._addStatistic}
         ></ha-statistic-picker>
       </div>

--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -274,6 +274,7 @@ export class HuiStatisticsGraphCardEditor
         @value-changed=${this._valueChanged}
       ></ha-form>
         <ha-statistics-picker
+          allow-custom-entity
           .hass=${this.hass}
           .pickStatisticLabel=${this.hass!.localize(
             "ui.panel.lovelace.editor.card.statistics-graph.pick_statistic"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Enable allow-custom-entity for the statistics picker in statistics graph card. This prevent the yaml editor from yanking text from the user while trying to type. (See screen recording in linked issue for example).

Without this property, if user try to change the name of an entity in the list, yaml tries to pass invalid entity to ha-statistics-picker, which rejects it and returns a new list of entities without the modified entity.

This makes it difficult for example to add name: property to a picked statistic, because it is immediately rejected when you type a single character. 


The minor drawback of this is it allow user to type an entity into the statistics picker that is not supposed to be allowed, it may cause some undefined behavior. But user can already do this in yaml, so I don't think this is too bad. The other alternative would be to try to have setConfig in the graph card throw an exception if the list of entities in config is not a valid combination, but that requires a lot of duplicating of the code from ha-statistic-picker, and I found it unnecessarily complicated. 


I also notice that ha-selector-statistic already passes allow-custom-entity to ha-statistic-picker, even though ha-statistic-picker does not currently honor that attribute. So when I add that attribute in this PR to ha-statistic-picker, that will make ha-selector-statistic able to use custom entity. I don't know if that is desired or not. If not, that attribute could be removed to maintain current behavior. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15687 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
