### PR TITLE
Fix disabled domain text color in entity settings

### DIFF
--- a/src/components/ha-textfield.ts
+++ b/src/components/ha-textfield.ts
@@ -163,6 +163,11 @@ export class HaTextField extends TextFieldBase {
       .mdc-text-field__affix--prefix {
         padding-right: var(--text-field-prefix-padding-right, 2px);
       }
+
+      .mdc-text-field:not(.mdc-text-field--disabled)
+        .mdc-text-field__affix--prefix {
+        color: var(--input-disabled-ink-color);
+      }
     `,
     // safari workaround - must be explicit
     document.dir === "rtl"

--- a/src/components/ha-textfield.ts
+++ b/src/components/ha-textfield.ts
@@ -166,7 +166,7 @@ export class HaTextField extends TextFieldBase {
 
       .mdc-text-field:not(.mdc-text-field--disabled)
         .mdc-text-field__affix--prefix {
-        color: var(--input-disabled-ink-color);
+        color: var(--mdc-text-field-label-ink-color);
       }
     `,
     // safari workaround - must be explicit


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

![image](https://github.com/home-assistant/frontend/assets/114137/a9ac6b11-1a5e-42d5-9b71-09d72b2f483d)

![image](https://github.com/home-assistant/frontend/assets/114137/455b8349-51e1-4438-ade1-03166e803186)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17110
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
