### PR TITLE
Remove the check for target from developer-tools/service

### DIFF
--- a/src/panels/developer-tools/service/developer-tools-service.ts
+++ b/src/panels/developer-tools/service/developer-tools-service.ts
@@ -297,7 +297,6 @@ class HaPanelDevService extends LitElement {
   private _validateServiceData = (
     serviceData,
     fields,
-    target,
     yamlMode: boolean,
     localize: LocalizeFunc
   ): string | undefined => {
@@ -312,17 +311,6 @@ class HaPanelDevService extends LitElement {
     if (!domain || !service) {
       return localize(
         `ui.panel.developer-tools.tabs.services.errors.${errorCategory}.invalid_service`
-      );
-    }
-    if (
-      target &&
-      !serviceData.target &&
-      !serviceData.data?.entity_id &&
-      !serviceData.data?.device_id &&
-      !serviceData.data?.area_id
-    ) {
-      return localize(
-        `ui.panel.developer-tools.tabs.services.errors.${errorCategory}.no_target`
       );
     }
     for (const field of fields) {
@@ -382,7 +370,7 @@ class HaPanelDevService extends LitElement {
       return;
     }
 
-    const { target, fields } = this._fields(
+    const { fields } = this._fields(
       this.hass.services,
       this._serviceData?.service
     );
@@ -390,7 +378,6 @@ class HaPanelDevService extends LitElement {
     this._error = this._validateServiceData(
       this._serviceData,
       fields,
-      target,
       this._yamlMode,
       this.hass.localize
     );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5642,14 +5642,12 @@
               "ui": {
                 "no_service": "No service selected, please select a service",
                 "invalid_service": "Selected service is invalid, please select a valid service",
-                "no_target": "This service requires a target, please select a target from the picker",
                 "missing_required_field": "This service requires field {key}, please enter a valid value for {key}"
               },
               "yaml": {
                 "invalid_yaml": "Service YAML contains syntax errors, please fix the syntax",
                 "no_service": "No service defined, please define a service: key",
                 "invalid_service": "Defined service is invalid, please provide a service in the format domain.service",
-                "no_target": "This service requires a target, please define a target entity_id, device_id, or area_id under target: or data:",
                 "missing_required_field": "This service requires field {key}, which must be provided under data:"
               }
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

A user mentioned they have a component with a service with a target field, but that they consider the target as optional. They could not call this service in developer tools because the frontend enforced that a target be defined.

If optional targets are supported in the backend, than the frontend check in `developer-tools/services` that a script with a target field must have a target defined is too strict.

Therefore propose to remove this check. 

If the service actually requires a target, we will get the backend error message in response to the attempted service call, instead of the frontend generated error message that a target must be defined. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
