### PR TITLE
Fix choose description when a non-list form of conditions is used

### DIFF
--- a/src/panels/config/automation/action/types/ha-automation-action-choose.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-choose.ts
@@ -82,26 +82,23 @@ export class HaChooseAction extends LitElement implements ActionElement {
     if (this.isExpanded(idx)) {
       return "";
     }
-    if (!option.conditions || option.conditions.length === 0) {
+    const conditions = ensureArray(option.conditions);
+    if (!conditions || conditions.length === 0) {
       return this.hass.localize(
         "ui.panel.config.automation.editor.actions.type.choose.no_conditions"
       );
     }
     let str = "";
-    if (typeof option.conditions[0] === "string") {
-      str += option.conditions[0];
+    if (typeof conditions[0] === "string") {
+      str += conditions[0];
     } else {
-      str += describeCondition(
-        option.conditions[0],
-        this.hass,
-        this._entityReg
-      );
+      str += describeCondition(conditions[0], this.hass, this._entityReg);
     }
-    if (option.conditions.length > 1) {
+    if (conditions.length > 1) {
       str += this.hass.localize(
         "ui.panel.config.automation.editor.actions.type.choose.option_description_additional",
         "numberOfAdditionalConditions",
-        option.conditions.length - 1
+        conditions.length - 1
       );
     }
     return str;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Fix choose description generation when conditions is not a list. This can't happen through the UI editor, but it is a valid yaml syntax. 

![vuUlGhP](https://github.com/home-assistant/frontend/assets/32912880/16633f52-d658-4578-bcfa-c9829b0d787b)



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
choose:
  - sequence: []
    conditions:
      condition: sun
      before: sunrise
enabled: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
