### PR TITLE
Enable custom entity types to use the new more-info design

### DIFF
--- a/src/data/entity_attributes.ts
+++ b/src/data/entity_attributes.ts
@@ -3,6 +3,7 @@ export const STATE_ATTRIBUTES = [
   "assumed_state",
   "attribution",
   "custom_ui_more_info",
+  "custom_ui_new_more_info",
   "custom_ui_state_card",
   "device_class",
   "editable",

--- a/src/dialogs/more-info/const.ts
+++ b/src/dialogs/more-info/const.ts
@@ -122,11 +122,10 @@ export const computeShowLogBookComponent = (
   return true;
 };
 
-export const computeCustomShowNewMoreInfo = (stateObj: HassEntity): boolean => {
-    return stateObj.attributes &&
-           "custom_ui_new_more_info" in stateObj.attributes &&
-           stateObj.attributes.custom_ui_new_more_info;
-}
+export const computeCustomShowNewMoreInfo = (stateObj: HassEntity): boolean =>
+  stateObj.attributes &&
+  "custom_ui_new_more_info" in stateObj.attributes &&
+  stateObj.attributes.custom_ui_new_more_info;
 
 export const computeShowNewMoreInfo = (stateObj: HassEntity): boolean => {
   const domain = computeDomain(stateObj.entity_id);

--- a/src/dialogs/more-info/const.ts
+++ b/src/dialogs/more-info/const.ts
@@ -15,6 +15,15 @@ export const EDITABLE_DOMAINS_WITH_ID = ["scene", "automation"];
  * Entity Domains that should always be editable; {@see shouldShowEditIcon}.
  * */
 export const EDITABLE_DOMAINS_WITH_UNIQUE_ID = ["script"];
+
+/**
+ * Entities from custom domains can access the new more info design by
+ * setting on each entity:
+ *   custom_ui_more_info attribute to the desired HTML element name
+ *        (e.g., one declared with customElements.define(...) )
+ *   custom_ui_new_more_info to True
+ * */
+
 /** Domains with with new more info design. */
 export const DOMAINS_WITH_NEW_MORE_INFO = [
   "alarm_control_panel",
@@ -112,6 +121,12 @@ export const computeShowLogBookComponent = (
 
   return true;
 };
+
+export const computeCustomShowNewMoreInfo = (stateObj: HassEntity): boolean => {
+    return stateObj.attributes &&
+           "custom_ui_new_more_info" in stateObj.attributes &&
+           stateObj.attributes.custom_ui_new_more_info;
+}
 
 export const computeShowNewMoreInfo = (stateObj: HassEntity): boolean => {
   const domain = computeDomain(stateObj.entity_id);

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -155,7 +155,8 @@ export class MoreInfoDialog extends LitElement {
     domain: string,
     stateObj: HassEntity | undefined
   ): boolean {
-    const isCustomNewMoreInfo = stateObj && computeCustomShowNewMoreInfo(stateObj);
+    const isCustomNewMoreInfo: boolean =
+      !!stateObj && computeCustomShowNewMoreInfo(stateObj);
     return (
       (DOMAINS_WITH_MORE_INFO.includes(domain) || isCustomNewMoreInfo) &&
       (computeShowHistoryComponent(this.hass, this._entityId!) ||

--- a/src/dialogs/more-info/ha-more-info-dialog.ts
+++ b/src/dialogs/more-info/ha-more-info-dialog.ts
@@ -43,6 +43,7 @@ import {
   EDITABLE_DOMAINS_WITH_UNIQUE_ID,
   computeShowHistoryComponent,
   computeShowLogBookComponent,
+  computeCustomShowNewMoreInfo,
 } from "./const";
 import "./controls/more-info-default";
 import "./ha-more-info-history-and-logbook";
@@ -150,9 +151,13 @@ export class MoreInfoDialog extends LitElement {
     return false;
   }
 
-  private shouldShowHistory(domain: string): boolean {
+  private shouldShowHistory(
+    domain: string,
+    stateObj: HassEntity | undefined
+  ): boolean {
+    const isCustomNewMoreInfo = stateObj && computeCustomShowNewMoreInfo(stateObj);
     return (
-      DOMAINS_WITH_MORE_INFO.includes(domain) &&
+      (DOMAINS_WITH_MORE_INFO.includes(domain) || isCustomNewMoreInfo) &&
       (computeShowHistoryComponent(this.hass, this._entityId!) ||
         computeShowLogBookComponent(this.hass, this._entityId!))
     );
@@ -299,7 +304,7 @@ export class MoreInfoDialog extends LitElement {
           </span>
           ${isInfoView
             ? html`
-                ${this.shouldShowHistory(domain)
+                ${this.shouldShowHistory(domain, stateObj)
                   ? html`
                       <ha-icon-button
                         slot="actionItems"

--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -40,9 +40,10 @@ export class MoreInfoInfo extends LitElement {
     const stateObj = this.hass.states[entityId] as HassEntity | undefined;
     const entityRegObj = this.hass.entities[entityId];
     const domain = computeDomain(entityId);
-    const isCustomNewMoreInfo = stateObj && computeCustomShowNewMoreInfo(stateObj);
-    const isNewMoreInfo = stateObj &&
-      (computeShowNewMoreInfo(stateObj) || isCustomNewMoreInfo);
+    const isCustomNewMoreInfo =
+      stateObj && computeCustomShowNewMoreInfo(stateObj);
+    const isNewMoreInfo =
+      stateObj && (computeShowNewMoreInfo(stateObj) || isCustomNewMoreInfo);
 
     return html`
       <div class="container" data-domain=${domain}>

--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -8,6 +8,7 @@ import type { HomeAssistant } from "../../types";
 import {
   computeShowHistoryComponent,
   computeShowLogBookComponent,
+  computeCustomShowNewMoreInfo,
   computeShowNewMoreInfo,
   DOMAINS_NO_INFO,
   DOMAINS_WITH_MORE_INFO,
@@ -39,7 +40,9 @@ export class MoreInfoInfo extends LitElement {
     const stateObj = this.hass.states[entityId] as HassEntity | undefined;
     const entityRegObj = this.hass.entities[entityId];
     const domain = computeDomain(entityId);
-    const isNewMoreInfo = stateObj && computeShowNewMoreInfo(stateObj);
+    const isCustomNewMoreInfo = stateObj && computeCustomShowNewMoreInfo(stateObj);
+    const isNewMoreInfo = stateObj &&
+      (computeShowNewMoreInfo(stateObj) || isCustomNewMoreInfo);
 
     return html`
       <div class="container" data-domain=${domain}>
@@ -71,6 +74,7 @@ export class MoreInfoInfo extends LitElement {
                 ></state-card-content>
               `}
           ${DOMAINS_WITH_MORE_INFO.includes(domain) ||
+          isCustomNewMoreInfo ||
           !computeShowHistoryComponent(this.hass, entityId)
             ? ""
             : html`<ha-more-info-history
@@ -78,6 +82,7 @@ export class MoreInfoInfo extends LitElement {
                 .entityId=${this.entityId}
               ></ha-more-info-history>`}
           ${DOMAINS_WITH_MORE_INFO.includes(domain) ||
+          isCustomNewMoreInfo ||
           !computeShowLogBookComponent(this.hass, entityId)
             ? ""
             : html`<ha-more-info-logbook


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This PR introduces an optional new entity attribute, `custom_ui_new_more_info`, that when set to `True` causes the more-info dialog for the entity to render using the "new" more-info design (already used by the `climate` or `light` entities). This extends the functionality of the already existing `custom_ui_more_info` attribute.

The new design (which predates this PR) gives components control over the content at the top of the more-info dialog, by moving the logbook & history sections to another tab.

This PR is primarily intended for custom components that create new entity types, want them to be accessible using the standard front-end entity cards and more-info dialogs, but want to surface important information earlier in the more-info dialog.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/discussions/17790
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
