### PR TITLE
Refactor strategy foundation

### DIFF
--- a/cast/src/receiver/layout/hc-main.ts
+++ b/cast/src/receiver/layout/hc-main.ts
@@ -260,7 +260,7 @@ export class HcMain extends HassElement {
           {
             strategy: {
               type: "energy",
-              options: { show_date_selection: true },
+              show_date_selection: true,
             },
           },
         ],

--- a/cast/src/receiver/layout/hc-main.ts
+++ b/cast/src/receiver/layout/hc-main.ts
@@ -32,6 +32,8 @@ import { HassElement } from "../../../../src/state/hass-element";
 import { castContext } from "../cast_context";
 import "./hc-launch-screen";
 
+const DEFAULT_STRATEGY = "original-states";
+
 let resourcesLoaded = false;
 @customElement("hc-main")
 export class HcMain extends HassElement {
@@ -318,16 +320,13 @@ export class HcMain extends HassElement {
       "../../../../src/panels/lovelace/strategies/get-strategy"
     );
     this._handleNewLovelaceConfig(
-      await generateLovelaceDashboardStrategy({
-        hass: this.hass!,
-        narrow: false,
-        config: {
-          strategy: {
-            type: "original-states",
-          },
-          views: [],
+      await generateLovelaceDashboardStrategy(
+        {
+          type: DEFAULT_STRATEGY,
         },
-      })
+        this.hass!,
+        { narrow: false }
+      )
     );
   }
 

--- a/cast/src/receiver/layout/hc-main.ts
+++ b/cast/src/receiver/layout/hc-main.ts
@@ -318,13 +318,16 @@ export class HcMain extends HassElement {
       "../../../../src/panels/lovelace/strategies/get-strategy"
     );
     this._handleNewLovelaceConfig(
-      await generateLovelaceDashboardStrategy(
-        {
-          hass: this.hass!,
-          narrow: false,
+      await generateLovelaceDashboardStrategy({
+        hass: this.hass!,
+        narrow: false,
+        config: {
+          strategy: {
+            type: "original-states",
+          },
+          views: [],
         },
-        "original-states"
-      )
+      })
     );
   }
 

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -17,9 +17,9 @@ export interface LovelacePanelConfig {
   mode: "yaml" | "storage";
 }
 
-export type LovelaceStrategyConfig<T = Record<string, any>> = {
+export type LovelaceStrategyConfig = {
   type: string;
-  options?: T;
+  [key: string]: any;
 };
 
 export interface LovelaceConfig {

--- a/src/data/lovelace.ts
+++ b/src/data/lovelace.ts
@@ -17,12 +17,14 @@ export interface LovelacePanelConfig {
   mode: "yaml" | "storage";
 }
 
+export type LovelaceStrategyConfig<T = Record<string, any>> = {
+  type: string;
+  options?: T;
+};
+
 export interface LovelaceConfig {
   title?: string;
-  strategy?: {
-    type: string;
-    options?: Record<string, unknown>;
-  };
+  strategy?: LovelaceStrategyConfig;
   views: LovelaceViewConfig[];
   background?: string;
 }
@@ -81,10 +83,7 @@ export interface LovelaceViewConfig {
   index?: number;
   title?: string;
   type?: string;
-  strategy?: {
-    type: string;
-    options?: Record<string, unknown>;
-  };
+  strategy?: LovelaceStrategyConfig;
   badges?: Array<string | LovelaceBadgeConfig>;
   cards?: LovelaceCardConfig[];
   path?: string;

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -24,14 +24,14 @@ const setupWizard = async (): Promise<LovelaceViewConfig> => {
   };
 };
 
-export type EnergeryViewStrategyOptions = {
+export interface EnergeryViewStrategyConfig extends LovelaceStrategyConfig {
   show_date_selection?: boolean;
-};
+}
 
 @customElement("energy-view-strategy")
 export class EnergyViewStrategy extends ReactiveElement {
   static async generate(
-    config: LovelaceStrategyConfig<EnergeryViewStrategyOptions>,
+    config: EnergeryViewStrategyConfig,
     hass: HomeAssistant,
     params: LovelaceStrategyParams
   ): Promise<LovelaceViewConfig> {
@@ -67,7 +67,7 @@ export class EnergyViewStrategy extends ReactiveElement {
       (source) => source.type === "water"
     );
 
-    if (params.narrow || config.options?.show_date_selection) {
+    if (params.narrow || config.show_date_selection) {
       view.cards!.push({
         type: "energy-date-selection",
         collection_key: "energy_dashboard",

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -1,10 +1,12 @@
+import { ReactiveElement } from "lit";
+import { customElement } from "lit/decorators";
 import {
   EnergyPreferences,
   getEnergyPreferences,
   GridSourceTypeEnergyPreference,
 } from "../../../data/energy";
 import { LovelaceViewConfig } from "../../../data/lovelace";
-import { LovelaceViewStrategy } from "../../lovelace/strategies/get-strategy";
+import { LovelaceStrategyInfo } from "../../lovelace/strategies/types";
 
 const setupWizard = async (): Promise<LovelaceViewConfig> => {
   await import("../cards/energy-setup-wizard-card");
@@ -18,10 +20,11 @@ const setupWizard = async (): Promise<LovelaceViewConfig> => {
   };
 };
 
-export class EnergyStrategy {
-  static async generateView(
-    info: Parameters<LovelaceViewStrategy["generateView"]>[0]
-  ): ReturnType<LovelaceViewStrategy["generateView"]> {
+@customElement("energy-view-strategy")
+export class EnergyViewStrategy extends ReactiveElement {
+  static async generate(
+    info: LovelaceStrategyInfo<LovelaceViewConfig>
+  ): Promise<LovelaceViewConfig> {
     const hass = info.hass;
 
     const view: LovelaceViewConfig = { cards: [] };
@@ -56,7 +59,7 @@ export class EnergyStrategy {
       (source) => source.type === "water"
     );
 
-    if (info.narrow || info.view.strategy?.options?.show_date_selection) {
+    if (info.narrow || info.config.strategy?.options?.show_date_selection) {
       view.cards!.push({
         type: "energy-date-selection",
         collection_key: "energy_dashboard",

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -6,7 +6,11 @@ import {
   GridSourceTypeEnergyPreference,
 } from "../../../data/energy";
 import { LovelaceViewConfig } from "../../../data/lovelace";
-import { LovelaceStrategyInfo } from "../../lovelace/strategies/types";
+import { HomeAssistant } from "../../../types";
+import {
+  LovelaceStrategyConfig,
+  LovelaceStrategyParams,
+} from "../../lovelace/strategies/types";
 
 const setupWizard = async (): Promise<LovelaceViewConfig> => {
   await import("../cards/energy-setup-wizard-card");
@@ -20,13 +24,17 @@ const setupWizard = async (): Promise<LovelaceViewConfig> => {
   };
 };
 
+export type EnergeryViewStrategyOptions = {
+  show_date_selection?: boolean;
+};
+
 @customElement("energy-view-strategy")
 export class EnergyViewStrategy extends ReactiveElement {
   static async generate(
-    info: LovelaceStrategyInfo<LovelaceViewConfig>
+    config: LovelaceStrategyConfig<EnergeryViewStrategyOptions>,
+    hass: HomeAssistant,
+    params: LovelaceStrategyParams
   ): Promise<LovelaceViewConfig> {
-    const hass = info.hass;
-
     const view: LovelaceViewConfig = { cards: [] };
 
     let prefs: EnergyPreferences;
@@ -59,7 +67,7 @@ export class EnergyViewStrategy extends ReactiveElement {
       (source) => source.type === "water"
     );
 
-    if (info.narrow || info.config.strategy?.options?.show_date_selection) {
+    if (params.narrow || config.options?.show_date_selection) {
       view.cards!.push({
         type: "energy-date-selection",
         collection_key: "energy_dashboard",

--- a/src/panels/energy/strategies/energy-view-strategy.ts
+++ b/src/panels/energy/strategies/energy-view-strategy.ts
@@ -5,12 +5,12 @@ import {
   getEnergyPreferences,
   GridSourceTypeEnergyPreference,
 } from "../../../data/energy";
-import { LovelaceViewConfig } from "../../../data/lovelace";
-import { HomeAssistant } from "../../../types";
 import {
   LovelaceStrategyConfig,
-  LovelaceStrategyParams,
-} from "../../lovelace/strategies/types";
+  LovelaceViewConfig,
+} from "../../../data/lovelace";
+import { HomeAssistant } from "../../../types";
+import { LovelaceStrategyParams } from "../../lovelace/strategies/types";
 
 const setupWizard = async (): Promise<LovelaceViewConfig> => {
   await import("../cards/energy-setup-wizard-card");

--- a/src/panels/lovelace/editor/hui-dialog-save-config.ts
+++ b/src/panels/lovelace/editor/hui-dialog-save-config.ts
@@ -174,10 +174,8 @@ export class HuiSaveConfig extends LitElement implements HassDialog {
       await lovelace.saveConfig(
         this._emptyConfig
           ? EMPTY_CONFIG
-          : await expandLovelaceConfigStrategies({
-              config: lovelace.config,
-              hass: this.hass!,
-              narrow: this._params!.narrow,
+          : await expandLovelaceConfigStrategies(lovelace.config, this.hass, {
+              narrow: this._params.narrow,
             })
       );
       lovelace.setEditMode(true);

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -163,16 +163,13 @@ export class LovelacePanel extends LitElement {
   }
 
   private async _regenerateConfig() {
-    const conf = await generateLovelaceDashboardStrategy({
-      hass: this.hass!,
-      narrow: this.narrow,
-      config: {
-        strategy: {
-          type: DEFAULT_STRATEGY,
-        },
-        views: [],
+    const conf = await generateLovelaceDashboardStrategy(
+      {
+        type: DEFAULT_STRATEGY,
       },
-    });
+      this.hass!,
+      { narrow: this.narrow }
+    );
     this._setLovelaceConfig(conf, undefined, "generated");
     this._panelState = "loaded";
   }
@@ -259,11 +256,11 @@ export class LovelacePanel extends LitElement {
 
       // If strategy defined, apply it here.
       if (rawConf.strategy) {
-        conf = await generateLovelaceDashboardStrategy({
-          config: rawConf,
-          hass: this.hass!,
-          narrow: this.narrow,
-        });
+        conf = await generateLovelaceDashboardStrategy(
+          rawConf.strategy,
+          this.hass!,
+          { narrow: this.narrow }
+        );
       } else {
         conf = rawConf;
       }
@@ -275,16 +272,13 @@ export class LovelacePanel extends LitElement {
         this._errorMsg = err.message;
         return;
       }
-      conf = await generateLovelaceDashboardStrategy({
-        hass: this.hass!,
-        narrow: this.narrow,
-        config: {
-          strategy: {
-            type: DEFAULT_STRATEGY,
-          },
-          views: [],
+      conf = await generateLovelaceDashboardStrategy(
+        {
+          type: DEFAULT_STRATEGY,
         },
-      });
+        this.hass!,
+        { narrow: this.narrow }
+      );
       confMode = "generated";
     } finally {
       // Ignore updates for another 2 seconds.
@@ -369,11 +363,11 @@ export class LovelacePanel extends LitElement {
         let conf: LovelaceConfig;
         // If strategy defined, apply it here.
         if (newConfig.strategy) {
-          conf = await generateLovelaceDashboardStrategy({
-            config: newConfig,
-            hass: this.hass!,
-            narrow: this.narrow,
-          });
+          conf = await generateLovelaceDashboardStrategy(
+            newConfig.strategy,
+            this.hass!,
+            { narrow: this.narrow }
+          );
         } else {
           conf = newConfig;
         }
@@ -406,16 +400,13 @@ export class LovelacePanel extends LitElement {
         } = this.lovelace!;
         try {
           // Optimistic update
-          const generatedConf = await generateLovelaceDashboardStrategy({
-            hass: this.hass!,
-            narrow: this.narrow,
-            config: {
-              strategy: {
-                type: DEFAULT_STRATEGY,
-              },
-              views: [],
+          const generatedConf = await generateLovelaceDashboardStrategy(
+            {
+              type: DEFAULT_STRATEGY,
             },
-          });
+            this.hass!,
+            { narrow: this.narrow }
+          );
           this._updateLovelace({
             config: generatedConf,
             rawConfig: undefined,

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -163,13 +163,16 @@ export class LovelacePanel extends LitElement {
   }
 
   private async _regenerateConfig() {
-    const conf = await generateLovelaceDashboardStrategy(
-      {
-        hass: this.hass!,
-        narrow: this.narrow,
+    const conf = await generateLovelaceDashboardStrategy({
+      hass: this.hass!,
+      narrow: this.narrow,
+      config: {
+        strategy: {
+          type: DEFAULT_STRATEGY,
+        },
+        views: [],
       },
-      DEFAULT_STRATEGY
-    );
+    });
     this._setLovelaceConfig(conf, undefined, "generated");
     this._panelState = "loaded";
   }
@@ -272,13 +275,16 @@ export class LovelacePanel extends LitElement {
         this._errorMsg = err.message;
         return;
       }
-      conf = await generateLovelaceDashboardStrategy(
-        {
-          hass: this.hass!,
-          narrow: this.narrow,
+      conf = await generateLovelaceDashboardStrategy({
+        hass: this.hass!,
+        narrow: this.narrow,
+        config: {
+          strategy: {
+            type: DEFAULT_STRATEGY,
+          },
+          views: [],
         },
-        DEFAULT_STRATEGY
-      );
+      });
       confMode = "generated";
     } finally {
       // Ignore updates for another 2 seconds.
@@ -400,13 +406,16 @@ export class LovelacePanel extends LitElement {
         } = this.lovelace!;
         try {
           // Optimistic update
-          const generatedConf = await generateLovelaceDashboardStrategy(
-            {
-              hass: this.hass!,
-              narrow: this.narrow,
+          const generatedConf = await generateLovelaceDashboardStrategy({
+            hass: this.hass!,
+            narrow: this.narrow,
+            config: {
+              strategy: {
+                type: DEFAULT_STRATEGY,
+              },
+              views: [],
             },
-            DEFAULT_STRATEGY
-          );
+          });
           this._updateLovelace({
             config: generatedConf,
             rawConfig: undefined,

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -1,11 +1,13 @@
-import { LovelaceConfig, LovelaceViewConfig } from "../../../data/lovelace";
+import {
+  LovelaceConfig,
+  LovelaceStrategyConfig,
+  LovelaceViewConfig,
+} from "../../../data/lovelace";
 import { AsyncReturnType, HomeAssistant } from "../../../types";
 import { isLegacyStrategy } from "./legacy-strategy";
 import {
   LovelaceDashboardStrategy,
   LovelaceStrategy,
-  LovelaceStrategyConfig,
-  LovelaceStrategyConfigType,
   LovelaceStrategyParams,
   LovelaceViewStrategy,
 } from "./types";
@@ -22,6 +24,8 @@ const STRATEGIES: Record<LovelaceStrategyConfigType, Record<string, any>> = {
     energy: () => import("../../energy/strategies/energy-view-strategy"),
   },
 };
+
+export type LovelaceStrategyConfigType = "dashboard" | "view";
 
 type Strategies = {
   dashboard: LovelaceDashboardStrategy;

--- a/src/panels/lovelace/strategies/get-strategy.ts
+++ b/src/panels/lovelace/strategies/get-strategy.ts
@@ -108,7 +108,14 @@ const generateStrategy = async <T extends LovelaceStrategyConfigType>(
       }
     }
 
-    return await strategy.generate(strategyConfig, hass, params);
+    const config = {
+      ...strategyConfig,
+      ...strategyConfig.options,
+    };
+
+    delete config.options;
+
+    return await strategy.generate(config, hass, params);
   } catch (err: any) {
     if (err.message !== "timeout") {
       // eslint-disable-next-line

--- a/src/panels/lovelace/strategies/legacy-strategy.ts
+++ b/src/panels/lovelace/strategies/legacy-strategy.ts
@@ -1,0 +1,24 @@
+import { LovelaceConfig, LovelaceViewConfig } from "../../../data/lovelace";
+import { HomeAssistant } from "../../../types";
+
+export const isLegacyStrategy = (
+  strategy: any
+): strategy is LovelaceDashboardStrategy | LovelaceViewStrategy =>
+  !("generate" in strategy);
+
+export interface LovelaceDashboardStrategy {
+  generateDashboard(info: {
+    config?: LovelaceConfig;
+    hass: HomeAssistant;
+    narrow: boolean | undefined;
+  }): Promise<LovelaceConfig>;
+}
+
+export interface LovelaceViewStrategy {
+  generateView(info: {
+    view: LovelaceViewConfig;
+    config: LovelaceConfig;
+    hass: HomeAssistant;
+    narrow: boolean | undefined;
+  }): Promise<LovelaceViewConfig>;
+}

--- a/src/panels/lovelace/strategies/original-states-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states-dashboard-strategy.ts
@@ -1,15 +1,18 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
 import { LovelaceConfig } from "../../../data/lovelace";
-import { LovelaceStrategyInfo } from "./types";
+import { HomeAssistant } from "../../../types";
+import { LovelaceStrategyConfig, LovelaceStrategyParams } from "./types";
 
 @customElement("original-states-dashboard-strategy")
 export class OriginalStatesDashboardStrategy extends ReactiveElement {
   static async generate(
-    info: LovelaceStrategyInfo<LovelaceConfig>
+    _config: LovelaceStrategyConfig,
+    hass: HomeAssistant,
+    _params?: LovelaceStrategyParams
   ): Promise<LovelaceConfig> {
     return {
-      title: info.hass.config.location_name,
+      title: hass.config.location_name,
       views: [
         {
           strategy: { type: "original-states" },

--- a/src/panels/lovelace/strategies/original-states-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states-dashboard-strategy.ts
@@ -1,0 +1,20 @@
+import { ReactiveElement } from "lit";
+import { customElement } from "lit/decorators";
+import { LovelaceConfig } from "../../../data/lovelace";
+import { LovelaceStrategyInfo } from "./types";
+
+@customElement("original-states-dashboard-strategy")
+export class OriginalStatesDashboardStrategy extends ReactiveElement {
+  static async generate(
+    info: LovelaceStrategyInfo<LovelaceConfig>
+  ): Promise<LovelaceConfig> {
+    return {
+      title: info.hass.config.location_name,
+      views: [
+        {
+          strategy: { type: "original-states" },
+        },
+      ],
+    };
+  }
+}

--- a/src/panels/lovelace/strategies/original-states-dashboard-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states-dashboard-strategy.ts
@@ -1,8 +1,8 @@
 import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
-import { LovelaceConfig } from "../../../data/lovelace";
+import { LovelaceConfig, LovelaceStrategyConfig } from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
-import { LovelaceStrategyConfig, LovelaceStrategyParams } from "./types";
+import { LovelaceStrategyParams } from "./types";
 
 @customElement("original-states-dashboard-strategy")
 export class OriginalStatesDashboardStrategy extends ReactiveElement {

--- a/src/panels/lovelace/strategies/original-states-view-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states-view-strategy.ts
@@ -3,17 +3,18 @@ import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { getEnergyPreferences } from "../../../data/energy";
-import { generateDefaultViewConfig } from "../common/generate-lovelace-config";
-import { LovelaceStrategyInfo } from "./types";
 import { LovelaceViewConfig } from "../../../data/lovelace";
+import { HomeAssistant } from "../../../types";
+import { generateDefaultViewConfig } from "../common/generate-lovelace-config";
+import { LovelaceStrategyConfig, LovelaceStrategyParams } from "./types";
 
 @customElement("original-states-view-strategy")
 export class OriginalStatesViewStrategy extends ReactiveElement {
   static async generate(
-    info: LovelaceStrategyInfo<LovelaceViewConfig>
+    _config: LovelaceStrategyConfig,
+    hass: HomeAssistant,
+    _params?: LovelaceStrategyParams
   ): Promise<LovelaceViewConfig> {
-    const hass = info.hass;
-
     if (hass.config.state === STATE_NOT_RUNNING) {
       return {
         cards: [{ type: "starting" }],

--- a/src/panels/lovelace/strategies/original-states-view-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states-view-strategy.ts
@@ -1,16 +1,17 @@
 import { STATE_NOT_RUNNING } from "home-assistant-js-websocket";
+import { ReactiveElement } from "lit";
+import { customElement } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { getEnergyPreferences } from "../../../data/energy";
 import { generateDefaultViewConfig } from "../common/generate-lovelace-config";
-import {
-  LovelaceDashboardStrategy,
-  LovelaceViewStrategy,
-} from "./get-strategy";
+import { LovelaceStrategyInfo } from "./types";
+import { LovelaceViewConfig } from "../../../data/lovelace";
 
-export class OriginalStatesStrategy {
-  static async generateView(
-    info: Parameters<LovelaceViewStrategy["generateView"]>[0]
-  ): ReturnType<LovelaceViewStrategy["generateView"]> {
+@customElement("original-states-view-strategy")
+export class OriginalStatesViewStrategy extends ReactiveElement {
+  static async generate(
+    info: LovelaceStrategyInfo<LovelaceViewConfig>
+  ): Promise<LovelaceViewConfig> {
     const hass = info.hass;
 
     if (hass.config.state === STATE_NOT_RUNNING) {
@@ -62,18 +63,5 @@ export class OriginalStatesStrategy {
     }
 
     return view;
-  }
-
-  static async generateDashboard(
-    info: Parameters<LovelaceDashboardStrategy["generateDashboard"]>[0]
-  ): ReturnType<LovelaceDashboardStrategy["generateDashboard"]> {
-    return {
-      title: info.hass.config.location_name,
-      views: [
-        {
-          strategy: { type: "original-states" },
-        },
-      ],
-    };
   }
 }

--- a/src/panels/lovelace/strategies/original-states-view-strategy.ts
+++ b/src/panels/lovelace/strategies/original-states-view-strategy.ts
@@ -3,10 +3,13 @@ import { ReactiveElement } from "lit";
 import { customElement } from "lit/decorators";
 import { isComponentLoaded } from "../../../common/config/is_component_loaded";
 import { getEnergyPreferences } from "../../../data/energy";
-import { LovelaceViewConfig } from "../../../data/lovelace";
+import {
+  LovelaceStrategyConfig,
+  LovelaceViewConfig,
+} from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
 import { generateDefaultViewConfig } from "../common/generate-lovelace-config";
-import { LovelaceStrategyConfig, LovelaceStrategyParams } from "./types";
+import { LovelaceStrategyParams } from "./types";
 
 @customElement("original-states-view-strategy")
 export class OriginalStatesViewStrategy extends ReactiveElement {

--- a/src/panels/lovelace/strategies/types.ts
+++ b/src/panels/lovelace/strategies/types.ts
@@ -1,12 +1,9 @@
-import { LovelaceConfig, LovelaceViewConfig } from "../../../data/lovelace";
+import {
+  LovelaceConfig,
+  LovelaceStrategyConfig,
+  LovelaceViewConfig,
+} from "../../../data/lovelace";
 import { HomeAssistant } from "../../../types";
-
-export type LovelaceStrategyConfigType = "dashboard" | "view";
-
-export type LovelaceStrategyConfig<T = Record<string, any>> = {
-  type: string;
-  options?: T;
-};
 
 export type LovelaceStrategyParams = {
   narrow?: boolean;

--- a/src/panels/lovelace/strategies/types.ts
+++ b/src/panels/lovelace/strategies/types.ts
@@ -1,0 +1,20 @@
+import { LovelaceConfig, LovelaceViewConfig } from "../../../data/lovelace";
+import { HomeAssistant } from "../../../types";
+
+export type LovelaceStrategyConfigType = "dashboard" | "view";
+
+export type LovelaceStrategyInfo<T = any> = {
+  config: T;
+  hass: HomeAssistant;
+  narrow: boolean | undefined;
+};
+
+export type LovelaceStrategy<T = any> = {
+  generate(info: LovelaceStrategyInfo<T>): Promise<T>;
+};
+
+export interface LovelaceDashboardStrategy
+  extends LovelaceStrategy<LovelaceConfig> {}
+
+export interface LovelaceViewStrategy
+  extends LovelaceStrategy<LovelaceViewConfig> {}

--- a/src/panels/lovelace/strategies/types.ts
+++ b/src/panels/lovelace/strategies/types.ts
@@ -3,14 +3,21 @@ import { HomeAssistant } from "../../../types";
 
 export type LovelaceStrategyConfigType = "dashboard" | "view";
 
-export type LovelaceStrategyInfo<T = any> = {
-  config: T;
-  hass: HomeAssistant;
-  narrow: boolean | undefined;
+export type LovelaceStrategyConfig<T = Record<string, any>> = {
+  type: string;
+  options?: T;
+};
+
+export type LovelaceStrategyParams = {
+  narrow?: boolean;
 };
 
 export type LovelaceStrategy<T = any> = {
-  generate(info: LovelaceStrategyInfo<T>): Promise<T>;
+  generate(
+    config: LovelaceStrategyConfig,
+    hass: HomeAssistant,
+    params?: LovelaceStrategyParams
+  ): Promise<T>;
 };
 
 export interface LovelaceDashboardStrategy

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -192,9 +192,8 @@ export class HUIView extends ReactiveElement {
       isStrategy = true;
       viewConfig = await generateLovelaceViewStrategy({
         hass: this.hass,
-        config: this.lovelace.config,
         narrow: this.narrow,
-        view: viewConfig,
+        config: viewConfig,
       });
     }
 

--- a/src/panels/lovelace/views/hui-view.ts
+++ b/src/panels/lovelace/views/hui-view.ts
@@ -190,11 +190,11 @@ export class HUIView extends ReactiveElement {
 
     if (viewConfig.strategy) {
       isStrategy = true;
-      viewConfig = await generateLovelaceViewStrategy({
-        hass: this.hass,
-        narrow: this.narrow,
-        config: viewConfig,
-      });
+      viewConfig = await generateLovelaceViewStrategy(
+        viewConfig.strategy,
+        this.hass!,
+        { narrow: this.narrow }
+      );
     }
 
     viewConfig = {


### PR DESCRIPTION
## Proposed change

This PR changes the way to define strategies. `original-states` and `energy` strategies has been migrated to the new API.

Dashboard and view strategies has been split into 2 class. This class share the same interface so we can easily extends it to other elements (section within a view for example). Also a config editor can be easily added by adding ```getConfigElement``` method to the class (https://github.com/home-assistant/frontend/pull/17916 will be edited with this changes)

### Config format

The options has been moved to the root (to be consistent with card config). Backward compatibility for current custom strategies has been added with a drawback : `options` property can not be used.

#### Before

```yaml
strategy:
  type: original-states
  options:
    foo: bar
views: []
```

#### After 
```yaml
strategy:
  type: original-states
  foo: bar
views: []
```

### Generate method parameters
- **config**: the user configuration of the strategy with options.
  ```ts
  { 
    type: "energy",
    show_date_selection: true
  }
  ```
- **hass**: Home Assistant object
- **params**: custom parameters injected by the frontend (e.g. `narrow`)
  

#### Before

```ts
class DemoStrategy {
    static generateView({
        view,
        config,
        hass,
        narrow
    })
    static generateDashboard({
        config,
        hass,
        narrow
    })
}
```

#### After 
```ts
class DemoDashboardStrategy {
    static generate(config, hass, params)
}

class DemoViewStrategy {
    static generate(config, hass, params)
}
```

### Note

I kept the custom element registry for storing the strategies (and custom ones) even if it's not valid because it will be easier for developer to have similar way to register strategies than cards.
A backward compatibility has been added to avoid issues with custom strategies that are not using the new format.

## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
