### PR TITLE
Use fuzzy filter/sort for target pickers

### DIFF
--- a/src/components/device/ha-device-picker.ts
+++ b/src/components/device/ha-device-picker.ts
@@ -125,13 +125,14 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
       deviceFilter: this["deviceFilter"],
       entityFilter: this["entityFilter"],
       excludeDevices: this["excludeDevices"]
-    ): Device[] => {
+    ): ScorableDevice[] => {
       if (!devices.length) {
         return [
           {
             id: "no_devices",
             area: "",
             name: this.hass.localize("ui.components.device-picker.no_devices"),
+            strings: [],
           },
         ];
       }
@@ -241,6 +242,7 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
           device.area_id && areaLookup[device.area_id]
             ? areaLookup[device.area_id].name
             : this.hass.localize("ui.components.device-picker.no_area"),
+        strings: [device.name || ""],
       }));
       if (!outputDevices.length) {
         return [
@@ -248,6 +250,7 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
             id: "no_devices",
             area: "",
             name: this.hass.localize("ui.components.device-picker.no_match"),
+            strings: [],
           },
         ];
       }
@@ -300,9 +303,9 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
         this.deviceFilter,
         this.entityFilter,
         this.excludeDevices
-      ).map((device) => ({ ...device, strings: [device.name] }));
-      (this.comboBox as any).items = devices;
-      (this.comboBox as any).filteredItems = devices;
+      );
+      this.comboBox.items = devices;
+      this.comboBox.filteredItems = devices;
     }
   }
 
@@ -332,11 +335,11 @@ export class HaDevicePicker extends SubscribeMixin(LitElement) {
   }
 
   private _filterChanged(ev: CustomEvent): void {
+    const target = ev.target as HaComboBox;
     const filterString = ev.detail.value.toLowerCase();
-    (this.comboBox as any).filteredItems = fuzzyFilterSort<ScorableDevice>(
-      filterString,
-      this.comboBox?.items || []
-    );
+    target.filteredItems = filterString.length
+      ? fuzzyFilterSort<ScorableDevice>(filterString, target.items || [])
+      : target.items;
   }
 
   private _deviceChanged(ev: ValueChangedEvent<string>) {

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -173,14 +173,22 @@ export class HaEntityPicker extends LitElement {
           this.includeEntities!.includes(entityId)
         );
 
-        return entityIds.map((key) => {
-          const friendly_name = computeStateName(hass!.states[key]) || key;
-          return {
-            ...hass!.states[key],
-            friendly_name,
-            strings: [key, friendly_name],
-          };
-        });
+        return entityIds
+          .map((key) => {
+            const friendly_name = computeStateName(hass!.states[key]) || key;
+            return {
+              ...hass!.states[key],
+              friendly_name,
+              strings: [key, friendly_name],
+            };
+          })
+          .sort((entityA, entityB) =>
+            caseInsensitiveStringCompare(
+              entityA.friendly_name,
+              entityB.friendly_name,
+              this.hass.locale.language
+            )
+          );
       }
 
       if (excludeEntities) {

--- a/src/components/ha-area-picker.ts
+++ b/src/components/ha-area-picker.ts
@@ -316,8 +316,8 @@ export class HaAreaPicker extends LitElement {
         ...area,
         strings: [area.area_id, ...area.aliases, area.name],
       }));
-      (this.comboBox as any).items = areas;
-      (this.comboBox as any).filteredItems = areas;
+      this.comboBox.items = areas;
+      this.comboBox.filteredItems = areas;
     }
   }
 
@@ -419,7 +419,7 @@ export class HaAreaPicker extends LitElement {
             name,
           });
           const areas = [...Object.values(this.hass.areas), area];
-          (this.comboBox as any).filteredItems = this._getAreas(
+          this.comboBox.filteredItems = this._getAreas(
             areas,
             Object.values(this.hass.devices)!,
             Object.values(this.hass.entities)!,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change
Switches to fuzzy filter & sort for the three target pickers (area, device & entity). Queries entered in these pickers will now be much more forgiving, but you will likely see a slight change in the list behavior due to the new filtering algorithm.
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Currently, the quick bar utilizes a fuzzy filter & sort utility that makes it very easy and forgiving to find desired entities. However, the target pickers utilized throughout the rest of the application are fairly strict and require almost exact partial strings to return the desired items.

As an example - I have many devices with apostrophes, such as `Jenny's Phone`, `Jenny's Lamp`, `Chris' Phone`, etc. To get to the desired device, e.g. `Jenny's Phone`, I either wind up typing something close to the full prefix, `jenny's p` (including apostrophe) or `phone` and then have to find the correct phone (out of 5 entities). The fuzzy sort utilized by the quick bar would allow me to type something like `jennp` and have `Jenny's Phone` be the top result. I'm guessing you guys generally don't need much extra info on the fuzzy sort itself; this is primarily to just extend a great feature to other parts of the UI.

For the searchable strings in the fuzzy sort, I included what I felt were relevant data-points for each type. However, if it should be more restrictive (or broad), I'm totally fine with that.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
I marked this as a breaking change, but am not sure if that is correct. The updates will have no impact on existing user configurations, but it does slightly alter the UX contract with end-users.

Also, I'm guessing that the `Tests have been added...` checklist item is inapplicable here, as there doesn't seem to be any test suite for the pickers (or most of the frontend codebase for that matter). If I've missed where tests are handled, please advise on how to proceed.
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
