### PR TITLE
Subscribe to config entries in helper config

### DIFF
--- a/src/components/ha-conversation-agent-picker.ts
+++ b/src/components/ha-conversation-agent-picker.ts
@@ -155,11 +155,12 @@ export class HaConversationAgentPicker extends LitElement {
     if (!this._configEntry) {
       return;
     }
-    showOptionsFlowDialog(
-      this,
-      this._configEntry,
-      await fetchIntegrationManifest(this.hass, this._configEntry.domain)
-    );
+    showOptionsFlowDialog(this, this._configEntry, {
+      manifest: await fetchIntegrationManifest(
+        this.hass,
+        this._configEntry.domain
+      ),
+    });
   }
 
   static get styles(): CSSResultGroup {

--- a/src/dialogs/config-flow/show-dialog-options-flow.ts
+++ b/src/dialogs/config-flow/show-dialog-options-flow.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { ConfigEntry } from "../../data/config_entries";
-import { domainToName, IntegrationManifest } from "../../data/integration";
+import { domainToName } from "../../data/integration";
 import {
   createOptionsFlow,
   deleteOptionsFlow,
@@ -8,6 +8,7 @@ import {
   handleOptionsFlowStep,
 } from "../../data/options_flow";
 import {
+  DataEntryFlowDialogParams,
   loadDataEntryFlowDialog,
   showFlowDialog,
 } from "./show-dialog-data-entry-flow";
@@ -17,14 +18,14 @@ export const loadOptionsFlowDialog = loadDataEntryFlowDialog;
 export const showOptionsFlowDialog = (
   element: HTMLElement,
   configEntry: ConfigEntry,
-  manifest?: IntegrationManifest | null
+  dialogParams?: Omit<DataEntryFlowDialogParams, "flowConfig">
 ): void =>
   showFlowDialog(
     element,
     {
       startFlowHandler: configEntry.entry_id,
       domain: configEntry.domain,
-      manifest,
+      ...dialogParams,
     },
     {
       flowType: "options_flow",

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -1336,7 +1336,7 @@ export class EntityRegistrySettingsEditor extends LitElement {
   }
 
   private async _showOptionsFlow() {
-    showOptionsFlowDialog(this, this.helperConfigEntry!, null);
+    showOptionsFlowDialog(this, this.helperConfigEntry!);
   }
 
   private _switchAsDomainsSorted = memoizeOne(

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -1157,9 +1157,8 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
   private async _removeIntegration(configEntry: ConfigEntry) {
     const entryId = configEntry.entry_id;
 
-    const applicationCredentialsId = await this._applicationCredentialForRemove(
-      entryId
-    );
+    const applicationCredentialsId =
+      await this._applicationCredentialForRemove(entryId);
 
     const confirmed = await showConfirmationDialog(this, {
       title: this.hass.localize(

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -1024,7 +1024,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
     showOptionsFlowDialog(
       this,
       ev.target.closest(".config_entry").configEntry,
-      this._manifest
+      { manifest: this._manifest }
     );
   }
 
@@ -1157,8 +1157,9 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
   private async _removeIntegration(configEntry: ConfigEntry) {
     const entryId = configEntry.entry_id;
 
-    const applicationCredentialsId =
-      await this._applicationCredentialForRemove(entryId);
+    const applicationCredentialsId = await this._applicationCredentialForRemove(
+      entryId
+    );
 
     const confirmed = await showConfirmationDialog(this, {
       title: this.hass.localize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

We did not update when config entries where changed, for example if they where deleted.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
