### PR TITLE
Cover position tile feature

### DIFF
--- a/src/components/ha-control-slider.ts
+++ b/src/components/ha-control-slider.ts
@@ -43,6 +43,9 @@ export class HaControlSlider extends LitElement {
   @property({ type: Boolean, attribute: "show-handle" })
   public showHandle = false;
 
+  @property({ type: Boolean, attribute: "inverted" })
+  public inverted = false;
+
   @property({ type: Number })
   public value?: number;
 
@@ -61,11 +64,16 @@ export class HaControlSlider extends LitElement {
   public pressed = false;
 
   valueToPercentage(value: number) {
-    return (this.boundedValue(value) - this.min) / (this.max - this.min);
+    const percentage =
+      (this.boundedValue(value) - this.min) / (this.max - this.min);
+    return this.inverted ? 1 - percentage : percentage;
   }
 
-  percentageToValue(value: number) {
-    return (this.max - this.min) * value + this.min;
+  percentageToValue(percentage: number) {
+    return (
+      (this.max - this.min) * (this.inverted ? 1 - percentage : percentage) +
+      this.min
+    );
   }
 
   steppedValue(value: number) {

--- a/src/dialogs/more-info/components/cover/ha-more-info-cover-position.ts
+++ b/src/dialogs/more-info/components/cover/ha-more-info-cover-position.ts
@@ -50,7 +50,7 @@ export class HaMoreInfoCoverPosition extends LitElement {
           this.hass.localize,
           this.stateObj,
           this.hass.entities,
-          "position"
+          "current_position"
         )}
         style=${styleMap({
           "--control-slider-color": color,

--- a/src/panels/lovelace/create-element/create-tile-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-tile-feature-element.ts
@@ -1,5 +1,6 @@
 import "../tile-features/hui-alarm-modes-tile-feature";
 import "../tile-features/hui-cover-open-close-tile-feature";
+import "../tile-features/hui-cover-position-tile-feature";
 import "../tile-features/hui-cover-tilt-tile-feature";
 import "../tile-features/hui-fan-speed-tile-feature";
 import "../tile-features/hui-light-brightness-tile-feature";
@@ -12,6 +13,7 @@ import {
 
 const TYPES: Set<LovelaceTileFeatureConfig["type"]> = new Set([
   "cover-open-close",
+  "cover-position",
   "cover-tilt",
   "light-brightness",
   "vacuum-commands",

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
@@ -27,6 +27,7 @@ import { HomeAssistant } from "../../../../types";
 import { getTileFeatureElementClass } from "../../create-element/create-tile-feature-element";
 import { supportsAlarmModesTileFeature } from "../../tile-features/hui-alarm-modes-tile-feature";
 import { supportsCoverOpenCloseTileFeature } from "../../tile-features/hui-cover-open-close-tile-feature";
+import { supportsCoverPositionTileFeature } from "../../tile-features/hui-cover-position-tile-feature";
 import { supportsCoverTiltTileFeature } from "../../tile-features/hui-cover-tilt-tile-feature";
 import { supportsFanSpeedTileFeature } from "../../tile-features/hui-fan-speed-tile-feature";
 import { supportsLightBrightnessTileFeature } from "../../tile-features/hui-light-brightness-tile-feature";
@@ -38,6 +39,7 @@ type SupportsFeature = (stateObj: HassEntity) => boolean;
 
 const FEATURE_TYPES: FeatureType[] = [
   "cover-open-close",
+  "cover-position",
   "cover-tilt",
   "light-brightness",
   "vacuum-commands",
@@ -53,6 +55,7 @@ const EDITABLES_FEATURE_TYPES = new Set<FeatureType>([
 const SUPPORTS_FEATURE_TYPES: Record<FeatureType, SupportsFeature | undefined> =
   {
     "cover-open-close": supportsCoverOpenCloseTileFeature,
+    "cover-position": supportsCoverPositionTileFeature,
     "cover-tilt": supportsCoverTiltTileFeature,
     "light-brightness": supportsLightBrightnessTileFeature,
     "vacuum-commands": supportsVacuumCommandTileFeature,

--- a/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
@@ -64,7 +64,9 @@ class HuiCoverPositionTileFeature
         .value=${value}
         min="0"
         max="100"
-        .step="1"
+        step="1"
+        inverted
+        show-handle
         @value-changed=${this._valueChanged}
         .ariaLabel=${computeAttributeNameDisplay(
           this.hass.localize,
@@ -90,6 +92,7 @@ class HuiCoverPositionTileFeature
   static get styles() {
     return css`
       ha-control-slider {
+        /* Force inactive state to be colored for the slider */
         --control-slider-color: var(--tile-color);
         --control-slider-background: var(--tile-color);
         --control-slider-background-opacity: 0.2;

--- a/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
@@ -64,13 +64,13 @@ class HuiCoverPositionTileFeature
         .value=${value}
         min="0"
         max="100"
-        .step=${this.stateObj.attributes.percentage_step ?? 1}
+        .step="1"
         @value-changed=${this._valueChanged}
         .ariaLabel=${computeAttributeNameDisplay(
           this.hass.localize,
           this.stateObj,
           this.hass.entities,
-          "percentage"
+          "current_position"
         )}
         .disabled=${this.stateObj!.state === UNAVAILABLE}
       ></ha-control-slider>
@@ -89,9 +89,16 @@ class HuiCoverPositionTileFeature
 
   static get styles() {
     return css`
-      ha-control-button-group {
-        margin: 0 12px 12px 12px;
-        --control-button-group-spacing: 12px;
+      ha-control-slider {
+        --control-slider-color: var(--tile-color);
+        --control-slider-background: var(--tile-color);
+        --control-slider-background-opacity: 0.2;
+        --control-slider-thickness: 40px;
+        --control-slider-border-radius: 10px;
+      }
+      .container {
+        padding: 0 12px 12px 12px;
+        width: auto;
       }
     `;
   }

--- a/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
@@ -1,0 +1,104 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import { supportsFeature } from "../../../common/entity/supports-feature";
+import { CoverEntityFeature } from "../../../data/cover";
+import { HomeAssistant } from "../../../types";
+import { LovelaceTileFeature } from "../types";
+import { CoverPositionTileFeatureConfig } from "./types";
+import { stateActive } from "../../../common/entity/state_active";
+import { computeAttributeNameDisplay } from "../../../common/entity/compute_attribute_display";
+import { UNAVAILABLE } from "../../../data/entity";
+
+export const supportsCoverPositionTileFeature = (stateObj: HassEntity) => {
+  const domain = computeDomain(stateObj.entity_id);
+  return (
+    domain === "cover" &&
+    supportsFeature(stateObj, CoverEntityFeature.SET_POSITION)
+  );
+};
+
+@customElement("hui-cover-position-tile-feature")
+class HuiCoverPositionTileFeature
+  extends LitElement
+  implements LovelaceTileFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state() private _config?: CoverPositionTileFeatureConfig;
+
+  static getStubConfig(): CoverPositionTileFeatureConfig {
+    return {
+      type: "cover-position",
+    };
+  }
+
+  public setConfig(config: CoverPositionTileFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render() {
+    if (
+      !this._config ||
+      !this.hass ||
+      !this.stateObj ||
+      !supportsCoverPositionTileFeature(this.stateObj)
+    ) {
+      return nothing;
+    }
+
+    const percentage = stateActive(this.stateObj)
+      ? this.stateObj.attributes.current_position ?? 0
+      : 0;
+
+    const value = Math.max(Math.round(percentage), 0);
+
+    return html` <div class="container">
+      <ha-control-slider
+        .value=${value}
+        min="0"
+        max="100"
+        .step=${this.stateObj.attributes.percentage_step ?? 1}
+        @value-changed=${this._valueChanged}
+        .ariaLabel=${computeAttributeNameDisplay(
+          this.hass.localize,
+          this.stateObj,
+          this.hass.entities,
+          "percentage"
+        )}
+        .disabled=${this.stateObj!.state === UNAVAILABLE}
+      ></ha-control-slider>
+    </div>`;
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    const value = (ev.detail as any).value;
+    if (isNaN(value)) return;
+
+    this.hass!.callService("cover", "set_cover_position", {
+      entity_id: this.stateObj!.entity_id,
+      position: value,
+    });
+  }
+
+  static get styles() {
+    return css`
+      ha-control-button-group {
+        margin: 0 12px 12px 12px;
+        --control-button-group-spacing: 12px;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-cover-position-tile-feature": HuiCoverPositionTileFeature;
+  }
+}

--- a/src/panels/lovelace/tile-features/types.ts
+++ b/src/panels/lovelace/tile-features/types.ts
@@ -33,7 +33,7 @@ export const VACUUM_COMMANDS = [
   "return_home",
 ] as const;
 
-export type VacuumCommand = typeof (VACUUM_COMMANDS)[number];
+export type VacuumCommand = (typeof VACUUM_COMMANDS)[number];
 
 export interface VacuumCommandsTileFeatureConfig {
   type: "vacuum-commands";

--- a/src/panels/lovelace/tile-features/types.ts
+++ b/src/panels/lovelace/tile-features/types.ts
@@ -33,7 +33,7 @@ export const VACUUM_COMMANDS = [
   "return_home",
 ] as const;
 
-export type VacuumCommand = typeof VACUUM_COMMANDS[number];
+export type VacuumCommand = typeof (VACUUM_COMMANDS)[number];
 
 export interface VacuumCommandsTileFeatureConfig {
   type: "vacuum-commands";

--- a/src/panels/lovelace/tile-features/types.ts
+++ b/src/panels/lovelace/tile-features/types.ts
@@ -4,6 +4,10 @@ export interface CoverOpenCloseTileFeatureConfig {
   type: "cover-open-close";
 }
 
+export interface CoverPositionTileFeatureConfig {
+  type: "cover-position";
+}
+
 export interface CoverTiltTileFeatureConfig {
   type: "cover-tilt";
 }
@@ -29,7 +33,7 @@ export const VACUUM_COMMANDS = [
   "return_home",
 ] as const;
 
-export type VacuumCommand = (typeof VACUUM_COMMANDS)[number];
+export type VacuumCommand = typeof VACUUM_COMMANDS[number];
 
 export interface VacuumCommandsTileFeatureConfig {
   type: "vacuum-commands";
@@ -38,6 +42,7 @@ export interface VacuumCommandsTileFeatureConfig {
 
 export type LovelaceTileFeatureConfig =
   | CoverOpenCloseTileFeatureConfig
+  | CoverPositionTileFeatureConfig
   | CoverTiltTileFeatureConfig
   | LightBrightnessTileFeatureConfig
   | VacuumCommandsTileFeatureConfig

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4457,6 +4457,9 @@
                   "cover-open-close": {
                     "label": "Cover open/close"
                   },
+                  "cover-position": {
+                    "label": "Cover position"
+                  },
                   "cover-tilt": {
                     "label": "Cover tilt"
                   },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add cover position tile feature.

![image](https://user-images.githubusercontent.com/1741838/230674150-eff27f43-9159-4750-b844-e8c904084975.png)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
