### PR TITLE
Revert "Avoid fetching unused stats state column for more info"

### DIFF
--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -27,7 +27,7 @@ declare global {
   }
 }
 
-const statTypes: StatisticsTypes = ["min", "mean", "max"];
+const statTypes: StatisticsTypes = ["state", "min", "mean", "max"];
 
 @customElement("ha-more-info-history")
 export class MoreInfoHistory extends LitElement {


### PR DESCRIPTION
Reverts home-assistant/frontend#16141

This caused a problem with stats that don't have `min/max/mean`

We need to look at the stats metadata to decide what to fetch but we don't have it at this point so revert this for now until I can come up with a better solution.  We can probably handle this on the backend instead by dropping columns that don't make sense with something like https://github.com/home-assistant/core/pull/92095 instead for next month.