### PR TITLE
Fix handling of negative zero in number selectors

### DIFF
--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -64,7 +64,7 @@ export class HaNumberSelector extends LitElement {
           class=${classMap({ single: this.selector.number?.mode === "box" })}
           .min=${this.selector.number?.min}
           .max=${this.selector.number?.max}
-          .value=${this.value ?? ""}
+          .value=${Object.is(this.value, -0) ? "-0" : this.value ?? ""}
           .step=${this.selector.number?.step ?? 1}
           helperPersistent
           .helper=${isBox ? this.helper : undefined}

--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement } from "lit";
+import { css, CSSResultGroup, html, LitElement, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { fireEvent } from "../../common/dom/fire_event";
@@ -25,6 +25,17 @@ export class HaNumberSelector extends LitElement {
   @property({ type: Boolean }) public required = true;
 
   @property({ type: Boolean }) public disabled = false;
+
+  private _valueStr = "";
+
+  protected willUpdate(changedProps: PropertyValues) {
+    if (changedProps.has("value")) {
+      if (this.value !== Number(this._valueStr)) {
+        this._valueStr =
+          !this.value || isNaN(this.value) ? "" : this.value.toString();
+      }
+    }
+  }
 
   protected render() {
     const isBox = this.selector.number?.mode === "box";
@@ -64,7 +75,7 @@ export class HaNumberSelector extends LitElement {
           class=${classMap({ single: this.selector.number?.mode === "box" })}
           .min=${this.selector.number?.min}
           .max=${this.selector.number?.max}
-          .value=${Object.is(this.value, -0) ? "-0" : this.value ?? ""}
+          .value=${this._valueStr ?? ""}
           .step=${this.selector.number?.step ?? 1}
           helperPersistent
           .helper=${isBox ? this.helper : undefined}
@@ -86,6 +97,7 @@ export class HaNumberSelector extends LitElement {
 
   private _handleInputChange(ev) {
     ev.stopPropagation();
+    this._valueStr = ev.target.value;
     const value =
       ev.target.value === "" || isNaN(ev.target.value)
         ? undefined

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -153,9 +153,9 @@ export class HuiGaugeCardEditor
       config = {
         ...config,
         severity: {
-          green: config.green ?? config.severity?.green ?? 0,
-          yellow: config.yellow ?? config.severity?.yellow ?? 0,
-          red: config.red ?? config.severity?.red ?? 0,
+          green: config.green || config.severity?.green || 0,
+          yellow: config.yellow || config.severity?.yellow || 0,
+          red: config.red || config.severity?.red || 0,
         },
       };
     } else if (!config.show_severity && config.severity) {

--- a/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-gauge-card-editor.ts
@@ -153,9 +153,9 @@ export class HuiGaugeCardEditor
       config = {
         ...config,
         severity: {
-          green: config.green || config.severity?.green || 0,
-          yellow: config.yellow || config.severity?.yellow || 0,
-          red: config.red || config.severity?.red || 0,
+          green: config.green ?? config.severity?.green ?? 0,
+          yellow: config.yellow ?? config.severity?.yellow ?? 0,
+          red: config.red ?? config.severity?.red ?? 0,
         },
       };
     } else if (!config.show_severity && config.severity) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix some quirks around number selector and negative decimals. 

It was difficult to input the value `-0.5` in a number selector because if I clear the field and enter `-0` it was immediately replaced with `0` by the ha-textfield. So typing `-` `0` `.` `5` was giving `0.5`

The only way to enter it was to enter `0.5` and then move the cursor to the front and add in the `-`. 

This PR fix that behavior so `-0` is not modified. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
