### PR TITLE
Fix problems in map card when hours_to_show is 0

### DIFF
--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -202,7 +202,11 @@ class HuiMapCard extends LitElement implements LovelaceCard {
   }
 
   private _subscribeHistory() {
-    if (!isComponentLoaded(this.hass!, "history") || this._subscribed) {
+    if (
+      !isComponentLoaded(this.hass!, "history") ||
+      this._subscribed ||
+      !(this._config?.hours_to_show ?? DEFAULT_HOURS_TO_SHOW)
+    ) {
       return;
     }
     this._subscribed = subscribeHistoryStatesTimeWindow(
@@ -323,7 +327,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       config: MapCardConfig,
       history?: HistoryStates
     ): HaMapPaths[] | undefined => {
-      if (!history) {
+      if (!history || !(config.hours_to_show ?? DEFAULT_HOURS_TO_SHOW)) {
         return undefined;
       }
 

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -33,6 +33,7 @@ import {
   HistoryStates,
   subscribeHistoryStatesTimeWindow,
 } from "../../../data/history";
+import { hasConfigOrEntitiesChanged } from "../common/has-changed";
 import { HomeAssistant } from "../../../types";
 import { findEntities } from "../common/find-entities";
 import { processConfigEntities } from "../common/process-config-entities";
@@ -185,7 +186,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       return true;
     }
 
-    return false;
+    return hasConfigOrEntitiesChanged(this, changedProps);
   }
 
   public connectedCallback() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This change fixes two related issues in map card.

Firstly, when hours_to_show is 0, calls to subscribeHistory may return an error. In this case the call to subscribeHistory is made with a start_time of `now()`, since hours to show is 0. 

As the frontend clock may not be identical to the backend (e.g. it could be one millisecond ahead), this can end up tripping an error check in the backend since it thinks the the start_time is in "the future", since it sees `start_time > now()`. It then returns an error to the subscribe call, and map card becomes permanently unhappy due to this error until it is recreated. The only reason the map card currently works at all with 0 hours_to_show is because it does not trigger rerender after receiving this error from the backend. 

This bug may not manifest in all installations, since the frontend could also be 1ms behind the backend, in which case it would not have an error, but it's kind of random luck.

I fix this by not subscribing history when hours_to_show is 0. 


This image shows the error manifesting when editing the map card, it happens when changing hours_to_show to 0, or when modifying entities list when hours_to_show is 0. The error is "invalid_start_time". 

![image](https://user-images.githubusercontent.com/32912880/226926484-93360dad-6071-4aba-bc2d-a5081bcb79d9.png)

Secondly, related, or perhaps possibly caused by my first change, the map card with 0 hours_to_show no longer rerenders when entities move, because it does not have any stateHistory. I fix this by checking configOrEntitiesChanged in shouldUpdate.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
