### PR TITLE
Include blueprint type in row id key

### DIFF
--- a/src/panels/config/blueprint/ha-blueprint-overview.ts
+++ b/src/panels/config/blueprint/ha-blueprint-overview.ts
@@ -96,6 +96,7 @@ class HaBlueprintOverview extends LitElement {
               type,
               error: true,
               path,
+              fullpath: `${type}/${path}`,
             });
           } else {
             result.push({
@@ -103,6 +104,7 @@ class HaBlueprintOverview extends LitElement {
               type,
               error: false,
               path,
+              fullpath: `${type}/${path}`,
             });
           }
         })
@@ -153,6 +155,10 @@ class HaBlueprintOverview extends LitElement {
         hidden: narrow,
         direction: "asc",
         width: "25%",
+      },
+      fullpath: {
+        title: "fullpath",
+        hidden: true,
       },
       actions: {
         title: "",
@@ -233,7 +239,7 @@ class HaBlueprintOverview extends LitElement {
         .tabs=${configSections.automations}
         .columns=${this._columns(this.narrow, this.hass.language)}
         .data=${this._processedBlueprints(this.blueprints)}
-        id="path"
+        id="fullpath"
         .noDataText=${this.hass.localize(
           "ui.panel.config.blueprint.overview.no_blueprints"
         )}
@@ -318,7 +324,7 @@ class HaBlueprintOverview extends LitElement {
 
   private _handleRowClicked(ev: HASSDomEvent<RowClickedEvent>) {
     const blueprint = this._processedBlueprints(this.blueprints).find(
-      (b) => b.path === ev.detail.id
+      (b) => b.fullpath === ev.detail.id
     );
     if (blueprint.error) {
       showAlertDialog(this, {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

I had two BPs with the same filename `script/foo.yaml` and `automation/foo.yaml`. 

These both appeared in the blueprints table, but clicking on both of them brought up the automation one only, since the table was not indexed by the blueprint type. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
