### PR TITLE
Prevent creating views with duplicate URL

### DIFF
--- a/src/panels/lovelace/editor/config-util.ts
+++ b/src/panels/lovelace/editor/config-util.ts
@@ -3,6 +3,7 @@ import {
   LovelaceConfig,
   LovelaceViewConfig,
 } from "../../../data/lovelace";
+import type { HomeAssistant } from "../../../types";
 
 export const addCard = (
   config: LovelaceConfig,
@@ -253,23 +254,44 @@ export const moveCard = (
 };
 
 export const addView = (
+  hass: HomeAssistant,
   config: LovelaceConfig,
   viewConfig: LovelaceViewConfig
-): LovelaceConfig => ({
-  ...config,
-  views: config.views.concat(viewConfig),
-});
+): LovelaceConfig => {
+  if (viewConfig.path && config.views.some((v) => v.path === viewConfig.path)) {
+    throw new Error(
+      hass.localize("ui.panel.lovelace.editor.edit_view.error_same_url")
+    );
+  }
+  return {
+    ...config,
+    views: config.views.concat(viewConfig),
+  };
+};
 
 export const replaceView = (
+  hass: HomeAssistant,
   config: LovelaceConfig,
   viewIndex: number,
   viewConfig: LovelaceViewConfig
-): LovelaceConfig => ({
-  ...config,
-  views: config.views.map((origView, index) =>
-    index === viewIndex ? viewConfig : origView
-  ),
-});
+): LovelaceConfig => {
+  if (
+    viewConfig.path &&
+    config.views.some(
+      (v, idx) => v.path === viewConfig.path && idx !== viewIndex
+    )
+  ) {
+    throw new Error(
+      hass.localize("ui.panel.lovelace.editor.edit_view.error_same_url")
+    );
+  }
+  return {
+    ...config,
+    views: config.views.map((origView, index) =>
+      index === viewIndex ? viewConfig : origView
+    ),
+  };
+};
 
 export const swapView = (
   config: LovelaceConfig,

--- a/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
+++ b/src/panels/lovelace/editor/view-editor/hui-dialog-edit-view.ts
@@ -405,8 +405,13 @@ export class HuiDialogEditView extends LitElement {
     try {
       await lovelace.saveConfig(
         this._creatingView
-          ? addView(lovelace.config, viewConf)
-          : replaceView(lovelace.config, this._params.viewIndex!, viewConf)
+          ? addView(this.hass!, lovelace.config, viewConf)
+          : replaceView(
+              this.hass!,
+              lovelace.config,
+              this._params.viewIndex!,
+              viewConf
+            )
       );
       if (this._params.saveCallback) {
         this._params.saveCallback(
@@ -417,7 +422,9 @@ export class HuiDialogEditView extends LitElement {
       this.closeDialog();
     } catch (err: any) {
       showAlertDialog(this, {
-        text: `Saving failed: ${err.message}`,
+        text: `${this.hass!.localize(
+          "ui.panel.lovelace.editor.edit_view.saving_failed"
+        )}: ${err.message}`,
       });
     } finally {
       this._saving = false;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4621,7 +4621,9 @@
             "subview": "Subview",
             "subview_helper": "Subviews don't appear in tabs and have a back button.",
             "edit_ui": "Edit in visual editor",
-            "edit_yaml": "Edit in YAML"
+            "edit_yaml": "Edit in YAML",
+            "saving_failed": "Saving failed",
+            "error_same_url": "You cannot save a view with the same URL as a different existing view."
           },
           "edit_badges": {
             "view_no_badges": "Badges are not be supported by the current view type."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Disallow a user from creating (or modifying) a view with the same URL as an existing view. I've done this myself a few times by accident and it is always somewhat annoying, as it creates a phantom tab that you cannot click on, and has to be cleaned up by manually editing it out of the yaml. 

I'm aware there was also some prior discussion about views with integer names aliasing with the view's index, but this PR does not attempt to address that, it only checks for view URLs with a string that match another view's URL with the same string. 


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
