### PR TITLE
Fix visual map issues

### DIFF
--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -159,6 +159,7 @@ export class HaMap extends ReactiveElement {
     const map = this.shadowRoot!.getElementById("map");
     map!.classList.toggle("dark", darkMode);
     map!.classList.toggle("forced-dark", this.darkMode);
+    map!.classList.toggle("foced-light", !darkMode);
   }
 
   private async _loadMap(): Promise<void> {
@@ -503,26 +504,29 @@ export class HaMap extends ReactiveElement {
         background: #090909;
       }
       #map.forced-dark {
+        color: #ffffff;
         --map-filter: invert(0.9) hue-rotate(170deg) brightness(1.5)
           contrast(1.2) saturate(0.3);
+      }
+      #map.foced-light {
+        background: #ffffff;
+        color: #000000;
+        --map-filter: invert(0);
       }
       #map:active {
         cursor: grabbing;
         cursor: -moz-grabbing;
         cursor: -webkit-grabbing;
       }
-      .light {
-        color: #000000;
-      }
-      .dark {
-        color: #ffffff;
-      }
       .leaflet-tile-pane {
         filter: var(--map-filter);
       }
       .dark .leaflet-bar a {
-        background-color: var(--card-background-color, #1c1c1c);
+        background-color: #1c1c1c;
         color: #ffffff;
+      }
+      .dark .leaflet-bar a:hover {
+        background-color: #313131;
       }
       .leaflet-marker-draggable {
         cursor: move !important;

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -138,7 +138,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       includeDomains
     );
 
-    return { type: "map", entities: foundEntities };
+    return { type: "map", entities: foundEntities, theme_mode: "auto" };
   }
 
   protected render() {
@@ -151,6 +151,11 @@ class HuiMapCard extends LitElement implements LovelaceCard {
         (${this._error.code})
       </ha-alert>`;
     }
+
+    const isDarkMode =
+      this._config.theme_mode === "dark" ||
+      (this._config.theme_mode === "auto" && this.hass.themes.darkMode);
+
     return html`
       <ha-card id="card" .header=${this._config.title}>
         <div id="root">
@@ -164,7 +169,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
             .zoom=${this._config.default_zoom ?? DEFAULT_ZOOM}
             .paths=${this._getHistoryPaths(this._config, this._stateHistory)}
             .autoFit=${this._config.auto_fit}
-            .darkMode=${this._config.dark_mode}
+            .darkMode=${isDarkMode}
             interactiveZones
             renderPassive
           ></ha-map>
@@ -173,6 +178,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
               "ui.panel.lovelace.cards.map.reset_focus"
             )}
             .path=${mdiImageFilterCenterFocus}
+            style=${isDarkMode ? "color:#ffffff" : "color:#000000"}
             @click=${this._fitMap}
             tabindex="0"
           ></ha-icon-button>

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -152,9 +152,18 @@ class HuiMapCard extends LitElement implements LovelaceCard {
       </ha-alert>`;
     }
 
-    const isDarkMode =
-      this._config.theme_mode === "dark" ||
-      (this._config.theme_mode === "auto" && this.hass.themes.darkMode);
+    let isDarkMode =
+      this._config.dark_mode !== null || this._config.dark_mode !== undefined
+        ? this._config.dark_mode
+        : this.hass.themes.darkMode;
+
+    if (this._config.theme_mode === "auto") {
+      isDarkMode = this.hass.themes.darkMode;
+    } else if (this._config.theme_mode === "light") {
+      isDarkMode = false;
+    } else if (this._config.theme_mode === "dark") {
+      isDarkMode = true;
+    }
 
     return html`
       <ha-card id="card" .header=${this._config.title}>

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -2,9 +2,9 @@ import { HaDurationData } from "../../../components/ha-duration-input";
 import { ActionConfig } from "../../../data/lovelace/config/action";
 import { LovelaceCardConfig } from "../../../data/lovelace/config/card";
 import { Statistic, StatisticType } from "../../../data/recorder";
-import { ForecastType } from "../../../data/weather";
-import { FullCalendarView, TranslationDict } from "../../../types";
+import { FullCalendarView, ThemeMode, TranslationDict } from "../../../types";
 import { Condition, LegacyCondition } from "../common/validate-condition";
+import { ForecastType } from "../../../data/weather";
 import { HuiImage } from "../components/hui-image";
 import { LovelaceElementConfig } from "../elements/types";
 import {
@@ -296,7 +296,7 @@ export interface MapCardConfig extends LovelaceCardConfig {
   entities?: Array<EntityConfig | string>;
   hours_to_show?: number;
   geo_location_sources?: string[];
-  dark_mode?: boolean;
+  theme_mode?: ThemeMode;
 }
 
 export interface MarkdownCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -296,6 +296,7 @@ export interface MapCardConfig extends LovelaceCardConfig {
   entities?: Array<EntityConfig | string>;
   hours_to_show?: number;
   geo_location_sources?: string[];
+  dark_mode?: boolean;
   theme_mode?: ThemeMode;
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -1,3 +1,4 @@
+import { mdiPalette } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import {
@@ -72,32 +73,41 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
         { name: "title", selector: { text: {} } },
         {
           name: "",
-          type: "grid",
+          type: "expandable",
+          iconPath: mdiPalette,
+          title: localize(`ui.panel.lovelace.editor.card.map.appearance`),
           schema: [
-            { name: "aspect_ratio", selector: { text: {} } },
             {
-              name: "default_zoom",
-              default: DEFAULT_ZOOM,
-              selector: { number: { mode: "box", min: 0 } },
-            },
-            {
-              name: "theme_mode",
-              default: "auto",
-              selector: {
-                select: {
-                  options: themeModes.map((themeMode) => ({
-                    value: themeMode,
-                    label: localize(
-                      `ui.panel.lovelace.editor.card.map.theme_mode.${themeMode}`
-                    ),
-                  })),
+              name: "",
+              type: "grid",
+              schema: [
+                { name: "aspect_ratio", selector: { text: {} } },
+                {
+                  name: "default_zoom",
+                  default: DEFAULT_ZOOM,
+                  selector: { number: { mode: "box", min: 0 } },
                 },
-              },
-            },
-            {
-              name: "hours_to_show",
-              default: DEFAULT_HOURS_TO_SHOW,
-              selector: { number: { mode: "box", min: 0 } },
+                {
+                  name: "theme_mode",
+                  default: "auto",
+                  selector: {
+                    select: {
+                      mode: "dropdown",
+                      options: themeModes.map((themeMode) => ({
+                        value: themeMode,
+                        label: localize(
+                          `ui.panel.lovelace.editor.card.map.theme_modes.${themeMode}`
+                        ),
+                      })),
+                    },
+                  },
+                },
+                {
+                  name: "hours_to_show",
+                  default: DEFAULT_HOURS_TO_SHOW,
+                  selector: { number: { mode: "box", min: 0 } },
+                },
+              ],
             },
           ],
         },
@@ -129,29 +139,28 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
-      <div class="card-config">
-        <hui-entity-editor
-          .hass=${this.hass}
-          .entities=${this._configEntities}
-          .entityFilter=${hasLocation}
-          @entities-changed=${this._entitiesValueChanged}
-        ></hui-entity-editor>
-        <h3>
-          ${this.hass.localize(
-            "ui.panel.lovelace.editor.card.map.geo_location_sources"
-          )}
-        </h3>
-        <div class="geo_location_sources">
-          <hui-input-list-editor
-            .inputLabel=${this.hass.localize(
-              "ui.panel.lovelace.editor.card.map.source"
-            )}
-            .hass=${this.hass}
-            .value=${this._geo_location_sources}
-            @value-changed=${this._geoSourcesChanged}
-          ></hui-input-list-editor>
-        </div>
-      </div>
+
+      <hui-entity-editor
+        .hass=${this.hass}
+        .entities=${this._configEntities}
+        .entityFilter=${hasLocation}
+        @entities-changed=${this._entitiesValueChanged}
+      ></hui-entity-editor>
+
+      <h3>
+        ${this.hass.localize(
+          "ui.panel.lovelace.editor.card.map.geo_location_sources"
+        )}
+      </h3>
+
+      <hui-input-list-editor
+        .inputLabel=${this.hass.localize(
+          "ui.panel.lovelace.editor.card.map.source"
+        )}
+        .hass=${this.hass}
+        .value=${this._geo_location_sources}
+        @value-changed=${this._geoSourcesChanged}
+      ></hui-input-list-editor>
     `;
   }
 
@@ -195,6 +204,10 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
     schema: SchemaUnion<ReturnType<typeof this._schema>>
   ) => {
     switch (schema.name) {
+      case "theme_mode":
+        return this.hass!.localize(
+          `ui.panel.lovelace.editor.card.map.${schema.name}`
+        );
       case "default_zoom":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.map.${schema.name}`
@@ -207,16 +220,7 @@ export class HuiMapCardEditor extends LitElement implements LovelaceCardEditor {
   };
 
   static get styles(): CSSResultGroup {
-    return [
-      configElementStyle,
-      css`
-        .geo_location_sources {
-          padding-left: 20px;
-          padding-inline-start: 20px;
-          direction: var(--direction);
-        }
-      `,
-    ];
+    return [configElementStyle, css``];
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5085,7 +5085,9 @@
               "name": "Map",
               "geo_location_sources": "Geolocation sources",
               "dark_mode": "Dark mode?",
-              "theme_mode": {
+              "appearance": "Appearance",
+              "theme_mode": "Theme Mode",
+              "theme_modes": {
                 "auto": "Auto",
                 "light": "Light",
                 "dark": "Dark"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5085,7 +5085,12 @@
               "name": "Map",
               "geo_location_sources": "Geolocation sources",
               "dark_mode": "Dark mode?",
-              "default_zoom": "Default zoom",
+              "theme_mode": {
+                "auto": "Auto",
+                "light": "Light",
+                "dark": "Dark"
+              },
+              "default_zoom": "Default Zoom",
               "source": "Source",
               "description": "The Map card that allows you to display entities on a map."
             },

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,8 @@ export type FullCalendarView =
   | "dayGridDay"
   | "listWeek";
 
+export type ThemeMode = "auto" | "light" | "dark";
+
 export interface ToggleButton {
   label: string;
   iconPath?: string;


### PR DESCRIPTION
- hover background color of zoom control in dark mode
- map light mode when dark theme is used
- background color of zoom control with map dark mode when light theme is used

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

### This PR contains multiple fixes for different visual issues with the map (card).
1. The hover background color of the maps zoom control when the map is in dark mode is way to white
![ha-map-hover-zoom-fix](https://github.com/home-assistant/frontend/assets/43651938/b46913f3-8026-4948-897f-ca36d33bbbab)
3. When setting the map to light mode when dark theme is used, the map isn't shown in light mode (it is dark mode but with a bit more contrast)
![ha-map-force-light-theme-fix](https://github.com/home-assistant/frontend/assets/43651938/88edcf81-cd6a-42f9-8c44-96dde733358d)
4. The background color of the maps zoom control with the map in dark mode when light theme is used is white (should be dark, so that the icons are visible)
![ha-map-lt-dm-zoom-bg-fix](https://github.com/home-assistant/frontend/assets/43651938/1fcb3578-d1e3-4df7-b372-846fe496775d)

This summery shows how the map's look with all possible configurations:
![ha-map-differences](https://github.com/home-assistant/frontend/assets/43651938/ab0b61db-d200-464c-b8c8-093d05cf2d20)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15587, #13333 (maybe, not sure)
- This PR is related to issue or discussion: #13227, #13333
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32352

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
