### PR TITLE
Support zwave config parameters not on endpoint 0

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -234,6 +234,8 @@ export interface ZWaveJSNodeComment {
 
 export interface ZWaveJSNodeConfigParam {
   property: number;
+  property_key: number | null;
+  endpoint: number;
   value: any;
   configuration_value_type: string;
   metadata: ZWaveJSNodeConfigParamMetadata;
@@ -255,6 +257,7 @@ export interface ZWaveJSSetConfigParamData {
   type: string;
   device_id: string;
   property: number;
+  endpoint: number;
   property_key?: number;
   value: string | number;
 }
@@ -622,6 +625,7 @@ export const setZwaveNodeConfigParameter = (
   hass: HomeAssistant,
   device_id: string,
   property: number,
+  endpoint: number,
   value: number,
   property_key?: number
 ): Promise<ZWaveJSSetConfigParamResult> => {
@@ -629,6 +633,7 @@ export const setZwaveNodeConfigParameter = (
     type: "zwave_js/set_config_parameter",
     device_id,
     property,
+    endpoint,
     value,
     property_key,
   };

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -27,6 +27,7 @@ import "../../../../../components/ha-settings-row";
 import "../../../../../components/ha-svg-icon";
 import "../../../../../components/ha-switch";
 import "../../../../../components/ha-textfield";
+import { groupBy } from "../../../../../common/util/group-by";
 import {
   computeDeviceName,
   DeviceRegistryEntry,
@@ -126,9 +127,6 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
     }
 
     const device = this._device!;
-    const endpoints = Object.values(this._config)
-      .map((item) => item.endpoint)
-      .filter((value, index, array) => array.indexOf(value) === index);
 
     return html`
       <hass-tabs-subpage
@@ -176,8 +174,12 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
               </em>
             </p>
           </div>
-          ${endpoints.map(
-            (endpoint) => html`<div class="content">
+          ${Object.entries(
+            groupBy(Object.entries(this._config), ([_, item]) =>
+              item.endpoint.toString()
+            )
+          ).map(
+            ([endpoint, configParamEntries]) => html`<div class="content">
               <h3>
                 ${this.hass.localize(
                   "ui.panel.config.zwave_js.node_config.endpoint",
@@ -186,17 +188,15 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
                 )}
               </h3>
               <ha-card>
-                ${Object.entries(this._config!)
-                  .filter(([_, item]) => item.endpoint === endpoint)
-                  .map(
-                    ([id, item]) => html` <ha-settings-row
-                      class="config-item"
-                      .configId=${id}
-                      .narrow=${this.narrow}
-                    >
-                      ${this._generateConfigBox(id, item)}
-                    </ha-settings-row>`
-                  )}
+                ${configParamEntries.map(
+                  ([id, item]) => html` <ha-settings-row
+                    class="config-item"
+                    .configId=${id}
+                    .narrow=${this.narrow}
+                  >
+                    ${this._generateConfigBox(id, item)}
+                  </ha-settings-row>`
+                )}
               </ha-card>
             </div>`
           )}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -188,15 +188,21 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
                 )}
               </h3>
               <ha-card>
-                ${configParamEntries.map(
-                  ([id, item]) => html` <ha-settings-row
-                    class="config-item"
-                    .configId=${id}
-                    .narrow=${this.narrow}
-                  >
-                    ${this._generateConfigBox(id, item)}
-                  </ha-settings-row>`
-                )}
+                ${configParamEntries
+                  .sort(([_, paramA], [__, paramB]) =>
+                    paramA.property !== paramB.property
+                      ? paramA.property - paramB.property
+                      : paramA.property_key! - paramA.property_key!
+                  )
+                  .map(
+                    ([id, item]) => html` <ha-settings-row
+                      class="config-item"
+                      .configId=${id}
+                      .narrow=${this.narrow}
+                    >
+                      ${this._generateConfigBox(id, item)}
+                    </ha-settings-row>`
+                  )}
               </ha-card>
             </div>`
           )}

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -192,7 +192,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
                   .sort(([_, paramA], [__, paramB]) =>
                     paramA.property !== paramB.property
                       ? paramA.property - paramB.property
-                      : paramA.property_key! - paramA.property_key!
+                      : paramA.property_key! - paramB.property_key!
                   )
                   .map(
                     ([id, item]) => html` <ha-settings-row

--- a/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/zwave_js-node-config.ts
@@ -36,6 +36,7 @@ import {
   fetchZwaveNodeConfigParameters,
   fetchZwaveNodeMetadata,
   setZwaveNodeConfigParameter,
+  ZWaveJSNodeConfigParam,
   ZWaveJSNodeConfigParams,
   ZwaveJSNodeMetadata,
   ZWaveJSSetConfigParamResult,
@@ -204,7 +205,10 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
     `;
   }
 
-  private _generateConfigBox(id, item): TemplateResult {
+  private _generateConfigBox(
+    id: string,
+    item: ZWaveJSNodeConfigParam
+  ): TemplateResult {
     const result = this._results[id];
     const labelAndDescription = html`
       <span slot="prefix" class="prefix">
@@ -323,7 +327,7 @@ class ZWaveJSNodeConfig extends SubscribeMixin(LitElement) {
       <p>${item.value}</p>`;
   }
 
-  private _isEnumeratedBool(item): boolean {
+  private _isEnumeratedBool(item: ZWaveJSNodeConfigParam): boolean {
     // Some Z-Wave config values use a states list with two options where index 0 = Disabled and 1 = Enabled
     // We want those to be considered boolean and show a toggle switch
     const disabledStates = ["disable", "disabled"];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3735,6 +3735,7 @@
             "header": "Z-Wave Device Configuration",
             "introduction": "Manage and adjust device specific configuration parameters for the selected device",
             "attribution": "Device configuration parameters and descriptions are provided by the {device_database}",
+            "endpoint": "Endpoint {endpoint}",
             "zwave_js_device_database": "Z-Wave JS Device Database",
             "battery_device_notice": "Battery devices must be awake to update their config. Please refer to your device manual for instructions on how to wake the device.",
             "parameter_is_read_only": "This parameter is read-only.",
@@ -3742,7 +3743,8 @@
             "set_param_accepted": "The parameter has been updated.",
             "set_param_queued": "The parameter change has been queued, and will be updated when the device wakes up.",
             "set_param_error": "An error occurred.",
-            "parameter": "Parameter"
+            "parameter": "Parameter",
+            "bitmask": "Bitmask"
           },
           "node_status": {
             "unknown": "Unknown",


### PR DESCRIPTION
## Proposed change
The UI was built with the assumption that config parameters were always on endpoint 0. That is no longer the case. In this PR, we create a separate card for each endpoint. I also:
- added the bitmask for partial parameters
- updated the set config parameter logic to include the endpoint
- sorted the parameters so they show up in the right order

Depends on https://github.com/home-assistant/core/pull/93383

Screenshot:
![screenshot](https://github.com/home-assistant/frontend/assets/7243222/a910b796-f5a8-4dcb-99e6-9059e3dae6c3)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
