### PR TITLE
Tile card current temperature for climate entity

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -41,6 +41,7 @@ import {
 import { isUnavailableState } from "../../../data/entity";
 import { FanEntity, computeFanSpeedStateDisplay } from "../../../data/fan";
 import type { HumidifierEntity } from "../../../data/humidifier";
+import type { ClimateEntity } from "../../../data/climate";
 import type { LightEntity } from "../../../data/light";
 import type { ActionHandlerEvent } from "../../../data/lovelace";
 import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
@@ -236,6 +237,20 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
           Math.round(humidity)
         );
         return `${stateDisplay} ⸱ ${formattedHumidity}`;
+      }
+    }
+
+    if (domain === "climate") {
+      const current_temperature = (stateObj as ClimateEntity).attributes
+        .current_temperature;
+      if (current_temperature) {
+        const formattedCurrentTemperature =
+          this.hass!.formatEntityAttributeValue(
+            stateObj,
+            "current_temperature",
+            current_temperature
+          );
+        return `${stateDisplay} ⸱ ${formattedCurrentTemperature}`;
       }
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Show current temperature for climate entities at the tile card:

![Kazam_screenshot_00027](https://github.com/home-assistant/frontend/assets/6751243/b76a3b6b-4d77-4759-b4be-7d8aa99f4c5a)

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/frontend/issues/17855
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
