### PR TITLE
Prevent duplicate sidebar toggle menu button

### DIFF
--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -234,7 +234,7 @@ class HUIRoot extends LitElement {
                           @click=${this._goBack}
                         ></ha-icon-button-arrow-prev>
                       `
-                    : this.narrow
+                    : this.narrow || this.hass.dockedSidebar === "always_hidden"
                     ? html` <ha-menu-button
                         slot="navigationIcon"
                         .hass=${this.hass}

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -234,13 +234,13 @@ class HUIRoot extends LitElement {
                           @click=${this._goBack}
                         ></ha-icon-button-arrow-prev>
                       `
-                    : html`
-                        <ha-menu-button
-                          slot="navigationIcon"
-                          .hass=${this.hass}
-                          .narrow=${this.narrow}
-                        ></ha-menu-button>
-                      `}
+                    : this.narrow
+                    ? html` <ha-menu-button
+                        slot="navigationIcon"
+                        .hass=${this.hass}
+                        .narrow=${this.narrow}
+                      ></ha-menu-button>`
+                    : ""}
                   ${curViewConfig?.subview
                     ? html`<div class="main-title">${curViewConfig.title}</div>`
                     : views.filter((view) => !view.subview).length > 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

This is a bit of a weird one. I do not observe the issue in my production instance, but in my dev instance I do, although not always. After some page refreshes I do, after some I don't. I also sometimes get not required left arrow/chevrons (in production as well, but that is a separate topic I think?).

![image](https://github.com/home-assistant/frontend/assets/114137/1acd13c7-fcab-4d72-99e1-a2f423b817c9)


I see two sidebar toggle menu buttons. The one from the sidebar itself, plus a second one in the header. Looking at the coding it seems to get added every time we are not showing a subview. But it only needs to be added for narrow/mobile when there is no sidebar visible.

I have no idea why I do not observe the same bug in production though.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
