### PR TITLE
State History Charts - Handle click to chart to open More Info for the clicked entity

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -35,6 +35,8 @@ export class StateHistoryChartLine extends LitElement {
 
   @property({ type: Boolean }) public showNames = true;
 
+  @property({ type: Boolean }) public clickForMoreInfo = true;
+
   @property({ attribute: false }) public startTime!: Date;
 
   @property({ attribute: false }) public endTime!: Date;
@@ -44,6 +46,8 @@ export class StateHistoryChartLine extends LitElement {
   @property({ type: Number }) public chartIndex?;
 
   @state() private _chartData?: ChartData<"line">;
+
+  @state() private _entityIds: string[] = [];
 
   @state() private _chartOptions?: ChartOptions;
 
@@ -171,6 +175,25 @@ export class StateHistoryChartLine extends LitElement {
         },
         // @ts-expect-error
         locale: numberFormatToLocale(this.hass.locale),
+        onClick: (e: any) => {
+          if (!this.clickForMoreInfo) {
+            return;
+          }
+
+          const points = e.chart.getElementsAtEventForMode(
+            e,
+            "nearest",
+            { intersect: true },
+            true
+          );
+
+          if (points.length) {
+            const firstPoint = points[0];
+            fireEvent(this, "hass-more-info", {
+              entityId: this._entityIds[firstPoint.datasetIndex],
+            });
+          }
+        },
       };
     }
     if (
@@ -191,6 +214,7 @@ export class StateHistoryChartLine extends LitElement {
     const computedStyles = getComputedStyle(this);
     const entityStates = this.data;
     const datasets: ChartDataset<"line">[] = [];
+    const entityIds: string[] = [];
     if (entityStates.length === 0) {
       return;
     }
@@ -242,6 +266,7 @@ export class StateHistoryChartLine extends LitElement {
           pointRadius: 0,
           data: [],
         });
+        entityIds.push(states.entity_id);
       };
 
       if (
@@ -493,6 +518,7 @@ export class StateHistoryChartLine extends LitElement {
     this._chartData = {
       datasets,
     };
+    this._entityIds = entityIds;
   }
 }
 customElements.define("state-history-chart-line", StateHistoryChartLine);

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -1,4 +1,5 @@
 import type { ChartData, ChartDataset, ChartOptions } from "chart.js";
+import { getRelativePosition } from "chart.js/helpers";
 import { css, CSSResultGroup, html, LitElement, PropertyValues } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
@@ -31,6 +32,8 @@ export class StateHistoryChartTimeline extends LitElement {
   @property() public identifier?: string;
 
   @property({ type: Boolean }) public showNames = true;
+
+  @property({ type: Boolean }) public clickForMoreInfo = true;
 
   @property({ type: Boolean }) public chunked = false;
 
@@ -220,6 +223,22 @@ export class StateHistoryChartTimeline extends LitElement {
       },
       // @ts-expect-error
       locale: numberFormatToLocale(this.hass.locale),
+      onClick: (e: any) => {
+        if (!this.clickForMoreInfo) {
+          return;
+        }
+
+        const chart = e.chart;
+        const canvasPosition = getRelativePosition(e, chart);
+
+        const index = Math.abs(
+          chart.scales.y.getValueForPixel(canvasPosition.y)
+        );
+        fireEvent(this, "hass-more-info", {
+          // @ts-ignore
+          entityId: this._chartData?.datasets[index]?.label,
+        });
+      },
     };
   }
 

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -69,6 +69,8 @@ export class StateHistoryCharts extends LitElement {
 
   @property({ type: Boolean }) public showNames = true;
 
+  @property({ type: Boolean }) public clickForMoreInfo = true;
+
   @property({ type: Boolean }) public isLoadingData = false;
 
   @state() private _computedStartTime!: Date;
@@ -181,6 +183,7 @@ export class StateHistoryCharts extends LitElement {
           .paddingYAxis=${this._maxYWidth}
           .names=${this.names}
           .chartIndex=${index}
+          .clickForMoreInfo=${this.clickForMoreInfo}
           @y-width-changed=${this._yWidthChanged}
         ></state-history-chart-line>
       </div> `;
@@ -197,6 +200,7 @@ export class StateHistoryCharts extends LitElement {
         .chunked=${this.virtualize}
         .paddingYAxis=${this._maxYWidth}
         .chartIndex=${index}
+        .clickForMoreInfo=${this.clickForMoreInfo}
         @y-width-changed=${this._yWidthChanged}
       ></state-history-chart-timeline>
     </div> `;

--- a/src/dialogs/more-info/ha-more-info-history.ts
+++ b/src/dialogs/more-info/ha-more-info-history.ts
@@ -99,6 +99,7 @@ export class MoreInfoHistory extends LitElement {
                 .historyData=${this._stateHistory}
                 .isLoadingData=${!this._stateHistory}
                 .showNames=${false}
+                .clickForMoreInfo=${false}
               ></state-history-charts>`}`
       : ""}`;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The history graph card is great, however it lacks details.
That is a problem especially for timeline history chart. Intervals between changes are short (as in door sensors) and sometimes the sensor is unavailable for a short period of time, which is not very obvious from the graph.

Therefore, I enhanced the state history charts by adding a small inline plugin to handle clicking on a timeline element and firing  "hass-more-info" to display the More info dialog of the displayed entity which is configurable by `clickForMoreInfo` (default true). Clicking on chart for more info is disabled when the chart is displayed in the actual More info dialog (`ha-more-info-history`).

Supporting both line chart and timeline chart makes a bit more sense as it will be consistent. Plus both charts will benefit from this functionality as users will be able to use "History" toolbar button on More Info to access even more history. 

I have tested the change on destkop and mobile and it performs fine.
Unless there are some other plans for clicking action on line state history chart I think this is better alternative to #17994 PR.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
