### PR TITLE
Fix menu button when sidebar is always_hidden

### DIFF
--- a/src/components/ha-menu-button.ts
+++ b/src/components/ha-menu-button.ts
@@ -73,25 +73,25 @@ class HaMenuButton extends LitElement {
       return;
     }
 
-    const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+    const oldHass = changedProps.has("hass")
+      ? (changedProps.get("hass") as HomeAssistant | undefined)
+      : this.hass;
+    const oldNarrow = changedProps.has("narrow")
+      ? (changedProps.get("narrow") as boolean | undefined)
+      : this.narrow;
 
-    let oldNarrow: boolean | undefined;
-    let newNarrow: boolean | undefined;
-    if (changedProps.has("narrow")) {
-      oldNarrow = changedProps.get("narrow");
-      newNarrow = this.narrow;
-    } else if (oldHass) {
-      oldNarrow = oldHass.dockedSidebar === "always_hidden";
-      newNarrow = this.hass.dockedSidebar === "always_hidden";
-    }
+    const oldShowButton =
+      oldNarrow || oldHass?.dockedSidebar === "always_hidden";
+    const showButton =
+      this.narrow || this.hass.dockedSidebar === "always_hidden";
 
-    if (oldNarrow === newNarrow) {
+    if (oldShowButton === showButton) {
       return;
     }
 
-    this.style.display = newNarrow || this._alwaysVisible ? "initial" : "none";
+    this.style.display = showButton || this._alwaysVisible ? "initial" : "none";
 
-    if (!newNarrow) {
+    if (!showButton) {
       if (this._unsubNotifications) {
         this._unsubNotifications();
         this._unsubNotifications = undefined;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

The menu button would be hidden when narrow updated.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
