### PR TITLE
Update developer-tools-template.ts: Vertical layout instead of horizo…

### DIFF
--- a/src/panels/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/developer-tools/template/developer-tools-template.ts
@@ -86,7 +86,7 @@ class HaPanelDevTemplate extends LitElement {
       <div
         class="content ${classMap({
           layout: !this.narrow,
-          horizontal: !this.narrow,
+          vertical: !this.narrow,
         })}"
       >
         <div class="edit-pane">
@@ -264,10 +264,6 @@ class HaPanelDevTemplate extends LitElement {
 
         .edit-pane a {
           color: var(--primary-color);
-        }
-
-        .horizontal .edit-pane {
-          max-width: 50%;
         }
 
         .render-pane {


### PR DESCRIPTION
## Proposed change


My templates, and I think, many other templates tend to be wider rather than longer.

Changing to a stacked vertical layout between the editor box and the result box allow me to see my absurdly long one-line templates without scrolling.


## Type of change

I don't know what type of change this is.

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ x ] Code quality improvements to existing code or addition of tests

## Example configuration


```yaml

```

## Additional information

- This PR is related to issue or discussion: [16002](https://github.com/home-assistant/frontend/discussions/16002)

Change to this:
![image](https://github.com/home-assistant/frontend/assets/29560911/1a1630a8-b33a-421d-a37a-a1ef7cd3f861)
instead of:
![image](https://github.com/home-assistant/frontend/assets/29560911/b95a720b-5efa-45cc-8dce-6f816a6bebb7)

## Checklist

I don't know how to do any checks.

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
