### PR TITLE
Show statistics bands when charting min/max only

### DIFF
--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -329,8 +329,14 @@ class StatisticsChart extends LitElement {
 
       const statTypes: this["statTypes"] = [];
 
-      const drawBands =
+      const hasMean =
         this.statTypes.includes("mean") && statisticsHaveType(stats, "mean");
+      const drawBands =
+        hasMean ||
+        (this.statTypes.includes("min") &&
+          statisticsHaveType(stats, "min") &&
+          this.statTypes.includes("max") &&
+          statisticsHaveType(stats, "max"));
 
       const sortedTypes = drawBands
         ? [...this.statTypes].sort((a, b) => {
@@ -358,13 +364,14 @@ class StatisticsChart extends LitElement {
                   `ui.components.statistics_charts.statistic_types.${type}`
                 ),
             fill: drawBands
-              ? type === "min"
+              ? type === "min" && hasMean
                 ? "+1"
                 : type === "max"
                 ? "-1"
                 : false
               : false,
-            borderColor: band ? color + (this.hideLegend ? "00" : "7F") : color,
+            borderColor:
+              band && hasMean ? color + (this.hideLegend ? "00" : "7F") : color,
             backgroundColor: band ? color + "3F" : color + "7F",
             pointRadius: 0,
             data: [],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Draw the statistics fill bands when min & max (but not mean) are selected. 

Current behavior requires mean to be selected to show the bands, which is unnecessarily restrictive. 

![image](https://github.com/home-assistant/frontend/assets/32912880/4c6cbeee-6544-435f-8a99-4fd118e9f67d)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17517
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
