### PR TITLE
Redefine browser requirements for legacy (ES5) builds

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -15,8 +15,8 @@ not dead
 
 [legacy]
 # Legacy builds are served when modern requirements are not met and support browsers:
-# - released in the last 10 year + current alpha/beta versionss
-# - with global utilization above 0.1%
+# - released in the last 7 years + current alpha/beta versionss
+# - with global utilization above 0.05%
 # The lattermost query ensures that support for popular old browsers is not dropped too early
 # (e.g. IE 11, Android 4.4, or Samsung 4).
 #
@@ -29,5 +29,5 @@ not dead
 # Nearly all of these are redundant with the above rules.
 # As of May 2023, only web sockets must be added to the query.
 unreleased versions
-last 10 years
-> 0.1% and supports websockets
+last 7 years
+> 0.05% and supports websockets

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -14,8 +14,20 @@ not iOS < 13
 not dead
 
 [legacy]
-# Legacy builds are transpiled to ES5 (strict mode) but also must support some features that cannot be polyfilled:
+# Legacy builds are served when modern requirements are not met and support browsers:
+# - released in the last 10 year + current alpha/beta versionss
+# - with global utilization above 0.1%
+# The lattermost query ensures that support for popular old browsers is not dropped too early
+# (e.g. IE 11, Android 4.4, or Samsung 4).
+#
+# In addition, legacy browsers must support some minimum features that cannot be polyfilled:
+# - ES5 (strict mode)
 # - web sockets to communicate with backend
 # - inline SVG used widely in buttons, widgets, etc.
 # - custom events used for most user interactions
-supports use-strict and supports websockets and supports svg-html5 and supports customevent
+# - CSS flexbox used in the majority of the layout
+# Nearly all of these are redundant with the above rules.
+# As of May 2023, only web sockets must be added to the query.
+unreleased versions
+last 10 years
+> 0.1% and supports websockets


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Browser requirements for legacy (ES5) builds of the frontend have been updated to create a sunset policy. Support will sunset for browsers more than 7 years old and when global utilization falls below a conservative threshold of 0.05%.  This will not affect the vast majority of users.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This builds on the `browserslist` implementation from #16267 by proposing a more practical set of requirements for legacy builds based on time and utilization instead of just features.  Without such a sunset policy, the builds will just keep growing with more transforms and polyfills likely without any benefit to real working devices in the wild.

I covered an explanation of the requirements I came up with in the comments of the config, so please read that first... ⏳ .

~~I tried to be pretty conservative - very old stuff will certainly be supported.  I used 10 years as the cutoff because, as of today, that's when browsers start losing support for those minimum feature requirements.  Beyond about 12 years, support drops off very quickly.  I picked 0.1% utilization just looking at the data.~~

_Numbers revised per discussion below.  Minimum browsers reported below have been adjusted._

In terms of polyfills and transforms that are dropped compared to `dev`, this only loses the 3 oldest Babel transforms and only ~~3~~ 11 of 413 possible Core JS polyfills.  So not much change to the actual build today, just trying to put it on a tractable path.

New requirements would be at least:
- Android ~~4.4~~ 4.4.3
- Chrome ~~28~~ 51
- Edge ~~12~~ 14
- Firefox ~~22~~ 47
- IE 11
- iOS ~~7~~ 9.3
- Opera ~~15~~ 37
- Safari ~~6.1~~ 10
- Samsung 4

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
