### PR TITLE
Add support for state content customization in tile card

### DIFF
--- a/src/components/ha-selector/ha-selector-select.ts
+++ b/src/components/ha-selector/ha-selector-select.ts
@@ -1,7 +1,8 @@
 import "@material/mwc-list/mwc-list-item";
-import { mdiClose } from "@mdi/js";
+import { mdiClose, mdiDrag } from "@mdi/js";
 import { customElement, property, query } from "lit/decorators";
 import { css, html, LitElement, nothing, PropertyValues } from "lit";
+import { repeat } from "lit/directives/repeat";
 import { SortableEvent } from "sortablejs";
 import { ensureArray } from "../../common/array/ensure-array";
 import { fireEvent } from "../../common/dom/fire_event";
@@ -45,8 +46,12 @@ export class HaSelectSelector extends LitElement {
   private _sortable?: SortableInstance;
 
   protected updated(changedProps: PropertyValues): void {
-    if (changedProps.has("value")) {
-      if (this.value?.length && !this._sortable) {
+    if (changedProps.has("value") || changedProps.has("selector")) {
+      if (
+        this.value?.length &&
+        !this._sortable &&
+        this.selector.select?.reorder
+      ) {
         this._createSortable();
       } else if (!this.value?.length && this._sortable) {
         this._destroySortable();
@@ -133,7 +138,11 @@ export class HaSelectSelector extends LitElement {
       );
     }
 
-    if (!this.selector.select?.custom_value && this._mode === "list") {
+    if (
+      !this.selector.select?.custom_value &&
+      !this.selector.select?.reorder &&
+      this._mode === "list"
+    ) {
       if (!this.selector.select?.multiple) {
         return html`
           <div>
@@ -188,9 +197,23 @@ export class HaSelectSelector extends LitElement {
         ${value?.length
           ? html`
               <ha-chip-set>
-                ${value.map(
+                ${repeat(
+                  value,
+                  (item) => item,
                   (item, idx) => html`
-                    <ha-chip hasTrailingIcon>
+                    <ha-chip
+                      hasTrailingIcon
+                      .hasIcon=${this.selector.select?.reorder}
+                    >
+                      ${this.selector.select?.reorder
+                        ? html`
+                            <ha-svg-icon
+                              slot="icon"
+                              .path=${mdiDrag}
+                              data-handle
+                            ></ha-svg-icon>
+                          `
+                        : nothing}
                       ${options.find((option) => option.value === item)
                         ?.label || item}
                       <ha-svg-icon

--- a/src/components/ha-selector/ha-selector-select.ts
+++ b/src/components/ha-selector/ha-selector-select.ts
@@ -1,7 +1,7 @@
 import "@material/mwc-list/mwc-list-item";
 import { mdiClose, mdiDrag } from "@mdi/js";
+import { LitElement, PropertyValues, css, html, nothing } from "lit";
 import { customElement, property, query } from "lit/decorators";
-import { css, html, LitElement, nothing, PropertyValues } from "lit";
 import { repeat } from "lit/directives/repeat";
 import { SortableEvent } from "sortablejs";
 import { ensureArray } from "../../common/array/ensure-array";
@@ -11,7 +11,6 @@ import { caseInsensitiveStringCompare } from "../../common/string/compare";
 import type { SelectOption, SelectSelector } from "../../data/selector";
 import { sortableStyles } from "../../resources/ha-sortable-style";
 import { SortableInstance } from "../../resources/sortable";
-import { loadSortable } from "../../resources/sortable.ondemand";
 import type { HomeAssistant } from "../../types";
 import "../ha-checkbox";
 import "../ha-chip";
@@ -47,20 +46,20 @@ export class HaSelectSelector extends LitElement {
 
   protected updated(changedProps: PropertyValues): void {
     if (changedProps.has("value") || changedProps.has("selector")) {
-      if (
-        this.value?.length &&
-        !this._sortable &&
-        this.selector.select?.reorder
-      ) {
+      const sortableNeeded =
+        this.selector.select?.multiple &&
+        this.selector.select.reorder &&
+        this.value?.length;
+      if (!this._sortable && sortableNeeded) {
         this._createSortable();
-      } else if (!this.value?.length && this._sortable) {
+      } else if (this._sortable && !sortableNeeded) {
         this._destroySortable();
       }
     }
   }
 
   private async _createSortable() {
-    const Sortable = await loadSortable();
+    const Sortable = (await import("../../resources/sortable")).default;
     this._sortable = new Sortable(
       this.shadowRoot!.querySelector("ha-chip-set")!,
       {

--- a/src/data/entity_attributes.ts
+++ b/src/data/entity_attributes.ts
@@ -70,4 +70,7 @@ export const DOMAIN_ATTRIBUTES_UNITS: Record<string, Record<string, string>> = {
   vacuum: {
     battery_level: "%",
   },
+  sensor: {
+    battery_level: "%",
+  },
 };

--- a/src/data/entity_attributes.ts
+++ b/src/data/entity_attributes.ts
@@ -28,6 +28,7 @@ export const TEMPERATURE_ATTRIBUTES = new Set([
   "target_temperature",
   "target_temp_temp",
   "target_temp_high",
+  "target_temp_low",
   "target_temp_step",
   "min_temp",
   "max_temp",

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -309,6 +309,7 @@ export interface SelectSelector {
     options: readonly string[] | readonly SelectOption[];
     translation_key?: string;
     sort?: boolean;
+    reorder?: boolean;
   } | null;
 }
 

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -206,6 +206,9 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             ></ha-relative-time>
           `;
         }
+        if (stateObj.attributes[content] == null) {
+          return undefined;
+        }
         return this.hass!.formatEntityAttributeValue(stateObj, content);
       })
       .filter(Boolean);

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -214,7 +214,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       .filter(Boolean);
 
     if (!values.length) {
-      return nothing;
+      return "-";
     }
 
     return html`

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -21,6 +21,7 @@ import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
 import { styleMap } from "lit/directives/style-map";
 import memoizeOne from "memoize-one";
+import { ensureArray } from "../../../common/array/ensure-array";
 import { computeCssColor } from "../../../common/color/compute-color";
 import { hsv2rgb, rgb2hex, rgb2hsv } from "../../../common/color/convert-color";
 import { DOMAINS_TOGGLE } from "../../../common/const";
@@ -34,15 +35,7 @@ import "../../../components/tile/ha-tile-icon";
 import "../../../components/tile/ha-tile-image";
 import "../../../components/tile/ha-tile-info";
 import { cameraUrlWithWidthHeight } from "../../../data/camera";
-import {
-  CoverEntity,
-  computeCoverPositionStateDisplay,
-} from "../../../data/cover";
 import { isUnavailableState } from "../../../data/entity";
-import { FanEntity, computeFanSpeedStateDisplay } from "../../../data/fan";
-import type { HumidifierEntity } from "../../../data/humidifier";
-import type { ClimateEntity } from "../../../data/climate";
-import type { LightEntity } from "../../../data/light";
 import type { ActionHandlerEvent } from "../../../data/lovelace";
 import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
 import { HomeAssistant } from "../../../types";
@@ -54,7 +47,6 @@ import "../tile-features/hui-tile-features";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import { computeTileBadge } from "./tile/badges/tile-badge";
 import type { ThermostatCardConfig, TileCardConfig } from "./types";
-import { ensureArray } from "../../../common/array/ensure-array";
 
 const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
 
@@ -182,20 +174,32 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     }
   );
 
-  private _computeStateContent(
+  private _renderStateContent(
     stateObj: HassEntity,
     stateContent: string | string[]
   ) {
     const contents = ensureArray(stateContent);
 
-    if (contents.length === 1 && contents[0] === "none") {
-      return nothing;
-    }
-
     const values = contents
-      .filter((content) => content !== "none")
       .map((content) => {
         if (content === "state") {
+          const domain = computeDomain(stateObj.entity_id);
+          if (
+            (stateObj.attributes.device_class ===
+              SENSOR_DEVICE_CLASS_TIMESTAMP ||
+              TIMESTAMP_STATE_DOMAINS.includes(domain)) &&
+            !isUnavailableState(stateObj.state)
+          ) {
+            return html`
+              <hui-timestamp-display
+                .hass=${this.hass}
+                .ts=${new Date(stateObj.state)}
+                format="relative"
+                capitalize
+              ></hui-timestamp-display>
+            `;
+          }
+
           return this.hass!.formatEntityState(stateObj);
         }
         if (content === "last-changed") {
@@ -214,7 +218,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       .filter(Boolean);
 
     if (!values.length) {
-      return "-";
+      return html`${this.hass!.formatEntityState(stateObj)}`;
     }
 
     return html`
@@ -225,80 +229,34 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
     `;
   }
 
-  private _formatState(stateObj: HassEntity): TemplateResult | string {
+  private _renderState(stateObj: HassEntity): TemplateResult | typeof nothing {
     const domain = computeDomain(stateObj.entity_id);
+    const active = stateActive(stateObj);
 
-    if (
-      (stateObj.attributes.device_class === SENSOR_DEVICE_CLASS_TIMESTAMP ||
-        TIMESTAMP_STATE_DOMAINS.includes(domain)) &&
-      !isUnavailableState(stateObj.state)
-    ) {
-      return html`
-        <hui-timestamp-display
-          .hass=${this.hass}
-          .ts=${new Date(stateObj.state)}
-          format="relative"
-          capitalize
-        ></hui-timestamp-display>
-      `;
+    if (domain === "light" && active) {
+      return this._renderStateContent(stateObj, ["brightness"]);
     }
 
-    if (domain === "light" && stateActive(stateObj)) {
-      const brightness = (stateObj as LightEntity).attributes.brightness;
-      if (brightness) {
-        return this.hass!.formatEntityAttributeValue(stateObj, "brightness");
-      }
+    if (domain === "fan" && active) {
+      return this._renderStateContent(stateObj, ["percentage"]);
     }
 
-    if (domain === "fan") {
-      const speedStateDisplay = computeFanSpeedStateDisplay(
-        stateObj as FanEntity,
-        this.hass!
-      );
-      if (speedStateDisplay) {
-        return speedStateDisplay;
-      }
+    if (domain === "cover" && active) {
+      return this._renderStateContent(stateObj, ["state", "current_position"]);
     }
 
-    const stateDisplay = this.hass!.formatEntityState(stateObj);
-
-    if (domain === "cover") {
-      const positionStateDisplay = computeCoverPositionStateDisplay(
-        stateObj as CoverEntity,
-        this.hass!
-      );
-      if (positionStateDisplay) {
-        return `${stateDisplay} ⸱ ${positionStateDisplay}`;
-      }
-    }
-
-    if (domain === "humidifier" && stateActive(stateObj)) {
-      const humidity = (stateObj as HumidifierEntity).attributes.humidity;
-      if (humidity) {
-        const formattedHumidity = this.hass!.formatEntityAttributeValue(
-          stateObj,
-          "humidity",
-          Math.round(humidity)
-        );
-        return `${stateDisplay} ⸱ ${formattedHumidity}`;
-      }
+    if (domain === "humidifier") {
+      return this._renderStateContent(stateObj, ["state", "current_humidity"]);
     }
 
     if (domain === "climate") {
-      const current_temperature = (stateObj as ClimateEntity).attributes
-        .current_temperature;
-      if (current_temperature) {
-        const formattedCurrentTemperature =
-          this.hass!.formatEntityAttributeValue(
-            stateObj,
-            "current_temperature",
-            current_temperature
-          );
-        return `${stateDisplay} ⸱ ${formattedCurrentTemperature}`;
-      }
+      return this._renderStateContent(stateObj, [
+        "state",
+        "current_temperature",
+      ]);
     }
 
-    return stateDisplay;
+    return this._renderStateContent(stateObj, "state");
   }
 
   @queryAsync("mwc-ripple") private _ripple!: Promise<Ripple | null>;
@@ -367,9 +325,11 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
 
     const name = this._config.name || stateObj.attributes.friendly_name;
 
-    const localizedState = this._config.state_content
-      ? this._computeStateContent(stateObj, this._config.state_content)
-      : this._formatState(stateObj);
+    const localizedState = this._config.hide_state
+      ? nothing
+      : this._config.state_content
+      ? this._renderStateContent(stateObj, this._config.state_content)
+      : this._renderState(stateObj);
 
     const active = stateActive(stateObj);
     const color = this._computeStateColor(stateObj, this._config.color);

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -519,6 +519,7 @@ export interface EnergyFlowCardConfig extends LovelaceCardConfig {
 export interface TileCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
+  state_content?: string | string[];
   icon?: string;
   color?: string;
   show_entity_picture?: string;

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -519,6 +519,7 @@ export interface EnergyFlowCardConfig extends LovelaceCardConfig {
 export interface TileCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
+  hide_state?: boolean;
   state_content?: string | string[];
   icon?: string;
   color?: string;

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -1,6 +1,6 @@
 import { mdiGestureTap, mdiPalette } from "@mdi/js";
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, html, LitElement, nothing } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import {
@@ -12,11 +12,17 @@ import {
   object,
   optional,
   string,
+  union,
 } from "superstruct";
-import { fireEvent, HASSDomEvent } from "../../../../common/dom/fire_event";
+import { ensureArray } from "../../../../common/array/ensure-array";
+import { HASSDomEvent, fireEvent } from "../../../../common/dom/fire_event";
+import { formatEntityAttributeNameFunc } from "../../../../common/translations/entity-state";
 import { LocalizeFunc } from "../../../../common/translations/localize";
 import "../../../../components/ha-form/ha-form";
-import type { SchemaUnion } from "../../../../components/ha-form/types";
+import type {
+  HaFormSchema,
+  SchemaUnion,
+} from "../../../../components/ha-form/types";
 import type { HomeAssistant } from "../../../../types";
 import type { TileCardConfig } from "../../cards/types";
 import {
@@ -31,12 +37,64 @@ import { EditSubElementEvent, SubElementEditorConfig } from "../types";
 import { configElementStyle } from "./config-elements-style";
 import "./hui-tile-card-features-editor";
 
+const HIDDEN_ATTRIBUTES = [
+  "access_token",
+  "available_modes",
+  "code_arm_required",
+  "code_format",
+  "color_modes",
+  "device_class",
+  "editable",
+  "effect_list",
+  "entity_id",
+  "entity_picture",
+  "event_types",
+  "fan_modes",
+  "fan_speed_list",
+  "friendly_name",
+  "frontend_stream_type",
+  "has_date",
+  "has_time",
+  "hvac_modes",
+  "icon",
+  "id",
+  "max_color_temp_kelvin",
+  "max_mireds",
+  "max_temp",
+  "max",
+  "min_color_temp_kelvin",
+  "min_mireds",
+  "min_temp",
+  "min",
+  "mode",
+  "operation_list",
+  "options",
+  "percentage_step",
+  "precipitation_unit",
+  "preset_modes",
+  "pressure_unit",
+  "sound_mode_list",
+  "source_list",
+  "state_class",
+  "step",
+  "supported_color_modes",
+  "supported_features",
+  "swing_modes",
+  "target_temp_step",
+  "temperature_unit",
+  "token",
+  "unit_of_measurement",
+  "visibility_unit",
+  "wind_speed_unit",
+];
+
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
   object({
     entity: optional(string()),
     name: optional(string()),
     icon: optional(string()),
+    state_content: optional(union([string(), array(string())])),
     color: optional(string()),
     show_entity_picture: optional(boolean()),
     vertical: optional(boolean()),
@@ -63,7 +121,11 @@ export class HuiTileCardEditor
   }
 
   private _schema = memoizeOne(
-    (localize: LocalizeFunc) =>
+    (
+      localize: LocalizeFunc,
+      formatEntityAttributeName: formatEntityAttributeNameFunc,
+      stateObj: HassEntity | undefined
+    ) =>
       [
         { name: "entity", selector: { entity: {} } },
         {
@@ -102,9 +164,34 @@ export class HuiTileCardEditor
                     boolean: {},
                   },
                 },
-              ] as const,
+              ],
             },
-          ] as const,
+            {
+              name: "state_content",
+              selector: {
+                select: {
+                  multiple: true,
+                  custom_value: true,
+                  options: [
+                    {
+                      label: "State",
+                      value: "state",
+                    },
+                    {
+                      label: "Last changed",
+                      value: "last-changed",
+                    },
+                    ...Object.keys(stateObj?.attributes ?? {})
+                      .filter((a) => !HIDDEN_ATTRIBUTES.includes(a))
+                      .map((attribute) => ({
+                        value: attribute,
+                        label: formatEntityAttributeName(stateObj!, attribute),
+                      })),
+                  ],
+                },
+              },
+            },
+          ],
         },
         {
           name: "",
@@ -124,9 +211,9 @@ export class HuiTileCardEditor
                 ui_action: {},
               },
             },
-          ] as const,
+          ],
         },
-      ] as const
+      ] as const satisfies readonly HaFormSchema[]
   );
 
   private _context = memoizeOne(
@@ -142,7 +229,11 @@ export class HuiTileCardEditor
       | HassEntity
       | undefined;
 
-    const schema = this._schema(this.hass!.localize);
+    const schema = this._schema(
+      this.hass!.localize,
+      this.hass.formatEntityAttributeName,
+      stateObj
+    );
 
     if (this._subElementEditorConfig) {
       return html`
@@ -157,10 +248,15 @@ export class HuiTileCardEditor
       `;
     }
 
+    const data = {
+      ...this._config,
+      state_content: ensureArray(this._config.state_content),
+    };
+
     return html`
       <ha-form
         .hass=${this.hass}
-        .data=${this._config}
+        .data=${data}
         .schema=${schema}
         .computeLabel=${this._computeLabelCallback}
         @value-changed=${this._valueChanged}
@@ -181,10 +277,21 @@ export class HuiTileCardEditor
       return;
     }
 
+    const newConfig = ev.detail.value as TileCardConfig;
+
     const config: TileCardConfig = {
       features: this._config.features,
-      ...ev.detail.value,
+      ...newConfig,
     };
+
+    if (config.state_content) {
+      if (config.state_content.length === 0) {
+        delete config.state_content;
+      } else if (config.state_content.length === 1) {
+        config.state_content = config.state_content[0];
+      }
+    }
+
     fireEvent(this, "config-changed", { config });
   }
 
@@ -252,6 +359,7 @@ export class HuiTileCardEditor
       case "icon_tap_action":
       case "show_entity_picture":
       case "vertical":
+      case "state_content":
         return this.hass!.localize(
           `ui.panel.lovelace.editor.card.tile.${schema.name}`
         );

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -170,8 +170,10 @@ export class HuiTileCardEditor
               name: "state_content",
               selector: {
                 select: {
-                  multiple: true,
+                  mode: "dropdown",
+                  reorder: true,
                   custom_value: true,
+                  multiple: true,
                   options: [
                     {
                       label: "State",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5059,6 +5059,7 @@
               "default_color": "Default color (state)",
               "show_entity_picture": "Show entity picture",
               "vertical": "Vertical",
+              "hide_state": "Hide state",
               "state_content": "State content",
               "features": {
                 "name": "Features",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5059,6 +5059,7 @@
               "default_color": "Default color (state)",
               "show_entity_picture": "Show entity picture",
               "vertical": "Vertical",
+              "state_content": "State content",
               "features": {
                 "name": "Features",
                 "not_compatible": "Not compatible",


### PR DESCRIPTION
### Card

The state can be replaced by one or multiple attribute to avoid the usage of templating. `state` and `last-changed` key are allowed too. An option as been added to totally state the state.

![CleanShot 2023-10-10 at 12 16 57](https://github.com/home-assistant/frontend/assets/5878303/2181a4e0-350f-4fa2-a780-5e6fe581ac11)

### Config

Two new options has been added.

```yaml
hide_state?: boolean
state_content?: string | string[]
```

### Editor

The editor uses a multiple select to let the user choose attributes. Items are draggable for re-ordering.

![CleanShot 2023-10-16 at 14 47 44](https://github.com/home-assistant/frontend/assets/5878303/4352d9c4-8733-4964-9805-64089e2e4e27)

### Demo

https://github.com/home-assistant/frontend/assets/5878303/8b0b1e13-60a9-42a3-b6c4-abec2533410b

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
