### PR TITLE
Warn when punctuation is used in conversation trigger

### DIFF
--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts
@@ -10,6 +10,8 @@ import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dial
 import { HomeAssistant } from "../../../../../types";
 import { TriggerElement } from "../ha-automation-trigger-row";
 
+const PATTERN = "^[^.。,，?¿？؟!！;；:：]+$";
+
 @customElement("ha-automation-trigger-conversation")
 export class HaConversationTrigger
   extends LitElement
@@ -44,7 +46,7 @@ export class HaConversationTrigger
                 )}
                 autoValidate
                 validateOnInitialRender
-                pattern="^[^.。,，?¿？؟!！;；:：]+$"
+                pattern=${PATTERN}
                 @change=${this._updateOption}
               >
                 <ha-icon-button
@@ -66,7 +68,7 @@ export class HaConversationTrigger
           "ui.panel.config.automation.editor.triggers.type.conversation.no_punctuation"
         )}
         autoValidate
-        pattern="^[^.。,，?¿？؟!！;；:：]+$"
+        pattern=${PATTERN}
         @keydown=${this._handleKeyAdd}
         @change=${this._addOption}
       ></ha-textfield>`;

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts
@@ -39,6 +39,12 @@ export class HaConversationTrigger
                 iconTrailing
                 .index=${index}
                 .value=${option}
+                .validationMessage=${this.hass.localize(
+                  "ui.panel.config.automation.editor.triggers.type.conversation.no_punctuation"
+                )}
+                autoValidate
+                validateOnInitialRender
+                pattern="^[^.。,，?¿？؟!！;；:：]+$"
                 @change=${this._updateOption}
               >
                 <ha-icon-button
@@ -56,6 +62,11 @@ export class HaConversationTrigger
         .label=${this.hass.localize(
           "ui.panel.config.automation.editor.triggers.type.conversation.add_sentence"
         )}
+        .validationMessage=${this.hass.localize(
+          "ui.panel.config.automation.editor.triggers.type.conversation.no_punctuation"
+        )}
+        autoValidate
+        pattern="^[^.。,，?¿？؟!！;；:：]+$"
         @keydown=${this._handleKeyAdd}
         @change=${this._addOption}
       ></ha-textfield>`;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2382,6 +2382,7 @@
                 },
                 "conversation": {
                   "label": "Sentence",
+                  "no_punctuation": "You should not use punctuation in your sentence",
                   "add_sentence": "Add sentence",
                   "delete": "Delete sentence",
                   "confirm_delete": "Are you sure you want to delete this sentence?",


### PR DESCRIPTION

## Proposed change

https://github.com/home-assistant/core/pull/95633

<img width="1045" alt="CleanShot 2023-06-30 at 16 51 46@2x" src="https://github.com/home-assistant/frontend/assets/5662298/b17e8d50-fa15-4506-9125-20a11ca5d4c0">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
