### PR TITLE
Fix overflow on sensor card

### DIFF
--- a/src/panels/lovelace/cards/hui-sensor-card.ts
+++ b/src/panels/lovelace/cards/hui-sensor-card.ts
@@ -76,6 +76,9 @@ class HuiSensorCard extends HuiEntityCard {
     return [
       HuiEntityCard.styles,
       css`
+        ha-card {
+          overflow: hidden;
+        }
         .info {
           direction: ltr;
           text-align: var(--float-start);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixes https://github.com/home-assistant/frontend/issues/15401

Currently, the `ha-card` component allows overflow. This results in graphs overflowing on the `hui-sensor-card`. It is especially noticeable on themes with large card border-radius:
<img width="774" alt="image" src="https://github.com/home-assistant/frontend/assets/51953549/d2b12f5a-da26-47aa-a6b7-a32df4cad560">


It is visible on the default theme too:
<img width="747" alt="image" src="https://github.com/home-assistant/frontend/assets/51953549/ec5a7d8b-0646-4c60-b447-d0dfc84c39fc">

`hui-sensor-card` inherits styles from `hui-entity-card`. Therefore, I have added `overflow: hidden` on the `hui-sensor-card` styles:
<img width="657" alt="image" src="https://github.com/home-assistant/frontend/assets/51953549/3ed94d2e-952e-46f8-a2c7-79b7c0e11e91">


Since `hui-entity-card` also applies styles to `ha-card`,  I'm not sure if they will be merged correctly and I am unable to test the change because I'm running HA on docker.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #15401
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
