### PR TITLE
Redefine browser requirements for modern (latest) builds

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -3,6 +3,7 @@
 # It is served to browsers meeting the following requirements:
 # - last 2 released + current alpha/beta versionss of all major browsers
 # - Firefox extended support release (ESR)
+# - released in the last year
 # - browsers with global utilization above 0.5%
 # - must support dynamic import of ES modules
 # - exclude browsers no longer being maintained
@@ -10,6 +11,7 @@
 unreleased versions
 last 2 versions
 Firefox ESR
+last 1 year
 > 0.5% and supports es6-module-dynamic-import
 not dead
 not KaiOS > 0

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,23 +1,20 @@
 [modern]
-# Support for dynamic import is the main litmus test for serving modern builds.
-# Although officially a ES2020 feature, browsers implemented it early, so this
-# enables all of ES2017 and some features in ES2018.
-supports es6-module-dynamic-import
-
-# Exclude Safari 11-12 because of a bug in tagged template literals
-# https://bugs.webkit.org/show_bug.cgi?id=190756
-# Note: Dropping version 11 also enables several more ES2018 features
-not Safari < 13
-not iOS < 13
-
-# Exclude KaiOS, QQ, and UC browsers due to lack of sufficient feature support data
-# Babel ignores these automatically, but we need here for Webpack to output ESM with dynamic imports
+# Modern builds target recent browsers supporting the latest features to minimize transpilation, polyfills,etc.
+# It is served to browsers meeting the following requirements:
+# - last 2 released + current alpha/beta versionss of all major browsers
+# - Firefox extended support release (ESR)
+# - browsers with global utilization above 0.5%
+# - must support dynamic import of ES modules
+# - exclude browsers no longer being maintained
+# - exclude KaiOS, QQ, and UC browsers due to lack of sufficient feature support data
+unreleased versions
+last 2 versions
+Firefox ESR
+> 0.5% and supports es6-module-dynamic-import
+not dead
 not KaiOS > 0
 not QQAndroid > 0
 not UCAndroid > 0
-
-# Exclude unsupported browsers
-not dead
 
 [legacy]
 # Legacy builds are served when modern requirements are not met and support browsers:

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,17 +1,15 @@
 [modern]
 # Modern builds target recent browsers supporting the latest features to minimize transpilation, polyfills,etc.
 # It is served to browsers meeting the following requirements:
-# - last 2 released + current alpha/beta versionss of all major browsers
+# - released in the last year + current alpha/beta versionss
 # - Firefox extended support release (ESR)
-# - released in the last year
 # - with global utilization at or above 0.5%
 # - must support dynamic import of ES modules
 # - exclude browsers no longer being maintained
 # - exclude KaiOS, QQ, and UC browsers due to lack of sufficient feature support data
 unreleased versions
-last 2 versions
-Firefox ESR
 last 1 year
+Firefox ESR
 >= 0.5% and supports es6-module-dynamic-import
 not dead
 not KaiOS > 0

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,7 +1,7 @@
 [modern]
-# Modern builds target recent browsers supporting the latest features to minimize transpilation, polyfills,etc.
+# Modern builds target recent browsers supporting the latest features to minimize transpilation, polyfills, etc.
 # It is served to browsers meeting the following requirements:
-# - released in the last year + current alpha/beta versionss
+# - released in the last year + current alpha/beta versions
 # - Firefox extended support release (ESR)
 # - with global utilization at or above 0.5%
 # - must support dynamic import of ES modules

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -4,7 +4,7 @@
 # - last 2 released + current alpha/beta versionss of all major browsers
 # - Firefox extended support release (ESR)
 # - released in the last year
-# - browsers with global utilization above 0.5%
+# - with global utilization at or above 0.5%
 # - must support dynamic import of ES modules
 # - exclude browsers no longer being maintained
 # - exclude KaiOS, QQ, and UC browsers due to lack of sufficient feature support data
@@ -12,7 +12,7 @@ unreleased versions
 last 2 versions
 Firefox ESR
 last 1 year
-> 0.5% and supports es6-module-dynamic-import
+>= 0.5% and supports es6-module-dynamic-import
 not dead
 not KaiOS > 0
 not QQAndroid > 0
@@ -21,7 +21,7 @@ not UCAndroid > 0
 [legacy]
 # Legacy builds are served when modern requirements are not met and support browsers:
 # - released in the last 7 years + current alpha/beta versionss
-# - with global utilization above 0.05%
+# - with global utilization at or above 0.05%
 # The lattermost query ensures that support for popular old browsers is not dropped too early
 # (e.g. IE 11, Android 4.4, or Samsung 4).
 #
@@ -35,10 +35,10 @@ not UCAndroid > 0
 # As of May 2023, only web sockets must be added to the query.
 unreleased versions
 last 7 years
-> 0.05% and supports websockets
+>= 0.05% and supports websockets
 
 [legacy-sw]
 # Same as legacy plus supports service workers
 unreleased versions
 last 7 years
-> 0.05% and supports websockets and supports serviceworkers
+>= 0.05% and supports websockets and supports serviceworkers

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -140,8 +140,13 @@ module.exports.babelOptions = ({
       "@babel/plugin-transform-runtime",
       { version: dependencies["@babel/runtime"] },
     ],
-    // Support  some proposals still in TC39 process
-    ["@babel/plugin-proposal-decorators", { decoratorsBeforeExport: true }],
+    // Transpile decorators (still in TC39 process)
+    // Modern browsers support class fields, but transform is required with the older decorator version dictated by Lit
+    [
+      "@babel/plugin-proposal-decorators",
+      { version: "2018-09", decoratorsBeforeExport: true },
+    ],
+    "@babel/plugin-proposal-class-properties",
   ].filter(Boolean),
   exclude: [
     // \\ for Windows, / for Mac OS and Linux

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -141,12 +141,13 @@ module.exports.babelOptions = ({
       { version: dependencies["@babel/runtime"] },
     ],
     // Transpile decorators (still in TC39 process)
-    // Modern browsers support class fields, but transform is required with the older decorator version dictated by Lit
+    // Modern browsers support class fields and private methods, but transform is required with the older decorator version dictated by Lit
     [
       "@babel/plugin-proposal-decorators",
       { version: "2018-09", decoratorsBeforeExport: true },
     ],
     "@babel/plugin-transform-class-properties",
+    "@babel/plugin-transform-private-methods",
   ].filter(Boolean),
   exclude: [
     // \\ for Windows, / for Mac OS and Linux

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -146,7 +146,7 @@ module.exports.babelOptions = ({
       "@babel/plugin-proposal-decorators",
       { version: "2018-09", decoratorsBeforeExport: true },
     ],
-    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-transform-class-properties",
   ].filter(Boolean),
   exclude: [
     // \\ for Windows, / for Mac OS and Linux

--- a/build-scripts/gulp/entry-html.js
+++ b/build-scripts/gulp/entry-html.js
@@ -21,6 +21,8 @@ const renderTemplate = (templateFile, data = {}) => {
     modernRegex: getUserAgentRegex({
       env: "modern",
       allowHigherVersions: true,
+      mobileToDesktop: true,
+      throwOnMissing: true,
     }).toString(),
     // Resolve any child/nested templates relative to the parent and pass the same data
     renderTemplate: (childTemplate) =>

--- a/build-scripts/gulp/entry-html.js
+++ b/build-scripts/gulp/entry-html.js
@@ -1,5 +1,6 @@
 // Tasks to generate entry HTML
 
+import { getUserAgentRegex } from "browserslist-useragent-regexp";
 import fs from "fs-extra";
 import gulp from "gulp";
 import { minify } from "html-minifier-terser";
@@ -17,6 +18,10 @@ const renderTemplate = (templateFile, data = {}) => {
     ...data,
     useRollup: env.useRollup(),
     useWDS: env.useWDS(),
+    modernRegex: getUserAgentRegex({
+      env: "modern",
+      allowHigherVersions: true,
+    }).toString(),
     // Resolve any child/nested templates relative to the parent and pass the same data
     renderTemplate: (childTemplate) =>
       renderTemplate(

--- a/cast/src/html/faq.html.template
+++ b/cast/src/html/faq.html.template
@@ -36,13 +36,7 @@
   </head>
   <body>
     <%= renderTemplate("../../../src/html/_js_base.html.template") %>
-    <script>
-      <% for (const entry of latestEntryJS) { %>
-        import("<%= entry %>");
-      <% } %>
-      window.latestJS = true;
-    </script>
-    <%= renderTemplate("../../../src/html/_script_load_es5.html.template") %>
+    <%= renderTemplate("../../../src/html/_script_loader.html.template") %>
     <hc-layout subtitle="FAQ">
       <style>
         a {

--- a/cast/src/html/index.html.template
+++ b/cast/src/html/index.html.template
@@ -13,15 +13,9 @@
     <%= renderTemplate("_social_meta.html.template") %>
   </head>
   <body>
-    <%= renderTemplate("../../../src/html/_js_base.html.template") %>
     <hc-connect></hc-connect>
-    <script>
-      <% for (const entry of latestEntryJS) { %>
-        import("<%= entry %>");
-      <% } %>
-      window.latestJS = true;
-    </script>
-    <%= renderTemplate("../../../src/html/_script_load_es5.html.template") %>
+    <%= renderTemplate("../../../src/html/_js_base.html.template") %>
+    <%= renderTemplate("../../../src/html/_script_loader.html.template") %>
     <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/cast/src/html/media.html.template
+++ b/cast/src/html/media.html.template
@@ -16,14 +16,8 @@
     </style>
   </head>
   <body>
-    <%= renderTemplate("../../../src/html/_js_base.html.template") %>
     <cast-media-player></cast-media-player>
-    <script>
-      <% for (const entry of latestEntryJS) { %>
-        import("<%= entry %>");
-      <% } %>
-      window.latestJS = true;
-    </script>
-    <%= renderTemplate("../../../src/html/_script_load_es5.html.template") %>
+    <%= renderTemplate("../../../src/html/_js_base.html.template") %>
+    <%= renderTemplate("../../../src/html/_script_loader.html.template") %>
   </body>
 </html>

--- a/demo/src/html/index.html.template
+++ b/demo/src/html/index.html.template
@@ -83,15 +83,6 @@
     <ha-demo></ha-demo>
     <%= renderTemplate("../../../src/html/_js_base.html.template") %>
     <%= renderTemplate("../../../src/html/_preload_roboto.html.template") %>
-    <script>
-      // Safari 12 and below does not have a compliant ES2015 implementation of template literals, so we ship ES5
-      if (!isS11_12) {
-        <% for (const entry of latestEntryJS) { %>
-          import("<%= entry %>");
-        <% } %>
-        window.latestJS = true;
-      }
-    </script>
-    <%= renderTemplate("../../../src/html/_script_load_es5.html.template") %>
+    <%= renderTemplate("../../../src/html/_script_loader.html.template") %>
   </body>
 </html>

--- a/hassio/src/entrypoint.js.template
+++ b/hassio/src/entrypoint.js.template
@@ -4,11 +4,7 @@
     el.src = src;
     document.body.appendChild(el);
   }
-  if (/.*Version\/(?:11|12)(?:\.\d+)*.*Safari\//.test(navigator.userAgent)) {
-    <% for (const entry of es5EntryJS) { %>
-      loadES5("<%= entry %>");
-    <% } %>
-  } else {
+  if (<%= modernRegex %>.test(navigator.userAgent)) {
     try {
         <% for (const entry of latestEntryJS) { %>
           new Function("import('<%= entry %>')")();
@@ -17,6 +13,10 @@
       <% for (const entry of es5EntryJS) { %>
         loadES5("<%= entry %>");
       <% } %>
+  } else {
+    <% for (const entry of es5EntryJS) { %>
+      loadES5("<%= entry %>");
+    <% } %>
   }
   }
 })();

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "@web/dev-server-rollup": "0.4.1",
     "babel-loader": "9.1.3",
     "babel-plugin-template-html-minifier": "4.1.0",
-    "browserslist-useragent-regexp": "4.1.0",
+    "browserslist-useragent-regexp": "4.1.3",
     "chai": "5.1.1",
     "del": "7.1.0",
     "eslint": "8.57.0",

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "@web/dev-server-rollup": "0.4.1",
     "babel-loader": "9.1.3",
     "babel-plugin-template-html-minifier": "4.1.0",
+    "browserslist-useragent-regexp": "4.1.0",
     "chai": "5.1.1",
     "del": "7.1.0",
     "eslint": "8.57.0",

--- a/src/html/_js_base.html.template
+++ b/src/html/_js_base.html.template
@@ -16,5 +16,9 @@
   ) {
     _ls("/static/polyfills/webcomponents-bundle.js", true);
   }
-  var isModern = <%= modernRegex %>.test(navigator.userAgent);
+  // Modern browsers are detected primarily using the user agent string.
+  // A feature detection which roughly lines up with the modern targets is used
+  // as a fallback to guard against spoofs. It should be updated periodically.
+  var isModern = <%= modernRegex %>.test(navigator.userAgent) &&
+    "findLast" in Array.prototype;
 </script>

--- a/src/html/_js_base.html.template
+++ b/src/html/_js_base.html.template
@@ -16,8 +16,5 @@
   ) {
     _ls("/static/polyfills/webcomponents-bundle.js", true);
   }
-  var isS11_12 =
-    /(?:.*(?:iPhone|iPad).*OS (?:11|12)_\d)|(?:.*Version\/(?:11|12)(?:\.\d+)*.*Safari\/)/.test(
-      navigator.userAgent
-    );
+  var isModern = <%= modernRegex %>.test(navigator.userAgent);
 </script>

--- a/src/html/_script_loader.html.template
+++ b/src/html/_script_loader.html.template
@@ -1,3 +1,11 @@
+<script <% if (!useWDS) { %>crossorigin="use-credentials"<% } %>>
+  if (isModern) {
+    <% for (const entry of latestEntryJS) { %>
+      import("<%= entry %>");
+    <% } %>
+    window.latestJS = true;
+  }
+</script>
 <script>
   (function() {
     if (!window.latestJS) {

--- a/src/html/authorize.html.template
+++ b/src/html/authorize.html.template
@@ -52,18 +52,13 @@
     </div>
     <%= renderTemplate("_js_base.html.template") %>
     <%= renderTemplate("_preload_roboto.html.template") %>
+    <%= renderTemplate("_script_loader.html.template") %>
     <script crossorigin="use-credentials">
-      // Safari 12 and below does not have a compliant ES2015 implementation of template literals, so we ship ES5
-      if (!isS11_12) {
-        <% for (const entry of latestEntryJS) { %>
-          import("<%= entry %>");
-        <% } %>
-        window.latestJS = true;
+      if (window.latestJS) {
         window.providersPromise = fetch("/auth/providers", {
           credentials: "same-origin",
         });
       }
     </script>
-    <%= renderTemplate("_script_load_es5.html.template") %>
   </body>
 </html>

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -60,8 +60,7 @@
     <%= renderTemplate("_js_base.html.template") %>
     <%= renderTemplate("_preload_roboto.html.template") %>
     <script <% if (!useWDS) { %>crossorigin="use-credentials"<% } %>>
-      // Safari 12 and below does not have a compliant ES2015 implementation of template literals, so we ship ES5
-      if (!isS11_12) {
+      if (isModern) {
         <% for (const entry of latestEntryJS) { %>
           import("<%= entry %>");
         <% } %>

--- a/src/html/onboarding.html.template
+++ b/src/html/onboarding.html.template
@@ -48,18 +48,13 @@
     </div>
     <%= renderTemplate("_js_base.html.template") %>
     <%= renderTemplate("_preload_roboto.html.template") %>
+    <%= renderTemplate("_script_loader.html.template") %>
     <script crossorigin="use-credentials">
-      // Safari 12 and below does not have a compliant ES2015 implementation of template literals, so we ship ES5
-      if (!isS11_12) {
-        <% for (const entry of latestEntryJS) { %>
-          import("<%= entry %>");
-        <% } %>
-        window.latestJS = true;
+      if (window.latestJS) {
         window.stepsPromise = fetch("/api/onboarding", {
           credentials: "same-origin",
         });
       }
     </script>
-    <%= renderTemplate("_script_load_es5.html.template") %>
   </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6058,21 +6058,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist-useragent-regexp@npm:4.1.0":
-  version: 4.1.0
-  resolution: "browserslist-useragent-regexp@npm:4.1.0"
+"browserslist-useragent-regexp@npm:4.1.3":
+  version: 4.1.3
+  resolution: "browserslist-useragent-regexp@npm:4.1.3"
   dependencies:
     argue-cli: "npm:^2.1.0"
-    easy-table: "npm:^1.1.1"
+    easy-table: "npm:^1.2.0"
     picocolors: "npm:^1.0.0"
     regexp-tree: "npm:^0.1.24"
-    ua-regexes-lite: "npm:^1.1.3"
+    ua-regexes-lite: "npm:^1.2.1"
   peerDependencies:
     browserslist: ">=4.0.0"
   bin:
     bluare: dist/cli.js
     browserslist-useragent-regexp: dist/cli.js
-  checksum: 10/ab777e63928ebbff895e9f523c42f4a1c80fdff0385c6fa87ef7ba024f3e563d7e553dc7b4abb4cd46f88e6f15af1b62c95e7274e21ab9e52221326269dfe53f
+  checksum: 10/f774feb5a766a0b2469c38b5a9f257213375ce106b7d50640ee529cea9c17b91da0f55c4f029fd1e075c8b846fa38cee6feb5620ea1a09f099bb0da61a7950eb
   languageName: node
   linkType: hard
 
@@ -7198,7 +7198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"easy-table@npm:^1.1.1":
+"easy-table@npm:^1.2.0":
   version: 1.2.0
   resolution: "easy-table@npm:1.2.0"
   dependencies:
@@ -9055,7 +9055,7 @@ __metadata:
     app-datepicker: "npm:5.1.1"
     babel-loader: "npm:9.1.3"
     babel-plugin-template-html-minifier: "npm:4.1.0"
-    browserslist-useragent-regexp: "npm:4.1.0"
+    browserslist-useragent-regexp: "npm:4.1.3"
     chai: "npm:5.1.1"
     chart.js: "npm:4.4.3"
     color-name: "npm:2.0.0"
@@ -14374,10 +14374,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ua-regexes-lite@npm:^1.1.3":
-  version: 1.1.4
-  resolution: "ua-regexes-lite@npm:1.1.4"
-  checksum: 10/c7a746cb6171ed898eb303b903f9cc813a0d52759b80b9d2fa6d3e1ca63f739d302d7de39179df8d512f6ed03ec5299779bbb1fb05127f712eb7974febb8fef8
+"ua-regexes-lite@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "ua-regexes-lite@npm:1.2.1"
+  checksum: 10/3545a3bd0bedc5a66912b5ba8248a230f0f31f6f6446dd0fa83f7bf77a5e9b206122ab30a8c4b1150bb5ffe5407da8d3b7a557adfa542c0af6bae5ebd77dd703
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5605,6 +5605,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"argue-cli@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "argue-cli@npm:2.1.0"
+  checksum: 10/0b300fa171895ad8856513a29320ff3db729637f0dcf0ff2e67a2991190d69d3eb08bc9318956e4bae42b0b6e2c8761b6929364c24640cadd12b5f04a4328a06
+  languageName: node
+  linkType: hard
+
 "aria-query@npm:^5.1.3":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
@@ -6048,6 +6055,24 @@ __metadata:
   version: 1.3.1
   resolution: "browser-stdout@npm:1.3.1"
   checksum: 10/ac70a84e346bb7afc5045ec6f22f6a681b15a4057447d4cc1c48a25c6dedb302a49a46dd4ddfb5cdd9c96e0c905a8539be1b98ae7bc440512152967009ec7015
+  languageName: node
+  linkType: hard
+
+"browserslist-useragent-regexp@npm:4.1.0":
+  version: 4.1.0
+  resolution: "browserslist-useragent-regexp@npm:4.1.0"
+  dependencies:
+    argue-cli: "npm:^2.1.0"
+    easy-table: "npm:^1.1.1"
+    picocolors: "npm:^1.0.0"
+    regexp-tree: "npm:^0.1.24"
+    ua-regexes-lite: "npm:^1.1.3"
+  peerDependencies:
+    browserslist: ">=4.0.0"
+  bin:
+    bluare: dist/cli.js
+    browserslist-useragent-regexp: dist/cli.js
+  checksum: 10/ab777e63928ebbff895e9f523c42f4a1c80fdff0385c6fa87ef7ba024f3e563d7e553dc7b4abb4cd46f88e6f15af1b62c95e7274e21ab9e52221326269dfe53f
   languageName: node
   linkType: hard
 
@@ -6950,7 +6975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"defaults@npm:^1.0.4":
+"defaults@npm:^1.0.3, defaults@npm:^1.0.4":
   version: 1.0.4
   resolution: "defaults@npm:1.0.4"
   dependencies:
@@ -7170,6 +7195,19 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 10/9b1d3e1baefeaf7d70799db8774149cef33b97183a6addceeba0cf6b85ba23ee2686f302f14482006df32df75d32b17c509c143a3689627929e4a8efaf483952
+  languageName: node
+  linkType: hard
+
+"easy-table@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "easy-table@npm:1.2.0"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    wcwidth: "npm:^1.0.1"
+  dependenciesMeta:
+    wcwidth:
+      optional: true
+  checksum: 10/0d1be7cd9419cd1b56ca5a978646b3cff241ccd8cf95bdb2742f36854084b3aef2e9af6ec14142855aa80e4cab1f4baad0f610a99c77509f23676b8330730177
   languageName: node
   linkType: hard
 
@@ -9017,6 +9055,7 @@ __metadata:
     app-datepicker: "npm:5.1.1"
     babel-loader: "npm:9.1.3"
     babel-plugin-template-html-minifier: "npm:4.1.0"
+    browserslist-useragent-regexp: "npm:4.1.0"
     chai: "npm:5.1.1"
     chart.js: "npm:4.4.3"
     color-name: "npm:2.0.0"
@@ -12435,6 +12474,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexp-tree@npm:^0.1.24":
+  version: 0.1.27
+  resolution: "regexp-tree@npm:0.1.27"
+  bin:
+    regexp-tree: bin/regexp-tree
+  checksum: 10/08c70c8adb5a0d4af1061bf9eb05d3b6e1d948c433d6b7008e4b5eb12a49429c2d6ca8e9106339a432aa0d07bd6e1bccc638d8f4ab0d045f3adad22182b300a2
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.5.2":
   version: 1.5.2
   resolution: "regexp.prototype.flags@npm:1.5.2"
@@ -14326,6 +14374,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ua-regexes-lite@npm:^1.1.3":
+  version: 1.1.4
+  resolution: "ua-regexes-lite@npm:1.1.4"
+  checksum: 10/c7a746cb6171ed898eb303b903f9cc813a0d52759b80b9d2fa6d3e1ca63f739d302d7de39179df8d512f6ed03ec5299779bbb1fb05127f712eb7974febb8fef8
+  languageName: node
+  linkType: hard
+
 "unbox-primitive@npm:^1.0.2":
   version: 1.0.2
   resolution: "unbox-primitive@npm:1.0.2"
@@ -14741,6 +14796,15 @@ __metadata:
   dependencies:
     minimalistic-assert: "npm:^1.0.0"
   checksum: 10/c18b51c4e1fb19705c94b93c0cf093ba014606abceee949399d56074ef1863bf4897a8d884be24e8d224d18c9ce411cf6924006d0a5430492729af51256e067a
+  languageName: node
+  linkType: hard
+
+"wcwidth@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "wcwidth@npm:1.0.1"
+  dependencies:
+    defaults: "npm:^1.0.3"
+  checksum: 10/182ebac8ca0b96845fae6ef44afd4619df6987fe5cf552fdee8396d3daa1fb9b8ec5c6c69855acb7b3c1231571393bd1f0a4cdc4028d421575348f64bb0a8817
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Browser requirements for serving modern (latest) builds of the frontend have been updated to include only those released in the last year or those still having high global utilization above 0.5%.  As before, legacy builds will be served whenever modern requirements are not met.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change implements a new and more practical way to decipher between "modern" and "legacy" browsers by:
1. Redefining the `browserslist` query to be more practical and evolve to always grab the most recent/utilized browser versions.  This does for the modern builds what #16384 did for legacy.
2. Generates a regex to match those browsers and uses it to decide which build to serve.  The `import()` syntax test is kept for simplicity of these changes and as a backup for now, but I think it can be safely eliminated in order to consolidate and simplify the loading code in a future PR.

This does turn off most of Babel's transforms, but only reduces the bundle by about 1%.  Of course that doesn't account for the fact that the current dynamic import test technically includes some pretty old browsers that should have a bunch of polyfills, so not really a fair comparison.  Also, a not-so-modest reduction might be obtained by not having to transpile class fields, but Lit's decorators are still on the stage 2 spec.

Lastly, I did try to consolidate more code in the templates.  The exception was the app index because of its special treatment, but I can fix that in a follow up.

New requirements as of today would be at least _(updated to reflect changes from discussion below)_:

| Browser | Legacy | Current Modern | New Modern |
|:---:|:---:|:---:|:---:|
| Android | 60 | 63 | 115 |
| Chrome | 60 | 63 | 109 |
| Edge | 16 | 79 | 115 |
| Firefox | 52 | 67 | 115 |
| iOS | 10.3 | 13 | 15.6 |
| Safari | 11 | 13 | 16.6 |
| Opera | 47 | 50 | 101 |
| Opera Mobile\* | - | 80 | 80 |
| Samsung | 4 | 8.2 | 22 |

\* = only latest version due to limitations of CanIUse database

<details>
<summary><h4>Modern Build Babel Plugins</h4></summary>

@babel/preset-env: `DEBUG` option

Using targets:
{
  "android": "115",
  "chrome": "109",
  "edge": "115",
  "firefox": "115",
  "ios": "15.6",
  "opera": "101",
  "opera_mobile": "80",
  "safari": "16.6",
  "samsung": "22"
}

Using modules transform: auto

Using plugins:
  transform-unicode-sets-regex { chrome < 112, firefox < 116, ios < 17, safari < 17, samsung }
  bugfix/transform-firefox-class-in-computed-class-key { firefox }
  proposal-class-static-block { ios < 16.4 }
  syntax-private-property-in-object
  syntax-class-properties
  syntax-numeric-separator
  syntax-nullish-coalescing-operator
  syntax-optional-chaining
  syntax-json-strings
  syntax-optional-catch-binding
  syntax-async-generators
  syntax-object-rest-spread
  syntax-export-namespace-from
  bugfix/transform-safari-id-destructuring-collision-in-function-expression { ios < 16.3 }
  syntax-dynamic-import
  syntax-top-level-await
  syntax-import-meta
  syntax-import-attributes
</details>

<details>
<summary><h4>Modern Build Core-JS Polyfills</h4></summary>

The following 56 polyfills may be injected by Babel:

  es.array.push { android < 122, chrome < 122, edge < 122, ios < 16.0, opera < 108, opera_mobile < 81, samsung < 26.0 }
  es.array.to-reversed { chrome < 110, ios < 16.0 }
  es.array.to-sorted { chrome < 110, ios < 16.0 }
  es.array.to-spliced { chrome < 110, ios < 16.0 }
  es.array.unshift { ios < 16.0 }
  es.array.with { chrome < 110, ios < 16.0 }
  es.array-buffer.detached { chrome < 114, firefox < 122, ios < 17.4, safari < 17.4, samsung < 23.0 }
  es.array-buffer.transfer { chrome < 114, firefox < 122, ios < 17.4, safari < 17.4, samsung < 23.0 }
  es.array-buffer.transfer-to-fixed-length { chrome < 114, firefox < 122, ios < 17.4, safari < 17.4, samsung < 23.0 }
  es.map.group-by { android < 117, chrome < 117, edge < 117, firefox < 119, ios, opera < 103, safari, samsung < 24.0 }
  es.object.group-by { android < 117, chrome < 117, edge < 117, firefox < 119, ios, opera < 103, safari, samsung < 24.0 }
  es.promise.with-resolvers { android < 119, chrome < 119, edge < 119, firefox < 121, ios < 17.4, opera < 105, safari < 17.4, samsung < 25.0 }
  es.regexp.flags { chrome < 111 }
  es.set.difference.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.intersection.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.is-disjoint-from.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.is-subset-of.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.is-superset-of.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.symmetric-difference.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.union.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.string.is-well-formed { chrome < 111, firefox < 119, ios < 16.4 }
  es.string.to-well-formed { chrome < 111, firefox < 119, ios < 16.4 }
  es.typed-array.to-reversed { chrome < 110, ios < 16.0 }
  es.typed-array.to-sorted { chrome < 110, ios < 16.0 }
  es.typed-array.with { chrome < 110, ios < 16.4 }
  esnext.suppressed-error.constructor { android, chrome, edge, firefox, ios, opera, opera_mobile, safari, samsung }
  esnext.array.from-async { android < 121, chrome < 121, edge < 121, ios, opera < 107, opera_mobile < 81, safari, samsung < 25.0 }
  esnext.array.group { android, chrome, edge, firefox, ios, opera, opera_mobile, safari, samsung }
  esnext.array.group-to-map { android, chrome, edge, firefox, ios, opera, opera_mobile, safari, samsung }
  esnext.iterator.constructor { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.drop { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.every { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.filter { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.find { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.flat-map { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.for-each { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.from { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.map { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.reduce { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.some { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.take { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.to-array { android < 122, chrome < 122, edge < 122, firefox, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.json.is-raw-json { chrome < 114, firefox, ios, safari, samsung < 23.0 }
  esnext.json.parse { chrome < 114, firefox, ios, safari, samsung < 23.0 }
  esnext.json.raw-json { chrome < 114, firefox, ios, safari, samsung < 23.0 }
  esnext.symbol.async-dispose { android, chrome, edge, firefox, ios, opera, opera_mobile, safari, samsung }
  esnext.symbol.dispose { android < 125, chrome < 125, edge < 125, firefox, ios, opera < 111, opera_mobile, safari, samsung }
  esnext.symbol.metadata { android, chrome, edge, firefox, ios, opera, opera_mobile, safari, samsung }
  web.dom-exception.stack { android, chrome, edge, ios, opera, opera_mobile, safari, samsung }
  web.immediate { android, chrome, edge, firefox, ios, opera, opera_mobile, safari, samsung }
  web.structured-clone { android, chrome, edge, firefox, ios, opera, opera_mobile, safari, samsung }
  web.url.can-parse { android < 120, chrome < 120, edge < 120, ios < 17.0, opera < 106, safari < 17.0, samsung < 25.0 }
  web.url.parse { android < 126, chrome < 126, edge < 126, firefox < 126, ios, opera < 112, opera_mobile, safari, samsung }
  web.url-search-params.delete { android < 118, chrome < 118, edge < 118, ios < 17.0, opera < 104, safari < 17.0, samsung < 25.0 }
  web.url-search-params.has { android < 118, chrome < 118, edge < 118, ios < 17.0, opera < 104, safari < 17.0, samsung < 25.0 }
  web.url-search-params.size { chrome < 113, ios < 17.0, safari < 17.0, samsung < 23.0 }
</details>

<details>
<summary><h4>Legacy Build Babel Plugins</h4></summary>

@babel/preset-env: `DEBUG` option

Using targets:
{
  "android": "60",
  "chrome": "60",
  "edge": "16",
  "firefox": "52",
  "ie": "11",
  "ios": "10.3",
  "opera": "47",
  "opera_mobile": "80",
  "safari": "11",
  "samsung": "4"
}

Using modules transform: auto

Using plugins:
  transform-unicode-sets-regex { android, chrome < 112, edge < 112, firefox < 116, ie, ios < 17, opera < 98, safari < 17, samsung }
  proposal-class-static-block { android, chrome < 94, edge < 94, firefox < 93, ie, ios < 16.4, opera < 80, safari < 16.4, samsung < 17 }
  proposal-private-property-in-object { android, chrome < 91, edge < 91, firefox < 90, ie, ios < 15, opera < 77, safari < 15, samsung < 16 }
  proposal-class-properties { android, chrome < 74, edge < 79, firefox < 90, ie, ios < 14.5, opera < 62, safari < 14.1, samsung < 11 }
  proposal-private-methods { android, chrome < 84, edge < 84, firefox < 90, ie, ios < 15, opera < 70, safari < 15, samsung < 14 }
  proposal-numeric-separator { android, chrome < 75, edge < 79, firefox < 70, ie, ios < 13, opera < 62, safari < 13, samsung < 11 }
  proposal-logical-assignment-operators { android, chrome < 85, edge < 85, firefox < 79, ie, ios < 14, opera < 71, safari < 14, samsung < 14 }
  proposal-nullish-coalescing-operator { android, chrome < 80, edge < 80, firefox < 72, ie, ios < 13.4, opera < 67, safari < 13.1, samsung < 13 }
  proposal-optional-chaining { android, chrome < 80, edge < 80, firefox < 74, ie, ios < 13.4, opera < 67, safari < 13.1, samsung < 13 }
  proposal-json-strings { android, chrome < 66, edge < 79, firefox < 62, ie, ios < 12, opera < 53, safari < 12, samsung < 9 }
  proposal-optional-catch-binding { android, chrome < 66, edge < 79, firefox < 58, ie, ios < 11.3, opera < 53, safari < 11.1, samsung < 9 }
  transform-parameters { firefox < 53, ie, samsung < 5 }
  proposal-async-generator-functions { android, chrome < 63, edge < 79, firefox < 57, ie, ios < 12, opera < 50, safari < 12, samsung < 8 }
  proposal-object-rest-spread { edge < 79, firefox < 55, ie, ios < 11.3, safari < 11.1, samsung < 8 }
  transform-dotall-regex { android, chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, opera < 49, safari < 11.1, samsung < 8 }
  proposal-unicode-property-regex { android, chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
  transform-named-capturing-groups-regex { android, chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, opera < 51, safari < 11.1, samsung < 9 }
  transform-async-to-generator { ie, samsung < 6 }
  transform-exponentiation-operator { ie, samsung < 6 }
  transform-template-literals { ie }
  transform-literals { firefox < 53, ie }
  transform-function-name { firefox < 53, ie, samsung < 5 }
  transform-arrow-functions { ie, samsung < 5 }
  transform-classes { ie, samsung < 5 }
  transform-object-super { ie, samsung < 5 }
  transform-shorthand-properties { ie }
  transform-duplicate-keys { ie }
  transform-computed-properties { ie }
  transform-for-of { firefox < 53, ie, samsung < 5 }
  transform-sticky-regex { ie, samsung < 5 }
  transform-unicode-escapes { firefox < 53, ie }
  transform-unicode-regex { ie, ios < 12, safari < 12, samsung < 5 }
  transform-spread { ie, samsung < 5 }
  transform-destructuring { firefox < 53, ie, samsung < 5 }
  transform-block-scoping { firefox < 53, ie, samsung < 5 }
  transform-typeof-symbol { ie }
  transform-new-target { ie, samsung < 5 }
  transform-regenerator { firefox < 53, ie, samsung < 5 }
  proposal-export-namespace-from { android < 72, chrome < 72, edge < 79, firefox < 80, ie, ios < 14.5, opera < 60, safari < 14.1, samsung < 11.0 }
  syntax-dynamic-import
  syntax-top-level-await
  syntax-import-meta
  syntax-import-attributes
</details>

<details>
<summary><h4>Legacy Build Core-JS Polyfills</h4></summary>

The following 273 polyfills may be injected by Babel:

  es.symbol { ie, samsung < 5.0 }
  es.symbol.description { android < 70, chrome < 70, edge < 79, firefox < 63, ie, ios < 12.2, opera < 57, safari < 12.1, samsung < 10.0 }
  es.symbol.async-iterator { android < 63, chrome < 63, edge < 79, firefox < 55, ie, ios < 12.0, opera < 50, safari < 12.0, samsung < 8.0 }
  es.symbol.has-instance { ie, samsung < 5.0 }
  es.symbol.is-concat-spreadable { ie, samsung < 5.0 }
  es.symbol.iterator { ie }
  es.symbol.match { edge < 79, ie, samsung < 5.0 }
  es.symbol.match-all { android < 73, chrome < 73, edge < 79, firefox < 67, ie, ios < 13.0, opera < 60, safari < 13, samsung < 11.0 }
  es.symbol.replace { edge < 79, ie, samsung < 5.0 }
  es.symbol.search { edge < 79, ie, samsung < 5.0 }
  es.symbol.species { ie, samsung < 5.0 }
  es.symbol.split { edge < 79, ie, samsung < 5.0 }
  es.symbol.to-primitive { ie, samsung < 5.0 }
  es.symbol.to-string-tag { ie, samsung < 5.0 }
  es.symbol.unscopables { ie }
  es.error.cause { android < 94, chrome < 94, edge < 94, firefox < 91, ie, ios < 15.0, opera < 80, safari < 15.0, samsung < 17.0 }
  es.aggregate-error { android < 85, chrome < 85, edge < 85, firefox < 79, ie, ios < 14.0, opera < 71, safari < 14.0, samsung < 14.0 }
  es.aggregate-error.cause { android < 94, chrome < 94, edge < 94, firefox < 91, ie, ios < 15.0, opera < 80, safari < 15.0, samsung < 17.0 }
  es.array.at { android < 92, chrome < 92, edge < 92, firefox < 90, ie, ios < 15.4, opera < 78, safari < 15.4, samsung < 16.0 }
  es.array.concat { ie, samsung < 5.0 }
  es.array.copy-within { ie, samsung < 5.0 }
  es.array.fill { ie, samsung < 5.0 }
  es.array.filter { ie, samsung < 5.0 }
  es.array.find { ie, samsung < 5.0 }
  es.array.find-index { ie, samsung < 5.0 }
  es.array.find-last { android < 97, chrome < 97, edge < 97, firefox < 104, ie, ios < 15.4, opera < 83, safari < 15.4, samsung < 18.0 }
  es.array.find-last-index { android < 97, chrome < 97, edge < 97, firefox < 104, ie, ios < 15.4, opera < 83, safari < 15.4, samsung < 18.0 }
  es.array.flat { android < 69, chrome < 69, edge < 79, firefox < 62, ie, ios < 12.0, opera < 56, safari < 12.0, samsung < 10.0 }
  es.array.flat-map { android < 69, chrome < 69, edge < 79, firefox < 62, ie, ios < 12.0, opera < 56, safari < 12.0, samsung < 10.0 }
  es.array.from { firefox < 53, ie, samsung < 5.0 }
  es.array.includes { firefox < 102, ie, samsung < 6.0 }
  es.array.index-of { samsung < 5.0 }
  es.array.iterator { android < 66, chrome < 66, firefox < 60, ie, opera < 53, samsung < 9.0 }
  es.array.join { ie }
  es.array.last-index-of { samsung < 5.0 }
  es.array.map { ie, samsung < 5.0 }
  es.array.of { ie, samsung < 5.0 }
  es.array.push { android < 122, chrome < 122, edge < 122, firefox < 55, ie, ios < 16.0, opera < 108, opera_mobile < 81, safari < 16.0, samsung < 26.0 }
  es.array.reduce { android < 83, chrome < 83, opera < 69, samsung < 13.0 }
  es.array.reduce-right { android < 83, chrome < 83, opera < 69, samsung < 13.0 }
  es.array.reverse { ios < 12.2, safari < 12.0.2 }
  es.array.slice { ie, samsung < 5.0 }
  es.array.sort { android < 70, chrome < 70, edge < 79, ie, ios < 12.0, opera < 57, safari < 12.0, samsung < 10.0 }
  es.array.species { ie, samsung < 5.0 }
  es.array.splice { ie, samsung < 5.0 }
  es.array.to-reversed { android < 110, chrome < 110, edge < 110, firefox < 115, ie, ios < 16.0, opera < 96, safari < 16.0, samsung < 21.0 }
  es.array.to-sorted { android < 110, chrome < 110, edge < 110, firefox < 115, ie, ios < 16.0, opera < 96, safari < 16.0, samsung < 21.0 }
  es.array.to-spliced { android < 110, chrome < 110, edge < 110, firefox < 115, ie, ios < 16.0, opera < 96, safari < 16.0, samsung < 21.0 }
  es.array.unscopables.flat { android < 73, chrome < 73, edge < 79, firefox < 67, ie, ios < 13.0, opera < 60, safari < 13, samsung < 11.0 }
  es.array.unscopables.flat-map { android < 73, chrome < 73, edge < 79, firefox < 67, ie, ios < 13.0, opera < 60, safari < 13, samsung < 11.0 }
  es.array.unshift { android < 71, chrome < 71, ios < 16.0, opera < 58, safari < 16.0, samsung < 10.0 }
  es.array.with { android < 110, chrome < 110, edge < 110, firefox < 115, ie, ios < 16.0, opera < 96, safari < 16.0, samsung < 21.0 }
  es.array-buffer.constructor { ie, ios < 12.0, safari < 12.0 }
  es.array-buffer.slice { ios < 12.2, safari < 12.1 }
  es.array-buffer.detached { android < 114, chrome < 114, edge < 114, firefox < 122, ie, ios < 17.4, opera < 100, safari < 17.4, samsung < 23.0 }
  es.array-buffer.transfer { android < 114, chrome < 114, edge < 114, firefox < 122, ie, ios < 17.4, opera < 100, safari < 17.4, samsung < 23.0 }
  es.array-buffer.transfer-to-fixed-length { android < 114, chrome < 114, edge < 114, firefox < 122, ie, ios < 17.4, opera < 100, safari < 17.4, samsung < 23.0 }
  es.date.to-primitive { ie, samsung < 5.0 }
  es.function.has-instance { ie, samsung < 5.0 }
  es.function.name { ie }
  es.global-this { android < 71, chrome < 71, edge < 79, firefox < 65, ie, ios < 12.2, opera < 58, safari < 12.1, samsung < 10.0 }
  es.json.stringify { android < 72, chrome < 72, edge < 79, firefox < 64, ie, ios < 12.2, opera < 59, safari < 12.1, samsung < 11.0 }
  es.json.to-string-tag { ie, samsung < 5.0 }
  es.map { firefox < 53, ie, samsung < 5.0 }
  es.map.group-by { android < 117, chrome < 117, edge < 117, firefox < 119, ie, ios, opera < 103, safari, samsung < 24.0 }
  es.math.acosh { ie, samsung < 6.0 }
  es.math.asinh { ie }
  es.math.atanh { ie }
  es.math.cbrt { ie }
  es.math.clz32 { ie }
  es.math.cosh { ie }
  es.math.expm1 { ie }
  es.math.fround { ie }
  es.math.hypot { android < 78, chrome < 78, ie, opera < 65, samsung < 12.0 }
  es.math.imul { ie }
  es.math.log10 { ie }
  es.math.log1p { ie }
  es.math.log2 { ie }
  es.math.sign { ie }
  es.math.sinh { ie }
  es.math.tanh { ie }
  es.math.to-string-tag { ie, samsung < 5.0 }
  es.math.trunc { ie }
  es.number.constructor { ie }
  es.number.epsilon { ie }
  es.number.is-finite { ie }
  es.number.is-integer { ie }
  es.number.is-nan { ie }
  es.number.is-safe-integer { ie }
  es.number.max-safe-integer { ie }
  es.number.min-safe-integer { ie }
  es.number.parse-float { edge < 79, ie, ios < 11.0 }
  es.number.parse-int { edge < 79, ie }
  es.number.to-exponential { edge < 18, firefox < 87, ie, ios < 11.0, samsung < 5.0 }
  es.number.to-fixed { edge < 79, ie }
  es.object.assign { edge < 79, ie, samsung < 5.0 }
  es.object.define-getter { android < 62, chrome < 62, ie, opera < 49, samsung < 8.0 }
  es.object.define-setter { android < 62, chrome < 62, ie, opera < 49, samsung < 8.0 }
  es.object.entries { ie, samsung < 6.0 }
  es.object.freeze { ie }
  es.object.from-entries { android < 73, chrome < 73, edge < 79, firefox < 63, ie, ios < 12.2, opera < 60, safari < 12.1, samsung < 11.0 }
  es.object.get-own-property-descriptor { ie }
  es.object.get-own-property-descriptors { ie, samsung < 6.0 }
  es.object.get-own-property-names { ie }
  es.object.get-prototype-of { ie }
  es.object.group-by { android < 117, chrome < 117, edge < 117, firefox < 119, ie, ios, opera < 103, safari, samsung < 24.0 }
  es.object.has-own { android < 93, chrome < 93, edge < 93, firefox < 92, ie, ios < 15.4, opera < 79, safari < 15.4, samsung < 17.0 }
  es.object.is { ie }
  es.object.is-extensible { ie }
  es.object.is-frozen { ie }
  es.object.is-sealed { ie }
  es.object.keys { ie }
  es.object.lookup-getter { android < 62, chrome < 62, ie, opera < 49, samsung < 8.0 }
  es.object.lookup-setter { android < 62, chrome < 62, ie, opera < 49, samsung < 8.0 }
  es.object.prevent-extensions { ie }
  es.object.seal { ie }
  es.object.to-string { ie, samsung < 5.0 }
  es.object.values { ie, samsung < 6.0 }
  es.parse-float { edge < 74 }
  es.parse-int { edge < 74 }
  es.promise { android < 67, chrome < 67, edge < 79, firefox < 69, ie, ios < 11.0, opera < 54, samsung < 9.0 }
  es.promise.all-settled { android < 76, chrome < 76, edge < 79, firefox < 71, ie, ios < 13.0, opera < 63, safari < 13, samsung < 12.0 }
  es.promise.any { android < 85, chrome < 85, edge < 85, firefox < 79, ie, ios < 14.0, opera < 71, safari < 14.0, samsung < 14.0 }
  es.promise.finally { android < 67, chrome < 67, edge < 79, firefox < 69, ie, ios < 13.2.3, opera < 54, safari < 13.0.3, samsung < 9.0 }
  es.promise.with-resolvers { android < 119, chrome < 119, edge < 119, firefox < 121, ie, ios < 17.4, opera < 105, safari < 17.4, samsung < 25.0 }
  es.reflect.apply { ie, samsung < 5.0 }
  es.reflect.construct { ie, samsung < 5.0 }
  es.reflect.define-property { ie, samsung < 5.0 }
  es.reflect.delete-property { ie, samsung < 5.0 }
  es.reflect.get { ie, samsung < 5.0 }
  es.reflect.get-own-property-descriptor { ie, samsung < 5.0 }
  es.reflect.get-prototype-of { ie, samsung < 5.0 }
  es.reflect.has { ie, samsung < 5.0 }
  es.reflect.is-extensible { ie, samsung < 5.0 }
  es.reflect.own-keys { ie, samsung < 5.0 }
  es.reflect.prevent-extensions { ie, samsung < 5.0 }
  es.reflect.set { edge < 79, ie, samsung < 5.0 }
  es.reflect.set-prototype-of { ie, samsung < 5.0 }
  es.reflect.to-string-tag { android < 86, chrome < 86, edge < 86, firefox < 82, ie, ios < 14.0, opera < 72, safari < 14.0, samsung < 14.0 }
  es.regexp.constructor { android < 64, chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, opera < 51, safari < 11.1, samsung < 9.0 }
  es.regexp.dot-all { android < 62, chrome < 62, edge < 79, firefox < 78, ie, ios < 11.3, opera < 49, safari < 11.1, samsung < 8.0 }
  es.regexp.exec { android < 64, chrome < 64, edge < 79, firefox < 78, ie, ios < 11.3, opera < 51, safari < 11.1, samsung < 9.0 }
  es.regexp.flags { android < 111, chrome < 111, edge < 111, firefox < 78, ie, ios < 11.3, opera < 97, safari < 11.1, samsung < 22.0 }
  es.regexp.sticky { ie, samsung < 5.0 }
  es.regexp.test { edge < 79, ie, samsung < 5.0 }
  es.regexp.to-string { edge < 79, ie, samsung < 5.0 }
  es.set { firefox < 53, ie, samsung < 5.0 }
  es.set.difference.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ie, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.intersection.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ie, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.is-disjoint-from.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ie, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.is-subset-of.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ie, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.is-superset-of.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ie, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.symmetric-difference.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ie, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.set.union.v2 { android < 123, chrome < 123, edge < 123, firefox < 127, ie, ios, opera < 109, opera_mobile < 82, safari, samsung }
  es.string.at-alternative { android < 92, chrome < 92, edge < 92, firefox < 90, ie, ios < 15.4, opera < 78, safari < 15.4, samsung < 16.0 }
  es.string.code-point-at { ie }
  es.string.ends-with { edge < 79, ie, samsung < 5.0 }
  es.string.from-code-point { ie }
  es.string.includes { edge < 79, ie, samsung < 5.0 }
  es.string.is-well-formed { android < 111, chrome < 111, edge < 111, firefox < 119, ie, ios < 16.4, opera < 97, safari < 16.4, samsung < 22.0 }
  es.string.iterator { ie }
  es.string.match { edge < 79, ie, samsung < 5.0 }
  es.string.match-all { android < 80, chrome < 80, edge < 80, firefox < 73, ie, ios < 13.4, opera < 67, safari < 13.1, samsung < 13.0 }
  es.string.pad-end { ie, ios < 11.0, samsung < 7.0 }
  es.string.pad-start { ie, ios < 11.0, samsung < 7.0 }
  es.string.raw { ie }
  es.string.repeat { ie }
  es.string.replace { android < 64, chrome < 64, edge < 79, firefox < 78, ie, ios < 14.0, opera < 51, safari < 14.0, samsung < 9.0 }
  es.string.replace-all { android < 85, chrome < 85, edge < 85, firefox < 77, ie, ios < 13.4, opera < 71, safari < 13.1, samsung < 14.0 }
  es.string.search { edge < 79, ie, samsung < 5.0 }
  es.string.split { edge < 79, ie, samsung < 6.0 }
  es.string.starts-with { edge < 79, ie, samsung < 5.0 }
  es.string.to-well-formed { android < 111, chrome < 111, edge < 111, firefox < 119, ie, ios < 16.4, opera < 97, safari < 16.4, samsung < 22.0 }
  es.string.trim { ie, ios < 12.2, safari < 12.1, samsung < 7.0 }
  es.string.trim-end { android < 66, chrome < 66, edge < 79, firefox < 61, ie, ios < 12.2, opera < 53, safari < 12.1, samsung < 9.0 }
  es.string.trim-start { android < 66, chrome < 66, edge < 79, firefox < 61, ie, ios < 12.0, opera < 53, safari < 12.0, samsung < 9.0 }
  es.string.anchor { ie }
  es.string.big { ie }
  es.string.blink { ie }
  es.string.bold { ie }
  es.string.fixed { ie }
  es.string.fontcolor { ie }
  es.string.fontsize { ie }
  es.string.italics { ie }
  es.string.link { ie }
  es.string.small { ie }
  es.string.strike { ie }
  es.string.sub { ie }
  es.string.sup { ie }
  es.typed-array.float32-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.float64-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.int8-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.int16-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.int32-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.uint8-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.uint8-clamped-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.uint16-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.uint32-array { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.at { android < 92, chrome < 92, edge < 92, firefox < 90, ie, ios < 15.4, opera < 78, safari < 15.4, samsung < 16.0 }
  es.typed-array.copy-within { ie, samsung < 5.0 }
  es.typed-array.every { ie, samsung < 5.0 }
  es.typed-array.fill { edge < 79, firefox < 55, ie, ios < 14.5, safari < 14.1, samsung < 7.0 }
  es.typed-array.filter { ie, samsung < 5.0 }
  es.typed-array.find { ie, samsung < 5.0 }
  es.typed-array.find-index { ie, samsung < 5.0 }
  es.typed-array.find-last { android < 97, chrome < 97, edge < 97, firefox < 104, ie, ios < 15.4, opera < 83, safari < 15.4, samsung < 18.0 }
  es.typed-array.find-last-index { android < 97, chrome < 97, edge < 97, firefox < 104, ie, ios < 15.4, opera < 83, safari < 15.4, samsung < 18.0 }
  es.typed-array.for-each { ie, samsung < 5.0 }
  es.typed-array.from { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.includes { ie, samsung < 5.0 }
  es.typed-array.index-of { ie, samsung < 5.0 }
  es.typed-array.iterator { ie, samsung < 5.0 }
  es.typed-array.join { ie, samsung < 5.0 }
  es.typed-array.last-index-of { ie, samsung < 5.0 }
  es.typed-array.map { ie, samsung < 5.0 }
  es.typed-array.of { firefox < 55, ie, ios < 14.0, safari < 14.0, samsung < 6.0 }
  es.typed-array.reduce { ie, samsung < 5.0 }
  es.typed-array.reduce-right { ie, samsung < 5.0 }
  es.typed-array.reverse { ie, samsung < 5.0 }
  es.typed-array.set { android < 95, chrome < 95, edge < 95, firefox < 54, ie, ios < 14.5, opera < 81, safari < 14.1, samsung < 17.0 }
  es.typed-array.slice { ie, samsung < 5.0 }
  es.typed-array.some { ie, samsung < 5.0 }
  es.typed-array.sort { android < 74, chrome < 74, edge < 79, firefox < 67, ie, ios < 14.5, opera < 61, safari < 14.1, samsung < 11.0 }
  es.typed-array.subarray { ie }
  es.typed-array.to-locale-string { edge < 79, ie, samsung < 5.0 }
  es.typed-array.to-reversed { android < 110, chrome < 110, edge < 110, firefox < 115, ie, ios < 16.0, opera < 96, safari < 16.0, samsung < 21.0 }
  es.typed-array.to-sorted { android < 110, chrome < 110, edge < 110, firefox < 115, ie, ios < 16.0, opera < 96, safari < 16.0, samsung < 21.0 }
  es.typed-array.to-string { ie, samsung < 5.0 }
  es.typed-array.with { android < 110, chrome < 110, edge < 110, firefox < 115, ie, ios < 16.4, opera < 96, safari < 16.4, samsung < 21.0 }
  es.weak-map { edge < 79, firefox < 53, ie, samsung < 5.0 }
  es.weak-set { firefox < 53, ie, samsung < 5.0 }
  esnext.suppressed-error.constructor { android, chrome, edge, firefox, ie, ios, opera, opera_mobile, safari, samsung }
  esnext.array.from-async { android < 121, chrome < 121, edge < 121, firefox < 115, ie, ios, opera < 107, opera_mobile < 81, safari, samsung < 25.0 }
  esnext.array.group { android, chrome, edge, firefox, ie, ios, opera, opera_mobile, safari, samsung }
  esnext.array.group-to-map { android, chrome, edge, firefox, ie, ios, opera, opera_mobile, safari, samsung }
  esnext.iterator.constructor { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.drop { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.every { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.filter { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.find { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.flat-map { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.for-each { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.from { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.map { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.reduce { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.some { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.take { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.iterator.to-array { android < 122, chrome < 122, edge < 122, firefox, ie, ios, opera < 108, opera_mobile < 81, safari, samsung < 26.0 }
  esnext.json.is-raw-json { android < 114, chrome < 114, edge < 114, firefox, ie, ios, opera < 100, safari, samsung < 23.0 }
  esnext.json.parse { android < 114, chrome < 114, edge < 114, firefox, ie, ios, opera < 100, safari, samsung < 23.0 }
  esnext.json.raw-json { android < 114, chrome < 114, edge < 114, firefox, ie, ios, opera < 100, safari, samsung < 23.0 }
  esnext.symbol.async-dispose { android, chrome, edge, firefox, ie, ios, opera, opera_mobile, safari, samsung }
  esnext.symbol.dispose { android < 125, chrome < 125, edge < 125, firefox, ie, ios, opera < 111, opera_mobile, safari, samsung }
  esnext.symbol.metadata { android, chrome, edge, firefox, ie, ios, opera, opera_mobile, safari, samsung }
  web.atob { ie }
  web.btoa { ie }
  web.dom-collections.for-each { ie, samsung < 7.0 }
  web.dom-collections.iterator { android < 66, chrome < 66, edge < 79, firefox < 60, ie, ios < 13.4, opera < 53, safari < 13.1, samsung < 9.0 }
  web.dom-exception.constructor { edge < 79, ie, ios < 11.3, safari < 11.1, samsung < 5.0 }
  web.dom-exception.stack { android, chrome, edge, ie, ios, opera, opera_mobile, safari, samsung }
  web.dom-exception.to-string-tag { edge < 79, ie, ios < 11.3, safari < 11.1, samsung < 5.0 }
  web.immediate { android, chrome, edge, firefox, ios, opera, opera_mobile, safari, samsung }
  web.queue-microtask { android < 71, chrome < 71, edge < 79, firefox < 69, ie, ios < 12.2, opera < 58, safari < 12.1, samsung < 10.0 }
  web.self { android < 86, chrome < 86, edge < 86, ie, opera < 72, samsung < 14.0 }
  web.structured-clone { android, chrome, edge, firefox, ie, ios, opera, opera_mobile, safari, samsung }
  web.url { android < 67, chrome < 67, edge < 79, firefox < 57, ie, ios < 14.0, opera < 54, safari < 14.0, samsung < 9.0 }
  web.url.can-parse { android < 120, chrome < 120, edge < 120, firefox < 115, ie, ios < 17.0, opera < 106, safari < 17.0, samsung < 25.0 }
  web.url.parse { android < 126, chrome < 126, edge < 126, firefox < 126, ie, ios, opera < 112, opera_mobile, safari, samsung }
  web.url.to-json { android < 71, chrome < 71, edge < 79, firefox < 57, ie, ios < 14.0, opera < 58, safari < 14.0, samsung < 10.0 }
  web.url-search-params { android < 67, chrome < 67, edge < 79, firefox < 57, ie, ios < 14.0, opera < 54, safari < 14.0, samsung < 9.0 }
  web.url-search-params.delete { android < 118, chrome < 118, edge < 118, firefox < 115, ie, ios < 17.0, opera < 104, safari < 17.0, samsung < 25.0 }
  web.url-search-params.has { android < 118, chrome < 118, edge < 118, firefox < 115, ie, ios < 17.0, opera < 104, safari < 17.0, samsung < 25.0 }
  web.url-search-params.size { android < 113, chrome < 113, edge < 113, firefox < 112, ie, ios < 17.0, opera < 99, safari < 17.0, samsung < 23.0 }
</details>




## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced browser compatibility and optimization for modern and legacy builds.
  - Improved script loading logic for better performance and compatibility.
  - Streamlined template rendering for JavaScript resources, reducing complexity in loading processes.

- **Chores**
  - Updated dependencies to include `browserslist-useragent-regexp`.

These updates aim to provide a smoother, faster experience across a wider range of browsers while maintaining support for older versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->