### PR TITLE
Catch errors when describeTrigger throws an exception

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -82,6 +82,26 @@ export const describeTrigger = (
   entityRegistry: EntityRegistryEntry[],
   ignoreAlias = false
 ) => {
+  try {
+    return tryDescribeTrigger(trigger, hass, entityRegistry, ignoreAlias);
+  } catch (error: any) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+
+    let msg = "Error in describing trigger";
+    if (error.message) {
+      msg += ": " + error.message;
+    }
+    return msg;
+  }
+};
+
+const tryDescribeTrigger = (
+  trigger: Trigger,
+  hass: HomeAssistant,
+  entityRegistry: EntityRegistryEntry[],
+  ignoreAlias = false
+) => {
   if (trigger.alias && !ignoreAlias) {
     return trigger.alias;
   }
@@ -621,6 +641,26 @@ export const describeTrigger = (
 };
 
 export const describeCondition = (
+  condition: Condition,
+  hass: HomeAssistant,
+  entityRegistry: EntityRegistryEntry[],
+  ignoreAlias = false
+) => {
+  try {
+    return tryDescribeCondition(condition, hass, entityRegistry, ignoreAlias);
+  } catch (error: any) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+
+    let msg = "Error in describing condition";
+    if (error.message) {
+      msg += ": " + error.message;
+    }
+    return msg;
+  }
+};
+
+const tryDescribeCondition = (
   condition: Condition,
   hass: HomeAssistant,
   entityRegistry: EntityRegistryEntry[],

--- a/src/data/script_i18n.ts
+++ b/src/data/script_i18n.ts
@@ -39,6 +39,32 @@ export const describeAction = <T extends ActionType>(
   actionType?: T,
   ignoreAlias = false
 ): string => {
+  try {
+    return tryDescribeAction(
+      hass,
+      entityRegistry,
+      action,
+      actionType,
+      ignoreAlias
+    );
+  } catch (error: any) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    let msg = "Error in describing action";
+    if (error.message) {
+      msg += ": " + error.message;
+    }
+    return msg;
+  }
+};
+
+const tryDescribeAction = <T extends ActionType>(
+  hass: HomeAssistant,
+  entityRegistry: EntityRegistryEntry[],
+  action: ActionTypes[T],
+  actionType?: T,
+  ignoreAlias = false
+): string => {
   if (action.alias && !ignoreAlias) {
     return action.alias;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If describeTrigger/describeCondition/describeAction throw an error, it can silently eat the entire row in the visual editor, and the trigger/condition/action may not be displayed.

Instead, let the trigger/condition/action remain visible, but display that an error occured in describing the row. 

![image](https://github.com/home-assistant/frontend/assets/32912880/93a8351e-46b7-42b0-b6c1-89438994b70e)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16643 fixes #16986
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
