### PR TITLE
Collapse empty Masonry columns (#5315, #6632)

### DIFF
--- a/src/panels/lovelace/views/hui-masonry-view.ts
+++ b/src/panels/lovelace/views/hui-masonry-view.ts
@@ -320,6 +320,10 @@ export class MasonryView extends LitElement implements LovelaceViewElement {
         min-width: 0;
       }
 
+      .column:not(:has(> *:not([hidden]))) {
+        flex-grow: 0;
+      }
+
       .column > *:not([hidden]) {
         display: block;
         margin: var(--masonry-view-card-margin, 4px 4px 8px);


### PR DESCRIPTION
Even though the conditional card is hidden and thus should not have styles applied and will not itself take up space, hui-masonry-view will still assign it to a column (with flex-grow=1), even if that column consists solely of hidden cards.

This uses CSS to conditionally reset `flex-grow=0` on any column that does not have a visible child.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## ~Breaking change~

This does not touch the existing `.column` styles, and only adds an override when there are no visible children - so it should not affect other styles.
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
  - title: Test
    subview: false
    badges: []
    cards:
      - type: entities
        entities:
          # Repeating only to take up vertical space, so that Masonry will create 3 columns.
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
      - type: conditional
        conditions:
          - entity: sun.sun
            state: never
        card:
          type: entities
          entities:
            - sun.sun
            - sun.sun
            - sun.sun
            - sun.sun
            - sun.sun
            - sun.sun
            - sun.sun
            - sun.sun
            - sun.sun
            - sun.sun
      - type: entities
        entities:
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
          - sun.sun
```

## Additional information

See also:
* https://community.home-assistant.io/t/wth-why-are-there-still-display-issues-with-conditional-cards/471426
* https://github.com/home-assistant/frontend/issues/6632
* https://github.com/home-assistant/frontend/issues/5315

Note that despite the historical tendency for people to conflate these issues, this _is not_ the same problem as the "vertical stack" issue that adds rogue spacing if the first card in a vertical stack is a hidden conditional - that is unrelated.

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #5315 #6632
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
