### PR TITLE
Fix overflow menu being above dialogs

### DIFF
--- a/src/components/ha-dialog.ts
+++ b/src/components/ha-dialog.ts
@@ -72,7 +72,7 @@ export class HaDialog extends DialogBase {
           --dialog-scroll-divider-color,
           var(--divider-color)
         );
-        z-index: var(--dialog-z-index, 7);
+        z-index: var(--dialog-z-index, 8);
         -webkit-backdrop-filter: var(--dialog-backdrop-filter, none);
         backdrop-filter: var(--dialog-backdrop-filter, none);
         --mdc-dialog-box-shadow: var(--dialog-box-shadow, none);

--- a/src/components/media-player/dialog-media-manage.ts
+++ b/src/components/media-player/dialog-media-manage.ts
@@ -277,7 +277,7 @@ class DialogMediaManage extends LitElement {
       haStyleDialog,
       css`
         ha-dialog {
-          --dialog-z-index: 8;
+          --dialog-z-index: 9;
           --dialog-content-padding: 0;
         }
 

--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -142,7 +142,7 @@ class DialogMediaPlayerBrowse extends LitElement {
       haStyleDialog,
       css`
         ha-dialog {
-          --dialog-z-index: 8;
+          --dialog-z-index: 9;
           --dialog-content-padding: 0;
         }
 

--- a/src/dialogs/quick-bar/ha-quick-bar.ts
+++ b/src/dialogs/quick-bar/ha-quick-bar.ts
@@ -775,7 +775,7 @@ export class QuickBar extends LitElement {
         }
 
         ha-dialog {
-          --dialog-z-index: 8;
+          --dialog-z-index: 9;
           --dialog-content-padding: 0;
         }
 

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -755,52 +755,52 @@ export class HaConfigDevicePage extends LitElement {
                                     )}
                                     .path=${mdiDotsVertical}
                                   ></ha-icon-button>
-                                  ${actions.map(
-                                    (deviceAction) => html`
-                                      <a
-                                        href=${ifDefined(deviceAction.href)}
-                                        target=${ifDefined(deviceAction.target)}
-                                        rel=${ifDefined(
-                                          deviceAction.target
-                                            ? "noreferrer"
-                                            : undefined
-                                        )}
-                                      >
-                                        <mwc-list-item
-                                          class=${ifDefined(
-                                            deviceAction.classes
+                                  ${actions.map((deviceAction) => {
+                                    const listItem = html`<mwc-list-item
+                                      class=${ifDefined(deviceAction.classes)}
+                                      .action=${deviceAction.action}
+                                      @click=${this._deviceActionClicked}
+                                      graphic="icon"
+                                      .hasMeta=${Boolean(
+                                        deviceAction.trailingIcon
+                                      )}
+                                    >
+                                      ${deviceAction.label}
+                                      ${deviceAction.icon
+                                        ? html`
+                                            <ha-svg-icon
+                                              class=${ifDefined(
+                                                deviceAction.classes
+                                              )}
+                                              .path=${deviceAction.icon}
+                                              slot="graphic"
+                                            ></ha-svg-icon>
+                                          `
+                                        : ""}
+                                      ${deviceAction.trailingIcon
+                                        ? html`
+                                            <ha-svg-icon
+                                              slot="meta"
+                                              .path=${deviceAction.trailingIcon}
+                                            ></ha-svg-icon>
+                                          `
+                                        : ""}
+                                    </mwc-list-item>`;
+                                    return deviceAction.href
+                                      ? html`<a
+                                          href=${deviceAction.href}
+                                          target=${ifDefined(
+                                            deviceAction.target
                                           )}
-                                          .action=${deviceAction.action}
-                                          @click=${this._deviceActionClicked}
-                                          graphic="icon"
-                                          .hasMeta=${Boolean(
-                                            deviceAction.trailingIcon
+                                          rel=${ifDefined(
+                                            deviceAction.target
+                                              ? "noreferrer"
+                                              : undefined
                                           )}
-                                        >
-                                          ${deviceAction.label}
-                                          ${deviceAction.icon
-                                            ? html`
-                                                <ha-svg-icon
-                                                  class=${ifDefined(
-                                                    deviceAction.classes
-                                                  )}
-                                                  .path=${deviceAction.icon}
-                                                  slot="graphic"
-                                                ></ha-svg-icon>
-                                              `
-                                            : ""}
-                                          ${deviceAction.trailingIcon
-                                            ? html`
-                                                <ha-svg-icon
-                                                  slot="meta"
-                                                  .path=${deviceAction.trailingIcon}
-                                                ></ha-svg-icon>
-                                              `
-                                            : ""}
-                                        </mwc-list-item>
-                                      </a>
-                                    `
-                                  )}
+                                          >${listItem}
+                                        </a>`
+                                      : listItem;
+                                  })}
                                 </ha-button-menu>
                               `
                             : ""}


### PR DESCRIPTION


## Proposed change

The overflow menu would not close, and be above the dialog, this fixes it in 2 ways, the overflow menu now closes, and the dialog will be above the overflow if it(somewhere else?) doesn't close.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
