### PR TITLE
Make lock active when unlocked

### DIFF
--- a/src/common/entity/state_active.ts
+++ b/src/common/entity/state_active.ts
@@ -37,7 +37,7 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
     case "lawn_mower":
       return ["mowing", "error"].includes(compareState);
     case "lock":
-      return compareState !== "locked";
+      return compareState !== "unlocked";
     case "media_player":
       return compareState !== "standby";
     case "vacuum":
@@ -45,7 +45,7 @@ export function stateActive(stateObj: HassEntity, state?: string): boolean {
     case "plant":
       return compareState === "problem";
     case "group":
-      return ["on", "home", "open", "locked", "problem"].includes(compareState);
+      return ["on", "home", "open", "unlocked", "problem"].includes(compareState);
     case "timer":
       return compareState === "active";
     case "camera":


### PR DESCRIPTION
## Breaking change

This marks locks active when *unlocked*, and inactive otherwise. This is contrary to the current status, where locks are marked as active when *locked*, and inactive otherwise.

## Proposed change

This PR is linked to https://github.com/home-assistant/android/pull/3862. As you can see in the discussion there, the Android Companion app made some changes to align the code and active state of entities with the frontend - but it broke the appearance of lock tiles on Android (flipped their appearance when locked/unlocked). This resulted in inconsistent appearance between Home Assistant tiles and Google Home tiles for locks.

I suggest marking locks as active when they are anything but unlocked. This aligns with the logic that a lock device's idle state (semantically speaking) is unlocked.

By the way, I marked it as a breaking change since it flips the active state logic, but I'm not sure what will be actually affected on the frontend side... As far as I can see, from a user perspective, it should not matter.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: https://github.com/home-assistant/android/pull/3862
