### PR TITLE
Hide tooltip after clicking on a chart to display more info (cosmetic change)

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -180,7 +180,9 @@ export class StateHistoryChartLine extends LitElement {
             return;
           }
 
-          const points = e.chart.getElementsAtEventForMode(
+          const chart = e.chart;
+
+          const points = chart.getElementsAtEventForMode(
             e,
             "nearest",
             { intersect: true },
@@ -192,6 +194,7 @@ export class StateHistoryChartLine extends LitElement {
             fireEvent(this, "hass-more-info", {
               entityId: this._entityIds[firstPoint.datasetIndex],
             });
+            chart.canvas.dispatchEvent(new Event("mouseout")); // to hide tooltip
           }
         },
       };

--- a/src/components/chart/state-history-chart-timeline.ts
+++ b/src/components/chart/state-history-chart-timeline.ts
@@ -238,6 +238,7 @@ export class StateHistoryChartTimeline extends LitElement {
           // @ts-ignore
           entityId: this._chartData?.datasets[index]?.label,
         });
+        chart.canvas.dispatchEvent(new Event("mouseout")); // to hide tooltip
       },
     };
   }

--- a/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-devices-graph-card.ts
@@ -164,6 +164,7 @@ export class HuiEnergyDevicesGraphCard
           // @ts-ignore
           entityId: this._chartData?.datasets[0]?.data[index]?.y,
         });
+        chart.canvas.dispatchEvent(new Event("mouseout")); // to hide tooltip
       },
     })
   );


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Follow up to #18036.

Desktop browsers fire mouseout when a new DOM element appears between a chart and the mouse pointer but mobile browsers never send it, they would only send `touchend` or `touchcancel`. But chartjs uses `touchend` to [emulate `mouseup` only](https://github.com/chartjs/Chart.js/blob/6516b0a150eebf3fb9eab596f89d63e27e1bc6d5/src/platform/platform.dom.js#L24).

Not having `mouseout` on mobile causes tooltip to stay visible after opening More Info dialog. Not a big deal as it can be hidden by clicking on the tooltip or elsewhere but it would be nicer if it hid automatically.

![photo_2023-10-02_23-13-40](https://github.com/home-assistant/frontend/assets/966992/e70a3231-fd5a-49be-acc6-4d3cd0c36e85)

This PR additionally sends `mouseout` event to the chart's canvas to [force tooltip to hide](https://github.com/chartjs/Chart.js/blob/6516b0a150eebf3fb9eab596f89d63e27e1bc6d5/src/plugins/plugin.tooltip.js#L1179).
While this is a workaround, it should be harmless.

Other possible way to fix this would be creating PR to chart.js to somehow make `touchend` to also automatically call `mouseout`. I am not sure if that would be a better option as I am worried that some people may want to keep tooltip visible on `mouseup` for some specific use-cases. Here in these three cases we are sure we want tooltips to hide so maybe it is more sensible to simply add this workaround.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
