### PR TITLE
Add translations for restore backup dialogs

### DIFF
--- a/hassio/src/backups/hassio-backups.ts
+++ b/hassio/src/backups/hassio-backups.ts
@@ -360,11 +360,9 @@ export class HassioBackups extends LitElement {
     if (this.supervisor!.info.state !== "running") {
       showAlertDialog(this, {
         title: this.supervisor!.localize("backup.could_not_create"),
-        text: this.supervisor!.localize(
-          "backup.create_blocked_not_running",
-          "state",
-          this.supervisor!.info.state
-        ),
+        text: this.supervisor!.localize("backup.create_blocked_not_running", {
+          state: this.supervisor!.info.state,
+        }),
       });
       return;
     }

--- a/hassio/src/dialogs/backup/dialog-hassio-backup.ts
+++ b/hassio/src/dialogs/backup/dialog-hassio-backup.ts
@@ -31,6 +31,7 @@ import { fileDownload } from "../../../../src/util/file_download";
 import "../../components/supervisor-backup-content";
 import type { SupervisorBackupContent } from "../../components/supervisor-backup-content";
 import { HassioBackupDialogParams } from "./show-dialog-hassio-backup";
+import { BackupOrRestoreKey } from "../../util/translations";
 
 @customElement("dialog-hassio-backup")
 class HassioBackupDialog
@@ -64,6 +65,13 @@ class HassioBackupDialog
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
+  private _localize(key: BackupOrRestoreKey) {
+    return (
+      this._dialogParams!.supervisor?.localize(`backup.${key}`) ||
+      this._dialogParams!.localize!(`ui.panel.page-onboarding.restore.${key}`)
+    );
+  }
+
   protected render() {
     if (!this._dialogParams || !this._backup) {
       return nothing;
@@ -79,7 +87,7 @@ class HassioBackupDialog
           <ha-header-bar>
             <span slot="title">${this._backup.name}</span>
             <ha-icon-button
-              .label=${this.hass?.localize("ui.common.close") || "Close"}
+              .label=${this._localize("close")}
               .path=${mdiClose}
               slot="actionItems"
               dialogAction="cancel"
@@ -87,29 +95,31 @@ class HassioBackupDialog
           </ha-header-bar>
         </div>
         ${this._restoringBackup
-          ? html` <ha-circular-progress active></ha-circular-progress>`
-          : html`<supervisor-backup-content
-              .hass=${this.hass}
-              .supervisor=${this._dialogParams.supervisor}
-              .backup=${this._backup}
-              .onboarding=${this._dialogParams.onboarding || false}
-              .localize=${this._dialogParams.localize}
-              dialogInitialFocus
-            >
-            </supervisor-backup-content>`}
+          ? html`<ha-circular-progress active></ha-circular-progress>`
+          : html`
+              <supervisor-backup-content
+                .hass=${this.hass}
+                .supervisor=${this._dialogParams.supervisor}
+                .backup=${this._backup}
+                .onboarding=${this._dialogParams.onboarding || false}
+                .localize=${this._dialogParams.localize}
+                dialogInitialFocus
+              >
+              </supervisor-backup-content>
+            `}
         ${this._error
           ? html`<ha-alert alert-type="error">${this._error}</ha-alert>`
-          : ""}
+          : nothing}
 
         <mwc-button
           .disabled=${this._restoringBackup}
           slot="secondaryAction"
           @click=${this._restoreClicked}
         >
-          Restore
+          ${this._localize("restore")}
         </mwc-button>
 
-        ${!this._dialogParams.onboarding
+        ${!this._dialogParams.onboarding && this._dialogParams.supervisor
           ? html`<ha-button-menu
               fixed
               slot="primaryAction"
@@ -117,22 +127,24 @@ class HassioBackupDialog
               @closed=${stopPropagation}
             >
               <ha-icon-button
-                .label=${this.hass!.localize("ui.common.menu") || "Menu"}
+                .label=${this._dialogParams.supervisor.localize(
+                  "backup.more_actions"
+                )}
                 .path=${mdiDotsVertical}
                 slot="trigger"
               ></ha-icon-button>
               <mwc-list-item
-                >${this._dialogParams.supervisor?.localize(
+                >${this._dialogParams.supervisor.localize(
                   "backup.download_backup"
                 )}</mwc-list-item
               >
               <mwc-list-item class="error"
-                >${this._dialogParams.supervisor?.localize(
+                >${this._dialogParams.supervisor.localize(
                   "backup.delete_backup_title"
                 )}</mwc-list-item
               >
             </ha-button-menu>`
-          : ""}
+          : nothing}
       </ha-dialog>
     `;
   }
@@ -183,21 +195,22 @@ class HassioBackupDialog
   }
 
   private async _partialRestoreClicked(backupDetails) {
-    if (
-      this._dialogParams?.supervisor !== undefined &&
-      this._dialogParams?.supervisor.info.state !== "running"
-    ) {
+    const supervisor = this._dialogParams?.supervisor;
+    if (supervisor !== undefined && supervisor.info.state !== "running") {
       await showAlertDialog(this, {
-        title: "Could not restore backup",
-        text: `Restoring a backup is not possible right now because the system is in ${this._dialogParams?.supervisor.info.state} state.`,
+        title: supervisor.localize("backup.could_not_restore"),
+        text: supervisor.localize("backup.restore_blocked_not_running", {
+          state: supervisor.info.state,
+        }),
       });
       return;
     }
     if (
       !(await showConfirmationDialog(this, {
-        title: "Are you sure you want to restore this partial backup?",
-        confirmText: "restore",
-        dismissText: "cancel",
+        title: this._localize("confirm_restore_partial_backup_title"),
+        text: this._localize("confirm_restore_partial_backup_text"),
+        confirmText: this._localize("restore"),
+        dismissText: this._localize("cancel"),
       }))
     ) {
       return;
@@ -230,22 +243,22 @@ class HassioBackupDialog
   }
 
   private async _fullRestoreClicked(backupDetails) {
-    if (
-      this._dialogParams?.supervisor !== undefined &&
-      this._dialogParams?.supervisor.info.state !== "running"
-    ) {
+    const supervisor = this._dialogParams?.supervisor;
+    if (supervisor !== undefined && supervisor.info.state !== "running") {
       await showAlertDialog(this, {
-        title: "Could not restore backup",
-        text: `Restoring a backup is not possible right now because the system is in ${this._dialogParams?.supervisor.info.state} state.`,
+        title: supervisor.localize("backup.could_not_restore"),
+        text: supervisor.localize("backup.restore_blocked_not_running", {
+          state: supervisor.info.state,
+        }),
       });
       return;
     }
     if (
       !(await showConfirmationDialog(this, {
-        title:
-          "Are you sure you want to wipe your system and restore this backup?",
-        confirmText: "restore",
-        dismissText: "cancel",
+        title: this._localize("confirm_restore_full_backup_title"),
+        text: this._localize("confirm_restore_full_backup_text"),
+        confirmText: this._localize("restore"),
+        dismissText: this._localize("cancel"),
       }))
     ) {
       return;
@@ -279,11 +292,15 @@ class HassioBackupDialog
   }
 
   private async _deleteClicked() {
+    const supervisor = this._dialogParams?.supervisor;
+    if (!supervisor) return;
+
     if (
       !(await showConfirmationDialog(this, {
-        title: "Are you sure you want to delete this backup?",
-        confirmText: "delete",
-        dismissText: "cancel",
+        title: supervisor!.localize("backup.confirm_delete_title"),
+        text: supervisor!.localize("backup.confirm_delete_text"),
+        confirmText: supervisor!.localize("backup.delete"),
+        dismissText: supervisor!.localize("backup.cancel"),
       }))
     ) {
       return;
@@ -301,6 +318,9 @@ class HassioBackupDialog
   }
 
   private async _downloadClicked() {
+    const supervisor = this._dialogParams?.supervisor;
+    if (!supervisor) return;
+
     let signedPath: { path: string };
     try {
       signedPath = await getSignedPath(
@@ -320,10 +340,10 @@ class HassioBackupDialog
 
     if (window.location.href.includes("ui.nabu.casa")) {
       const confirm = await showConfirmationDialog(this, {
-        title: "Potential slow download",
-        text: "Downloading backups over the Nabu Casa URL will take some time, it is recomended to use your local URL instead, do you want to continue?",
-        confirmText: "continue",
-        dismissText: "cancel",
+        title: supervisor.localize("backup.remote_download_title"),
+        text: supervisor.localize("backup.remote_download_text"),
+        confirmText: supervisor.localize("backup.download"),
+        dismissText: this._localize("cancel"),
       });
       if (!confirm) {
         return;

--- a/hassio/src/dialogs/backup/dialog-hassio-create-backup.ts
+++ b/hassio/src/dialogs/backup/dialog-hassio-create-backup.ts
@@ -89,8 +89,7 @@ class HassioCreateBackupDialog extends LitElement {
         ),
         text: this._dialogParams!.supervisor.localize(
           "backup.create_blocked_not_running",
-          "state",
-          this._dialogParams!.supervisor.info.state
+          { state: this._dialogParams!.supervisor.info.state }
         ),
       });
       return;

--- a/hassio/src/util/translations.ts
+++ b/hassio/src/util/translations.ts
@@ -1,0 +1,4 @@
+import type { TranslationDict } from "../../../src/types";
+
+export type BackupOrRestoreKey = keyof TranslationDict["supervisor"]["backup"] &
+  keyof TranslationDict["ui"]["panel"]["page-onboarding"]["restore"];

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5853,7 +5853,14 @@
           "addons": "[%key:supervisor::backup::addons%]",
           "password_protection": "[%key:supervisor::backup::password_protection%]",
           "password": "[%key:supervisor::backup::password%]",
-          "confirm_password": "[%key:supervisor::backup::confirm_password%]"
+          "confirm_password": "[%key:supervisor::backup::confirm_password%]",
+          "confirm_restore_partial_backup_title": "[%key:supervisor::backup::confirm_restore_partial_backup_title%]",
+          "confirm_restore_partial_backup_text": "[%key:supervisor::backup::confirm_restore_partial_backup_text%]",
+          "confirm_restore_full_backup_title": "[%key:supervisor::backup::confirm_restore_full_backup_title%]",
+          "confirm_restore_full_backup_text": "[%key:supervisor::backup::confirm_restore_full_backup_text%]",
+          "restore": "[%key:supervisor::backup::restore%]",
+          "close": "[%key:ui::common::close%]",
+          "cancel": "[%key:ui::common::cancel%]"
         }
       },
       "custom": {
@@ -6256,7 +6263,8 @@
     "backup": {
       "search": "[%key:ui::panel::config::backup::picker::search%]",
       "no_backups": "You don't have any backups yet.",
-      "create_blocked_not_running": "Creating a backup is not possible right now because the system is in {state} state.",
+      "create_blocked_not_running": "Creating a backup is not possible right now because the system is in \"{state}\" state.",
+      "restore_blocked_not_running": "Restoring a backup is not possible right now because the system is in \"{state}\" state.",
       "delete_selected": "Delete selected backups",
       "delete_backup_title": "Delete backup",
       "delete_backup_text": "Do you want to delete {number} {number, plural,\n  one {backup}\n  other {backups}\n}?",
@@ -6264,6 +6272,7 @@
       "selected": "{number} selected",
       "failed_to_delete": "Failed to delete",
       "could_not_create": "Could not create backup",
+      "could_not_restore": "Could not restore backup",
       "upload_backup": "Upload backup",
       "download_backup": "Download backup",
       "create_backup": "Create backup",
@@ -6284,7 +6293,21 @@
       "password_protection": "Password protection",
       "enter_password": "Please enter a password.",
       "passwords_not_matching": "The passwords does not match",
-      "backup_already_running": "A backup or restore is already running, creating a new backup is currently not possible, try again later."
+      "backup_already_running": "A backup or restore is already running, creating a new backup is currently not possible, try again later.",
+      "confirm_restore_partial_backup_title": "Restore partial backup",
+      "confirm_restore_partial_backup_text": "The backup will be restored. Depending of the size of the backup, this can take up to 45 min.",
+      "confirm_restore_full_backup_title": "Restore full backup",
+      "confirm_restore_full_backup_text": "Your entire system will be wiped and the backup will be restored. Depending of the size of the backup, this can take up to 45 min.",
+      "confirm_delete_title": "Delete backup",
+      "confirm_delete_text": "This backup will be permanently deleted and cannot be restored later.",
+      "restore": "Restore",
+      "close": "[%key:ui::common::close%]",
+      "cancel": "[%key:ui::common::cancel%]",
+      "delete": "[%key:ui::common::delete%]",
+      "download": "Download",
+      "more_actions": "More actions",
+      "remote_download_title": "Potential slow download",
+      "remote_download_text": "Downloading backups over the Nabu Casa URL will take some time, it is recomended to use your local URL instead, do you want to continue?"
     },
     "dialog": {
       "network": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6306,7 +6306,7 @@
       "delete": "[%key:ui::common::delete%]",
       "download": "Download",
       "more_actions": "More actions",
-      "remote_download_title": "Potential slow download",
+      "remote_download_title": "Potentially slow download",
       "remote_download_text": "Downloading backups over the Nabu Casa URL will take some time, it is recomended to use your local URL instead, do you want to continue?"
     },
     "dialog": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6295,7 +6295,7 @@
       "passwords_not_matching": "The passwords does not match",
       "backup_already_running": "A backup or restore is already running. Creating a new backup is currently not possible, try again later.",
       "confirm_restore_partial_backup_title": "Restore partial backup",
-      "confirm_restore_partial_backup_text": "The backup will be restored. Depending of the size of the backup, this can take up to 45 min.",
+      "confirm_restore_partial_backup_text": "The backup will be restored. Depending on the size of the backup, this can take up to 45 min.",
       "confirm_restore_full_backup_title": "Restore full backup",
       "confirm_restore_full_backup_text": "Your entire system will be wiped and the backup will be restored. Depending of the size of the backup, this can take up to 45 min.",
       "confirm_delete_title": "Delete backup",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6307,7 +6307,7 @@
       "download": "Download",
       "more_actions": "More actions",
       "remote_download_title": "Potentially slow download",
-      "remote_download_text": "Downloading backups over the Nabu Casa URL will take some time, it is recomended to use your local URL instead, do you want to continue?"
+      "remote_download_text": "You are accessing Home Assistant via remote access. Downloading backups over the Nabu Casa URL will take some time. If you are at home, cancel this dialog and enter your local URL, such as 'http://homeassistant.local:8123'"
     },
     "dialog": {
       "network": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6297,7 +6297,7 @@
       "confirm_restore_partial_backup_title": "Restore partial backup",
       "confirm_restore_partial_backup_text": "The backup will be restored. Depending on the size of the backup, this can take up to 45 min.",
       "confirm_restore_full_backup_title": "Restore full backup",
-      "confirm_restore_full_backup_text": "Your entire system will be wiped and the backup will be restored. Depending of the size of the backup, this can take up to 45 min.",
+      "confirm_restore_full_backup_text": "Your entire system will be wiped and the backup will be restored. Depending on the size of the backup, this can take up to 45 min.",
       "confirm_delete_title": "Delete backup",
       "confirm_delete_text": "This backup will be permanently deleted and cannot be restored later.",
       "restore": "Restore",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -6293,7 +6293,7 @@
       "password_protection": "Password protection",
       "enter_password": "Please enter a password.",
       "passwords_not_matching": "The passwords does not match",
-      "backup_already_running": "A backup or restore is already running, creating a new backup is currently not possible, try again later.",
+      "backup_already_running": "A backup or restore is already running. Creating a new backup is currently not possible, try again later.",
       "confirm_restore_partial_backup_title": "Restore partial backup",
       "confirm_restore_partial_backup_text": "The backup will be restored. Depending of the size of the backup, this can take up to 45 min.",
       "confirm_restore_full_backup_title": "Restore full backup",


### PR DESCRIPTION
## Proposed change

Add descriptions and translations for restore backup dialogs.

### Delete backup
![CleanShot 2023-10-04 at 09 54 13](https://github.com/home-assistant/frontend/assets/5878303/8f5e224d-b1ef-4181-ab75-fcd32b1a475c)

### Restore partial backup
![CleanShot 2023-10-04 at 09 53 32](https://github.com/home-assistant/frontend/assets/5878303/33488fd5-d347-42cb-94e7-d0d0a9284ae9)

### Restore full backup
![CleanShot 2023-10-04 at 09 53 12](https://github.com/home-assistant/frontend/assets/5878303/e80d3ae3-e533-4d98-9c8c-7d03fdef3a63)

### Slow download
![CleanShot 2023-10-04 at 09 57 21](https://github.com/home-assistant/frontend/assets/5878303/812de970-68c0-415e-a90d-c7f19bc3bac3)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
