### PR TITLE
Fix too wide energy chart bars

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-gas-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-gas-graph-card.ts
@@ -379,6 +379,7 @@ export class HuiEnergyGasGraphCard
       if (source.stat_energy_from in statistics) {
         const stats = statistics[source.stat_energy_from];
         let end;
+
         for (const point of stats) {
           if (point.change === null || point.change === undefined) {
             continue;

--- a/src/panels/lovelace/cards/energy/hui-energy-gas-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-gas-graph-card.ts
@@ -378,7 +378,7 @@ export class HuiEnergyGasGraphCard
       // Process gas consumption data.
       if (source.stat_energy_from in statistics) {
         const stats = statistics[source.stat_energy_from];
-
+        let end;
         for (const point of stats) {
           if (point.change === null || point.change === undefined) {
             continue;
@@ -392,6 +392,13 @@ export class HuiEnergyGasGraphCard
             y: point.change,
           });
           prevStart = point.start;
+          end = point.end;
+        }
+        if (gasConsumptionData.length === 1) {
+          gasConsumptionData.push({
+            x: end,
+            y: 0,
+          });
         }
       }
 

--- a/src/panels/lovelace/cards/energy/hui-energy-solar-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-solar-graph-card.ts
@@ -401,6 +401,7 @@ export class HuiEnergySolarGraphCard
       // Process solar production data.
       if (source.stat_energy_from in statistics) {
         const stats = statistics[source.stat_energy_from];
+        let end;
 
         for (const point of stats) {
           if (point.change === null || point.change === undefined) {
@@ -415,6 +416,13 @@ export class HuiEnergySolarGraphCard
             y: point.change,
           });
           prevStart = point.start;
+          end = point.end;
+        }
+        if (solarProductionData.length === 1) {
+          solarProductionData.push({
+            x: end,
+            y: 0,
+          });
         }
       }
 

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -523,6 +523,7 @@ export class HuiEnergyUsageGraphCard
       solar?: { [start: number]: number };
     } = {};
 
+    let pointEndTime;
     Object.entries(statIdsByCat).forEach(([key, statIds]) => {
       const sum = [
         "solar",
@@ -550,9 +551,11 @@ export class HuiEnergyUsageGraphCard
           if (sum) {
             totalStats[stat.start] =
               stat.start in totalStats ? totalStats[stat.start] + val : val;
+            pointEndTime = stat.end;
           }
           if (add && !(stat.start in set)) {
             set[stat.start] = val;
+            pointEndTime = stat.end;
           }
         });
         sets[id] = set;
@@ -668,6 +671,12 @@ export class HuiEnergyUsageGraphCard
               value && ["to_grid", "to_battery"].includes(type)
                 ? -1 * value
                 : value,
+          });
+        }
+        if (points.length === 1) {
+          points.push({
+            x: pointEndTime,
+            y: 0,
           });
         }
 

--- a/src/panels/lovelace/cards/energy/hui-energy-water-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-water-graph-card.ts
@@ -376,6 +376,7 @@ export class HuiEnergyWaterGraphCard
       // Process water consumption data.
       if (source.stat_energy_from in statistics) {
         const stats = statistics[source.stat_energy_from];
+        let end;
 
         for (const point of stats) {
           if (point.change === null || point.change === undefined) {
@@ -390,6 +391,13 @@ export class HuiEnergyWaterGraphCard
             y: point.change,
           });
           prevStart = point.start;
+          end = point.end;
+        }
+        if (waterConsumptionData.length === 1) {
+          waterConsumptionData.push({
+            x: end,
+            y: 0,
+          });
         }
       }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

When an energy chart has only one datapoint in the series, chart.js does not understand how wide the bar should be. This leads it to render it as wide as a major tick, which can be much larger than normal when there are multiple points in the series. 

This change adds a dummy 0-height point at the appropriate interval to dataseries that only have one point, so that energy charts are always rendered at the same width. 

examples of problem charts:
![image](https://github.com/home-assistant/frontend/assets/32912880/30fcc6b4-20d0-470f-96bc-38e8dc1ecb82)

![image](https://github.com/home-assistant/frontend/assets/32912880/78bfc571-e18f-4c97-8999-e54e5714624f)




## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17766 , fixes #14950
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
