### PR TITLE
Keep area field next to use device area field

### DIFF
--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -608,11 +608,10 @@ export class EntityRegistrySettingsEditor extends LitElement {
         .disabled=${this.disabled}
         @input=${this._entityIdChanged}
       ></ha-textfield>
-      ${!this.entry.device_id || this._areaId || this._noDeviceArea
+      ${!this.entry.device_id
         ? html`<ha-area-picker
             .hass=${this.hass}
             .value=${this._areaId}
-            .placeholder=${this._device?.area_id}
             .disabled=${this.disabled}
             @value-changed=${this._areaPicked}
           ></ha-area-picker>`
@@ -794,40 +793,49 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
       ${this.entry.device_id
         ? html`<ha-settings-row>
-            <span slot="heading"
-              >${this.hass.localize(
-                "ui.dialogs.entity_registry.editor.use_device_area"
-              )}
-              ${this.hass.devices[this.entry.device_id].area_id
-                ? `(${
-                    this.hass.areas[
-                      this.hass.devices[this.entry.device_id].area_id!
-                    ]?.name
-                  })`
-                : ""}</span
-            >
-            <span slot="description"
-              >${this.hass.localize(
-                "ui.dialogs.entity_registry.editor.change_device_settings",
-                {
-                  link: html`<button
-                    class="link"
-                    @click=${this._openDeviceSettings}
-                  >
-                    ${this.hass.localize(
-                      "ui.dialogs.entity_registry.editor.change_device_area_link"
-                    )}
-                  </button>`,
-                }
-              )}</span
-            >
-            <ha-switch
-              .checked=${!this._areaId || this._noDeviceArea}
-              .disabled=${this.disabled}
-              @change=${this._useDeviceAreaChanged}
-            >
-            </ha-switch
-          ></ha-settings-row>`
+              <span slot="heading"
+                >${this.hass.localize(
+                  "ui.dialogs.entity_registry.editor.use_device_area"
+                )}
+                ${this.hass.devices[this.entry.device_id].area_id
+                  ? `(${
+                      this.hass.areas[
+                        this.hass.devices[this.entry.device_id].area_id!
+                      ]?.name
+                    })`
+                  : ""}</span
+              >
+              <span slot="description"
+                >${this.hass.localize(
+                  "ui.dialogs.entity_registry.editor.change_device_settings",
+                  {
+                    link: html`<button
+                      class="link"
+                      @click=${this._openDeviceSettings}
+                    >
+                      ${this.hass.localize(
+                        "ui.dialogs.entity_registry.editor.change_device_area_link"
+                      )}
+                    </button>`,
+                  }
+                )}</span
+              >
+              <ha-switch
+                .checked=${!this._areaId || this._noDeviceArea}
+                .disabled=${this.disabled}
+                @change=${this._useDeviceAreaChanged}
+              >
+              </ha-switch
+            ></ha-settings-row>
+            ${this._areaId || this._noDeviceArea
+              ? html`<ha-area-picker
+                  .hass=${this.hass}
+                  .value=${this._areaId}
+                  .placeholder=${this._device?.area_id}
+                  .disabled=${this.disabled}
+                  @value-changed=${this._areaPicked}
+                ></ha-area-picker>`
+              : ""} `
         : ""}
     `;
   }


### PR DESCRIPTION
## Proposed change

Seen with @matthiasdebaat . Better to keep the area field below the use device area switch for UX like we have before. In 2023.4 the area field for device was inside advanced while the area for entity wasn't. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
