### PR TITLE
Add white mode to more info light

### DIFF
--- a/src/dialogs/more-info/controls/more-info-light.ts
+++ b/src/dialogs/more-info/controls/more-info-light.ts
@@ -2,6 +2,7 @@ import "@material/mwc-list/mwc-list-item";
 import "@material/web/iconbutton/outlined-icon-button";
 import {
   mdiCreation,
+  mdiFileWordBox,
   mdiLightbulb,
   mdiLightbulbOff,
   mdiPalette,
@@ -72,6 +73,11 @@ class MoreInfoLight extends LitElement {
     );
 
     const supportsColor = lightSupportsColor(this.stateObj);
+
+    const supportsWhite = lightSupportsColorMode(
+      this.stateObj,
+      LightColorMode.WHITE
+    );
 
     const supportsBrightness = lightSupportsBrightness(this.stateObj);
 
@@ -148,6 +154,22 @@ class MoreInfoLight extends LitElement {
                       </md-outlined-icon-button>
                     `
                   : null}
+                ${supportsWhite
+                  ? html`
+                      <md-outlined-icon-button
+                        .disabled=${this.stateObj.state === UNAVAILABLE}
+                        .title=${this.hass.localize(
+                          "ui.dialogs.more_info_control.light.set_white"
+                        )}
+                        .ariaLabel=${this.hass.localize(
+                          "ui.dialogs.more_info_control.light.set_white"
+                        )}
+                        @click=${this._setWhiteColor}
+                      >
+                        <ha-svg-icon .path=${mdiFileWordBox}></ha-svg-icon>
+                      </md-outlined-icon-button>
+                    `
+                  : null}
                 ${supportsEffects && this.stateObj.attributes.effect_list
                   ? html`
                       <ha-button-menu
@@ -214,6 +236,13 @@ class MoreInfoLight extends LitElement {
         entityId: this.stateObj!.entity_id,
       }
     );
+  };
+
+  private _setWhiteColor = () => {
+    this.hass.callService("light", "turn_on", {
+      entity_id: this.stateObj!.entity_id,
+      white: true,
+    });
   };
 
   private _handleEffectButton(ev) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -899,6 +899,7 @@
         "light": {
           "toggle": "Toggle",
           "change_color": "Change color",
+          "set_white": "Set white",
           "select_effect": "Select effect",
           "brightness": "Brightness",
           "color_picker": {


### PR DESCRIPTION
## Proposed change

White mode was missing in the more info light

Needs : https://github.com/home-assistant/core/pull/89803

![image](https://user-images.githubusercontent.com/5878303/224001850-e6b2665c-6020-4cad-80bf-a710570e1728.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15756
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
