### PR TITLE
Improve grammar for single periodic second/minute/hour

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -425,7 +425,7 @@ const tryDescribeTrigger = (
         return "Invalid Time Pattern Seconds";
       }
 
-      if (seconds_all) {
+      if (seconds_all || seconds_interval === 1) {
         result += "every second of ";
       } else if (seconds_interval) {
         result += `every ${seconds} seconds of `;
@@ -454,7 +454,7 @@ const tryDescribeTrigger = (
         return "Invalid Time Pattern Minutes";
       }
 
-      if (minutes_all) {
+      if (minutes_all || minutes_interval === 1) {
         result += "every minute of ";
       } else if (minutes_interval) {
         result += `every ${minutes} minutes of `;
@@ -491,7 +491,7 @@ const tryDescribeTrigger = (
         return "Invalid Time Pattern Hours";
       }
 
-      if (hours_all) {
+      if (hours_all || hours_interval === 1) {
         result += "every hour";
       } else if (hours_interval) {
         result += `every ${hours} hours`;

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -425,7 +425,7 @@ const tryDescribeTrigger = (
         return "Invalid Time Pattern Seconds";
       }
 
-      if (seconds_all || seconds_interval === 1) {
+      if (seconds_all || (seconds_interval && seconds === 1)) {
         result += "every second of ";
       } else if (seconds_interval) {
         result += `every ${seconds} seconds of `;
@@ -454,7 +454,7 @@ const tryDescribeTrigger = (
         return "Invalid Time Pattern Minutes";
       }
 
-      if (minutes_all || minutes_interval === 1) {
+      if (minutes_all || (minutes_interval && minutes === 1)) {
         result += "every minute of ";
       } else if (minutes_interval) {
         result += `every ${minutes} minutes of `;
@@ -491,7 +491,7 @@ const tryDescribeTrigger = (
         return "Invalid Time Pattern Hours";
       }
 
-      if (hours_all || hours_interval === 1) {
+      if (hours_all || (hours_interval && hours === 1)) {
         result += "every hour";
       } else if (hours_interval) {
         result += `every ${hours} hours`;


### PR DESCRIPTION
Trigger every 1 hours -> Trigger every hour
Trigger every 1 minutes -> Trigger every minute
Trigger every 1 seconds -> Trigger every second

(and combinations thereof)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Grammar annoyed me for single periodic triggers, so here's a small fix. "New feature" since nothing else fits.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Automation like so, redundant intervals just to demo in one go (/1 second would be enough...):

```yaml
alias: Trigger every second of every minute of every hour 
description: ""
trigger:
  - minutes: /1
    platform: time_pattern
    hours: /1
    seconds: /1
condition:
action:
mode: single

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/16520 (augments slightly)
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
