### PR TITLE
Blueprints: show error in alert dialog when clicked

### DIFF
--- a/src/panels/config/blueprint/ha-blueprint-overview.ts
+++ b/src/panels/config/blueprint/ha-blueprint-overview.ts
@@ -321,6 +321,12 @@ class HaBlueprintOverview extends LitElement {
       (b) => b.path === ev.detail.id
     );
     if (blueprint.error) {
+      showAlertDialog(this, {
+        title: this.hass.localize("ui.panel.config.blueprint.overview.error", {
+          path: blueprint.path,
+        }),
+        text: blueprint.name,
+      });
       return;
     }
     this._createNew(blueprint);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2636,6 +2636,7 @@
               "automation": "automations",
               "script": "scripts"
             },
+            "error": "{path} could not be loaded.",
             "blueprint_in_use_title": "This blueprint is in use, and can not be deleted",
             "blueprint_in_use_text": "Please remove all below {type} that use this blueprint before deleting it. {list}",
             "blueprint_in_use_view": "view {type}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2636,7 +2636,7 @@
               "automation": "automations",
               "script": "scripts"
             },
-            "error": "{path} could not be loaded.",
+            "error": "{path} could not be loaded",
             "blueprint_in_use_title": "This blueprint is in use, and can not be deleted",
             "blueprint_in_use_text": "Please remove all below {type} that use this blueprint before deleting it. {list}",
             "blueprint_in_use_view": "view {type}",


### PR DESCRIPTION


## Proposed change

<img width="651" alt="CleanShot 2023-05-31 at 11 15 18@2x" src="https://github.com/home-assistant/frontend/assets/5662298/36c97cd2-322d-4d3a-9d21-1ab1a906e327">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
