### PR TITLE
Add current humidity to humidifier history chart

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -328,23 +328,94 @@ class StateHistoryChartLine extends LitElement {
           }
         });
       } else if (domain === "humidifier") {
+        const hasAction = states.states.some(
+          (entityState) => entityState.attributes?.action
+        );
+        const hasCurrent = states.states.some(
+          (entityState) => entityState.attributes?.current_humidity
+        );
+
+        const hasHumidifying =
+          hasAction &&
+          states.states.some(
+            (entityState: LineChartState) =>
+              entityState.attributes?.action === "humidifying"
+          );
+        const hasDrying =
+          hasAction &&
+          states.states.some(
+            (entityState: LineChartState) =>
+              entityState.attributes?.action === "drying"
+          );
+
         addDataSet(
           `${this.hass.localize("ui.card.humidifier.target_humidity_entity", {
             name: name,
           })}`
         );
-        addDataSet(
-          `${this.hass.localize("ui.card.humidifier.on_entity", {
-            name: name,
-          })}`,
-          true
-        );
+
+        if (hasCurrent) {
+          addDataSet(
+            `${this.hass.localize(
+              "ui.card.humidifier.current_humidity_entity",
+              {
+                name: name,
+              }
+            )}`
+          );
+        }
+
+        // If action attribute is available, we used it to shade the area below the humidity.
+        // If action attribute is not available, we shade the area when the device is on
+        if (hasHumidifying) {
+          addDataSet(
+            `${this.hass.localize("ui.card.humidifier.humidifying", {
+              name: name,
+            })}`,
+            true,
+            computedStyles.getPropertyValue("--state-humidifier-humidify-color")
+          );
+        } else if (hasDrying) {
+          addDataSet(
+            `${this.hass.localize("ui.card.humidifier.drying", {
+              name: name,
+            })}`,
+            true,
+            computedStyles.getPropertyValue("--state-humidifier-dry-color")
+          );
+        } else {
+          addDataSet(
+            `${this.hass.localize("ui.card.humidifier.on_entity", {
+              name: name,
+            })}`,
+            true
+          );
+        }
 
         states.states.forEach((entityState) => {
           if (!entityState.attributes) return;
           const target = safeParseFloat(entityState.attributes.humidity);
+          // If the current humidity is not available, then we fill up to the target humidity
+          const current = hasCurrent
+            ? safeParseFloat(entityState.attributes?.current_humidity)
+            : target;
           const series = [target];
-          series.push(entityState.state === "on" ? target : null);
+
+          if (hasCurrent) {
+            series.push(current);
+          }
+
+          if (hasHumidifying) {
+            series.push(
+              entityState.attributes?.action === "humidifying" ? current : null
+            );
+          } else if (hasDrying) {
+            series.push(
+              entityState.attributes?.action === "drying" ? current : null
+            );
+          } else {
+            series.push(entityState.state === "on" ? current : null);
+          }
           pushData(new Date(entityState.last_changed), series);
         });
       } else {

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -373,7 +373,7 @@ class StateHistoryChartLine extends LitElement {
               name: name,
             })}`,
             true,
-            computedStyles.getPropertyValue("--state-humidifier-humidify-color")
+            computedStyles.getPropertyValue("--state-humidifier-on-color")
           );
         } else if (hasDrying) {
           addDataSet(
@@ -381,7 +381,7 @@ class StateHistoryChartLine extends LitElement {
               name: name,
             })}`,
             true,
-            computedStyles.getPropertyValue("--state-humidifier-dry-color")
+            computedStyles.getPropertyValue("--state-humidifier-on-color")
           );
         } else {
           addDataSet(

--- a/src/data/history.ts
+++ b/src/data/history.ts
@@ -29,6 +29,8 @@ const LINE_ATTRIBUTES_TO_KEEP = [
   "hvac_action",
   "humidity",
   "mode",
+  "action",
+  "current_humidity",
 ];
 
 export interface LineChartState {

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -156,9 +156,7 @@ documentContainer.innerHTML = `<custom-style>
       --state-device_tracker-active-color: var(--blue-color);
       --state-device_tracker-home-color: var(--green-color);
       --state-fan-active-color: var(--cyan-color);
-      --state-humidifier-active-color: var(--blue-color);
-      --state-humidifier-humidify-color: var(--blue-color);
-      --state-humidifier-dry-color: var(--orange-color);
+      --state-humidifier-on-color: var(--blue-color);
       --state-light-active-color: var(--amber-color);
       --state-lock-jammed-color: var(--red-color);
       --state-lock-locked-color: var(--green-color);

--- a/src/resources/ha-style.ts
+++ b/src/resources/ha-style.ts
@@ -157,6 +157,8 @@ documentContainer.innerHTML = `<custom-style>
       --state-device_tracker-home-color: var(--green-color);
       --state-fan-active-color: var(--cyan-color);
       --state-humidifier-active-color: var(--blue-color);
+      --state-humidifier-humidify-color: var(--blue-color);
+      --state-humidifier-dry-color: var(--orange-color);
       --state-light-active-color: var(--amber-color);
       --state-lock-jammed-color: var(--red-color);
       --state-lock-locked-color: var(--green-color);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -134,6 +134,9 @@
         "state": "State",
         "mode": "Mode",
         "target_humidity_entity": "{name} target humidity",
+        "current_humidity_entity": "{name} current humidity",
+        "humidifying": "{name} humidifying",
+        "drying": "{name} drying",
         "on_entity": "{name} on"
       },
       "light": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add current humidity to the humidifier history chart.
Also, if the `action` attribute is available, the graph is filled (shaded) depending on active/idle state instead of on/off state.
This replicates the thermostat card behavior when these new attributes are present while keeping backwards compatibility and old behavior when they are not present.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

![image](https://github.com/home-assistant/frontend/assets/2741408/84f83780-2e0f-4a60-b25e-f282284cf3f3)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
