### PR TITLE
Fix assist devtools default language

### DIFF
--- a/src/panels/developer-tools/assist/developer-tools-assist.ts
+++ b/src/panels/developer-tools/assist/developer-tools-assist.ts
@@ -39,7 +39,7 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
     subscribe: false,
     storage: "localStorage",
   })
-  _language = "en";
+  _language?: string;
 
   @state() _results: SentenceParsingResult[] = [];
 
@@ -63,7 +63,7 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
     const sentences = this._sentencesInput.value
       .split("\n")
       .filter((a) => a !== "");
-    const { results } = await debugAgent(this.hass, sentences, this._language);
+    const { results } = await debugAgent(this.hass, sentences, this._language!);
 
     this._sentencesInput.value = "";
 
@@ -75,7 +75,7 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
 
       newResults.push({
         sentence,
-        language: this._language,
+        language: this._language!,
         result,
         time: now,
       });
@@ -90,6 +90,15 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
       assistAgent?.supported_languages === "*"
         ? undefined
         : assistAgent?.supported_languages;
+
+    if (
+      !this._language &&
+      this.supportedLanguages?.includes(this.hass.locale.language)
+    ) {
+      this._language = this.hass.locale.language;
+    } else if (!this._language) {
+      this._language = "en";
+    }
   }
 
   protected firstUpdated(): void {
@@ -124,7 +133,10 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
             ></ha-textarea>
           </div>
           <div class="card-actions">
-            <ha-button @click=${this._parse} .disabled=${!this._validInput}>
+            <ha-button
+              @click=${this._parse}
+              .disabled=${!this._language || !this._validInput}
+            >
               Parse sentences
             </ha-button>
           </div>

--- a/src/panels/developer-tools/assist/developer-tools-assist.ts
+++ b/src/panels/developer-tools/assist/developer-tools-assist.ts
@@ -39,7 +39,7 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
     subscribe: false,
     storage: "localStorage",
   })
-  _language?: string;
+  _language = "en";
 
   @state() _results: SentenceParsingResult[] = [];
 
@@ -63,7 +63,7 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
     const sentences = this._sentencesInput.value
       .split("\n")
       .filter((a) => a !== "");
-    const { results } = await debugAgent(this.hass, sentences, this._language!);
+    const { results } = await debugAgent(this.hass, sentences, this._language);
 
     this._sentencesInput.value = "";
 
@@ -75,7 +75,7 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
 
       newResults.push({
         sentence,
-        language: this._language!,
+        language: this._language,
         result,
         time: now,
       });
@@ -111,7 +111,7 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
                   <ha-language-picker
                     .languages=${this.supportedLanguages}
                     .hass=${this.hass}
-                    .value=${this._language ?? "en"}
+                    .value=${this._language}
                     @value-changed=${this._languageChanged}
                   ></ha-language-picker>
                 `
@@ -124,10 +124,7 @@ class HaPanelDevAssist extends SubscribeMixin(LitElement) {
             ></ha-textarea>
           </div>
           <div class="card-actions">
-            <ha-button
-              @click=${this._parse}
-              .disabled=${!this._language || !this._validInput}
-            >
+            <ha-button @click=${this._parse} .disabled=${!this._validInput}>
               Parse sentences
             </ha-button>
           </div>


### PR DESCRIPTION


## Proposed change

`this._language` would be undefined until a language was picked, but the picker showed as already picked.

Making the parse button disabled.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
