### PR TITLE
Hide no theme option when required

### DIFF
--- a/src/components/ha-theme-picker.ts
+++ b/src/components/ha-theme-picker.ts
@@ -42,9 +42,13 @@ export class HaThemePicker extends LitElement {
         fixedMenuPosition
         naturalMenuWidth
       >
-        <mwc-list-item value="remove">
-          ${this.hass!.localize("ui.components.theme-picker.no_theme")}
-        </mwc-list-item>
+        ${!this.required
+          ? html`
+              <mwc-list-item value="remove">
+                ${this.hass!.localize("ui.components.theme-picker.no_theme")}
+              </mwc-list-item>
+            `
+          : nothing}
         ${this.includeDefault
           ? html`
               <mwc-list-item .value=${DEFAULT_THEME}>


### PR DESCRIPTION
## Proposed change

No theme option doesn't make sense when field is required (e.g. in the set_theme service) because the form will be invalid.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
