### PR TITLE
Fix automation picker overflow menu closing when automation triggers

### DIFF
--- a/src/components/data-table/ha-data-table.ts
+++ b/src/components/data-table/ha-data-table.ts
@@ -129,6 +129,8 @@ export class HaDataTable extends LitElement {
 
   @property({ type: String }) public filter = "";
 
+  @property({ type: Boolean }) public attemptInPlaceUpdates = false;
+
   @state() private _filterable = false;
 
   @state() private _filter = "";
@@ -482,11 +484,32 @@ export class HaDataTable extends LitElement {
       if (this.hasFab) {
         items.push({ empty: true });
       }
-      this._items = items;
+      this._inPlaceUpdateItems(items);
     } else {
-      this._items = data;
+      this._inPlaceUpdateItems(data);
     }
     this._filteredData = data;
+  }
+
+  private _inPlaceUpdateItems(items: DataTableRowData[]) {
+    // This function attemps to update the original DataTableRowData objects
+    // instead of overwriting them with new objects. Prevents popup menus
+    // from being destroyed when table data updates.
+
+    if (
+      !this.attemptInPlaceUpdates ||
+      !this._items ||
+      this._items.length !== items.length
+    ) {
+      this._items = items;
+      return;
+    }
+    for (let i = 0; i < items.length; i++) {
+      Object.assign(this._items[i], items[i]);
+    }
+
+    // Update the items pointer so that lit-virtualizer performs an update.
+    this._items = [...this._items];
   }
 
   private _memFilterData = memoizeOne(

--- a/src/layouts/hass-tabs-subpage-data-table.ts
+++ b/src/layouts/hass-tabs-subpage-data-table.ts
@@ -37,6 +37,8 @@ export class HaTabsSubpageDataTable extends LitElement {
 
   @property({ type: Boolean, attribute: "main-page" }) public mainPage = false;
 
+  @property({ type: Boolean }) public attemptInPlaceUpdates = false;
+
   /**
    * Object with the columns.
    * @type {Object}
@@ -240,6 +242,7 @@ export class HaTabsSubpageDataTable extends LitElement {
           .dir=${computeRTLDirection(this.hass)}
           .clickable=${this.clickable}
           .appendRow=${this.appendRow}
+          .attemptInPlaceUpdates=${this.attemptInPlaceUpdates}
         >
           ${!this.narrow
             ? html`

--- a/src/panels/config/automation/ha-automation-picker.ts
+++ b/src/panels/config/automation/ha-automation-picker.ts
@@ -282,6 +282,7 @@ class HaAutomationPicker extends LitElement {
         @clear-filter=${this._clearFilter}
         hasFab
         clickable
+        attemptInPlaceUpdates
       >
         <ha-icon-button
           slot="toolbar-icon"

--- a/src/panels/config/script/ha-script-picker.ts
+++ b/src/panels/config/script/ha-script-picker.ts
@@ -222,6 +222,7 @@ class HaScriptPicker extends LitElement {
         hasFab
         clickable
         @row-click=${this._handleRowClicked}
+        attemptInPlaceUpdates
       >
         <ha-icon-button
           slot="toolbar-icon"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This change allows the automation picker overflow menu to not automatically close every time any automation the system is triggered. 

I don't perfectly understand exactly what is happening here, but I believe that anytime an automation is triggered the entire data table is recreated with new objects. Then when the table data is eventually passed down to lit-virtualizer, it thinks all the rows are "new" and it destroys and recreates all the html elements, forcing the mwc-menu to be recreated fresh (and closed). 

I did some trial and error to work around this and eventually found that in the ha-data-table, if I keep the DataTableRowData from being destroyed when the data updates, and instead just re-use the existing objects, the overflow menu is not closed just by a piece of the table data updating. 

I restricted this behavior change to only the automation/script pickers to minimize the scope of the change, and not affect other data tables. 

![automation-picker](https://github.com/home-assistant/frontend/assets/32912880/4636a92d-6810-48e5-8914-9cd557bca833)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13664 fixes #15897
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
