### PR TITLE
Fix group more-info to show the state of the group entity

### DIFF
--- a/src/dialogs/more-info/controls/more-info-group.ts
+++ b/src/dialogs/more-info/controls/more-info-group.ts
@@ -46,7 +46,8 @@ class MoreInfoGroup extends LitElement {
       return;
     }
 
-    const baseStateObj = states.find((s) => s.state === "on") || states[0];
+    const baseStateObj =
+      states.find((s) => s.state === this.stateObj!.state) || states[0];
 
     const groupDomain = computeGroupDomain(this.stateObj);
 
@@ -55,7 +56,9 @@ class MoreInfoGroup extends LitElement {
     if (groupDomain && groupDomain !== "group") {
       this._groupDomainStateObj = {
         ...baseStateObj,
-        ...this.stateObj,
+        entity_id: this.stateObj.entity_id,
+        last_updated: this.stateObj.last_updated,
+        last_changed: this.stateObj.last_changed,
         attributes: {
           ...baseStateObj.attributes,
           friendly_name: this.stateObj.attributes.friendly_name,

--- a/src/dialogs/more-info/controls/more-info-group.ts
+++ b/src/dialogs/more-info/controls/more-info-group.ts
@@ -55,7 +55,7 @@ class MoreInfoGroup extends LitElement {
     if (groupDomain && groupDomain !== "group") {
       this._groupDomainStateObj = {
         ...baseStateObj,
-        entity_id: this.stateObj.entity_id,
+        ...this.stateObj,
         attributes: {
           ...baseStateObj.attributes,
           friendly_name: this.stateObj.attributes.friendly_name,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Fixes #16977, where a group that was `off` was showing as `on` in the more info. 

Instead of selecting the first group member that is "on" as the base, select the first group member that has the same state as the group. 

Don't fully understand why constructing this baseStateObj was necessary, perhaps in some case the group has less attributes than its members, and we wanted to preserve them for the control. I blamed it way back to #61 and #735

Also unrelated but I preserved the last_updated/last_changed from the group stateObj, since the control was incorrectly showing the last_changed of the selected member instead of the group. 


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16977
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
