### PR TITLE
Fix some minor issues with cost display in energy sources table

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-sources-table-card.ts
@@ -80,6 +80,10 @@ export class HuiEnergySourcesTableCard
     let totalWater = 0;
     let totalWaterCost = 0;
 
+    let hasGridCost = false;
+    let hasGasCost = false;
+    let hasWaterCost = false;
+
     let totalGridCompare = 0;
     let totalGridCostCompare = 0;
     let totalSolarCompare = 0;
@@ -477,6 +481,7 @@ export class HuiEnergySourcesTableCard
                         ) || 0
                       : null;
                     if (cost !== null) {
+                      hasGridCost = true;
                       totalGridCost += cost;
                     }
 
@@ -575,6 +580,7 @@ export class HuiEnergySourcesTableCard
                         ) || 0) * -1
                       : null;
                     if (cost !== null) {
+                      hasGridCost = true;
                       totalGridCost += cost;
                     }
 
@@ -686,14 +692,16 @@ export class HuiEnergySourcesTableCard
                             ? html`<td
                                 class="mdc-data-table__cell mdc-data-table__cell--numeric"
                               >
-                                ${formatNumber(
-                                  totalGridCostCompare,
-                                  this.hass.locale,
-                                  {
-                                    style: "currency",
-                                    currency: this.hass.config.currency!,
-                                  }
-                                )}
+                                ${hasGridCost
+                                  ? formatNumber(
+                                      totalGridCostCompare,
+                                      this.hass.locale,
+                                      {
+                                        style: "currency",
+                                        currency: this.hass.config.currency!,
+                                      }
+                                    )
+                                  : ""}
                               </td>`
                             : ""}`
                       : ""}
@@ -706,10 +714,12 @@ export class HuiEnergySourcesTableCard
                       ? html`<td
                           class="mdc-data-table__cell mdc-data-table__cell--numeric"
                         >
-                          ${formatNumber(totalGridCost, this.hass.locale, {
-                            style: "currency",
-                            currency: this.hass.config.currency!,
-                          })}
+                          ${hasGridCost
+                            ? formatNumber(totalGridCost, this.hass.locale, {
+                                style: "currency",
+                                currency: this.hass.config.currency!,
+                              })
+                            : ""}
                         </td>`
                       : ""}
                   </tr>`
@@ -737,6 +747,7 @@ export class HuiEnergySourcesTableCard
                     0
                   : null;
                 if (cost !== null) {
+                  hasGasCost = true;
                   totalGasCost += cost;
                 }
 
@@ -835,14 +846,16 @@ export class HuiEnergySourcesTableCard
                             ? html`<td
                                 class="mdc-data-table__cell mdc-data-table__cell--numeric"
                               >
-                                ${formatNumber(
-                                  totalGasCostCompare,
-                                  this.hass.locale,
-                                  {
-                                    style: "currency",
-                                    currency: this.hass.config.currency!,
-                                  }
-                                )}
+                                ${hasGasCost
+                                  ? formatNumber(
+                                      totalGasCostCompare,
+                                      this.hass.locale,
+                                      {
+                                        style: "currency",
+                                        currency: this.hass.config.currency!,
+                                      }
+                                    )
+                                  : ""}
                               </td>`
                             : ""}`
                       : ""}
@@ -855,10 +868,12 @@ export class HuiEnergySourcesTableCard
                       ? html`<td
                           class="mdc-data-table__cell mdc-data-table__cell--numeric"
                         >
-                          ${formatNumber(totalGasCost, this.hass.locale, {
-                            style: "currency",
-                            currency: this.hass.config.currency!,
-                          })}
+                          ${hasGasCost
+                            ? formatNumber(totalGasCost, this.hass.locale, {
+                                style: "currency",
+                                currency: this.hass.config.currency!,
+                              })
+                            : ""}
                         </td>`
                       : ""}
                   </tr>`
@@ -886,6 +901,7 @@ export class HuiEnergySourcesTableCard
                     0
                   : null;
                 if (cost !== null) {
+                  hasWaterCost = true;
                   totalWaterCost += cost;
                 }
 
@@ -984,14 +1000,16 @@ export class HuiEnergySourcesTableCard
                             ? html`<td
                                 class="mdc-data-table__cell mdc-data-table__cell--numeric"
                               >
-                                ${formatNumber(
-                                  totalWaterCostCompare,
-                                  this.hass.locale,
-                                  {
-                                    style: "currency",
-                                    currency: this.hass.config.currency!,
-                                  }
-                                )}
+                                ${hasWaterCost
+                                  ? formatNumber(
+                                      totalWaterCostCompare,
+                                      this.hass.locale,
+                                      {
+                                        style: "currency",
+                                        currency: this.hass.config.currency!,
+                                      }
+                                    )
+                                  : ""}
                               </td>`
                             : ""}`
                       : ""}
@@ -1004,16 +1022,18 @@ export class HuiEnergySourcesTableCard
                       ? html`<td
                           class="mdc-data-table__cell mdc-data-table__cell--numeric"
                         >
-                          ${formatNumber(totalWaterCost, this.hass.locale, {
-                            style: "currency",
-                            currency: this.hass.config.currency!,
-                          })}
+                          ${hasWaterCost
+                            ? formatNumber(totalWaterCost, this.hass.locale, {
+                                style: "currency",
+                                currency: this.hass.config.currency!,
+                              })
+                            : ""}
                         </td>`
                       : ""}
                   </tr>`
                 : ""}
-              ${[totalGasCost, totalWaterCost, totalGridCost].filter(Boolean)
-                .length > 1
+              ${[hasGasCost, hasWaterCost, hasGridCost].filter(Boolean).length >
+              1
                 ? html`<tr class="mdc-data-table__row total">
                     <td class="mdc-data-table__cell"></td>
                     <th class="mdc-data-table__cell" scope="row">
@@ -1022,9 +1042,7 @@ export class HuiEnergySourcesTableCard
                       )}
                     </th>
                     ${compare
-                      ? html`${showCosts
-                            ? html`<td class="mdc-data-table__cell"></td>`
-                            : ""}
+                      ? html`<td class="mdc-data-table__cell"></td>
                           <td
                             class="mdc-data-table__cell mdc-data-table__cell--numeric"
                           >


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix two small issues with energy costs: 

1. Current logic only displays the final "Total" row if we have two categories of sources with non-zero cost. This makes the row appear and disappear based on the current slice of data being viewed, it will be hidden when viewing a time window that did not have any recorded consumption for one of the categories. I feel it would be more correct to show the total row consistently based on if there are at least two categories of sources with any cost configured. This means the total will always be shown or hidden regardless of the slice of data being viewed. 

2. Per-category totals currently show "$0.00" in the cost column, even if no sensors in that category have a cost configured. I feel it would be more correct to show an empty cell instead of "$0.00" if no sensors in a category have a configured cost. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17444
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
