### PR TITLE
Use restart dialog confirmation for quick command

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1203,6 +1203,11 @@
           "confirm_action": "Restart",
           "failed": "Failed to restart Home Assistant"
         },
+        "stop": {
+          "confirm_title": "Stop Home Assistant?",
+          "confirm_description": "This will interrupt all running automations and scripts.",
+          "confirm_action": "Stop"
+        },
         "reboot": {
           "title": "Reboot system",
           "description": "Restart the system running Home Assistant and all Add-ons.",


### PR DESCRIPTION
## Proposed change

Use the confirm restart dialog when restarting home assistant from quick command. Similar action has been added for stop action.

### Before

![CleanShot 2023-10-04 at 13 49 32](https://github.com/home-assistant/frontend/assets/5878303/f7223013-3e76-4e58-92f9-2d642151257d)

### After

![CleanShot 2023-10-04 at 13 48 53](https://github.com/home-assistant/frontend/assets/5878303/39209876-50f0-407f-99e0-a5007c50cf61)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
