### PR TITLE
Clear wake word when new engine is picked, select first wake word. by…

### DIFF
--- a/src/panels/config/voice-assistants/assist-pipeline-detail/assist-pipeline-detail-wakeword.ts
+++ b/src/panels/config/voice-assistants/assist-pipeline-detail/assist-pipeline-detail-wakeword.ts
@@ -128,8 +128,8 @@ export class AssistPipelineDetailWakeWord extends LitElement {
   }
 
   private async _fetchWakeWords() {
+    this._wakeWords = undefined;
     if (!this.data?.wake_word_entity) {
-      this._wakeWords = undefined;
       return;
     }
     const wakeWordEntity = this.data.wake_word_entity;

--- a/src/panels/config/voice-assistants/assist-pipeline-detail/assist-pipeline-detail-wakeword.ts
+++ b/src/panels/config/voice-assistants/assist-pipeline-detail/assist-pipeline-detail-wakeword.ts
@@ -14,6 +14,7 @@ import { AssistPipeline } from "../../../../data/assist_pipeline";
 import { HomeAssistant } from "../../../../types";
 import { fetchWakeWordInfo, WakeWord } from "../../../../data/wake_word";
 import { documentationUrl } from "../../../../util/documentation-url";
+import { fireEvent } from "../../../../common/dom/fire_event";
 
 @customElement("assist-pipeline-detail-wakeword")
 export class AssistPipelineDetailWakeWord extends LitElement {
@@ -71,6 +72,11 @@ export class AssistPipelineDetailWakeWord extends LitElement {
       changedProps.has("data") &&
       changedProps.get("data")?.wake_word_entity !== this.data?.wake_word_entity
     ) {
+      if (this.data?.wake_word_id) {
+        fireEvent(this, "value-changed", {
+          value: { ...this.data, wake_word_id: undefined },
+        });
+      }
       this._fetchWakeWords();
     }
   }
@@ -126,9 +132,16 @@ export class AssistPipelineDetailWakeWord extends LitElement {
       this._wakeWords = undefined;
       return;
     }
-    this._wakeWords = (
-      await fetchWakeWordInfo(this.hass, this.data.wake_word_entity)
-    ).wake_words;
+    const wakeWordEntity = this.data.wake_word_entity;
+    const wakewordInfo = await fetchWakeWordInfo(this.hass, wakeWordEntity);
+    if (this.data.wake_word_entity !== wakeWordEntity) {
+      // wake word entity changed while we were fetching
+      return;
+    }
+    this._wakeWords = wakewordInfo.wake_words;
+    fireEvent(this, "value-changed", {
+      value: { ...this.data, wake_word_id: this._wakeWords[0]?.id },
+    });
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
… default


## Proposed change
Clear wake word when new engine is picked, select first wake word. by default

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
