### PR TITLE
Show card positions in edit dashboard mode

### DIFF
--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -81,6 +81,18 @@ export class HuiCardOptions extends LitElement {
                 .length ===
               this.path![1] + 1}
             ></ha-icon-button>
+            <div class="position-badge">
+              ${this.path![1] + 1}
+              <simple-tooltip
+                >${this.hass!.localize(
+                  "ui.panel.lovelace.editor.edit_card.position",
+                  "position",
+                  `${this.path![1] + 1}`,
+                  "total",
+                  `${this.lovelace!.config.views[this.path![0]].cards!.length}`
+                )}</simple-tooltip
+              >
+            </div>
             <ha-icon-button
               .label=${this.hass!.localize(
                 "ui.panel.lovelace.editor.edit_card.move_up"
@@ -153,6 +165,20 @@ export class HuiCardOptions extends LitElement {
         display: flex;
         justify-content: space-between;
         align-items: center;
+      }
+
+      .position-badge {
+        display: inline-block;
+        vertical-align: bottom;
+        width: 48px;
+        line-height: 48px;
+        box-sizing: border-box;
+        border-radius: 50%;
+        font-weight: 400;
+        font-size: 1.25em;
+        background-color: var(--divider-color);
+        text-align: center;
+        color: var(--text-accent-color, var(--text-primary-color));
       }
 
       ha-icon-button {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4462,6 +4462,7 @@
             "move_down": "Move card down",
             "move_before": "Move card before",
             "move_after": "Move card after",
+            "position": "Card is in position {position} of {total}",
             "options": "More options",
             "search_cards": "Search cards"
           },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Wanted to float this idea for the dashboard editor, to display the card positions next to the up/down arrows. 

I think this would help demystify the masonry layout process and make it easier to move cards around on the board, since with this information you can quickly get an idea when you move a card up or down which card it will be switching position with. 

E.g. in this example. If I look at card 3, just by looking at this I know if I click the up button exactly where it will go, it will go where the 2 currently is. Without this information I have no idea where it will go, could be left column, center column, right column in first/second/third position. Currently rearranging dashboard feels sometimes like I just end up mashing up/down buttons at random until I develop an intuitive sense of the ordering. 

Not sure if the styling is good, maybe it still needs some UI polish.

(my mouse pointer is not shown in the screenshot, but it is hovering on 3 to show the tooltip)

![image](https://github.com/home-assistant/frontend/assets/32912880/b1a35c7c-d596-4cab-83dc-67502b1a3c58)


Or maybe an alternative more compact style (no width and no background color):

![image](https://github.com/home-assistant/frontend/assets/32912880/f567e2dd-027e-4213-b696-07f0754c1daa)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
