### PR TITLE
Fix RTL & missing translation & misalign hostnam

### DIFF
--- a/src/panels/config/network/ha-config-url-form.ts
+++ b/src/panels/config/network/ha-config-url-form.ts
@@ -344,7 +344,10 @@ class ConfigUrlForm extends LitElement {
       }
 
       .card-actions {
-        text-align: right;
+        display: flex;
+        flex-direction: row-reverse;
+        justify-content: space-between;
+        align-items: center;
       }
 
       a {

--- a/src/panels/config/network/ha-config-url-form.ts
+++ b/src/panels/config/network/ha-config-url-form.ts
@@ -346,8 +346,6 @@ class ConfigUrlForm extends LitElement {
       .card-actions {
         display: flex;
         flex-direction: row-reverse;
-        justify-content: space-between;
-        align-items: center;
       }
 
       a {

--- a/src/panels/config/network/supervisor-hostname.ts
+++ b/src/panels/config/network/supervisor-hostname.ts
@@ -51,22 +51,23 @@ export class HassioHostname extends LitElement {
       <ha-card
         class="no-padding"
         outlined
-        .header=${this.hass.localize("ui.panel.config.network.hostname.title")}
+        .header=${this.hass.localize(
+          "ui.panel.config.network.supervisor.hostname.title"
+        )}
       >
-        <div>
-          <ha-settings-row .narrow=${this.narrow}>
-            <span slot="heading">Hostname</span>
-            <span slot="description"
-              >The name your instance will have on your network</span
-            >
-            <ha-textfield
-              .disabled=${this._processing}
-              .value=${this._hostname}
-              @change=${this._handleChange}
-              placeholder="homeassistant"
-            >
-            </ha-textfield>
-          </ha-settings-row>
+        <div class="card-content">
+          <span slot="description"
+            >${this.hass.localize(
+              "ui.panel.config.network.supervisor.hostname.description"
+            )}</span
+          >
+          <ha-textfield
+            .disabled=${this._processing}
+            .value=${this._hostname}
+            @change=${this._handleChange}
+            placeholder="homeassistant"
+          >
+          </ha-textfield>
         </div>
         <div class="card-actions">
           <mwc-button @click=${this._save} .disabled=${this._processing}>
@@ -91,7 +92,7 @@ export class HassioHostname extends LitElement {
     } catch (err: any) {
       showAlertDialog(this, {
         title: this.hass.localize(
-          "ui.panel.config.network.hostname.failed_to_set_hostname"
+          "ui.panel.config.network.supervisor.hostname.failed_to_set_hostname"
         ),
         text: extractApiErrorMessage(err),
       });
@@ -110,8 +111,12 @@ export class HassioHostname extends LitElement {
       justify-content: space-between;
       align-items: center;
     }
-    ha-settings-row {
-      border-top: none;
+    .card-content {
+      display: block;
+    }
+    span[slot="description"] {
+      display: block;
+      padding-bottom: 1em;
     }
   `;
 }

--- a/src/panels/config/network/supervisor-hostname.ts
+++ b/src/panels/config/network/supervisor-hostname.ts
@@ -56,11 +56,11 @@ export class HassioHostname extends LitElement {
         )}
       >
         <div class="card-content">
-          <span slot="description"
-            >${this.hass.localize(
+          <p>
+            ${this.hass.localize(
               "ui.panel.config.network.supervisor.hostname.description"
-            )}</span
-          >
+            )}
+          </p>
           <ha-textfield
             .disabled=${this._processing}
             .value=${this._hostname}
@@ -111,11 +111,7 @@ export class HassioHostname extends LitElement {
       justify-content: space-between;
       align-items: center;
     }
-    .card-content {
-      display: block;
-    }
-    span[slot="description"] {
-      display: block;
+    .card-content > p {
       padding-bottom: 1em;
     }
   `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3778,7 +3778,12 @@
             "gateway": "Gateway address",
             "dns_servers": "DNS Servers",
             "unsaved": "You have unsaved changes, these will get lost if you change tabs, do you want to continue?",
-            "failed_to_change": "Failed to change network settings"
+            "failed_to_change": "Failed to change network settings",
+            "hostname": {
+              "title": "Host Name",
+              "description": "The name your instance will have on your network",
+              "failed_to_set_hostname": "Setting hostname failed"
+            }
           }
         },
         "storage": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixing RTL in config -> external network.
Hostname card was totally off + not localized

Button in one of the cards was not aligned

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
