### PR TITLE
Fix language picker in profile displaying wrong language

### DIFF
--- a/src/components/ha-language-picker.ts
+++ b/src/components/ha-language-picker.ts
@@ -32,6 +32,8 @@ export class HaLanguagePicker extends LitElement {
 
   @state() _defaultLanguages: string[] = [];
 
+  @state() redrawFlag = false;
+
   @query("ha-select") private _select!: HaSelect;
 
   protected firstUpdated(changedProps: PropertyValues) {
@@ -41,6 +43,17 @@ export class HaLanguagePicker extends LitElement {
 
   protected updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
+    this.redrawFlag = false;
+    if (changedProperties.has("hass")) {
+      const oldHass = changedProperties.get("hass");
+      if (
+        this.hass &&
+        oldHass &&
+        oldHass.locale.language !== this.hass.locale.language
+      ) {
+        this.redrawFlag = true;
+      }
+    }
     if (changedProperties.has("languages") || changedProperties.has("value")) {
       this._select.layoutOptions();
       if (this._select.value !== this.value) {
@@ -120,8 +133,9 @@ export class HaLanguagePicker extends LitElement {
       this.nativeName
     );
 
-    const value =
-      this.value ?? (this.required ? languageOptions[0]?.value : this.value);
+    const value = this.redrawFlag
+      ? ""
+      : this.value ?? (this.required ? languageOptions[0]?.value : this.value);
 
     return html`
       <ha-select


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

In the language picker in profile, in some cases when selecting a new language, it will cause a different incorrect language to be displayed in the picker. 

This happens because the sort order of languages in different locales is different, and the mwc-select is not handling correctly when the underlying list changes order of items.

E.g. if I pick item N in the list, and that language choice causes the sort order to change, the picker will now display item N from the newly sorted list to be displayed, which may not the same as the original language that was picked. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16642 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
