### PR TITLE
Updates to alarm panel card configuration

### DIFF
--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -22,17 +22,14 @@ import {
   callAlarmAction,
   FORMAT_NUMBER,
   ALARM_MODES,
+  AlarmMode,
 } from "../../../data/alarm_control_panel";
 import { UNAVAILABLE } from "../../../data/entity";
 import type { HomeAssistant } from "../../../types";
 import { findEntities } from "../common/find-entities";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import type { LovelaceCard } from "../types";
-import {
-  AlarmPanelCardConfig,
-  AlarmPanelCardConfigState,
-  ALARM_MODE_STATE_MAP,
-} from "./types";
+import { AlarmPanelCardConfig, AlarmPanelCardConfigState } from "./types";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 
 const BUTTONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "clear"];
@@ -41,6 +38,17 @@ export const DEFAULT_STATES = [
   "arm_home",
   "arm_away",
 ] as AlarmPanelCardConfigState[];
+
+export const ALARM_MODE_STATE_MAP: Record<
+  AlarmPanelCardConfigState,
+  AlarmMode
+> = {
+  arm_home: "armed_home",
+  arm_away: "armed_away",
+  arm_night: "armed_night",
+  arm_vacation: "armed_vacation",
+  arm_custom_bypass: "armed_custom_bypass",
+};
 
 export const filterSupportedAlarmStates = (
   stateObj: HassEntity | undefined,

--- a/src/panels/lovelace/cards/hui-alarm-panel-card.ts
+++ b/src/panels/lovelace/cards/hui-alarm-panel-card.ts
@@ -9,6 +9,7 @@ import {
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { styleMap } from "lit/directives/style-map";
+import { HassEntity } from "home-assistant-js-websocket";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { fireEvent } from "../../../common/dom/fire_event";
 import { alarmPanelIcon } from "../../../common/entity/alarm_panel_icon";
@@ -20,15 +21,39 @@ import type { HaTextField } from "../../../components/ha-textfield";
 import {
   callAlarmAction,
   FORMAT_NUMBER,
+  ALARM_MODES,
 } from "../../../data/alarm_control_panel";
 import { UNAVAILABLE } from "../../../data/entity";
 import type { HomeAssistant } from "../../../types";
 import { findEntities } from "../common/find-entities";
 import { createEntityNotFoundWarning } from "../components/hui-warning";
 import type { LovelaceCard } from "../types";
-import { AlarmPanelCardConfig } from "./types";
+import {
+  AlarmPanelCardConfig,
+  AlarmPanelCardConfigState,
+  ALARM_MODE_STATE_MAP,
+} from "./types";
+import { supportsFeature } from "../../../common/entity/supports-feature";
 
 const BUTTONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "clear"];
+
+export const DEFAULT_STATES = [
+  "arm_home",
+  "arm_away",
+] as AlarmPanelCardConfigState[];
+
+export const filterSupportedAlarmStates = (
+  stateObj: HassEntity | undefined,
+  states: AlarmPanelCardConfigState[]
+): AlarmPanelCardConfigState[] =>
+  states.filter(
+    (s) =>
+      stateObj &&
+      supportsFeature(
+        stateObj,
+        ALARM_MODES[ALARM_MODE_STATE_MAP[s]].feature || 0
+      )
+  );
 
 @customElement("hui-alarm-panel-card")
 class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
@@ -52,10 +77,13 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       includeDomains
     );
 
+    const entity = foundEntities[0] || "";
+    const stateObj = hass.states[entity];
+
     return {
       type: "alarm-panel",
-      states: ["arm_home", "arm_away"],
-      entity: foundEntities[0] || "",
+      states: filterSupportedAlarmStates(stateObj, DEFAULT_STATES),
+      entity,
     };
   }
 
@@ -86,11 +114,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       throw new Error("Invalid configuration");
     }
 
-    const defaults = {
-      states: ["arm_away", "arm_home"] as const,
-    };
-
-    this._config = { ...defaults, ...config };
+    this._config = { ...config };
   }
 
   protected updated(changedProps: PropertyValues): void {
@@ -138,6 +162,9 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
       return nothing;
     }
     const stateObj = this.hass.states[this._config.entity];
+    const states =
+      this._config.states ||
+      filterSupportedAlarmStates(stateObj, DEFAULT_STATES);
 
     if (!stateObj) {
       return html`
@@ -170,7 +197,7 @@ class HuiAlarmPanelCard extends LitElement implements LovelaceCard {
         </h1>
         <div id="armActions" class="actions">
           ${(stateObj.state === "disarmed"
-            ? this._config.states!
+            ? states
             : (["disarm"] as const)
           ).map(
             (stateAction) => html`

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -13,7 +13,6 @@ import { LovelaceHeaderFooterConfig } from "../header-footer/types";
 import { HaDurationData } from "../../../components/ha-duration-input";
 import { LovelaceTileFeatureConfig } from "../tile-features/types";
 import { ForecastType } from "../../../data/weather";
-import { AlarmMode } from "../../../data/alarm_control_panel";
 
 export type AlarmPanelCardConfigState =
   | "arm_away"
@@ -21,17 +20,6 @@ export type AlarmPanelCardConfigState =
   | "arm_night"
   | "arm_vacation"
   | "arm_custom_bypass";
-
-export const ALARM_MODE_STATE_MAP: Record<
-  AlarmPanelCardConfigState,
-  AlarmMode
-> = {
-  arm_home: "armed_home",
-  arm_away: "armed_away",
-  arm_night: "armed_night",
-  arm_vacation: "armed_vacation",
-  arm_custom_bypass: "armed_custom_bypass",
-};
 
 export interface AlarmPanelCardConfig extends LovelaceCardConfig {
   entity: string;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -13,11 +13,30 @@ import { LovelaceHeaderFooterConfig } from "../header-footer/types";
 import { HaDurationData } from "../../../components/ha-duration-input";
 import { LovelaceTileFeatureConfig } from "../tile-features/types";
 import { ForecastType } from "../../../data/weather";
+import { AlarmMode } from "../../../data/alarm_control_panel";
+
+export type AlarmPanelCardConfigState =
+  | "arm_away"
+  | "arm_home"
+  | "arm_night"
+  | "arm_vacation"
+  | "arm_custom_bypass";
+
+export const ALARM_MODE_STATE_MAP: Record<
+  AlarmPanelCardConfigState,
+  AlarmMode
+> = {
+  arm_home: "armed_home",
+  arm_away: "armed_away",
+  arm_night: "armed_night",
+  arm_vacation: "armed_vacation",
+  arm_custom_bypass: "armed_custom_bypass",
+};
 
 export interface AlarmPanelCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
-  states?: readonly (keyof TranslationDict["ui"]["card"]["alarm_control_panel"])[];
+  states?: AlarmPanelCardConfigState[];
   theme?: string;
 }
 

--- a/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -2,14 +2,26 @@ import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { array, assert, assign, object, optional, string } from "superstruct";
+import { HassEntity } from "home-assistant-js-websocket";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import type { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
 import type { SchemaUnion } from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
-import type { AlarmPanelCardConfig } from "../../cards/types";
+import type {
+  AlarmPanelCardConfig,
+  AlarmPanelCardConfigState,
+} from "../../cards/types";
+import { ALARM_MODE_STATE_MAP } from "../../cards/types";
 import type { LovelaceCardEditor } from "../../types";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
+import {
+  DEFAULT_STATES,
+  filterSupportedAlarmStates,
+} from "../../cards/hui-alarm-panel-card";
+import { deepEqual } from "../../../../common/util/deep-equal";
+import { supportsFeature } from "../../../../common/entity/supports-feature";
+import { ALARM_MODES } from "../../../../data/alarm_control_panel";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -21,13 +33,7 @@ const cardConfigStruct = assign(
   })
 );
 
-const states = [
-  "arm_home",
-  "arm_away",
-  "arm_night",
-  "arm_vacation",
-  "arm_custom_bypass",
-] as const;
+const states = Object.keys(ALARM_MODE_STATE_MAP) as AlarmPanelCardConfigState[];
 
 @customElement("hui-alarm-panel-card-editor")
 export class HuiAlarmPanelCardEditor
@@ -44,7 +50,11 @@ export class HuiAlarmPanelCardEditor
   }
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc) =>
+    (
+      localize: LocalizeFunc,
+      stateObj: HassEntity | undefined,
+      config_states: AlarmPanelCardConfigState[]
+    ) =>
       [
         {
           name: "entity",
@@ -60,12 +70,24 @@ export class HuiAlarmPanelCardEditor
           ],
         },
         {
-          type: "multi_select",
           name: "states",
-          options: states.map((s) => [
-            s,
-            localize(`ui.card.alarm_control_panel.${s}`),
-          ]) as [string, string][],
+          selector: {
+            select: {
+              multiple: true,
+              mode: "list",
+              options: states.map((s) => ({
+                value: s,
+                label: localize(`ui.card.alarm_control_panel.${s}`),
+                disabled:
+                  !config_states.includes(s) &&
+                  (!stateObj ||
+                    !supportsFeature(
+                      stateObj,
+                      ALARM_MODES[ALARM_MODE_STATE_MAP[s]].feature || 0
+                    )),
+              })),
+            },
+          },
         },
       ] as const
   );
@@ -75,11 +97,18 @@ export class HuiAlarmPanelCardEditor
       return nothing;
     }
 
+    const stateObj = this.hass.states[this._config.entity];
+    const defaultFilteredStates = filterSupportedAlarmStates(
+      stateObj,
+      DEFAULT_STATES
+    );
+    const config = { states: defaultFilteredStates, ...this._config };
+
     return html`
       <ha-form
         .hass=${this.hass}
-        .data=${this._config}
-        .schema=${this._schema(this.hass.localize)}
+        .data=${config}
+        .schema=${this._schema(this.hass.localize, stateObj, config.states)}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
       ></ha-form>
@@ -87,6 +116,44 @@ export class HuiAlarmPanelCardEditor
   }
 
   private _valueChanged(ev: CustomEvent): void {
+    // Delete states key if it was inferred from default and still matches the default
+    if (!this._config?.states) {
+      if (this._config?.entity === ev.detail.value.entity) {
+        const stateObj = this.hass?.states[ev.detail.value.entity];
+        const defaultFilteredStates = filterSupportedAlarmStates(
+          stateObj,
+          DEFAULT_STATES
+        );
+        if (deepEqual(defaultFilteredStates, ev.detail.value.states)) {
+          delete ev.detail.value.states;
+        }
+      } else {
+        delete ev.detail.value.states;
+      }
+    }
+
+    // Sort states in a consistent order
+    if (ev.detail.value.states) {
+      const sortStates = states.filter((s) =>
+        ev.detail.value.states.includes(s)
+      );
+      ev.detail.value.states = sortStates;
+    }
+
+    // When changing entities, clear any states that the new entity does not support
+    if (
+      ev.detail.value.states &&
+      ev.detail.value.entity !== this._config?.entity
+    ) {
+      const newStateObj = this.hass?.states[ev.detail.value.entity];
+      if (newStateObj) {
+        ev.detail.value.states = filterSupportedAlarmStates(
+          newStateObj,
+          ev.detail.value.states
+        );
+      }
+    }
+
     fireEvent(this, "config-changed", { config: ev.detail.value });
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Minor UI Improvements for alarm panels:

In alarm-panel-card:
 - When generating stub config, don't choose states the chosen entity does not support. 
 - When rendering with a default states config, don't render buttons the entity does not support. 
 - Fix order of buttons to be consistent (previously default config renders `[AWAY] [HOME]`, but the stub config generates `[HOME] [AWAY]`)

In alarm-panel-card-editor:
 - Keep states checkboxes in sync with card when using default states config. 
 - Disable checkboxes for states that the chosen entity does not support.
 - Clear checkboxes when changing entity if the new entity does not support those states. 
 - Keep output order of buttons consistent, regardless of the order in which they were checked.

Overall some types improvements to try to reuse more defines between alarm more info and alarm card, they were using parallel definitions that didn't really overlap. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17566
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
