### PR TITLE
Fix default precision display in entity settings

### DIFF
--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -261,7 +261,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
 
   private precisionLabel(precision?: number, stateValue?: string) {
     const stateValueNumber = Number(stateValue);
-    const value = !isNaN(stateValueNumber) ? stateValueNumber : 0;
+    const value = !isNaN(stateValueNumber) ? stateValue! : 0;
     return formatNumber(value, this.hass.locale, {
       minimumFractionDigits: precision,
       maximumFractionDigits: precision,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix the number displayed for "default" precision in the entity settings. 

Currently the number displayed as the "example" number for default precision is different from how that number actually displays in the frontend. 

![image](https://github.com/home-assistant/frontend/assets/32912880/8cfb183f-8d0c-456a-99c6-2442d79e02b8)

![image](https://github.com/home-assistant/frontend/assets/32912880/dfbb9799-596c-45c6-8c26-00b7e1880f0a)

The reason for this is the `formatNumber` function behaves differently if you pass it a string versus a number. 

* If you pass it a string with no defined precision options, it returns the same number of significant digits as it was passed. 
* If you pass it a number with no defined precision options, it chooses some locale-specific maximum number of digits to round to (in this case 3). 

Since all other uses in frontend of formatNumber use the string version (the raw state), pass string verison of the state to the function in the entity settings as well. 

Fixed:
![image](https://github.com/home-assistant/frontend/assets/32912880/493c97ca-2dda-4396-8d51-0e79bcd23c41)



## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17487
- This PR is related to issue or discussion: 
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
