### PR TITLE
Use ES modules and dynamic import for Webpack latest builds

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -10,6 +10,12 @@ supports es6-module-dynamic-import
 not Safari < 13
 not iOS < 13
 
+# Exclude KaiOS, QQ, and UC browsers due to lack of sufficient feature support data
+# Babel ignores these automatically, but we need here for Webpack to output ESM with dynamic imports
+not KaiOS > 0
+not QQAndroid > 0
+not UCAndroid > 0
+
 # Exclude unsupported browsers
 not dead
 

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -77,6 +77,7 @@ module.exports.htmlMinifierOptions = {
 module.exports.terserOptions = ({ latestBuild, isTestBuild }) => ({
   safari10: !latestBuild,
   ecma: latestBuild ? 2015 : 5,
+  module: latestBuild,
   format: { comments: false },
   sourceMap: !isTestBuild,
 });

--- a/build-scripts/webpack.cjs
+++ b/build-scripts/webpack.cjs
@@ -41,7 +41,7 @@ const createWebpackConfig = ({
   return {
     name,
     mode: isProdBuild ? "production" : "development",
-    target: ["web", latestBuild ? "es2017" : "es5"],
+    target: `browserslist:${latestBuild ? "modern" : "legacy"}`,
     // For tests/CI, source maps are skipped to gain build speed
     // For production, generate source maps for accurate stack traces without source code
     // For development, generate "cheap" versions that can map to original line numbers
@@ -163,6 +163,7 @@ const createWebpackConfig = ({
       },
     },
     output: {
+      module: latestBuild,
       filename: ({ chunk }) =>
         !isProdBuild || isStatsBuild || dontHash.has(chunk.name)
           ? "[name].js"
@@ -196,7 +197,7 @@ const createWebpackConfig = ({
           : undefined,
     },
     experiments: {
-      topLevelAwait: true,
+      outputModule: true,
     },
   };
 };

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -1,8 +1,13 @@
 import webpack from "../build-scripts/webpack.cjs";
 
-export default webpack.createAppConfig({
+const config = webpack.createAppConfig({
   isProdBuild: false,
   latestBuild: true,
   isStatsBuild: false,
   isTestBuild: true,
 });
+
+// instant-mocha forces a CJS library, so cannot output ESM
+config.output.module = false;
+
+export default config;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Output ESM for chunks instead of classic scripts, and have Webpack load them with `import()` instead of `script` elements.  Technically, this is still "experimental" in Webpack, but it's been implemented for quite some time, seems pretty stable in the release notes, and this change is overdue I think.  A few details:

- Use the `browserslist` environments to set the runtime code features, which required removing KaiOS, UC, and QQ from the list (ref: https://github.com/webpack/webpack/issues/14226)
- Flip on the associated Terser flag to permit mangling at top levels

I did try to compare page load time for the demo content and this change was pretty much always faster, maybe by about 1.5-2x (with large variability obviously).

As a sign of stability, the bundle is more or less identical aside from the format change and considerably less injected runtime code:


| Entrypoint | Old | New | Change |
|:--- |:---:|:---:|:---:|
| app | 248K | 246K | -1% |
| core | 19K | 18K | -6% |
| custom-panel | 34K | 33K | -3% |
| authorize | 271K | 270K | -0% |
| onboarding | 294K | 293K | -0% |
| _Total Bundle_ | _18M_ | _18M_ | _-0%_ |


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
