### PR TITLE
Clean system health subscription after data is collected

### DIFF
--- a/src/data/system_health.ts
+++ b/src/data/system_health.ts
@@ -69,7 +69,7 @@ type SystemHealthEvent =
 
 export const subscribeSystemHealthInfo = (
   hass: HomeAssistant,
-  callback: (info: SystemHealthInfo) => void
+  callback: (info: SystemHealthInfo | undefined) => void
 ) => {
   let data = {};
 
@@ -82,6 +82,7 @@ export const subscribeSystemHealthInfo = (
       }
       if (updateEvent.type === "finish") {
         unsubProm.then((unsub) => unsub());
+        callback(undefined);
         return;
       }
 


### PR DESCRIPTION
## Proposed change
The subscription is already unsubscribed after the data is collected. When closing the dialog, the subscription that was already unsubscribed is unsubscribed again.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #13304
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
