### PR TITLE
Fix adjust statistic dialog after a period of sensor unavailability

### DIFF
--- a/src/panels/developer-tools/statistics/dialog-statistics-adjust-sum.ts
+++ b/src/panels/developer-tools/statistics/dialog-statistics-adjust-sum.ts
@@ -132,20 +132,20 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
 
     if (!this._stats5min || !this._statsHour) {
       stats = html`<ha-circular-progress active></ha-circular-progress>`;
-    } else if (this._statsHour.length < 2 && this._stats5min.length < 2) {
+    } else if (this._statsHour.length < 1 && this._stats5min.length < 1) {
       stats = html`<p>No statistics found for this period.</p>`;
     } else {
       const data =
-        this._stats5min.length >= 2 ? this._stats5min : this._statsHour;
+        this._stats5min.length >= 1 ? this._stats5min : this._statsHour;
       const unit = getDisplayUnit(
         this.hass,
         this._params!.statistic.statistic_id,
         this._params!.statistic
       );
       const rows: TemplateResult[] = [];
-      for (let i = 1; i < data.length; i++) {
+      for (let i = data.length < 6 ? 0 : 1; i < data.length; i++) {
         const stat = data[i];
-        const growth = Math.round((stat.sum! - data[i - 1].sum!) * 100) / 100;
+        const growth = Math.round(stat.change! * 100) / 100;
         rows.push(html`
           <mwc-list-item
             twoline

--- a/src/panels/developer-tools/statistics/dialog-statistics-adjust-sum.ts
+++ b/src/panels/developer-tools/statistics/dialog-statistics-adjust-sum.ts
@@ -143,7 +143,7 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
         this._params!.statistic
       );
       const rows: TemplateResult[] = [];
-      for (let i = data.length < 6 ? 0 : 1; i < data.length; i++) {
+      for (let i = 0; i < data.length; i++) {
         const stat = data[i];
         const growth = Math.round(stat.change! * 100) / 100;
         rows.push(html`
@@ -273,9 +273,9 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
     // Here we convert it to an ISO string.
     const moment = new Date(this._moment!.replace(" ", "T"));
 
-    // Search 3 hours before and 3 hours after chosen time
+    // Search 2 hours before and 3 hours after chosen time
     const hourStatStart = new Date(moment.getTime());
-    hourStatStart.setTime(hourStatStart.getTime() - 3 * 3600 * 1000);
+    hourStatStart.setTime(hourStatStart.getTime() - 2 * 3600 * 1000);
     const hourStatEnd = new Date(moment.getTime());
     hourStatEnd.setTime(hourStatEnd.getTime() + 3 * 3600 * 1000);
 
@@ -287,7 +287,7 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
       "hour"
     );
     this._statsHour =
-      statId in statsHourData ? statsHourData[statId].slice(0, 6) : [];
+      statId in statsHourData ? statsHourData[statId].slice(0, 5) : [];
 
     // Can't have 5 min data if no hourly data
     if (this._statsHour.length === 0) {
@@ -295,9 +295,9 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
       return;
     }
 
-    // Search 15 minutes before and 15 minutes after chosen time
+    // Search 10 minutes before and 15 minutes after chosen time
     const minStatStart = new Date(moment.getTime());
-    minStatStart.setTime(minStatStart.getTime() - 15 * 60 * 1000);
+    minStatStart.setTime(minStatStart.getTime() - 10 * 60 * 1000);
     const minStatEnd = new Date(moment.getTime());
     minStatEnd.setTime(minStatEnd.getTime() + 15 * 60 * 1000);
 
@@ -310,7 +310,7 @@ export class DialogStatisticsFixUnsupportedUnitMetadata extends LitElement {
     );
 
     this._stats5min =
-      statId in stats5MinData ? stats5MinData[statId].slice(0, 6) : [];
+      statId in stats5MinData ? stats5MinData[statId].slice(0, 5) : [];
   }
 
   private async _fixIssue(): Promise<void> {


### PR DESCRIPTION
## Proposed change

The adjust a statistic dialog is currently not sufficient when dealing with a sensor that has a period of unavailability, followed by a spike in energy usage. This happens frequently to energy users, who see a spike in energy dashboard, but when they go to adjust, they cannot find the datapoint. 

Here is an example `statistics_total_increasing_sensor` went unavailable from sometime in the morning until ~1:57pm. When it came back, it reported a large spike in energy usage, 448kWh for that hour. 

![image](https://github.com/home-assistant/frontend/assets/32912880/16f3a898-9c51-4280-b0cb-f19b3c18a62b)

The user may want to remove this data, and go to adjust a statistic, and look at 2:00pm. The data spike is mysteriously not there. 

![image](https://github.com/home-assistant/frontend/assets/32912880/a70fbe2e-fdc7-493d-b893-599d1892413b)

This occurs because statistics queries a time range, but then _does not show the first datapoint_ returned in this time window, because it thinks it needs to subtract the delta between two points to see the change. However this does not work if the sensor is unavailable for a while, as the point with the large change will never be visible, because it will never be the non-zeroth index in a query.

Here is an example of the data returned from the statistics platform when showing this dialog. There is a datapoint (1:55pm-2:00pm) that shows this 448kWh change, but it is always hidden from the dialog, as it is in the 0th position.

![image](https://github.com/home-assistant/frontend/assets/32912880/b8b46d42-f512-4dde-9cec-7a16a38eb49a)

Since core statistics returns the `change` property along with each statistics datapoint, I don't think we actually need to calculate the change ourselves, which means we should be fine to show the 0th index. When we do this, the user can correctly find this datapoint with the large energy spike.

Fixed dialog:

![image](https://github.com/home-assistant/frontend/assets/32912880/16c6f1c0-073c-4b98-99f1-1df4f1dbca1c)








## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #17919
- Link to documentation pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
