### PR TITLE
Lock entity options

### DIFF
--- a/src/data/entity_registry.ts
+++ b/src/data/entity_registry.ts
@@ -78,6 +78,10 @@ export interface NumberEntityOptions {
   unit_of_measurement?: string | null;
 }
 
+export interface LockEntityOptions {
+  default_code?: string | null;
+}
+
 export interface WeatherEntityOptions {
   precipitation_unit?: string | null;
   pressure_unit?: string | null;
@@ -101,7 +105,11 @@ export interface EntityRegistryEntryUpdateParams {
   hidden_by: string | null;
   new_entity_id?: string;
   options_domain?: string;
-  options?: SensorEntityOptions | NumberEntityOptions | WeatherEntityOptions;
+  options?:
+    | SensorEntityOptions
+    | NumberEntityOptions
+    | LockEntityOptions
+    | WeatherEntityOptions;
   aliases?: string[];
 }
 

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -68,6 +68,7 @@ import {
   removeEntityRegistryEntry,
   SensorEntityOptions,
   updateEntityRegistryEntry,
+  LockEntityOptions,
 } from "../../../data/entity_registry";
 import { domainToName } from "../../../data/integration";
 import { getNumberDeviceClassConvertibleUnits } from "../../../data/number";
@@ -178,6 +179,8 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
 
   @state() private _weatherConvertibleUnits?: WeatherUnits;
 
+  @state() private _default_code?: string | null;
+
   private _origEntityId!: string;
 
   private _deviceLookup?: Record<string, DeviceRegistryEntry>;
@@ -259,6 +262,10 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
       this._precision = this.entry.options?.sensor?.display_precision;
     }
 
+    if (domain === "lock") {
+      this._default_code = this.entry.options?.lock?.default_code;
+    }
+
     if (domain === "weather") {
       const stateObj: HassEntity | undefined =
         this.hass.states[this.entry.entity_id];
@@ -292,6 +299,13 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
       minimumFractionDigits: precision,
       maximumFractionDigits: precision,
     });
+  }
+
+  private testDefaultCode(code_format?: string, value?: string | null) {
+    if (code_format && value) {
+      return RegExp(code_format).test(value);
+    }
+    return true;
   }
 
   protected async updated(changedProps: PropertyValues): Promise<void> {
@@ -339,6 +353,10 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
     const domain = computeDomain(this.entry.entity_id);
 
     const invalidDomainUpdate = computeDomain(this._entityId.trim()) !== domain;
+
+    const regexCodeFormat = stateObj.attributes?.code_format;
+    const invalidDefaultCode =
+      this.testDefaultCode(regexCodeFormat, this._default_code) !== true;
 
     const defaultPrecision =
       this.entry.options?.sensor?.suggested_display_precision ?? undefined;
@@ -471,6 +489,22 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
                   `
                 )}
               </ha-select>
+            `
+          : ""}
+        ${domain === "lock"
+          ? html`
+              <ha-textfield
+                error-message="Code does not match code format"
+                .value=${this._default_code == null
+                  ? ""
+                  : this._default_code.toString()}
+                .label=${this.hass.localize(
+                  "ui.dialogs.entity_registry.editor.default_code"
+                )}
+                .invalid=${invalidDefaultCode}
+                .disabled=${this._submitting}
+                @input=${this._defaultcodeChanged}
+              ></ha-textfield>
             `
           : ""}
         ${domain === "sensor" &&
@@ -959,6 +993,12 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
     this._unit_of_measurement = ev.target.value;
   }
 
+  private _defaultcodeChanged(ev): void {
+    this._error = undefined;
+    this._default_code =
+      ev.target.value === "" ? null : String(ev.target.value);
+  }
+
   private _precipitationUnitChanged(ev): void {
     this._error = undefined;
     this._precipitation_unit = ev.target.value;
@@ -1176,6 +1216,14 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
       params.options = params.options || this.entry.options?.[domain] || {};
       (params.options as SensorEntityOptions).display_precision =
         this._precision;
+    }
+    if (
+      domain === "lock" &&
+      this.entry.options?.[domain]?.default_code !== this._default_code
+    ) {
+      params.options_domain = domain;
+      params.options = params.options || this.entry.options?.[domain] || {};
+      (params.options as LockEntityOptions).default_code = this._default_code;
     }
     if (
       domain === "weather" &&

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -921,6 +921,7 @@
           "name": "Name",
           "icon": "Icon",
           "icon_error": "Icons should be in the format 'prefix:iconname', e.g. 'mdi:home'",
+          "default_code": "Default code",
           "entity_id": "Entity ID",
           "unit_of_measurement": "Unit of Measurement",
           "precipitation_unit": "Precipitation unit",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add entity option to `lock` for providing a default `code`
As described in https://github.com/home-assistant/architecture/discussions/870
Backend PR: https://github.com/home-assistant/core/pull/88139

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
