### PR TITLE
Introduce custom binary sensor option

### DIFF
--- a/src/common/entity/binary_sensor_icon.ts
+++ b/src/common/entity/binary_sensor_icon.ts
@@ -61,6 +61,8 @@ export const binarySensorIcon = (state?: string, stateObj?: HassEntity) => {
       return is_off ? mdiThermometer : mdiSnowflake;
     case "connectivity":
       return is_off ? mdiCloseNetworkOutline : mdiCheckNetworkOutline;
+    case "custom":
+      return is_off ? stateObj?.attributes.icon_off : stateObj?.attributes.icon_on;
     case "door":
       return is_off ? mdiDoorClosed : mdiDoorOpen;
     case "garage_door":


### PR DESCRIPTION
## Proposed change

This change introduces the custom device_class for binary_sensors.

What does it address ?

The need for a custom binary_sensor was raised in [THIS](https://community.home-assistant.io/t/custom-device-classes/368238/33) forum discussion.

The main concept is the following:
```
device_class:
  - binary_sensor:
      - gate:
          state_off: 'Closed'
          state_on: 'Open'
          icon_off: 'mdi:gate'
          icon_on: 'mdi:gate-open'
          device_class: custom
      - mailbox:
          state_off: 'Empty'
          state_on: 'Full'
          icon_off: 'mdi:mailbox'
          icon_on: 'mdi:mailbox-up'
          device_class: custom
```

Basically to be able to define custom device classes for binary_sensors, by defining custom on and off state names and also custom on and off icons.

This change only impacts the frontend, and it wont break anything but prepares for the change in backend, so if the backend supports the custom device_class then the frontend already supports it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

No custom configuration on the frontend side.

## Additional information

- This PR is related to issue or discussion: [Forum Discussion](https://community.home-assistant.io/t/custom-device-classes/368238/14)

## Checklist

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
