### PR TITLE
Add prefix support to text selector

### DIFF
--- a/src/components/ha-selector/ha-selector-text.ts
+++ b/src/components/ha-selector/ha-selector-text.ts
@@ -65,6 +65,7 @@ export class HaTextSelector extends LitElement {
         .type=${this._unmaskedPassword ? "text" : this.selector.text?.type}
         @input=${this._handleChange}
         .label=${this.label || ""}
+        .prefix=${this.selector.text?.prefix}
         .suffix=${this.selector.text?.type === "password"
           ? // reserve some space for the icon.
             html`<div style="width: 24px"></div>`

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -329,6 +329,7 @@ export interface StringSelector {
       | "time"
       | "datetime-local"
       | "color";
+    prefix?: string;
     suffix?: string;
     autocomplete?: string;
   } | null;

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -122,7 +122,9 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
               {
                 name: "id",
                 selector: {
-                  text: {},
+                  text: {
+                    prefix: "script.",
+                  },
                 },
               },
             ] as const)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Add support for setting a prefix text on a text selector. A suffix was already supported.

![image](https://github.com/home-assistant/frontend/assets/195327/8379d05d-037b-4444-bc5b-0280bb054155)

Applied it to setting an entity ID for a script, which was actually asking for an object ID. Adding the prefix removes the confusion.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
