### PR TITLE
Close dialog when clicked on link

### DIFF
--- a/src/common/dom/is-navigation-click.ts
+++ b/src/common/dom/is-navigation-click.ts
@@ -1,4 +1,4 @@
-export const isNavigationClick = (e: MouseEvent) => {
+export const isNavigationClick = (e: MouseEvent, preventDefault = true) => {
   // Taken from polymer/pwa-helpers. BSD-3 licensed
   if (
     e.defaultPrevented ||
@@ -40,6 +40,8 @@ export const isNavigationClick = (e: MouseEvent) => {
     return undefined;
   }
 
-  e.preventDefault();
+  if (preventDefault) {
+    e.preventDefault();
+  }
   return href;
 };

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -21,6 +21,7 @@ import type { DataEntryFlowStepForm } from "../../data/data_entry_flow";
 import type { HomeAssistant } from "../../types";
 import type { FlowConfig } from "./show-dialog-data-entry-flow";
 import { configFlowContentStyles } from "./styles";
+import { isNavigationClick } from "../../common/dom/is-navigation-click";
 
 @customElement("step-flow-form")
 class StepFlowForm extends LitElement {
@@ -47,7 +48,7 @@ class StepFlowForm extends LitElement {
 
     return html`
       <h2>${this.flowConfig.renderShowFormStepHeader(this.hass, this.step)}</h2>
-      <div class="content">
+      <div class="content" @click=${this._clickHandler}>
         ${this.flowConfig.renderShowFormStepDescription(this.hass, this.step)}
         ${this._errorMsg
           ? html`<ha-alert alert-type="error">${this._errorMsg}</ha-alert>`
@@ -90,6 +91,14 @@ class StepFlowForm extends LitElement {
     super.firstUpdated(changedProps);
     setTimeout(() => this.shadowRoot!.querySelector("ha-form")!.focus(), 0);
     this.addEventListener("keydown", this._handleKeyDown);
+  }
+
+  private _clickHandler(ev: MouseEvent) {
+    if (isNavigationClick(ev, false)) {
+      fireEvent(this, "flow-update", {
+        step: undefined,
+      });
+    }
   }
 
   private _handleKeyDown = (ev: KeyboardEvent) => {

--- a/src/panels/config/repairs/dialog-repairs-issue.ts
+++ b/src/panels/config/repairs/dialog-repairs-issue.ts
@@ -3,6 +3,7 @@ import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { formatDateNumeric } from "../../../common/datetime/format_date";
 import { fireEvent } from "../../../common/dom/fire_event";
+import { isNavigationClick } from "../../../common/dom/is-navigation-click";
 import { createCloseHeading } from "../../../components/ha-dialog";
 import "../../../components/ha-markdown";
 import { ignoreRepairsIssue, RepairsIssue } from "../../../data/repairs";
@@ -71,6 +72,7 @@ class DialogRepairsIssue extends LitElement {
           <ha-markdown
             allowsvg
             breaks
+            @click=${this._clickHandler}
             .content=${this.hass.localize(
               `component.${this._issue.domain}.issues.${
                 this._issue.translation_key || this._issue.issue_id
@@ -110,13 +112,13 @@ class DialogRepairsIssue extends LitElement {
                   ? this._issue.learn_more_url.replace("homeassistant://", "/")
                   : this._issue.learn_more_url}
                 .target=${learnMoreUrlIsHomeAssistant ? "" : "_blank"}
+                @click=${learnMoreUrlIsHomeAssistant
+                  ? this.closeDialog
+                  : undefined}
                 slot="primaryAction"
                 rel="noopener noreferrer"
               >
                 <mwc-button
-                  @click=${learnMoreUrlIsHomeAssistant
-                    ? this.closeDialog
-                    : undefined}
                   .label=${this.hass!.localize(
                     "ui.panel.config.repairs.dialog.learn"
                   )}
@@ -138,6 +140,12 @@ class DialogRepairsIssue extends LitElement {
   private _ignoreIssue() {
     ignoreRepairsIssue(this.hass, this._issue!, !this._issue!.ignored);
     this.closeDialog();
+  }
+
+  private _clickHandler(ev: MouseEvent) {
+    if (isNavigationClick(ev, false)) {
+      this.closeDialog();
+    }
   }
 
   static styles: CSSResultGroup = [


### PR DESCRIPTION


## Proposed change

Repair issue dialogs would be kept open while you clicked on a link to navigate away. This closes the dialog, if you click a link that is not opened in another window.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
