### PR TITLE
Allow user to theme all cover states in tile card and more info.

### DIFF
--- a/src/dialogs/more-info/components/cover/ha-more-info-cover-position.ts
+++ b/src/dialogs/more-info/components/cover/ha-more-info-cover-position.ts
@@ -35,9 +35,8 @@ export class HaMoreInfoCoverPosition extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
-
-    const color = stateColorCss(this.stateObj, forcedState);
+    const openColor = stateColorCss(this.stateObj, "open");
+    const color = stateColorCss(this.stateObj);
 
     return html`
       <ha-control-slider
@@ -55,6 +54,8 @@ export class HaMoreInfoCoverPosition extends LitElement {
           "current_position"
         )}
         style=${styleMap({
+          // Use open color for inactive state to avoid grey slider that looks disabled
+          "--state-cover-inactive-color": openColor,
           "--control-slider-color": color,
           "--control-slider-background": color,
         })}

--- a/src/dialogs/more-info/components/cover/ha-more-info-cover-tilt-position.ts
+++ b/src/dialogs/more-info/components/cover/ha-more-info-cover-tilt-position.ts
@@ -72,9 +72,8 @@ export class HaMoreInfoCoverTiltPosition extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
-
-    const color = stateColorCss(this.stateObj, forcedState);
+    const openColor = stateColorCss(this.stateObj, "open");
+    const color = stateColorCss(this.stateObj);
 
     return html`
       <ha-control-slider
@@ -91,6 +90,8 @@ export class HaMoreInfoCoverTiltPosition extends LitElement {
           "current_tilt_position"
         )}
         style=${styleMap({
+          // Use open color for inactive state to avoid grey slider that looks disabled
+          "--state-cover-inactive-color": openColor,
           "--control-slider-color": color,
           "--control-slider-background": color,
         })}

--- a/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-position-tile-feature.ts
@@ -64,14 +64,16 @@ class HuiCoverPositionTileFeature
 
     const value = Math.max(Math.round(percentage), 0);
 
-    const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
+    const openColor = stateColorCss(this.stateObj, "open");
 
     const color = this.color
       ? computeCssColor(this.color)
-      : stateColorCss(this.stateObj, forcedState);
+      : stateColorCss(this.stateObj);
 
     const style = {
       "--color": color,
+      // Use open color for inactive state to avoid grey slider that looks disabled
+      "--state-cover-inactive-color": openColor,
     };
 
     return html`

--- a/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
+++ b/src/panels/lovelace/tile-features/hui-cover-tilt-position-tile-feature.ts
@@ -64,14 +64,16 @@ class HuiCoverTiltPositionTileFeature
 
     const value = Math.max(Math.round(percentage), 0);
 
-    const forcedState = this.stateObj.state === "closed" ? "open" : undefined;
+    const openColor = stateColorCss(this.stateObj, "open");
 
     const color = this.color
       ? computeCssColor(this.color)
-      : stateColorCss(this.stateObj, forcedState);
+      : stateColorCss(this.stateObj);
 
     const style = {
       "--color": color,
+      // Use open color for inactive state to avoid grey slider that looks disabled
+      "--state-cover-inactive-color": openColor,
     };
 
     return html`


### PR DESCRIPTION
Allow user to theme all cover states in tile card and more info.

Replace https://github.com/home-assistant/frontend/pull/17874

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
