### PR TITLE
Add 'Default' option to theme-picker

### DIFF
--- a/src/components/ha-selector/ha-selector-theme.ts
+++ b/src/components/ha-selector/ha-selector-theme.ts
@@ -24,6 +24,7 @@ export class HaThemeSelector extends LitElement {
         .hass=${this.hass}
         .value=${this.value}
         .label=${this.label}
+        .includeDefault=${this.selector.theme?.include_default}
         .disabled=${this.disabled}
         .required=${this.required}
       ></ha-theme-picker>

--- a/src/components/ha-theme-picker.ts
+++ b/src/components/ha-theme-picker.ts
@@ -1,5 +1,12 @@
 import "@material/mwc-list/mwc-list-item";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import {
+  css,
+  CSSResultGroup,
+  html,
+  nothing,
+  LitElement,
+  TemplateResult,
+} from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import { stopPropagation } from "../common/dom/stop_propagation";
@@ -11,6 +18,8 @@ export class HaThemePicker extends LitElement {
   @property() public value?: string;
 
   @property() public label?: string;
+
+  @property() includeDefault?: boolean = false;
 
   @property({ attribute: false }) public hass?: HomeAssistant;
 
@@ -36,11 +45,13 @@ export class HaThemePicker extends LitElement {
             "ui.components.theme-picker.no_theme"
           )}</mwc-list-item
         >
-        <mwc-list-item value="default"
-          >${this.hass!.localize(
-            "ui.components.theme-picker.default"
-          )}</mwc-list-item
-        >
+        ${this.includeDefault
+          ? html` <mwc-list-item value="default"
+              >${this.hass!.localize(
+                "ui.components.theme-picker.default"
+              )}</mwc-list-item
+            >`
+          : nothing}
         ${Object.keys(this.hass!.themes.themes)
           .sort()
           .map(

--- a/src/components/ha-theme-picker.ts
+++ b/src/components/ha-theme-picker.ts
@@ -13,6 +13,8 @@ import { stopPropagation } from "../common/dom/stop_propagation";
 import { HomeAssistant } from "../types";
 import "./ha-select";
 
+const DEFAULT_THEME = "default";
+
 @customElement("ha-theme-picker")
 export class HaThemePicker extends LitElement {
   @property() public value?: string;
@@ -46,7 +48,7 @@ export class HaThemePicker extends LitElement {
           )}</mwc-list-item
         >
         ${this.includeDefault
-          ? html` <mwc-list-item value="default"
+          ? html`<mwc-list-item .value=${DEFAULT_THEME}
               >${this.hass!.localize(
                 "ui.components.theme-picker.default"
               )}</mwc-list-item

--- a/src/components/ha-theme-picker.ts
+++ b/src/components/ha-theme-picker.ts
@@ -36,6 +36,11 @@ export class HaThemePicker extends LitElement {
             "ui.components.theme-picker.no_theme"
           )}</mwc-list-item
         >
+        <mwc-list-item value="default"
+          >${this.hass!.localize(
+            "ui.components.theme-picker.default"
+          )}</mwc-list-item
+        >
         ${Object.keys(this.hass!.themes.themes)
           .sort()
           .map(

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -346,7 +346,7 @@ export interface TemplateSelector {
 
 export interface ThemeSelector {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  theme: {} | null;
+  theme: { include_default?: boolean } | null;
 }
 export interface TimeSelector {
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -345,7 +345,6 @@ export interface TemplateSelector {
 }
 
 export interface ThemeSelector {
-  // eslint-disable-next-line @typescript-eslint/ban-types
   theme: { include_default?: boolean } | null;
 }
 export interface TimeSelector {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -396,7 +396,8 @@
       },
       "theme-picker": {
         "theme": "Theme",
-        "no_theme": "No theme"
+        "no_theme": "No theme",
+        "default": "Default"
       },
       "language-picker": {
         "language": "Language",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -397,7 +397,7 @@
       "theme-picker": {
         "theme": "Theme",
         "no_theme": "No theme",
-        "default": "Default"
+        "default": "[%key:ui::panel::profile::themes::default%]"
       },
       "language-picker": {
         "language": "Language",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add 'Default' as an option to the theme picker. As a usecase, `frontend.set_theme` service call can pass 'default' to change the theme back to the default, but that cannot currently be chosen in the UI. Also as a usecase, for cards that allow to set an overriding theme (like entities card), this allow to choose the default theme for the card, which otherwise cannot be chosen in the picker. 

![image](https://github.com/home-assistant/frontend/assets/32912880/01b566f2-a014-4818-b461-cef26f1aadb3)

This is subtly different from "No Theme" option, which is the null value, and is not a valid option for `frontend.set_theme`. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
