### PR TITLE
Add setting to localize numeric dates independent from language (#15770)

### DIFF
--- a/gallery/sidebar.js
+++ b/gallery/sidebar.js
@@ -46,6 +46,10 @@ export default [
     pages: ["user-types", "configuration-menu"],
   },
   {
+    category: "date-time",
+    header: "Date and Time",
+  },
+  {
     category: "design.home-assistant.io",
     header: "About",
   },

--- a/gallery/src/pages/date-time/date.markdown
+++ b/gallery/src/pages/date-time/date.markdown
@@ -1,0 +1,7 @@
+---
+title: (Numeric) Date Formatting
+---
+
+This pages lists all supported languages with their available (numeric) date formats.
+
+Formatting function: `const formatDateNumeric: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/date.ts
+++ b/gallery/src/pages/date-time/date.ts
@@ -1,0 +1,106 @@
+import { html, css, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import { HomeAssistant } from "../../../../src/types";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatDateNumeric } from "../../../../src/common/datetime/format_date";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-date")
+export class DemoDateTimeDate extends LitElement {
+  @property({ attribute: false }) hass!: HomeAssistant;
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+    };
+    const date = new Date();
+    return html`
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">Day-Month-Year</div>
+          <div class="center">Month-Day-Year</div>
+          <div class="center">Year-Month-Day</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatDateNumeric(date, {
+                    ...defaultLocale,
+                    language: key,
+                    date_format: DateFormat.language,
+                  })}
+                </div>
+                <div class="center">
+                  ${formatDateNumeric(date, {
+                    ...defaultLocale,
+                    language: key,
+                    date_format: DateFormat.DMY,
+                  })}
+                </div>
+                <div class="center">
+                  ${formatDateNumeric(date, {
+                    ...defaultLocale,
+                    language: key,
+                    date_format: DateFormat.MDY,
+                  })}
+                </div>
+                <div class="center">
+                  ${formatDateNumeric(date, {
+                    ...defaultLocale,
+                    language: key,
+                    date_format: DateFormat.YMD,
+                  })}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 600px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-date": DemoDateTimeDate;
+  }
+}

--- a/src/common/datetime/format_date_time.ts
+++ b/src/common/datetime/format_date_time.ts
@@ -2,6 +2,8 @@ import memoizeOne from "memoize-one";
 import { FrontendLocaleData } from "../../data/translation";
 import "../../resources/intl-polyfill";
 import { useAmPm } from "./use_am_pm";
+import { formatDateNumeric } from "./format_date";
+import { formatTime } from "./format_time";
 
 // August 9, 2021, 8:23 AM
 export const formatDateTime = (dateObj: Date, locale: FrontendLocaleData) =>
@@ -74,21 +76,4 @@ const formatDateTimeWithSecondsMem = memoizeOne(
 export const formatDateTimeNumeric = (
   dateObj: Date,
   locale: FrontendLocaleData
-) => formatDateTimeNumericMem(locale).format(dateObj);
-
-const formatDateTimeNumericMem = memoizeOne(
-  (locale: FrontendLocaleData) =>
-    new Intl.DateTimeFormat(
-      locale.language === "en" && !useAmPm(locale)
-        ? "en-u-hc-h23"
-        : locale.language,
-      {
-        year: "numeric",
-        month: "numeric",
-        day: "numeric",
-        hour: "numeric",
-        minute: "2-digit",
-        hour12: useAmPm(locale),
-      }
-    )
-);
+) => `${formatDateNumeric(dateObj, locale)}, ${formatTime(dateObj, locale)}`;

--- a/src/data/translation.ts
+++ b/src/data/translation.ts
@@ -17,6 +17,14 @@ export enum TimeFormat {
   twenty_four = "24",
 }
 
+export enum DateFormat {
+  language = "language",
+  system = "system",
+  DMY = "DMY",
+  MDY = "MDY",
+  YMD = "YMD",
+}
+
 export enum FirstWeekday {
   language = "language",
   monday = "monday",
@@ -32,6 +40,7 @@ export interface FrontendLocaleData {
   language: string;
   number_format: NumberFormat;
   time_format: TimeFormat;
+  date_format: DateFormat;
   first_weekday: FirstWeekday;
 }
 

--- a/src/fake_data/provide_hass.ts
+++ b/src/fake_data/provide_hass.ts
@@ -6,7 +6,12 @@ import {
 import { fireEvent } from "../common/dom/fire_event";
 import { computeLocalize } from "../common/translations/localize";
 import { DEFAULT_PANEL } from "../data/panel";
-import { FirstWeekday, NumberFormat, TimeFormat } from "../data/translation";
+import {
+  FirstWeekday,
+  NumberFormat,
+  DateFormat,
+  TimeFormat,
+} from "../data/translation";
 import { translationMetadata } from "../resources/translations-metadata";
 import { HomeAssistant } from "../types";
 import { getLocalLanguage, getTranslation } from "../util/common-translation";
@@ -224,6 +229,7 @@ export const provideHass = (
       language: localLanguage,
       number_format: NumberFormat.language,
       time_format: TimeFormat.language,
+      date_format: DateFormat.language,
       first_weekday: FirstWeekday.language,
     },
     resources: null as any,

--- a/src/panels/profile/ha-panel-profile.ts
+++ b/src/panels/profile/ha-panel-profile.ts
@@ -27,6 +27,7 @@ import "./ha-pick-language-row";
 import "./ha-pick-number-format-row";
 import "./ha-pick-theme-row";
 import "./ha-pick-time-format-row";
+import "./ha-pick-date-format-row";
 import "./ha-push-notifications-row";
 import "./ha-refresh-tokens-card";
 import "./ha-set-suspend-row";
@@ -96,6 +97,10 @@ class HaPanelProfile extends LitElement {
               .narrow=${this.narrow}
               .hass=${this.hass}
             ></ha-pick-time-format-row>
+            <ha-pick-date-format-row
+              .narrow=${this.narrow}
+              .hass=${this.hass}
+            ></ha-pick-date-format-row>
             <ha-pick-first-weekday-row
               .narrow=${this.narrow}
               .hass=${this.hass}

--- a/src/panels/profile/ha-pick-date-format-row.ts
+++ b/src/panels/profile/ha-pick-date-format-row.ts
@@ -1,0 +1,64 @@
+import "@material/mwc-list/mwc-list-item";
+import { html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators";
+import { formatDateNumeric } from "../../common/datetime/format_date";
+import { fireEvent } from "../../common/dom/fire_event";
+import "../../components/ha-card";
+import "../../components/ha-select";
+import "../../components/ha-settings-row";
+import { DateFormat } from "../../data/translation";
+import { HomeAssistant } from "../../types";
+
+@customElement("ha-pick-date-format-row")
+class DateFormatRow extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public narrow!: boolean;
+
+  protected render(): TemplateResult {
+    const date = new Date();
+    return html`
+      <ha-settings-row .narrow=${this.narrow}>
+        <span slot="heading">
+          ${this.hass.localize("ui.panel.profile.date_format.header")}
+        </span>
+        <span slot="description">
+          ${this.hass.localize("ui.panel.profile.date_format.description")}
+        </span>
+        <ha-select
+          .label=${this.hass.localize(
+            "ui.panel.profile.date_format.dropdown_label"
+          )}
+          .disabled=${this.hass.locale === undefined}
+          .value=${this.hass.locale.date_format}
+          @selected=${this._handleFormatSelection}
+          naturalMenuWidth
+        >
+          ${Object.values(DateFormat).map((format) => {
+            const formattedDate = formatDateNumeric(date, {
+              ...this.hass.locale,
+              date_format: format,
+            });
+            const value = this.hass.localize(
+              `ui.panel.profile.date_format.formats.${format}`
+            );
+            return html`<mwc-list-item .value=${format} twoline>
+              <span>${value}</span>
+              <span slot="secondary">${formattedDate}</span>
+            </mwc-list-item>`;
+          })}
+        </ha-select>
+      </ha-settings-row>
+    `;
+  }
+
+  private async _handleFormatSelection(ev) {
+    fireEvent(this, "hass-date-format-select", ev.target.value);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-pick-date-format-row": DateFormatRow;
+  }
+}

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -18,7 +18,12 @@ import { subscribeFrontendUserData } from "../data/frontend";
 import { forwardHaptic } from "../data/haptics";
 import { DEFAULT_PANEL } from "../data/panel";
 import { serviceCallWillDisconnect } from "../data/service";
-import { FirstWeekday, NumberFormat, TimeFormat } from "../data/translation";
+import {
+  FirstWeekday,
+  NumberFormat,
+  DateFormat,
+  TimeFormat,
+} from "../data/translation";
 import { subscribePanels } from "../data/ws-panels";
 import { translationMetadata } from "../resources/translations-metadata";
 import { Constructor, HomeAssistant, ServiceCallResponse } from "../types";
@@ -57,6 +62,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
           language,
           number_format: NumberFormat.language,
           time_format: TimeFormat.language,
+          date_format: DateFormat.language,
           first_weekday: FirstWeekday.language,
         },
         resources: null as any,

--- a/src/state/translations-mixin.ts
+++ b/src/state/translations-mixin.ts
@@ -13,6 +13,7 @@ import {
   NumberFormat,
   saveTranslationPreferences,
   TimeFormat,
+  DateFormat,
   TranslationCategory,
 } from "../data/translation";
 import { translationMetadata } from "../resources/translations-metadata";
@@ -36,6 +37,9 @@ declare global {
     };
     "hass-time-format-select": {
       time_format: TimeFormat;
+    };
+    "hass-date-format-select": {
+      date_format: DateFormat;
     };
     "hass-first-weekday-select": {
       first_weekday: FirstWeekday;
@@ -80,6 +84,9 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
       this.addEventListener("hass-time-format-select", (e) => {
         this._selectTimeFormat((e as CustomEvent).detail, true);
       });
+      this.addEventListener("hass-date-format-select", (e) => {
+        this._selectDateFormat((e as CustomEvent).detail, true);
+      });
       this.addEventListener("hass-first-weekday-select", (e) => {
         this._selectFirstWeekday((e as CustomEvent).detail, true);
       });
@@ -120,6 +127,13 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         ) {
           // We just got time_format from backend, no need to save back
           this._selectTimeFormat(locale.time_format, false);
+        }
+        if (
+          locale?.date_format &&
+          this.hass!.locale.date_format !== locale.date_format
+        ) {
+          // We just got date_format from backend, no need to save back
+          this._selectDateFormat(locale.date_format, false);
         }
         if (
           locale?.first_weekday &&
@@ -169,6 +183,18 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
     private _selectTimeFormat(time_format: TimeFormat, saveToBackend: boolean) {
       this._updateHass({
         locale: { ...this.hass!.locale, time_format: time_format },
+      });
+      if (saveToBackend) {
+        saveTranslationPreferences(this.hass!, this.hass!.locale);
+      }
+    }
+
+    private _selectDateFormat(date_format: DateFormat, saveToBackend: boolean) {
+      this._updateHass({
+        locale: {
+          ...this.hass!.locale,
+          date_format: date_format,
+        },
       });
       if (saveToBackend) {
         saveTranslationPreferences(this.hass!, this.hass!.locale);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4856,6 +4856,18 @@
             "24": "24 hours"
           }
         },
+        "date_format": {
+          "header": "Date Format",
+          "dropdown_label": "Date format",
+          "description": "Choose how dates are formatted.",
+          "formats": {
+            "language": "Auto (use language setting)",
+            "system": "Use system locale",
+            "DMY": "Day-Month-Year",
+            "MDY": "Month-Day-Year",
+            "YMD": "Year-Month-Day"
+          }
+        },
         "first_weekday": {
           "header": "First day of the week",
           "dropdown_label": "First day of the week",

--- a/src/util/common-translation.ts
+++ b/src/util/common-translation.ts
@@ -76,6 +76,7 @@ export async function getUserLocale(
   const language = result?.language;
   const number_format = result?.number_format;
   const time_format = result?.time_format;
+  const date_format = result?.date_format;
   const first_weekday = result?.first_weekday;
   if (language) {
     const availableLanguage = findAvailableLanguage(language);
@@ -84,6 +85,7 @@ export async function getUserLocale(
         language: availableLanguage,
         number_format,
         time_format,
+        date_format: date_format,
         first_weekday,
       };
     }
@@ -91,6 +93,7 @@ export async function getUserLocale(
   return {
     number_format,
     time_format,
+    date_format: date_format,
     first_weekday,
   };
 }

--- a/test/common/datetime/format_date.ts
+++ b/test/common/datetime/format_date.ts
@@ -5,6 +5,7 @@ import {
   NumberFormat,
   TimeFormat,
   FirstWeekday,
+  DateFormat,
 } from "../../../src/data/translation";
 
 describe("formatDate", () => {
@@ -16,6 +17,7 @@ describe("formatDate", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.language,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "November 18, 2017"

--- a/test/common/datetime/format_date_time.ts
+++ b/test/common/datetime/format_date_time.ts
@@ -8,6 +8,7 @@ import {
   NumberFormat,
   TimeFormat,
   FirstWeekday,
+  DateFormat,
 } from "../../../src/data/translation";
 
 describe("formatDateTime", () => {
@@ -19,6 +20,7 @@ describe("formatDateTime", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.am_pm,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "November 18, 2017 at 11:12 PM"
@@ -28,6 +30,7 @@ describe("formatDateTime", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.twenty_four,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "November 18, 2017 at 23:12"
@@ -44,6 +47,7 @@ describe("formatDateTimeWithSeconds", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.am_pm,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "November 18, 2017 at 11:12:13 PM"
@@ -53,6 +57,7 @@ describe("formatDateTimeWithSeconds", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.twenty_four,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "November 18, 2017 at 23:12:13"

--- a/test/common/datetime/format_time.ts
+++ b/test/common/datetime/format_time.ts
@@ -9,6 +9,7 @@ import {
   NumberFormat,
   TimeFormat,
   FirstWeekday,
+  DateFormat,
 } from "../../../src/data/translation";
 
 describe("formatTime", () => {
@@ -20,6 +21,7 @@ describe("formatTime", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.am_pm,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "11:12 PM"
@@ -29,6 +31,7 @@ describe("formatTime", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.twenty_four,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "23:12"
@@ -45,6 +48,7 @@ describe("formatTimeWithSeconds", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.am_pm,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "11:12:13 PM"
@@ -54,6 +58,7 @@ describe("formatTimeWithSeconds", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.twenty_four,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "23:12:13"
@@ -70,6 +75,7 @@ describe("formatTimeWeekday", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.am_pm,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "Saturday 11:12 PM"
@@ -79,6 +85,7 @@ describe("formatTimeWeekday", () => {
         language: "en",
         number_format: NumberFormat.language,
         time_format: TimeFormat.twenty_four,
+        date_format: DateFormat.language,
         first_weekday: FirstWeekday.language,
       }),
       "Saturday 23:12"

--- a/test/common/datetime/relative_time.ts
+++ b/test/common/datetime/relative_time.ts
@@ -5,6 +5,7 @@ import {
   NumberFormat,
   TimeFormat,
   FirstWeekday,
+  DateFormat,
 } from "../../../src/data/translation";
 
 describe("relativeTime", () => {
@@ -12,6 +13,7 @@ describe("relativeTime", () => {
     language: "en",
     number_format: NumberFormat.language,
     time_format: TimeFormat.language,
+    date_format: DateFormat.language,
     first_weekday: FirstWeekday.language,
   };
 
@@ -19,6 +21,7 @@ describe("relativeTime", () => {
     language: "en",
     number_format: NumberFormat.language,
     time_format: TimeFormat.language,
+    date_format: DateFormat.language,
     first_weekday: FirstWeekday.monday,
   };
 

--- a/test/common/entity/compute_state_display.ts
+++ b/test/common/entity/compute_state_display.ts
@@ -6,6 +6,7 @@ import {
   NumberFormat,
   TimeFormat,
   FirstWeekday,
+  DateFormat,
 } from "../../../src/data/translation";
 
 let localeData: FrontendLocaleData;
@@ -20,6 +21,7 @@ describe("computeStateDisplay", () => {
       language: "en",
       number_format: NumberFormat.comma_decimal,
       time_format: TimeFormat.am_pm,
+      date_format: DateFormat.language,
       first_weekday: FirstWeekday.language,
     };
   });

--- a/test/common/string/format_number.ts
+++ b/test/common/string/format_number.ts
@@ -11,6 +11,7 @@ import {
   NumberFormat,
   TimeFormat,
   FirstWeekday,
+  DateFormat,
 } from "../../../src/data/translation";
 
 describe("formatNumber", () => {
@@ -19,6 +20,7 @@ describe("formatNumber", () => {
     language: "en",
     number_format: NumberFormat.language,
     time_format: TimeFormat.language,
+    date_format: DateFormat.language,
     first_weekday: FirstWeekday.language,
   };
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Issue #15770 

Problem: Language set to English used by numeric date formatting -> result 5/9/2023 (M/D/YY used with en-US).
Wanted: Language set to English, but date should be displayed as DD/MM/YY (like en-GB)
Solution: Numeric date format can be changed with a profile setting independent of the set language

Setting in user profile:

![User profile](https://github.com/home-assistant/frontend/assets/43651938/4109f3d1-b8d1-4827-9317-9a0c52504d69)

Effect: 

![Adjust a statistic](https://github.com/home-assistant/frontend/assets/43651938/af50feb5-ea0a-468e-80fa-111447c7ea53)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15770 
- This PR is related to issue or discussion: #15770 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
