### PR TITLE
Add todo component that supports multiple To-do lists.

### DIFF
--- a/src/components/ha-sidebar.ts
+++ b/src/components/ha-sidebar.ts
@@ -2,12 +2,12 @@ import "@material/mwc-button/mwc-button";
 import {
   mdiBell,
   mdiCalendar,
-  mdiCart,
   mdiCellphoneCog,
   mdiChartBox,
   mdiClose,
   mdiCog,
   mdiFormatListBulletedType,
+  mdiCartCheck,
   mdiHammer,
   mdiLightningBolt,
   mdiMenu,
@@ -81,7 +81,7 @@ const PANEL_ICONS = {
   lovelace: mdiViewDashboard,
   map: mdiTooltipAccount,
   "media-browser": mdiPlayBoxMultiple,
-  "shopping-list": mdiCart,
+  todo: mdiCartCheck,
 };
 
 const panelSorter = (

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -2,7 +2,6 @@ import { HomeAssistant } from "../types";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateName } from "../common/entity/compute_state_name";
 import { isUnavailableState } from "./entity";
-import { string } from "superstruct";
 
 export enum TodoItemStatus {
   NeedsAction = "NEEDS-ACTION",

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -1,0 +1,101 @@
+import { HomeAssistant } from "../types";
+import { computeDomain } from "../common/entity/compute_domain";
+import { computeStateName } from "../common/entity/compute_state_name";
+import { isUnavailableState } from "./entity";
+
+export enum TodoItemStatus {
+  NeedsAction = "NEEDS-ACTION",
+  Completed = "COMPLETED",
+}
+
+export interface TodoList {
+  entity_id: string;
+  name: string;
+}
+
+export interface TodoItem {
+  uid?: string;
+  summary: string;
+  status: TodoItemStatus;
+}
+
+export const enum TodoListEntityFeature {
+  CREATE_TODO_ITEM = 1,
+  DELETE_TODO_ITEM = 2,
+  UPDATE_TODO_ITEM = 4,
+}
+
+export const getTodoLists = (hass: HomeAssistant): TodoList[] =>
+  Object.keys(hass.states)
+    .filter(
+      (entityId) =>
+        computeDomain(entityId) === "todo" &&
+        !isUnavailableState(hass.states[entityId].state)
+    )
+    .sort()
+    .map((entityId) => ({
+      entity_id: entityId,
+      name: computeStateName(hass.states[entityId]),
+    }));
+
+// export const fetchTodoLists = (hass: HomeAssistant): Promise<TodoItem[]> =>
+//   hass.callWS({
+//       type: "todo/list",
+//   });
+
+export interface TodoItems {
+  items: TodoItem[];
+}
+
+export const fetchItems = async (
+  hass: HomeAssistant,
+  entityId: string
+): Promise<TodoItem[]> => {
+  const result = await hass.callWS<TodoItems>({
+    type: "todo/item/list",
+    entity_id: entityId,
+  });
+  return result.items;
+};
+
+export const updateItem = (
+  hass: HomeAssistant,
+  entityId: string,
+  item: TodoItem
+): Promise<void> =>
+  hass.callWS({
+    type: "todo/item/update",
+    entity_id: entityId,
+    item: item,
+  });
+
+export const addItem = (
+  hass: HomeAssistant,
+  entityId: string,
+  name: string
+): Promise<void> =>
+  hass.callWS({
+    type: "todo/items/create",
+    entity_id: entityId,
+    item: { name: name },
+  });
+
+export const removeItem = (
+  hass: HomeAssistant,
+  entityId: string,
+  itemId: string
+): Promise<void> =>
+  hass.callWS({
+    type: "todo/item/delete",
+    entity_id: entityId,
+    item_id: itemId,
+  });
+
+// export const reorderItems = (
+//   hass: HomeAssistant,
+//   itemIds: string[]
+// ): Promise<ShoppingListItem> =>
+//   hass.callWS({
+//     type: "shopping_list/items/reorder",
+//     item_ids: itemIds,
+//   });

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -23,6 +23,7 @@ export const enum TodoListEntityFeature {
   CREATE_TODO_ITEM = 1,
   DELETE_TODO_ITEM = 2,
   UPDATE_TODO_ITEM = 4,
+  MOVE_TODO_ITEM = 8,
 }
 
 export const getTodoLists = (hass: HomeAssistant): TodoList[] =>

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -2,6 +2,7 @@ import { HomeAssistant } from "../types";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateName } from "../common/entity/compute_state_name";
 import { isUnavailableState } from "./entity";
+import { string } from "superstruct";
 
 export enum TodoItemStatus {
   NeedsAction = "NEEDS-ACTION",
@@ -38,11 +39,6 @@ export const getTodoLists = (hass: HomeAssistant): TodoList[] =>
       name: computeStateName(hass.states[entityId]),
     }));
 
-// export const fetchTodoLists = (hass: HomeAssistant): Promise<TodoItem[]> =>
-//   hass.callWS({
-//       type: "todo/list",
-//   });
-
 export interface TodoItems {
   items: TodoItem[];
 }
@@ -69,33 +65,37 @@ export const updateItem = (
     item: item,
   });
 
-export const addItem = (
+export const createItem = (
   hass: HomeAssistant,
   entityId: string,
-  name: string
+  summary: string
 ): Promise<void> =>
   hass.callWS({
-    type: "todo/items/create",
+    type: "todo/item/create",
     entity_id: entityId,
-    item: { name: name },
+    item: { summary: summary },
   });
 
-export const removeItem = (
+export const deleteItems = (
   hass: HomeAssistant,
   entityId: string,
-  itemId: string
+  uids: Array<string>
 ): Promise<void> =>
   hass.callWS({
     type: "todo/item/delete",
     entity_id: entityId,
-    item_id: itemId,
+    uids: uids,
   });
 
-// export const reorderItems = (
-//   hass: HomeAssistant,
-//   itemIds: string[]
-// ): Promise<ShoppingListItem> =>
-//   hass.callWS({
-//     type: "shopping_list/items/reorder",
-//     item_ids: itemIds,
-//   });
+export const moveItem = (
+  hass: HomeAssistant,
+  entityId: string,
+  uid: string,
+  previous: string
+): Promise<void> =>
+  hass.callWS({
+    type: "todo/item/move",
+    entity_id: entityId,
+    uid: uid,
+    previous: previous,
+  });

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -107,7 +107,6 @@ class HuiShoppingListCard
           this._config!.entities.length === 0 ||
           todoList.entity_id in this._config!.entities
       );
-      this._todoLists.push({ entity_id: "fake", name: "Fake" });
       if (!this._entityId && this._todoLists.length > 0) {
         this._entityId = this._todoLists[0].entity_id;
       }
@@ -297,7 +296,7 @@ class HuiShoppingListCard
     const checkedItems: TodoItem[] = [];
     const uncheckedItems: TodoItem[] = [];
     const items = await fetchItems(this.hass!, this._entityId!);
-    const records: Record<string, TodoItemList> = {};
+    const records: Record<string, TodoItem> = {};
     items.forEach((item) => {
       records[item.uid] = item;
       if (item.status === TodoItemStatus.Completed) {
@@ -324,7 +323,7 @@ class HuiShoppingListCard
       status: ev.target.checked
         ? TodoItemStatus.Completed
         : TodoItemStatus.NeedsAction,
-    }).catch(() => this._fetchData());
+    }).finally(() => this._fetchData());
   }
 
   private _saveEdit(ev): void {
@@ -334,9 +333,9 @@ class HuiShoppingListCard
       updateItem(this.hass!, this._entityId!, {
         ...item,
         summary: ev.target.value,
-      }).catch(() => this._fetchData());
+      }).finally(() => this._fetchData());
     } else {
-      deleteItems(this.hass!, this._entityId!, [ev.target.itemId]).catch(() =>
+      deleteItems(this.hass!, this._entityId!, [ev.target.itemId]).finally(() =>
         this._fetchData()
       );
     }
@@ -350,7 +349,7 @@ class HuiShoppingListCard
       this._checkedItems.forEach((item: TodoItem) => {
         uids.push(item.uid);
       });
-      deleteItems(this.hass, this._entityId!, uids).catch(() =>
+      deleteItems(this.hass, this._entityId!, uids).finally(() =>
         this._fetchData()
       );
     }
@@ -362,9 +361,8 @@ class HuiShoppingListCard
 
   private _addItem(ev): void {
     const newItem = this._newItem;
-
     if (newItem.value!.length > 0) {
-      createItem(this.hass!, this._entityId!, newItem.value!).catch(() =>
+      createItem(this.hass!, this._entityId!, newItem.value!).finally(() =>
         this._fetchData()
       );
     }

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -149,7 +149,7 @@ class HuiShoppingListCard
               <ha-select
                 class="todoList"
                 label=${this.hass.localize(
-                  "ui.panel.lovelace.cards.todo.lists"
+                  "ui.panel.lovelace.cards.shopping-list.lists"
                 )}
                 .value=${this._entityId}
                 @selected=${this._selectTodoList}
@@ -298,7 +298,7 @@ class HuiShoppingListCard
     const items = await fetchItems(this.hass!, this._entityId!);
     const records: Record<string, TodoItem> = {};
     items.forEach((item) => {
-      records[item.uid] = item;
+      records[item.uid!] = item;
       if (item.status === TodoItemStatus.Completed) {
         checkedItems.push(item);
       } else {
@@ -346,8 +346,8 @@ class HuiShoppingListCard
   private _clearCompletedItems(): void {
     if (this.hass) {
       const uids: Array<string> = [];
-      this._checkedItems.forEach((item: TodoItem) => {
-        uids.push(item.uid);
+      this._checkedItems!.forEach((item: TodoItem) => {
+        uids.push(item.uid!);
       });
       deleteItems(this.hass, this._entityId!, uids).finally(() =>
         this._fetchData()

--- a/src/panels/lovelace/cards/hui-shopping-list-card.ts
+++ b/src/panels/lovelace/cards/hui-shopping-list-card.ts
@@ -156,39 +156,42 @@ class HuiShoppingListCard
         })}
       >
         ${this._todoLists.length >= 0
-          ? html` <ha-button-menu
-              class="todoList"
-              label=${this.hass.localize(
-                "ui.panel.lovelace.cards.shopping-list.lists"
-              )}
-              .value=${this._entityId}
-              @selected=${this._selectTodoList}
-              activatable
-              fixed
-            >
-              <ha-button slot="trigger">
-                ${this._entityName}
-                <ha-svg-icon
-                  slot="trailingIcon"
-                  .path=${mdiChevronDown}
-                ></ha-svg-icon>
-              </ha-button>
-              ${this._todoLists?.map(
-                (item) =>
-                  html` <ha-list-item
-                    ?selected=${item.entity_id === this._entityId}
-                    .value=${item.entity_id}
-                    .item=${item}
-                    @click=${this._selectTodoList}
-                  >
-                    ${item.name}
-                  </ha-list-item>`
-              )}
-            </ha-button-menu>`
+          ? html`
+              <ha-button-menu
+                class="todoList"
+                label=${this.hass.localize(
+                  "ui.panel.lovelace.cards.shopping-list.lists"
+                )}
+                .value=${this._entityId}
+                @selected=${this._selectTodoList}
+                activatable
+                fixed
+              >
+                <ha-button slot="trigger">
+                  ${this._entityName}
+                  <ha-svg-icon
+                    slot="trailingIcon"
+                    .path=${mdiChevronDown}
+                  ></ha-svg-icon>
+                </ha-button>
+                ${this._todoLists?.map(
+                  (item) =>
+                    html` <ha-list-item
+                      ?selected=${item.entity_id === this._entityId}
+                      .value=${item.entity_id}
+                      .item=${item}
+                      @click=${this._selectTodoList}
+                    >
+                      ${item.name}
+                    </ha-list-item>`
+                )}
+              </ha-button-menu>
+            `
           : nothing}
         <div class="addRow">
           ${this.todoListSupportsFeature(TodoListEntityFeature.CREATE_TODO_ITEM)
-            ? html` <ha-svg-icon
+            ? html`
+                <ha-svg-icon
                   class="addButton"
                   .path=${mdiPlus}
                   .title=${this.hass!.localize(
@@ -203,18 +206,21 @@ class HuiShoppingListCard
                     "ui.panel.lovelace.cards.shopping-list.add_item"
                   )}
                   @keydown=${this._addKeyPress}
-                ></ha-textfield>`
+                ></ha-textfield>
+              `
             : nothing}
           ${this.todoListSupportsFeature(TodoListEntityFeature.MOVE_TODO_ITEM)
-            ? html` <ha-svg-icon
-                class="reorderButton"
-                .path=${mdiSort}
-                .title=${this.hass!.localize(
-                  "ui.panel.lovelace.cards.shopping-list.reorder_items"
-                )}
-                @click=${this._toggleReorder}
-              >
-              </ha-svg-icon>`
+            ? html`
+                <ha-svg-icon
+                  class="reorderButton"
+                  .path=${mdiSort}
+                  .title=${this.hass!.localize(
+                    "ui.panel.lovelace.cards.shopping-list.reorder_items"
+                  )}
+                  @click=${this._toggleReorder}
+                >
+                </ha-svg-icon>
+              `
             : nothing}
         </div>
         ${this._reordering

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -429,7 +429,7 @@ export interface SensorCardConfig extends LovelaceCardConfig {
 export interface ShoppingListCardConfig extends LovelaceCardConfig {
   title?: string;
   theme?: string;
-  entities: Array<string>;
+  entities?: Array<string>;
 }
 
 export interface StackCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -429,6 +429,7 @@ export interface SensorCardConfig extends LovelaceCardConfig {
 export interface ShoppingListCardConfig extends LovelaceCardConfig {
   title?: string;
   theme?: string;
+  entities: Array<string>;
 }
 
 export interface StackCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/editor/config-elements/hui-shopping-list-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-shopping-list-editor.ts
@@ -1,10 +1,11 @@
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { assert, assign, object, optional, string } from "superstruct";
+import { array, assert, assign, object, optional, string } from "superstruct";
 import { isComponentLoaded } from "../../../../common/config/is_component_loaded";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import "../../../../components/ha-textfield";
 import "../../../../components/ha-theme-picker";
+import "../../../../components/entity/ha-entities-picker";
 import { HomeAssistant } from "../../../../types";
 import { ShoppingListCardConfig } from "../../cards/types";
 import { LovelaceCardEditor } from "../../types";
@@ -16,6 +17,7 @@ const cardConfigStruct = assign(
   object({
     title: optional(string()),
     theme: optional(string()),
+    entities: optional(array(string())),
   })
 );
 
@@ -67,6 +69,13 @@ export class HuiShoppingListEditor
           .configValue=${"title"}
           @input=${this._valueChanged}
         ></ha-textfield>
+        <ha-entities-picker
+          .hass=${this.hass!}
+          .value=${this._config.entities}
+          .includeDomains=${["todo"]}
+          @value-changed=${this._entitiesChanged}
+        >
+        </ha-entities-picker>
         <ha-theme-picker
           .hass=${this.hass}
           .value=${this._theme}
@@ -103,6 +112,11 @@ export class HuiShoppingListEditor
       }
     }
     fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  private _entitiesChanged(ev): void {
+    const config = { ...this._config!, entities: ev.detail.value };
+    fireEvent(this, "config-changed", { config });
   }
 
   static get styles(): CSSResultGroup {

--- a/src/panels/shopping-list/ha-panel-shopping-list.ts
+++ b/src/panels/shopping-list/ha-panel-shopping-list.ts
@@ -55,7 +55,7 @@ class PanelShoppingList extends LitElement {
           .hass=${this.hass}
           .narrow=${this.narrow}
         ></ha-menu-button>
-        <div slot="title">${this.hass.localize("panel.shopping_list")}</div>
+        <div slot="title">${this.hass.localize("panel.todo")}</div>
         ${this._conversation(this.hass.config.components)
           ? html`
               <ha-icon-button

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8,7 +8,7 @@
     "logbook": "Logbook",
     "history": "History",
     "mailbox": "Mailbox",
-    "todo": "To-do List",
+    "todo": "To-do Lists",
     "developer_tools": "Developer tools",
     "media_browser": "Media",
     "profile": "Profile"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -8,7 +8,7 @@
     "logbook": "Logbook",
     "history": "History",
     "mailbox": "Mailbox",
-    "shopping_list": "Shopping list",
+    "todo": "To-do List",
     "developer_tools": "Developer tools",
     "media_browser": "Media",
     "profile": "Profile"
@@ -4421,6 +4421,7 @@
             "never_triggered": "Never triggered"
           },
           "shopping-list": {
+            "lists": "To-do Lists",
             "checked_items": "Checked items",
             "clear_items": "Clear checked items",
             "add_item": "Add item",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

This updates the existing shopping-list card with support for managing multiple To-do lists using the todo component. The component is compatible with shopping-list and can support other integrations providing a To-do List. 

The shopping_list panel is renamed to todo. However, to avoid confusion for existing shopping cart users, the icon still looks like a shopping card, but it has a check next to it like a to-do check.  

The shopping_list card now can show a drop down list of a To-do list to select, or it can be configured with a specific To-do list to just show that list.

An alternative could be to leave shopping list alone and create another To-do List card, rather than going with this hybrid approach that could be a little confusing. Open to discussing the right approach for backwards compatibility as well as maintenance.

Work items:
- [ ] Fix translations
- [x] Implement switching between entities
- [x] Move edit commands to To-do list websocket APIs
- [x] verify on a second todo implementation (e.g. local todo, todoist)

Initial demo extending Shopping list card to support To-do lists:
![Todo lists](https://github.com/home-assistant/frontend/assets/6026418/30d13782-368e-4c26-9a9f-93fb67983b5c)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to architecture proposal: https://github.com/home-assistant/architecture/discussions/962
- Link to core pull request: https://github.com/home-assistant/core/pull/100019
- Link to brands pull request: https://github.com/home-assistant/brands/pull/4682
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/28925
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/1929

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
