### PR TITLE
Fix ha-combo-box open direction

### DIFF
--- a/src/components/ha-combo-box.ts
+++ b/src/components/ha-combo-box.ts
@@ -243,6 +243,7 @@ export class HaComboBox extends LitElement {
       );
 
       if (overlay) {
+        overlay.setAttribute("required-vertical-space", "0");
         this._removeInert(overlay);
       }
       this._observeBody();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`ha-combo-box` currently frequently opens in a wrong direction (opens down when there is not enough space, it should open up instead.

I tracked the reason for this into the vaadin combo-box, it seems to set a default requiredVerticalSpace of 200 for the combobox overlay. This value overrides the actual calculated size of the overlay, so it treats our overlay as always 200 pixels high for purposes of calculating open direction, even when it is larger. If I just disable this behavior by setting the requiredVerticalSpace to 0, the ha-combo-box works properly and opens upwards when there is not enough space to open downward.

See: https://github.com/vaadin/web-components/blob/main/packages/combo-box/src/vaadin-combo-box-overlay.js#L59

See: https://github.com/vaadin/web-components/blob/main/packages/overlay/src/vaadin-overlay-position-mixin.js#L278

This feels like kind of an ugly hack, overriding attribute so on vaadin internals, though I'm not seeing any better way to set this attribute. I'm not sure if this should be a vaadin bug, but I'm not that familiar with it, and I see we're doing some hacky looking stuff to the overlay, so maybe that's also a contributing factor. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16113, fixes #15840
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
