### PR TITLE
Add 'max devices' config to Energy Devices Graph

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -277,6 +277,8 @@ export class HuiEnergyDevicesGraphCard
 
     chartData.sort((a, b) => b.x - a.x);
 
+    chartData.length = this._config?.max_devices || chartData.length;
+
     chartData.forEach((d: any) => {
       const color = getColorByIndex(d.idx);
 

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -146,6 +146,7 @@ export interface EnergyDevicesGraphCardConfig extends LovelaceCardConfig {
   type: "energy-devices-graph";
   title?: string;
   collection_key?: string;
+  max_devices?: number;
 }
 
 export interface EnergySourcesTableCardConfig extends LovelaceCardConfig {


### PR DESCRIPTION
## Proposed change

I'd like to propose adding an optional `max_devices` config setting to the [Devices Energy Graph](https://www.home-assistant.io/dashboards/energy/#devices-energy-graph). If the setting is present, the card will only list the top N devices instead of all devices.

The use case is that users might want to only show the N biggest energy consumers in their home without occupying too much space on the dashboard.

![Screenshot 2023-08-11 at 08 53 12](https://github.com/home-assistant/frontend/assets/2149539/2fdd8901-cc7e-44ce-b1d2-1d93e55695d2)

Note that this change does not change the current behaviour. If the config setting is not present, it will list all devices.

Docs PR: <https://github.com/home-assistant/home-assistant.io/pull/29255>

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: energy-devices-graph
max_devices: 3
```

## Additional information

N/A

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
