### PR TITLE
Ensure custom colors work with cover tile features

### DIFF
--- a/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
@@ -70,8 +70,8 @@ class HuiCoverPositionTileFeature
       ? computeCssColor(this.color)
       : stateColorCss(this.stateObj, forcedState);
 
-    // Since we are overwriting/forcing the closed color to be the open one for
-    // the default HA theme, we need to explicitly include the custom color var here.
+    // Since we are overwriting/forcing the closed state color to be the open one (to prevent
+    // gray sliders in the default theme), we need to explicitly include the custom color var here.
     if (this.stateObj.state === "closed") {
       color = `var(--state-cover-closed-color, ${color})`;
     }

--- a/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
@@ -66,9 +66,15 @@ class HuiCoverPositionTileFeature
 
     const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
 
-    const color = this.color
+    let color = this.color
       ? computeCssColor(this.color)
       : stateColorCss(this.stateObj, forcedState);
+
+    // Since we are overwriting/forcing the closed color to be the open one for
+    // the default HA theme, we need to explicitly include the custom color var here.
+    if (this.stateObj.state === "closed") {
+      color = `var(--state-cover-closed-color, ${color})`;
+    }
 
     const style = {
       "--color": color,

--- a/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
@@ -66,9 +66,15 @@ class HuiCoverTiltPositionTileFeature
 
     const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
 
-    const color = this.color
+    let color = this.color
       ? computeCssColor(this.color)
       : stateColorCss(this.stateObj, forcedState);
+
+    // Since we are overwriting/forcing the closed color to be the open one for
+    // the default HA theme, we need to explicitly include the custom color var here.
+    if (this.stateObj.state === "closed") {
+      color = `var(--state-cover-closed-color, ${color})`;
+    }
 
     const style = {
       "--color": color,

--- a/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
@@ -70,8 +70,8 @@ class HuiCoverTiltPositionTileFeature
       ? computeCssColor(this.color)
       : stateColorCss(this.stateObj, forcedState);
 
-    // Since we are overwriting/forcing the closed color to be the open one for
-    // the default HA theme, we need to explicitly include the custom color var here.
+    // Since we are overwriting/forcing the closed state color to be the open one (to prevent
+    // gray sliders in the default theme), we need to explicitly include the custom color var here.
     if (this.stateObj.state === "closed") {
       color = `var(--state-cover-closed-color, ${color})`;
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

Issue reported in release thread: https://community.home-assistant.io/t/2023-9-new-climate-entity-dialogs-lots-of-tile-features-and-template-sensors-from-the-ui/611299/206

This PR https://github.com/home-assistant/frontend/pull/17685 enforced that the closed state color should be the same as the open one (needed for the HA default theme to prevent gray sliders). However that means we are ignoring the color vars from themes. This PR is a workarund, although there might be a nicer way perhaps?

To recreate use a theme that sets:
```
      state-cover-closed-color: maroon
      state-cover-closing-color: blue
      state-cover-open-color: gold
      state-cover-opening-color: orange
      state-cover-unknown-color: slategrey
```

Closed state should be maroon, but is actually gold without this fix.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
