### PR TITLE
Improve password show/hide buttons

### DIFF
--- a/src/auth/ha-auth-form-string.ts
+++ b/src/auth/ha-auth-form-string.ts
@@ -26,14 +26,10 @@ export class HaAuthFormString extends HaFormString {
         }
         ha-auth-form-string ha-icon-button {
           position: absolute;
-          top: 1em;
-          right: 12px;
-          --mdc-icon-button-size: 24px;
+          top: 8px;
+          inset-inline-end: 8px;
+          --mdc-icon-button-size: 40px;
           color: var(--secondary-text-color);
-        }
-        ha-auth-form-string ha-icon-button {
-          inset-inline-start: initial;
-          inset-inline-end: 12px;
           direction: var(--direction);
         }
       </style>
@@ -63,7 +59,7 @@ export class HaAuthFormString extends HaFormString {
         .validationMessage=${this.schema.required ? "Required" : undefined}
         @input=${this._valueChanged}
         @change=${this._valueChanged}
-        ></ha-auth-textfield> 
+        ></ha-auth-textfield>
         ${this.renderIcon()}
       </ha-auth-textfield>
     `;

--- a/src/auth/ha-auth-form-string.ts
+++ b/src/auth/ha-auth-form-string.ts
@@ -27,8 +27,11 @@ export class HaAuthFormString extends HaFormString {
         ha-auth-form-string ha-icon-button {
           position: absolute;
           top: 8px;
+          right: 8px;
+          inset-inline-start: initial;
           inset-inline-end: 8px;
           --mdc-icon-button-size: 40px;
+          --mdc-icon-size: 20px;
           color: var(--secondary-text-color);
           direction: var(--direction);
         }

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -138,15 +138,10 @@ export class HaFormString extends LitElement implements HaFormElement {
       }
       ha-icon-button {
         position: absolute;
-        top: 1em;
-        right: 12px;
-        --mdc-icon-button-size: 24px;
+        top: 8px;
+        inset-inline-end: 8px;
+        --mdc-icon-button-size: 40px;
         color: var(--secondary-text-color);
-      }
-
-      ha-icon-button {
-        inset-inline-start: initial;
-        inset-inline-end: 12px;
         direction: var(--direction);
       }
     `;

--- a/src/components/ha-form/ha-form-string.ts
+++ b/src/components/ha-form/ha-form-string.ts
@@ -139,8 +139,11 @@ export class HaFormString extends LitElement implements HaFormElement {
       ha-icon-button {
         position: absolute;
         top: 8px;
+        right: 8px;
+        inset-inline-start: initial;
         inset-inline-end: 8px;
         --mdc-icon-button-size: 40px;
+        --mdc-icon-size: 20px;
         color: var(--secondary-text-color);
         direction: var(--direction);
       }

--- a/src/components/ha-selector/ha-selector-text.ts
+++ b/src/components/ha-selector/ha-selector-text.ts
@@ -111,13 +111,10 @@ export class HaTextSelector extends LitElement {
       }
       ha-icon-button {
         position: absolute;
-        top: 10px;
-        right: 10px;
-        --mdc-icon-button-size: 36px;
-        --mdc-icon-size: 20px;
+        top: 8px;
+        inset-inline-end: 8px;
+        --mdc-icon-button-size: 40px;
         color: var(--secondary-text-color);
-        inset-inline-start: initial;
-        inset-inline-end: 10px;
         direction: var(--direction);
       }
     `;

--- a/src/components/ha-selector/ha-selector-text.ts
+++ b/src/components/ha-selector/ha-selector-text.ts
@@ -112,8 +112,11 @@ export class HaTextSelector extends LitElement {
       ha-icon-button {
         position: absolute;
         top: 8px;
+        right: 8px;
+        inset-inline-start: initial;
         inset-inline-end: 8px;
         --mdc-icon-button-size: 40px;
+        --mdc-icon-size: 20px;
         color: var(--secondary-text-color);
         direction: var(--direction);
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
- Right now the show/hide password buttons are a bit all over the place, with some redundant CSS, and either too small touch targets (ha-form-string/ha-auth-form-string) or too small icons (ha-selector-text).
- This changes them to have a consistent style that looks good and is easier to tap.
- On the auth page:
Before:
![image](https://github.com/home-assistant/frontend/assets/10727862/b86e2088-a001-41ab-90e2-1f593a2b14d9)
After:
![image](https://github.com/home-assistant/frontend/assets/10727862/e511321a-9b75-4902-8301-5e046f0b64a4)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.