### PR TITLE
Fix clicking on radio buttons (and improve code)

### DIFF
--- a/src/components/ha-formfield.ts
+++ b/src/components/ha-formfield.ts
@@ -8,21 +8,24 @@ import { fireEvent } from "../common/dom/fire_event";
 export class HaFormfield extends FormfieldBase {
   protected _labelClick() {
     const input = this.input;
-    if (input) {
-      input.focus();
-      switch (input.tagName) {
-        case "HA-CHECKBOX":
-        case "HA-RADIO":
-          if ((input as any).disabled) {
-            break;
-          }
-          (input as any).checked = !(input as any).checked;
-          fireEvent(input, "change");
-          break;
-        default:
-          input.click();
-          break;
-      }
+    if (!input) return;
+
+    input.focus();
+    if (input.disabled) {
+      break;
+    }
+    switch (input.tagName) {
+      case "HA-CHECKBOX":
+        input.checked = !input.checked;
+        fireEvent(input, "change");
+        break;
+      case "HA-RADIO":
+        input.checked = true;
+        fireEvent(input, "change");
+        break;
+      default:
+        input.click();
+        break;
     }
   }
 

--- a/src/components/ha-formfield.ts
+++ b/src/components/ha-formfield.ts
@@ -7,12 +7,12 @@ import { fireEvent } from "../common/dom/fire_event";
 @customElement("ha-formfield")
 export class HaFormfield extends FormfieldBase {
   protected _labelClick() {
-    const input = this.input;
+    const input = this.input as HTMLInputElement | undefined;
     if (!input) return;
 
     input.focus();
     if (input.disabled) {
-      break;
+      return;
     }
     switch (input.tagName) {
       case "HA-CHECKBOX":


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Right now if you click on the label for a radio button, you can deselect it. This is silly as you aren't supposed to be able to deselect radio buttons. This PR cleans up the ha-formfield code a bit and makes sure you can't deselect radio buttons.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

You can see the bug right now by going to https://demo.home-assistant.io, going to your profile, choosing the Home Assistant theme, and clicking the **text** on one of the radio buttons. You'll deselect the option.

*no issues, discussions, or prs are relevant here*

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io