### PR TITLE
Fix default formatEntityState function

### DIFF
--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -177,10 +177,10 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
           // @ts-ignore
           this._loadFragmentTranslations(this.hass?.language, fragment),
         formatEntityState: (stateObj, state) =>
-          (state !== null ? state : stateObj.state) ?? "",
+          (state != null ? state : stateObj.state) ?? "",
         formatEntityAttributeName: (_stateObj, attribute) => attribute,
         formatEntityAttributeValue: (stateObj, attribute, value) =>
-          value !== null ? value : stateObj.attributes[attribute] ?? "",
+          value != null ? value : stateObj.attributes[attribute] ?? "",
         ...getState(),
         ...this._pendingHass,
       };


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change

The default formatEntityState seems to not be checking for undefined correctly. It says if `(state !== null)`, to render `state`. But since `undefined !== null`, any caller that omits the state value will render no state at all, instead of getting the state from the stateObj like intended. 

This is causing cards to render blank values for their state on page reload, before the hass function is updated. 

A second related problem is that many cards are not checking for formatEntityState to be updated in their `shouldUpdate` functions, and so rejecting updates when the hass.formatEntityState function changes, as it often does on first reload. All those cards will need to be fixed. 

But this is at least a band-aid on that problem.  


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue or discussion: #17846
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
