### PR TITLE
Adjust top bar on supervisor addon cards

### DIFF
--- a/hassio/src/components/hassio-card-content.ts
+++ b/hassio/src/components/hassio-card-content.ts
@@ -117,11 +117,11 @@ class HassioCardContent extends LitElement {
       .topbar {
         position: absolute;
         width: 100%;
-        height: 2px;
+        height: 11px;
         top: 0;
         left: 0;
-        border-top-left-radius: 2px;
-        border-top-right-radius: 2px;
+        border-top-left-radius: 11px;
+        border-top-right-radius: 11px;
       }
       .topbar.installed {
         background-color: var(--primary-color);


### PR DESCRIPTION
Fix blue line in add-on store. 

Top bar edges now match rounded corners and installed add-ons are better distinguishable.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change


## Proposed change

Small visual fix of the blue line which did not fit nicely in it's box. 

## Type of change

- [ ] Dependency upgrade
- [ X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Not applicable

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [ X ] The code change is tested and works locally.
- [ X ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
