### PR TITLE
Fix time and date-time 12h formats  (#16692)

### DIFF
--- a/gallery/src/data/date-options.ts
+++ b/gallery/src/data/date-options.ts
@@ -1,0 +1,24 @@
+import type { ControlSelectOption } from "../../../src/components/ha-control-select";
+
+export const timeOptions: ControlSelectOption[] = [
+  {
+    value: "now",
+    label: "Now",
+  },
+  {
+    value: "00:15:30",
+    label: "12:15:30 AM",
+  },
+  {
+    value: "06:15:30",
+    label: "06:15:30 AM",
+  },
+  {
+    value: "12:15:30",
+    label: "12:15:30 PM",
+  },
+  {
+    value: "18:15:30",
+    label: "06:15:30 PM",
+  },
+];

--- a/gallery/src/pages/date-time/date-time-numeric.markdown
+++ b/gallery/src/pages/date-time/date-time-numeric.markdown
@@ -1,0 +1,7 @@
+---
+title: Date-Time Format (Numeric)
+---
+
+This pages lists all supported languages with their available date-time formats.
+
+Formatting function: `const formatDateTimeNumeric: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/date-time-numeric.ts
+++ b/gallery/src/pages/date-time/date-time-numeric.ts
@@ -1,0 +1,136 @@
+import { html, css, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import "../../../../src/components/ha-control-select";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatDateTimeNumeric } from "../../../../src/common/datetime/format_date_time";
+import { timeOptions } from "../../data/date-options";
+import { demoConfig } from "../../../../src/fake_data/demo_config";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+  TimeZone,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-date-time-numeric")
+export class DemoDateTimeDateTimeNumeric extends LitElement {
+  @state() private selection?: string = "now";
+
+  @state() private date: Date = new Date();
+
+  handleValueChanged(e: CustomEvent) {
+    this.selection = e.detail.value as string;
+    this.date = new Date();
+    if (this.selection !== "now") {
+      const [hours, minutes, seconds] = this.selection.split(":").map(Number);
+      this.date.setHours(hours);
+      this.date.setMinutes(minutes);
+      this.date.setSeconds(seconds);
+    }
+  }
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+      time_zone: TimeZone.local,
+    };
+    return html`
+      <ha-control-select
+        .value=${this.selection}
+        .options=${timeOptions}
+        @value-changed=${this.handleValueChanged}
+      >
+      </ha-control-select>
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">12 Hours</div>
+          <div class="center">24 Hours</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatDateTimeNumeric(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.language,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatDateTimeNumeric(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.am_pm,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatDateTimeNumeric(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.twenty_four,
+                    },
+                    demoConfig
+                  )}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-select {
+        max-width: 800px;
+        margin: 12px auto;
+      }
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 900px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-date-time-numeric": DemoDateTimeDateTimeNumeric;
+  }
+}

--- a/gallery/src/pages/date-time/date-time-seconds.markdown
+++ b/gallery/src/pages/date-time/date-time-seconds.markdown
@@ -1,0 +1,7 @@
+---
+title: Date-Time Format (Seconds)
+---
+
+This pages lists all supported languages with their available date-time formats.
+
+Formatting function: `const formatDateTimeWithSeconds: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/date-time-seconds.ts
+++ b/gallery/src/pages/date-time/date-time-seconds.ts
@@ -1,0 +1,136 @@
+import { html, css, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import "../../../../src/components/ha-control-select";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatDateTimeWithSeconds } from "../../../../src/common/datetime/format_date_time";
+import { timeOptions } from "../../data/date-options";
+import { demoConfig } from "../../../../src/fake_data/demo_config";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+  TimeZone,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-date-time-seconds")
+export class DemoDateTimeDateTimeSeconds extends LitElement {
+  @state() private selection?: string = "now";
+
+  @state() private date: Date = new Date();
+
+  handleValueChanged(e: CustomEvent) {
+    this.selection = e.detail.value as string;
+    this.date = new Date();
+    if (this.selection !== "now") {
+      const [hours, minutes, seconds] = this.selection.split(":").map(Number);
+      this.date.setHours(hours);
+      this.date.setMinutes(minutes);
+      this.date.setSeconds(seconds);
+    }
+  }
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+      time_zone: TimeZone.local,
+    };
+    return html`
+      <ha-control-select
+        .value=${this.selection}
+        .options=${timeOptions}
+        @value-changed=${this.handleValueChanged}
+      >
+      </ha-control-select>
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">12 Hours</div>
+          <div class="center">24 Hours</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatDateTimeWithSeconds(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.language,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatDateTimeWithSeconds(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.am_pm,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatDateTimeWithSeconds(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.twenty_four,
+                    },
+                    demoConfig
+                  )}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-select {
+        max-width: 800px;
+        margin: 12px auto;
+      }
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 900px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-date-time-seconds": DemoDateTimeDateTimeSeconds;
+  }
+}

--- a/gallery/src/pages/date-time/date-time-short-year.markdown
+++ b/gallery/src/pages/date-time/date-time-short-year.markdown
@@ -1,0 +1,7 @@
+---
+title: Date-Time Format (Short w/ Year)
+---
+
+This pages lists all supported languages with their available date-time formats.
+
+Formatting function: `const formatShortDateTimeWithYear: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/date-time-short-year.ts
+++ b/gallery/src/pages/date-time/date-time-short-year.ts
@@ -1,0 +1,136 @@
+import { html, css, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import "../../../../src/components/ha-control-select";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatShortDateTimeWithYear } from "../../../../src/common/datetime/format_date_time";
+import { timeOptions } from "../../data/date-options";
+import { demoConfig } from "../../../../src/fake_data/demo_config";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+  TimeZone,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-date-time-short-year")
+export class DemoDateTimeDateTimeShortYear extends LitElement {
+  @state() private selection?: string = "now";
+
+  @state() private date: Date = new Date();
+
+  handleValueChanged(e: CustomEvent) {
+    this.selection = e.detail.value as string;
+    this.date = new Date();
+    if (this.selection !== "now") {
+      const [hours, minutes, seconds] = this.selection.split(":").map(Number);
+      this.date.setHours(hours);
+      this.date.setMinutes(minutes);
+      this.date.setSeconds(seconds);
+    }
+  }
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+      time_zone: TimeZone.local,
+    };
+    return html`
+      <ha-control-select
+        .value=${this.selection}
+        .options=${timeOptions}
+        @value-changed=${this.handleValueChanged}
+      >
+      </ha-control-select>
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">12 Hours</div>
+          <div class="center">24 Hours</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatShortDateTimeWithYear(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.language,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatShortDateTimeWithYear(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.am_pm,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatShortDateTimeWithYear(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.twenty_four,
+                    },
+                    demoConfig
+                  )}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-select {
+        max-width: 800px;
+        margin: 12px auto;
+      }
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 900px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-date-time-short-year": DemoDateTimeDateTimeShortYear;
+  }
+}

--- a/gallery/src/pages/date-time/date-time-short.markdown
+++ b/gallery/src/pages/date-time/date-time-short.markdown
@@ -1,0 +1,7 @@
+---
+title: Date-Time Format (Short)
+---
+
+This pages lists all supported languages with their available date-time formats.
+
+Formatting function: `const formatShortDateTime: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/date-time-short.ts
+++ b/gallery/src/pages/date-time/date-time-short.ts
@@ -1,0 +1,136 @@
+import { html, css, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import "../../../../src/components/ha-control-select";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatShortDateTime } from "../../../../src/common/datetime/format_date_time";
+import { timeOptions } from "../../data/date-options";
+import { demoConfig } from "../../../../src/fake_data/demo_config";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+  TimeZone,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-date-time-short")
+export class DemoDateTimeDateTimeShort extends LitElement {
+  @state() private selection?: string = "now";
+
+  @state() private date: Date = new Date();
+
+  handleValueChanged(e: CustomEvent) {
+    this.selection = e.detail.value as string;
+    this.date = new Date();
+    if (this.selection !== "now") {
+      const [hours, minutes, seconds] = this.selection.split(":").map(Number);
+      this.date.setHours(hours);
+      this.date.setMinutes(minutes);
+      this.date.setSeconds(seconds);
+    }
+  }
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+      time_zone: TimeZone.local,
+    };
+    return html`
+      <ha-control-select
+        .value=${this.selection}
+        .options=${timeOptions}
+        @value-changed=${this.handleValueChanged}
+      >
+      </ha-control-select>
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">12 Hours</div>
+          <div class="center">24 Hours</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatShortDateTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.language,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatShortDateTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.am_pm,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatShortDateTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.twenty_four,
+                    },
+                    demoConfig
+                  )}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-select {
+        max-width: 800px;
+        margin: 12px auto;
+      }
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 900px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-date-time-short": DemoDateTimeDateTimeShort;
+  }
+}

--- a/gallery/src/pages/date-time/date-time.markdown
+++ b/gallery/src/pages/date-time/date-time.markdown
@@ -1,0 +1,7 @@
+---
+title: Date-Time Format
+---
+
+This pages lists all supported languages with their available date-time formats.
+
+Formatting function: `const formatDateTime: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/date-time.ts
+++ b/gallery/src/pages/date-time/date-time.ts
@@ -1,0 +1,136 @@
+import { html, css, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import "../../../../src/components/ha-control-select";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatDateTime } from "../../../../src/common/datetime/format_date_time";
+import { timeOptions } from "../../data/date-options";
+import { demoConfig } from "../../../../src/fake_data/demo_config";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+  TimeZone,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-date-time")
+export class DemoDateTimeDateTime extends LitElement {
+  @state() private selection?: string = "now";
+
+  @state() private date: Date = new Date();
+
+  handleValueChanged(e: CustomEvent) {
+    this.selection = e.detail.value as string;
+    this.date = new Date();
+    if (this.selection !== "now") {
+      const [hours, minutes, seconds] = this.selection.split(":").map(Number);
+      this.date.setHours(hours);
+      this.date.setMinutes(minutes);
+      this.date.setSeconds(seconds);
+    }
+  }
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+      time_zone: TimeZone.local,
+    };
+    return html`
+      <ha-control-select
+        .value=${this.selection}
+        .options=${timeOptions}
+        @value-changed=${this.handleValueChanged}
+      >
+      </ha-control-select>
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">12 Hours</div>
+          <div class="center">24 Hours</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatDateTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.language,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatDateTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.am_pm,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatDateTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.twenty_four,
+                    },
+                    demoConfig
+                  )}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-select {
+        max-width: 800px;
+        margin: 12px auto;
+      }
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 900px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-date-time": DemoDateTimeDateTime;
+  }
+}

--- a/gallery/src/pages/date-time/date.markdown
+++ b/gallery/src/pages/date-time/date.markdown
@@ -1,5 +1,5 @@
 ---
-title: (Numeric) Date Formatting
+title: Date Format (Numeric)
 ---
 
 This pages lists all supported languages with their available (numeric) date formats.

--- a/gallery/src/pages/date-time/time-seconds.markdown
+++ b/gallery/src/pages/date-time/time-seconds.markdown
@@ -1,0 +1,7 @@
+---
+title: Time Format (Seconds)
+---
+
+This pages lists all supported languages with their available time formats.
+
+Formatting function: `const formatTimeWithSeconds: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/time-seconds.ts
+++ b/gallery/src/pages/date-time/time-seconds.ts
@@ -1,0 +1,135 @@
+import { html, css, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatTimeWithSeconds } from "../../../../src/common/datetime/format_time";
+import { timeOptions } from "../../data/date-options";
+import { demoConfig } from "../../../../src/fake_data/demo_config";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+  TimeZone,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-time-seconds")
+export class DemoDateTimeTimeSeconds extends LitElement {
+  @state() private selection?: string = "now";
+
+  @state() private date: Date = new Date();
+
+  handleValueChanged(e: CustomEvent) {
+    this.selection = e.detail.value as string;
+    this.date = new Date();
+    if (this.selection !== "now") {
+      const [hours, minutes, seconds] = this.selection.split(":").map(Number);
+      this.date.setHours(hours);
+      this.date.setMinutes(minutes);
+      this.date.setSeconds(seconds);
+    }
+  }
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+      time_zone: TimeZone.local,
+    };
+    return html`
+      <ha-control-select
+        .value=${this.selection}
+        .options=${timeOptions}
+        @value-changed=${this.handleValueChanged}
+      >
+      </ha-control-select>
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">12 Hours</div>
+          <div class="center">24 Hours</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatTimeWithSeconds(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.language,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatTimeWithSeconds(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.am_pm,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatTimeWithSeconds(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.twenty_four,
+                    },
+                    demoConfig
+                  )}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-select {
+        max-width: 800px;
+        margin: 12px auto;
+      }
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 600px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-time-seconds": DemoDateTimeTimeSeconds;
+  }
+}

--- a/gallery/src/pages/date-time/time-weekday.markdown
+++ b/gallery/src/pages/date-time/time-weekday.markdown
@@ -1,0 +1,7 @@
+---
+title: Time Format (Weekday)
+---
+
+This pages lists all supported languages with their available time formats.
+
+Formatting function: `const formatTimeWeekday: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/time-weekday.ts
+++ b/gallery/src/pages/date-time/time-weekday.ts
@@ -1,0 +1,135 @@
+import { html, css, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatTimeWeekday } from "../../../../src/common/datetime/format_time";
+import { timeOptions } from "../../data/date-options";
+import { demoConfig } from "../../../../src/fake_data/demo_config";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+  TimeZone,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-time-weekday")
+export class DemoDateTimeTimeWeekday extends LitElement {
+  @state() private selection?: string = "now";
+
+  @state() private date: Date = new Date();
+
+  handleValueChanged(e: CustomEvent) {
+    this.selection = e.detail.value as string;
+    this.date = new Date();
+    if (this.selection !== "now") {
+      const [hours, minutes, seconds] = this.selection.split(":").map(Number);
+      this.date.setHours(hours);
+      this.date.setMinutes(minutes);
+      this.date.setSeconds(seconds);
+    }
+  }
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+      time_zone: TimeZone.local,
+    };
+    return html`
+      <ha-control-select
+        .value=${this.selection}
+        .options=${timeOptions}
+        @value-changed=${this.handleValueChanged}
+      >
+      </ha-control-select>
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">12 Hours</div>
+          <div class="center">24 Hours</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatTimeWeekday(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.language,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatTimeWeekday(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.am_pm,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatTimeWeekday(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.twenty_four,
+                    },
+                    demoConfig
+                  )}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-select {
+        max-width: 800px;
+        margin: 12px auto;
+      }
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 800px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-time-weekday": DemoDateTimeTimeWeekday;
+  }
+}

--- a/gallery/src/pages/date-time/time.markdown
+++ b/gallery/src/pages/date-time/time.markdown
@@ -1,0 +1,7 @@
+---
+title: Time Format
+---
+
+This pages lists all supported languages with their available time formats.
+
+Formatting function: `const formatTime: (dateObj: Date, locale: FrontendLocaleData) => string`

--- a/gallery/src/pages/date-time/time.ts
+++ b/gallery/src/pages/date-time/time.ts
@@ -1,0 +1,136 @@
+import { html, css, LitElement } from "lit";
+import { customElement, state } from "lit/decorators";
+import "../../../../src/components/ha-card";
+import "../../../../src/components/ha-control-select";
+import { translationMetadata } from "../../../../src/resources/translations-metadata";
+import { formatTime } from "../../../../src/common/datetime/format_time";
+import { timeOptions } from "../../data/date-options";
+import { demoConfig } from "../../../../src/fake_data/demo_config";
+import {
+  FrontendLocaleData,
+  NumberFormat,
+  TimeFormat,
+  DateFormat,
+  FirstWeekday,
+  TimeZone,
+} from "../../../../src/data/translation";
+
+@customElement("demo-date-time-time")
+export class DemoDateTimeTime extends LitElement {
+  @state() private selection?: string = "now";
+
+  @state() private date: Date = new Date();
+
+  handleValueChanged(e: CustomEvent) {
+    this.selection = e.detail.value as string;
+    this.date = new Date();
+    if (this.selection !== "now") {
+      const [hours, minutes, seconds] = this.selection.split(":").map(Number);
+      this.date.setHours(hours);
+      this.date.setMinutes(minutes);
+      this.date.setSeconds(seconds);
+    }
+  }
+
+  protected render() {
+    const defaultLocale: FrontendLocaleData = {
+      language: "en",
+      number_format: NumberFormat.language,
+      time_format: TimeFormat.language,
+      date_format: DateFormat.language,
+      first_weekday: FirstWeekday.language,
+      time_zone: TimeZone.local,
+    };
+    return html`
+      <ha-control-select
+        .value=${this.selection}
+        .options=${timeOptions}
+        @value-changed=${this.handleValueChanged}
+      >
+      </ha-control-select>
+      <mwc-list>
+        <div class="container header">
+          <div>Language</div>
+          <div class="center">Default (lang)</div>
+          <div class="center">12 Hours</div>
+          <div class="center">24 Hours</div>
+        </div>
+        ${Object.entries(translationMetadata.translations)
+          .filter(([key, _]) => key !== "test")
+          .map(
+            ([key, value]) => html`
+              <div class="container">
+                <div>${value.nativeName}</div>
+                <div class="center">
+                  ${formatTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.language,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.am_pm,
+                    },
+                    demoConfig
+                  )}
+                </div>
+                <div class="center">
+                  ${formatTime(
+                    this.date,
+                    {
+                      ...defaultLocale,
+                      language: key,
+                      time_format: TimeFormat.twenty_four,
+                    },
+                    demoConfig
+                  )}
+                </div>
+              </div>
+            `
+          )}
+      </mwc-list>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      ha-control-select {
+        max-width: 800px;
+        margin: 12px auto;
+      }
+      .header {
+        font-weight: bold;
+      }
+      .center {
+        text-align: center;
+      }
+      .container {
+        max-width: 600px;
+        margin: 12px auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+      }
+
+      .container > div {
+        flex-grow: 1;
+        width: 20%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-date-time-time": DemoDateTimeTime;
+  }
+}

--- a/src/common/datetime/format_date_time.ts
+++ b/src/common/datetime/format_date_time.ts
@@ -15,20 +15,15 @@ export const formatDateTime = (
 
 const formatDateTimeMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
-    new Intl.DateTimeFormat(
-      locale.language === "en" && !useAmPm(locale)
-        ? "en-u-hc-h23"
-        : locale.language,
-      {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-        hour: useAmPm(locale) ? "numeric" : "2-digit",
-        minute: "2-digit",
-        hour12: useAmPm(locale),
-        timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
-      }
-    )
+    new Intl.DateTimeFormat(locale.language, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: useAmPm(locale) ? "numeric" : "2-digit",
+      minute: "2-digit",
+      hourCycle: useAmPm(locale) ? "h12" : "h23",
+      timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
+    })
 );
 
 // Aug 9, 2021, 8:23 AM
@@ -40,20 +35,15 @@ export const formatShortDateTimeWithYear = (
 
 const formatShortDateTimeWithYearMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
-    new Intl.DateTimeFormat(
-      locale.language === "en" && !useAmPm(locale)
-        ? "en-u-hc-h23"
-        : locale.language,
-      {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: useAmPm(locale) ? "numeric" : "2-digit",
-        minute: "2-digit",
-        hour12: useAmPm(locale),
-        timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
-      }
-    )
+    new Intl.DateTimeFormat(locale.language, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: useAmPm(locale) ? "numeric" : "2-digit",
+      minute: "2-digit",
+      hourCycle: useAmPm(locale) ? "h12" : "h23",
+      timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
+    })
 );
 
 // Aug 9, 8:23 AM
@@ -65,19 +55,14 @@ export const formatShortDateTime = (
 
 const formatShortDateTimeMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
-    new Intl.DateTimeFormat(
-      locale.language === "en" && !useAmPm(locale)
-        ? "en-u-hc-h23"
-        : locale.language,
-      {
-        month: "short",
-        day: "numeric",
-        hour: useAmPm(locale) ? "numeric" : "2-digit",
-        minute: "2-digit",
-        hour12: useAmPm(locale),
-        timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
-      }
-    )
+    new Intl.DateTimeFormat(locale.language, {
+      month: "short",
+      day: "numeric",
+      hour: useAmPm(locale) ? "numeric" : "2-digit",
+      minute: "2-digit",
+      hourCycle: useAmPm(locale) ? "h12" : "h23",
+      timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
+    })
 );
 
 // August 9, 2021, 8:23:15 AM
@@ -89,21 +74,16 @@ export const formatDateTimeWithSeconds = (
 
 const formatDateTimeWithSecondsMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
-    new Intl.DateTimeFormat(
-      locale.language === "en" && !useAmPm(locale)
-        ? "en-u-hc-h23"
-        : locale.language,
-      {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-        hour: useAmPm(locale) ? "numeric" : "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        hour12: useAmPm(locale),
-        timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
-      }
-    )
+    new Intl.DateTimeFormat(locale.language, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: useAmPm(locale) ? "numeric" : "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: useAmPm(locale) ? "h12" : "h23",
+      timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
+    })
 );
 
 // 9/8/2021, 8:23 AM

--- a/src/common/datetime/format_time.ts
+++ b/src/common/datetime/format_time.ts
@@ -13,17 +13,12 @@ export const formatTime = (
 
 const formatTimeMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
-    new Intl.DateTimeFormat(
-      locale.language === "en" && !useAmPm(locale)
-        ? "en-u-hc-h23"
-        : locale.language,
-      {
-        hour: "numeric",
-        minute: "2-digit",
-        hour12: useAmPm(locale),
-        timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
-      }
-    )
+    new Intl.DateTimeFormat(locale.language, {
+      hour: "numeric",
+      minute: "2-digit",
+      hourCycle: useAmPm(locale) ? "h12" : "h23",
+      timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
+    })
 );
 
 // 9:15:24 PM || 21:15:24
@@ -35,18 +30,13 @@ export const formatTimeWithSeconds = (
 
 const formatTimeWithSecondsMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
-    new Intl.DateTimeFormat(
-      locale.language === "en" && !useAmPm(locale)
-        ? "en-u-hc-h23"
-        : locale.language,
-      {
-        hour: useAmPm(locale) ? "numeric" : "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        hour12: useAmPm(locale),
-        timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
-      }
-    )
+    new Intl.DateTimeFormat(locale.language, {
+      hour: useAmPm(locale) ? "numeric" : "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: useAmPm(locale) ? "h12" : "h23",
+      timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
+    })
 );
 
 // Tuesday 7:00 PM || Tuesday 19:00
@@ -58,18 +48,13 @@ export const formatTimeWeekday = (
 
 const formatTimeWeekdayMem = memoizeOne(
   (locale: FrontendLocaleData, serverTimeZone: string) =>
-    new Intl.DateTimeFormat(
-      locale.language === "en" && !useAmPm(locale)
-        ? "en-u-hc-h23"
-        : locale.language,
-      {
-        weekday: "long",
-        hour: useAmPm(locale) ? "numeric" : "2-digit",
-        minute: "2-digit",
-        hour12: useAmPm(locale),
-        timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
-      }
-    )
+    new Intl.DateTimeFormat(locale.language, {
+      weekday: "long",
+      hour: useAmPm(locale) ? "numeric" : "2-digit",
+      minute: "2-digit",
+      hourCycle: useAmPm(locale) ? "h12" : "h23",
+      timeZone: locale.time_zone === "server" ? serverTimeZone : undefined,
+    })
 );
 
 // 21:15

--- a/src/common/datetime/use_am_pm.ts
+++ b/src/common/datetime/use_am_pm.ts
@@ -8,7 +8,7 @@ export const useAmPm = memoizeOne((locale: FrontendLocaleData): boolean => {
   ) {
     const testLanguage =
       locale.time_format === TimeFormat.language ? locale.language : undefined;
-    const test = new Date("Januar 1, 2023 22:00:00").toLocaleString(
+    const test = new Date("January 1, 2023 22:00:00").toLocaleString(
       testLanguage
     );
     return test.includes("10");

--- a/src/common/datetime/use_am_pm.ts
+++ b/src/common/datetime/use_am_pm.ts
@@ -8,8 +8,10 @@ export const useAmPm = memoizeOne((locale: FrontendLocaleData): boolean => {
   ) {
     const testLanguage =
       locale.time_format === TimeFormat.language ? locale.language : undefined;
-    const test = new Date().toLocaleString(testLanguage);
-    return test.includes("AM") || test.includes("PM");
+    const test = new Date("Januar 1, 2023 22:00:00").toLocaleString(
+      testLanguage
+    );
+    return test.includes("10");
   }
 
   return locale.time_format === TimeFormat.am_pm;


### PR DESCRIPTION
- am/pm check possible for other languages
- adjusted date format gallery page for consistency
- added gallery pages for date-time and time formats

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Problem: Time in the 12h format shows 0:15 PM instead of 12:15PM #16692 
Wanted: correct 12h format
Solution: Added correct hour cycle to formatting functions

Additionally adapted check if am/pm is the default for a given language the other supported languages which don't use "AM"/"PM".

Adapted gallery pages for the numeric date format to be consistent with the new pages (date-time and time formats).

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

To verify the changes for all supported languages, there are new gallery pages in the "Date and Time" category.

- This PR fixes or closes issue: fixes #16692 #11891 
- This PR is related to issue or discussion: #9379 [Community Topic](https://community.home-assistant.io/t/wth-ha-energy-graph-should-be-12-00pm-not-00-00pm-for-midday/479342)
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
