### PR TITLE
Fix overview failing to render in some cases with toUpperCase exception

### DIFF
--- a/src/common/entity/strip_prefix_from_entity_name.ts
+++ b/src/common/entity/strip_prefix_from_entity_name.ts
@@ -17,12 +17,13 @@ export const stripPrefixFromEntityName = (
 
     if (lowerCasedEntityName.startsWith(lowerCasedPrefixWithSuffix)) {
       const newName = entityName.substring(lowerCasedPrefixWithSuffix.length);
-
-      // If first word already has an upper case letter (e.g. from brand name)
-      // leave as-is, otherwise capitalize the first word.
-      return hasUpperCase(newName.substr(0, newName.indexOf(" ")))
-        ? newName
-        : newName[0].toUpperCase() + newName.slice(1);
+      if (newName.length) {
+        // If first word already has an upper case letter (e.g. from brand name)
+        // leave as-is, otherwise capitalize the first word.
+        return hasUpperCase(newName.substr(0, newName.indexOf(" ")))
+          ? newName
+          : newName[0].toUpperCase() + newName.slice(1);
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If an entity has a friendly name with a trailing space like `"Gym "`, and it is assigned to an area of the same name like `"Gym"`, the overview dashboard will fail to render and throw the following exception:

```
get-strategy.ts:88 TypeError: Cannot read properties of undefined (reading 'toUpperCase')
    at stripPrefixFromEntityName (strip_prefix_from_entity_name.ts:23:1)
    at computeCards (generate-lovelace-config.ts:194:1)
    at generateDefaultViewConfig (generate-lovelace-config.ts:503:1)
    at OriginalStatesStrategy.generateView (original-states-strategy.ts:38:1)
    at async generateStrategy (get-strategy.ts:84:1)
    at async HUIView._initializeConfig (hui-view.ts:192:1)
 ```
 
It is not normally possible for an entity to have a trailing space in the name, but in some cases it is possible if it is created that way by an integration. I did it with a Shelly by giving it that name in the shelly console, and I saw a report that it is possible with the Kasa app as well. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16260 fixes #16645 fixes #17019
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
