### PR TITLE
Fix history issue when closing more info dialog by clicking update

### DIFF
--- a/src/dialogs/more-info/show-ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/show-ha-more-info-dialog.ts
@@ -5,6 +5,3 @@ export const showMoreInfoDialog = (
   element: HTMLElement,
   params: MoreInfoDialogParams
 ) => fireEvent(element, "hass-more-info", params);
-
-export const hideMoreInfoDialog = (element: HTMLElement) =>
-  fireEvent(element, "hass-more-info", { entityId: null });

--- a/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
+++ b/src/panels/config/entities/editor-tabs/settings/entity-settings-helper-tab.ts
@@ -16,7 +16,6 @@ import {
 } from "../../../../../data/entity_registry";
 import { HELPERS_CRUD } from "../../../../../data/helpers_crud";
 import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dialog-box";
-import { hideMoreInfoDialog } from "../../../../../dialogs/more-info/show-ha-more-info-dialog";
 import { haStyle } from "../../../../../resources/styles";
 import type { HomeAssistant } from "../../../../../types";
 import type { Helper } from "../../../helpers/const";
@@ -151,7 +150,7 @@ export class EntityRegistrySettingsHelper extends LitElement {
       }
       const result = await this._registryEditor!.updateEntry();
       if (result.close) {
-        hideMoreInfoDialog(this);
+        fireEvent(this, "close-dialog");
       }
     } catch (err: any) {
       this._error = err.message || "Unknown error";

--- a/src/panels/config/entities/entity-registry-settings.ts
+++ b/src/panels/config/entities/entity-registry-settings.ts
@@ -22,7 +22,6 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../dialogs/generic/show-dialog-box";
-import { hideMoreInfoDialog } from "../../../dialogs/more-info/show-ha-more-info-dialog";
 import { SubscribeMixin } from "../../../mixins/subscribe-mixin";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
@@ -200,7 +199,7 @@ export class EntityRegistrySettings extends SubscribeMixin(LitElement) {
     try {
       const result = await this._registryEditor!.updateEntry();
       if (result.close) {
-        hideMoreInfoDialog(this);
+        fireEvent(this, "close-dialog");
       }
     } catch (err: any) {
       this._error = err.message || "Unknown error";

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -55,10 +55,7 @@ import {
   showAlertDialog,
   showConfirmationDialog,
 } from "../../../dialogs/generic/show-dialog-box";
-import {
-  hideMoreInfoDialog,
-  showMoreInfoDialog,
-} from "../../../dialogs/more-info/show-ha-more-info-dialog";
+import { showMoreInfoDialog } from "../../../dialogs/more-info/show-ha-more-info-dialog";
 import "../../../layouts/hass-loading-screen";
 import "../../../layouts/hass-tabs-subpage-data-table";
 import type { HaTabsSubpageDataTable } from "../../../layouts/hass-tabs-subpage-data-table";
@@ -485,11 +482,6 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         this._areas = areas;
       }),
     ];
-  }
-
-  public disconnectedCallback() {
-    super.disconnectedCallback();
-    hideMoreInfoDialog(this);
   }
 
   protected render() {


### PR DESCRIPTION
## Proposed change

This caused duplicated history and user had to click multiple time to back button to go back.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
