### PR TITLE
Create a dedicated button for dialog enlargement

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -1,6 +1,8 @@
 import {
   mdiChartBoxOutline,
   mdiClose,
+  mdiArrowExpand,
+  mdiArrowCollapse,
   mdiCogOutline,
   mdiDevices,
   mdiDotsVertical,
@@ -288,9 +290,15 @@ export class MoreInfoDialog extends LitElement {
                   )}
                 ></ha-icon-button-prev>
               `}
-          <span slot="title" .title=${title} @click=${this._enlarge}>
-            ${title}
-          </span>
+          <ha-icon-button
+            slot="navigationIcon"
+            .path=${this.large ? mdiArrowCollapse : mdiArrowExpand}
+            .label=${this.hass.localize(
+              `ui.dialogs.generic.${this.large ? "reduce" : "enlarge"}`
+            )}
+            @click=${this._enlarge}
+          ></ha-icon-button>
+          <span slot="title" .title=${title}> ${title} </span>
           ${isInfoView
             ? html`
                 ${this.shouldShowHistory(domain)

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-manage-zigbee-device.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-manage-zigbee-device.ts
@@ -1,6 +1,6 @@
 import "@material/mwc-tab-bar/mwc-tab-bar";
 import "@material/mwc-tab/mwc-tab";
-import { mdiClose } from "@mdi/js";
+import { mdiClose, mdiArrowExpand, mdiArrowCollapse } from "@mdi/js";
 import {
   css,
   CSSResultGroup,
@@ -108,10 +108,17 @@ class DialogZHAManageZigbeeDevice extends LitElement {
             .label=${this.hass.localize("ui.dialogs.more_info_control.dismiss")}
             .path=${mdiClose}
           ></ha-icon-button>
+          <ha-icon-button
+            slot="navigationIcon"
+            .path=${this.large ? mdiArrowCollapse : mdiArrowExpand}
+            .label=${this.hass.localize(
+              `ui.dialogs.generic.${this.large ? "reduce" : "enlarge"}`
+            )}
+            @click=${this._enlarge}
+          ></ha-icon-button>
           <span
             slot="title"
             .title=${this.hass.localize("ui.dialogs.zha_manage_device.heading")}
-            @click=${this._enlarge}
           >
             ${this.hass.localize("ui.dialogs.zha_manage_device.heading")}
           </span>

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -1,4 +1,9 @@
-import { mdiClose, mdiHelpCircle } from "@mdi/js";
+import {
+  mdiClose,
+  mdiHelpCircle,
+  mdiArrowExpand,
+  mdiArrowCollapse,
+} from "@mdi/js";
 import deepFreeze from "deep-freeze";
 import {
   css,
@@ -185,7 +190,15 @@ export class HuiDialogEditCard
             .label=${this.hass.localize("ui.common.close")}
             .path=${mdiClose}
           ></ha-icon-button>
-          <span slot="title" @click=${this._enlarge}>${heading}</span>
+          <ha-icon-button
+            slot="navigationIcon"
+            .path=${this.large ? mdiArrowCollapse : mdiArrowExpand}
+            .label=${this.hass.localize(
+              `ui.dialogs.generic.${this.large ? "reduce" : "enlarge"}`
+            )}
+            @click=${this._enlarge}
+          ></ha-icon-button>
+          <span slot="title">${heading}</span>
           ${this._documentationURL !== undefined
             ? html`
                 <a

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -851,7 +851,9 @@
         "cancel": "Cancel",
         "ok": "OK",
         "default_confirmation_title": "Are you sure?",
-        "close": "Close"
+        "close": "Close",
+        "enlarge": "Enlarge",
+        "reduce": "Reduce"
       },
       "image_cropper": {
         "crop": "Crop",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Replace the 'hidden' enlargement functionality that you get by clicking on a dialog title with a dedicated button. 

I'm a little torn on this. On the one hand, the current behavior is very obscure, and I would guess most do not even know this it is possible. I have a couple times seen feature requests for enlarging a card editor by users who were not aware this existed. 

On the other hand, I don't know if this feature is useful enough to be given a prominent button. I don't personally love the way it looks. Very occasionally it is useful to be able to enlarge, but in most cases the enlarged box becomes comically oversized with much empty wasted space. So I hesitate to spend the prominent screen space for the button. 

[#11625](https://github.com/home-assistant/frontend/issues/11625) says the current accessibility is bad, which I can sympathize with, so I wrote this up to get some feedback.

![enlarge-button](https://github.com/home-assistant/frontend/assets/32912880/7296061e-a2fe-40a1-b74f-5241b99772cf)


I partially tested this change, but I was not able to access the ZHA dialog, so I can't confirm that. 


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #11625
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
