### PR TITLE
Replace paper-input elements in supervisor network dialog

### DIFF
--- a/src/panels/config/network/supervisor-network.ts
+++ b/src/panels/config/network/supervisor-network.ts
@@ -484,7 +484,7 @@ export class HassioNetwork extends LitElement {
     this._interface = { ...this._interfaces[ev.detail.index] };
   }
 
-  private _handleRadioValueChanged(ev: CustomEvent): void {
+  private _handleRadioValueChanged(ev: Event): void {
     const source = ev.target as HaRadio;
     const value = source.value as "disabled" | "auto" | "static";
     const version = (ev.target as any).version as "ipv4" | "ipv6";
@@ -502,7 +502,7 @@ export class HassioNetwork extends LitElement {
     this.requestUpdate("_interface");
   }
 
-  private _handleRadioValueChangedAp(ev: CustomEvent): void {
+  private _handleRadioValueChangedAp(ev: Event): void {
     const source = ev.target as HaRadio;
     const value = source.value as string as "open" | "wep" | "wpa-psk";
     this._wifiConfiguration!.auth = value;
@@ -510,7 +510,7 @@ export class HassioNetwork extends LitElement {
     this.requestUpdate("_wifiConfiguration");
   }
 
-  private _handleInputValueChanged(ev: CustomEvent): void {
+  private _handleInputValueChanged(ev: Event): void {
     const source = ev.target as HaTextField;
     const value = source.value;
     const version = (ev.target as any).version as "ipv4" | "ipv6";
@@ -528,7 +528,7 @@ export class HassioNetwork extends LitElement {
     this._interface[version]![id] = value;
   }
 
-  private _handleInputValueChangedWifi(ev: CustomEvent): void {
+  private _handleInputValueChangedWifi(ev: Event): void {
     const source = ev.target as HaTextField;
     const value = source.value;
     const id = source.id;

--- a/src/panels/config/network/supervisor-network.ts
+++ b/src/panels/config/network/supervisor-network.ts
@@ -369,7 +369,7 @@ export class HassioNetwork extends LitElement {
               >
               </ha-textfield>
               <ha-textfield
-                id="${version}-nameservers"
+                id="nameservers"
                 .label=${this.hass.localize(
                   "ui.panel.config.network.supervisor.dns_servers"
                 )}

--- a/src/panels/config/network/supervisor-network.ts
+++ b/src/panels/config/network/supervisor-network.ts
@@ -4,7 +4,6 @@ import "@material/mwc-list/mwc-list-item";
 import "@material/mwc-tab";
 import "@material/mwc-tab-bar";
 import { mdiDotsVertical } from "@mdi/js";
-import { PaperInputElement } from "@polymer/paper-input/paper-input";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { cache } from "lit/directives/cache";
@@ -15,7 +14,6 @@ import "../../../components/ha-circular-progress";
 import "../../../components/ha-expansion-panel";
 import "../../../components/ha-formfield";
 import "../../../components/ha-icon-button";
-import "../../../components/ha-radio";
 import { extractApiErrorMessage } from "../../../data/hassio/common";
 import {
   AccessPoints,
@@ -31,6 +29,10 @@ import {
 } from "../../../dialogs/generic/show-dialog-box";
 import type { HomeAssistant } from "../../../types";
 import { showIPDetailDialog } from "./show-ip-detail-dialog";
+import "../../../components/ha-textfield";
+import type { HaTextField } from "../../../components/ha-textfield";
+import "../../../components/ha-radio";
+import type { HaRadio } from "../../../components/ha-radio";
 
 const IP_VERSIONS = ["ipv4", "ipv6"];
 
@@ -213,18 +215,16 @@ export class HassioNetwork extends LitElement {
                       ${this._wifiConfiguration.auth === "wpa-psk" ||
                       this._wifiConfiguration.auth === "wep"
                         ? html`
-                            <paper-input
-                              class="flex-auto"
+                            <ha-textfield
                               type="password"
                               id="psk"
                               .label=${this.hass.localize(
                                 "ui.panel.config.network.supervisor.wifi_password"
                               )}
-                              version="wifi"
-                              @value-changed=${this
-                                ._handleInputValueChangedWifi}
+                              .version="wifi"
+                              @change=${this._handleInputValueChangedWifi}
                             >
-                            </paper-input>
+                            </ha-textfield>
                           `
                         : ""}
                     `
@@ -348,39 +348,36 @@ export class HassioNetwork extends LitElement {
         </div>
         ${this._interface![version].method === "static"
           ? html`
-              <paper-input
-                class="flex-auto"
+              <ha-textfield
                 id="address"
                 .label=${this.hass.localize(
                   "ui.panel.config.network.supervisor.ip_netmask"
                 )}
                 .version=${version}
                 .value=${this._toString(this._interface![version].address)}
-                @value-changed=${this._handleInputValueChanged}
+                @change=${this._handleInputValueChanged}
               >
-              </paper-input>
-              <paper-input
-                class="flex-auto"
+              </ha-textfield>
+              <ha-textfield
                 id="gateway"
                 .label=${this.hass.localize(
                   "ui.panel.config.network.supervisor.gateway"
                 )}
                 .version=${version}
                 .value=${this._interface![version].gateway}
-                @value-changed=${this._handleInputValueChanged}
+                @change=${this._handleInputValueChanged}
               >
-              </paper-input>
-              <paper-input
-                class="flex-auto"
-                id="nameservers"
+              </ha-textfield>
+              <ha-textfield
+                id="${version}-nameservers"
                 .label=${this.hass.localize(
                   "ui.panel.config.network.supervisor.dns_servers"
                 )}
                 .version=${version}
                 .value=${this._toString(this._interface![version].nameservers)}
-                @value-changed=${this._handleInputValueChanged}
+                @change=${this._handleInputValueChanged}
               >
-              </paper-input>
+              </ha-textfield>
             `
           : ""}
       </ha-expansion-panel>
@@ -488,7 +485,8 @@ export class HassioNetwork extends LitElement {
   }
 
   private _handleRadioValueChanged(ev: CustomEvent): void {
-    const value = (ev.target as any).value as "disabled" | "auto" | "static";
+    const source = ev.target as HaRadio;
+    const value = source.value as "disabled" | "auto" | "static";
     const version = (ev.target as any).version as "ipv4" | "ipv6";
 
     if (
@@ -505,20 +503,18 @@ export class HassioNetwork extends LitElement {
   }
 
   private _handleRadioValueChangedAp(ev: CustomEvent): void {
-    const value = (ev.target as any).value as string as
-      | "open"
-      | "wep"
-      | "wpa-psk";
+    const source = ev.target as HaRadio;
+    const value = source.value as string as "open" | "wep" | "wpa-psk";
     this._wifiConfiguration!.auth = value;
     this._dirty = true;
     this.requestUpdate("_wifiConfiguration");
   }
 
   private _handleInputValueChanged(ev: CustomEvent): void {
-    const value: string | null | undefined = (ev.target as PaperInputElement)
-      .value;
+    const source = ev.target as HaTextField;
+    const value = source.value;
     const version = (ev.target as any).version as "ipv4" | "ipv6";
-    const id = (ev.target as PaperInputElement).id;
+    const id = source.id;
 
     if (
       !value ||
@@ -533,9 +529,9 @@ export class HassioNetwork extends LitElement {
   }
 
   private _handleInputValueChangedWifi(ev: CustomEvent): void {
-    const value: string | null | undefined = (ev.target as PaperInputElement)
-      .value;
-    const id = (ev.target as PaperInputElement).id;
+    const source = ev.target as HaTextField;
+    const value = source.value;
+    const id = source.id;
 
     if (
       !value ||
@@ -573,8 +569,9 @@ export class HassioNetwork extends LitElement {
           --expansion-panel-summary-padding: 0 16px;
           margin: 4px 0;
         }
-        paper-input {
-          padding: 0 14px;
+        ha-textfield {
+          display: block;
+          margin-top: 16px;
         }
         mwc-list-item {
           --mdc-list-side-padding: 10px;


### PR DESCRIPTION
## Proposed change
Replace the paper-input elements in supervisor network dialog to HaTextFields. 
This brings the number of paper-input elements down to under 20 references. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
