### PR TITLE
Add example data filler for service Object selectors

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -549,7 +549,8 @@
         "target": "Targets",
         "target_description": "What should this service use as targeted areas, devices or entities.",
         "data": "Service data",
-        "integration_doc": "Integration documentation"
+        "integration_doc": "Integration documentation",
+        "fill_example_data": "[%key:ui::panel::developer-tools::tabs::services::fill_example_data%]"
       },
       "related-items": {
         "no_related_found": "No related items found.",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Novice users unfamiliar with yaml seem likely to get confused when confronted with an "object" selector in a service call. It's just an empty box with no real indication of what is supposed to go in it or how to structure their data. 

Example data can help, but this is only visible in developer tools, and only if user manually goes into yaml mode. Users will not find it if they stay in the visual-mode service control. 

This change adds a button for object selectors in service control, which will fill the selector with its example service data. I think this can be helpful to help teach how the service field expects its data to be formatted. Note this button appears in both automation editor, and in developer tools, whereas the previous example data feature only appears in developer tools. 

![object-example-data](https://github.com/home-assistant/frontend/assets/32912880/17f2a8ac-052b-46a1-8844-0db3d68362e5)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue or discussion: #17512
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
