### PR TITLE
Use `__STATIC_PATH__` in more places so the supervisor panel can reach paths

### DIFF
--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -259,6 +259,7 @@ module.exports.config = {
       isHassioBuild: true,
       defineOverlay: {
         __SUPERVISOR__: true,
+        __STATIC_PATH__: `"${paths.hassio_publicPath}/static/"`,
       },
     };
   },

--- a/build-scripts/gulp/gather-static.js
+++ b/build-scripts/gulp/gather-static.js
@@ -111,9 +111,10 @@ gulp.task("copy-translations-supervisor", async () => {
   copyTranslations(staticDir);
 });
 
-gulp.task("copy-locale-data-supervisor", async () => {
+gulp.task("copy-static-supervisor", async () => {
   const staticDir = paths.hassio_output_static;
   copyLocaleData(staticDir);
+  copyFonts(staticDir);
 });
 
 gulp.task("copy-static-app", async () => {

--- a/build-scripts/gulp/hassio.js
+++ b/build-scripts/gulp/hassio.js
@@ -21,7 +21,7 @@ gulp.task(
     "build-supervisor-translations",
     "copy-translations-supervisor",
     "build-locale-data",
-    "copy-locale-data-supervisor",
+    "copy-static-supervisor",
     env.useRollup() ? "rollup-watch-hassio" : "webpack-watch-hassio"
   )
 );
@@ -37,7 +37,7 @@ gulp.task(
     "build-supervisor-translations",
     "copy-translations-supervisor",
     "build-locale-data",
-    "copy-locale-data-supervisor",
+    "copy-static-supervisor",
     env.useRollup() ? "rollup-prod-hassio" : "webpack-prod-hassio",
     "gen-pages-hassio-prod",
     ...// Don't compress running tests

--- a/hassio/src/supervisor-base-element.ts
+++ b/hassio/src/supervisor-base-element.ts
@@ -98,11 +98,7 @@ export class SupervisorBaseElement extends urlSyncMixin(
   }
 
   private async _initializeLocalize() {
-    const { language, data } = await getTranslation(
-      null,
-      this._language,
-      "/api/hassio/app/static/translations"
-    );
+    const { language, data } = await getTranslation(null, this._language);
 
     this._updateSupervisor({
       localize: await computeLocalize<SupervisorKeys>(

--- a/src/resources/locale-data-polyfill.ts
+++ b/src/resources/locale-data-polyfill.ts
@@ -15,7 +15,7 @@ export const polyfillLocaleData = async (language: string) => {
       typeof Intl.NumberFormat.__addLocaleData === "function"
     ) {
       const result = await fetch(
-        `/static/locale-data/intl-numberformat/${language}.json`
+        `${__STATIC_PATH__}locale-data/intl-numberformat/${language}.json`
       );
       // @ts-ignore
       Intl.NumberFormat.__addLocaleData(await result.json());
@@ -26,7 +26,7 @@ export const polyfillLocaleData = async (language: string) => {
       typeof Intl.RelativeTimeFormat.__addLocaleData === "function"
     ) {
       const result = await fetch(
-        `/static/locale-data/intl-relativetimeformat/${language}.json`
+        `${__STATIC_PATH__}locale-data/intl-relativetimeformat/${language}.json`
       );
       // @ts-ignore
       Intl.RelativeTimeFormat.__addLocaleData(await result.json());
@@ -37,7 +37,7 @@ export const polyfillLocaleData = async (language: string) => {
       typeof Intl.DateTimeFormat.__addLocaleData === "function"
     ) {
       const result = await fetch(
-        `/static/locale-data/intl-datetimeformat/${language}.json`
+        `${__STATIC_PATH__}locale-data/intl-datetimeformat/${language}.json`
       );
       // @ts-ignore
       Intl.DateTimeFormat.__addLocaleData(await result.json());
@@ -48,7 +48,7 @@ export const polyfillLocaleData = async (language: string) => {
       typeof Intl.DisplayNames.__addLocaleData === "function"
     ) {
       const result = await fetch(
-        `/static/locale-data/intl-displaynames/${language}.json`
+        `${__STATIC_PATH__}locale-data/intl-displaynames/${language}.json`
       );
       // @ts-ignore
       Intl.DisplayNames.__addLocaleData(await result.json());

--- a/src/resources/roboto.js
+++ b/src/resources/roboto.js
@@ -9,7 +9,7 @@ font-family: "Roboto";
 src:
   local("Roboto Thin"),
   local("Roboto-Thin"),
-  url(/static/fonts/roboto/Roboto-Thin.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-Thin.woff2) format("woff2");
 font-weight: 100;
 font-style: normal;
 }
@@ -18,7 +18,7 @@ font-family: "Roboto";
 src:
   local("Roboto Thin Italic"),
   local("Roboto-ThinItalic"),
-  url(/static/fonts/roboto/Roboto-ThinItalic.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-ThinItalic.woff2) format("woff2");
 font-weight: 100;
 font-style: italic;
 }
@@ -27,7 +27,7 @@ font-family: "Roboto";
 src:
   local("Roboto Light"),
   local("Roboto-Light"),
-  url(/static/fonts/roboto/Roboto-Light.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-Light.woff2) format("woff2");
 font-weight: 300;
 font-style: normal;
 }
@@ -36,7 +36,7 @@ font-family: "Roboto";
 src:
   local("Roboto Light Italic"),
   local("Roboto-LightItalic"),
-  url(/static/fonts/roboto/Roboto-LightItalic.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-LightItalic.woff2) format("woff2");
 font-weight: 300;
 font-style: italic;
 }
@@ -45,7 +45,7 @@ font-family: "Roboto";
 src:
   local("Roboto Regular"),
   local("Roboto-Regular"),
-  url(/static/fonts/roboto/Roboto-Regular.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-Regular.woff2) format("woff2");
 font-weight: 400;
 font-style: normal;
 }
@@ -54,7 +54,7 @@ font-family: "Roboto";
 src:
   local("Roboto Italic"),
   local("Roboto-Italic"),
-  url(/static/fonts/roboto/Roboto-RegularItalic.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-RegularItalic.woff2) format("woff2");
 font-weight: 400;
 font-style: italic;
 }
@@ -63,7 +63,7 @@ font-family: "Roboto";
 src:
   local("Roboto Medium"),
   local("Roboto-Medium"),
-  url(/static/fonts/roboto/Roboto-Medium.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-Medium.woff2) format("woff2");
 font-weight: 500;
 font-style: normal;
 }
@@ -72,7 +72,7 @@ font-family: "Roboto";
 src:
   local("Roboto Medium Italic"),
   local("Roboto-MediumItalic"),
-  url(/static/fonts/roboto/Roboto-MediumItalic.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-MediumItalic.woff2) format("woff2");
 font-weight: 500;
 font-style: italic;
 }
@@ -81,7 +81,7 @@ font-family: "Roboto";
 src:
   local("Roboto Bold"),
   local("Roboto-Bold"),
-  url(/static/fonts/roboto/Roboto-Bold.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-Bold.woff2) format("woff2");
 font-weight: 700;
 font-style: normal;
 }
@@ -90,7 +90,7 @@ font-family: "Roboto";
 src:
   local("Roboto Bold Italic"),
   local("Roboto-BoldItalic"),
-  url(/static/fonts/roboto/Roboto-BoldItalic.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-BoldItalic.woff2) format("woff2");
 font-weight: 700;
 font-style: italic;
 }
@@ -99,7 +99,7 @@ font-family: "Roboto";
 src:
   local("Roboto Black"),
   local("Roboto-Black"),
-  url(/static/fonts/roboto/Roboto-Black.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-Black.woff2) format("woff2");
 font-weight: 900;
 font-style: normal;
 }
@@ -108,7 +108,7 @@ font-family: "Roboto";
 src:
   local("Roboto Black Italic"),
   local("Roboto-BlackItalic"),
-  url(/static/fonts/roboto/Roboto-BlackItalic.woff2) format("woff2");
+  url(${__STATIC_PATH__}fonts/roboto/Roboto-BlackItalic.woff2) format("woff2");
 font-weight: 900;
 font-style: italic;
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

While looking at the traffic for static assets requested from the supervisor panel I noticed some paths that are problematic now and can be more problematic in the future.

As we now set `__STATIC_PATH__` on the supervisor build to the static paths served by the supervisor, I also removed the base_url workaround we added a long time ago for translations.

Background on the problem:
The supervisor panel can be newer (or older) than the code running on core.
Which could result in paths served statically by core not existing.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
