### PR TITLE
Use ha-icon-button-group in more info cover

### DIFF
--- a/src/dialogs/more-info/controls/more-info-cover.ts
+++ b/src/dialogs/more-info/controls/more-info-cover.ts
@@ -11,6 +11,8 @@ import { customElement, property, state } from "lit/decorators";
 import { computeStateDisplay } from "../../../common/entity/compute_state_display";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import "../../../components/ha-attributes";
+import "../../../components/ha-icon-button-group";
+import "../../../components/ha-icon-button-toggle";
 import {
   computeCoverPositionStateDisplay,
   CoverEntity,
@@ -24,6 +26,8 @@ import "../components/cover/ha-more-info-cover-toggle";
 import { moreInfoControlStyle } from "../components/ha-more-info-control-style";
 import "../components/ha-more-info-state-header";
 
+type Mode = "position" | "button";
+
 @customElement("more-info-cover")
 class MoreInfoCover extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -34,10 +38,10 @@ class MoreInfoCover extends LitElement {
 
   @state() private _liveTilt?: number;
 
-  @state() private _mode?: "position" | "button";
+  @state() private _mode?: Mode;
 
-  private _toggleMode() {
-    this._mode = this._mode === "position" ? "button" : "position";
+  private _setMode(ev) {
+    this._mode = ev.currentTarget.mode;
   }
 
   private _positionSliderMoved(ev) {
@@ -192,19 +196,26 @@ class MoreInfoCover extends LitElement {
             (supportsPosition || supportsTiltPosition) &&
             (supportsOpenClose || supportsTilt)
               ? html`
-                  <div class="actions">
-                    <ha-icon-button
+                  <ha-icon-button-group>
+                    <ha-icon-button-toggle
                       .label=${this.hass.localize(
-                        `ui.dialogs.more_info_control.cover.switch_mode.${
-                          this._mode === "position" ? "button" : "position"
-                        }`
+                        `ui.dialogs.more_info_control.cover.switch_mode.position`
                       )}
-                      .path=${this._mode === "position"
-                        ? mdiSwapVertical
-                        : mdiMenu}
-                      @click=${this._toggleMode}
-                    ></ha-icon-button>
-                  </div>
+                      .selected=${this._mode === "position"}
+                      .path=${mdiMenu}
+                      .mode=${"position"}
+                      @click=${this._setMode}
+                    ></ha-icon-button-toggle>
+                    <ha-icon-button-toggle
+                      .label=${this.hass.localize(
+                        `ui.dialogs.more_info_control.cover.switch_mode.button`
+                      )}
+                      .selected=${this._mode === "button"}
+                      .path=${mdiSwapVertical}
+                      .mode=${"button"}
+                      @click=${this._setMode}
+                    ></ha-icon-button-toggle>
+                  </ha-icon-button-group>
                 `
               : nothing
           }


### PR DESCRIPTION
## Proposed change

![CleanShot 2023-06-14 at 18 26 36](https://github.com/home-assistant/frontend/assets/5878303/e9dac1d4-7289-464f-91d4-675148c5bf95)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
