### PR TITLE
Make action-choose options collapsible

### DIFF
--- a/src/panels/config/automation/action/types/ha-automation-action-choose.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-choose.ts
@@ -296,16 +296,15 @@ export class HaChooseAction extends LitElement implements ActionElement {
           inset-inline-start: initial;
           inset-inline-end: 0;
           direction: var(--direction);
-          padding: 4px;
         }
         ha-svg-icon {
           height: 20px;
         }
         .link-button-row {
-          padding: 14px;
+          padding: 14px 14px 0 14px;
         }
         .card-content {
-          padding: 0 0 8px 8px;
+          padding: 0 16px 16px 16px;
         }
       `,
     ];

--- a/src/panels/config/automation/action/types/ha-automation-action-choose.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-choose.ts
@@ -1,5 +1,6 @@
+import { consume } from "@lit-labs/context";
 import { mdiDelete, mdiPlus } from "@mdi/js";
-import { CSSResultGroup, LitElement, css, html } from "lit";
+import { CSSResultGroup, LitElement, PropertyValues, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { ensureArray } from "../../../../../common/array/ensure-array";
 import { fireEvent } from "../../../../../common/dom/fire_event";
@@ -10,6 +11,9 @@ import { Action, ChooseAction } from "../../../../../data/script";
 import { haStyle } from "../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../types";
 import { ActionElement } from "../ha-automation-action-row";
+import { describeCondition } from "../../../../../data/automation_i18n";
+import { fullEntitiesContext } from "../../../../../data/context";
+import { EntityRegistryEntry } from "../../../../../data/entity_registry";
 
 @customElement("ha-automation-action-choose")
 export class HaChooseAction extends LitElement implements ActionElement {
@@ -23,8 +27,81 @@ export class HaChooseAction extends LitElement implements ActionElement {
 
   @state() private _showDefault = false;
 
+  @state() private expandedUpdateFlag = false;
+
+  @state()
+  @consume({ context: fullEntitiesContext, subscribe: true })
+  _entityReg!: EntityRegistryEntry[];
+
   public static get defaultConfig() {
     return { choose: [{ conditions: [], sequence: [] }] };
+  }
+
+  protected willUpdate(changedProperties: PropertyValues) {
+    if (!changedProperties.has("action")) {
+      return;
+    }
+
+    const oldCnt =
+      changedProperties.get("action") === undefined ||
+      changedProperties.get("action").choose === undefined
+        ? 0
+        : ensureArray(changedProperties.get("action").choose).length;
+    const newCnt = this.action.choose
+      ? ensureArray(this.action.choose).length
+      : 0;
+    if (newCnt === oldCnt + 1) {
+      this.expand(newCnt - 1);
+    }
+  }
+
+  private expand(i: number) {
+    this.updateComplete.then(() => {
+      this.shadowRoot!.querySelectorAll("ha-expansion-panel")[i].expanded =
+        true;
+      this.expandedUpdateFlag = !this.expandedUpdateFlag;
+    });
+  }
+
+  private isExpanded(i: number) {
+    const nodes = this.shadowRoot!.querySelectorAll("ha-expansion-panel");
+    if (nodes[i]) {
+      return nodes[i].expanded;
+    }
+    return false;
+  }
+
+  private _expandedChanged() {
+    this.expandedUpdateFlag = !this.expandedUpdateFlag;
+  }
+
+  private _getDescription(option, idx: number) {
+    if (this.isExpanded(idx)) {
+      return "";
+    }
+    if (!option.conditions || option.conditions.length === 0) {
+      return this.hass.localize(
+        "ui.panel.config.automation.editor.actions.type.choose.no_conditions"
+      );
+    }
+    let str = "";
+    if (typeof option.conditions[0] === "string") {
+      str += option.conditions[0];
+    } else {
+      str += describeCondition(
+        option.conditions[0],
+        this.hass,
+        this._entityReg
+      );
+    }
+    if (option.conditions.length > 1) {
+      str += this.hass.localize(
+        "ui.panel.config.automation.editor.actions.type.choose.option_description_additional",
+        "numberOfAdditionalConditions",
+        option.conditions.length - 1
+      );
+    }
+    return str;
   }
 
   protected render() {
@@ -33,52 +110,62 @@ export class HaChooseAction extends LitElement implements ActionElement {
     return html`
       ${(action.choose ? ensureArray(action.choose) : []).map(
         (option, idx) => html`<ha-card>
-          <ha-icon-button
-            .idx=${idx}
-            .disabled=${this.disabled}
-            @click=${this._removeOption}
-            .label=${this.hass.localize(
-              "ui.panel.config.automation.editor.actions.type.choose.remove_option"
-            )}
-            .path=${mdiDelete}
-          ></ha-icon-button>
-          <div class="card-content">
-            <h2>
+          <ha-expansion-panel
+            leftChevron
+            @expanded-changed=${this._expandedChanged}
+          >
+            <h3 slot="header">
               ${this.hass.localize(
                 "ui.panel.config.automation.editor.actions.type.choose.option",
                 "number",
                 idx + 1
               )}:
-            </h2>
-            <h3>
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.actions.type.choose.conditions"
-              )}:
+              ${this._getDescription(option, idx)}
             </h3>
-            <ha-automation-condition
-              nested
-              .conditions=${ensureArray<string | Condition>(option.conditions)}
-              .reOrderMode=${this.reOrderMode}
-              .disabled=${this.disabled}
-              .hass=${this.hass}
+
+            <ha-icon-button
+              slot="icons"
               .idx=${idx}
-              @value-changed=${this._conditionChanged}
-            ></ha-automation-condition>
-            <h3>
-              ${this.hass.localize(
-                "ui.panel.config.automation.editor.actions.type.choose.sequence"
-              )}:
-            </h3>
-            <ha-automation-action
-              nested
-              .actions=${ensureArray(option.sequence) || []}
-              .reOrderMode=${this.reOrderMode}
               .disabled=${this.disabled}
-              .hass=${this.hass}
-              .idx=${idx}
-              @value-changed=${this._actionChanged}
-            ></ha-automation-action>
-          </div>
+              @click=${this._removeOption}
+              .label=${this.hass.localize(
+                "ui.panel.config.automation.editor.actions.type.choose.remove_option"
+              )}
+              .path=${mdiDelete}
+            ></ha-icon-button>
+            <div class="card-content">
+              <h4>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.type.choose.conditions"
+                )}:
+              </h4>
+              <ha-automation-condition
+                nested
+                .conditions=${ensureArray<string | Condition>(
+                  option.conditions
+                )}
+                .reOrderMode=${this.reOrderMode}
+                .disabled=${this.disabled}
+                .hass=${this.hass}
+                .idx=${idx}
+                @value-changed=${this._conditionChanged}
+              ></ha-automation-condition>
+              <h4>
+                ${this.hass.localize(
+                  "ui.panel.config.automation.editor.actions.type.choose.sequence"
+                )}:
+              </h4>
+              <ha-automation-action
+                nested
+                .actions=${ensureArray(option.sequence) || []}
+                .reOrderMode=${this.reOrderMode}
+                .disabled=${this.disabled}
+                .hass=${this.hass}
+                .idx=${idx}
+                @value-changed=${this._actionChanged}
+              ></ha-automation-action>
+            </div>
+          </ha-expansion-panel>
         </ha-card>`
       )}
       <ha-button
@@ -188,11 +275,20 @@ export class HaChooseAction extends LitElement implements ActionElement {
       haStyle,
       css`
         ha-card {
-          margin: 16px 0;
+          margin: 0 0 16px 0;
         }
         .add-card mwc-button {
           display: block;
           text-align: center;
+        }
+        ha-expansion-panel {
+          --expansion-panel-summary-padding: 0 0 0 8px;
+          --expansion-panel-content-padding: 0;
+        }
+        h3 {
+          margin: 0;
+          font-size: inherit;
+          font-weight: inherit;
         }
         ha-icon-button {
           position: absolute;
@@ -207,6 +303,9 @@ export class HaChooseAction extends LitElement implements ActionElement {
         }
         .link-button-row {
           padding: 14px;
+        }
+        .card-content {
+          padding: 0 0 8px 8px;
         }
       `,
     ];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2690,7 +2690,9 @@
                   "option": "Option {number}",
                   "add_option": "Add option",
                   "remove_option": "Remove option",
+                  "option_description_additional": " {numberOfAdditionalConditions, plural,\n one {and 1 more condition}\n other {and {numberOfAdditionalConditions} more conditions}}",
                   "conditions": "Conditions",
+                  "no_conditions": "[%key:ui::panel::config::devices::automation::conditions::no_conditions%]",
                   "sequence": "Actions",
                   "description": {
                     "full": "Choose between {number} {number, plural,\n one {action}\n other{actions}\n}",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Was playing around with expansion panel and wanted to see if we like the idea of making the choose options collapsible. They take up quite a lot of vertical space in their current form, so a choose with a couple options easily fills the page. Thought this might be a little nicer visually. 

![choose-expansion](https://github.com/home-assistant/frontend/assets/32912880/d6a6d38d-5fa9-461f-829e-c364aef263ca)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
