### PR TITLE
Form fields should not init in the error state

### DIFF
--- a/src/panels/calendar/dialog-calendar-event-editor.ts
+++ b/src/panels/calendar/dialog-calendar-event-editor.ts
@@ -176,7 +176,7 @@ class DialogCalendarEventEditor extends LitElement {
             .value=${this._summary}
             required
             @change=${this._handleSummaryChanged}
-            error-message=${this.hass.localize("ui.common.error_required")}
+            .validationMessage=${this.hass.localize("ui.common.error_required")}
             dialogInitialFocus
           ></ha-textfield>
           <ha-textarea

--- a/src/panels/config/application_credentials/dialog-add-application-credential.ts
+++ b/src/panels/config/application_credentials/dialog-add-application-credential.ts
@@ -191,7 +191,7 @@ export class DialogAddApplicationCredential extends LitElement {
             .value=${this._name}
             required
             @input=${this._handleValueChanged}
-            error-message=${this.hass.localize("ui.common.error_required")}
+            .validationMessage=${this.hass.localize("ui.common.error_required")}
             dialogInitialFocus
           ></ha-textfield>
           <ha-textfield
@@ -203,7 +203,7 @@ export class DialogAddApplicationCredential extends LitElement {
             .value=${this._clientId}
             required
             @input=${this._handleValueChanged}
-            error-message=${this.hass.localize("ui.common.error_required")}
+            .validationMessage=${this.hass.localize("ui.common.error_required")}
             dialogInitialFocus
             .helper=${this.hass.localize(
               "ui.panel.config.application_credentials.editor.client_id_helper"
@@ -219,7 +219,7 @@ export class DialogAddApplicationCredential extends LitElement {
             .value=${this._clientSecret}
             required
             @input=${this._handleValueChanged}
-            error-message=${this.hass.localize("ui.common.error_required")}
+            .validationMessage=${this.hass.localize("ui.common.error_required")}
             .helper=${this.hass.localize(
               "ui.panel.config.application_credentials.editor.client_secret_helper"
             )}

--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -93,10 +93,11 @@ class DialogAreaDetail extends LitElement {
               .value=${this._name}
               @input=${this._nameChanged}
               .label=${this.hass.localize("ui.panel.config.areas.editor.name")}
-              .errorMessage=${this.hass.localize(
+              .validationMessage=${this.hass.localize(
                 "ui.panel.config.areas.editor.name_required"
               )}
-              .invalid=${nameInvalid}
+              required
+              autoValidate
               dialogInitialFocus
             ></ha-textfield>
 

--- a/src/panels/config/areas/dialog-area-registry-detail.ts
+++ b/src/panels/config/areas/dialog-area-registry-detail.ts
@@ -97,7 +97,6 @@ class DialogAreaDetail extends LitElement {
                 "ui.panel.config.areas.editor.name_required"
               )}
               required
-              autoValidate
               dialogInitialFocus
             ></ha-textfield>
 

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -513,7 +513,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
       ${domain === "lock"
         ? html`
             <ha-textfield
-              .errorMessage=${this.hass.localize(
+              .validationMessage=${this.hass.localize(
                 "ui.dialogs.entity_registry.editor.default_code_error"
               )}
               .value=${this._defaultCode == null ? "" : this._defaultCode}
@@ -523,6 +523,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
               .invalid=${invalidDefaultCode}
               .disabled=${this.disabled}
               @input=${this._defaultcodeChanged}
+              autoValidate
             ></ha-textfield>
           `
         : ""}

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -523,7 +523,6 @@ export class EntityRegistrySettingsEditor extends LitElement {
               .invalid=${invalidDefaultCode}
               .disabled=${this.disabled}
               @input=${this._defaultcodeChanged}
-              autoValidate
             ></ha-textfield>
           `
         : ""}

--- a/src/panels/config/person/dialog-person-detail.ts
+++ b/src/panels/config/person/dialog-person-detail.ts
@@ -121,11 +121,11 @@ class DialogPersonDetail extends LitElement {
               .value=${this._name}
               @input=${this._nameChanged}
               label=${this.hass!.localize("ui.panel.config.person.detail.name")}
-              error-message=${this.hass!.localize(
+              .validationMessage=${this.hass!.localize(
                 "ui.panel.config.person.detail.name_error_msg"
               )}
               required
-              auto-validate
+              autoValidate
             ></ha-textfield>
             <ha-picture-upload
               .hass=${this.hass}

--- a/src/panels/config/person/dialog-person-detail.ts
+++ b/src/panels/config/person/dialog-person-detail.ts
@@ -125,7 +125,6 @@ class DialogPersonDetail extends LitElement {
                 "ui.panel.config.person.detail.name_error_msg"
               )}
               required
-              autoValidate
             ></ha-textfield>
             <ha-picture-upload
               .hass=${this.hass}

--- a/src/panels/config/tags/dialog-tag-detail.ts
+++ b/src/panels/config/tags/dialog-tag-detail.ts
@@ -95,11 +95,11 @@ class DialogTagDetail
               .configValue=${"name"}
               @input=${this._valueChanged}
               .label=${this.hass!.localize("ui.panel.config.tag.detail.name")}
-              .errorMessage=${this.hass!.localize(
+              .validationMessage=${this.hass!.localize(
                 "ui.panel.config.tag.detail.required_error_msg"
               )}
               required
-              auto-validate
+              autoValidate
             ></ha-textfield>
             ${!this._params.entry
               ? html`<ha-textfield
@@ -154,7 +154,7 @@ class DialogTagDetail
         <mwc-button
           slot="primaryAction"
           @click=${this._updateEntry}
-          .disabled=${this._submitting}
+          .disabled=${this._submitting || !this._name}
         >
           ${this._params.entry
             ? this.hass!.localize("ui.panel.config.tag.detail.update")
@@ -164,7 +164,7 @@ class DialogTagDetail
           ? html` <mwc-button
               slot="primaryAction"
               @click=${this._updateWriteEntry}
-              .disabled=${this._submitting}
+              .disabled=${this._submitting || !this._name}
             >
               ${this.hass!.localize(
                 "ui.panel.config.tag.detail.create_and_write"
@@ -270,6 +270,10 @@ class DialogTagDetail
         }
         #qr {
           text-align: center;
+        }
+        ha-textfield {
+          display: block;
+          margin: 8px 0;
         }
       `,
     ];

--- a/src/panels/config/tags/dialog-tag-detail.ts
+++ b/src/panels/config/tags/dialog-tag-detail.ts
@@ -99,7 +99,6 @@ class DialogTagDetail
                 "ui.panel.config.tag.detail.required_error_msg"
               )}
               required
-              autoValidate
             ></ha-textfield>
             ${!this._params.entry
               ? html`<ha-textfield

--- a/src/panels/config/users/dialog-add-user.ts
+++ b/src/panels/config/users/dialog-add-user.ts
@@ -113,7 +113,6 @@ export class DialogAddUser extends LitElement {
                 @input=${this._handleValueChanged}
                 @blur=${this._maybePopulateUsername}
                 dialogInitialFocus
-                autoValidate
               ></ha-textfield>`
             : ""}
           <ha-textfield
@@ -127,7 +126,6 @@ export class DialogAddUser extends LitElement {
             @input=${this._handleValueChanged}
             .validationMessage=${this.hass.localize("ui.common.error_required")}
             dialogInitialFocus
-            autoValidate
           ></ha-textfield>
 
           <ha-textfield
@@ -140,7 +138,6 @@ export class DialogAddUser extends LitElement {
             required
             @input=${this._handleValueChanged}
             .validationMessage=${this.hass.localize("ui.common.error_required")}
-            autoValidate
           ></ha-textfield>
 
           <ha-textfield
@@ -158,7 +155,6 @@ export class DialogAddUser extends LitElement {
             .validationMessage=${this.hass.localize(
               "ui.panel.config.users.add_user.password_not_match"
             )}
-            autoValidate
           ></ha-textfield>
           <div class="row">
             <ha-formfield

--- a/src/panels/config/users/dialog-add-user.ts
+++ b/src/panels/config/users/dialog-add-user.ts
@@ -107,10 +107,13 @@ export class DialogAddUser extends LitElement {
                 )}
                 .value=${this._name}
                 required
-                .errorMessage=${this.hass.localize("ui.common.error_required")}
+                .validationMessage=${this.hass.localize(
+                  "ui.common.error_required"
+                )}
                 @input=${this._handleValueChanged}
                 @blur=${this._maybePopulateUsername}
                 dialogInitialFocus
+                autoValidate
               ></ha-textfield>`
             : ""}
           <ha-textfield
@@ -122,8 +125,9 @@ export class DialogAddUser extends LitElement {
             .value=${this._username}
             required
             @input=${this._handleValueChanged}
-            .errorMessage=${this.hass.localize("ui.common.error_required")}
+            .validationMessage=${this.hass.localize("ui.common.error_required")}
             dialogInitialFocus
+            autoValidate
           ></ha-textfield>
 
           <ha-textfield
@@ -135,7 +139,8 @@ export class DialogAddUser extends LitElement {
             .value=${this._password}
             required
             @input=${this._handleValueChanged}
-            .errorMessage=${this.hass.localize("ui.common.error_required")}
+            .validationMessage=${this.hass.localize("ui.common.error_required")}
+            autoValidate
           ></ha-textfield>
 
           <ha-textfield
@@ -150,9 +155,10 @@ export class DialogAddUser extends LitElement {
             .invalid=${this._password !== "" &&
             this._passwordConfirm !== "" &&
             this._passwordConfirm !== this._password}
-            .errorMessage=${this.hass.localize(
+            .validationMessage=${this.hass.localize(
               "ui.panel.config.users.add_user.password_not_match"
             )}
+            autoValidate
           ></ha-textfield>
           <div class="row">
             <ha-formfield


### PR DESCRIPTION

## Proposed change
This is a following up PR for #17111 extending the idea behind it to other forms in the frontend. 
This PR also includes some small changes in the tag create/edit dialog form to make it look better.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
