### PR TITLE
Cache brand images

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "vue": "2.7.14",
     "vue2-daterange-picker": "0.6.8",
     "weekstart": "2.0.0",
+    "workbox-cacheable-response": "7.0.0",
     "workbox-core": "7.0.0",
     "workbox-expiration": "7.0.0",
     "workbox-precaching": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "vue": "2.7.14",
     "vue2-daterange-picker": "0.6.8",
     "weekstart": "2.0.0",
-    "workbox-cacheable-response": "7.0.0",
     "workbox-core": "7.0.0",
     "workbox-expiration": "7.0.0",
     "workbox-precaching": "7.0.0",

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -136,10 +136,9 @@ export class StateBadge extends LitElement {
         backgroundImage = `url(${imageUrl})`;
         this._showIcon = false;
         if (domain === "update") {
-          hostStyle.borderRadius = "0";
-        }
-        if (domain === "media_player") {
-          hostStyle.borderRadius = "8%";
+          this.style.borderRadius = "0";
+        } else if (domain === "media_player") {
+          this.style.borderRadius = "8%";
         }
       } else if (this.color) {
         // Externally provided overriding color wins over state color

--- a/src/components/entity/state-badge.ts
+++ b/src/components/entity/state-badge.ts
@@ -112,9 +112,7 @@ export class StateBadge extends LitElement {
     const stateObj = this.stateObj;
 
     const iconStyle: { [name: string]: string } = {};
-    const hostStyle: Partial<CSSStyleDeclaration> = {
-      backgroundImage: "",
-    };
+    let backgroundImage = "";
 
     this._showIcon = true;
 
@@ -135,7 +133,7 @@ export class StateBadge extends LitElement {
         if (domain === "camera") {
           imageUrl = cameraUrlWithWidthHeight(imageUrl, 80, 80);
         }
-        hostStyle.backgroundImage = `url(${imageUrl})`;
+        backgroundImage = `url(${imageUrl})`;
         this._showIcon = false;
         if (domain === "update") {
           hostStyle.borderRadius = "0";
@@ -182,12 +180,12 @@ export class StateBadge extends LitElement {
       if (this.hass) {
         imageUrl = this.hass.hassUrl(imageUrl);
       }
-      hostStyle.backgroundImage = `url(${imageUrl})`;
+      backgroundImage = `url(${imageUrl})`;
       this._showIcon = false;
     }
 
     this._iconStyle = iconStyle;
-    Object.assign(this.style, hostStyle);
+    this.style.backgroundImage = backgroundImage;
   }
 
   static get styles(): CSSResultGroup {

--- a/src/components/ha-config-entry-picker.ts
+++ b/src/components/ha-config-entry-picker.ts
@@ -64,6 +64,7 @@ class HaConfigEntryPicker extends LitElement {
           type: "icon",
           darkOptimized: this.hass.themes?.darkMode,
         })}
+        crossorigin="anonymous"
         referrerpolicy="no-referrer"
         @error=${this._onImageError}
         @load=${this._onImageLoad}

--- a/src/components/ha-related-items.ts
+++ b/src/components/ha-related-items.ts
@@ -154,6 +154,8 @@ export class HaRelatedItems extends LitElement {
                           useFallback: true,
                           darkOptimized: this.hass.themes?.darkMode,
                         })}
+                        crossorigin="anonymous"
+                        referrerpolicy="no-referrer"
                         alt=${entry.domain}
                         slot="graphic"
                       />

--- a/src/entrypoints/service_worker.ts
+++ b/src/entrypoints/service_worker.ts
@@ -28,10 +28,7 @@ const initRouting = () => {
   // Cache static content (including translations) on first access.
   registerRoute(
     /\/(static|frontend_latest|frontend_es5)\/.+/,
-    new CacheFirst({
-      cacheName: "static",
-      matchOptions: { ignoreSearch: true },
-    })
+    new CacheFirst({ matchOptions: { ignoreSearch: true } })
   );
 
   // Cache any brand images used for 30 days
@@ -75,7 +72,7 @@ const initRouting = () => {
   registerRoute(
     /\/.*/,
     new StaleWhileRevalidate({
-      cacheName: "other",
+      cacheName: "file-cache",
       plugins: [
         new ExpirationPlugin({
           maxAgeSeconds: 60 * 60 * 24,

--- a/src/entrypoints/service_worker.ts
+++ b/src/entrypoints/service_worker.ts
@@ -42,6 +42,8 @@ const initRouting = () => {
       request.destination === "image",
     new StaleWhileRevalidate({
       cacheName: "brands",
+      // CORS must be forced to work for CSS images
+      fetchOptions: { mode: "cors", credentials: "omit" },
       plugins: [
         new ExpirationPlugin({
           maxAgeSeconds: 60 * 60 * 24 * 30,

--- a/src/entrypoints/service_worker.ts
+++ b/src/entrypoints/service_worker.ts
@@ -3,6 +3,7 @@
 /// <reference path="../types/service-worker.d.ts" />
 /* eslint-env serviceworker */
 import { cacheNames, RouteHandler } from "workbox-core";
+import { CacheableResponsePlugin } from "workbox-cacheable-response";
 import { ExpirationPlugin } from "workbox-expiration";
 import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching";
 import { registerRoute, setCatchHandler } from "workbox-routing";
@@ -42,6 +43,8 @@ const initRouting = () => {
       // CORS must be forced to work for CSS images
       fetchOptions: { mode: "cors", credentials: "omit" },
       plugins: [
+        // Add 404 so we quicly respond to domains with missing images
+        new CacheableResponsePlugin({ statuses: [0, 200, 404] }),
         new ExpirationPlugin({
           maxAgeSeconds: 60 * 60 * 24 * 30,
           purgeOnQuotaError: true,

--- a/src/onboarding/integration-badge.ts
+++ b/src/onboarding/integration-badge.ts
@@ -23,6 +23,7 @@ class IntegrationBadge extends LitElement {
             type: "icon",
             darkOptimized: this.darkOptimizedIcon,
           })}
+          crossorigin="anonymous"
           referrerpolicy="no-referrer"
         />
       </div>

--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -3,6 +3,7 @@ import "@material/mwc-list/mwc-list";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import { ifDefined } from "lit/directives/if-defined";
 import memoizeOne from "memoize-one";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/entity/state-badge";
@@ -87,7 +88,9 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
             <ha-list-item
               twoline
               graphic="medium"
-              class=${entity.attributes.skipped_version ? "skipped" : ""}
+              class=${ifDefined(
+                entity.attributes.skipped_version ? "skipped" : undefined
+              )}
               .entity_id=${entity.entity_id}
               .hasMeta=${!this.narrow}
               @click=${this._openMoreInfo}
@@ -97,9 +100,11 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
                 .title=${entity.attributes.title ||
                 entity.attributes.friendly_name}
                 .stateObj=${entity}
-                class=${this.narrow && entity.attributes.in_progress
-                  ? "updating"
-                  : ""}
+                class=${ifDefined(
+                  this.narrow && entity.attributes.in_progress
+                    ? "updating"
+                    : undefined
+                )}
               ></state-badge>
               ${this.narrow && entity.attributes.in_progress
                 ? html`<ha-circular-progress

--- a/src/panels/config/devices/ha-config-device-page.ts
+++ b/src/panels/config/devices/ha-config-device-page.ts
@@ -353,6 +353,7 @@ export class HaConfigDevicePage extends LitElement {
                 type: "icon",
                 darkOptimized: this.hass.themes?.darkMode,
               })}
+              crossorigin="anonymous"
               referrerpolicy="no-referrer"
             />
 
@@ -741,6 +742,7 @@ export class HaConfigDevicePage extends LitElement {
                               type: "logo",
                               darkOptimized: this.hass.themes?.darkMode,
                             })}
+                            crossorigin="anonymous"
                             referrerpolicy="no-referrer"
                             @load=${this._onImageLoad}
                             @error=${this._onImageError}

--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -298,6 +298,7 @@ export class HaConfigDeviceDashboard extends LitElement {
           device.domains.length
             ? html`<img
                 alt=""
+                crossorigin="anonymous"
                 referrerpolicy="no-referrer"
                 src=${brandsUrl({
                   domain: device.domains[0],

--- a/src/panels/config/energy/components/ha-energy-grid-settings.ts
+++ b/src/panels/config/energy/components/ha-energy-grid-settings.ts
@@ -221,6 +221,7 @@ export class EnergyGridSettings extends LitElement {
             ? html`<div class="row" .entry=${this._co2ConfigEntry}>
                 <img
                   alt=""
+                  crossorigin="anonymous"
                   referrerpolicy="no-referrer"
                   src=${brandsUrl({
                     domain: "co2signal",
@@ -246,6 +247,7 @@ export class EnergyGridSettings extends LitElement {
                 <div class="row border-bottom">
                   <img
                     alt=""
+                    crossorigin="anonymous"
                     referrerpolicy="no-referrer"
                     src=${brandsUrl({
                       domain: "co2signal",

--- a/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
+++ b/src/panels/config/energy/dialogs/dialog-energy-solar-settings.ts
@@ -155,6 +155,7 @@ export class DialogEnergySolarSettings
                     >
                       <img
                         alt=""
+                        crossorigin="anonymous"
                         referrerpolicy="no-referrer"
                         style="height: 24px; margin-right: 16px;"
                         src=${brandsUrl({

--- a/src/panels/config/hardware/ha-config-hardware.ts
+++ b/src/panels/config/hardware/ha-config-hardware.ts
@@ -282,7 +282,14 @@ class HaConfigHardware extends SubscribeMixin(LitElement) {
             ? html`
                 <ha-card outlined>
                   <div class="card-content">
-                    ${imageURL ? html`<img alt="" src=${imageURL} />` : ""}
+                    ${imageURL
+                      ? html`<img
+                          alt=""
+                          src=${imageURL}
+                          crossorigin="anonymous"
+                          referrerpolicy="no-referrer"
+                        />`
+                      : ""}
                     <div class="board-info">
                       <p class="primary-text">
                         ${boardName ||

--- a/src/panels/config/helpers/dialog-helper-detail.ts
+++ b/src/panels/config/helpers/dialog-helper-detail.ts
@@ -207,13 +207,14 @@ export class DialogHelperDetail extends LitElement {
                 <img
                   slot="graphic"
                   loading="lazy"
+                  alt=""
                   src=${brandsUrl({
                     domain,
                     type: "icon",
                     useFallback: true,
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
-                  aria-hidden="true"
+                  crossorigin="anonymous"
                   referrerpolicy="no-referrer"
                 />
                 <span class="item-text"> ${label} </span>

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -261,6 +261,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
                       type: "logo",
                       darkOptimized: this.hass.themes?.darkMode,
                     })}
+                    crossorigin="anonymous"
                     referrerpolicy="no-referrer"
                     @load=${this._onImageLoad}
                     @error=${this._onImageError}

--- a/src/panels/config/integrations/ha-domain-integrations.ts
+++ b/src/panels/config/integrations/ha-domain-integrations.ts
@@ -61,6 +61,7 @@ class HaDomainIntegrations extends LitElement {
                       useFallback: true,
                       darkOptimized: this.hass.themes?.darkMode,
                     })}
+                    crossorigin="anonymous"
                     referrerpolicy="no-referrer"
                   />
                   <span
@@ -106,6 +107,7 @@ class HaDomainIntegrations extends LitElement {
                     useFallback: true,
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
+                  crossorigin="anonymous"
                   referrerpolicy="no-referrer"
                 />
                 <span
@@ -168,6 +170,7 @@ class HaDomainIntegrations extends LitElement {
                 useFallback: true,
                 darkOptimized: this.hass.themes?.darkMode,
               })}
+              crossorigin="anonymous"
               referrerpolicy="no-referrer"
             />
             <span

--- a/src/panels/config/integrations/ha-integration-action-card.ts
+++ b/src/panels/config/integrations/ha-integration-action-card.ts
@@ -35,6 +35,7 @@ export class HaIntegrationActionCard extends LitElement {
               type: "icon",
               darkOptimized: this.hass.themes?.darkMode,
             })}
+            crossorigin="anonymous"
             referrerpolicy="no-referrer"
             @error=${this._onImageError}
             @load=${this._onImageLoad}

--- a/src/panels/config/integrations/ha-integration-header.ts
+++ b/src/panels/config/integrations/ha-integration-header.ts
@@ -35,6 +35,7 @@ export class HaIntegrationHeader extends LitElement {
             type: "icon",
             darkOptimized: this.hass.themes?.darkMode,
           })}
+          crossorigin="anonymous"
           referrerpolicy="no-referrer"
           @error=${this._onImageError}
           @load=${this._onImageLoad}

--- a/src/panels/config/integrations/ha-integration-list-item.ts
+++ b/src/panels/config/integrations/ha-integration-list-item.ts
@@ -58,6 +58,7 @@ export class HaIntegrationListItem extends ListItemBase {
           darkOptimized: this.hass.themes?.darkMode,
           brand: this.brand,
         })}
+        crossorigin="anonymous"
         referrerpolicy="no-referrer"
       />
     </span>`;

--- a/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
+++ b/src/panels/config/integrations/integration-panels/thread/thread-config-panel.ts
@@ -183,6 +183,7 @@ export class ThreadConfigPanel extends SubscribeMixin(LitElement) {
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
                   alt=${router.brand}
+                  crossorigin="anonymous"
                   referrerpolicy="no-referrer"
                   @error=${this._onImageError}
                   @load=${this._onImageLoad}

--- a/src/panels/config/repairs/ha-config-repairs.ts
+++ b/src/panels/config/repairs/ha-config-repairs.ts
@@ -60,6 +60,7 @@ class HaConfigRepairs extends LitElement {
                   darkOptimized: this.hass.themes?.darkMode,
                 })}
                 .title=${domainToName(this.hass.localize, issue.domain)}
+                crossorigin="anonymous"
                 referrerpolicy="no-referrer"
                 slot="graphic"
               />

--- a/src/panels/config/repairs/integrations-startup-time.ts
+++ b/src/panels/config/repairs/integrations-startup-time.ts
@@ -72,6 +72,7 @@ class IntegrationsStartupTime extends LitElement {
                   useFallback: true,
                   darkOptimized: this.hass.themes?.darkMode,
                 })}
+                crossorigin="anonymous"
                 referrerpolicy="no-referrer"
                 slot="graphic"
               />

--- a/src/panels/config/voice-assistants/assist-pref.ts
+++ b/src/panels/config/voice-assistants/assist-pref.ts
@@ -69,6 +69,7 @@ export class AssistPref extends LitElement {
               type: "icon",
               darkOptimized: this.hass.themes?.darkMode,
             })}
+            crossorigin="anonymous"
             referrerpolicy="no-referrer"
           />Assist
         </h1>

--- a/src/panels/config/voice-assistants/cloud-alexa-pref.ts
+++ b/src/panels/config/voice-assistants/cloud-alexa-pref.ts
@@ -67,6 +67,7 @@ export class CloudAlexaPref extends LitElement {
               type: "icon",
               darkOptimized: this.hass.themes?.darkMode,
             })}
+            crossorigin="anonymous"
             referrerpolicy="no-referrer"
           />${this.hass.localize("ui.panel.config.cloud.account.alexa.title")}
         </h1>

--- a/src/panels/config/voice-assistants/cloud-discover.ts
+++ b/src/panels/config/voice-assistants/cloud-discover.ts
@@ -54,6 +54,7 @@ export class CloudDiscover extends LitElement {
                     type: "icon",
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
+                  crossorigin="anonymous"
                   referrerpolicy="no-referrer"
                 />
                 <img
@@ -63,6 +64,7 @@ export class CloudDiscover extends LitElement {
                     type: "icon",
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
+                  crossorigin="anonymous"
                   referrerpolicy="no-referrer"
                 />
               </div>

--- a/src/panels/config/voice-assistants/cloud-google-pref.ts
+++ b/src/panels/config/voice-assistants/cloud-google-pref.ts
@@ -72,6 +72,7 @@ export class CloudGooglePref extends LitElement {
               type: "icon",
               darkOptimized: this.hass.themes?.darkMode,
             })}
+            crossorigin="anonymous"
             referrerpolicy="no-referrer"
           />${this.hass.localize("ui.panel.config.cloud.account.google.title")}
         </h1>

--- a/src/panels/config/voice-assistants/entity-voice-settings.ts
+++ b/src/panels/config/voice-assistants/entity-voice-settings.ts
@@ -225,6 +225,7 @@ export class EntityVoiceSettings extends SubscribeMixin(LitElement) {
                     type: "icon",
                     darkOptimized: this.hass.themes?.darkMode,
                   })}
+                  crossorigin="anonymous"
                   referrerpolicy="no-referrer"
                   slot="prefix"
                 />

--- a/src/panels/config/voice-assistants/expose/expose-assistant-icon.ts
+++ b/src/panels/config/voice-assistants/expose/expose-assistant-icon.ts
@@ -37,6 +37,7 @@ export class VoiceAssistantExposeAssistantIcon extends LitElement {
             type: "icon",
             darkOptimized: this.hass.themes?.darkMode,
           })}
+          crossorigin="anonymous"
           referrerpolicy="no-referrer"
           slot="prefix"
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9855,6 +9855,7 @@ __metadata:
     webpackbar: 5.0.2
     weekstart: 2.0.0
     workbox-build: 7.0.0
+    workbox-cacheable-response: 7.0.0
     workbox-core: 7.0.0
     workbox-expiration: 7.0.0
     workbox-precaching: 7.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -9855,7 +9855,6 @@ __metadata:
     webpackbar: 5.0.2
     weekstart: 2.0.0
     workbox-build: 7.0.0
-    workbox-cacheable-response: 7.0.0
     workbox-core: 7.0.0
     workbox-expiration: 7.0.0
     workbox-precaching: 7.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Needs https://github.com/home-assistant/brands/pull/4652

Enable the service worker to cache any brand images used for speed and in case of a power/internet outage.  Need to enable CORS so JS can read the response, otherwise the allocated cache size is [heavily padded due to the opaque response](https://developer.chrome.com/docs/workbox/caching-resources-during-runtime/#cross-origin-considerations).

Also...
- Adds a couple missing `referrerpolicy="no-referrer"` attributes
- Reorganize the service worker a bit to make it easier to read
- Remove cacheable response plugin (`StaleWhileRevalidate` accepts opaque responses by default)

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17560 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
