### PR TITLE
Added support for color temperature tile feature

### DIFF
--- a/gallery/src/pages/lovelace/tile-card.ts
+++ b/gallery/src/pages/lovelace/tile-card.ts
@@ -14,7 +14,7 @@ const ENTITIES = [
   }),
   getEntity("light", "bed_light", "on", {
     friendly_name: "Bed Light",
-    supported_color_modes: [LightColorMode.HS],
+    supported_color_modes: [LightColorMode.HS, LightColorMode.COLOR_TEMP],
   }),
   getEntity("light", "unavailable", "unavailable", {
     friendly_name: "Unavailable entity",
@@ -114,6 +114,15 @@ const CONFIGS = [
   entity: light.bed_light
   features:
     - type: "light-brightness"
+    `,
+  },
+  {
+    heading: "Light color temperature feature",
+    config: `
+- type: tile
+  entity: light.bed_light
+  features:
+    - type: "color-temp"
     `,
   },
   {

--- a/src/panels/lovelace/create-element/create-tile-feature-element.ts
+++ b/src/panels/lovelace/create-element/create-tile-feature-element.ts
@@ -3,6 +3,7 @@ import "../tile-features/hui-cover-open-close-tile-feature";
 import "../tile-features/hui-cover-tilt-tile-feature";
 import "../tile-features/hui-fan-speed-tile-feature";
 import "../tile-features/hui-light-brightness-tile-feature";
+import "../tile-features/hui-light-color-temp-tile-feature";
 import "../tile-features/hui-vacuum-commands-tile-feature";
 import { LovelaceTileFeatureConfig } from "../tile-features/types";
 import {
@@ -14,6 +15,7 @@ const TYPES: Set<LovelaceTileFeatureConfig["type"]> = new Set([
   "cover-open-close",
   "cover-tilt",
   "light-brightness",
+  "light-color-temp",
   "vacuum-commands",
   "fan-speed",
   "alarm-modes",

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-features-editor.ts
@@ -30,6 +30,7 @@ import { supportsCoverOpenCloseTileFeature } from "../../tile-features/hui-cover
 import { supportsCoverTiltTileFeature } from "../../tile-features/hui-cover-tilt-tile-feature";
 import { supportsFanSpeedTileFeature } from "../../tile-features/hui-fan-speed-tile-feature";
 import { supportsLightBrightnessTileFeature } from "../../tile-features/hui-light-brightness-tile-feature";
+import { supportsLightColorTempTileFeature } from "../../tile-features/hui-light-color-temp-tile-feature";
 import { supportsVacuumCommandTileFeature } from "../../tile-features/hui-vacuum-commands-tile-feature";
 import { LovelaceTileFeatureConfig } from "../../tile-features/types";
 
@@ -40,6 +41,7 @@ const FEATURE_TYPES: FeatureType[] = [
   "cover-open-close",
   "cover-tilt",
   "light-brightness",
+  "light-color-temp",
   "vacuum-commands",
   "fan-speed",
   "alarm-modes",
@@ -55,6 +57,7 @@ const SUPPORTS_FEATURE_TYPES: Record<FeatureType, SupportsFeature | undefined> =
     "cover-open-close": supportsCoverOpenCloseTileFeature,
     "cover-tilt": supportsCoverTiltTileFeature,
     "light-brightness": supportsLightBrightnessTileFeature,
+    "light-color-temp": supportsLightColorTempTileFeature,
     "vacuum-commands": supportsVacuumCommandTileFeature,
     "fan-speed": supportsFanSpeedTileFeature,
     "alarm-modes": supportsAlarmModesTileFeature,

--- a/src/panels/lovelace/tile-features/hui-light-color-temp-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-light-color-temp-tile-feature.ts
@@ -61,8 +61,6 @@ class HuiLightColorTempTileFeature
       <div class="container">
         <ha-control-slider
           .value=${position}
-          min="1"
-          max="100"
           mode="cursor"
           .showHandle=${stateActive(this.stateObj)}
           .disabled=${this.stateObj!.state === UNAVAILABLE}

--- a/src/panels/lovelace/tile-features/hui-light-color-temp-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-light-color-temp-tile-feature.ts
@@ -1,0 +1,113 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { computeDomain } from "../../../common/entity/compute_domain";
+import { stateActive } from "../../../common/entity/state_active";
+import "../../../components/ha-control-slider";
+import { UNAVAILABLE } from "../../../data/entity";
+import { LightColorMode, lightSupportsColorMode } from "../../../data/light";
+import { HomeAssistant } from "../../../types";
+import { LovelaceTileFeature } from "../types";
+import { LightColorTempTileFeatureConfig } from "./types";
+
+export const supportsLightColorTempTileFeature = (stateObj: HassEntity) => {
+  const domain = computeDomain(stateObj.entity_id);
+  return (
+    domain === "light" &&
+    lightSupportsColorMode(stateObj, LightColorMode.COLOR_TEMP)
+  );
+};
+
+@customElement("hui-light-color-temp-tile-feature")
+class HuiLightColorTempTileFeature
+  extends LitElement
+  implements LovelaceTileFeature
+{
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj?: HassEntity;
+
+  @state() private _config?: LightColorTempTileFeatureConfig;
+
+  static getStubConfig(): LightColorTempTileFeatureConfig {
+    return {
+      type: "light-color-temp",
+    };
+  }
+
+  public setConfig(config: LightColorTempTileFeatureConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected render() {
+    if (
+      !this._config ||
+      !this.hass ||
+      !this.stateObj ||
+      !supportsLightColorTempTileFeature(this.stateObj)
+    ) {
+      return nothing;
+    }
+
+    const position =
+      this.stateObj.attributes.color_temp_kelvin != null
+        ? this.stateObj.attributes.color_temp_kelvin
+        : undefined;
+
+    return html`
+      <div class="container">
+        <ha-control-slider
+          .value=${position}
+          min="1"
+          max="100"
+          mode="cursor"
+          .showHandle=${stateActive(this.stateObj)}
+          .disabled=${this.stateObj!.state === UNAVAILABLE}
+          @value-changed=${this._valueChanged}
+          .label=${this.hass.localize("ui.card.light.color_temperature")}
+          .min=${this.stateObj.attributes.min_color_temp_kelvin!}
+          .max=${this.stateObj.attributes.max_color_temp_kelvin!}
+        ></ha-control-slider>
+      </div>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const value = ev.detail.value;
+
+    this.hass!.callService("light", "turn_on", {
+      entity_id: this.stateObj!.entity_id,
+      color_temp_kelvin: value,
+    });
+  }
+
+  static get styles() {
+    return css`
+      ha-control-slider {
+        --control-slider-background: -webkit-linear-gradient(
+          left,
+          rgb(255, 160, 0) 0%,
+          white 50%,
+          rgb(166, 209, 255) 100%
+        );
+        --control-slider-background-opacity: 1;
+        --control-slider-thickness: 40px;
+        --control-slider-border-radius: 10px;
+      }
+      .container {
+        padding: 0 12px 12px 12px;
+        width: auto;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-light-color-temp-tile-feature": HuiLightColorTempTileFeature;
+  }
+}

--- a/src/panels/lovelace/tile-features/types.ts
+++ b/src/panels/lovelace/tile-features/types.ts
@@ -12,6 +12,10 @@ export interface LightBrightnessTileFeatureConfig {
   type: "light-brightness";
 }
 
+export interface LightColorTempTileFeatureConfig {
+  type: "light-color-temp";
+}
+
 export interface FanSpeedTileFeatureConfig {
   type: "fan-speed";
 }
@@ -40,6 +44,7 @@ export type LovelaceTileFeatureConfig =
   | CoverOpenCloseTileFeatureConfig
   | CoverTiltTileFeatureConfig
   | LightBrightnessTileFeatureConfig
+  | LightColorTempTileFeatureConfig
   | VacuumCommandsTileFeatureConfig
   | FanSpeedTileFeatureConfig
   | AlarmModesFileFeatureConfig;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4650,6 +4650,9 @@
                   "light-brightness": {
                     "label": "Light brightness"
                   },
+                  "light-color-temp": {
+                    "label": "Light color temperature"
+                  },
                   "vacuum-commands": {
                     "label": "Vacuum commands",
                     "commands": "Commands",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The color temperature tile feature has been added for lights that support CCT control.
![chrome_Ysk1iY4zfE](https://github.com/home-assistant/frontend/assets/60204407/939229e3-a4db-429d-838d-f2e3de97fbc0)
![chrome_8Xg8kTDezP](https://github.com/home-assistant/frontend/assets/60204407/a2a387f2-a244-4976-b18c-312d107c6b39)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
entity: light.ceiling_lights
features:
  - type: light-color-temp

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Something to discuss about the current features implementation is the inability to see the current value for the feature. With brightness being the only stock feature right now this is not a problem, because the brightness percentage is listed under the entity name. We could add dynamic text based on the features enabled for the card? But if a lot of features are added I think it would be verbose. An idea I had was to flash for a few seconds the value set in the feature in place of the current brightness percentage for lights. For example this is what the card would look like after setting the picker for the color temperature:
![chrome_f2HtGL4b9d](https://github.com/home-assistant/frontend/assets/60204407/03ceb600-fa11-4944-998c-c5a51bb3b6a3)

Thoughts?

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
