### PR TITLE
Refactor Intl polyfills and remove from ES5 entrypoints

### DIFF
--- a/build-scripts/webpack.cjs
+++ b/build-scripts/webpack.cjs
@@ -132,6 +132,17 @@ const createWebpackConfig = ({
         ),
         path.resolve(paths.polymer_dir, "src/util/empty.js")
       ),
+      // See `src/resources/intl-polyfill-legacy.ts` for explanation
+      !latestBuild &&
+        new webpack.NormalModuleReplacementPlugin(
+          new RegExp(
+            path.resolve(paths.polymer_dir, "src/resources/intl-polyfill.ts")
+          ),
+          path.resolve(
+            paths.polymer_dir,
+            "src/resources/intl-polyfill-legacy.ts"
+          )
+        ),
       !isProdBuild && new LogStartCompilePlugin(),
     ].filter(Boolean),
     resolve: {

--- a/src/common/datetime/first_weekday.ts
+++ b/src/common/datetime/first_weekday.ts
@@ -1,11 +1,7 @@
 import { getWeekStartByLocale } from "weekstart";
 import { FrontendLocaleData, FirstWeekday } from "../../data/translation";
 
-import { polyfillsLoaded } from "../translations/localize";
-
-if (__BUILD__ === "latest" && polyfillsLoaded) {
-  await polyfillsLoaded;
-}
+import "../../resources/intl-polyfill";
 
 export const weekdays = [
   "sunday",

--- a/src/common/datetime/format_date.ts
+++ b/src/common/datetime/format_date.ts
@@ -1,10 +1,6 @@
 import memoizeOne from "memoize-one";
 import { FrontendLocaleData } from "../../data/translation";
-import { polyfillsLoaded } from "../translations/localize";
-
-if (__BUILD__ === "latest" && polyfillsLoaded) {
-  await polyfillsLoaded;
-}
+import "../../resources/intl-polyfill";
 
 // Tuesday, August 10
 export const formatDateWeekdayDay = (

--- a/src/common/datetime/format_date_time.ts
+++ b/src/common/datetime/format_date_time.ts
@@ -1,11 +1,7 @@
 import memoizeOne from "memoize-one";
 import { FrontendLocaleData } from "../../data/translation";
-import { polyfillsLoaded } from "../translations/localize";
+import "../../resources/intl-polyfill";
 import { useAmPm } from "./use_am_pm";
-
-if (__BUILD__ === "latest" && polyfillsLoaded) {
-  await polyfillsLoaded;
-}
 
 // August 9, 2021, 8:23 AM
 export const formatDateTime = (dateObj: Date, locale: FrontendLocaleData) =>

--- a/src/common/datetime/format_time.ts
+++ b/src/common/datetime/format_time.ts
@@ -1,11 +1,7 @@
 import memoizeOne from "memoize-one";
 import { FrontendLocaleData } from "../../data/translation";
-import { polyfillsLoaded } from "../translations/localize";
+import "../../resources/intl-polyfill";
 import { useAmPm } from "./use_am_pm";
-
-if (__BUILD__ === "latest" && polyfillsLoaded) {
-  await polyfillsLoaded;
-}
 
 // 9:15 PM || 21:15
 export const formatTime = (dateObj: Date, locale: FrontendLocaleData) =>

--- a/src/common/datetime/relative_time.ts
+++ b/src/common/datetime/relative_time.ts
@@ -1,11 +1,7 @@
 import memoizeOne from "memoize-one";
 import { FrontendLocaleData } from "../../data/translation";
-import { polyfillsLoaded } from "../translations/localize";
+import "../../resources/intl-polyfill";
 import { selectUnit } from "../util/select-unit";
-
-if (__BUILD__ === "latest" && polyfillsLoaded) {
-  await polyfillsLoaded;
-}
 
 const formatRelTimeMem = memoizeOne(
   (locale: FrontendLocaleData) =>

--- a/src/common/translations/localize.ts
+++ b/src/common/translations/localize.ts
@@ -1,11 +1,6 @@
-import { shouldPolyfill as shouldPolyfillLocale } from "@formatjs/intl-locale/lib/should-polyfill";
-import { shouldPolyfill as shouldPolyfillPluralRules } from "@formatjs/intl-pluralrules/lib/should-polyfill";
-import { shouldPolyfill as shouldPolyfillRelativeTime } from "@formatjs/intl-relativetimeformat/lib/should-polyfill";
-import { shouldPolyfill as shouldPolyfillDateTime } from "@formatjs/intl-datetimeformat/lib/should-polyfill";
-import { shouldPolyfill as shouldPolyfillDisplayName } from "@formatjs/intl-displaynames/lib/should-polyfill";
 import IntlMessageFormat from "intl-messageformat";
+import { polyfillLocaleData } from "../../resources/locale-data-polyfill";
 import { Resources, TranslationDict } from "../../types";
-import { getLocalLanguage } from "../../util/common-translation";
 
 // Exclude some patterns from key type checking for now
 // These are intended to be removed as errors are fixed
@@ -64,40 +59,6 @@ export interface FormatsType {
   time: FormatType;
 }
 
-const loadedPolyfillLocale = new Set();
-
-const locale = getLocalLanguage();
-
-const polyfills: Promise<any>[] = [];
-if (__BUILD__ === "latest") {
-  if (shouldPolyfillLocale()) {
-    await import("@formatjs/intl-locale/polyfill");
-  }
-  if (shouldPolyfillPluralRules(locale)) {
-    polyfills.push(import("@formatjs/intl-pluralrules/polyfill"));
-    polyfills.push(import("@formatjs/intl-pluralrules/locale-data/en"));
-  }
-  if (shouldPolyfillRelativeTime(locale)) {
-    polyfills.push(import("@formatjs/intl-relativetimeformat/polyfill"));
-  }
-  if (shouldPolyfillDateTime(locale)) {
-    polyfills.push(import("@formatjs/intl-datetimeformat/polyfill"));
-    polyfills.push(import("@formatjs/intl-datetimeformat/add-all-tz"));
-  }
-  if (shouldPolyfillDisplayName(locale)) {
-    polyfills.push(import("@formatjs/intl-displaynames/polyfill"));
-    polyfills.push(import("@formatjs/intl-displaynames/locale-data/en"));
-  }
-}
-
-export const polyfillsLoaded =
-  polyfills.length === 0
-    ? undefined
-    : Promise.all(polyfills).then(() =>
-        // Load the default language
-        loadPolyfillLocales(locale)
-      );
-
 /**
  * Adapted from Polymer app-localize-behavior.
  *
@@ -125,11 +86,9 @@ export const computeLocalize = async <Keys extends string = LocalizeKeys>(
   resources: Resources,
   formats?: FormatsType
 ): Promise<LocalizeFunc<Keys>> => {
-  if (polyfillsLoaded) {
-    await polyfillsLoaded;
-  }
-
-  await loadPolyfillLocales(language);
+  await import("../../resources/intl-polyfill").then(() =>
+    polyfillLocaleData(language)
+  );
 
   // Every time any of the parameters change, invalidate the strings cache.
   cache._localizationCache = {};
@@ -180,59 +139,4 @@ export const computeLocalize = async <Keys extends string = LocalizeKeys>(
       return "Translation " + err;
     }
   };
-};
-
-export const loadPolyfillLocales = async (language: string) => {
-  if (loadedPolyfillLocale.has(language)) {
-    return;
-  }
-  loadedPolyfillLocale.add(language);
-  try {
-    if (
-      Intl.NumberFormat &&
-      // @ts-ignore
-      typeof Intl.NumberFormat.__addLocaleData === "function"
-    ) {
-      const result = await fetch(
-        `/static/locale-data/intl-numberformat/${language}.json`
-      );
-      // @ts-ignore
-      Intl.NumberFormat.__addLocaleData(await result.json());
-    }
-    if (
-      Intl.RelativeTimeFormat &&
-      // @ts-ignore
-      typeof Intl.RelativeTimeFormat.__addLocaleData === "function"
-    ) {
-      const result = await fetch(
-        `/static/locale-data/intl-relativetimeformat/${language}.json`
-      );
-      // @ts-ignore
-      Intl.RelativeTimeFormat.__addLocaleData(await result.json());
-    }
-    if (
-      Intl.DateTimeFormat &&
-      // @ts-ignore
-      typeof Intl.DateTimeFormat.__addLocaleData === "function"
-    ) {
-      const result = await fetch(
-        `/static/locale-data/intl-datetimeformat/${language}.json`
-      );
-      // @ts-ignore
-      Intl.DateTimeFormat.__addLocaleData(await result.json());
-    }
-    if (
-      Intl.DisplayNames &&
-      // @ts-ignore
-      typeof Intl.DisplayNames.__addLocaleData === "function"
-    ) {
-      const result = await fetch(
-        `/static/locale-data/intl-displaynames/${language}.json`
-      );
-      // @ts-ignore
-      Intl.DisplayNames.__addLocaleData(await result.json());
-    }
-  } catch (e) {
-    // Ignore
-  }
 };

--- a/src/resources/compatibility.ts
+++ b/src/resources/compatibility.ts
@@ -3,21 +3,6 @@ import "core-js";
 import "regenerator-runtime/runtime";
 import "lit/polyfill-support";
 
-// For localize & formatting
-import "@formatjs/intl-getcanonicallocales/polyfill";
-import "@formatjs/intl-locale/polyfill";
-import "@formatjs/intl-pluralrules/polyfill";
-import "@formatjs/intl-pluralrules/locale-data/en";
-import "@formatjs/intl-numberformat/polyfill";
-import "@formatjs/intl-numberformat/locale-data/en";
-import "@formatjs/intl-relativetimeformat/polyfill";
-import "@formatjs/intl-relativetimeformat/locale-data/en";
-import "@formatjs/intl-datetimeformat/polyfill";
-import "@formatjs/intl-datetimeformat/locale-data/en";
-import "@formatjs/intl-datetimeformat/add-all-tz";
-import "@formatjs/intl-displaynames/polyfill";
-import "@formatjs/intl-displaynames/locale-data/en";
-
 // To use comlink under ES5
 import "proxy-polyfill";
 import "unfetch/polyfill";

--- a/src/resources/intl-polyfill-legacy.ts
+++ b/src/resources/intl-polyfill-legacy.ts
@@ -1,0 +1,17 @@
+// This module is a simpler version of `intl-polyfill` without top level await, and replaces it for legacy builds.
+// Babel cannot transform TLA, and Webpack uses an async function to support it,
+// so builds with browser targets without async support will be broken.
+
+import "@formatjs/intl-getcanonicallocales/polyfill";
+import "@formatjs/intl-locale/polyfill";
+import "@formatjs/intl-pluralrules/polyfill";
+import "@formatjs/intl-pluralrules/locale-data/en";
+import "@formatjs/intl-numberformat/polyfill";
+import "@formatjs/intl-numberformat/locale-data/en";
+import "@formatjs/intl-relativetimeformat/polyfill";
+import "@formatjs/intl-relativetimeformat/locale-data/en";
+import "@formatjs/intl-datetimeformat/polyfill";
+import "@formatjs/intl-datetimeformat/locale-data/en";
+import "@formatjs/intl-datetimeformat/add-all-tz";
+import "@formatjs/intl-displaynames/polyfill";
+import "@formatjs/intl-displaynames/locale-data/en";

--- a/src/resources/intl-polyfill.ts
+++ b/src/resources/intl-polyfill.ts
@@ -1,0 +1,43 @@
+import { shouldPolyfill as shouldPolyfillDateTime } from "@formatjs/intl-datetimeformat/lib/should-polyfill";
+import { shouldPolyfill as shouldPolyfillDisplayName } from "@formatjs/intl-displaynames/lib/should-polyfill";
+import { shouldPolyfill as shouldPolyfillLocale } from "@formatjs/intl-locale/lib/should-polyfill";
+import { shouldPolyfill as shouldPolyfillPluralRules } from "@formatjs/intl-pluralrules/lib/should-polyfill";
+import { shouldPolyfill as shouldPolyfillRelativeTime } from "@formatjs/intl-relativetimeformat/lib/should-polyfill";
+import { getLocalLanguage } from "../util/common-translation";
+import { polyfillLocaleData } from "./locale-data-polyfill";
+
+const polyfillIntl = async () => {
+  const locale = getLocalLanguage();
+  const polyfills: Promise<unknown>[] = [];
+
+  if (shouldPolyfillLocale()) {
+    await import("@formatjs/intl-locale/polyfill");
+  }
+  if (shouldPolyfillPluralRules(locale)) {
+    polyfills.push(
+      import("@formatjs/intl-pluralrules/polyfill"),
+      import("@formatjs/intl-pluralrules/locale-data/en")
+    );
+  }
+  if (shouldPolyfillRelativeTime(locale)) {
+    polyfills.push(import("@formatjs/intl-relativetimeformat/polyfill"));
+  }
+  if (shouldPolyfillDateTime(locale)) {
+    polyfills.push(
+      import("@formatjs/intl-datetimeformat/polyfill"),
+      import("@formatjs/intl-datetimeformat/add-all-tz")
+    );
+  }
+  if (shouldPolyfillDisplayName(locale)) {
+    polyfills.push(
+      import("@formatjs/intl-displaynames/polyfill"),
+      import("@formatjs/intl-displaynames/locale-data/en")
+    );
+  }
+  await Promise.all(polyfills).then(() =>
+    // Load the default language
+    polyfillLocaleData(locale)
+  );
+};
+
+await polyfillIntl();

--- a/src/resources/intl-polyfill.ts
+++ b/src/resources/intl-polyfill.ts
@@ -11,27 +11,30 @@ const polyfillIntl = async () => {
   const polyfills: Promise<unknown>[] = [];
 
   if (shouldPolyfillLocale()) {
-    await import("@formatjs/intl-locale/polyfill");
+    await import("@formatjs/intl-locale/polyfill-force");
   }
   if (shouldPolyfillPluralRules(locale)) {
     polyfills.push(
-      import("@formatjs/intl-pluralrules/polyfill"),
-      import("@formatjs/intl-pluralrules/locale-data/en")
+      import("@formatjs/intl-pluralrules/polyfill-force").then(
+        () => import("@formatjs/intl-pluralrules/locale-data/en")
+      )
     );
   }
   if (shouldPolyfillRelativeTime(locale)) {
-    polyfills.push(import("@formatjs/intl-relativetimeformat/polyfill"));
+    polyfills.push(import("@formatjs/intl-relativetimeformat/polyfill-force"));
   }
   if (shouldPolyfillDateTime(locale)) {
     polyfills.push(
-      import("@formatjs/intl-datetimeformat/polyfill"),
-      import("@formatjs/intl-datetimeformat/add-all-tz")
+      import("@formatjs/intl-datetimeformat/polyfill-force").then(
+        () => import("@formatjs/intl-datetimeformat/add-all-tz")
+      )
     );
   }
   if (shouldPolyfillDisplayName(locale)) {
     polyfills.push(
-      import("@formatjs/intl-displaynames/polyfill"),
-      import("@formatjs/intl-displaynames/locale-data/en")
+      import("@formatjs/intl-displaynames/polyfill-force").then(
+        () => import("@formatjs/intl-displaynames/locale-data/en")
+      )
     );
   }
   await Promise.all(polyfills).then(() =>

--- a/src/resources/locale-data-polyfill.ts
+++ b/src/resources/locale-data-polyfill.ts
@@ -1,0 +1,59 @@
+// Loads the static locale data for a given language from FormatJS
+// Parents need to load polyfills first; they are not imported here to avoid a circular reference
+
+const loadedPolyfillLocale = new Set();
+
+export const polyfillLocaleData = async (language: string) => {
+  if (loadedPolyfillLocale.has(language)) {
+    return;
+  }
+  loadedPolyfillLocale.add(language);
+  try {
+    if (
+      Intl.NumberFormat &&
+      // @ts-ignore
+      typeof Intl.NumberFormat.__addLocaleData === "function"
+    ) {
+      const result = await fetch(
+        `/static/locale-data/intl-numberformat/${language}.json`
+      );
+      // @ts-ignore
+      Intl.NumberFormat.__addLocaleData(await result.json());
+    }
+    if (
+      Intl.RelativeTimeFormat &&
+      // @ts-ignore
+      typeof Intl.RelativeTimeFormat.__addLocaleData === "function"
+    ) {
+      const result = await fetch(
+        `/static/locale-data/intl-relativetimeformat/${language}.json`
+      );
+      // @ts-ignore
+      Intl.RelativeTimeFormat.__addLocaleData(await result.json());
+    }
+    if (
+      Intl.DateTimeFormat &&
+      // @ts-ignore
+      typeof Intl.DateTimeFormat.__addLocaleData === "function"
+    ) {
+      const result = await fetch(
+        `/static/locale-data/intl-datetimeformat/${language}.json`
+      );
+      // @ts-ignore
+      Intl.DateTimeFormat.__addLocaleData(await result.json());
+    }
+    if (
+      Intl.DisplayNames &&
+      // @ts-ignore
+      typeof Intl.DisplayNames.__addLocaleData === "function"
+    ) {
+      const result = await fetch(
+        `/static/locale-data/intl-displaynames/${language}.json`
+      );
+      // @ts-ignore
+      Intl.DisplayNames.__addLocaleData(await result.json());
+    }
+  } catch (e) {
+    // Ignore
+  }
+};

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -10,7 +10,6 @@ import {
   subscribeServices,
 } from "home-assistant-js-websocket";
 import { fireEvent } from "../common/dom/fire_event";
-import { polyfillsLoaded } from "../common/translations/localize";
 import { subscribeAreaRegistry } from "../data/area_registry";
 import { broadcastConnectionStatus } from "../data/connection-status";
 import { subscribeDeviceRegistry } from "../data/device_registry";
@@ -224,17 +223,12 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
       });
       subscribeConfig(conn, (config) => {
         if (this.hass?.config?.time_zone !== config.time_zone) {
-          if (__BUILD__ === "latest" && polyfillsLoaded) {
-            polyfillsLoaded.then(() => {
-              if ("__setDefaultTimeZone" in Intl.DateTimeFormat) {
-                // @ts-ignore
-                Intl.DateTimeFormat.__setDefaultTimeZone(config.time_zone);
-              }
-            });
-          } else if ("__setDefaultTimeZone" in Intl.DateTimeFormat) {
-            // @ts-ignore
-            Intl.DateTimeFormat.__setDefaultTimeZone(config.time_zone);
-          }
+          import("../resources/intl-polyfill").then(() => {
+            if ("__setDefaultTimeZone" in Intl.DateTimeFormat) {
+              // @ts-ignore
+              Intl.DateTimeFormat.__setDefaultTimeZone(config.time_zone);
+            }
+          });
         }
         this._updateHass({ config });
       });


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change drastically reduces the entrypoint sizes for the ES5 build by removing the _FormatJS_ `Intl` polyfills and loading them with the same timing logic as the latest build.  It also greatly simplifies use of `Intl` where desired by only requiring a single import.  Steps are roughly:

1. Split the dynamic import and top level await version for the latest build into its own module.  Also split out the locale data polyfill function so there's no circular dependency.
2. Move the TLA to the new `intl-polyfill` module, and just write code to import it before using `Intl`.
3. Split the static import version for the ES5 build as well.  Code is written for latest build, but Webpack makes the swap for the ES5 build.

And here's the result on the ES5 build:

| ES5 Entrypoint | Old | New |
|:--- |:---:|:---:|
| app | 582K | 596K |
| core | 2.1M | 345K |
| custom-panel | 2.0M | 317K |
| authorize | 2.5M | 859K |
| onboarding | 2.7M | 1.1M |
| _Total Bundle_ | _36M_ | _32M_ |


And as a happy accident, the latest build entries go down a little too.  This is because the connection mixin is no longer importing the `localize` module early:

| Latest Entrypoint | Old | New |
|:--- |:---:|:---:|
| app | 315K | 293K |
| core | 19K | 19K |
| custom-panel | 35K | 35K |
| authorize | 388K | 367K |
| onboarding | 417K | 395K |
| _Total Bundle_ | _26M_ | _26M_ |

I mean... I knew that was going to happen. 🦊 

This may actually fix the Webpack upgrade issue as well because that's reportedly related to conditional TLAs, which are eliminated here.  I'll have to check that out.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
