### PR TITLE
Improve padding to avoid input number overflow

### DIFF
--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -98,7 +98,7 @@ export class MoreInfoInfo extends LitElement {
         display: flex;
         flex-direction: column;
         flex: 1;
-        padding: 8px 24px 24px 24px;
+        padding: 24px;
         padding-bottom: max(env(safe-area-inset-bottom), 24px);
       }
 


### PR DESCRIPTION
## Proposed change

Alternative fix to https://github.com/home-assistant/frontend/pull/15871
Revert the padding to the previous value.
I totally agree, it's not perfect, the pin should be totally visible. It's an old paper component that we should replace by a new component. The pin should overflow the header but that's not possible with this component.

### Before `2022.2`

![CleanShot 2023-03-23 at 15 21 49](https://user-images.githubusercontent.com/5878303/227233511-ee437f9b-639c-4878-95ff-806deec71468.png)

### After `2022.3`

![CleanShot 2023-03-23 at 15 25 18](https://user-images.githubusercontent.com/5878303/227234327-79a644dd-f8d5-4c75-87e7-8f004e103f55.png)

### Now

![CleanShot 2023-03-23 at 15 16 27](https://user-images.githubusercontent.com/5878303/227231960-5121375e-a7de-493b-a34b-cd08a742cff2.png)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15684 fixes #15828
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
