### PR TITLE
Fix notifications subscription leak when in narrow mode

### DIFF
--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -74,11 +74,16 @@ class HaMenuButton extends LitElement {
     }
 
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
-    const oldNarrow =
-      changedProps.get("narrow") ||
-      (oldHass && oldHass.dockedSidebar === "always_hidden");
-    const newNarrow =
-      this.narrow || this.hass.dockedSidebar === "always_hidden";
+
+    let oldNarrow: boolean | undefined;
+    let newNarrow: boolean | undefined;
+    if (changedProps.has("narrow")) {
+      oldNarrow = changedProps.get("narrow");
+      newNarrow = this.narrow;
+    } else if (oldHass) {
+      oldNarrow = oldHass.dockedSidebar === "always_hidden";
+      newNarrow = this.hass.dockedSidebar === "always_hidden";
+    }
 
     if (oldNarrow === newNarrow) {
       return;
@@ -98,6 +103,9 @@ class HaMenuButton extends LitElement {
   }
 
   private _subscribeNotifications() {
+    if (this._unsubNotifications) {
+      throw new Error("Already subscribed");
+    }
     this._unsubNotifications = subscribeNotifications(
       this.hass.connection,
       (notifications) => {


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

In narrow mode (inspect, toggle into device mode) this is observed on the console
<img width="939" alt="Screenshot 2023-06-17 at 6 05 36 PM" src="https://github.com/home-assistant/frontend/assets/663432/165b5d96-f1e8-4fa9-bde2-35bfd849097e">

tested with mobile ✅  always hide sidebar ✅  normal ✅

fixes #16952

`oldNarrow` was always false every time `hass` changed so it would always make a new subscription.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
