### PR TITLE
Add new config options for map entity markers

### DIFF
--- a/src/components/map/ha-entity-marker.ts
+++ b/src/components/map/ha-entity-marker.ts
@@ -15,7 +15,7 @@ class HaEntityMarker extends LitElement {
   protected render() {
     return html`
       <div
-        class="marker"
+        class="marker ${this.entityPicture ? "picture" : ""}"
         style=${styleMap({ "border-color": this.entityColor })}
         @click=${this._badgeTap}
       >
@@ -45,7 +45,6 @@ class HaEntityMarker extends LitElement {
         justify-content: center;
         align-items: center;
         box-sizing: border-box;
-        overflow: hidden;
         width: 48px;
         height: 48px;
         font-size: var(--ha-marker-font-size, 1.5em);
@@ -53,6 +52,9 @@ class HaEntityMarker extends LitElement {
         border: 1px solid var(--ha-marker-color, var(--primary-color));
         color: var(--primary-text-color);
         background-color: var(--card-background-color);
+      }
+      .marker.picture {
+        overflow: hidden;
       }
       .entity-picture {
         background-size: cover;

--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -37,6 +37,8 @@ export interface HaMapPaths {
 export interface HaMapEntity {
   entity_id: string;
   color: string;
+  label_mode?: "name" | "state";
+  name?: string;
 }
 
 @customElement("ha-map")
@@ -353,7 +355,8 @@ export class HaMap extends ReactiveElement {
       if (!stateObj) {
         continue;
       }
-      const title = computeStateName(stateObj);
+      const customTitle = typeof entity !== "string" ? entity.name : undefined;
+      const title = customTitle ?? computeStateName(stateObj);
       const {
         latitude,
         longitude,
@@ -413,11 +416,15 @@ export class HaMap extends ReactiveElement {
 
       // DRAW ENTITY
       // create icon
-      const entityName = title
-        .split(" ")
-        .map((part) => part[0])
-        .join("")
-        .substr(0, 3);
+      const entityName =
+        typeof entity !== "string" && entity.label_mode === "state"
+          ? this.hass.formatEntityState(stateObj)
+          : customTitle ??
+            title
+              .split(" ")
+              .map((part) => part[0])
+              .join("")
+              .substr(0, 3);
 
       // create marker with the icon
       this._mapItems.push(
@@ -440,7 +447,7 @@ export class HaMap extends ReactiveElement {
             iconSize: [48, 48],
             className: "",
           }),
-          title: computeStateName(stateObj),
+          title: title,
         })
       );
 

--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -455,7 +455,7 @@ export class HaMap extends ReactiveElement {
         title: title,
       });
       this._mapItems.push(marker);
-      if (typeof entity !== "string" && entity.focus !== false) {
+      if (typeof entity === "string" || entity.focus !== false) {
         this._mapFocusItems.push(marker);
       }
 

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -50,6 +50,7 @@ export const DEFAULT_ZOOM = 14;
 
 interface MapEntityConfig extends EntityConfig {
   label_mode?: "state" | "name";
+  focus?: boolean;
 }
 
 @customElement("hui-map-card")
@@ -337,6 +338,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
           entity_id: entityConf.entity,
           color: this._getColor(entityConf.entity),
           label_mode: entityConf.label_mode,
+          focus: entityConf.focus,
           name: entityConf.name,
         })),
         ...geoEntities.map((entity) => ({

--- a/src/panels/lovelace/cards/hui-map-card.ts
+++ b/src/panels/lovelace/cards/hui-map-card.ts
@@ -48,6 +48,10 @@ import { MapCardConfig } from "./types";
 export const DEFAULT_HOURS_TO_SHOW = 0;
 export const DEFAULT_ZOOM = 14;
 
+interface MapEntityConfig extends EntityConfig {
+  label_mode?: "state" | "name";
+}
+
 @customElement("hui-map-card")
 class HuiMapCard extends LitElement implements LovelaceCard {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -63,7 +67,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
   @query("ha-map")
   private _map?: HaMap;
 
-  private _configEntities?: string[];
+  private _configEntities?: MapEntityConfig[];
 
   private _colorDict: Record<string, string> = {};
 
@@ -94,11 +98,9 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     }
 
     this._config = config;
-    this._configEntities = (
-      config.entities
-        ? processConfigEntities<EntityConfig>(config.entities)
-        : []
-    ).map((entity) => entity.entity);
+    this._configEntities = config.entities
+      ? processConfigEntities<MapEntityConfig>(config.entities)
+      : [];
   }
 
   public getCardSize(): number {
@@ -238,7 +240,7 @@ class HuiMapCard extends LitElement implements LovelaceCard {
         this._stateHistory = combinedHistory;
       },
       this._config!.hours_to_show! ?? DEFAULT_HOURS_TO_SHOW,
-      this._configEntities!,
+      (this._configEntities || []).map((entity) => entity.entity)!,
       false,
       false,
       false
@@ -309,16 +311,14 @@ class HuiMapCard extends LitElement implements LovelaceCard {
     (
       states: HassEntities,
       config: MapCardConfig,
-      configEntities?: string[]
+      configEntities?: MapEntityConfig[]
     ) => {
       if (!states || !config) {
         return undefined;
       }
 
-      let entities = configEntities || [];
-
+      const geoEntities: string[] = [];
       if (config.geo_location_sources) {
-        const geoEntities: string[] = [];
         // Calculate visible geo location sources
         const includesAll = config.geo_location_sources.includes("all");
         for (const stateObj of Object.values(states)) {
@@ -330,14 +330,20 @@ class HuiMapCard extends LitElement implements LovelaceCard {
             geoEntities.push(stateObj.entity_id);
           }
         }
-
-        entities = [...entities, ...geoEntities];
       }
 
-      return entities.map((entity) => ({
-        entity_id: entity,
-        color: this._getColor(entity),
-      }));
+      return [
+        ...(configEntities || []).map((entityConf) => ({
+          entity_id: entityConf.entity,
+          color: this._getColor(entityConf.entity),
+          label_mode: entityConf.label_mode,
+          name: entityConf.name,
+        })),
+        ...geoEntities.map((entity) => ({
+          entity_id: entity,
+          color: this._getColor(entity),
+        })),
+      ];
     }
   );
 

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -9,6 +9,7 @@ import {
   object,
   optional,
   string,
+  union,
 } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { hasLocation } from "../../../../common/entity/has_location";
@@ -25,9 +26,17 @@ import { EntityConfig } from "../../entity-rows/types";
 import { LovelaceCardEditor } from "../../types";
 import { processEditorEntities } from "../process-editor-entities";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
-import { entitiesConfigStruct } from "../structs/entities-struct";
 import { EntitiesEditorEvent } from "../types";
 import { configElementStyle } from "./config-elements-style";
+
+export const mapEntitiesConfigStruct = union([
+  object({
+    entity: string(),
+    label_mode: optional(string()),
+    name: optional(string()),
+  }),
+  string(),
+]);
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -36,7 +45,7 @@ const cardConfigStruct = assign(
     aspect_ratio: optional(string()),
     default_zoom: optional(number()),
     dark_mode: optional(boolean()),
-    entities: array(entitiesConfigStruct),
+    entities: array(mapEntitiesConfigStruct),
     hours_to_show: optional(number()),
     geo_location_sources: optional(array(string())),
     auto_fit: optional(boolean()),

--- a/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-map-card-editor.ts
@@ -33,6 +33,7 @@ export const mapEntitiesConfigStruct = union([
   object({
     entity: string(),
     label_mode: optional(string()),
+    focus: optional(boolean()),
     name: optional(string()),
   }),
   string(),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Propose some new config options per-entity in map card:

* `label_mode` - when set to `state`, renders the entity's state as the label for the map marker instead of the entity's name. Allows to build interesting data visualization on top of a map. Possibly for things like: a map of gas prices at nearby gas stations, displaying the next time a bus arrives at select bus stops, or air quality readings at various neighborhood weather stations, etc. 

* `focus` - markers with focus set to `false` will be added to the map, but they will not be considered for calculating the center of the map or zoom level. May be useful if user wants to add a lot of informational entities to a map, but doesn't want the map to zoom out to fit all those entities by default (perhaps preferring a more localized map focused on the user's current position only).  (maybe should add something similar for geo_location_sources?)

* `name` - allows to override the name of the marker. In case something is preferred other than the 3-letter initials of entity name. Possibly multiple markers have a name that alias to the same initial and want to differentiate them, or user want to display something else entirely. 

![image](https://github.com/home-assistant/frontend/assets/32912880/4ff6a3c9-301c-4988-91fa-a9f68f15a378)


## Type of change

<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29017

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
