### PR TITLE
Fix cover more info state display

### DIFF
--- a/src/data/cover.ts
+++ b/src/data/cover.ts
@@ -3,7 +3,9 @@ import {
   HassEntityBase,
 } from "home-assistant-js-websocket";
 import { supportsFeature } from "../common/entity/supports-feature";
+import { blankBeforePercent } from "../common/translations/blank_before_percent";
 import { UNAVAILABLE } from "./entity";
+import { FrontendLocaleData } from "./translation";
 
 export const enum CoverEntityFeature {
   OPEN = 1,
@@ -105,4 +107,19 @@ interface CoverEntityAttributes extends HassEntityAttributeBase {
 
 export interface CoverEntity extends HassEntityBase {
   attributes: CoverEntityAttributes;
+}
+
+export function computeCoverPositionStateDisplay(
+  stateObj: CoverEntity,
+  locale: FrontendLocaleData,
+  position?: number
+) {
+  const currentPosition =
+    position ??
+    stateObj.attributes.current_position ??
+    stateObj.attributes.current_tilt_position;
+
+  return currentPosition && currentPosition !== 100
+    ? `${Math.round(currentPosition)}${blankBeforePercent(locale)}%`
+    : "";
 }

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -36,8 +36,11 @@ import "../../../components/tile/ha-tile-icon";
 import "../../../components/tile/ha-tile-image";
 import "../../../components/tile/ha-tile-info";
 import { cameraUrlWithWidthHeight } from "../../../data/camera";
-import { CoverEntity } from "../../../data/cover";
-import { isUnavailableState, ON } from "../../../data/entity";
+import {
+  computeCoverPositionStateDisplay,
+  CoverEntity,
+} from "../../../data/cover";
+import { isUnavailableState } from "../../../data/entity";
 import { FanEntity } from "../../../data/fan";
 import { LightEntity } from "../../../data/light";
 import { ActionHandlerEvent } from "../../../data/lovelace";
@@ -202,7 +205,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       `;
     }
 
-    if (domain === "light" && stateObj.state === ON) {
+    if (domain === "light" && stateActive(stateObj)) {
       const brightness = (stateObj as LightEntity).attributes.brightness;
       if (brightness) {
         return `${Math.round((brightness * 100) / 255)}${blankBeforePercent(
@@ -211,7 +214,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       }
     }
 
-    if (domain === "fan" && stateObj.state === ON) {
+    if (domain === "fan" && stateActive(stateObj)) {
       const speed = (stateObj as FanEntity).attributes.percentage;
       if (speed) {
         return `${Math.round(speed)}${blankBeforePercent(this.hass!.locale)}%`;
@@ -225,15 +228,14 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       this.hass!.entities
     );
 
-    if (
-      domain === "cover" &&
-      ["open", "opening", "closing"].includes(stateObj.state)
-    ) {
-      const position = (stateObj as CoverEntity).attributes.current_position;
-      if (position && position !== 100) {
-        return `${stateDisplay} - ${Math.round(position)}${blankBeforePercent(
-          this.hass!.locale
-        )}%`;
+    if (domain === "cover" && stateActive(stateObj)) {
+      const positionStateDisplay = computeCoverPositionStateDisplay(
+        stateObj as CoverEntity,
+        this.hass!.locale
+      );
+
+      if (positionStateDisplay) {
+        return `${stateDisplay} ⸱ ${positionStateDisplay}`;
       }
     }
     return stateDisplay;


### PR DESCRIPTION
## Proposed change

State display was wrong with opening and closing state.
It also now display the tilt position if only tilt is supported.
## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
