### PR TITLE
Allow selecting CIFS version in mount dialog

### DIFF
--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -34,6 +34,8 @@ const getValue = (obj, item) =>
 
 const getError = (obj, item) => (obj && item.name ? obj[item.name] : null);
 
+const getWarning = (obj, item) => (obj && item.name ? obj[item.name] : null);
+
 @customElement("ha-form")
 export class HaForm extends LitElement implements HaFormElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -44,9 +46,13 @@ export class HaForm extends LitElement implements HaFormElement {
 
   @property() public error?: Record<string, string>;
 
+  @property() public warning?: Record<string, string>;
+
   @property({ type: Boolean }) public disabled = false;
 
   @property() public computeError?: (schema: any, error) => string;
+
+  @property() public computeWarning?: (schema: any, error) => string;
 
   @property() public computeLabel?: (
     schema: any,
@@ -98,12 +104,19 @@ export class HaForm extends LitElement implements HaFormElement {
           : ""}
         ${this.schema.map((item) => {
           const error = getError(this.error, item);
+          const warning = getWarning(this.warning, item);
 
           return html`
             ${error
               ? html`
                   <ha-alert own-margin alert-type="error">
                     ${this._computeError(error, item)}
+                  </ha-alert>
+                `
+              : warning
+              ? html`
+                  <ha-alert own-margin alert-type="warning">
+                    ${this._computeWarning(warning, item)}
                   </ha-alert>
                 `
               : ""}
@@ -185,6 +198,13 @@ export class HaForm extends LitElement implements HaFormElement {
 
   private _computeError(error, schema: HaFormSchema | readonly HaFormSchema[]) {
     return this.computeError ? this.computeError(error, schema) : error;
+  }
+
+  private _computeWarning(
+    warning,
+    schema: HaFormSchema | readonly HaFormSchema[]
+  ) {
+    return this.computeWarning ? this.computeWarning(warning, schema) : warning;
   }
 
   static get styles(): CSSResultGroup {

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -52,7 +52,7 @@ export class HaForm extends LitElement implements HaFormElement {
 
   @property() public computeError?: (schema: any, error) => string;
 
-  @property() public computeWarning?: (schema: any, error) => string;
+  @property() public computeWarning?: (schema: any, warning) => string;
 
   @property() public computeLabel?: (
     schema: any,

--- a/src/data/supervisor/mounts.ts
+++ b/src/data/supervisor/mounts.ts
@@ -44,7 +44,7 @@ export interface SupervisorNFSMount extends SupervisorMountResponse {
 export interface SupervisorCIFSMount extends SupervisorMountResponse {
   type: SupervisorMountType.CIFS;
   share: string;
-  cifs_version?: CIFSVersion;
+  version?: CIFSVersion;
 }
 
 export type SupervisorMount = SupervisorNFSMount | SupervisorCIFSMount;
@@ -54,7 +54,7 @@ export type SupervisorNFSMountRequestParams = SupervisorNFSMount;
 export interface SupervisorCIFSMountRequestParams extends SupervisorCIFSMount {
   username?: string;
   password?: string;
-  cifs_version?: CIFSVersion;
+  version?: CIFSVersion;
 }
 
 export type SupervisorMountRequestParams =

--- a/src/data/supervisor/mounts.ts
+++ b/src/data/supervisor/mounts.ts
@@ -22,6 +22,8 @@ interface MountOptions {
   default_backup_mount?: string | null;
 }
 
+export type CIFSVersion = "auto" | "1.0" | "2.0";
+
 interface SupervisorMountBase {
   name: string;
   usage: SupervisorMountUsage;
@@ -42,6 +44,7 @@ export interface SupervisorNFSMount extends SupervisorMountResponse {
 export interface SupervisorCIFSMount extends SupervisorMountResponse {
   type: SupervisorMountType.CIFS;
   share: string;
+  cifs_version?: CIFSVersion;
 }
 
 export type SupervisorMount = SupervisorNFSMount | SupervisorCIFSMount;
@@ -51,6 +54,7 @@ export type SupervisorNFSMountRequestParams = SupervisorNFSMount;
 export interface SupervisorCIFSMountRequestParams extends SupervisorCIFSMount {
   username?: string;
   password?: string;
+  cifs_version?: CIFSVersion;
 }
 
 export type SupervisorMountRequestParams =

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -90,7 +90,7 @@ const mountSchema = memoizeOne(
             ...(showCIFSVersion
               ? ([
                   {
-                    name: "cifs_version",
+                    name: "version",
                     required: true,
                     selector: {
                       select: {
@@ -170,7 +170,8 @@ class ViewMountDialog extends LitElement {
     this._reloadMounts = dialogParams.reloadMounts;
     if (
       dialogParams.mount?.type === "cifs" &&
-      dialogParams.mount.cifs_version !== "auto"
+      dialogParams.mount.version &&
+      dialogParams.mount.version !== "auto"
     ) {
       this._showCIFSVersion = true;
     }
@@ -289,15 +290,15 @@ class ViewMountDialog extends LitElement {
     if (this._data?.name && !/^\w+$/.test(this._data.name)) {
       this._validationError.name = "invalid_name";
     }
-    if (this._data?.type === "cifs" && !this._data.cifs_version) {
-      this._data.cifs_version = "auto";
+    if (this._data?.type === "cifs" && !this._data.version) {
+      this._data.version = "auto";
     }
     if (
       this._data?.type === "cifs" &&
-      this._data.cifs_version &&
-      ["1.0", "2.0"].includes(this._data.cifs_version)
+      this._data.version &&
+      ["1.0", "2.0"].includes(this._data.version)
     ) {
-      this._validationWarning.cifs_version = "not_recomeded_cifs_version";
+      this._validationWarning.version = "not_recomeded_cifs_version";
     }
   }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4070,6 +4070,10 @@
               "nfs": "Network File Share (NFS)",
               "cifs": "Samba/Windows (CIFS)"
             },
+            "cifs_versions": {
+              "auto": "Auto (2.1+)",
+              "legacy": "Legacy ({version})"
+            },
             "options": {
               "name": {
                 "title": "Name",
@@ -4099,6 +4103,10 @@
                 "title": "Usage",
                 "description": "This determines how the share is intended to be used"
               },
+              "cifs_version": {
+                "title": "Samba/Windows (CIFS) version",
+                "description": "This choses the version of the protocol to use"
+              },
               "username": {
                 "title": "Username",
                 "description": "This is your username for the samba share"
@@ -4113,6 +4121,9 @@
             "errors": {
               "reload": "Could not reload mount {mount}",
               "invalid_name": "Invalid name, can only contain alphanumeric characters and underscores"
+            },
+            "warnings": {
+              "not_recomeded_cifs_version": "The selected CIFS version is not recommended to use, you should only use this if you have problems with auto and your server does not support version 2.1 or newer"
             }
           }
         },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4103,7 +4103,7 @@
                 "title": "Usage",
                 "description": "This determines how the share is intended to be used"
               },
-              "cifs_version": {
+              "version": {
                 "title": "Samba/Windows (CIFS) version",
                 "description": "This choses the version of the protocol to use"
               },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

For https://github.com/home-assistant/supervisor/pull/4395

Add an option to select CIFS version in the mount dialog.
![image](https://github.com/home-assistant/frontend/assets/15093472/c02ff692-f84d-4d89-9559-35aed7f6f025)
![image](https://github.com/home-assistant/frontend/assets/15093472/fa812ffb-d5cf-47fb-a862-883fa15b6f95)



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
