### PR TITLE
Use active color for position cover tile feature even if it's closed

### DIFF
--- a/src/dialogs/more-info/components/cover/ha-more-info-cover-position.ts
+++ b/src/dialogs/more-info/components/cover/ha-more-info-cover-position.ts
@@ -35,7 +35,9 @@ export class HaMoreInfoCoverPosition extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const color = stateColorCss(this.stateObj);
+    const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
+
+    const color = stateColorCss(this.stateObj, forcedState);
 
     return html`
       <ha-control-slider
@@ -64,10 +66,6 @@ export class HaMoreInfoCoverPosition extends LitElement {
 
   static get styles(): CSSResultGroup {
     return css`
-      :host {
-        /* Force inactive state to be colored for the slider */
-        --state-cover-inactive-color: var(--state-cover-active-color);
-      }
       ha-control-slider {
         height: 45vh;
         max-height: 320px;

--- a/src/dialogs/more-info/components/cover/ha-more-info-cover-position.ts
+++ b/src/dialogs/more-info/components/cover/ha-more-info-cover-position.ts
@@ -64,12 +64,14 @@ export class HaMoreInfoCoverPosition extends LitElement {
 
   static get styles(): CSSResultGroup {
     return css`
+      :host {
+        /* Force inactive state to be colored for the slider */
+        --state-cover-inactive-color: var(--state-cover-active-color);
+      }
       ha-control-slider {
         height: 45vh;
         max-height: 320px;
         min-height: 200px;
-        /* Force inactive state to be colored for the slider */
-        --state-cover-inactive-color: var(--state-cover-active-color);
         --control-slider-thickness: 100px;
         --control-slider-border-radius: 24px;
         --control-slider-color: var(--primary-color);

--- a/src/dialogs/more-info/components/cover/ha-more-info-cover-tilt-position.ts
+++ b/src/dialogs/more-info/components/cover/ha-more-info-cover-tilt-position.ts
@@ -72,8 +72,9 @@ export class HaMoreInfoCoverTiltPosition extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const color = stateColorCss(this.stateObj);
-    const isUnavailable = this.stateObj.state === UNAVAILABLE;
+    const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
+
+    const color = stateColorCss(this.stateObj, forcedState);
 
     return html`
       <ha-control-slider
@@ -93,7 +94,7 @@ export class HaMoreInfoCoverTiltPosition extends LitElement {
           "--control-slider-color": color,
           "--control-slider-background": color,
         })}
-        .disabled=${isUnavailable}
+        .disabled=${this.stateObj.state === UNAVAILABLE}
       >
         <div slot="background" class="gradient"></div>
       </ha-control-slider>
@@ -102,10 +103,6 @@ export class HaMoreInfoCoverTiltPosition extends LitElement {
 
   static get styles(): CSSResultGroup {
     return css`
-      :host {
-        /* Force inactive state to be colored for the slider */
-        --state-cover-inactive-color: var(--state-cover-active-color);
-      }
       ha-control-slider {
         height: 45vh;
         max-height: 320px;

--- a/src/dialogs/more-info/components/cover/ha-more-info-cover-tilt-position.ts
+++ b/src/dialogs/more-info/components/cover/ha-more-info-cover-tilt-position.ts
@@ -102,12 +102,14 @@ export class HaMoreInfoCoverTiltPosition extends LitElement {
 
   static get styles(): CSSResultGroup {
     return css`
+      :host {
+        /* Force inactive state to be colored for the slider */
+        --state-cover-inactive-color: var(--state-cover-active-color);
+      }
       ha-control-slider {
         height: 45vh;
         max-height: 320px;
         min-height: 200px;
-        /* Force inactive state to be colored for the slider */
-        --state-cover-inactive-color: var(--state-cover-active-color);
         --control-slider-thickness: 100px;
         --control-slider-border-radius: 24px;
         --control-slider-color: var(--primary-color);

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -424,6 +424,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     if (this.hass) {
       element.hass = this.hass;
       (element as LovelaceTileFeature).stateObj = stateObj;
+      (element as LovelaceTileFeature).color = this._config!.color;
     }
 
     return html`${element}`;

--- a/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
@@ -64,9 +64,11 @@ class HuiCoverPositionTileFeature
 
     const value = Math.max(Math.round(percentage), 0);
 
+    const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
+
     const color = this.color
       ? computeCssColor(this.color)
-      : stateColorCss(this.stateObj);
+      : stateColorCss(this.stateObj, forcedState);
 
     const style = {
       "--color": color,
@@ -106,10 +108,6 @@ class HuiCoverPositionTileFeature
 
   static get styles() {
     return css`
-      :host {
-        /* Force inactive state to be colored for the slider */
-        --state-cover-inactive-color: var(--state-cover-active-color);
-      }
       ha-control-slider {
         --control-slider-color: var(--color);
         --control-slider-background: var(--color);

--- a/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
@@ -64,9 +64,11 @@ class HuiCoverTiltPositionTileFeature
 
     const value = Math.max(Math.round(percentage), 0);
 
+    const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
+
     const color = this.color
       ? computeCssColor(this.color)
-      : stateColorCss(this.stateObj);
+      : stateColorCss(this.stateObj, forcedState);
 
     const style = {
       "--color": color,
@@ -107,10 +109,6 @@ class HuiCoverTiltPositionTileFeature
 
   static get styles() {
     return css`
-      :host {
-        /* Force inactive state to be colored for the slider */
-        --state-cover-inactive-color: var(--state-cover-active-color);
-      }
       ha-control-slider {
         /* Force inactive state to be colored for the slider */
         --control-slider-color: var(--color);

--- a/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
@@ -1,8 +1,11 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import { computeCssColor } from "../../../common/color/compute-color";
 import { computeAttributeNameDisplay } from "../../../common/entity/compute_attribute_display";
 import { computeDomain } from "../../../common/entity/compute_domain";
+import { stateColorCss } from "../../../common/entity/state_color";
 import { supportsFeature } from "../../../common/entity/supports-feature";
 import { CoverEntity, CoverEntityFeature } from "../../../data/cover";
 import { UNAVAILABLE } from "../../../data/entity";
@@ -29,6 +32,8 @@ class HuiCoverTiltPositionTileFeature
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @property({ attribute: false }) public stateObj?: CoverEntity;
+
+  @property({ attribute: false }) public color?: string;
 
   @state() private _config?: CoverTiltPositionTileFeatureConfig;
 
@@ -59,8 +64,16 @@ class HuiCoverTiltPositionTileFeature
 
     const value = Math.max(Math.round(percentage), 0);
 
+    const color = this.color
+      ? computeCssColor(this.color)
+      : stateColorCss(this.stateObj);
+
+    const style = {
+      "--color": color,
+    };
+
     return html`
-      <div class="container">
+      <div class="container" style=${styleMap(style)}>
         <ha-control-slider
           .value=${value}
           min="0"
@@ -94,10 +107,14 @@ class HuiCoverTiltPositionTileFeature
 
   static get styles() {
     return css`
+      :host {
+        /* Force inactive state to be colored for the slider */
+        --state-cover-inactive-color: var(--state-cover-active-color);
+      }
       ha-control-slider {
         /* Force inactive state to be colored for the slider */
-        --control-slider-color: var(--tile-color);
-        --control-slider-background: var(--tile-color);
+        --control-slider-color: var(--color);
+        --control-slider-background: var(--color);
         --control-slider-background-opacity: 0.2;
         --control-slider-thickness: 40px;
         --control-slider-border-radius: 10px;

--- a/src/panels/lovelace/types.ts
+++ b/src/panels/lovelace/types.ts
@@ -116,6 +116,7 @@ export interface LovelaceTileFeature extends HTMLElement {
   hass?: HomeAssistant;
   stateObj?: HassEntity;
   setConfig(config: LovelaceTileFeatureConfig);
+  color?: string;
 }
 
 export interface LovelaceTileFeatureConstructor


### PR DESCRIPTION
## Proposed change

Use active color for position cover tile feature even if it's closed to match more info colors. There is inconsistency with icon but we don't have a better solution for now.

### Open

![CleanShot 2023-08-23 at 15 18 52](https://github.com/home-assistant/frontend/assets/5878303/435bc16e-76f0-41a2-9f65-6b0dfebbaa09)

### Closed

![CleanShot 2023-08-23 at 15 18 40](https://github.com/home-assistant/frontend/assets/5878303/dc674d6c-7cd7-459f-9bbd-a460e399a870)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
