### PR TITLE
Use icon button to switch between code and editor

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -1,7 +1,7 @@
 import "@material/mwc-list/mwc-list-item";
 import "@material/mwc-tab-bar/mwc-tab-bar";
 import "@material/mwc-tab/mwc-tab";
-import { mdiContentCopy } from "@mdi/js";
+import { mdiCodeBraces, mdiContentCopy, mdiListBoxOutline } from "@mdi/js";
 import deepClone from "deep-clone-simple";
 import type { MDCTabBarActivatedEvent } from "@material/tab-bar";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
@@ -92,6 +92,8 @@ export class HuiConditionalCardEditor
       return nothing;
     }
 
+    const isGuiMode = !this._cardEditorEl || this._GUImode;
+
     return html`
       <mwc-tab-bar
         .activeIndex=${this._cardTab ? 1 : 0}
@@ -114,17 +116,17 @@ export class HuiConditionalCardEditor
               ${this._config.card.type !== undefined
                 ? html`
                     <div class="card-options">
-                      <mwc-button
+                      <ha-icon-button
+                        class="gui-mode-button"
                         @click=${this._toggleMode}
                         .disabled=${!this._guiModeAvailable}
-                        class="gui-mode-button"
-                      >
-                        ${this.hass!.localize(
-                          !this._cardEditorEl || this._GUImode
+                        .label=${this.hass!.localize(
+                          isGuiMode
                             ? "ui.panel.lovelace.editor.edit_card.show_code_editor"
                             : "ui.panel.lovelace.editor.edit_card.show_visual_editor"
                         )}
-                      </mwc-button>
+                        .path=${isGuiMode ? mdiCodeBraces : mdiListBoxOutline}
+                      ></ha-icon-button>
 
                       <ha-icon-button
                         .label=${this.hass!.localize(

--- a/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-stack-card-editor.ts
@@ -1,15 +1,17 @@
 import {
   mdiArrowLeft,
   mdiArrowRight,
-  mdiDelete,
-  mdiContentCut,
+  mdiCodeBraces,
   mdiContentCopy,
+  mdiContentCut,
+  mdiDelete,
+  mdiListBoxOutline,
   mdiPlus,
 } from "@mdi/js";
 import "@polymer/paper-tabs";
 import "@polymer/paper-tabs/paper-tab";
 import deepClone from "deep-clone-simple";
-import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
+import { CSSResultGroup, LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import {
   any,
@@ -21,7 +23,7 @@ import {
   string,
 } from "superstruct";
 import { storage } from "../../../../common/decorators/storage";
-import { fireEvent, HASSDomEvent } from "../../../../common/dom/fire_event";
+import { HASSDomEvent, fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-icon-button";
 import { LovelaceCardConfig, LovelaceConfig } from "../../../../data/lovelace";
 import { HomeAssistant } from "../../../../types";
@@ -87,6 +89,8 @@ export class HuiStackCardEditor
     const selected = this._selectedCard!;
     const numcards = this._config.cards.length;
 
+    const isGuiMode = !this._cardEditorEl || this._GUImode;
+
     return html`
       <div class="card-config">
         <div class="toolbar">
@@ -114,17 +118,17 @@ export class HuiStackCardEditor
           ${selected < numcards
             ? html`
                 <div id="card-options">
-                  <mwc-button
+                  <ha-icon-button
+                    class="gui-mode-button"
                     @click=${this._toggleMode}
                     .disabled=${!this._guiModeAvailable}
-                    class="gui-mode-button"
-                  >
-                    ${this.hass!.localize(
-                      !this._cardEditorEl || this._GUImode
+                    .label=${this.hass!.localize(
+                      isGuiMode
                         ? "ui.panel.lovelace.editor.edit_card.show_code_editor"
                         : "ui.panel.lovelace.editor.edit_card.show_visual_editor"
                     )}
-                  </mwc-button>
+                    .path=${isGuiMode ? mdiCodeBraces : mdiListBoxOutline}
+                  ></ha-icon-button>
 
                   <ha-icon-button
                     .disabled=${selected === 0}

--- a/src/panels/lovelace/editor/hui-sub-element-editor.ts
+++ b/src/panels/lovelace/editor/hui-sub-element-editor.ts
@@ -1,5 +1,5 @@
 import "@material/mwc-button";
-import { mdiArrowLeft } from "@mdi/js";
+import { mdiArrowLeft, mdiCodeBraces, mdiListBoxOutline } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { fireEvent, HASSDomEvent } from "../../../common/dom/fire_event";
@@ -50,17 +50,17 @@ export class HuiSubElementEditor extends LitElement {
             )}</span
           >
         </div>
-        <mwc-button
-          slot="secondaryAction"
-          .disabled=${!this._guiModeAvailable}
+        <ha-icon-button
+          class="gui-mode-button"
           @click=${this._toggleMode}
-        >
-          ${this.hass.localize(
+          .disabled=${!this._guiModeAvailable}
+          .label=${this.hass!.localize(
             this._guiMode
               ? "ui.panel.lovelace.editor.edit_card.show_code_editor"
               : "ui.panel.lovelace.editor.edit_card.show_visual_editor"
           )}
-        </mwc-button>
+          .path=${this._guiMode ? mdiCodeBraces : mdiListBoxOutline}
+        ></ha-icon-button>
       </div>
       ${this.config.type === "row"
         ? html`


### PR DESCRIPTION
## Proposed change

![CleanShot 2023-07-13 at 12 41 51](https://github.com/home-assistant/frontend/assets/5878303/8bd63e3e-5e34-4986-a3a5-0de97a366b5f)

Switch between code editor and visual editor is a text button but with the add of copy and cut button, its broken on mobile. This PR adds a toggle icon button for this action instead of a text button to be consistent with other actions and it takes less space.

The "show code editor" button in footer dialog is unchanged because footer action should be text.

### Current design

![CleanShot 2023-07-13 at 12 38 21](https://github.com/home-assistant/frontend/assets/5878303/71cff1ee-5a16-4ce9-a989-df50e9688bff)

### Design proposal

#### Stack editor (grid, vertical, horizontal)
![CleanShot 2023-07-13 at 12 34 34](https://github.com/home-assistant/frontend/assets/5878303/ef4bf503-67f2-4bcb-a067-3458c725b972)

#### Entity row editor
![CleanShot 2023-07-13 at 12 35 05](https://github.com/home-assistant/frontend/assets/5878303/77529ec1-5b4b-4393-b39b-c867b0b8ef50)

#### Conditional editor

BTW, for conditional editor, we should change the "change type" button to an icon button too.

![CleanShot 2023-07-13 at 12 34 48](https://github.com/home-assistant/frontend/assets/5878303/ff6b1224-d8d9-410a-8c3c-02806a87029c)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
