### PR TITLE
Fix multiline select text in zwave info

### DIFF
--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-info-zwave_js.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/ha-device-info-zwave_js.ts
@@ -93,70 +93,76 @@ export class HaDeviceInfoZWaveJS extends SubscribeMixin(LitElement) {
           "ui.panel.config.zwave_js.device_info.zwave_info"
         )}
       >
-        ${this._multipleConfigEntries
-          ? html`
-              <div>
-                ${this.hass.localize("ui.panel.config.zwave_js.common.source")}:
-                ${this._configEntry!.title}
-              </div>
-            `
-          : ""}
         <div>
-          ${this.hass.localize("ui.panel.config.zwave_js.device_info.node_id")}:
-          ${this._node.node_id}
+          ${this._multipleConfigEntries
+            ? html`
+                <div>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.common.source"
+                  )}:
+                  ${this._configEntry!.title}
+                </div>
+              `
+            : nothing}
+          <div>
+            ${this.hass.localize(
+              "ui.panel.config.zwave_js.device_info.node_id"
+            )}:
+            ${this._node.node_id}
+          </div>
+          ${!this._node.is_controller_node
+            ? html`
+                <div>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.device_info.node_status"
+                  )}:
+                  ${this.hass.localize(
+                    `ui.panel.config.zwave_js.node_status.${
+                      nodeStatus[this._node.status]
+                    }`
+                  )}
+                </div>
+                <div>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.device_info.node_ready"
+                  )}:
+                  ${this._node.ready
+                    ? this.hass.localize("ui.common.yes")
+                    : this.hass.localize("ui.common.no")}
+                </div>
+                <div>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.device_info.highest_security"
+                  )}:
+                  ${this._node.highest_security_class !== null
+                    ? this.hass.localize(
+                        `ui.panel.config.zwave_js.security_classes.${
+                          SecurityClass[this._node.highest_security_class]
+                        }.title`
+                      )
+                    : this._node.is_secure === false
+                    ? this.hass.localize(
+                        "ui.panel.config.zwave_js.security_classes.none.title"
+                      )
+                    : this.hass.localize(
+                        "ui.panel.config.zwave_js.device_info.unknown"
+                      )}
+                </div>
+                <div>
+                  ${this.hass.localize(
+                    "ui.panel.config.zwave_js.device_info.zwave_plus"
+                  )}:
+                  ${this._node.zwave_plus_version
+                    ? this.hass.localize(
+                        "ui.panel.config.zwave_js.device_info.zwave_plus_version",
+                        "version",
+                        this._node.zwave_plus_version
+                      )
+                    : this.hass.localize("ui.common.no")}
+                </div>
+              `
+            : nothing}
         </div>
-        ${!this._node.is_controller_node
-          ? html`
-              <div>
-                ${this.hass.localize(
-                  "ui.panel.config.zwave_js.device_info.node_status"
-                )}:
-                ${this.hass.localize(
-                  `ui.panel.config.zwave_js.node_status.${
-                    nodeStatus[this._node.status]
-                  }`
-                )}
-              </div>
-              <div>
-                ${this.hass.localize(
-                  "ui.panel.config.zwave_js.device_info.node_ready"
-                )}:
-                ${this._node.ready
-                  ? this.hass.localize("ui.common.yes")
-                  : this.hass.localize("ui.common.no")}
-              </div>
-              <div>
-                ${this.hass.localize(
-                  "ui.panel.config.zwave_js.device_info.highest_security"
-                )}:
-                ${this._node.highest_security_class !== null
-                  ? this.hass.localize(
-                      `ui.panel.config.zwave_js.security_classes.${
-                        SecurityClass[this._node.highest_security_class]
-                      }.title`
-                    )
-                  : this._node.is_secure === false
-                  ? this.hass.localize(
-                      "ui.panel.config.zwave_js.security_classes.none.title"
-                    )
-                  : this.hass.localize(
-                      "ui.panel.config.zwave_js.device_info.unknown"
-                    )}
-              </div>
-              <div>
-                ${this.hass.localize(
-                  "ui.panel.config.zwave_js.device_info.zwave_plus"
-                )}:
-                ${this._node.zwave_plus_version
-                  ? this.hass.localize(
-                      "ui.panel.config.zwave_js.device_info.zwave_plus_version",
-                      "version",
-                      this._node.zwave_plus_version
-                    )
-                  : this.hass.localize("ui.common.no")}
-              </div>
-            `
-          : ""}
       </ha-expansion-panel>
     `;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Not quite sure why, but firefox cannot reliably select the text in zwave info panel of a zwave info device. 90% of the time you move to a new line it drops the select when you're trying to click and drag.

![zwave-select-text](https://github.com/home-assistant/frontend/assets/32912880/cfc07a54-34bb-469b-92ff-1d52565bde71)

I'm guessing it has something to do with the 2px margin inbetween individual divs, when the mouse touches that void space it seems to get confused and releases the drag. 

Wrapping the expansion panel content in div seems to fix this in my testing. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #12799
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
