### PR TITLE
Fix unit label for static grid energy price

### DIFF
--- a/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-gas-settings.ts
@@ -227,7 +227,7 @@ export class DialogEnergyGasSettings
                 "ui.panel.config.energy.gas.dialog.cost_number_input"
               )} ${unitPrice ? ` (${unitPrice})` : ""}`}
               class="price-options"
-              step=".01"
+              step="any"
               type="number"
               .value=${this._source.number_energy_price}
               @change=${this._numberPriceChanged}

--- a/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-grid-flow-settings.ts
@@ -96,9 +96,11 @@ export class DialogEnergyGridFlowSettings
 
     const pickableUnit = this._energy_units?.join(", ") || "";
 
-    const unitPrice = this._pickedDisplayUnit
+    const unitPriceSensor = this._pickedDisplayUnit
       ? `${this.hass.config.currency}/${this._pickedDisplayUnit}`
       : undefined;
+
+    const unitPriceFixed = `${this.hass.config.currency}/kWh`;
 
     const externalSource =
       this._source[
@@ -223,7 +225,7 @@ export class DialogEnergyGridFlowSettings
               .value=${this._source.entity_energy_price}
               .label=${`${this.hass.localize(
                 `ui.panel.config.energy.grid.flow_dialog.${this._params.direction}.cost_entity_input`
-              )} ${unitPrice ? ` (${unitPrice})` : ""}`}
+              )} ${unitPriceSensor ? ` (${unitPriceSensor})` : ""}`}
               @value-changed=${this._priceEntityChanged}
             ></ha-entity-picker>`
           : ""}
@@ -244,12 +246,12 @@ export class DialogEnergyGridFlowSettings
           ? html`<ha-textfield
               .label=${`${this.hass.localize(
                 `ui.panel.config.energy.grid.flow_dialog.${this._params.direction}.cost_number_input`
-              )} ${unitPrice ? ` (${unitPrice})` : ""}`}
+              )} (${unitPriceFixed})`}
               class="price-options"
-              step=".01"
+              step="any"
               type="number"
               .value=${this._source.number_energy_price}
-              .suffix=${unitPrice || ""}
+              .suffix=${unitPriceFixed}
               @change=${this._numberPriceChanged}
             >
             </ha-textfield>`


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix the unit label in the textbox for static energy price/rate.  Currently it shows a label with the unit of the source sensor. E.g. if the source sensor is in `Wh`, it the static energy price textbox prompts user to input a price in `<currency>/Wh`.

This is incorrect as the backend always treats this value as `<currency>/kWh`, regardless of the unit of the source sensor. [source](https://github.com/home-assistant/core/blob/369a484a786a6734c7b6bf59151304fc6db03fef/homeassistant/components/energy/sensor.py#L264)

I fixed this for water previously in #16616, but did not realize the same applied to grid also.

This bug does not apply to gas, as gas does not have a default static price unit. [source](https://github.com/home-assistant/core/blob/369a484a786a6734c7b6bf59151304fc6db03fef/homeassistant/components/energy/sensor.py#L269)

Additionally I propose to remove the step=0.01 on these fields. There is no reason to throw an error at the user if they use a finer granularity for price.


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #17494
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
