### PR TITLE
Prune empty value_template field from numeric_state

### DIFF
--- a/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
+++ b/src/panels/config/automation/condition/types/ha-automation-condition-numeric_state.ts
@@ -237,15 +237,19 @@ export default class HaNumericStateCondition extends LitElement {
 
   private _valueChanged(ev: CustomEvent): void {
     ev.stopPropagation();
-    const newTrigger = ev.detail.value;
+    const newCondition = ev.detail.value;
 
-    this._inputAboveIsEntity = newTrigger.mode_above === "input";
-    this._inputBelowIsEntity = newTrigger.mode_below === "input";
+    this._inputAboveIsEntity = newCondition.mode_above === "input";
+    this._inputBelowIsEntity = newCondition.mode_below === "input";
 
-    delete newTrigger.mode_above;
-    delete newTrigger.mode_below;
+    delete newCondition.mode_above;
+    delete newCondition.mode_below;
 
-    fireEvent(this, "value-changed", { value: newTrigger });
+    if (newCondition.value_template === "") {
+      delete newCondition.value_template;
+    }
+
+    fireEvent(this, "value-changed", { value: newCondition });
   }
 
   private _computeLabelCallback = (

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-numeric_state.ts
@@ -288,6 +288,10 @@ export class HaNumericStateTrigger extends LitElement {
     delete newTrigger.mode_above;
     delete newTrigger.mode_below;
 
+    if (newTrigger.value_template === "") {
+      delete newTrigger.value_template;
+    }
+
     fireEvent(this, "value-changed", { value: newTrigger });
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Prune empty string value_templates from numeric_state trigger & condition. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17245
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
