### PR TITLE
Fix cropped person image transparency

### DIFF
--- a/src/panels/config/person/dialog-person-detail.ts
+++ b/src/panels/config/person/dialog-person-detail.ts
@@ -33,7 +33,6 @@ const includeDomains = ["device_tracker"];
 
 const cropOptions: CropOptions = {
   round: true,
-  type: "image/jpeg",
   quality: 0.75,
   aspectRatio: 1,
 };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This change aims to fix alpha channel preservation for images uploaded and cropped via the person dialog UI component. Currently, any image uploaded will be saved as a JPEG once cropped, and I believe this is _not_ the intended behavior.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
`CropOptions.type` is being explicitly set in [src/panels/config/person/dialog-person-detail.ts](https://github.com/home-assistant/frontend/blob/dev/src/panels/config/person/dialog-person-detail.ts#L36), which forces `_cropImage` to set type to `image/jpeg` in the callback and args passed to `toBlob()` in [src/dialogs/image-cropper-dialog/image-cropper-dialog.ts](https://github.com/home-assistant/frontend/blob/dev/src/dialogs/image-cropper-dialog/image-cropper-dialog.ts#L88-L103).

From my very cursory understanding, explicitly setting `CropOptions.type` is unnecessary since `_cropImage` will fallback to the MIME type of the file if left unset.

I'm unsure when this problem started, but I can't seem to find any recent changes that would have started triggering it. I've tested in `20230406.1`, and removing the explicit setting of type restores the correct behavior.

### Prior to change
<img width="210" alt="image" src="https://user-images.githubusercontent.com/169469/229977900-743acf12-4417-4066-a2ec-1faf4ee1fe87.png">

### After change
<img width="202" alt="image" src="https://user-images.githubusercontent.com/169469/230703335-58391aa6-caf3-4109-9525-b15ac395734b.png">

I've also confirmed that this doesn't affect functionality with JPEG or GIF images.

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14689
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
