### PR TITLE
Fix displayed unit for fixed water price

### DIFF
--- a/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
@@ -40,8 +40,6 @@ export class DialogEnergyWaterSettings
 
   @state() private _pickedDisplayUnit?: string | null;
 
-  @state() private _defaultDisplayUnit?: string | null;
-
   @state() private _water_units?: string[];
 
   @state() private _error?: string;
@@ -58,9 +56,6 @@ export class DialogEnergyWaterSettings
       params.source?.stat_energy_from,
       params.metadata
     );
-    this._defaultDisplayUnit =
-      this.hass.config.unit_system.volume === "gal" ? "gal" : "m³";
-
     this._costs = this._source.entity_energy_price
       ? "entity"
       : this._source.number_energy_price
@@ -78,7 +73,6 @@ export class DialogEnergyWaterSettings
     this._source = undefined;
     this._error = undefined;
     this._pickedDisplayUnit = undefined;
-    this._defaultDisplayUnit = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -93,9 +87,9 @@ export class DialogEnergyWaterSettings
       ? `${this.hass.config.currency}/${this._pickedDisplayUnit}`
       : undefined;
 
-    const unitPriceFixed = this._defaultDisplayUnit
-      ? `${this.hass.config.currency}/${this._defaultDisplayUnit}`
-      : undefined;
+    const unitPriceFixed = `${this.hass.config.currency}/${
+      this.hass.config.unit_system.volume === "gal" ? "gal" : "m³"
+    }`;
 
     const externalSource =
       this._source.stat_energy_from &&
@@ -220,13 +214,13 @@ export class DialogEnergyWaterSettings
           ? html`<ha-textfield
               .label=${`${this.hass.localize(
                 "ui.panel.config.energy.water.dialog.cost_number_input"
-              )}${unitPriceFixed ? ` (${unitPriceFixed})` : ""}`}
+              )} (${unitPriceFixed})`}
               class="price-options"
               step="any"
               type="number"
               .value=${this._source.number_energy_price}
               @change=${this._numberPriceChanged}
-              .suffix=${unitPriceFixed || ""}
+              .suffix=${unitPriceFixed}
             >
             </ha-textfield>`
           : ""}

--- a/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
@@ -38,6 +38,8 @@ export class DialogEnergyWaterSettings
 
   @state() private _costs?: "no-costs" | "number" | "entity" | "statistic";
 
+  @state() private _pickedDisplayUnit?: string | null;
+
   @state() private _defaultDisplayUnit?: string | null;
 
   @state() private _water_units?: string[];

--- a/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
@@ -222,7 +222,7 @@ export class DialogEnergyWaterSettings
                 "ui.panel.config.energy.water.dialog.cost_number_input"
               )}${unitPriceFixed ? ` (${unitPriceFixed})` : ""}`}
               class="price-options"
-              step=".01"
+              step="any"
               type="number"
               .value=${this._source.number_energy_price}
               @change=${this._numberPriceChanged}

--- a/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-water-settings.ts
@@ -38,7 +38,7 @@ export class DialogEnergyWaterSettings
 
   @state() private _costs?: "no-costs" | "number" | "entity" | "statistic";
 
-  @state() private _pickedDisplayUnit?: string | null;
+  @state() private _defaultDisplayUnit?: string | null;
 
   @state() private _water_units?: string[];
 
@@ -56,6 +56,9 @@ export class DialogEnergyWaterSettings
       params.source?.stat_energy_from,
       params.metadata
     );
+    this._defaultDisplayUnit =
+      this.hass.config.unit_system.volume === "gal" ? "gal" : "m³";
+
     this._costs = this._source.entity_energy_price
       ? "entity"
       : this._source.number_energy_price
@@ -73,6 +76,7 @@ export class DialogEnergyWaterSettings
     this._source = undefined;
     this._error = undefined;
     this._pickedDisplayUnit = undefined;
+    this._defaultDisplayUnit = undefined;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -83,8 +87,12 @@ export class DialogEnergyWaterSettings
 
     const pickableUnit = this._water_units?.join(", ") || "";
 
-    const unitPrice = this._pickedDisplayUnit
+    const unitPriceSensor = this._pickedDisplayUnit
       ? `${this.hass.config.currency}/${this._pickedDisplayUnit}`
+      : undefined;
+
+    const unitPriceFixed = this._defaultDisplayUnit
+      ? `${this.hass.config.currency}/${this._defaultDisplayUnit}`
       : undefined;
 
     const externalSource =
@@ -189,7 +197,7 @@ export class DialogEnergyWaterSettings
               .value=${this._source.entity_energy_price}
               .label=${`${this.hass.localize(
                 "ui.panel.config.energy.water.dialog.cost_entity_input"
-              )}${unitPrice ? ` (${unitPrice})` : ""}`}
+              )}${unitPriceSensor ? ` (${unitPriceSensor})` : ""}`}
               @value-changed=${this._priceEntityChanged}
             ></ha-entity-picker>`
           : ""}
@@ -210,13 +218,13 @@ export class DialogEnergyWaterSettings
           ? html`<ha-textfield
               .label=${`${this.hass.localize(
                 "ui.panel.config.energy.water.dialog.cost_number_input"
-              )}${unitPrice ? ` (${unitPrice})` : ""}`}
+              )}${unitPriceFixed ? ` (${unitPriceFixed})` : ""}`}
               class="price-options"
               step=".01"
               type="number"
               .value=${this._source.number_energy_price}
               @change=${this._numberPriceChanged}
-              .suffix=${unitPrice || ""}
+              .suffix=${unitPriceFixed || ""}
             >
             </ha-textfield>`
           : ""}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When adding water consumption sensor in energy dashboard, if user selects "fixed price" for water, the displayed unit may not be correct. It is currently picking up the unit from the source sensor, e.g. if I select a sensor that has a unit of `CCF`, it will display in the fixed price field a unit of `USD/CCF`. 

![image](https://github.com/home-assistant/frontend/assets/32912880/893786c5-4b4b-41a6-b0ba-c1a1ebc8681d)



However this is incorrect, the backend will always treat this number as price/gal if using imperial units, or price/m^3 if using metric. 



See: 
https://github.com/home-assistant/core/blob/dev/homeassistant/components/energy/sensor.py#L272
https://github.com/home-assistant/core/blob/dev/homeassistant/components/energy/sensor.py#L331

Therefore user must enter a price/gal or price/m3 in this field, or else the computed price will be incorrect. 

Fix the display to always display either price/gal or price/m3, regardless of the source unit:

![image](https://github.com/home-assistant/frontend/assets/32912880/6b50159a-7582-4d2d-a861-1d455ea08060)

![image](https://github.com/home-assistant/frontend/assets/32912880/ad7acc5e-c136-4bbd-a00e-8079c31328ee)


I considered if this should be a backend behavior change instead of a frontend change, but this seemed less disruptive. 


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14960
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
