### PR TITLE
Add min/max support for prompt dialog (e.g. used for card moving)

### DIFF
--- a/src/dialogs/generic/dialog-box.ts
+++ b/src/dialogs/generic/dialog-box.ts
@@ -81,6 +81,8 @@ class DialogBox extends LitElement {
                   .type=${this._params.inputType
                     ? this._params.inputType
                     : "text"}
+                  .min=${this._params.inputMin}
+                  .max=${this._params.inputMax}
                 ></ha-textfield>
               `
             : ""}

--- a/src/dialogs/generic/show-dialog-box.ts
+++ b/src/dialogs/generic/show-dialog-box.ts
@@ -26,6 +26,8 @@ export interface PromptDialogParams extends BaseDialogBoxParams {
   placeholder?: string;
   confirm?: (out?: string) => void;
   cancel?: () => void;
+  inputMin?: number | string;
+  inputMax?: number | string;
 }
 
 export interface DialogBoxParams

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -288,6 +288,7 @@ export class HuiCardOptions extends LitElement {
         "ui.panel.lovelace.editor.change_position.text"
       ),
       inputType: "number",
+      inputMin: "1",
       placeholder: String(path[1] + 1),
     });
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

I just tested the new "move card to position" feature (https://github.com/home-assistant/frontend/pull/17077) and thought it might be good if the prompt dialog prevents the user from specifying negative values => quickly added support for that.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
