### PR TITLE
Fix schedule helper form when resizing or dragging to or past midnight

### DIFF
--- a/src/panels/config/helpers/forms/ha-schedule-form.ts
+++ b/src/panels/config/helpers/forms/ha-schedule-form.ts
@@ -340,7 +340,7 @@ class HaScheduleForm extends LitElement {
     });
 
     if (!isSameDay(start, end)) {
-      this[`_${day}`] = this[`_${day}`].concat();
+      this.requestUpdate(`_${day}`);
       info.revert();
     }
   }
@@ -375,7 +375,7 @@ class HaScheduleForm extends LitElement {
     });
 
     if (!isSameDay(start, end)) {
-      this[`_${day}`] = this[`_${day}`].concat();
+      this.requestUpdate(`_${day}`);
       info.revert();
     }
   }

--- a/src/panels/config/helpers/forms/ha-schedule-form.ts
+++ b/src/panels/config/helpers/forms/ha-schedule-form.ts
@@ -340,6 +340,7 @@ class HaScheduleForm extends LitElement {
     });
 
     if (!isSameDay(start, end)) {
+      this[`_${day}`] = this[`_${day}`].concat();
       info.revert();
     }
   }
@@ -374,6 +375,7 @@ class HaScheduleForm extends LitElement {
     });
 
     if (!isSameDay(start, end)) {
+      this[`_${day}`] = this[`_${day}`].concat();
       info.revert();
     }
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Schedule helper form has a bug when either dragging an event to midnight or later, or resizing an event to midnight or later. 

The intended behavior is to snap the end of the dragged event to midnight, cancel the event pushed from the calendar, and then in the next update clear and redraw all the calendar events so that the view correctly shows the event ending at midnight. 

The select function (new event) handles this correctly, but resize and drop do not, since those functions mutate the existing `_xxxday` array, but do not change it, so the `state` decorator does not trigger the willUpdate function to reset all the events. 

This means the resized/dropped event gets reverted back to its original time, which is out of sync with the actual value of the control in memory, which correctly reflects the end time as midnight. 

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17888
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
