### PR TITLE
Fix line chart tooltips to use XY mode

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -63,7 +63,7 @@ class StateHistoryChartLine extends LitElement {
         animation: false,
         interaction: {
           mode: "nearest",
-          axis: "x",
+          axis: "xy",
         },
         scales: {
           x: {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

I am making this change because the changes from #15887 seem broken to me. Line charts with multiple lines now feel unusable. 

I see in this change we changed initially interaction mode to "x", then to "xy", and then back to "x" at the very end. Why was this done? `xy` seems to work perfectly for me, but the current `x` mode is very hard to use. For example, here is the current `x` mode trying to trace the blue chart line with my pointer. The selected tooltip is all over the place, more often than not getting the wrong line, and jumping to different lines with the move of a single pixel. It's nearly impossible to get the blue line datapoints in many locations:

![chart-tooltips](https://github.com/home-assistant/frontend/assets/32912880/474aa253-af41-4fd5-86b8-90dac7e5e8e6)

And the proposed change with `xy`

![chart-tooltips-xy](https://github.com/home-assistant/frontend/assets/32912880/e0455546-4a9b-495c-b02f-cf250765f6fb)


Can we revisit why `x` was chosen? 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #16203 #16306
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
