### PR TITLE
Fix support for alternate-audio and subtitles for hls

### DIFF
--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -109,7 +109,7 @@ class HaHLSPlayer extends LitElement {
   private async _startHls(): Promise<void> {
     const masterPlaylistPromise = fetch(this.url);
 
-    const Hls: typeof HlsType = (await import("hls.js/dist/hls.light.mjs"))
+    const Hls: typeof HlsType = (await import("hls.js/dist/hls.mjs"))
       .default;
 
     if (!this.isConnected) {
@@ -144,12 +144,15 @@ class HaHLSPlayer extends LitElement {
       /#EXT-X-STREAM-INF:.*?(?:CODECS=".*?(hev1|hvc1)?\..*?".*?)?(?:\n|\r\n)(.+)/g;
     const match = playlistRegexp.exec(masterPlaylist);
     const matchTwice = playlistRegexp.exec(masterPlaylist);
+    // Audio and Subtitles can be part of dedicated playlists #EXT-X-MEDIA
+    const altMediaRegexp = /#EXT-X-MEDIA:/g
+    const matchAltMedia = altMediaRegexp.exec(masterPlaylist);
 
     // Get the regular playlist url from the input (master) playlist, falling back to the input playlist if necessary
     // This avoids the player having to load and parse the master playlist again before loading the regular playlist
     let playlist_url: string;
-    if (match !== null && matchTwice === null) {
-      // Only send the regular playlist url if we match exactly once
+    if (match !== null && matchTwice === null && matchAltMedia === null) {
+      // Only send the regular playlist url if we match exactly once and no alternate media
       playlist_url = new URL(match[2], this.url).href;
     } else {
       playlist_url = this.url;

--- a/src/components/ha-hls-player.ts
+++ b/src/components/ha-hls-player.ts
@@ -41,6 +41,9 @@ class HaHLSPlayer extends LitElement {
   @property({ type: Boolean, attribute: "allow-exoplayer" })
   public allowExoPlayer = false;
 
+  @property({ type: Boolean, attribute: "allow-altmedia" })
+  public allowAltMedia = false;
+
   // don't cache this, as we remove it on disconnects
   @query("video") private _videoEl!: HTMLVideoElement;
 
@@ -109,8 +112,13 @@ class HaHLSPlayer extends LitElement {
   private async _startHls(): Promise<void> {
     const masterPlaylistPromise = fetch(this.url);
 
-    const Hls: typeof HlsType = (await import("hls.js/dist/hls.mjs"))
-      .default;
+    // Load Hls full module only if needed
+    let Hls: typeof HlsType;
+    if (this.allowAltMedia) {
+      Hls = (await import("hls.js/dist/hls.mjs")).default;
+    } else {
+      Hls = (await import("hls.js/dist/hls.light.mjs")).default;
+    }
 
     if (!this.isConnected) {
       return;
@@ -145,7 +153,7 @@ class HaHLSPlayer extends LitElement {
     const match = playlistRegexp.exec(masterPlaylist);
     const matchTwice = playlistRegexp.exec(masterPlaylist);
     // Audio and Subtitles can be part of dedicated playlists #EXT-X-MEDIA
-    const altMediaRegexp = /#EXT-X-MEDIA:/g
+    const altMediaRegexp = /#EXT-X-MEDIA:/g;
     const matchAltMedia = altMediaRegexp.exec(masterPlaylist);
 
     // Get the regular playlist url from the input (master) playlist, falling back to the input playlist if necessary

--- a/src/panels/media-browser/hui-dialog-web-browser-play-media.ts
+++ b/src/panels/media-browser/hui-dialog-web-browser-play-media.ts
@@ -71,6 +71,7 @@ export class HuiDialogWebBrowserPlayMedia extends LitElement {
                 controls
                 autoplay
                 playsinline
+                allow-altmedia
                 .hass=${this.hass}
                 .url=${this._params.sourceUrl}
               ></ha-hls-player>


### PR DESCRIPTION
## Proposed change

Fix the HLS wrapping implementation in order to support the HLS standard 'alternate-audio' and subtitles feature.
There is currently an optimization in the software that prevent this feature to work:

- The 'light' version of hls.js is used and this one does not support 'alternate-audio' as per [documentation](https://github.com/video-dev/hls.js/blob/35cf55a8748aa9cfc062803cf9ecbdfbc5d65904/README.md?plain=1#L195)
- The optimization consisting in reading the master playlist only once in case it contains only a basic playlist needs to be corrected to also consider the case of 'alternate-audio' (tag #EXT-X-MEDIA used).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16972

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
