### PR TITLE
Fix hide disabled entities button

### DIFF
--- a/src/panels/config/devices/device-detail/ha-device-entities-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-entities-card.ts
@@ -112,7 +112,7 @@ export class HaDeviceEntitiesCard extends LitElement {
                 ${hiddenEntities.map((entry) => this._renderEntry(entry))}
                 <button class="show-more" @click=${this._toggleShowHidden}>
                   ${this.hass.localize(
-                    "ui.panel.config.devices.entities.hide_disabled"
+                    "ui.panel.config.devices.entities.show_less"
                   )}
                 </button>
               `


### PR DESCRIPTION
## Proposed change

Right now the button to collapse disabled entities is broken, because it uses a non-existent translation key. This fixes it to use the one that was probably intended.
How it is right now:
![image](https://github.com/home-assistant/frontend/assets/10727862/fdae396b-816d-49c1-b080-f80b5db7f75c)

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## How to test

Settings > integrations > open a device with hidden entities > click "+x entities not shown" > see collapse button

## Additional information

All of these translations also need to be fixed (I'm not doing them because I don't know how Lokalize works):
```
not found event ui.panel.config.automation.editor.conditions.type.zone.event
not found traces_not_available ui.panel.config.automation.picker.traces_not_available
not found hide_disabled ui.panel.config.devices.entities.hide_disabled
not found none ui.panel.config.zwave_js.security_classes.none.title
not found state ui.panel.config.scene.picker.headers.state
not found device_entities ui.panel.config.scene.editor.entities.device_entities
```

*no issues, discussions, or documentation is relevant here*

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io