### PR TITLE
Fix more info type test

### DIFF
--- a/test/common/entity/state_more_info_type_test.ts
+++ b/test/common/entity/state_more_info_type_test.ts
@@ -18,9 +18,9 @@ describe("stateMoreInfoType", () => {
     assert.strictEqual(stateMoreInfoType(stateObj), "hidden");
   });
 
-  it("Returns default for switch states", () => {
+  it("Returns default for tts states", () => {
     const stateObj: any = {
-      entity_id: "switch.bla",
+      entity_id: "tts.bla",
       attributes: {},
     };
     assert.strictEqual(stateMoreInfoType(stateObj), "default");


### PR DESCRIPTION
## Proposed change

I don't know why it worked before but this test was broken. Switch more info has been added few releases before.
I replaced `switch` by `tts` because switch has its own more info now.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
