### PR TITLE
Add entity attribute value translations for humidifier

### DIFF
--- a/src/data/humidifier.ts
+++ b/src/data/humidifier.ts
@@ -3,14 +3,11 @@ import {
   HassEntityBase,
 } from "home-assistant-js-websocket";
 import { FIXED_DOMAIN_STATES } from "../common/entity/get_states";
-import { TranslationDict } from "../types";
 import { UNAVAILABLE_STATES } from "./entity";
 
 type HumidifierState =
   | (typeof FIXED_DOMAIN_STATES.humidifier)[number]
   | (typeof UNAVAILABLE_STATES)[number];
-type HumidifierMode =
-  keyof TranslationDict["state_attributes"]["humidifier"]["mode"];
 
 export type HumidifierEntity = HassEntityBase & {
   state: HumidifierState;
@@ -18,8 +15,8 @@ export type HumidifierEntity = HassEntityBase & {
     humidity?: number;
     min_humidity?: number;
     max_humidity?: number;
-    mode?: HumidifierMode;
-    available_modes?: HumidifierMode[];
+    mode?: string;
+    available_modes?: string[];
   };
 };
 

--- a/src/dialogs/more-info/controls/more-info-humidifier.ts
+++ b/src/dialogs/more-info/controls/more-info-humidifier.ts
@@ -10,6 +10,7 @@ import {
 import { property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { computeAttributeValueDisplay } from "../../../common/entity/compute_attribute_display";
 import { stopPropagation } from "../../../common/dom/stop_propagation";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import { computeRTLDirection } from "../../../common/util/compute_rtl";
@@ -78,9 +79,14 @@ class MoreInfoHumidifier extends LitElement {
                 ${stateObj.attributes.available_modes!.map(
                   (mode) => html`
                     <mwc-list-item .value=${mode}>
-                      ${hass.localize(
-                        `state_attributes.humidifier.mode.${mode}`
-                      ) || mode}
+                      ${computeAttributeValueDisplay(
+                        hass.localize,
+                        stateObj,
+                        hass.locale,
+                        hass.entities,
+                        "mode",
+                        mode
+                      )}
                     </mwc-list-item>
                   `
                 )}

--- a/src/panels/lovelace/cards/hui-humidifier-card.ts
+++ b/src/panels/lovelace/cards/hui-humidifier-card.ts
@@ -14,6 +14,7 @@ import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { computeAttributeValueDisplay } from "../../../common/entity/compute_attribute_display";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import { computeRTLDirection } from "../../../common/util/compute_rtl";
 import "../../../components/ha-card";
@@ -135,9 +136,13 @@ export class HuiHumidifierCard extends LitElement implements LovelaceCard {
           ${stateObj.attributes.mode && !isUnavailableState(stateObj.state)
             ? html`
                 -
-                ${this.hass!.localize(
-                  `state_attributes.humidifier.mode.${stateObj.attributes.mode}`
-                ) || stateObj.attributes.mode}
+                ${computeAttributeValueDisplay(
+                  this.hass.localize,
+                  stateObj,
+                  this.hass.locale,
+                  this.hass.entities,
+                  "mode"
+                )}
               `
             : ""}
         </text>

--- a/src/panels/lovelace/entity-rows/hui-humidifier-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-humidifier-entity-row.ts
@@ -5,6 +5,7 @@ import { HumidifierEntity } from "../../../data/humidifier";
 import { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
+import { computeAttributeValueDisplay } from "../../../common/entity/compute_attribute_display";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { EntityConfig, LovelaceRow } from "./types";
 
@@ -49,11 +50,13 @@ class HuiHumidifierEntityRow extends LitElement implements LovelaceRow {
           ? `${this.hass!.localize("ui.card.humidifier.humidity")}:
             ${stateObj.attributes.humidity} %${
               stateObj.attributes.mode
-                ? ` (${
-                    this.hass!.localize(
-                      `state_attributes.humidifier.mode.${stateObj.attributes.mode}`
-                    ) || stateObj.attributes.mode
-                  })`
+                ? ` (${computeAttributeValueDisplay(
+                    this.hass.localize,
+                    stateObj,
+                    this.hass.locale,
+                    this.hass.entities,
+                    "mode"
+                  )})`
                 : ""
             }`
           : ""}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -21,21 +21,6 @@
       "unavailable": "Unavailable"
     }
   },
-  "state_attributes": {
-    "humidifier": {
-      "mode": {
-        "normal": "Normal",
-        "eco": "Eco",
-        "away": "Away",
-        "boost": "Boost",
-        "comfort": "Comfort",
-        "home": "Home",
-        "sleep": "Sleep",
-        "auto": "Auto",
-        "baby": "Baby"
-      }
-    }
-  },
   "state_badge": {
     "default": {
       "unknown": "Unk",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Adds entity state attribute value translations for the mode of humidifiers.

The translations appeared to be missing in the backend, for which I've created:

https://github.com/home-assistant/core/pull/93206

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
