### PR TITLE
Automatic casing of nouns based on language

### DIFF
--- a/src/common/string/lowercase_first_letter.ts
+++ b/src/common/string/lowercase_first_letter.ts
@@ -1,0 +1,2 @@
+export const lowercaseFirstLetter = (str: string) =>
+  str.charAt(0).toLowerCase() + str.slice(1);

--- a/src/common/string/lowercase_first_letter.ts
+++ b/src/common/string/lowercase_first_letter.ts
@@ -1,2 +1,0 @@
-export const lowercaseFirstLetter = (str: string) =>
-  str.charAt(0).toLowerCase() + str.slice(1);

--- a/src/common/translations/auto_case_noun.ts
+++ b/src/common/translations/auto_case_noun.ts
@@ -1,0 +1,20 @@
+// In a few languages nouns are always capitalized. This helper
+// indicates if for a given language that is the case.
+
+import { capitalizeFirstLetter } from "../string/capitalize-first-letter";
+import { lowercaseFirstLetter } from "../string/lowercase_first_letter";
+
+export const useCapitalizedNouns = (language: string): boolean => {
+  switch (language) {
+    case "de":
+    case "lb":
+      return true;
+    default:
+      return false;
+  }
+};
+
+export const autoCaseNoun = (noun: string, language: string): string =>
+  useCapitalizedNouns(language)
+    ? capitalizeFirstLetter(noun)
+    : lowercaseFirstLetter(noun);

--- a/src/common/translations/auto_case_noun.ts
+++ b/src/common/translations/auto_case_noun.ts
@@ -2,7 +2,6 @@
 // indicates if for a given language that is the case.
 
 import { capitalizeFirstLetter } from "../string/capitalize-first-letter";
-import { lowercaseFirstLetter } from "../string/lowercase_first_letter";
 
 export const useCapitalizedNouns = (language: string): boolean => {
   switch (language) {
@@ -17,4 +16,4 @@ export const useCapitalizedNouns = (language: string): boolean => {
 export const autoCaseNoun = (noun: string, language: string): string =>
   useCapitalizedNouns(language)
     ? capitalizeFirstLetter(noun)
-    : lowercaseFirstLetter(noun);
+    : noun.toLocaleLowerCase(language);

--- a/src/data/logbook.ts
+++ b/src/data/logbook.ts
@@ -7,6 +7,7 @@ import {
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateDisplay } from "../common/entity/compute_state_display";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
+import { autoCaseNoun } from "../common/translations/auto_case_noun";
 import { LocalizeFunc } from "../common/translations/localize";
 import { HaEntityPickerEntityFilterFunc } from "../components/entity/ha-entity-picker";
 import { HomeAssistant } from "../types";
@@ -359,15 +360,21 @@ export const localizeStateMessage = (
         case "vibration":
           if (isOn) {
             return localize(`${LOGBOOK_LOCALIZE_PATH}.detected_device_class`, {
-              device_class: localize(
-                `component.binary_sensor.entity_component.${device_class}.name`
+              device_class: autoCaseNoun(
+                localize(
+                  `component.binary_sensor.entity_component.${device_class}.name`
+                ),
+                hass.language
               ),
             });
           }
           if (isOff) {
             return localize(`${LOGBOOK_LOCALIZE_PATH}.cleared_device_class`, {
-              device_class: localize(
-                `component.binary_sensor.entity_component.${device_class}.name`
+              device_class: autoCaseNoun(
+                localize(
+                  `component.binary_sensor.entity_component.${device_class}.name`
+                ),
+                hass.language
               ),
             });
           }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Follow-up to https://github.com/home-assistant/frontend/pull/17034 to ensure logical casing of the device class based history text.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
