### PR TITLE
Don't wait for slider release to update color temp

### DIFF
--- a/src/dialogs/more-info/components/lights/ha-more-info-view-light-color-picker.ts
+++ b/src/dialogs/more-info/components/lights/ha-more-info-view-light-color-picker.ts
@@ -11,6 +11,7 @@ import {
   PropertyValues,
 } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { throttle } from "../../../../common/util/throttle";
 import "../../../../components/ha-button-toggle-group";
 import "../../../../components/ha-color-picker";
 import "../../../../components/ha-control-slider";
@@ -297,17 +298,26 @@ class MoreInfoViewLightColorPicker extends LitElement {
   private _ctSliderMoved(ev: CustomEvent) {
     const ct = ev.detail.value;
 
-    if (isNaN(ct)) {
+    if (isNaN(ct) || this._ctSliderValue === ct) {
       return;
     }
 
     this._ctSliderValue = ct;
+
+    this._throttleUpdateColorTemp();
   }
+
+  private _throttleUpdateColorTemp = throttle(() => {
+    this.hass.callService("light", "turn_on", {
+      entity_id: this.stateObj!.entity_id,
+      color_temp_kelvin: this._ctSliderValue,
+    });
+  }, 500);
 
   private _ctSliderChanged(ev: CustomEvent) {
     const ct = ev.detail.value;
 
-    if (isNaN(ct)) {
+    if (isNaN(ct) || this._ctSliderValue === ct) {
       return;
     }
 


### PR DESCRIPTION
## Proposed change

Live update the color temperature (like we have for rgb color) with a throttle of 500ms. It also fix #15889 as color temp is update when dragging the slider.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15889
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
