### PR TITLE
Minor UI bugfixes for selector-datetime and dialog-date-picker

### DIFF
--- a/src/components/ha-dialog-date-picker.ts
+++ b/src/components/ha-dialog-date-picker.ts
@@ -66,11 +66,19 @@ export class HaDialogDatePicker extends LitElement {
   }
 
   private _setToday() {
-    // en-CA locale used for date format YYYY-MM-DD
-    this._value = new Date().toLocaleDateString("en-CA");
+    const today = new Date();
+    const y = today.getFullYear();
+    const m = (today.getMonth() + 1 < 10 ? "0" : "") + (today.getMonth() + 1);
+    const d = (today.getDate() < 10 ? "0" : "") + today.getDate();
+    this._value = y + "-" + m + "-" + d;
   }
 
   private _setValue() {
+    if (!this._value) {
+      // Date picker opens to today if value is undefined. If user click OK
+      // without changing the date, should return todays date, not undefined.
+      this._setToday();
+    }
     this._params?.onChange(this._value!);
     this.closeDialog();
   }

--- a/src/components/ha-dialog-date-picker.ts
+++ b/src/components/ha-dialog-date-picker.ts
@@ -1,5 +1,6 @@
 import "@material/mwc-button/mwc-button";
 import "app-datepicker";
+import { format } from "date-fns";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
@@ -67,10 +68,7 @@ export class HaDialogDatePicker extends LitElement {
 
   private _setToday() {
     const today = new Date();
-    const y = today.getFullYear();
-    const m = (today.getMonth() + 1 < 10 ? "0" : "") + (today.getMonth() + 1);
-    const d = (today.getDate() < 10 ? "0" : "") + today.getDate();
-    this._value = y + "-" + m + "-" + d;
+    this._value = format(today, "yyyy-MM-dd");
   }
 
   private _setValue() {

--- a/src/components/ha-selector/ha-selector-datetime.ts
+++ b/src/components/ha-selector/ha-selector-datetime.ts
@@ -39,7 +39,7 @@ export class HaDateTimeSelector extends LitElement {
           .locale=${this.hass.locale}
           .disabled=${this.disabled}
           .required=${this.required}
-          .value=${values?.[0] === "undefined" ? undefined : values?.[0]}
+          .value=${values?.[0]}
           @value-changed=${this._valueChanged}
         >
         </ha-date-input>
@@ -72,7 +72,7 @@ export class HaDateTimeSelector extends LitElement {
 
   private _sendChangedEvent(): void {
     fireEvent(this, "value-changed", {
-      value: `${this._dateInput.value} ${this._timeInput.value}`,
+      value: `${this._dateInput.value ?? ""} ${this._timeInput.value}`,
     });
   }
 

--- a/src/components/ha-selector/ha-selector-datetime.ts
+++ b/src/components/ha-selector/ha-selector-datetime.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement, PropertyValues } from "lit";
+import { css, html, LitElement } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { DateTimeSelector } from "../../data/selector";
@@ -58,22 +58,13 @@ export class HaDateTimeSelector extends LitElement {
     `;
   }
 
-  protected updated(changedProps: PropertyValues): void {
-    super.updated(changedProps);
-    if (changedProps.has("disabled") && !this.disabled && !this.value) {
-      this._sendChangedEvent();
-    }
-  }
-
   private _valueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
-    this._sendChangedEvent();
-  }
-
-  private _sendChangedEvent(): void {
-    fireEvent(this, "value-changed", {
-      value: `${this._dateInput.value ?? ""} ${this._timeInput.value}`,
-    });
+    if (this._dateInput.value && this._timeInput.value) {
+      fireEvent(this, "value-changed", {
+        value: `${this._dateInput.value} ${this._timeInput.value}`,
+      });
+    }
   }
 
   static styles = css`

--- a/src/components/ha-selector/ha-selector-datetime.ts
+++ b/src/components/ha-selector/ha-selector-datetime.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, PropertyValues } from "lit";
 import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { DateTimeSelector } from "../../data/selector";
@@ -39,13 +39,13 @@ export class HaDateTimeSelector extends LitElement {
           .locale=${this.hass.locale}
           .disabled=${this.disabled}
           .required=${this.required}
-          .value=${values?.[0]}
+          .value=${values?.[0] === "undefined" ? undefined : values?.[0]}
           @value-changed=${this._valueChanged}
         >
         </ha-date-input>
         <ha-time-input
           enable-second
-          .value=${values?.[1] || "0:00:00"}
+          .value=${values?.[1] || "00:00:00"}
           .locale=${this.hass.locale}
           .disabled=${this.disabled}
           .required=${this.required}
@@ -58,8 +58,19 @@ export class HaDateTimeSelector extends LitElement {
     `;
   }
 
+  protected updated(changedProps: PropertyValues): void {
+    super.updated(changedProps);
+    if (changedProps.has("disabled") && !this.disabled && !this.value) {
+      this._sendChangedEvent();
+    }
+  }
+
   private _valueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
+    this._sendChangedEvent();
+  }
+
+  private _sendChangedEvent(): void {
     fireEvent(this, "value-changed", {
       value: `${this._dateInput.value} ${this._timeInput.value}`,
     });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

A few miscellaneous bugfixes: 

* The date format for en-CA was recently changed from "yyyy-mm-dd" to "mm/dd/yyyy". This has broken the `today` button on the date picker, which relied on the specific en-CA format. It looks like it may change back in the future, but just change the code to format the date in the correct way as needed, rather than rely on the future politicial whims of Canadians. 
See https://github.com/nodejs/node/issues/45945 and https://unicode-org.atlassian.net/browse/CLDR-16399 for more background. 

* When opening a date-picker-dialog with the value of undefined, it was not possible to select today's date without first clicking to a different date, and then clicking back on today. Fix this behavior. 

* The datetime selector has some problems, detailed in #15755, which are fixed here. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15755
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
