### PR TITLE
Move polyfill time zone data out of bundles

### DIFF
--- a/src/resources/intl-polyfill.ts
+++ b/src/resources/intl-polyfill.ts
@@ -5,7 +5,10 @@ import { shouldPolyfill as shouldPolyfillPluralRules } from "@formatjs/intl-plur
 import { shouldPolyfill as shouldPolyfillRelativeTime } from "@formatjs/intl-relativetimeformat/should-polyfill";
 import { shouldPolyfill as shouldPolyfillListFormat } from "@formatjs/intl-listformat/should-polyfill";
 import { getLocalLanguage } from "../util/common-translation";
-import { polyfillLocaleData } from "./locale-data-polyfill";
+import {
+  polyfillLocaleData,
+  polyfillTimeZoneData,
+} from "./locale-data-polyfill";
 
 const polyfillIntl = async () => {
   const locale = getLocalLanguage();
@@ -22,8 +25,8 @@ const polyfillIntl = async () => {
   }
   if (shouldPolyfillDateTime(locale)) {
     polyfills.push(
-      import("@formatjs/intl-datetimeformat/polyfill-force").then(
-        () => import("@formatjs/intl-datetimeformat/add-all-tz")
+      import("@formatjs/intl-datetimeformat/polyfill-force").then(() =>
+        polyfillTimeZoneData()
       )
     );
   }

--- a/src/resources/locale-data-polyfill.ts
+++ b/src/resources/locale-data-polyfill.ts
@@ -13,16 +13,17 @@ const loadedLocales: Set<string> = new Set();
 
 const addData = async (
   obj: (typeof INTL_POLYFILLS)[number],
-  language: string
+  language: string,
+  addFunc = "__addLocaleData"
 ) => {
   // Add function will only exist if constructor is polyfilled
-  if (typeof (Intl[obj] as any)?.__addLocaleData === "function") {
+  if (typeof (Intl[obj] as any)?.[addFunc] === "function") {
     const result = await fetch(
       `${__STATIC_PATH__}locale-data/intl-${obj.toLowerCase()}/${language}.json`
     );
     // Ignore if polyfill data does not exist for language
     if (result.ok) {
-      (Intl[obj] as any).__addLocaleData(await result.json());
+      (Intl[obj] as any)[addFunc](await result.json());
     }
   }
 };
@@ -34,3 +35,6 @@ export const polyfillLocaleData = async (language: string) => {
   loadedLocales.add(language);
   await Promise.all(INTL_POLYFILLS.map((obj) => addData(obj, language)));
 };
+
+export const polyfillTimeZoneData = () =>
+  addData("DateTimeFormat", "add-all-tz", "__addTZData");


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Time zone data from `@formatjs` is 1.4 MB, which is currently in the bundles being precached.  Modern browsers with `Intl.DateTimeFormat` support don't need it, so this moves it out with the other locale data.  I only did this for the modern polyfill (i.e. only the modern build) because in a couple more PRs I should be able to remove the legacy version without TLA.

The current regex to extract the data object doesn't apply to the JS file that loads the time zone data (different function and different formatting).  So I rewrote it to just look for the function call and capture its argument.  I did verify the extracted locale data is exactly the same.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
