### PR TITLE
Adapt circular slider style for climate, water_heater and humidifier

### DIFF
--- a/src/components/ha-control-circular-slider.ts
+++ b/src/components/ha-control-circular-slider.ts
@@ -430,91 +430,94 @@ export class HaControlCircularSlider extends LitElement {
     const target = value ?? limit;
 
     const showActive =
-      !this.inactive &&
-      (mode === "end"
+      mode === "end"
         ? target <= current
         : mode === "start"
         ? current <= target
-        : false);
+        : false;
 
-    const showBackground = !this.inactive;
-
-    const activeArcDashArray = showActive
+    const activeArc = showActive
       ? mode === "end"
         ? this._strokeDashArc(target, current)
         : this._strokeDashArc(current, target)
       : this._strokeCircleDashArc(target);
 
-    const arcDashArray = showBackground
-      ? mode === "full"
+    const coloredArc =
+      mode === "full"
         ? this._strokeDashArc(this.min, this.max)
         : mode === "end"
         ? this._strokeDashArc(target, limit)
-        : this._strokeDashArc(limit, target)
-      : this._strokeCircleDashArc(target);
+        : this._strokeDashArc(limit, target);
 
-    const targetCircleDashArray = this._strokeCircleDashArc(target);
+    const targetCircle = this._strokeCircleDashArc(target);
 
-    const currentCircleDashArray =
+    const currentCircle =
       this.current != null &&
       this.current <= this.max &&
       this.current >= this.min &&
-      (showActive || this.mode === "full") &&
-      !this.inactive
+      (showActive || this.mode === "full")
         ? this._strokeCircleDashArc(this.current)
         : undefined;
 
     return svg`
-      <path
-        class="arc arc-clear"
-        d=${path}
-        stroke-dasharray=${arcDashArray[0]}
-        stroke-dashoffset=${arcDashArray[1]}
-      />
-      <path
-        class="arc arc-background ${classMap({ [id]: true })}"
-        d=${path}
-        stroke-dasharray=${arcDashArray[0]}
-        stroke-dashoffset=${arcDashArray[1]}
-      />
-      <path
-        .id=${id}
-        d=${path}
-        class="arc arc-active ${classMap({ [id]: true })}"
-        stroke-dasharray=${activeArcDashArray[0]}
-        stroke-dashoffset=${activeArcDashArray[1]}
-        role="slider"
-        tabindex="0"
-        aria-valuemin=${this.min}
-        aria-valuemax=${this.max}
-        aria-valuenow=${
-          this._localValue != null
-            ? this._steppedValue(this._localValue)
-            : undefined
+      <g class=${classMap({ inactive: Boolean(this.inactive) })}>
+        <path
+          class="arc arc-clear"
+          d=${path}
+          stroke-dasharray=${coloredArc[0]}
+          stroke-dashoffset=${coloredArc[1]}
+        />
+        <path
+          class="arc arc-colored ${classMap({ [id]: true })}"
+          d=${path}
+          stroke-dasharray=${coloredArc[0]}
+          stroke-dashoffset=${coloredArc[1]}
+        />
+        <path
+          .id=${id}
+          d=${path}
+          class="arc arc-active ${classMap({ [id]: true })}"
+          stroke-dasharray=${activeArc[0]}
+          stroke-dashoffset=${activeArc[1]}
+          role="slider"
+          tabindex="0"
+          aria-valuemin=${this.min}
+          aria-valuemax=${this.max}
+          aria-valuenow=${
+            this._localValue != null
+              ? this._steppedValue(this._localValue)
+              : undefined
+          }
+          aria-disabled=${this.disabled}
+          aria-label=${ifDefined(this.lowLabel ?? this.label)}
+          @keydown=${this._handleKeyDown}
+          @keyup=${this._handleKeyUp}
+        />
+        ${
+          currentCircle
+            ? svg`
+              <path
+                class="current arc-current"
+                d=${path}
+                stroke-dasharray=${currentCircle[0]}
+                stroke-dashoffset=${currentCircle[1]}
+              />
+          `
+            : nothing
         }
-        aria-disabled=${this.disabled}
-        aria-label=${ifDefined(this.lowLabel ?? this.label)}
-        @keydown=${this._handleKeyDown}
-        @keyup=${this._handleKeyUp}
-      />
-      ${
-        currentCircleDashArray
-          ? svg`
-            <path
-              class="current arc-current"
-              d=${path}
-              stroke-dasharray=${currentCircleDashArray[0]}
-              stroke-dashoffset=${currentCircleDashArray[1]}
-            />
-        `
-          : nothing
-      }
-      <path
-        class="target"
-        d=${path}
-        stroke-dasharray=${targetCircleDashArray[0]}
-        stroke-dashoffset=${targetCircleDashArray[1]}
-      />
+        <path
+          class="target-border ${classMap({ [id]: true })}"
+          d=${path}
+          stroke-dasharray=${targetCircle[0]}
+          stroke-dashoffset=${targetCircle[1]}
+        />
+        <path
+          class="target"
+          d=${path}
+          stroke-dasharray=${targetCircle[0]}
+          stroke-dashoffset=${targetCircle[1]}
+        />
+      </g>
     `;
   }
 
@@ -652,6 +655,19 @@ export class HaControlCircularSlider extends LitElement {
           opacity 180ms ease-in-out;
       }
 
+      .target-border {
+        fill: none;
+        stroke-linecap: round;
+        stroke-width: 24px;
+        stroke: white;
+        transition:
+          stroke-width 300ms ease-in-out,
+          stroke-dasharray 300ms ease-in-out,
+          stroke-dashoffset 300ms ease-in-out,
+          stroke 180ms ease-in-out,
+          opacity 180ms ease-in-out;
+      }
+
       .current {
         fill: none;
         stroke-linecap: round;
@@ -673,7 +689,7 @@ export class HaControlCircularSlider extends LitElement {
       .arc-clear {
         stroke: var(--clear-background-color);
       }
-      .arc-background {
+      .arc-colored {
         opacity: 0.5;
       }
       .arc-active {
@@ -685,11 +701,17 @@ export class HaControlCircularSlider extends LitElement {
 
       .pressed .arc,
       .pressed .target,
+      .pressed .target-border,
       .pressed .current {
         transition:
           stroke-width 300ms ease-in-out,
           stroke 180ms ease-in-out,
           opacity 180ms ease-in-out;
+      }
+
+      .inactive .arc,
+      .inactive .arc-current {
+        opacity: 0;
       }
 
       .value {

--- a/src/dialogs/more-info/components/climate/ha-more-info-climate-humidity.ts
+++ b/src/dialogs/more-info/components/climate/ha-more-info-climate-humidity.ts
@@ -163,6 +163,7 @@ export class HaMoreInfoClimateHumidity extends LitElement {
           })}
         >
           <ha-control-circular-slider
+            .inactive=${!active}
             .value=${this._targetHumidity}
             .min=${this._min}
             .max=${this._max}

--- a/src/dialogs/more-info/components/climate/ha-more-info-climate-temperature.ts
+++ b/src/dialogs/more-info/components/climate/ha-more-info-climate-temperature.ts
@@ -279,6 +279,10 @@ export class HaMoreInfoClimateTemperature extends LitElement {
       );
     }
 
+    const activeModes = this.stateObj.attributes.hvac_modes.filter(
+      (m) => m !== "off"
+    );
+
     if (
       supportsTargetTemperature &&
       this._targetTemperature.value != null &&
@@ -294,7 +298,9 @@ export class HaMoreInfoClimateTemperature extends LitElement {
         >
           <ha-control-circular-slider
             .inactive=${!active}
-            .mode=${SLIDER_MODES[mode]}
+            .mode=${mode === "off" && activeModes.length === 1
+              ? SLIDER_MODES[activeModes[0]]
+              : SLIDER_MODES[mode]}
             .value=${this._targetTemperature.value}
             .min=${this._min}
             .max=${this._max}

--- a/src/dialogs/more-info/components/climate/ha-more-info-climate-temperature.ts
+++ b/src/dialogs/more-info/components/climate/ha-more-info-climate-temperature.ts
@@ -18,18 +18,30 @@ import { clamp } from "../../../../common/number/clamp";
 import { formatNumber } from "../../../../common/number/format_number";
 import { debounce } from "../../../../common/util/debounce";
 import "../../../../components/ha-control-circular-slider";
+import type { ControlCircularSliderMode } from "../../../../components/ha-control-circular-slider";
 import "../../../../components/ha-outlined-icon-button";
 import "../../../../components/ha-svg-icon";
 import {
   CLIMATE_HVAC_ACTION_TO_MODE,
   ClimateEntity,
   ClimateEntityFeature,
+  HvacMode,
 } from "../../../../data/climate";
 import { UNAVAILABLE } from "../../../../data/entity";
 import { HomeAssistant } from "../../../../types";
 import { moreInfoControlCircularSliderStyle } from "../ha-more-info-control-circular-slider-style";
 
 type Target = "value" | "low" | "high";
+
+const SLIDER_MODES: Record<HvacMode, ControlCircularSliderMode> = {
+  auto: "full",
+  cool: "end",
+  dry: "full",
+  fan_only: "full",
+  heat: "start",
+  heat_cool: "full",
+  off: "full",
+};
 
 @customElement("ha-more-info-climate-temperature")
 export class HaMoreInfoClimateTemperature extends LitElement {
@@ -267,17 +279,11 @@ export class HaMoreInfoClimateTemperature extends LitElement {
       );
     }
 
-    const hvacModes = this.stateObj.attributes.hvac_modes;
-
     if (
       supportsTargetTemperature &&
       this._targetTemperature.value != null &&
       this.stateObj.state !== UNAVAILABLE
     ) {
-      const hasOnlyCoolMode =
-        hvacModes.length === 2 &&
-        hvacModes.includes("cool") &&
-        hvacModes.includes("off");
       return html`
         <div
           class="container"
@@ -287,7 +293,8 @@ export class HaMoreInfoClimateTemperature extends LitElement {
           })}
         >
           <ha-control-circular-slider
-            .inverted=${mode === "cool" || hasOnlyCoolMode}
+            .inactive=${!active}
+            .mode=${SLIDER_MODES[mode]}
             .value=${this._targetTemperature.value}
             .min=${this._min}
             .max=${this._max}
@@ -324,6 +331,7 @@ export class HaMoreInfoClimateTemperature extends LitElement {
           })}
         >
           <ha-control-circular-slider
+            .inactive=${!active}
             dual
             .low=${this._targetTemperature.low}
             .high=${this._targetTemperature.high}

--- a/src/dialogs/more-info/components/humidifier/ha-more-info-humidifier-humidity.ts
+++ b/src/dialogs/more-info/components/humidifier/ha-more-info-humidifier-humidity.ts
@@ -184,7 +184,8 @@ export class HaMoreInfoHumidifierHumidity extends LitElement {
           })}
         >
           <ha-control-circular-slider
-            .inverted=${inverted}
+            .inactive=${!active}
+            .mode=${inverted ? "end" : "start"}
             .value=${targetHumidity}
             .min=${this._min}
             .max=${this._max}

--- a/src/dialogs/more-info/components/water_heater/ha-more-info-water_heater-temperature.ts
+++ b/src/dialogs/more-info/components/water_heater/ha-more-info-water_heater-temperature.ts
@@ -9,6 +9,7 @@ import {
 } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { styleMap } from "lit/directives/style-map";
+import { stateActive } from "../../../../common/entity/state_active";
 import { stateColorCss } from "../../../../common/entity/state_color";
 import { supportsFeature } from "../../../../common/entity/supports-feature";
 import { clamp } from "../../../../common/number/clamp";
@@ -163,6 +164,7 @@ export class HaMoreInfoWaterHeaterTemperature extends LitElement {
     );
 
     const stateColor = stateColorCss(this.stateObj);
+    const active = stateActive(this.stateObj);
 
     if (
       supportsTargetTemperature &&
@@ -177,6 +179,7 @@ export class HaMoreInfoWaterHeaterTemperature extends LitElement {
           })}
         >
           <ha-control-circular-slider
+            .inactive=${!active}
             .value=${this._targetTemperature}
             .min=${this._min}
             .max=${this._max}


### PR DESCRIPTION
## Proposed change

Use different style for circular slider depending on mode.

Climate (based of mode) : 
- `heat` : colored from start with active zone
- `cool` : colored from end with active zone
- `auto`, `fan_only`, `dry` : full colored without active zone

Water Heater : always colored from start with active zone

Humidifier (based of device class) : 
- `humidifier` : colored from start with active zone
- `dehumidifier` : colored from end with active zone

Off state will be no colored and no active zone.

### Demo

Note : it's a demo entity with hvac action forced to cooling. Pay no attention to this label.

https://github.com/home-assistant/frontend/assets/5878303/793b9057-a423-4ed2-af57-e44a8f3b56d6

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
