### PR TITLE
Show helper config entries without entities

### DIFF
--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -1,5 +1,5 @@
 import "@lrnwebcomponents/simple-tooltip/simple-tooltip";
-import { mdiPencilOff, mdiPlus } from "@mdi/js";
+import { mdiAlertCircle, mdiPencilOff, mdiPlus } from "@mdi/js";
 import { HassEntity, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { LitElement, PropertyValues, TemplateResult, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -86,10 +86,10 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           template: (icon, helper: any) =>
             helper.entity
               ? html`<ha-state-icon .state=${helper.entity}></ha-state-icon>`
-              : html`<ha-icon
-                  .icon=${icon}
+              : html`<ha-svg-icon
+                  .path=${icon}
                   style="color: var(--error-color)"
-                ></ha-icon>`,
+                ></ha-svg-icon>`,
         },
         name: {
           title: localize("ui.panel.config.helpers.picker.headers.name"),
@@ -194,7 +194,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
       const entries = Object.values(configEntriesCopy).map((configEntry) => ({
         id: configEntry.entry_id,
         entity_id: "",
-        icon: "mdi:alert-circle",
+        icon: mdiAlertCircle,
         name: configEntry.title || "",
         editable: true,
         type: configEntry.domain,

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -37,6 +37,7 @@ import { configSections } from "../ha-panel-config";
 import "../integrations/ha-integration-overflow-menu";
 import { HelperDomain, isHelperDomain } from "./const";
 import { showHelperDetailDialog } from "./show-dialog-helper-detail";
+import { showOptionsFlowDialog } from "../../../dialogs/config-flow/show-dialog-options-flow";
 
 // This groups items by a key but only returns last entry per key.
 const groupByOne = <T>(
@@ -82,8 +83,13 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           title: "",
           label: localize("ui.panel.config.helpers.picker.headers.icon"),
           type: "icon",
-          template: (_, helper: any) =>
-            html`<ha-state-icon .state=${helper.entity}></ha-state-icon>`,
+          template: (icon, helper: any) =>
+            helper.entity
+              ? html`<ha-state-icon .state=${helper.entity}></ha-state-icon>`
+              : html`<ha-icon
+                  .icon=${icon}
+                  style="color: var(--error-color)"
+                ></ha-icon>`,
         },
         name: {
           title: localize("ui.panel.config.helpers.picker.headers.name"),
@@ -95,7 +101,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           template: (name, item: any) => html`
             ${name}
             ${narrow
-              ? html` <div class="secondary">${item.entity_id}</div> `
+              ? html`<div class="secondary">${item.entity_id}</div> `
               : ""}
           `,
         },
@@ -153,17 +159,22 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
       stateItems: HassEntity[],
       entityEntries: Record<string, EntityRegistryEntry>,
       configEntries: Record<string, ConfigEntry>
-    ) =>
-      stateItems.map((entityState) => {
+    ) => {
+      const configEntriesCopy = { ...configEntries };
+
+      const states = stateItems.map((entityState) => {
         const configEntry = getConfigEntry(
           entityEntries,
           configEntries,
           entityState.entity_id
         );
 
+        if (configEntry) {
+          delete configEntriesCopy[configEntry!.entry_id];
+        }
+
         return {
           id: entityState.entity_id,
-          icon: entityState.attributes.icon,
           name: entityState.attributes.friendly_name || "",
           entity_id: entityState.entity_id,
           editable:
@@ -174,7 +185,25 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           configEntry,
           entity: entityState,
         };
-      })
+      });
+
+      if (!Object.keys(configEntriesCopy).length) {
+        return states;
+      }
+
+      const entries = Object.values(configEntriesCopy).map((configEntry) => ({
+        id: configEntry.entry_id,
+        entity_id: "",
+        icon: "mdi:alert-circle",
+        name: configEntry.title || "",
+        editable: true,
+        type: configEntry.domain,
+        configEntry,
+        entity: undefined,
+      }));
+
+      return [...states, ...entries];
+    }
   );
 
   protected render(): TemplateResult {
@@ -353,8 +382,12 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
   }
 
   private async _openEditDialog(ev: CustomEvent): Promise<void> {
-    const entityId = (ev.detail as RowClickedEvent).id;
-    showMoreInfoDialog(this, { entityId });
+    const id = (ev.detail as RowClickedEvent).id;
+    if (id.includes(".")) {
+      showMoreInfoDialog(this, { entityId: id });
+    } else {
+      showOptionsFlowDialog(this, this._configEntries![id]);
+    }
   }
 
   private _createHelpler() {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If an helper doesnt create an entity, it is not shown in the helpers list now.

This will show the config entry without entity with an error icon, clicking it will open the options flow.

<img width="921" alt="CleanShot 2023-09-01 at 16 25 28@2x" src="https://github.com/home-assistant/frontend/assets/5662298/cc191cab-0b96-4b57-89a2-7778baf9c53b">


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
