### PR TITLE
Fix statistics graph days_to_show can't be erased

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistics-graph-card-editor.ts
@@ -172,7 +172,7 @@ export class HuiStatisticsGraphCardEditor
             },
             {
               name: "days_to_show",
-              required: true,
+              default: 30,
               selector: { number: { min: 1, mode: "box" } },
             },
             {
@@ -258,7 +258,6 @@ export class HuiStatisticsGraphCardEditor
     const data = {
       chart_type: "line",
       period: "hour",
-      days_to_show: 30,
       ...this._config,
       stat_types: configured_stat_types,
     };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

"Days to show" field in statistics graph card editor cannot be erased, that makes it difficult to type in a new number. If I want to change the number I would typically backspace to clear the field then try to type a number, but it always fights me. 

![daystoshow](https://user-images.githubusercontent.com/32912880/226610081-a7ddd4c5-4823-40d5-b27a-4c84ed1831ed.gif)


Instead of forcing the value, just let it have an empty value, but show a placeholder instead to show that the default value is 30. It is not a required field in the yaml. 

![image](https://user-images.githubusercontent.com/32912880/226610607-9cc35e10-3f79-4194-b055-8a8ff0a8e74f.png)



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
