### PR TITLE
Filter energy grid sources to not allow duplicates

### DIFF
--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -170,13 +170,13 @@ export class HaStatisticPicker extends LitElement {
 
       const output: StatisticItem[] = [];
       statisticIds.forEach((meta) => {
-        const entityState = this.hass.states[meta.statistic_id];
         if (
           excludeStatistics &&
           excludeStatistics.includes(meta.statistic_id)
         ) {
           return;
         }
+        const entityState = this.hass.states[meta.statistic_id];
         if (!entityState) {
           if (!entitiesOnly) {
             const id = meta.statistic_id;

--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -79,6 +79,14 @@ export class HaStatisticPicker extends LitElement {
   @property({ type: Boolean, attribute: "entities-only" })
   public entitiesOnly = false;
 
+  /**
+   * List of statistics to be excluded.
+   * @type {Array}
+   * @attr exclude-statistics
+   */
+  @property({ type: Array, attribute: "exclude-statistics" })
+  public excludeStatistics?: string[];
+
   @state() private _opened?: boolean;
 
   @query("ha-combo-box", true) public comboBox!: HaComboBox;
@@ -116,7 +124,8 @@ export class HaStatisticPicker extends LitElement {
       includeStatisticsUnitOfMeasurement?: string | string[],
       includeUnitClass?: string | string[],
       includeDeviceClass?: string | string[],
-      entitiesOnly?: boolean
+      entitiesOnly?: boolean,
+      excludeStatistics?: string[]
     ): StatisticItem[] => {
       if (!statisticIds.length) {
         return [
@@ -162,6 +171,12 @@ export class HaStatisticPicker extends LitElement {
       const output: StatisticItem[] = [];
       statisticIds.forEach((meta) => {
         const entityState = this.hass.states[meta.statistic_id];
+        if (
+          excludeStatistics &&
+          excludeStatistics.includes(meta.statistic_id)
+        ) {
+          return;
+        }
         if (!entityState) {
           if (!entitiesOnly) {
             const id = meta.statistic_id;
@@ -238,7 +253,8 @@ export class HaStatisticPicker extends LitElement {
           this.includeStatisticsUnitOfMeasurement,
           this.includeUnitClass,
           this.includeDeviceClass,
-          this.entitiesOnly
+          this.entitiesOnly,
+          this.excludeStatistics
         );
       } else {
         this.updateComplete.then(() => {
@@ -247,7 +263,8 @@ export class HaStatisticPicker extends LitElement {
             this.includeStatisticsUnitOfMeasurement,
             this.includeUnitClass,
             this.includeDeviceClass,
-            this.entitiesOnly
+            this.entitiesOnly,
+            this.excludeStatistics
           );
         });
       }

--- a/src/panels/config/energy/components/ha-energy-grid-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-grid-settings.ts
@@ -294,13 +294,13 @@ export class EnergyGridSettings extends LitElement {
   }
 
   private _addFromSource() {
+    const gridSource = this.preferences.energy_sources.find(
+      (src) => src.type === "grid"
+    ) as GridSourceTypeEnergyPreference | undefined;
     showEnergySettingsGridFlowFromDialog(this, {
+      current_preference: gridSource,
       saveCallback: async (flow) => {
         let preferences: EnergyPreferences;
-        const gridSource = this.preferences.energy_sources.find(
-          (src) => src.type === "grid"
-        ) as GridSourceTypeEnergyPreference | undefined;
-
         if (!gridSource) {
           preferences = {
             ...this.preferences,
@@ -328,13 +328,13 @@ export class EnergyGridSettings extends LitElement {
   }
 
   private _addToSource() {
+    const gridSource = this.preferences.energy_sources.find(
+      (src) => src.type === "grid"
+    ) as GridSourceTypeEnergyPreference | undefined;
     showEnergySettingsGridFlowToDialog(this, {
+      current_preference: gridSource,
       saveCallback: async (flow) => {
         let preferences: EnergyPreferences;
-        const gridSource = this.preferences.energy_sources.find(
-          (src) => src.type === "grid"
-        ) as GridSourceTypeEnergyPreference | undefined;
-
         if (!gridSource) {
           preferences = {
             ...this.preferences,
@@ -364,8 +364,12 @@ export class EnergyGridSettings extends LitElement {
   private _editFromSource(ev) {
     const origSource: FlowFromGridSourceEnergyPreference =
       ev.currentTarget.closest(".row").source;
+    const gridSource = this.preferences.energy_sources.find(
+      (src) => src.type === "grid"
+    ) as GridSourceTypeEnergyPreference | undefined;
     showEnergySettingsGridFlowFromDialog(this, {
       source: { ...origSource },
+      current_preference: gridSource,
       metadata: this.statsMetadata?.[origSource.stat_energy_from],
       saveCallback: async (source) => {
         const flowFrom = energySourcesByType(this.preferences).grid![0]
@@ -392,8 +396,12 @@ export class EnergyGridSettings extends LitElement {
   private _editToSource(ev) {
     const origSource: FlowToGridSourceEnergyPreference =
       ev.currentTarget.closest(".row").source;
+    const gridSource = this.preferences.energy_sources.find(
+      (src) => src.type === "grid"
+    ) as GridSourceTypeEnergyPreference | undefined;
     showEnergySettingsGridFlowToDialog(this, {
       source: { ...origSource },
+      current_preference: gridSource,
       metadata: this.statsMetadata?.[origSource.stat_energy_to],
       saveCallback: async (source) => {
         const flowTo = energySourcesByType(this.preferences).grid![0].flow_to;

--- a/src/panels/config/energy/components/ha-energy-grid-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-grid-settings.ts
@@ -298,7 +298,7 @@ export class EnergyGridSettings extends LitElement {
       (src) => src.type === "grid"
     ) as GridSourceTypeEnergyPreference | undefined;
     showEnergySettingsGridFlowFromDialog(this, {
-      current_preference: gridSource,
+      grid_source: gridSource,
       saveCallback: async (flow) => {
         let preferences: EnergyPreferences;
         if (!gridSource) {
@@ -332,7 +332,7 @@ export class EnergyGridSettings extends LitElement {
       (src) => src.type === "grid"
     ) as GridSourceTypeEnergyPreference | undefined;
     showEnergySettingsGridFlowToDialog(this, {
-      current_preference: gridSource,
+      grid_source: gridSource,
       saveCallback: async (flow) => {
         let preferences: EnergyPreferences;
         if (!gridSource) {
@@ -369,7 +369,7 @@ export class EnergyGridSettings extends LitElement {
     ) as GridSourceTypeEnergyPreference | undefined;
     showEnergySettingsGridFlowFromDialog(this, {
       source: { ...origSource },
-      current_preference: gridSource,
+      grid_source: gridSource,
       metadata: this.statsMetadata?.[origSource.stat_energy_from],
       saveCallback: async (source) => {
         const flowFrom = energySourcesByType(this.preferences).grid![0]
@@ -401,7 +401,7 @@ export class EnergyGridSettings extends LitElement {
     ) as GridSourceTypeEnergyPreference | undefined;
     showEnergySettingsGridFlowToDialog(this, {
       source: { ...origSource },
-      current_preference: gridSource,
+      grid_source: gridSource,
       metadata: this.statsMetadata?.[origSource.stat_energy_to],
       saveCallback: async (source) => {
         const flowTo = energySourcesByType(this.preferences).grid![0].flow_to;

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
@@ -87,10 +87,10 @@ export class DialogEnergyGridFlowSettings
     ).units;
 
     this._excludeList = [
-      ...(this._params.current_preference?.flow_from?.map(
+      ...(this._params.grid_source?.flow_from?.map(
         (entry) => entry.stat_energy_from
       ) || []),
-      ...(this._params.current_preference?.flow_to?.map(
+      ...(this._params.grid_source?.flow_to?.map(
         (entry) => entry.stat_energy_to
       ) || []),
     ].filter((id) => id !== initialSourceId);

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
@@ -49,6 +49,8 @@ export class DialogEnergyGridFlowSettings
 
   @state() private _error?: string;
 
+  private _excludeList?: string[];
+
   public async showDialog(
     params: EnergySettingsGridFlowDialogParams
   ): Promise<void> {
@@ -67,18 +69,31 @@ export class DialogEnergyGridFlowSettings
         ]
       ? "statistic"
       : "no-costs";
-    this._pickedDisplayUnit = getDisplayUnit(
-      this.hass,
+
+    const initialSourceId =
       this._source[
         this._params.direction === "from"
           ? "stat_energy_from"
           : "stat_energy_to"
-      ],
+      ];
+
+    this._pickedDisplayUnit = getDisplayUnit(
+      this.hass,
+      initialSourceId,
       params.metadata
     );
     this._energy_units = (
       await getSensorDeviceClassConvertibleUnits(this.hass, "energy")
     ).units;
+
+    this._excludeList = [
+      ...(this._params.current_preference?.flow_from?.map(
+        (entry) => entry.stat_energy_from
+      ) || []),
+      ...(this._params.current_preference?.flow_to?.map(
+        (entry) => entry.stat_energy_to
+      ) || []),
+    ].filter((id) => id !== initialSourceId);
   }
 
   public closeDialog(): void {
@@ -152,6 +167,7 @@ export class DialogEnergyGridFlowSettings
           .label=${this.hass.localize(
             `ui.panel.config.energy.grid.flow_dialog.${this._params.direction}.energy_stat`
           )}
+          .excludeStatistics=${this._excludeList}
           @value-changed=${this._statisticChanged}
           dialogInitialFocus
         ></ha-statistic-picker>

--- a/src/panels/config/energy/dialogs/show-dialogs-energy.ts
+++ b/src/panels/config/energy/dialogs/show-dialogs-energy.ts
@@ -19,7 +19,7 @@ export interface EnergySettingsGridFlowDialogParams {
     | FlowToGridSourceEnergyPreference;
   metadata?: StatisticsMetaData;
   direction: "from" | "to";
-  current_preference?: GridSourceTypeEnergyPreference;
+  grid_source?: GridSourceTypeEnergyPreference;
   saveCallback: (
     source:
       | FlowFromGridSourceEnergyPreference
@@ -30,14 +30,14 @@ export interface EnergySettingsGridFlowDialogParams {
 export interface EnergySettingsGridFlowFromDialogParams {
   source?: FlowFromGridSourceEnergyPreference;
   metadata?: StatisticsMetaData;
-  current_preference?: GridSourceTypeEnergyPreference;
+  grid_source?: GridSourceTypeEnergyPreference;
   saveCallback: (source: FlowFromGridSourceEnergyPreference) => Promise<void>;
 }
 
 export interface EnergySettingsGridFlowToDialogParams {
   source?: FlowToGridSourceEnergyPreference;
   metadata?: StatisticsMetaData;
-  current_preference?: GridSourceTypeEnergyPreference;
+  grid_source?: GridSourceTypeEnergyPreference;
   saveCallback: (source: FlowToGridSourceEnergyPreference) => Promise<void>;
 }
 

--- a/src/panels/config/energy/dialogs/show-dialogs-energy.ts
+++ b/src/panels/config/energy/dialogs/show-dialogs-energy.ts
@@ -7,6 +7,7 @@ import {
   FlowFromGridSourceEnergyPreference,
   FlowToGridSourceEnergyPreference,
   GasSourceTypeEnergyPreference,
+  GridSourceTypeEnergyPreference,
   SolarSourceTypeEnergyPreference,
   WaterSourceTypeEnergyPreference,
 } from "../../../../data/energy";
@@ -18,6 +19,7 @@ export interface EnergySettingsGridFlowDialogParams {
     | FlowToGridSourceEnergyPreference;
   metadata?: StatisticsMetaData;
   direction: "from" | "to";
+  current_preference?: GridSourceTypeEnergyPreference;
   saveCallback: (
     source:
       | FlowFromGridSourceEnergyPreference
@@ -28,12 +30,14 @@ export interface EnergySettingsGridFlowDialogParams {
 export interface EnergySettingsGridFlowFromDialogParams {
   source?: FlowFromGridSourceEnergyPreference;
   metadata?: StatisticsMetaData;
+  current_preference?: GridSourceTypeEnergyPreference;
   saveCallback: (source: FlowFromGridSourceEnergyPreference) => Promise<void>;
 }
 
 export interface EnergySettingsGridFlowToDialogParams {
   source?: FlowToGridSourceEnergyPreference;
   metadata?: StatisticsMetaData;
+  current_preference?: GridSourceTypeEnergyPreference;
   saveCallback: (source: FlowToGridSourceEnergyPreference) => Promise<void>;
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

On the energy config page, filter the statistics selector for electricity grid to not allow sensors to be selected multiple times. 

There are two categories here, consumption and return. I chose to consider both categories for filtering, such that a sensor added to consumption:
 * can neither be added to consumption sources a second time
 * nor be added to return sources
 
 The former is currently a backend error, the latter is not. However I don't think it makes much sense to allow that. 
 
 I question if the filter could be even more broad and consider other energy categories as well. E.g. should a sensor currently added to solar production or battery storage be filtered to be unselectable for electricity grid, and vice versa? Or does that eliminate legitimate use cases. I believe I have seen people claim to add invidual devices to grid consumption sensors because they like the graphs better that way. 
 
 I can add similar filtering to other categories as well in a following PR, but just want to get this proof of concept approved first. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:  
related: #17359
https://community.home-assistant.io/t/wth-are-entities-not-added-to-energy-integration-automatically/467717
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
