### PR TITLE
Improve lovelace view navigation with purely numerical names/paths

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -628,7 +628,7 @@ class HUIRoot extends LitElement {
         if (!matchFound) {
           // If nothing was found with a direct path match, we try via the index.
           // This is done in two steps, since otherwise a view named "1" (and by default
-          // has path "1") would not be accessable.
+          // has path "1") would not be accessible.
           for (let i = 0; i < views.length; i++) {
             if (i === selectedViewInt) {
               index = i;

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -616,10 +616,24 @@ class HUIRoot extends LitElement {
         const selectedView = viewPath;
         const selectedViewInt = Number(selectedView);
         let index = 0;
+        let matchFound = false;
+        // Look for path match
         for (let i = 0; i < views.length; i++) {
-          if (views[i].path === selectedView || i === selectedViewInt) {
+          if (views[i].path === selectedView) {
             index = i;
+            matchFound = true;
             break;
+          }
+        }
+        if (!matchFound) {
+          // If nothing was found with a direct path match, we try via the index.
+          // This is done in two steps, since otherwise a view named "1" (and by default
+          // has path "1") would not be accessable.
+          for (let i = 0; i < views.length; i++) {
+            if (i === selectedViewInt) {
+              index = i;
+              break;
+            }
           }
         }
         newSelectView = index;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

**Not sure if this is technically breaking?** It might be for the scenario I listed below as risk / gap.

## Proposed change

Before this PR a view just named "1" (and which has by default then a view path "1") could not be accessed as the root logic searched for either a path match or an index match. So when clicking on that view "1" you ended up in the 2nd view (as index goes from 0..n).

With this change we first try to find a path match and only as a fallback look for an index match.

Only risk / gap: If you have created a view with an explicit empty path (meaning the view is only accessible via its index) and you create then a new tab where name (and therefore path) match the index of the view without a path, then you will not be able to access the view without a path anymore.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17060
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
