### PR TITLE
Automation UI support for non-string state attributes

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -74,8 +74,8 @@ export interface StateTrigger extends BaseTrigger {
   platform: "state";
   entity_id: string | string[];
   attribute?: string;
-  from?: string | number;
-  to?: string | string[] | number;
+  from?: string | number | boolean;
+  to?: string | string[] | number | boolean;
   for?: string | number | ForDict;
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2299,10 +2299,14 @@
                 "state": {
                   "label": "State",
                   "attribute": "Attribute (optional)",
+                  "attribute_type": "Attribute Type",
+                  "attribute_type_string": "String",
+                  "attribute_type_number_boolean": "Number/Boolean",
                   "from": "From (optional)",
                   "for": "For",
                   "to": "To (optional)",
-                  "any_state_ignore_attributes": "Any state (ignoring attribute changes)"
+                  "any_state_ignore_attributes": "Any state (ignoring attribute changes)",
+                  "ui_error_attribute_type_mismatch": "The UI mode does not support attributes with mismatched types."
                 },
                 "homeassistant": {
                   "label": "Home Assistant",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

_This PR is a repost of #16148. I accidentally blew up that branch while attempting to rebase and resolve conflicts in a way that I could not recover. Sorry for the churn._

I would like to improve how non-string attributes are handled in the UI editor for state trigger. This seems to be a frequent point of confusion for new users, and I have seen this discussed many times; where entering `true` or a number fails a test because of type mismatch between strings and numbers/booleans. 

My idea for this would be to add a radio button shown for attributes, that selects if the to/from values should be parsed as strings, or as raw numbers/booleans. This could be further extended to automatically lookup the current attribute value & type to change the default suggested value, reducing the chances of making an error further, but for now just want to float this to get opinions on the UI. 

I'm open to other ideas, but would like to see _something_ done to improve this situation. I saw another possible suggestion to change the boxes from textboxes to YAML editors for attributes, though I'm not sure if this would be more intuitive or not. Also that would be a feature regression for attributes that currently offer choices as a dropdown. 

Whatever is settled on here will eventually need to be applied to state conditions as well, but I'll save that for later. 

![state-trigger-attributes](https://user-images.githubusercontent.com/32912880/231474138-ecd82651-5c0f-4af7-b744-21b0e1d03053.gif)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue or discussion:
#7231
#7708
#8029
#8606
#12340
#12634 
#13511
#14629 
#16071
#17101 

https://community.home-assistant.io/t/automation-not-running-on-state-attribute-change-what-am-i-doing-wrong/338285/10
https://community.home-assistant.io/t/using-state-attribute-number-values-in-automation/369490
https://community.home-assistant.io/t/attribute-as-trigger-isnt-working/266979/22

- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
