### PR TITLE
Say "log in" instead of "login" on the authorize page

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5443,7 +5443,7 @@
       },
       "page-authorize": {
         "initializing": "Initializing",
-        "authorizing": "Login to your Home Assistant instance",
+        "authorizing": "Log in to your Home Assistant instance",
         "authorizing_app": "You're about to give the Home Assistant Companion app for {app} access to your Home Assistant instance.",
         "authorizing_client": "You're about to give {clientId} access to your Home Assistant instance.",
         "logging_in_with": "Logging in with {authProviderName}.",
@@ -5453,7 +5453,7 @@
         "form": {
           "working": "Please wait",
           "unknown_error": "Something went wrong",
-          "next": "Login",
+          "next": "Log in",
           "start_over": "Start over",
           "error": "Error: {error}",
           "providers": {
@@ -5500,7 +5500,7 @@
                 "invalid_code": "Invalid authentication code"
               },
               "abort": {
-                "login_expired": "Session expired, please login again."
+                "login_expired": "Session expired, please log in again."
               }
             },
             "legacy_api_password": {
@@ -5533,7 +5533,7 @@
                   "data": {
                     "user": "User"
                   },
-                  "description": "Please select a user you want to login as:"
+                  "description": "Please select a user you want to log in as:"
                 }
               },
               "abort": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
- Right now we use "login" as a verb.
![image](https://github.com/home-assistant/frontend/assets/10727862/1df7203c-5c9f-4622-8266-73fad0c13f7b)
- While "login" is a word, it isn't proper grammar to use it this way.
- This PR updates the authorize page's English strings to say "log in" instead.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
N/A

## Additional information
N/A
*I realize that the docs could refer to the previous wording, but the effort (looking through all the times it says "login" and seeing if it refers to the authorize page) isn't worth the tradeoff (not much given most users will still click on "log in" even if the docs say "login").*

## Checklist
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
