### PR TITLE
Prevent voice settings to override entity registry settings dialog

### DIFF
--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -411,54 +411,54 @@ export class MoreInfoDialog extends LitElement {
           @entity-entry-updated=${this._entryUpdated}
           @toggle-edit-mode=${this._handleToggleInfoEditModeEvent}
         >
-          ${this._childView
-            ? html`
-                <div class="child-view">
-                  ${dynamicElement(this._childView.viewTag, {
-                    hass: this.hass,
-                    entry: this._entry,
-                    params: this._childView.viewParams,
-                  })}
-                </div>
-              `
-            : cache(
-                this._currView === "info"
-                  ? html`
-                      <ha-more-info-info
-                        dialogInitialFocus
-                        .hass=${this.hass}
-                        .entityId=${this._entityId}
-                        .entry=${this._entry}
-                        .editMode=${this._infoEditMode}
-                      ></ha-more-info-info>
-                    `
-                  : this._currView === "history"
-                  ? html`
-                      <ha-more-info-history-and-logbook
-                        .hass=${this.hass}
-                        .entityId=${this._entityId}
-                      ></ha-more-info-history-and-logbook>
-                    `
-                  : this._currView === "settings"
-                  ? html`
-                      <ha-more-info-settings
-                        .hass=${this.hass}
-                        .entityId=${this._entityId}
-                        .entry=${this._entry}
-                      ></ha-more-info-settings>
-                    `
-                  : this._currView === "related"
-                  ? html`
-                      <ha-related-items
-                        .hass=${this.hass}
-                        .itemId=${entityId}
-                        .itemType=${SearchableDomains.has(domain)
-                          ? domain
-                          : "entity"}
-                      ></ha-related-items>
-                    `
-                  : nothing
-              )}
+          ${cache(
+            this._childView
+              ? html`
+                  <div class="child-view">
+                    ${dynamicElement(this._childView.viewTag, {
+                      hass: this.hass,
+                      entry: this._entry,
+                      params: this._childView.viewParams,
+                    })}
+                  </div>
+                `
+              : this._currView === "info"
+              ? html`
+                  <ha-more-info-info
+                    dialogInitialFocus
+                    .hass=${this.hass}
+                    .entityId=${this._entityId}
+                    .entry=${this._entry}
+                    .editMode=${this._infoEditMode}
+                  ></ha-more-info-info>
+                `
+              : this._currView === "history"
+              ? html`
+                  <ha-more-info-history-and-logbook
+                    .hass=${this.hass}
+                    .entityId=${this._entityId}
+                  ></ha-more-info-history-and-logbook>
+                `
+              : this._currView === "settings"
+              ? html`
+                  <ha-more-info-settings
+                    .hass=${this.hass}
+                    .entityId=${this._entityId}
+                    .entry=${this._entry}
+                  ></ha-more-info-settings>
+                `
+              : this._currView === "related"
+              ? html`
+                  <ha-related-items
+                    .hass=${this.hass}
+                    .itemId=${entityId}
+                    .itemType=${SearchableDomains.has(domain)
+                      ? domain
+                      : "entity"}
+                  ></ha-related-items>
+                `
+              : nothing
+          )}
         </div>
       </ha-dialog>
     `;

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -186,7 +186,10 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   protected willUpdate(changedProperties: PropertyValues) {
     super.willUpdate(changedProperties);
-    if (!changedProperties.has("entry")) {
+    if (
+      !changedProperties.has("entry") ||
+      changedProperties.get("entry")?.id === this.entry.id
+    ) {
       return;
     }
 


### PR DESCRIPTION


## Proposed change

If you would make a change to voice setting in the entity registry dialog, it would clear all unsaved changes in the entity registry dialog.

This prevents that.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
