### PR TITLE
Allow map card to render passive zones

### DIFF
--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -50,6 +50,10 @@ export class HaMap extends ReactiveElement {
 
   @property({ type: Boolean }) public autoFit = false;
 
+  @property({ type: Boolean }) public renderPassive = false;
+
+  @property({ type: Boolean }) public interactiveZones = false;
+
   @property({ type: Boolean }) public fitZones?: boolean;
 
   @property({ type: Boolean }) public darkMode?: boolean;
@@ -321,6 +325,10 @@ export class HaMap extends ReactiveElement {
 
     const computedStyles = getComputedStyle(this);
     const zoneColor = computedStyles.getPropertyValue("--accent-color");
+    const passiveZoneColor = computedStyles.getPropertyValue(
+      "--secondary-text-color"
+    );
+
     const darkPrimaryColor = computedStyles.getPropertyValue(
       "--dark-primary-color"
     );
@@ -350,7 +358,7 @@ export class HaMap extends ReactiveElement {
 
       if (computeStateDomain(stateObj) === "zone") {
         // DRAW ZONE
-        if (passive) {
+        if (passive && !this.renderPassive) {
           continue;
         }
 
@@ -374,7 +382,7 @@ export class HaMap extends ReactiveElement {
               iconSize: [24, 24],
               className,
             }),
-            interactive: false,
+            interactive: this.interactiveZones,
             title,
           })
         );
@@ -383,7 +391,7 @@ export class HaMap extends ReactiveElement {
         this._mapZones.push(
           Leaflet.circle([latitude, longitude], {
             interactive: false,
-            color: zoneColor,
+            color: passive ? passiveZoneColor : zoneColor,
             radius,
           })
         );

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -16,7 +16,7 @@ import { getColorByIndex } from "../../../common/color/colors";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { formatDateTime } from "../../../common/datetime/format_date_time";
 import {
-  formatTime,
+  formatTimeWithSeconds,
   formatTimeWeekday,
 } from "../../../common/datetime/format_time";
 import { computeDomain } from "../../../common/entity/compute_domain";
@@ -152,6 +152,8 @@ class HuiMapCard extends LitElement implements LovelaceCard {
             .paths=${this._getHistoryPaths(this._config, this._stateHistory)}
             .autoFit=${this._config.auto_fit}
             .darkMode=${this._config.dark_mode}
+            interactiveZones
+            renderPassive
           ></ha-map>
           <ha-icon-button
             .label=${this.hass!.localize(
@@ -329,6 +331,9 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       const paths: HaMapPaths[] = [];
 
       for (const entityId of Object.keys(history)) {
+        if (computeDomain(entityId) === "zone") {
+          continue;
+        }
         const entityStates = history[entityId];
         if (!entityStates?.length) {
           continue;
@@ -349,7 +354,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
             // date and time
             p.tooltip = formatDateTime(t, this.hass.locale);
           } else if (isToday(t)) {
-            p.tooltip = formatTime(t, this.hass.locale);
+            p.tooltip = formatTimeWithSeconds(t, this.hass.locale);
           } else {
             p.tooltip = formatTimeWeekday(t, this.hass.locale);
           }

--- a/src/panels/map/ha-panel-map.ts
+++ b/src/panels/map/ha-panel-map.ts
@@ -38,7 +38,12 @@ class HaPanelMap extends LitElement {
               : ""}
           </app-toolbar>
         </app-header>
-        <ha-map .hass=${this.hass} .entities=${this._entities} autoFit></ha-map>
+        <ha-map
+          .hass=${this.hass}
+          .entities=${this._entities}
+          autoFit
+          interactiveZones
+        ></ha-map>
       </ha-app-layout>
     `;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

I would like to suggest the following changes/improvements to map card rendering:

1) Allow map card to render passive zones when specifically requested. I know they are supposed to be hidden by default in frontend, but by allowing them to be rendered in map card when requested, it can help with automation debugging, when you want to see specifically when certain trackers moved in or out of passive zones. Use the same gray styling as in the location editor. 

2) In the same spirit of automation debugging, add the seconds to the timestamp in the map history trails. I initially thought this was too much information, but I was debugging some automation and this really would have helped, since otherwise I see 10 different points all with the same timestamp in high accuracy mode, and I can't correllate which point corresponded to other specific events that have a timestamp with seconds. 

3) Give zones the interactive property in leaflet in map card and map panel, so they show their name in a tooltip on mouse hover. Leave it non-interactive in the ha-location-editor, since that one already renders the zone name on the map. 

4) Don't draw "history trails" for zones. 

![map](https://user-images.githubusercontent.com/32912880/226947750-d4b9d072-7a08-4e1b-9173-413c9066c44d.gif)

Hope this is not too much miscellany for one PR; it all seemed related-enough to me, but if you want me to take something out just ask. Thanks!

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
