### PR TITLE
Fix chart tooltip crash for disabled entity

### DIFF
--- a/src/common/number/format_number.ts
+++ b/src/common/number/format_number.ts
@@ -108,7 +108,7 @@ export const formatNumber = (
  * @returns An `Intl.NumberFormatOptions` object with `maximumFractionDigits` set to 0, or `undefined`
  */
 export const getNumberFormatOptions = (
-  entityState: HassEntity,
+  entityState?: HassEntity,
   entity?: EntityRegistryDisplayEntry
 ): Intl.NumberFormatOptions | undefined => {
   const precision = entity?.display_precision;
@@ -119,8 +119,8 @@ export const getNumberFormatOptions = (
     };
   }
   if (
-    Number.isInteger(Number(entityState.attributes?.step)) &&
-    Number.isInteger(Number(entityState.state))
+    Number.isInteger(Number(entityState?.attributes?.step)) &&
+    Number.isInteger(Number(entityState?.state))
   ) {
     return { maximumFractionDigits: 0 };
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

#17648 in 2023.9 added using sensor precision for chart tooltips, but if a chart is rendered for a disabled entity, the tooltips rendering crashes because `getNumberFormatOptions` does not handle undefined entityState. 

I chose to allow the function to handle undefined, if that is not desirable, I will need to make the change to not call the function here if entity is disabled:

https://github.com/home-assistant/frontend/pull/17648/files#diff-cbb506d7413ab7d58f309a68f4fcf3ebf95acffe6696abe28721df61a01de7f2R130-R134

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
