### PR TITLE
Allow custom responses for sentence triggers

### DIFF
--- a/gallery/src/pages/automation/editor-trigger.ts
+++ b/gallery/src/pages/automation/editor-trigger.ts
@@ -121,7 +121,7 @@ const SCHEMAS: { name: string; triggers: Trigger[] }[] = [
         platform: "conversation",
         command: ["Turn on the lights", "Turn the lights on"],
         response_success: "Lights are now on",
-        response_error: "Lights could not be turned on"
+        response_error: "Lights could not be turned on",
       },
     ],
   },

--- a/gallery/src/pages/automation/editor-trigger.ts
+++ b/gallery/src/pages/automation/editor-trigger.ts
@@ -120,6 +120,8 @@ const SCHEMAS: { name: string; triggers: Trigger[] }[] = [
       {
         platform: "conversation",
         command: ["Turn on the lights", "Turn the lights on"],
+        response_success: "Lights are now on",
+        response_error: "Lights could not be turned on"
       },
     ],
   },

--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -110,6 +110,8 @@ export interface NumericStateTrigger extends BaseTrigger {
 export interface ConversationTrigger extends BaseTrigger {
   platform: "conversation";
   command: string | string[];
+  response_success: string;
+  response_error: string;
 }
 
 export interface SunTrigger extends BaseTrigger {

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-conversation.ts
@@ -9,8 +9,13 @@ import { ConversationTrigger } from "../../../../../data/automation";
 import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dialog-box";
 import { HomeAssistant } from "../../../../../types";
 import { TriggerElement } from "../ha-automation-trigger-row";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
 
 const PATTERN = "^[^.。,，?¿？؟!！;；:：]+$";
+const RESPONSE_SCHEMA = [
+  { name: "response_success", selector: { template: {} } },
+  { name: "response_error", selector: { text: {} } },
+] as const;
 
 @customElement("ha-automation-trigger-conversation")
 export class HaConversationTrigger
@@ -26,7 +31,7 @@ export class HaConversationTrigger
   @query("#option_input", true) private _optionInput?: HaTextField;
 
   public static get defaultConfig(): Omit<ConversationTrigger, "platform"> {
-    return { command: "" };
+    return { command: "", response_success: "", response_error: "" };
   }
 
   protected render() {
@@ -71,7 +76,13 @@ export class HaConversationTrigger
         pattern=${PATTERN}
         @keydown=${this._handleKeyAdd}
         @change=${this._addOption}
-      ></ha-textfield>`;
+      ></ha-textfield>
+      <ha-form
+        .hass=${this.hass}
+        .data=${this.trigger}
+        .schema=${RESPONSE_SCHEMA}
+        .computeLabel=${this._computeLabelCallback}
+      ></ha-form>`;
   }
 
   private _handleKeyAdd(ev: KeyboardEvent) {
@@ -142,6 +153,13 @@ export class HaConversationTrigger
       value: { ...this.trigger, command },
     });
   }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<typeof RESPONSE_SCHEMA>
+  ): string =>
+    this.hass.localize(
+      `ui.panel.config.automation.editor.triggers.type.conversation.${schema.name}`
+    );
 
   static get styles(): CSSResultGroup {
     return css`

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2462,6 +2462,8 @@
                   "no_punctuation": "You should not use punctuation in your sentence",
                   "add_sentence": "Add sentence",
                   "delete": "Delete sentence",
+                  "response_success": "Response when the automation runs successfully",
+                  "response_error": "Response when the automation run produces errors",
                   "confirm_delete": "Are you sure you want to delete this sentence?",
                   "description": {
                     "empty": "When a sentence is said",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add selectors for `response_success` (template) and `response_error` (text) in the sentence trigger input, as UI support for https://github.com/home-assistant/core/pull/99870.

Along with https://github.com/home-assistant/core/pull/99870 this is the first time the user is able to configure an entire voice query/response flow **strictly from the UI**.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
automation:
  trigger:
    - platform: conversation
      command: "what's on my calendar today"
      response_success: "{{ my_events.events | map(attribute='summary') | join(', ') }}"
      response_error: "Sorry, I can't get your calendar events right now"
  action:
    - service: calendar.list_events
      data:
        duration:
          hours: 24
          minutes: 0
          seconds: 0
      target:
        entity_id: calendar.my_calendar
      response_variable: my_events
```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/intents/issues/1450
- This PR is related to issue or discussion: https://github.com/home-assistant/core/pull/99870
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28829

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
