### PR TITLE
Add format state/attribute to hass

### DIFF
--- a/src/common/entity/compute_attribute_display.ts
+++ b/src/common/entity/compute_attribute_display.ts
@@ -1,7 +1,6 @@
 import { HassConfig, HassEntity } from "home-assistant-js-websocket";
-import { html, TemplateResult } from "lit";
-import { until } from "lit/directives/until";
 import { EntityRegistryDisplayEntry } from "../../data/entity_registry";
+import { FrontendLocaleData } from "../../data/translation";
 import { HomeAssistant } from "../../types";
 import checkValidDate from "../datetime/check_valid_date";
 import { formatDate } from "../datetime/format_date";
@@ -12,9 +11,6 @@ import { isDate } from "../string/is_date";
 import { isTimestamp } from "../string/is_timestamp";
 import { LocalizeFunc } from "../translations/localize";
 import { computeDomain } from "./compute_domain";
-import { FrontendLocaleData } from "../../data/translation";
-
-let jsYamlPromise: Promise<typeof import("../../resources/js-yaml-dump")>;
 
 export const computeAttributeValueDisplay = (
   localize: LocalizeFunc,
@@ -24,7 +20,7 @@ export const computeAttributeValueDisplay = (
   entities: HomeAssistant["entities"],
   attribute: string,
   value?: any
-): string | TemplateResult => {
+): string => {
   const attributeValue =
     value !== undefined ? value : stateObj.attributes[attribute];
 
@@ -40,23 +36,6 @@ export const computeAttributeValueDisplay = (
 
   // Special handling in case this is a string with an known format
   if (typeof attributeValue === "string") {
-    // URL handling
-    if (attributeValue.startsWith("http")) {
-      try {
-        // If invalid URL, exception will be raised
-        const url = new URL(attributeValue);
-        if (url.protocol === "http:" || url.protocol === "https:")
-          return html`<a
-            target="_blank"
-            rel="noopener noreferrer"
-            href=${attributeValue}
-            >${attributeValue}</a
-          >`;
-      } catch (_) {
-        // Nothing to do here
-      }
-    }
-
     // Date handling
     if (isDate(attributeValue, true)) {
       // Timestamp handling
@@ -81,13 +60,8 @@ export const computeAttributeValueDisplay = (
       attributeValue.some((val) => val instanceof Object)) ||
     (!Array.isArray(attributeValue) && attributeValue instanceof Object)
   ) {
-    if (!jsYamlPromise) {
-      jsYamlPromise = import("../../resources/js-yaml-dump");
-    }
-    const yaml = jsYamlPromise.then((jsYaml) => jsYaml.dump(attributeValue));
-    return html`<pre>${until(yaml, "")}</pre>`;
+    return JSON.stringify(attributeValue);
   }
-
   // If this is an array, try to determine the display value for each item
   if (Array.isArray(attributeValue)) {
     return attributeValue

--- a/src/common/translations/entity-state.ts
+++ b/src/common/translations/entity-state.ts
@@ -3,14 +3,17 @@ import type { FrontendLocaleData } from "../../data/translation";
 import type { HomeAssistant } from "../../types";
 import type { LocalizeFunc } from "./localize";
 
-export type FormatStateFunc = {
-  formatState: (stateObj: HassEntity, state?: string) => string;
-  formatAttributeValue: (
+export type FormatEntityStateFunc = {
+  formatEntityState: (stateObj: HassEntity, state?: string) => string;
+  formatEntityAttributeValue: (
     stateObj: HassEntity,
     attribute: string,
     value?: any
   ) => string;
-  formatAttributeName: (stateObj: HassEntity, attribute: string) => string;
+  formatEntityAttributeName: (
+    stateObj: HassEntity,
+    attribute: string
+  ) => string;
 };
 
 export const computeFormatFunctions = async (
@@ -18,7 +21,7 @@ export const computeFormatFunctions = async (
   locale: FrontendLocaleData,
   config: HassConfig,
   entities: HomeAssistant["entities"]
-): Promise<FormatStateFunc> => {
+): Promise<FormatEntityStateFunc> => {
   const { computeStateDisplay } = await import(
     "../entity/compute_state_display"
   );
@@ -26,9 +29,9 @@ export const computeFormatFunctions = async (
     await import("../entity/compute_attribute_display");
 
   return {
-    formatState: (stateObj, state) =>
+    formatEntityState: (stateObj, state) =>
       computeStateDisplay(localize, stateObj, locale, config, entities, state),
-    formatAttributeValue: (stateObj, attribute, value) =>
+    formatEntityAttributeValue: (stateObj, attribute, value) =>
       computeAttributeValueDisplay(
         localize,
         stateObj,
@@ -38,7 +41,7 @@ export const computeFormatFunctions = async (
         attribute,
         value
       ),
-    formatAttributeName: (stateObj, attribute) =>
+    formatEntityAttributeName: (stateObj, attribute) =>
       computeAttributeNameDisplay(localize, stateObj, entities, attribute),
   };
 };

--- a/src/common/translations/state.ts
+++ b/src/common/translations/state.ts
@@ -1,30 +1,20 @@
 import type { HassConfig, HassEntity } from "home-assistant-js-websocket";
-import type { EntityRegistryDisplayEntry } from "../../data/entity_registry";
-import type { LocalizeFunc } from "./localize";
 import type { FrontendLocaleData } from "../../data/translation";
+import type { HomeAssistant } from "../../types";
+import type { LocalizeFunc } from "./localize";
 
-export type FormatStateFunc = (
-  stateObj: HassEntity,
-  entity?: EntityRegistryDisplayEntry,
-  state?: string
-) => string;
+export type FormatStateFunc = (stateObj: HassEntity, state?: string) => string;
 
 export const computeFormatState = async (
   localize: LocalizeFunc,
   locale: FrontendLocaleData,
-  config: HassConfig
+  config: HassConfig,
+  entities: HomeAssistant["entities"]
 ): Promise<FormatStateFunc> => {
-  const { computeStateDisplaySingleEntity } = await import(
+  const { computeStateDisplay } = await import(
     "../entity/compute_state_display"
   );
 
-  return (stateObj, entity, state) =>
-    computeStateDisplaySingleEntity(
-      localize,
-      stateObj,
-      locale,
-      config,
-      entity,
-      state
-    );
+  return (stateObj, state) =>
+    computeStateDisplay(localize, stateObj, locale, config, entities, state);
 };

--- a/src/common/translations/state.ts
+++ b/src/common/translations/state.ts
@@ -3,9 +3,17 @@ import type { FrontendLocaleData } from "../../data/translation";
 import type { HomeAssistant } from "../../types";
 import type { LocalizeFunc } from "./localize";
 
-export type FormatStateFunc = (stateObj: HassEntity, state?: string) => string;
+export type FormatStateFunc = {
+  formatState: (stateObj: HassEntity, state?: string) => string;
+  formatAttributeValue: (
+    stateObj: HassEntity,
+    attribute: string,
+    value?: any
+  ) => string;
+  formatAttributeName: (stateObj: HassEntity, attribute: string) => string;
+};
 
-export const computeFormatState = async (
+export const computeFormatFunctions = async (
   localize: LocalizeFunc,
   locale: FrontendLocaleData,
   config: HassConfig,
@@ -14,7 +22,23 @@ export const computeFormatState = async (
   const { computeStateDisplay } = await import(
     "../entity/compute_state_display"
   );
+  const { computeAttributeValueDisplay, computeAttributeNameDisplay } =
+    await import("../entity/compute_attribute_display");
 
-  return (stateObj, state) =>
-    computeStateDisplay(localize, stateObj, locale, config, entities, state);
+  return {
+    formatState: (stateObj, state) =>
+      computeStateDisplay(localize, stateObj, locale, config, entities, state),
+    formatAttributeValue: (stateObj, attribute, value) =>
+      computeAttributeValueDisplay(
+        localize,
+        stateObj,
+        locale,
+        config,
+        entities,
+        attribute,
+        value
+      ),
+    formatAttributeName: (stateObj, attribute) =>
+      computeAttributeNameDisplay(localize, stateObj, entities, attribute),
+  };
 };

--- a/src/common/translations/state.ts
+++ b/src/common/translations/state.ts
@@ -1,0 +1,30 @@
+import type { HassConfig, HassEntity } from "home-assistant-js-websocket";
+import type { EntityRegistryDisplayEntry } from "../../data/entity_registry";
+import type { LocalizeFunc } from "./localize";
+import type { FrontendLocaleData } from "../../data/translation";
+
+export type FormatStateFunc = (
+  stateObj: HassEntity,
+  entity?: EntityRegistryDisplayEntry,
+  state?: string
+) => string;
+
+export const computeFormatState = async (
+  localize: LocalizeFunc,
+  locale: FrontendLocaleData,
+  config: HassConfig
+): Promise<FormatStateFunc> => {
+  const { computeStateDisplaySingleEntity } = await import(
+    "../entity/compute_state_display"
+  );
+
+  return (stateObj, entity, state) =>
+    computeStateDisplaySingleEntity(
+      localize,
+      stateObj,
+      locale,
+      config,
+      entity,
+      state
+    );
+};

--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -1,0 +1,73 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import { until } from "lit/directives/until";
+import { computeAttributeValueDisplay } from "../common/entity/compute_attribute_display";
+import { HomeAssistant } from "../types";
+import "./ha-expansion-panel";
+
+let jsYamlPromise: Promise<typeof import("../resources/js-yaml-dump")>;
+
+@customElement("ha-attribute-value")
+class HaAttributeValue extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public stateObj?: HassEntity;
+
+  @property() public attribute!: string;
+
+  protected render() {
+    if (!this.stateObj) {
+      return nothing;
+    }
+    const attributeValue = this.stateObj.attributes[this.attribute];
+    if (typeof attributeValue === "string") {
+      // URL handling
+      if (attributeValue.startsWith("http")) {
+        try {
+          // If invalid URL, exception will be raised
+          const url = new URL(attributeValue);
+          if (url.protocol === "http:" || url.protocol === "https:")
+            return html`
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href=${attributeValue}
+              >
+                ${attributeValue}
+              </a>
+            `;
+        } catch (_) {
+          // Nothing to do here
+        }
+      }
+    }
+
+    if (
+      (Array.isArray(attributeValue) &&
+        attributeValue.some((val) => val instanceof Object)) ||
+      (!Array.isArray(attributeValue) && attributeValue instanceof Object)
+    ) {
+      if (!jsYamlPromise) {
+        jsYamlPromise = import("../resources/js-yaml-dump");
+      }
+      const yaml = jsYamlPromise.then((jsYaml) => jsYaml.dump(attributeValue));
+      return html`<pre>${until(yaml, "")}</pre>`;
+    }
+
+    return computeAttributeValueDisplay(
+      this.hass.localize,
+      this.stateObj!,
+      this.hass.locale,
+      this.hass.config,
+      this.hass.entities,
+      this.attribute
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-attribute-value": HaAttributeValue;
+  }
+}

--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -2,9 +2,7 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { until } from "lit/directives/until";
-import { computeAttributeValueDisplay } from "../common/entity/compute_attribute_display";
 import { HomeAssistant } from "../types";
-import "./ha-expansion-panel";
 
 let jsYamlPromise: Promise<typeof import("../resources/js-yaml-dump")>;
 
@@ -55,14 +53,7 @@ class HaAttributeValue extends LitElement {
       return html`<pre>${until(yaml, "")}</pre>`;
     }
 
-    return computeAttributeValueDisplay(
-      this.hass.localize,
-      this.stateObj!,
-      this.hass.locale,
-      this.hass.config,
-      this.hass.entities,
-      this.attribute
-    );
+    return this.hass.formatEntityAttributeValue(this.stateObj!, this.attribute);
   }
 }
 

--- a/src/components/ha-attributes.ts
+++ b/src/components/ha-attributes.ts
@@ -1,15 +1,12 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import {
-  computeAttributeNameDisplay,
-  computeAttributeValueDisplay,
-} from "../common/entity/compute_attribute_display";
+import { computeAttributeNameDisplay } from "../common/entity/compute_attribute_display";
 import { STATE_ATTRIBUTES } from "../data/entity_attributes";
 import { haStyle } from "../resources/styles";
 import { HomeAssistant } from "../types";
-
 import "./ha-expansion-panel";
+import "./ha-attribute-value";
 
 @customElement("ha-attributes")
 class HaAttributes extends LitElement {
@@ -58,14 +55,11 @@ class HaAttributes extends LitElement {
                         )}
                       </div>
                       <div class="value">
-                        ${computeAttributeValueDisplay(
-                          this.hass.localize,
-                          this.stateObj!,
-                          this.hass.locale,
-                          this.hass.config,
-                          this.hass.entities,
-                          attribute
-                        )}
+                        <ha-attribute-value
+                          .hass=${this.hass}
+                          .attribute=${attribute}
+                          .stateObj=${this.stateObj}
+                        ></ha-attribute-value>
                       </div>
                     </div>
                   `

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -68,7 +68,8 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     `;
   }
 
-  willUpdate(changedProps: PropertyValues<this>) {
+  protected willUpdate(changedProps: PropertyValues<this>) {
+    super.willUpdate(changedProps);
     if (
       this._databaseMigration === undefined &&
       changedProps.has("hass") &&
@@ -79,7 +80,7 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     }
   }
 
-  update(changedProps: PropertyValues<this>) {
+  protected update(changedProps: PropertyValues<this>) {
     if (
       this.hass?.states &&
       this.hass.config &&

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -12,13 +12,12 @@ import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";
-import { computeAttributeValueDisplay } from "../../../common/entity/compute_attribute_display";
 import { computeStateDisplay } from "../../../common/entity/compute_state_display";
 import { computeStateDomain } from "../../../common/entity/compute_state_domain";
 import { computeStateName } from "../../../common/entity/compute_state_name";
 import {
-  stateColorCss,
   stateColorBrightness,
+  stateColorCss,
 } from "../../../common/entity/state_color";
 import { isValidEntityId } from "../../../common/entity/valid_entity_id";
 import {
@@ -27,6 +26,7 @@ import {
   isNumericState,
 } from "../../../common/number/format_number";
 import { iconColorCSS } from "../../../common/style/icon_color_css";
+import "../../../components/ha-attribute-value";
 import "../../../components/ha-card";
 import "../../../components/ha-icon";
 import { CLIMATE_HVAC_ACTION_TO_MODE } from "../../../data/climate";
@@ -157,14 +157,14 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
           <span class="value"
             >${"attribute" in this._config
               ? stateObj.attributes[this._config.attribute!] !== undefined
-                ? computeAttributeValueDisplay(
-                    this.hass.localize,
-                    stateObj,
-                    this.hass.locale,
-                    this.hass.config,
-                    this.hass.entities,
-                    this._config.attribute!
-                  )
+                ? html`
+                    <ha-attribute-value
+                      .hass=${this.hass}
+                      .stateObj=${stateObj}
+                      .attribute=${this._config.attribute!}
+                    >
+                    </ha-attribute-value>
+                  `
                 : this.hass.localize("state.default.unknown")
               : isNumericState(stateObj) || this._config.unit
               ? formatNumber(

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -233,10 +233,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       }
     }
 
-    const stateDisplay = this.hass!.stateDisplay(
-      stateObj,
-      this.hass!.entities[stateObj.entity_id]
-    );
+    const stateDisplay = this.hass!.stateDisplay(stateObj);
 
     if (domain === "cover") {
       const positionStateDisplay = computeCoverPositionStateDisplay(

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -25,7 +25,6 @@ import { computeCssColor } from "../../../common/color/compute-color";
 import { hsv2rgb, rgb2hex, rgb2hsv } from "../../../common/color/convert-color";
 import { DOMAINS_TOGGLE } from "../../../common/const";
 import { computeDomain } from "../../../common/entity/compute_domain";
-import { computeStateDisplay } from "../../../common/entity/compute_state_display";
 import { stateActive } from "../../../common/entity/state_active";
 import { stateColorCss } from "../../../common/entity/state_color";
 import { stateIconPath } from "../../../common/entity/state_icon_path";
@@ -234,12 +233,9 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       }
     }
 
-    const stateDisplay = computeStateDisplay(
-      this.hass!.localize,
+    const stateDisplay = this.hass!.stateDisplay(
       stateObj,
-      this.hass!.locale,
-      this.hass!.config,
-      this.hass!.entities
+      this.hass!.entities[stateObj.entity_id]
     );
 
     if (domain === "cover") {

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -233,7 +233,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       }
     }
 
-    const stateDisplay = this.hass!.formatState(stateObj);
+    const stateDisplay = this.hass!.formatEntityState(stateObj);
 
     if (domain === "cover") {
       const positionStateDisplay = computeCoverPositionStateDisplay(

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -233,7 +233,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       }
     }
 
-    const stateDisplay = this.hass!.stateDisplay(stateObj);
+    const stateDisplay = this.hass!.formatState(stateObj);
 
     if (domain === "cover") {
       const positionStateDisplay = computeCoverPositionStateDisplay(

--- a/src/panels/lovelace/special-rows/hui-attribute-row.ts
+++ b/src/panels/lovelace/special-rows/hui-attribute-row.ts
@@ -1,20 +1,20 @@
 import {
-  css,
   CSSResultGroup,
-  html,
   LitElement,
   PropertyValues,
+  css,
+  html,
   nothing,
 } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import checkValidDate from "../../../common/datetime/check_valid_date";
+import "../../../components/ha-attribute-value";
 import { HomeAssistant } from "../../../types";
 import { hasConfigOrEntityChanged } from "../common/has-changed";
 import "../components/hui-generic-entity-row";
 import "../components/hui-timestamp-display";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import { AttributeRowConfig, LovelaceRow } from "../entity-rows/types";
-import { computeAttributeValueDisplay } from "../../../common/entity/compute_attribute_display";
 
 @customElement("hui-attribute-row")
 class HuiAttributeRow extends LitElement implements LovelaceRow {
@@ -71,15 +71,14 @@ class HuiAttributeRow extends LitElement implements LovelaceRow {
               capitalize
             ></hui-timestamp-display>`
           : attribute !== undefined
-          ? computeAttributeValueDisplay(
-              this.hass.localize,
-              stateObj,
-              this.hass.locale,
-              this.hass.config,
-              this.hass.entities,
-              this._config.attribute,
-              attribute
-            )
+          ? html`
+              <ha-attribute-value
+                .hass=${this.hass}
+                .stateObj=${stateObj}
+                .attribute=${this._config.attribute}
+              >
+              </ha-attribute-value>
+            `
           : "—"}
         ${this._config.suffix}
       </hui-generic-entity-row>

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -176,7 +176,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         loadFragmentTranslation: (fragment) =>
           // @ts-ignore
           this._loadFragmentTranslations(this.hass?.language, fragment),
-        stateDisplay: (stateObj, _entity, state) =>
+        stateDisplay: (stateObj, state) =>
           (state !== null ? state : stateObj.state) ?? "",
         ...getState(),
         ...this._pendingHass,

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -19,9 +19,9 @@ import { forwardHaptic } from "../data/haptics";
 import { DEFAULT_PANEL } from "../data/panel";
 import { serviceCallWillDisconnect } from "../data/service";
 import {
+  DateFormat,
   FirstWeekday,
   NumberFormat,
-  DateFormat,
   TimeFormat,
   TimeZone,
 } from "../data/translation";
@@ -176,6 +176,8 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         loadFragmentTranslation: (fragment) =>
           // @ts-ignore
           this._loadFragmentTranslations(this.hass?.language, fragment),
+        stateDisplay: (stateObj, _entity, state) =>
+          (state !== null ? state : stateObj.state) ?? "",
         ...getState(),
         ...this._pendingHass,
       };

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -176,8 +176,11 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         loadFragmentTranslation: (fragment) =>
           // @ts-ignore
           this._loadFragmentTranslations(this.hass?.language, fragment),
-        stateDisplay: (stateObj, state) =>
+        formatState: (stateObj, state) =>
           (state !== null ? state : stateObj.state) ?? "",
+        formatAttributeName: (_stateObj, attribute) => attribute,
+        formatAttributeValue: (stateObj, attribute, value) =>
+          value !== null ? value : stateObj.attributes[attribute] ?? "",
         ...getState(),
         ...this._pendingHass,
       };

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -176,10 +176,10 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
         loadFragmentTranslation: (fragment) =>
           // @ts-ignore
           this._loadFragmentTranslations(this.hass?.language, fragment),
-        formatState: (stateObj, state) =>
+        formatEntityState: (stateObj, state) =>
           (state !== null ? state : stateObj.state) ?? "",
-        formatAttributeName: (_stateObj, attribute) => attribute,
-        formatAttributeValue: (stateObj, attribute, value) =>
+        formatEntityAttributeName: (_stateObj, attribute) => attribute,
+        formatEntityAttributeValue: (stateObj, attribute, value) =>
           value !== null ? value : stateObj.attributes[attribute] ?? "",
         ...getState(),
         ...this._pendingHass,

--- a/src/state/hass-element.ts
+++ b/src/state/hass-element.ts
@@ -14,6 +14,7 @@ import { panelTitleMixin } from "./panel-title-mixin";
 import SidebarMixin from "./sidebar-mixin";
 import ThemesMixin from "./themes-mixin";
 import TranslationsMixin from "./translations-mixin";
+import StateDisplayMixin from "./state-display-mixin";
 import { urlSyncMixin } from "./url-sync-mixin";
 
 const ext = <T extends Constructor>(baseClass: T, mixins): T =>
@@ -23,6 +24,7 @@ export class HassElement extends ext(HassBaseEl, [
   AuthMixin,
   ThemesMixin,
   TranslationsMixin,
+  StateDisplayMixin,
   MoreInfoMixin,
   ActionMixin,
   SidebarMixin,

--- a/src/state/state-display-mixin.ts
+++ b/src/state/state-display-mixin.ts
@@ -1,4 +1,4 @@
-import { computeFormatFunctions } from "../common/translations/state";
+import { computeFormatFunctions } from "../common/translations/entity-state";
 import { Constructor, HomeAssistant } from "../types";
 import { HassBaseEl } from "./hass-base-mixin";
 
@@ -31,17 +31,20 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
 
     private _updateStateDisplay = async () => {
       if (!this.hass) return;
-      const { formatState, formatAttributeName, formatAttributeValue } =
-        await computeFormatFunctions(
-          this.hass.localize,
-          this.hass.locale,
-          this.hass.config,
-          this.hass.entities
-        );
+      const {
+        formatEntityState,
+        formatEntityAttributeName,
+        formatEntityAttributeValue,
+      } = await computeFormatFunctions(
+        this.hass.localize,
+        this.hass.locale,
+        this.hass.config,
+        this.hass.entities
+      );
       this._updateHass({
-        formatState,
-        formatAttributeName,
-        formatAttributeValue,
+        formatEntityState,
+        formatEntityAttributeName,
+        formatEntityAttributeValue,
       });
     };
   }

--- a/src/state/state-display-mixin.ts
+++ b/src/state/state-display-mixin.ts
@@ -2,15 +2,16 @@ import { computeFormatState } from "../common/translations/state";
 import { Constructor, HomeAssistant } from "../types";
 import { HassBaseEl } from "./hass-base-mixin";
 
-export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
-  class extends superClass {
+export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
+  class StateDisplayMixin extends superClass {
     protected hassConnected() {
       super.hassConnected();
       this._updateStateDisplay();
     }
 
-    protected updated(changedProps) {
-      super.updated(changedProps);
+    protected willUpdate(changedProps) {
+      super.willUpdate(changedProps);
+
       if (!changedProps.has("hass")) {
         return;
       }
@@ -39,4 +40,6 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         ),
       });
     };
-  };
+  }
+  return StateDisplayMixin;
+};

--- a/src/state/state-display-mixin.ts
+++ b/src/state/state-display-mixin.ts
@@ -1,0 +1,40 @@
+import { computeFormatState } from "../common/translations/state";
+import { Constructor, HomeAssistant } from "../types";
+import { HassBaseEl } from "./hass-base-mixin";
+
+export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
+  class extends superClass {
+    protected hassConnected() {
+      super.hassConnected();
+      this._updateStateDisplay();
+    }
+
+    protected updated(changedProps) {
+      super.updated(changedProps);
+      if (!changedProps.has("hass")) {
+        return;
+      }
+      const oldHass = changedProps.get("hass") as HomeAssistant | undefined;
+
+      if (this.hass) {
+        if (
+          this.hass.localize !== oldHass?.localize ||
+          this.hass.locale !== oldHass.locale ||
+          this.hass.config !== oldHass.config
+        ) {
+          this._updateStateDisplay();
+        }
+      }
+    }
+
+    private _updateStateDisplay = async () => {
+      if (!this.hass) return;
+      this._updateHass({
+        stateDisplay: await computeFormatState(
+          this.hass.localize,
+          this.hass.locale,
+          this.hass.config
+        ),
+      });
+    };
+  };

--- a/src/state/state-display-mixin.ts
+++ b/src/state/state-display-mixin.ts
@@ -1,4 +1,4 @@
-import { computeFormatState } from "../common/translations/state";
+import { computeFormatFunctions } from "../common/translations/state";
 import { Constructor, HomeAssistant } from "../types";
 import { HassBaseEl } from "./hass-base-mixin";
 
@@ -31,13 +31,17 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) => {
 
     private _updateStateDisplay = async () => {
       if (!this.hass) return;
-      this._updateHass({
-        stateDisplay: await computeFormatState(
+      const { formatState, formatAttributeName, formatAttributeValue } =
+        await computeFormatFunctions(
           this.hass.localize,
           this.hass.locale,
           this.hass.config,
           this.hass.entities
-        ),
+        );
+      this._updateHass({
+        formatState,
+        formatAttributeName,
+        formatAttributeValue,
       });
     };
   }

--- a/src/state/state-display-mixin.ts
+++ b/src/state/state-display-mixin.ts
@@ -20,7 +20,8 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         if (
           this.hass.localize !== oldHass?.localize ||
           this.hass.locale !== oldHass.locale ||
-          this.hass.config !== oldHass.config
+          this.hass.config !== oldHass.config ||
+          this.hass.entities !== oldHass.entities
         ) {
           this._updateStateDisplay();
         }
@@ -33,7 +34,8 @@ export default <T extends Constructor<HassBaseEl>>(superClass: T) =>
         stateDisplay: await computeFormatState(
           this.hass.localize,
           this.hass.locale,
-          this.hass.config
+          this.hass.config,
+          this.hass.entities
         ),
       });
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,7 +257,13 @@ export interface HomeAssistant {
     configFlow?: Parameters<typeof getHassTranslations>[4]
   ): Promise<LocalizeFunc>;
   loadFragmentTranslation(fragment: string): Promise<LocalizeFunc | undefined>;
-  stateDisplay(stateObj: HassEntity, state?: string): string;
+  formatState(stateObj: HassEntity, state?: string): string;
+  formatAttributeValue(
+    stateObj: HassEntity,
+    attribute: string,
+    value?: string
+  ): string;
+  formatAttributeName(stateObj: HassEntity, attribute: string): string;
 }
 
 export interface Route {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import {
   Connection,
   HassConfig,
   HassEntities,
+  HassEntity,
   HassServices,
   HassServiceTarget,
   MessageBase,
@@ -256,6 +257,11 @@ export interface HomeAssistant {
     configFlow?: Parameters<typeof getHassTranslations>[4]
   ): Promise<LocalizeFunc>;
   loadFragmentTranslation(fragment: string): Promise<LocalizeFunc | undefined>;
+  stateDisplay(
+    stateObj: HassEntity,
+    entity: EntityRegistryDisplayEntry,
+    state?: string
+  ): string;
 }
 
 export interface Route {

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,11 +257,7 @@ export interface HomeAssistant {
     configFlow?: Parameters<typeof getHassTranslations>[4]
   ): Promise<LocalizeFunc>;
   loadFragmentTranslation(fragment: string): Promise<LocalizeFunc | undefined>;
-  stateDisplay(
-    stateObj: HassEntity,
-    entity: EntityRegistryDisplayEntry,
-    state?: string
-  ): string;
+  stateDisplay(stateObj: HassEntity, state?: string): string;
 }
 
 export interface Route {

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,13 +257,13 @@ export interface HomeAssistant {
     configFlow?: Parameters<typeof getHassTranslations>[4]
   ): Promise<LocalizeFunc>;
   loadFragmentTranslation(fragment: string): Promise<LocalizeFunc | undefined>;
-  formatState(stateObj: HassEntity, state?: string): string;
-  formatAttributeValue(
+  formatEntityState(stateObj: HassEntity, state?: string): string;
+  formatEntityAttributeValue(
     stateObj: HassEntity,
     attribute: string,
     value?: string
   ): string;
-  formatAttributeName(stateObj: HassEntity, attribute: string): string;
+  formatEntityAttributeName(stateObj: HassEntity, attribute: string): string;
 }
 
 export interface Route {


### PR DESCRIPTION
## Proposed change

Add `state display` to `hass` object like we do for `localize`. This avoids passing all the config, locale and localize to every compute state display function.

3 new functions have been added : 
- formatEntityState
- formatEntityAttributeName
- formatEntityAttributeValue

I also removed the non-string value from the compute attribute value function (for links and object). I created a new component `ha-attribute-value` for this as it's only used in `ha-attributes`, `hui-entity-card` and `ha-attribute-row`.
This special formatting in for dashboard components only and shouldn't be part of the compute attribute display function.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
