### PR TITLE
Gauge card form fields can be decimal

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -82,12 +82,12 @@ export class HuiGaugeCardEditor
             {
               name: "min",
               default: DEFAULT_MIN,
-              selector: { number: { mode: "box" } },
+              selector: { number: { mode: "box", step: "any" } },
             },
             {
               name: "max",
               default: DEFAULT_MAX,
-              selector: { number: { mode: "box" } },
+              selector: { number: { mode: "box", step: "any" } },
             },
           ],
         },
@@ -107,15 +107,15 @@ export class HuiGaugeCardEditor
                 schema: [
                   {
                     name: "green",
-                    selector: { number: { mode: "box" } },
+                    selector: { number: { mode: "box", step: "any" } },
                   },
                   {
                     name: "yellow",
-                    selector: { number: { mode: "box" } },
+                    selector: { number: { mode: "box", step: "any" } },
                   },
                   {
                     name: "red",
-                    selector: { number: { mode: "box" } },
+                    selector: { number: { mode: "box", step: "any" } },
                   },
                 ],
               },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Don't display a validation error if user enters a decimal value for gauge min/max/red/yellow/green

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
