### PR TITLE
Use switch instead of checkbox for network adapter selector

### DIFF
--- a/src/components/ha-network.ts
+++ b/src/components/ha-network.ts
@@ -18,8 +18,8 @@ import {
 } from "../data/network";
 import { haStyle } from "../resources/styles";
 import { HomeAssistant } from "../types";
-import "./ha-checkbox";
-import type { HaCheckbox } from "./ha-checkbox";
+import "./ha-switch";
+import type { HaSwitch } from "./ha-switch";
 import "./ha-settings-row";
 import "./ha-svg-icon";
 
@@ -61,35 +61,23 @@ export class HaNetwork extends LitElement {
     const configured_adapters = this.networkConfig.configured_adapters || [];
     return html`
       <ha-settings-row>
-        <span slot="prefix">
-          <ha-checkbox
-            id="auto_configure"
-            @change=${this._handleAutoConfigureCheckboxClick}
-            .checked=${!configured_adapters.length}
-            name="auto_configure"
-          >
-          </ha-checkbox>
-        </span>
         <span slot="heading" data-for="auto_configure"> Auto Configure </span>
         <span slot="description" data-for="auto_configure">
           Detected:
           ${format_auto_detected_interfaces(this.networkConfig.adapters)}
         </span>
+        <ha-switch
+          id="auto_configure"
+          @change=${this._handleAutoConfigureSwitchClick}
+          .checked=${!configured_adapters.length}
+          name="auto_configure"
+        >
+        </ha-switch>
       </ha-settings-row>
       ${configured_adapters.length || this._expanded
         ? this.networkConfig.adapters.map(
             (adapter) =>
               html`<ha-settings-row>
-                <span slot="prefix">
-                  <ha-checkbox
-                    id=${adapter.name}
-                    @change=${this._handleAdapterCheckboxClick}
-                    .checked=${configured_adapters.includes(adapter.name)}
-                    .adapter=${adapter.name}
-                    name=${adapter.name}
-                  >
-                  </ha-checkbox>
-                </span>
                 <span slot="heading">
                   Adapter: ${adapter.name}
                   ${adapter.default
@@ -100,21 +88,29 @@ export class HaNetwork extends LitElement {
                 <span slot="description">
                   ${format_addresses([...adapter.ipv4, ...adapter.ipv6])}
                 </span>
+                <ha-switch
+                  id=${adapter.name}
+                  @change=${this._handleAdapterSwitchClick}
+                  .checked=${configured_adapters.includes(adapter.name)}
+                  .adapter=${adapter.name}
+                  name=${adapter.name}
+                >
+                </ha-switch>
               </ha-settings-row>`
           )
         : ""}
     `;
   }
 
-  private _handleAutoConfigureCheckboxClick(ev: Event) {
-    const checkbox = ev.currentTarget as HaCheckbox;
+  private _handleAutoConfigureSwitchClick(ev: Event) {
+    const switch_ = ev.currentTarget as HaSwitch;
     if (this.networkConfig === undefined) {
       return;
     }
 
     let configured_adapters = [...this.networkConfig.configured_adapters];
 
-    if (checkbox.checked) {
+    if (switch_.checked) {
       this._expanded = false;
       configured_adapters = [];
     } else {
@@ -132,16 +128,16 @@ export class HaNetwork extends LitElement {
     });
   }
 
-  private _handleAdapterCheckboxClick(ev: Event) {
-    const checkbox = ev.currentTarget as HaCheckbox;
-    const adapter_name = (checkbox as any).name;
+  private _handleAdapterSwitchClick(ev: Event) {
+    const switch_ = ev.currentTarget as HaSwitch;
+    const adapter_name = (switch_ as any).adapter;
     if (this.networkConfig === undefined) {
       return;
     }
 
     const configured_adapters = [...this.networkConfig.configured_adapters];
 
-    if (checkbox.checked) {
+    if (switch_.checked) {
       configured_adapters.push(adapter_name);
     } else {
       const index = configured_adapters.indexOf(adapter_name, 0);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4324,7 +4324,7 @@
             }
           },
           "network_adapter": "Network adapter",
-          "network_adapter_info": "Configure which network adapters integrations will use. Currently this setting only affects multicast traffic. A restart is required for these settings to apply.",
+          "network_adapter_info": "Configure which network adapters integrations will use. This is used for multicast and broadcast purposes. A restart is required for these settings to apply.",
           "ip_information": "IP Information"
         },
         "storage": {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR changes the network configuration pane to use selects instead of checkboxes for usability reasons, making it more clear that toggling will reveal new items as discussed in https://github.com/home-assistant/frontend/pull/11769#issuecomment-1337803052 .
This also updates the documentation string as at least steamist, wiz, elkm1, flux_led, and tplink call `async_get_ipv4_broadcast_addresses`.

![Screenshot_20231009_151350](https://github.com/home-assistant/frontend/assets/3705853/1f8fed1c-3a44-41cb-97ff-dd82c580d640)

![Screenshot_20231009_151240](https://github.com/home-assistant/frontend/assets/3705853/c9cad9f8-3948-4d53-8a74-ddea4be6101e)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: #11769
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
