### PR TITLE
Add browserslist config and use for Babel preset environment

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,21 @@
+[modern]
+# Support for dynamic import is the main litmus test for serving modern builds.
+# Although officially a ES2020 feature, browsers implemented it early, so this
+# enables all of ES2017 and some features in ES2018.
+supports es6-module-dynamic-import
+
+# Exclude Safari 11-12 because of a bug in tagged template literals
+# https://bugs.webkit.org/show_bug.cgi?id=190756
+# Note: Dropping version 11 also enables several more ES2018 features
+not Safari < 13
+not iOS < 13
+
+# Exclude unsupported browsers
+not dead
+
+[legacy]
+# Legacy builds are transpiled to ES5 (strict mode) but also must support some features that cannot be polyfilled:
+# - web sockets to communicate with backend
+# - inline SVG used widely in buttons, widgets, etc.
+# - custom events used for most user interactions
+supports use-strict and supports websockets and supports svg-html5 and supports customevent

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -89,18 +89,18 @@ module.exports.babelOptions = ({ latestBuild, isProdBuild, isTestBuild }) => ({
     setPublicClassFields: true,
     setSpreadProperties: true,
   },
-
+  browserslistEnv: latestBuild ? "modern" : "legacy",
   presets: [
-    !latestBuild && [
+    [
       "@babel/preset-env",
       {
-        useBuiltIns: "entry",
-        corejs: { version: "3.30", proposals: true },
+        useBuiltIns: latestBuild ? false : "entry",
+        corejs: latestBuild ? false : { version: "3.30", proposals: true },
         bugfixes: true,
       },
     ],
     "@babel/preset-typescript",
-  ].filter(Boolean),
+  ],
   plugins: [
     [
       path.resolve(
@@ -112,22 +112,8 @@ module.exports.babelOptions = ({ latestBuild, isProdBuild, isTestBuild }) => ({
         ignoreModuleNotFound: true,
       },
     ],
-    // Part of ES2018. Converts {...a, b: 2} to Object.assign({}, a, {b: 2})
-    !latestBuild && [
-      "@babel/plugin-proposal-object-rest-spread",
-      { useBuiltIns: true },
-    ],
-    // Only support the syntax, Webpack will handle it.
-    "@babel/plugin-syntax-import-meta",
-    "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-syntax-top-level-await",
-    // Support  various proposals
-    "@babel/plugin-proposal-optional-chaining",
-    "@babel/plugin-proposal-nullish-coalescing-operator",
+    // Support  some proposals still in TC39 process
     ["@babel/plugin-proposal-decorators", { decoratorsBeforeExport: true }],
-    "@babel/plugin-proposal-private-methods",
-    "@babel/plugin-proposal-private-property-in-object",
-    "@babel/plugin-proposal-class-properties",
     // Minify template literals for production
     isProdBuild && [
       "template-html-minifier",

--- a/build-scripts/list-preset-env-plugins.js
+++ b/build-scripts/list-preset-env-plugins.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Script to print Babel plugins that will be used by browserslist environments
+
+import { version as babelVersion } from "@babel/core";
+import presetEnv from "@babel/preset-env";
+import { babelOptions } from "./bundle.cjs";
+
+const dummyAPI = {
+  version: babelVersion,
+  assertVersion: () => {},
+  caller: (callback) =>
+    callback({
+      name: "Dummy Bundler",
+      supportsStaticESM: true,
+      supportsDynamicImport: true,
+      supportsTopLevelAwait: true,
+      supportsExportNamespaceFrom: true,
+    }),
+  targets: () => ({}),
+};
+
+for (const browserslistEnv of ["modern", "legacy"]) {
+  console.log("\nBrowsersList Environment = %s\n", browserslistEnv);
+  presetEnv.default(dummyAPI, {
+    ...babelOptions({ latestBuild: browserslistEnv === "modern" })
+      .presets[0][1],
+    browserslistEnv,
+    debug: true,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -150,9 +150,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.21.4",
-    "@babel/plugin-external-helpers": "7.18.6",
     "@babel/plugin-proposal-decorators": "7.21.0",
-    "@babel/plugin-syntax-import-meta": "7.10.4",
     "@babel/preset-env": "7.21.4",
     "@babel/preset-typescript": "7.21.4",
     "@koa/cors": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -397,17 +397,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-external-helpers@npm:7.18.6":
-  version: 7.18.6
-  resolution: "@babel/plugin-external-helpers@npm:7.18.6"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.18.6
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: aaf681b6339d7ab3c82c157f3e9c7e9404a5e2120dca35b1ceff5a8bb1a9a3d5646af9a53ed4440ba376e2a25db5bfae2b65d0f458ada9ae8ed11450a5329c6a
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-proposal-async-generator-functions@npm:^7.20.7":
   version: 7.20.7
   resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.20.7"
@@ -686,17 +675,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 6a86220e0aae40164cd3ffaf80e7c076a1be02a8f3480455dddbae05fda8140f429290027604df7a11b3f3f124866e8a6d69dbfa1dda61ee7377b920ad144d5b
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-import-meta@npm:7.10.4":
-  version: 7.10.4
-  resolution: "@babel/plugin-syntax-import-meta@npm:7.10.4"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.4
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 166ac1125d10b9c0c430e4156249a13858c0366d38844883d75d27389621ebe651115cb2ceb6dc011534d5055719fa1727b59f39e1ab3ca97820eef3dcab5b9b
   languageName: node
   linkType: hard
 
@@ -9444,9 +9422,7 @@ __metadata:
   resolution: "home-assistant-frontend@workspace:."
   dependencies:
     "@babel/core": 7.21.4
-    "@babel/plugin-external-helpers": 7.18.6
     "@babel/plugin-proposal-decorators": 7.21.0
-    "@babel/plugin-syntax-import-meta": 7.10.4
     "@babel/preset-env": 7.21.4
     "@babel/preset-typescript": 7.21.4
     "@braintree/sanitize-url": 6.0.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Adds a [`browserslist`](https://browsersl.ist/#) configuration that is consumed by Babel's `preset-env` plugin.  The result is a simpler configuration without plugin micro-management, and an easier and more sustainable way to separate modern and legacy builds.  After a lot of playing with `browserslist` queries, what I ended up pushing here is pretty simple:
- **Modern:** Does nothing more than mimic the actual test for serving it - must support dynamic import and not be Safari 11/12
- **Legacy:** Must support ES5 strict mode as a base and then a few features the frontend cannot live without from the [`caniuse-light` data](https://github.com/browserslist/caniuse-lite/tree/main/data/features) (each just shaves off a few of the oldest browsers from the base)

There's a lot that can be done with these queries, but I tried to keep things as status quo as possible for this pull request.  Setting this up also opens the door to using other tools that operate on `browserslist` queries.  It also becomes an easy task to display a "browser not supported" or "you're using a legacy build" message if that's desirable.

I also added a script which outputs the list of Babel plugins that will be applied for each build (without actually having to run the build with a ridiculous amount of debug output).  Output is pasted below.  At a high level, the effect compared to current builds is:
- **Latest:** Adds the plugins that were missing from ES 2022 back to about ES 2017-2018.  The effect is a fairly tiny increase in bundle size (~10K of unminified code).
- **ES5:** Babel plugin list actually doesn't change, but builds drop a bunch of unnecessary polyfills from `core-js` (~100K of unminified code).

<details><summary>Modern browser targets & Babel plugins</summary>
BrowsersList Environment = modern

@babel/preset-env: `DEBUG` option

Using targets:
{
  "android": "112",
  "chrome": "63",
  "edge": "79",
  "firefox": "67",
  "ios": "13",
  "opera": "50",
  "safari": "13",
  "samsung": "8.2"
}

Using modules transform: auto

Using plugins:
  proposal-class-static-block { chrome < 94, edge < 94, firefox < 93, ios, opera < 80, safari, samsung < 17 }
  proposal-private-property-in-object { chrome < 91, edge < 91, firefox < 90, ios < 15, opera < 77, safari < 15, samsung < 16 }
  proposal-class-properties { chrome < 74, firefox < 90, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
  proposal-private-methods { chrome < 84, edge < 84, firefox < 90, ios < 15, opera < 70, safari < 15, samsung < 14 }
  proposal-numeric-separator { chrome < 75, firefox < 70, opera < 62, samsung < 11 }
  proposal-logical-assignment-operators { chrome < 85, edge < 85, firefox < 79, ios < 14, opera < 71, safari < 14, samsung < 14 }
  proposal-nullish-coalescing-operator { chrome < 80, edge < 80, firefox < 72, ios < 13.4, opera < 67, safari < 13.1, samsung < 13 }
  proposal-optional-chaining { chrome < 80, edge < 80, firefox < 74, ios < 13.4, opera < 67, safari < 13.1, samsung < 13 }
  proposal-json-strings { chrome < 66, opera < 53, samsung < 9 }
  proposal-optional-catch-binding { chrome < 66, opera < 53, samsung < 9 }
  syntax-async-generators
  syntax-object-rest-spread
  transform-dotall-regex { firefox < 78 }
  proposal-unicode-property-regex { chrome < 64, firefox < 78, opera < 51, samsung < 9 }
  transform-named-capturing-groups-regex { chrome < 64, firefox < 78, opera < 51, samsung < 9 }
  proposal-export-namespace-from { chrome < 72, firefox < 80, ios, opera < 60, safari, samsung < 11.0 }
  bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios, safari }
  syntax-dynamic-import
  syntax-export-namespace-from
  syntax-top-level-await

Using polyfills: No polyfills were added, since the `useBuiltIns` option was not set.
</details>

<details><summary>Legacy browser targets & Babel plugins</summary>
BrowsersList Environment = legacy

@babel/preset-env: `DEBUG` option

Using targets:
{
  "android": "4.4",
  "chrome": "15",
  "edge": "12",
  "firefox": "6",
  "ie": "10",
  "ios": "5",
  "opera": "11.6",
  "safari": "5.1",
  "samsung": "4"
}

Using modules transform: auto

Using plugins:
  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ie, ios, opera < 80, safari, samsung < 17 }
  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ie, ios < 15, opera < 77, safari < 15, samsung < 16 }
  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ie, ios < 15, opera < 62, safari < 14.1, samsung < 11 }
  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ie, ios < 15, opera < 70, safari < 15, samsung < 14 }
  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ie, ios < 13, opera < 62, safari < 13, samsung < 11 }
  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ie, ios < 14, opera < 71, safari < 14, samsung < 14 }
  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, opera < 67, safari < 13.1, samsung < 13 }
  proposal-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ie, ios < 13.4, opera < 67, safari < 13.1, samsung < 13 }
  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ie, ios < 12, opera < 53, safari < 12, samsung < 9 }
  proposal-optional-catch-binding { android, chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
  transform-parameters { android, chrome < 49, edge < 15, firefox < 53, ie, ios < 10, opera < 36, safari < 10, samsung < 5 }
  proposal-async-generator-functions { android, chrome < 63, edge < 79, firefox < 57, ie, ios < 12, opera < 50, safari < 12, samsung < 8 }
  proposal-object-rest-spread { android, chrome < 60, edge < 79, firefox < 55, ie, ios < 11.3, opera < 47, safari < 11.1, samsung < 8 }
  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, opera < 49, safari < 11.1, samsung < 8 }
  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
  transform-async-to-generator { android, chrome < 55, edge < 15, firefox < 52, ie, ios < 10.3, opera < 42, safari < 10.1, samsung < 6 }
  transform-exponentiation-operator { android, chrome < 52, edge < 14, firefox < 52, ie, ios < 10.3, opera < 39, safari < 10.1, samsung < 6 }
  transform-template-literals { android, chrome < 41, edge < 13, firefox < 34, ie, ios < 9, opera < 28, safari < 9 }
  transform-literals { android, chrome < 44, firefox < 53, ie, ios < 9, opera < 31, safari < 9 }
  transform-function-name { android, chrome < 51, edge < 14, firefox < 53, ie, ios < 10, opera < 38, safari < 10, samsung < 5 }
  transform-arrow-functions { android, chrome < 47, edge < 13, firefox < 43, ie, ios < 10, opera < 34, safari < 10, samsung < 5 }
  transform-block-scoped-functions { android, chrome < 41, firefox < 46, ie < 11, ios < 10, opera < 28, safari < 10 }
  transform-classes { android, chrome < 46, edge < 13, firefox < 45, ie, ios < 10, opera < 33, safari < 10, samsung < 5 }
  transform-object-super { android, chrome < 46, edge < 13, firefox < 45, ie, ios < 10, opera < 33, safari < 10, samsung < 5 }
  transform-shorthand-properties { android, chrome < 43, firefox < 33, ie, ios < 9, opera < 30, safari < 9 }
  transform-duplicate-keys { android, chrome < 42, firefox < 34, ie, ios < 9, opera < 29, safari < 9 }
  transform-computed-properties { android, chrome < 44, firefox < 34, ie, ios < 8, opera < 31, safari < 7.1 }
  transform-for-of { android, chrome < 51, edge < 15, firefox < 53, ie, ios < 10, opera < 38, safari < 10, samsung < 5 }
  transform-sticky-regex { android, chrome < 49, edge < 13, ie, ios < 10, opera < 36, safari < 10, samsung < 5 }
  transform-unicode-escapes { android, chrome < 44, firefox < 53, ie, ios < 9, opera < 31, safari < 9 }
  transform-unicode-regex { android, chrome < 50, edge < 13, firefox < 46, ie, ios < 12, opera < 37, safari < 12, samsung < 5 }
  transform-spread { android, chrome < 46, edge < 13, firefox < 45, ie, ios < 10, opera < 33, safari < 10, samsung < 5 }
  transform-destructuring { android, chrome < 51, edge < 15, firefox < 53, ie, ios < 10, opera < 38, safari < 10, samsung < 5 }
  transform-block-scoping { android, chrome < 49, edge < 14, firefox < 51, ie, ios < 10, opera < 36, safari < 10, samsung < 5 }
  transform-typeof-symbol { android, chrome < 38, firefox < 36, ie, ios < 9, opera < 25, safari < 9 }
  transform-new-target { android, chrome < 46, edge < 14, firefox < 41, ie, ios < 10, opera < 33, safari < 10, samsung < 5 }
  transform-regenerator { android, chrome < 50, edge < 13, firefox < 53, ie, ios < 10, opera < 37, safari < 10, samsung < 5 }
  transform-member-expression-literals { ios < 6, opera < 12 }
  transform-property-literals { ios < 6, opera < 12 }
  transform-reserved-words { ios < 6 }
  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ie, ios, opera < 60, safari, samsung < 11.0 }
  syntax-dynamic-import
  syntax-export-namespace-from
  syntax-top-level-await
</details>

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
