### PR TITLE
Always show "polling for updates" switch

### DIFF
--- a/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
@@ -86,33 +86,30 @@ class DialogConfigEntrySystemOptions extends LitElement {
             dialogInitialFocus
           ></ha-switch>
         </ha-formfield>
-        ${this._allowUpdatePolling()
-          ? html`
-              <ha-formfield
-                .label=${html`<p>
-                    ${this.hass.localize(
-                      "ui.dialogs.config_entry_system_options.enable_polling_label"
-                    )}
-                  </p>
-                  <p class="secondary">
-                    ${this.hass.localize(
-                      "ui.dialogs.config_entry_system_options.enable_polling_description",
-                      "integration",
-                      this.hass.localize(
-                        `component.${this._params.entry.domain}.title`
-                      ) || this._params.entry.domain
-                    )}
-                  </p>`}
-                .dir=${computeRTLDirection(this.hass)}
-              >
-                <ha-switch
-                  .checked=${!this._disablePolling}
-                  @change=${this._disablePollingChanged}
-                  .disabled=${this._submitting}
-                ></ha-switch>
-              </ha-formfield>
-            `
-          : ""}
+
+        <ha-formfield
+          .label=${html`<p>
+              ${this.hass.localize(
+                "ui.dialogs.config_entry_system_options.enable_polling_label"
+              )}
+            </p>
+            <p class="secondary">
+              ${this.hass.localize(
+                "ui.dialogs.config_entry_system_options.enable_polling_description",
+                "integration",
+                this.hass.localize(
+                  `component.${this._params.entry.domain}.title`
+                ) || this._params.entry.domain
+              )}
+            </p>`}
+          .dir=${computeRTLDirection(this.hass)}
+        >
+          <ha-switch
+            .checked=${!this._disablePolling}
+            @change=${this._disablePollingChanged}
+            .disabled=${this._submitting}
+          ></ha-switch>
+        </ha-formfield>
         <mwc-button
           slot="secondaryAction"
           @click=${this.closeDialog}
@@ -131,10 +128,6 @@ class DialogConfigEntrySystemOptions extends LitElement {
     `;
   }
 
-  private _allowUpdatePolling() {
-    return true;
-  }
-
   private _disableNewEntitiesChanged(ev: Event): void {
     this._error = undefined;
     this._disableNewEntities = !(ev.target as HaSwitch).checked;
@@ -150,9 +143,7 @@ class DialogConfigEntrySystemOptions extends LitElement {
     const data: ConfigEntryMutableParams = {
       pref_disable_new_entities: this._disableNewEntities,
     };
-    if (this._allowUpdatePolling()) {
-      data.pref_disable_polling = this._disablePolling;
-    }
+    data.pref_disable_polling = this._disablePolling;
     try {
       const result = await updateConfigEntry(
         this.hass,

--- a/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
+++ b/src/dialogs/config-entry-system-options/dialog-config-entry-system-options.ts
@@ -132,11 +132,7 @@ class DialogConfigEntrySystemOptions extends LitElement {
   }
 
   private _allowUpdatePolling() {
-    return (
-      this._params!.manifest &&
-      (this._params!.manifest.iot_class === "local_polling" ||
-        this._params!.manifest.iot_class === "cloud_polling")
-    );
+    return true;
   }
 
   private _disableNewEntitiesChanged(ev: Event): void {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Always show the "polling for updates" switch in the system options of a integration.

It is quite common for integrations to use a combination of push+polling as backup or for some specific entities that do not support push. For example the motion_blinds and reolink integrations use push + fallback polling.
For those integration it would be nice to disable the fallback polling and make it faster if the push does not work for a user with network issues. This used to be possible (the option used to be shown a long time ago).
Not sure when this check was implemented.

Also discussed on discord and identified as a problem.

I normally never work with the frontend, so my appologies if this is not the way to fix it.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
