### PR TITLE
handle rgbw in computeColor

### DIFF
--- a/src/panels/lovelace/cards/hui-button-card.ts
+++ b/src/panels/lovelace/cards/hui-button-card.ts
@@ -338,6 +338,30 @@ export class HuiButtonCard extends LitElement implements LovelaceCard {
   }
 
   private _computeColor(stateObj: HassEntity): string | undefined {
+    // on rgbw/rgbww, if only white color(s) are turned off, set rgb to white, otherwise return rgb part
+    if (stateObj.attributes.rgbww_color) {
+      if (
+        stateObj.attributes.rgbww_color[0] === 0 &&
+        stateObj.attributes.rgbww_color[1] === 0 &&
+        stateObj.attributes.rgbww_color[2] === 0 &&
+        (stateObj.attributes.rgbww_color[3] > 0 ||
+          stateObj.attributes.rgbww_color[4] > 0)
+      ) {
+        return `rgb(255, 255, 255)`;
+      }
+      return `rgb(${stateObj.attributes.rgbww_color.slice(0, 3).join(",")})`;
+    }
+    if (stateObj.attributes.rgbw_color) {
+      if (
+        stateObj.attributes.rgbw_color[0] === 0 &&
+        stateObj.attributes.rgbw_color[1] === 0 &&
+        stateObj.attributes.rgbw_color[2] === 0 &&
+        stateObj.attributes.rgbw_color[3] > 0
+      ) {
+        return `rgb(255, 255, 255)`;
+      }
+      return `rgb(${stateObj.attributes.rgbw_color.slice(0, 3).join(",")})`;
+    }
     if (stateObj.attributes.rgb_color) {
       return `rgb(${stateObj.attributes.rgb_color.join(",")})`;
     }

--- a/src/panels/lovelace/cards/hui-entity-card.ts
+++ b/src/panels/lovelace/cards/hui-entity-card.ts
@@ -200,6 +200,30 @@ export class HuiEntityCard extends LitElement implements LovelaceCard {
       }
       return undefined;
     }
+    // on rgbw/rgbww, if only white color(s) are turned off, set rgb to white, otherwise return rgb part
+    if (stateObj.attributes.rgbww_color) {
+      if (
+        stateObj.attributes.rgbww_color[0] === 0 &&
+        stateObj.attributes.rgbww_color[1] === 0 &&
+        stateObj.attributes.rgbww_color[2] === 0 &&
+        (stateObj.attributes.rgbww_color[3] > 0 ||
+          stateObj.attributes.rgbww_color[4] > 0)
+      ) {
+        return `rgb(255, 255, 255)`;
+      }
+      return `rgb(${stateObj.attributes.rgbww_color.slice(0, 3).join(",")})`;
+    }
+    if (stateObj.attributes.rgbw_color) {
+      if (
+        stateObj.attributes.rgbw_color[0] === 0 &&
+        stateObj.attributes.rgbw_color[1] === 0 &&
+        stateObj.attributes.rgbw_color[2] === 0 &&
+        stateObj.attributes.rgbw_color[3] > 0
+      ) {
+        return `rgb(255, 255, 255)`;
+      }
+      return `rgb(${stateObj.attributes.rgbw_color.slice(0, 3).join(",")})`;
+    }
     if (stateObj.attributes.rgb_color) {
       return `rgb(${stateObj.attributes.rgb_color.join(",")})`;
     }

--- a/src/panels/lovelace/cards/hui-light-card.ts
+++ b/src/panels/lovelace/cards/hui-light-card.ts
@@ -236,6 +236,30 @@ export class HuiLightCard extends LitElement implements LovelaceCard {
     if (stateObj.state === "off") {
       return "";
     }
+    // on rgbw/rgbww, if only white color(s) are turned off, set rgb to white, otherwise return rgb part
+    if (stateObj.attributes.rgbww_color) {
+      if (
+        stateObj.attributes.rgbww_color[0] === 0 &&
+        stateObj.attributes.rgbww_color[1] === 0 &&
+        stateObj.attributes.rgbww_color[2] === 0 &&
+        (stateObj.attributes.rgbww_color[3] > 0 ||
+          stateObj.attributes.rgbww_color[4] > 0)
+      ) {
+        return `rgb(255, 255, 255)`;
+      }
+      return `rgb(${stateObj.attributes.rgbww_color.slice(0, 3).join(",")})`;
+    }
+    if (stateObj.attributes.rgbw_color) {
+      if (
+        stateObj.attributes.rgbw_color[0] === 0 &&
+        stateObj.attributes.rgbw_color[1] === 0 &&
+        stateObj.attributes.rgbw_color[2] === 0 &&
+        stateObj.attributes.rgbw_color[3] > 0
+      ) {
+        return `rgb(255, 255, 255)`;
+      }
+      return `rgb(${stateObj.attributes.rgbw_color.slice(0, 3).join(",")})`;
+    }
     return stateObj.attributes.rgb_color
       ? `rgb(${stateObj.attributes.rgb_color.join(",")})`
       : "";


### PR DESCRIPTION
## Proposed change

Hello,

Following [this issue](https://github.com/home-assistant/frontend/issues/10814): "The color of the bulb is black for a RGBW light with low white level".

I tried a solution, so I ask for review and help :pray: 

Thank you

## Type of change

- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

A RGBW or RGBWW light

## Additional information

- This PR fixes or closes issue: fixes #10814
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
