### PR TITLE
Always show translated labels for ha-form-multi_select

### DIFF
--- a/src/components/ha-form/ha-form-multi_select.ts
+++ b/src/components/ha-form/ha-form-multi_select.ts
@@ -91,7 +91,11 @@ export class HaFormMultiSelect extends LitElement implements HaFormElement {
           slot="trigger"
           .label=${this.label}
           .value=${data
-            .map((value) => this.schema.options![value] || value)
+            .map(
+              (value) =>
+                optionLabel(options.find((v) => optionValue(v) === value)) ||
+                value
+            )
             .join(", ")}
           .disabled=${this.disabled}
           tabindex="-1"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix ha-form-multi_select to always show the translated labels in the collapsed textbox, and not the raw untranslated values.

Before:
![image](https://github.com/home-assistant/frontend/assets/32912880/390dbd40-6f83-4358-9e57-3300df941400)


After:
![image](https://github.com/home-assistant/frontend/assets/32912880/2f672db7-9a98-481a-8896-be2e2ee911ce)



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17355
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
