### PR TITLE
Handle "unknown" for date, time and datetime entities

### DIFF
--- a/src/dialogs/more-info/controls/more-info-date.ts
+++ b/src/dialogs/more-info/controls/more-info-date.ts
@@ -4,7 +4,7 @@ import { customElement, property } from "lit/decorators";
 import "../../../components/ha-date-input";
 import "../../../components/ha-time-input";
 import { setDateValue } from "../../../data/date";
-import { isUnavailableState } from "../../../data/entity";
+import { isUnavailableState, UNAVAILABLE } from "../../../data/entity";
 import type { HomeAssistant } from "../../../types";
 
 @customElement("more-info-date")
@@ -14,15 +14,17 @@ class MoreInfoDate extends LitElement {
   @property({ attribute: false }) public stateObj?: HassEntity;
 
   protected render() {
-    if (!this.stateObj || isUnavailableState(this.stateObj.state)) {
+    if (!this.stateObj || this.stateObj.state === UNAVAILABLE) {
       return nothing;
     }
 
     return html`
       <ha-date-input
         .locale=${this.hass.locale}
-        .value=${this.stateObj.state}
-        .disabled=${isUnavailableState(this.stateObj.state)}
+        .value=${isUnavailableState(this.stateObj.state)
+          ? undefined
+          : this.stateObj.state}
+        .disabled=${this.stateObj.state === UNAVAILABLE}
         @value-changed=${this._dateChanged}
       >
       </ha-date-input>
@@ -30,7 +32,9 @@ class MoreInfoDate extends LitElement {
   }
 
   private _dateChanged(ev: CustomEvent<{ value: string }>): void {
-    setDateValue(this.hass!, this.stateObj!.entity_id, ev.detail.value);
+    if (ev.detail.value) {
+      setDateValue(this.hass!, this.stateObj!.entity_id, ev.detail.value);
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/dialogs/more-info/controls/more-info-time.ts
+++ b/src/dialogs/more-info/controls/more-info-time.ts
@@ -3,7 +3,7 @@ import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../components/ha-date-input";
 import "../../../components/ha-time-input";
-import { UNAVAILABLE } from "../../../data/entity";
+import { isUnavailableState, UNAVAILABLE } from "../../../data/entity";
 import { setTimeValue } from "../../../data/time";
 import type { HomeAssistant } from "../../../types";
 
@@ -20,7 +20,9 @@ class MoreInfoTime extends LitElement {
 
     return html`
       <ha-time-input
-        .value=${this.stateObj.state}
+        .value=${isUnavailableState(this.stateObj.state)
+          ? undefined
+          : this.stateObj.state}
         .locale=${this.hass.locale}
         .disabled=${this.stateObj.state === UNAVAILABLE}
         @value-changed=${this._timeChanged}

--- a/src/dialogs/more-info/controls/more-info-time.ts
+++ b/src/dialogs/more-info/controls/more-info-time.ts
@@ -3,7 +3,7 @@ import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import "../../../components/ha-date-input";
 import "../../../components/ha-time-input";
-import { isUnavailableState } from "../../../data/entity";
+import { UNAVAILABLE } from "../../../data/entity";
 import { setTimeValue } from "../../../data/time";
 import type { HomeAssistant } from "../../../types";
 
@@ -14,7 +14,7 @@ class MoreInfoTime extends LitElement {
   @property({ attribute: false }) public stateObj?: HassEntity;
 
   protected render() {
-    if (!this.stateObj || isUnavailableState(this.stateObj.state)) {
+    if (!this.stateObj || this.stateObj.state === UNAVAILABLE) {
       return nothing;
     }
 
@@ -22,7 +22,7 @@ class MoreInfoTime extends LitElement {
       <ha-time-input
         .value=${this.stateObj.state}
         .locale=${this.hass.locale}
-        .disabled=${isUnavailableState(this.stateObj.state)}
+        .disabled=${this.stateObj.state === UNAVAILABLE}
         @value-changed=${this._timeChanged}
         @click=${this._stopEventPropagation}
       ></ha-time-input>
@@ -34,7 +34,9 @@ class MoreInfoTime extends LitElement {
   }
 
   private _timeChanged(ev: CustomEvent<{ value: string }>): void {
-    setTimeValue(this.hass!, this.stateObj!.entity_id, ev.detail.value);
+    if (ev.detail.value) {
+      setTimeValue(this.hass!, this.stateObj!.entity_id, ev.detail.value);
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/entity-rows/hui-date-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-date-entity-row.ts
@@ -1,7 +1,7 @@
 import { html, LitElement, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../components/ha-date-input";
-import { isUnavailableState } from "../../../data/entity";
+import { isUnavailableState, UNAVAILABLE } from "../../../data/entity";
 import { setDateValue } from "../../../data/date";
 import type { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
@@ -41,14 +41,16 @@ class HuiDateEntityRow extends LitElement implements LovelaceRow {
       `;
     }
 
-    const unavailable = isUnavailableState(stateObj.state);
+    const unavailable = stateObj.state === UNAVAILABLE;
 
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <ha-date-input
           .locale=${this.hass.locale}
           .disabled=${unavailable}
-          .value=${unavailable ? "" : stateObj.state}
+          .value=${isUnavailableState(stateObj.state)
+            ? undefined
+            : stateObj.state}
           @value-changed=${this._dateChanged}
         >
         </ha-date-input>
@@ -57,7 +59,9 @@ class HuiDateEntityRow extends LitElement implements LovelaceRow {
   }
 
   private _dateChanged(ev: CustomEvent<{ value: string }>): void {
-    setDateValue(this.hass!, this._config!.entity, ev.detail.value);
+    if (ev.detail.value) {
+      setDateValue(this.hass!, this._config!.entity, ev.detail.value);
+    }
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-datetime-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-datetime-entity-row.ts
@@ -10,7 +10,7 @@ import {
 import { customElement, property, state } from "lit/decorators";
 import "../../../components/ha-date-input";
 import { format } from "date-fns";
-import { isUnavailableState } from "../../../data/entity";
+import { isUnavailableState, UNAVAILABLE } from "../../../data/entity";
 import { setDateTimeValue } from "../../../data/datetime";
 import type { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
@@ -52,11 +52,13 @@ class HuiInputDatetimeEntityRow extends LitElement implements LovelaceRow {
       `;
     }
 
-    const unavailable = isUnavailableState(stateObj.state);
+    const unavailable = stateObj.state === UNAVAILABLE;
 
-    const dateObj = unavailable ? undefined : new Date(stateObj.state);
-    const time = dateObj ? format(dateObj, "HH:mm:ss") : "";
-    const date = dateObj ? format(dateObj, "yyyy-MM-dd") : "";
+    const dateObj = isUnavailableState(stateObj.state)
+      ? undefined
+      : new Date(stateObj.state);
+    const time = dateObj ? format(dateObj, "HH:mm:ss") : undefined;
+    const date = dateObj ? format(dateObj, "yyyy-MM-dd") : undefined;
 
     return html`
       <hui-generic-entity-row
@@ -90,21 +92,25 @@ class HuiInputDatetimeEntityRow extends LitElement implements LovelaceRow {
   }
 
   private _timeChanged(ev: CustomEvent<{ value: string }>): void {
-    const stateObj = this.hass!.states[this._config!.entity];
-    const dateObj = new Date(stateObj.state);
-    const newTime = ev.detail.value.split(":").map(Number);
-    dateObj.setHours(newTime[0], newTime[1], newTime[2]);
+    if (ev.detail.value) {
+      const stateObj = this.hass!.states[this._config!.entity];
+      const dateObj = new Date(stateObj.state);
+      const newTime = ev.detail.value.split(":").map(Number);
+      dateObj.setHours(newTime[0], newTime[1], newTime[2]);
 
-    setDateTimeValue(this.hass!, stateObj.entity_id, dateObj);
+      setDateTimeValue(this.hass!, stateObj.entity_id, dateObj);
+    }
   }
 
   private _dateChanged(ev: CustomEvent<{ value: string }>): void {
-    const stateObj = this.hass!.states[this._config!.entity];
-    const dateObj = new Date(stateObj.state);
-    const newDate = ev.detail.value.split("-").map(Number);
-    dateObj.setFullYear(newDate[0], newDate[1] - 1, newDate[2]);
+    if (ev.detail.value) {
+      const stateObj = this.hass!.states[this._config!.entity];
+      const dateObj = new Date(stateObj.state);
+      const newDate = ev.detail.value.split("-").map(Number);
+      dateObj.setFullYear(newDate[0], newDate[1] - 1, newDate[2]);
 
-    setDateTimeValue(this.hass!, stateObj.entity_id, dateObj);
+      setDateTimeValue(this.hass!, stateObj.entity_id, dateObj);
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/lovelace/entity-rows/hui-time-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-time-entity-row.ts
@@ -1,7 +1,7 @@
 import { html, LitElement, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../components/ha-date-input";
-import { isUnavailableState } from "../../../data/entity";
+import { UNAVAILABLE } from "../../../data/entity";
 import { setTimeValue } from "../../../data/time";
 import type { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
@@ -42,7 +42,7 @@ class HuiTimeEntityRow extends LitElement implements LovelaceRow {
       `;
     }
 
-    const unavailable = isUnavailableState(stateObj.state);
+    const unavailable = stateObj.state === UNAVAILABLE;
 
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
@@ -62,8 +62,10 @@ class HuiTimeEntityRow extends LitElement implements LovelaceRow {
   }
 
   private _timeChanged(ev: CustomEvent<{ value: string }>): void {
-    const stateObj = this.hass!.states[this._config!.entity];
-    setTimeValue(this.hass!, stateObj.entity_id, ev.detail.value);
+    if (ev.detail.value) {
+      const stateObj = this.hass!.states[this._config!.entity];
+      setTimeValue(this.hass!, stateObj.entity_id, ev.detail.value);
+    }
   }
 }
 

--- a/src/panels/lovelace/entity-rows/hui-time-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-time-entity-row.ts
@@ -1,7 +1,7 @@
 import { html, LitElement, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../../../components/ha-date-input";
-import { UNAVAILABLE } from "../../../data/entity";
+import { isUnavailableState, UNAVAILABLE } from "../../../data/entity";
 import { setTimeValue } from "../../../data/time";
 import type { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
@@ -47,7 +47,9 @@ class HuiTimeEntityRow extends LitElement implements LovelaceRow {
     return html`
       <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
         <ha-time-input
-          .value=${unavailable ? "" : stateObj.state}
+          .value=${isUnavailableState(stateObj.state)
+            ? undefined
+            : stateObj.state}
           .locale=${this.hass.locale}
           .disabled=${unavailable}
           @value-changed=${this._timeChanged}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Previously the state "unknown" meant that the user could not input any time values as the controls were hidden and/or disabled. This PR reduces that behavior to the state "unavailable" only.

Example of all three being in state "unknown"

![image](https://github.com/home-assistant/frontend/assets/114137/2d6bc2aa-8827-4d12-be19-c2c928a5deaf)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17041
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
