### PR TITLE
Fix period selector in statistic card

### DIFF
--- a/src/panels/lovelace/editor/config-elements/hui-statistic-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-statistic-card-editor.ts
@@ -196,7 +196,7 @@ export class HuiStatisticCardEditor
   }
 
   private async _valueChanged(ev: CustomEvent) {
-    const config = ev.detail.value as StatisticCardConfig;
+    const config = { ...ev.detail.value } as StatisticCardConfig;
     Object.keys(config).forEach((k) => config[k] === "" && delete config[k]);
 
     if (typeof config.period === "string") {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This was a bit of a puzzler at first, since the code seemed to be written correctly, but I believe what is happening is that on line 205 when config.period was assigned to period (replacing the string version of period with the object form), this was actually leaking back up into the selector-select (or perhaps ha-form?), since the event.detail.value is just a reference to the actual value inside the selector.

So when we assigned that variable it it modified the actual `value` property inside the selector-select, and the next time it rendered, the `value` was an object instead of the original string, causing it to then fire valueChanged with an empty string, since that object didn't match any of the string options. 

Cloning ev.detail.value into a duplicate object before modifying it breaks this link and the selector works correctly. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18129
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
