### PR TITLE
Add a description for time condition

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -653,6 +653,67 @@ export const describeCondition = (
     return base;
   }
 
+  // Time condition
+  if (condition.condition === "time") {
+    const weekdaysArray = ensureArray(condition.weekday);
+    const validWeekdays =
+      weekdaysArray && weekdaysArray.length > 0 && weekdaysArray.length < 7;
+    if (condition.before || condition.after || validWeekdays) {
+      const before = condition.before?.toString().includes(".")
+        ? `entity ${
+            hass.states[condition.before]
+              ? computeStateName(hass.states[condition.before])
+              : condition.before
+          }`
+        : condition.before;
+
+      const after = condition.after?.toString().includes(".")
+        ? `entity ${
+            hass.states[condition.after]
+              ? computeStateName(hass.states[condition.after])
+              : condition.after
+          }`
+        : condition.after;
+
+      let result = "Confirm the ";
+      if (after || before) {
+        result += "time is ";
+      }
+      if (after) {
+        result += "after " + after;
+      }
+      if (before && after) {
+        result += " and ";
+      }
+      if (before) {
+        result += "before " + before;
+      }
+      if ((after || before) && validWeekdays) {
+        result += " and the ";
+      }
+      if (validWeekdays) {
+        const localizedDays = weekdaysArray.map((d) =>
+          hass.localize(
+            `ui.panel.config.automation.editor.conditions.type.time.weekdays.${d}`
+          )
+        );
+        const last = localizedDays.pop();
+
+        result += " day is " + localizedDays.join(", ");
+
+        if (localizedDays.length) {
+          if (localizedDays.length > 1) {
+            result += ",";
+          }
+          result += " or ";
+        }
+        result += last;
+      }
+
+      return result;
+    }
+  }
+
   // Sun condition
   if (
     condition.condition === "sun" &&


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This change adds an summary description for time condition in automation editor, currently it has none. 

Examples of new proposed description:

 - Confirm the day is Monday
 - Confirm the time is before 12:00:00
 - Confirm the time is after 06:00:00 and before 16:00:00
 - Confirm the time is after 06:00:00 and before 16:00:00 and the day is Wednesday
 - Confirm the time is after 06:00:00 and before 16:00:00 and the day is Wednesday or Thursday
 - Confirm the time is after entity Sun Next dusk and before entity Sun Next dawn and the day is Monday, Thursday, Saturday, or Sunday


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
