### PR TITLE
Put button menu above toolbar in automation editor

### DIFF
--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -191,6 +191,7 @@ export default class HaAutomationActionRow extends LitElement {
                   slot="icons"
                   @action=${this._handleAction}
                   @click=${preventDefault}
+                  fixed
                 >
                   <ha-icon-button
                     slot="trigger"

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -147,7 +147,11 @@ export default class HaAutomationAction extends LitElement {
           `
         )}
       </div>
-      <ha-button-menu @action=${this._addAction} .disabled=${this.disabled}>
+      <ha-button-menu
+        @action=${this._addAction}
+        .disabled=${this.disabled}
+        fixed
+      >
         <ha-button
           slot="trigger"
           outlined

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -130,6 +130,7 @@ export default class HaAutomationConditionRow extends LitElement {
                   slot="icons"
                   @action=${this._handleAction}
                   @click=${preventDefault}
+                  fixed
                 >
                   <ha-icon-button
                     slot="trigger"

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -191,7 +191,11 @@ export default class HaAutomationCondition extends LitElement {
           `
         )}
       </div>
-      <ha-button-menu @action=${this._addCondition} .disabled=${this.disabled}>
+      <ha-button-menu
+        @action=${this._addCondition}
+        .disabled=${this.disabled}
+        fixed
+      >
         <ha-button
           slot="trigger"
           outlined

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -153,6 +153,7 @@ export default class HaAutomationTriggerRow extends LitElement {
                   slot="icons"
                   @action=${this._handleAction}
                   @click=${preventDefault}
+                  fixed
                 >
                   <ha-icon-button
                     slot="trigger"

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -75,27 +75,25 @@ export default class HaAutomationTrigger extends LitElement {
 
   protected render() {
     return html`
-      ${
-        this.reOrderMode && !this.nested
-          ? html`
-              <ha-alert
-                alert-type="info"
-                .title=${this.hass.localize(
-                  "ui.panel.config.automation.editor.re_order_mode.title"
-                )}
-              >
+      ${this.reOrderMode && !this.nested
+        ? html`
+            <ha-alert
+              alert-type="info"
+              .title=${this.hass.localize(
+                "ui.panel.config.automation.editor.re_order_mode.title"
+              )}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.re_order_mode.description_triggers"
+              )}
+              <mwc-button slot="action" @click=${this._exitReOrderMode}>
                 ${this.hass.localize(
-                  "ui.panel.config.automation.editor.re_order_mode.description_triggers"
+                  "ui.panel.config.automation.editor.re_order_mode.exit"
                 )}
-                <mwc-button slot="action" @click=${this._exitReOrderMode}>
-                  ${this.hass.localize(
-                    "ui.panel.config.automation.editor.re_order_mode.exit"
-                  )}
-                </mwc-button>
-              </ha-alert>
-            `
-          : null
-      }
+              </mwc-button>
+            </ha-alert>
+          `
+        : null}
       <div class="triggers">
         ${repeat(
           this.triggers,
@@ -141,8 +139,11 @@ export default class HaAutomationTrigger extends LitElement {
             </ha-automation-trigger-row>
           `
         )}
-        </div>
-        <ha-button-menu @action=${this._addTrigger} .disabled=${this.disabled}>
+        <ha-button-menu
+          @action=${this._addTrigger}
+          .disabled=${this.disabled}
+          fixed
+        >
           <ha-button
             slot="trigger"
             outlined
@@ -153,22 +154,20 @@ export default class HaAutomationTrigger extends LitElement {
           >
             <ha-svg-icon .path=${mdiPlus} slot="icon"></ha-svg-icon>
           </ha-button>
-          ${
-            this.clipboard?.trigger
-              ? html` <mwc-list-item .value=${PASTE_VALUE} graphic="icon">
-                  ${this.hass.localize(
-                    "ui.panel.config.automation.editor.triggers.paste"
-                  )}
-                  (${this.hass.localize(
-                    `ui.panel.config.automation.editor.triggers.type.${this.clipboard.trigger.platform}.label`
-                  )})
-                  <ha-svg-icon
-                    slot="graphic"
-                    .path=${mdiContentPaste}
-                  ></ha-svg-icon
-                ></mwc-list-item>`
-              : nothing
-          }
+          ${this.clipboard?.trigger
+            ? html` <mwc-list-item .value=${PASTE_VALUE} graphic="icon">
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.paste"
+                )}
+                (${this.hass.localize(
+                  `ui.panel.config.automation.editor.triggers.type.${this.clipboard.trigger.platform}.label`
+                )})
+                <ha-svg-icon
+                  slot="graphic"
+                  .path=${mdiContentPaste}
+                ></ha-svg-icon
+              ></mwc-list-item>`
+            : nothing}
           ${this._processedTypes(this.hass.localize).map(
             ([opt, label, icon]) => html`
               <mwc-list-item .value=${opt} graphic="icon">


### PR DESCRIPTION
## Proposed change

It was difficult to reach the "paste" item in the list with the toolbar.

Before

![CleanShot 2023-06-01 at 11 55 04](https://github.com/home-assistant/frontend/assets/5878303/901d4720-c333-4a04-bb0b-3f73eb2548f0)

After

![CleanShot 2023-06-01 at 11 54 41](https://github.com/home-assistant/frontend/assets/5878303/edf3b89b-e1fd-4970-a7f7-ae708cb3b600)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
