### PR TITLE
Add help button to get documentation from mount dialog

### DIFF
--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -1,8 +1,10 @@
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
+import { mdiHelpCircle } from "@mdi/js";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-form/ha-form";
+import "../../../components/ha-icon-button";
 import { extractApiErrorMessage } from "../../../data/hassio/common";
 import {
   createSupervisorMount,
@@ -17,6 +19,8 @@ import { HomeAssistant } from "../../../types";
 import { MountViewDialogParams } from "./show-dialog-view-mount";
 import { LocalizeFunc } from "../../../common/translations/localize";
 import type { SchemaUnion } from "../../../components/ha-form/types";
+import { documentationUrl } from "../../../util/documentation-url";
+import { computeRTLDirection } from "../../../common/util/compute_rtl";
 
 const mountSchema = memoizeOne(
   (
@@ -149,15 +153,36 @@ class ViewMountDialog extends LitElement {
         open
         scrimClickAction
         escapeKeyAction
-        .heading=${this._existing
-          ? this.hass.localize(
-              "ui.panel.config.storage.network_mounts.update_title"
-            )
-          : this.hass.localize(
-              "ui.panel.config.storage.network_mounts.add_title"
-            )}
+        .heading=${true}
         @closed=${this.closeDialog}
       >
+        <ha-dialog-header slot="heading">
+          <span slot="title"
+            >${this._existing
+              ? this.hass.localize(
+                  "ui.panel.config.storage.network_mounts.update_title"
+                )
+              : this.hass.localize(
+                  "ui.panel.config.storage.network_mounts.add_title"
+                )}
+          </span>
+          <a
+            slot="actionItems"
+            class="header_button"
+            href=${documentationUrl(
+              this.hass,
+              "/common-tasks/os#network-storage"
+            )}
+            title=${this.hass.localize(
+              "ui.panel.config.storage.network_mounts.documentation"
+            )}
+            target="_blank"
+            rel="noreferrer"
+            dir=${computeRTLDirection(this.hass)}
+          >
+            <ha-icon-button .path=${mdiHelpCircle}></ha-icon-button>
+          </a>
+        </ha-dialog-header>
         ${this._error
           ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
           : nothing}
@@ -274,6 +299,9 @@ class ViewMountDialog extends LitElement {
       haStyle,
       haStyleDialog,
       css`
+        ha-icon-button {
+          color: var(--primary-text-color);
+        }
         .delete-btn {
           --mdc-theme-primary: var(--error-color);
         }

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -153,7 +153,13 @@ class ViewMountDialog extends LitElement {
         open
         scrimClickAction
         escapeKeyAction
-        .heading=${true}
+        .heading=${this._existing
+          ? this.hass.localize(
+              "ui.panel.config.storage.network_mounts.update_title"
+            )
+          : this.hass.localize(
+              "ui.panel.config.storage.network_mounts.add_title"
+            )}
         @closed=${this.closeDialog}
       >
         <ha-dialog-header slot="heading">

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4055,6 +4055,7 @@
             "add_title": "Add network storage",
             "update_title": "Update network storage",
             "no_mounts": "No connected network storage",
+            "documentation": "Documentation",
             "not_supported": {
               "title": "The operating system does not support network storage",
               "supervised": "Network storage is not supported on this host",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds a help button for mount documentation, similar to what we have in card editors.
![image](https://github.com/home-assistant/frontend/assets/15093472/da0ba361-377e-4a37-ba5d-f2a8a70e089a)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
