### PR TITLE
Add interval duration to history tooltip

### DIFF
--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -2,6 +2,7 @@ import type { ChartData, ChartDataset, ChartOptions } from "chart.js";
 import { css, CSSResultGroup, html, LitElement, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
+import millisecondsToDuration from "../../common/datetime/milliseconds_to_duration";
 import { fireEvent } from "../../common/dom/fire_event";
 import { numberFormatToLocale } from "../../common/number/format_number";
 import { computeRTL } from "../../common/util/compute_rtl";
@@ -173,10 +174,16 @@ export class StateHistoryChartTimeline extends LitElement {
             beforeBody: (context) => context[0].dataset.label || "",
             label: (item) => {
               const d = item.dataset.data[item.dataIndex] as TimeLineData;
+              const durationInMs = d.end.getTime() - d.start.getTime();
+              const formattedDuration = `${this.hass.localize(
+                "ui.components.history_charts.duration"
+              )}: ${millisecondsToDuration(durationInMs)}`;
+
               return [
                 d.label || "",
                 formatDateTimeWithSeconds(d.start, this.hass.locale),
                 formatDateTimeWithSeconds(d.end, this.hass.locale),
+                formattedDuration,
               ];
             },
             labelColor: (item) => ({

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -513,7 +513,8 @@
         "history_disabled": "History integration disabled",
         "loading_history": "Loading state history…",
         "no_history_found": "No state history found.",
-        "error": "Unable to load history"
+        "error": "Unable to load history",
+        "duration": "Duration"
       },
       "map": {
         "error": "Unable to load map"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When I'm checking entities history, sometimes I would like to know the duration of certain interval and I have to hover over the interval to see the tooltip and get the start and end dates to do the math.

This PR adds the duration to the tooltip.

### Before

![image](https://github.com/home-assistant/frontend/assets/8275052/0db75e1e-6311-4f9b-b601-948fb49d5d88)

### After

![image](https://github.com/home-assistant/frontend/assets/8275052/05827cb9-f554-4bed-8ddf-7adcf481a962)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
