### PR TITLE
Add last_used option for pipeline and explicit default

### DIFF
--- a/src/components/ha-assist-pipeline-picker.ts
+++ b/src/components/ha-assist-pipeline-picker.ts
@@ -37,11 +37,15 @@ export class HaAssistPipelinePicker extends LitElement {
 
   @state() _preferredPipeline: string | null = null;
 
+  private get _default() {
+    return this.includeLastUsed ? LAST_USED : PREFERRED;
+  }
+
   protected render() {
     if (!this._pipelines) {
       return nothing;
     }
-    const value = this.value ?? PREFERRED;
+    const value = this.value ?? this._default;
     return html`
       <ha-select
         .label=${this.label ||
@@ -54,13 +58,6 @@ export class HaAssistPipelinePicker extends LitElement {
         fixedMenuPosition
         naturalMenuWidth
       >
-        <ha-list-item .value=${PREFERRED}>
-          ${this.hass!.localize("ui.components.pipeline-picker.preferred", {
-            preferred: this._pipelines.find(
-              (pipeline) => pipeline.id === this._preferredPipeline
-            )?.name,
-          })}
-        </ha-list-item>
         ${this.includeLastUsed
           ? html`
               <ha-list-item .value=${LAST_USED}>
@@ -70,6 +67,13 @@ export class HaAssistPipelinePicker extends LitElement {
               </ha-list-item>
             `
           : null}
+        <ha-list-item .value=${PREFERRED}>
+          ${this.hass!.localize("ui.components.pipeline-picker.preferred", {
+            preferred: this._pipelines.find(
+              (pipeline) => pipeline.id === this._preferredPipeline
+            )?.name,
+          })}
+        </ha-list-item>
         ${this._pipelines.map(
           (pipeline) =>
             html`<ha-list-item .value=${pipeline.id}>
@@ -105,11 +109,11 @@ export class HaAssistPipelinePicker extends LitElement {
       !this.hass ||
       target.value === "" ||
       target.value === this.value ||
-      (this.value === undefined && target.value === PREFERRED)
+      (this.value === undefined && target.value === this._default)
     ) {
       return;
     }
-    this.value = target.value === PREFERRED ? undefined : target.value;
+    this.value = target.value === this._default ? undefined : target.value;
     fireEvent(this, "value-changed", { value: this.value });
   }
 }

--- a/src/components/ha-assist-pipeline-picker.ts
+++ b/src/components/ha-assist-pipeline-picker.ts
@@ -16,7 +16,8 @@ import "./ha-list-item";
 import "./ha-select";
 import type { HaSelect } from "./ha-select";
 
-const PREFERRED = "__PREFERRED_PIPELINE_OPTION__";
+const PREFERRED = "preferred";
+const LAST_USED = "last_used";
 
 @customElement("ha-assist-pipeline-picker")
 export class HaAssistPipelinePicker extends LitElement {
@@ -29,6 +30,8 @@ export class HaAssistPipelinePicker extends LitElement {
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
   @property({ type: Boolean }) public required = false;
+
+  @property() public includeLastUsed = false;
 
   @state() _pipelines?: AssistPipeline[];
 
@@ -58,6 +61,15 @@ export class HaAssistPipelinePicker extends LitElement {
             )?.name,
           })}
         </ha-list-item>
+        ${this.includeLastUsed
+          ? html`
+              <ha-list-item .value=${LAST_USED}>
+                ${this.hass!.localize(
+                  "ui.components.pipeline-picker.last_used"
+                )}
+              </ha-list-item>
+            `
+          : null}
         ${this._pipelines.map(
           (pipeline) =>
             html`<ha-list-item .value=${pipeline.id}>

--- a/src/components/ha-selector/ha-selector-assist-pipeline.ts
+++ b/src/components/ha-selector/ha-selector-assist-pipeline.ts
@@ -21,14 +21,19 @@ export class HaAssistPipelineSelector extends LitElement {
   @property({ type: Boolean }) public required = true;
 
   protected render() {
-    return html`<ha-assist-pipeline-picker
-      .hass=${this.hass}
-      .value=${this.value}
-      .label=${this.label}
-      .helper=${this.helper}
-      .disabled=${this.disabled}
-      .required=${this.required}
-    ></ha-assist-pipeline-picker>`;
+    return html`
+      <ha-assist-pipeline-picker
+        .hass=${this.hass}
+        .value=${this.value}
+        .label=${this.label}
+        .helper=${this.helper}
+        .disabled=${this.disabled}
+        .required=${this.required}
+        .includeLastUsed=${Boolean(
+          this.selector.assist_pipeline?.include_last_used
+        )}
+      ></ha-assist-pipeline-picker>
+    `;
   }
 
   static styles = css`

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -278,7 +278,9 @@ export interface ObjectSelector {
 
 export interface AssistPipelineSelector {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  assist_pipeline: {} | null;
+  assist_pipeline: {
+    include_last_used?: boolean;
+  } | null;
 }
 
 export interface SelectOption {

--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -87,9 +87,14 @@ export class HaVoiceCommandDialog extends LitElement {
 
   private _pipelinePromise?: Promise<AssistPipeline>;
 
-  public async showDialog(params?: VoiceCommandDialogParams): Promise<void> {
-    if (params?.pipeline_id) {
-      this._pipelineId = params?.pipeline_id;
+  public async showDialog(params: VoiceCommandDialogParams): Promise<void> {
+    if (params.pipeline_id === "last_used") {
+      // Do not set pipeline id
+    } else if (params.pipeline_id === "preferred") {
+      await this._loadPipelines();
+      this._pipelineId = this._preferredPipeline;
+    } else {
+      this._pipelineId = params.pipeline_id;
     }
 
     this._conversation = [

--- a/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/ha-voice-command-dialog.ts
@@ -87,9 +87,11 @@ export class HaVoiceCommandDialog extends LitElement {
 
   private _pipelinePromise?: Promise<AssistPipeline>;
 
-  public async showDialog(params: VoiceCommandDialogParams): Promise<void> {
+  public async showDialog(
+    params: Required<VoiceCommandDialogParams>
+  ): Promise<void> {
     if (params.pipeline_id === "last_used") {
-      // Do not set pipeline id
+      // Do not set pipeline id (retrieve from storage)
     } else if (params.pipeline_id === "preferred") {
       await this._loadPipelines();
       this._pipelineId = this._preferredPipeline;
@@ -108,7 +110,11 @@ export class HaVoiceCommandDialog extends LitElement {
     this._scrollMessagesBottom();
 
     await this._pipelinePromise;
-    if (params?.start_listening && this._pipeline?.stt_engine) {
+    if (
+      params?.start_listening &&
+      this._pipeline?.stt_engine &&
+      AudioRecorder.isSupported
+    ) {
       this._toggleListening();
     }
   }

--- a/src/dialogs/voice-command-dialog/show-ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/show-ha-voice-command-dialog.ts
@@ -18,6 +18,7 @@ export const showVoiceCommandDialog = (
       type: "assist/show",
       payload: {
         pipeline_id: dialogParams.pipeline_id,
+        // Start listening by default for app
         start_listening: dialogParams.start_listening ?? true,
       },
     });
@@ -28,6 +29,7 @@ export const showVoiceCommandDialog = (
     dialogImport: loadVoiceCommandDialog,
     dialogParams: {
       pipeline_id: dialogParams.pipeline_id,
+      // Don't start listening by default for web
       start_listening: dialogParams.start_listening ?? false,
     },
   });

--- a/src/dialogs/voice-command-dialog/show-ha-voice-command-dialog.ts
+++ b/src/dialogs/voice-command-dialog/show-ha-voice-command-dialog.ts
@@ -4,21 +4,21 @@ import { HomeAssistant } from "../../types";
 const loadVoiceCommandDialog = () => import("./ha-voice-command-dialog");
 
 export interface VoiceCommandDialogParams {
-  pipeline_id?: string;
+  pipeline_id: "last_used" | "preferred" | string;
   start_listening?: boolean;
 }
 
 export const showVoiceCommandDialog = (
   element: HTMLElement,
   hass: HomeAssistant,
-  dialogParams?: VoiceCommandDialogParams
+  dialogParams: VoiceCommandDialogParams
 ): void => {
   if (hass.auth.external?.config.hasAssist) {
     hass.auth.external!.fireMessage({
       type: "assist/show",
       payload: {
-        pipeline_id: dialogParams?.pipeline_id,
-        start_listening: dialogParams?.start_listening,
+        pipeline_id: dialogParams.pipeline_id,
+        start_listening: dialogParams.start_listening ?? true,
       },
     });
     return;
@@ -26,6 +26,9 @@ export const showVoiceCommandDialog = (
   fireEvent(element, "show-dialog", {
     dialogTag: "ha-voice-command-dialog",
     dialogImport: loadVoiceCommandDialog,
-    dialogParams,
+    dialogParams: {
+      pipeline_id: dialogParams.pipeline_id,
+      start_listening: dialogParams.start_listening ?? false,
+    },
   });
 };

--- a/src/external_app/external_messaging.ts
+++ b/src/external_app/external_messaging.ts
@@ -98,8 +98,8 @@ interface EMOutgoingMessageSidebarShow extends EMMessage {
 interface EMOutgoingMessageAssistShow extends EMMessage {
   type: "assist/show";
   payload?: {
-    pipeline_id?: string;
-    start_listening?: boolean;
+    pipeline_id: "preferred" | "last_used" | string;
+    start_listening: boolean;
   };
 }
 

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -165,7 +165,7 @@ export const handleAction = async (
     case "assist": {
       showVoiceCommandDialog(node, hass, {
         start_listening: actionConfig.start_listening ?? false,
-        pipeline_id: actionConfig.pipeline_id ?? "preferred",
+        pipeline_id: actionConfig.pipeline_id ?? "last_used",
       });
       break;
     }

--- a/src/panels/lovelace/common/handle-action.ts
+++ b/src/panels/lovelace/common/handle-action.ts
@@ -164,8 +164,8 @@ export const handleAction = async (
     }
     case "assist": {
       showVoiceCommandDialog(node, hass, {
-        start_listening: actionConfig.start_listening,
-        pipeline_id: actionConfig.pipeline_id,
+        start_listening: actionConfig.start_listening ?? false,
+        pipeline_id: actionConfig.pipeline_id ?? "preferred",
       });
       break;
     }

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -38,7 +38,9 @@ const ASSIST_SCHEMA = [
       {
         name: "pipeline_id",
         selector: {
-          assist_pipeline: {},
+          assist_pipeline: {
+            include_last_used: true,
+          },
         },
       },
       {

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -567,7 +567,7 @@ class HUIRoot extends LitElement {
     if (searchParams.edit === "1") {
       this.lovelace!.setEditMode(true);
     } else if (searchParams.conversation === "1") {
-      showVoiceCommandDialog(this, this.hass);
+      this._showVoiceCommandDialog();
       window.history.replaceState(
         null,
         "",
@@ -793,7 +793,7 @@ class HUIRoot extends LitElement {
   }
 
   private _showVoiceCommandDialog(): void {
-    showVoiceCommandDialog(this, this.hass);
+    showVoiceCommandDialog(this, this.hass, { pipeline_id: "last_used" });
   }
 
   private _handleEnableEditMode(ev: CustomEvent<RequestSelectedDetail>): void {

--- a/src/panels/shopping-list/ha-panel-shopping-list.ts
+++ b/src/panels/shopping-list/ha-panel-shopping-list.ts
@@ -76,7 +76,7 @@ class PanelShoppingList extends LitElement {
   }
 
   private _showVoiceCommandDialog(): void {
-    showVoiceCommandDialog(this, this.hass);
+    showVoiceCommandDialog(this, this.hass, { pipeline_id: "last_used" });
   }
 
   static get styles(): CSSResultGroup {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -398,7 +398,8 @@
       },
       "pipeline-picker": {
         "pipeline": "Assistant",
-        "preferred": "Preferred assistant ({preferred})"
+        "preferred": "Preferred assistant ({preferred})",
+        "last_used": "Last used assistant"
       },
       "theme-picker": {
         "theme": "Theme",


### PR DESCRIPTION
## Breaking changes

Assist action will open last used pipeline by default instead of preferred to be consistent with toolbar assist.

## Proposed change

Adds new `last_used` option to assist action.

![CleanShot 2023-07-17 at 17 14 04](https://github.com/home-assistant/frontend/assets/5878303/1fc9cd79-f826-409e-a3ac-d0d90f855d86)

**Trigger assist from the toolbar :** 
It will start listening on app but not on web because web users often have a keyboard on web and it will not work on insecure contexts.
It will use the last used pipeline.

**Trigger assist from the assist action :** 
If the `pipeline_id` is not set, the assist action will use the last used pipeline.
If the `start_listening` option is not set, this assist action will not start listening on web and app.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17322, fixes #17301
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
