### PR TITLE
Update state on tile card when slider moves

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -405,11 +405,17 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     if (!entity) return;
 
     const domain = computeDomain(entity_id);
-    if (domain === "light") {
-      entity.attributes.brightness = Math.round((value * 255) / 100);
-      this.requestUpdate();
-    } else if (domain === "fan") {
-      entity.attributes.percentage = value;
+    if (domain === "light" || domain === "fan") {
+      if (value === 0) {
+        entity.state = "off";
+      } else {
+        entity.state = "on";
+      }
+      if (domain === "light") {
+        entity.attributes.brightness = Math.round((value * 255) / 100);
+      } else if (domain === "fan") {
+        entity.attributes.percentage = value;
+      }
       this.requestUpdate();
     }
   }

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -406,14 +406,16 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
 
     const domain = computeDomain(entity_id);
     if (domain === "light" || domain === "fan") {
-      if (value === 0) {
+      if (value === 0 && entity.state === "on") {
         entity.state = "off";
-      } else {
+        this._computeStateColor.clear();
+      } else if (value > 0 && entity.state === "off") {
         entity.state = "on";
+        this._computeStateColor.clear();
       }
       if (domain === "light") {
         entity.attributes.brightness = Math.round((value * 255) / 100);
-      } else if (domain === "fan") {
+      } else {
         entity.attributes.percentage = value;
       }
       this.requestUpdate();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Currently the Tile card doesn't update the state (percentage) of lights and fans when the user moves a slider:

https://github.com/home-assistant/frontend/assets/1219836/448ac812-4d22-4086-b1f5-811548e56b78

This is fixed in this PR:

https://github.com/home-assistant/frontend/assets/1219836/0bbde579-e3a9-45ca-9798-fc1783eea3e6

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #14669
- An eventlistener is added for the `slider-moved` event at the `<ha-card>` level. This eventhandler updates the state in the Tile card by making the following changes:
1.  The state of the entity is set to `off` when the slider value reaches 0 and the state is `on`, or to `on` if the slider value is greater than 0 and the entity state is `off`. The memoized computed color is also cleared in these cases, so the proper color value corresponding to `on` or `off` get's calculated during the next `render()`. This fixes the following bugs:
    - Adjusting the slider to 0 would remove the percentage and instead show "On". This would change to "Off" when the slider is released.
    - Sliding the slider when the entity is turned off doesn't update the state:
 
https://github.com/home-assistant/frontend/assets/1219836/8b1f15b7-7bc8-4dff-b132-54587636ae97

https://github.com/home-assistant/frontend/assets/1219836/036bed56-c2f8-426c-baee-8f52872dbd61

 2. The brightness (for lights) or percentage (for fans) is updated in the `hass` object.
 3. `requestUpdate` is called so the interface shows the new values

- Note that only the state in the frontend (the `hass` object) gets updated. No calls are being made to the backend until the user releases the slider. When the user releases the slider, a call is made to the backend and the card is updated at which point the state of the card is synchronized with the actual state on the backend and the changes made in the slider-moved eventlistener are overriden. All of this is existing functionality and has not been changed.


## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
