### PR TITLE
Fix split area into separate devices and entities

### DIFF
--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -249,9 +249,13 @@ export class HaServiceControl extends LitElement {
   ) {
     const targetSelector = target ? { target } : { target: {} };
     const targetEntities =
-      ensureArray(value?.target?.entity_id || value?.data?.entity_id) || [];
+      ensureArray(
+        value?.target?.entity_id?.slice() || value?.data?.entity_id
+      ) || [];
     const targetDevices =
-      ensureArray(value?.target?.device_id || value?.data?.device_id) || [];
+      ensureArray(
+        value?.target?.device_id?.slice() || value?.data?.device_id
+      ) || [];
     const targetAreas = ensureArray(
       value?.target?.area_id || value?.data?.area_id
     );

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -250,15 +250,15 @@ export class HaServiceControl extends LitElement {
     const targetSelector = target ? { target } : { target: {} };
     const targetEntities =
       ensureArray(
-        value?.target?.entity_id?.slice() || value?.data?.entity_id
-      ) || [];
+        value?.target?.entity_id || value?.data?.entity_id
+      )?.slice() || [];
     const targetDevices =
       ensureArray(
-        value?.target?.device_id?.slice() || value?.data?.device_id
-      ) || [];
+        value?.target?.device_id || value?.data?.device_id
+      )?.slice() || [];
     const targetAreas = ensureArray(
       value?.target?.area_id || value?.data?.area_id
-    );
+    )?.slice();
     if (targetAreas) {
       targetAreas.forEach((areaId) => {
         const expanded = expandAreaTarget(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

So that it only expands the devices and entities from within the area. 
The comboboxes beneath the pickers contain all the possible devices, entities and areas. Unfortunately, the current selected devices, entities and areas was used as a starting point to calculate that and modified after calculation. 
See the videos in the issue. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

With 3 lamps: Assign first lamp to area1, second lamp to area2, and third lamp to area1 and area2.
Then use the call service action, add area1 and area2. Then expand area2: first, second and third lamp show as expansion of area2 whereof the first lamp in area1 shouldn't be there and third lamp shows twice.

So the devices not assigned to the just expanded area are the devices which are in the other areas added.

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16836
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
