### PR TITLE
Integrations view optimization for multiple devices per integration

### DIFF
--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -112,7 +112,10 @@ const groupByIntegration = (
       result.set(entry.domain, [entry]);
     }
   });
-  return result;
+
+  return new Map(
+    [...result.entries()].sort((a, b) => b[1].length - a[1].length)
+  );
 };
 
 @customElement("ha-config-integrations")
@@ -496,6 +499,11 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
             ? Array.from(disabledConfigEntries.entries()).map(
                 ([domain, items]) =>
                   html`<ha-integration-card
+                    class=${items.length > 10
+                      ? "x3"
+                      : items.length > 5
+                      ? "x2"
+                      : null}
                     data-domain=${domain}
                     entryDisabled
                     .hass=${this.hass}
@@ -510,6 +518,11 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
             ? Array.from(groupedConfigEntries.entries()).map(
                 ([domain, items]) =>
                   html`<ha-integration-card
+                    class=${items.length > 10
+                      ? "x3"
+                      : items.length > 5
+                      ? "x2"
+                      : ""}
                     data-domain=${domain}
                     .hass=${this.hass}
                     .domain=${domain}
@@ -821,9 +834,16 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         .container {
           display: grid;
           grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+          grid-auto-rows: minmax(162px, auto);
           grid-gap: 16px 16px;
           padding: 8px 16px 16px;
           margin-bottom: 64px;
+        }
+        ha-integration-card.x2 {
+          grid-row: span 2;
+        }
+        ha-integration-card.x3 {
+          grid-row: span 3;
         }
         .container > * {
           max-width: 500px;

--- a/src/panels/config/integrations/ha-config-integrations.ts
+++ b/src/panels/config/integrations/ha-config-integrations.ts
@@ -499,9 +499,11 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
             ? Array.from(disabledConfigEntries.entries()).map(
                 ([domain, items]) =>
                   html`<ha-integration-card
-                    class=${items.length > 10
+                    class=${items.length > 11
+                      ? "x4"
+                      : items.length > 7
                       ? "x3"
-                      : items.length > 5
+                      : items.length > 3
                       ? "x2"
                       : null}
                     data-domain=${domain}
@@ -518,11 +520,13 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
             ? Array.from(groupedConfigEntries.entries()).map(
                 ([domain, items]) =>
                   html`<ha-integration-card
-                    class=${items.length > 10
+                    class=${items.length > 11
+                      ? "x4"
+                      : items.length > 7
                       ? "x3"
-                      : items.length > 5
+                      : items.length > 3
                       ? "x2"
-                      : ""}
+                      : null}
                     data-domain=${domain}
                     .hass=${this.hass}
                     .domain=${domain}
@@ -844,6 +848,9 @@ class HaConfigIntegrations extends SubscribeMixin(LitElement) {
         }
         ha-integration-card.x3 {
           grid-row: span 3;
+        }
+        ha-integration-card.x4 {
+          grid-row: span 4;
         }
         .container > * {
           max-width: 500px;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The order of cards on the integration page will change based on the number of config entries.
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When having multiple devices per integration (for example Shelly) it is hard to find devices on the list, especially when having device names auto-generated.

I propose:
 - sort integrations by the number of config entries. This will show integrations that have multiple devices as first on the list.
 - modify container style to allow expanding card to multiple rows
 - expand the integration card to two rows if they have more than 5 config entries
 - expand the integration card to three rows if they have more than 10 config entries

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

I'm looking for feedback on this PR, because number of items that decide on card height is just my proposition and I'm open for suggestions/better options on this.
This can be extended to four rows it there are even more config entries, of we can stay with only two heights (this will also help)

I can remove sort, but when the integration with multiple config entries was on the las row the entire layout didn't look good.

The new layout:
![image](https://user-images.githubusercontent.com/1741838/234518483-e68f089f-6b2f-44fc-af2e-e12dc06ec266.png)

![image](https://user-images.githubusercontent.com/1741838/234518689-5dcdbef1-8bd3-41bb-a628-2d31cb1871f7.png)

![image](https://user-images.githubusercontent.com/1741838/234518756-f82d895a-b917-4c45-860f-ce1cab668cef.png)



<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/discussions/16076
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/discussions/10375
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
