### PR TITLE
Fix synchronous loading for ES5 build

### DIFF
--- a/src/html/_js_base.html.template
+++ b/src/html/_js_base.html.template
@@ -1,18 +1,21 @@
-    <script>
-      function _ls(src) {
-        var doc = document.documentElement;
-        var script = doc.insertBefore(
-          document.createElement("script"),
-          doc.lastChild
-        );
-        script.defer = true;
-        script.src = src;
-        return script;
-      }
-      window.polymerSkipLoadingFontRoboto = true;
-      if (!("customElements" in window &&
-            "content" in document.createElement("template"))) {
-        document.write("<script src='/static/polyfills/webcomponents-bundle.js'><"+"/script>");
-      }
-      var isS11_12 = /(?:.*(?:iPhone|iPad).*OS (?:11|12)_\d)|(?:.*Version\/(?:11|12)(?:\.\d+)*.*Safari\/)/.test(navigator.userAgent);
-    </script>
+<script>
+  function _ls(src) {
+    var script = document.createElement("script");
+    script.async = false;
+    script.src = src;
+    return document.head.appendChild(script);
+  }
+  window.polymerSkipLoadingFontRoboto = true;
+  if (
+    !(
+      "customElements" in window &&
+      "content" in document.createElement("template")
+    )
+  ) {
+    _ls("/static/polyfills/webcomponents-bundle.js");
+  }
+  var isS11_12 =
+    /(?:.*(?:iPhone|iPad).*OS (?:11|12)_\d)|(?:.*Version\/(?:11|12)(?:\.\d+)*.*Safari\/)/.test(
+      navigator.userAgent
+    );
+</script>

--- a/src/html/_js_base.html.template
+++ b/src/html/_js_base.html.template
@@ -1,7 +1,9 @@
 <script>
-  function _ls(src) {
+  function _ls(src, sync) {
     var script = document.createElement("script");
-    script.async = false;
+    if (sync) {
+      script.async = false;
+    }
     script.src = src;
     return document.head.appendChild(script);
   }
@@ -12,7 +14,7 @@
       "content" in document.createElement("template")
     )
   ) {
-    _ls("/static/polyfills/webcomponents-bundle.js");
+    _ls("/static/polyfills/webcomponents-bundle.js", true);
   }
   var isS11_12 =
     /(?:.*(?:iPhone|iPad).*OS (?:11|12)_\d)|(?:.*Version\/(?:11|12)(?:\.\d+)*.*Safari\/)/.test(

--- a/src/html/_script_load_es5.html.template
+++ b/src/html/_script_load_es5.html.template
@@ -9,7 +9,7 @@
         }
       <% } else { %>
         <% for (const entry of es5EntryJS) { %>
-          _ls("<%= entry %>");
+          _ls("<%= entry %>", true);
         <% } %>
       <% } %>
     }

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -112,7 +112,7 @@
             }
           <% } else { %>
             <% for (const entry of es5EntryJS) { %>
-              _ls("<%= entry %>");
+              _ls("<%= entry %>", true);
             <% } %>
           <% } %>
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Sets `async = false` on loaded scripts for ES5 build.  This should fix the polyfill race condition reported in https://github.com/home-assistant/frontend/pull/16386#issuecomment-1534732960, but I need help testing as I don't have hardware to reproduce and cannot seem to get Browser Stack working yet.

I think the expectation was that setting `defer = true` would load the scripts synchronously, but that's not the case per the HTML specification.  Dynamically added script tags are always loaded async by default unless the flag is explicitly set to false.  (See use of [`forceAsync` in the spec](https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model).

Also applies the same load function to the web components polyfill so it loads before core.  It looks like adding `defer = true` and using `document.write()` here was added way back in #3346 as an attempt to fix the same issue, but use of [`write()` is strongly discouraged](https://developer.mozilla.org/en-US/docs/Web/API/Document/write).

Lastly, this appends the `script` elements to `head` instead of unconventionally to the `html` element.

Note this will also load the "extra scripts" from core synchronously now, which may or may not be desirable?

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
