### PR TITLE
Fix number slider clipping in more-info

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -100,6 +100,11 @@ export class HaDialog extends DialogBase {
         position: var(--dialog-content-position, relative);
         padding: var(--dialog-content-padding, 24px);
       }
+
+      :host([overflowVisible]) .mdc-dialog__content {
+        overflow: visible;
+      }
+
       :host([hideactions]) .mdc-dialog .mdc-dialog__content {
         padding-bottom: max(
           var(--dialog-content-padding, 24px),

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -242,8 +242,16 @@ export class MoreInfoDialog extends LitElement {
     const isInfoView = this._currView === "info" && !this._childView;
     const isNewMoreInfo = stateObj && computeShowNewMoreInfo(stateObj);
 
+    const overflow = domain === "input_number" || domain === "number";
+
     return html`
-      <ha-dialog open @closed=${this.closeDialog} .heading=${title} hideActions>
+      <ha-dialog
+        open
+        ?overflowVisible=${overflow}
+        @closed=${this.closeDialog}
+        .heading=${title}
+        hideActions
+      >
         <div slot="heading" class="heading">
           <ha-header-bar>
             ${isInfoView


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix number slider popup being cut off by the top of more info card. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15684 fixes #15828
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
