### PR TITLE
Fix ha-tabs chevrons bug

### DIFF
--- a/src/components/ha-tabs.ts
+++ b/src/components/ha-tabs.ts
@@ -65,6 +65,7 @@ export class HaTabs extends PaperTabs {
     const selected = this.querySelector(".iron-selected");
     if (selected) {
       selected.scrollIntoView();
+      this._affectScroll(0); // Ensure scroll arrows match scroll position
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
As #16091 has not been touched since the issue was first created 4 releases ago, this proposes a workaround to fix the bug of scrolling chevrons appearing on the `ha-tabs` bar when they are not required. This is done by calling the scroll handling functions when the tabs are changed (populated).

This also fixes a non-reported bug that may occur in edge cases where by selecting a partially visible tab that causes the `ha-tabs` container to scroll that item into view, the chevrons are not updated while they should be, as now tabs have scrolled out of sight.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16091
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
