### PR TITLE
Add sortable options to input_select settings menu

### DIFF
--- a/src/panels/config/helpers/forms/ha-input_select-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_select-form.ts
@@ -1,5 +1,4 @@
-import "@material/mwc-button/mwc-button";
-import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-list/mwc-list";
 import { mdiDelete, mdiDrag } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
@@ -7,7 +6,9 @@ import { repeat } from "lit/directives/repeat";
 import type { SortableEvent } from "sortablejs";
 import { sortableStyles } from "../../../../resources/ha-sortable-style";
 import { fireEvent } from "../../../../common/dom/fire_event";
+import "../../../../components/ha-button";
 import "../../../../components/ha-icon-button";
+import "../../../../components/ha-list-item";
 import "../../../../components/ha-icon-picker";
 import "../../../../components/ha-textfield";
 import type { HaTextField } from "../../../../components/ha-textfield";
@@ -144,13 +145,13 @@ class HaInputSelectForm extends LitElement {
             "ui.dialogs.helper_settings.input_select.options"
           )}:
         </div>
-        <div class="options">
+        <mwc-list class="options">
           ${this._options.length
             ? repeat(
                 this._options,
                 (option) => option,
                 (option, index) => html`
-                  <mwc-list-item class="option" hasMeta>
+                  <ha-list-item class="option" hasMeta>
                     <div class="optioncontent">
                       <div class="handle">
                         <ha-svg-icon .path=${mdiDrag}></ha-svg-icon>
@@ -166,17 +167,17 @@ class HaInputSelectForm extends LitElement {
                       @click=${this._removeOption}
                       .path=${mdiDelete}
                     ></ha-icon-button>
-                  </mwc-list-item>
+                  </ha-list-item>
                 `
               )
             : html`
-                <mwc-list-item noninteractive>
+                <ha-list-item noninteractive>
                   ${this.hass!.localize(
                     "ui.dialogs.helper_settings.input_select.no_options"
                   )}
-                </mwc-list-item>
+                </ha-list-item>
               `}
-        </div>
+        </mwc-list>
         <div class="layout horizontal center">
           <ha-textfield
             class="flex-auto"
@@ -186,10 +187,10 @@ class HaInputSelectForm extends LitElement {
             )}
             @keydown=${this._handleKeyAdd}
           ></ha-textfield>
-          <mwc-button @click=${this._addOption}
+          <ha-button @click=${this._addOption}
             >${this.hass!.localize(
               "ui.dialogs.helper_settings.input_select.add"
-            )}</mwc-button
+            )}</ha-button
           >
         </div>
       </div>
@@ -268,6 +269,7 @@ class HaInputSelectForm extends LitElement {
           margin-top: 4px;
           --mdc-icon-button-size: 24px;
           --mdc-ripple-color: transparent;
+          --mdc-list-side-padding: 16px;
           cursor: default;
           background-color: var(--card-background-color);
         }

--- a/src/panels/config/helpers/forms/ha-input_select-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_select-form.ts
@@ -265,6 +265,8 @@ class HaInputSelectForm extends LitElement {
           border-radius: 4px;
           margin-top: 4px;
           --mdc-icon-button-size: 24px;
+          --mdc-ripple-color: transparent;
+          cursor: default;
         }
         mwc-button {
           margin-left: 8px;

--- a/src/panels/config/helpers/forms/ha-input_select-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_select-form.ts
@@ -267,6 +267,7 @@ class HaInputSelectForm extends LitElement {
           --mdc-icon-button-size: 24px;
           --mdc-ripple-color: transparent;
           cursor: default;
+          background-color: var(--card-background-color);
         }
         mwc-button {
           margin-left: 8px;

--- a/src/panels/config/helpers/forms/ha-input_select-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_select-form.ts
@@ -4,6 +4,7 @@ import { mdiDelete, mdiDrag } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
+import type { SortableEvent } from "sortablejs";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-icon-button";
 import "../../../../components/ha-icon-picker";
@@ -72,8 +73,8 @@ class HaInputSelectForm extends LitElement {
     if (ev.oldIndex === ev.newIndex) return;
 
     const options = this._options.concat();
-    const option = options.splice(ev.oldIndex, 1)[0];
-    options.splice(ev.newIndex, 0, option);
+    const option = options.splice(ev.oldIndex!, 1)[0];
+    options.splice(ev.newIndex!, 0, option);
 
     fireEvent(this, "value-changed", {
       value: { ...this._item, options },

--- a/src/panels/config/helpers/forms/ha-input_select-form.ts
+++ b/src/panels/config/helpers/forms/ha-input_select-form.ts
@@ -5,6 +5,7 @@ import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { repeat } from "lit/directives/repeat";
 import type { SortableEvent } from "sortablejs";
+import { sortableStyles } from "../../../../resources/ha-sortable-style";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-icon-button";
 import "../../../../components/ha-icon-picker";
@@ -256,6 +257,7 @@ class HaInputSelectForm extends LitElement {
   static get styles(): CSSResultGroup {
     return [
       haStyle,
+      sortableStyles,
       css`
         .form {
           color: var(--primary-text-color);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add handles to sort the items in the input select config page. Originally proposed by @ChrisBit in #10107, but it was abandoned/never reviewed. Trying to revive it. 

![sortable-input_select](https://github.com/home-assistant/frontend/assets/32912880/a0f3cab3-06ef-4d96-94ae-c4624fc64293)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://github.com/home-assistant/frontend/discussions/11238
https://github.com/home-assistant/frontend/issues/10107
https://github.com/home-assistant/frontend/pull/10361
https://community.home-assistant.io/t/ability-to-re-organize-dropdown-helpers/272398/14
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
