### PR TITLE
Use progress button when adding/updating mount

### DIFF
--- a/src/components/buttons/ha-progress-button.ts
+++ b/src/components/buttons/ha-progress-button.ts
@@ -1,6 +1,13 @@
 import "@material/mwc-button";
 import { mdiAlertOctagram, mdiCheckBold } from "@mdi/js";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  nothing,
+  TemplateResult,
+} from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "../ha-circular-progress";
 import "../ha-svg-icon";
@@ -27,7 +34,7 @@ export class HaProgressButton extends LitElement {
         <slot></slot>
       </mwc-button>
       ${!overlay
-        ? ""
+        ? nothing
         : html`
             <div class="progress">
               ${this._result === "success"

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -1,11 +1,15 @@
+import { mdiHelpCircle } from "@mdi/js";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
-import { mdiHelpCircle } from "@mdi/js";
 import { fireEvent } from "../../../common/dom/fire_event";
-import "../../../components/ha-form/ha-form";
-import "../../../components/ha-icon-button";
+import { LocalizeFunc } from "../../../common/translations/localize";
+import { computeRTLDirection } from "../../../common/util/compute_rtl";
 import "../../../components/buttons/ha-progress-button";
+import type { HaProgressButton } from "../../../components/buttons/ha-progress-button";
+import "../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../components/ha-form/types";
+import "../../../components/ha-icon-button";
 import { extractApiErrorMessage } from "../../../data/hassio/common";
 import {
   createSupervisorMount,
@@ -17,11 +21,8 @@ import {
 } from "../../../data/supervisor/mounts";
 import { haStyle, haStyleDialog } from "../../../resources/styles";
 import { HomeAssistant } from "../../../types";
-import { MountViewDialogParams } from "./show-dialog-view-mount";
-import { LocalizeFunc } from "../../../common/translations/localize";
-import type { SchemaUnion } from "../../../components/ha-form/types";
 import { documentationUrl } from "../../../util/documentation-url";
-import { computeRTLDirection } from "../../../common/util/compute_rtl";
+import { MountViewDialogParams } from "./show-dialog-view-mount";
 
 const mountSchema = memoizeOne(
   (
@@ -334,7 +335,8 @@ class ViewMountDialog extends LitElement {
     }
   }
 
-  private async _connectMount() {
+  private async _connectMount(ev) {
+    const progressButton = ev.target as HaProgressButton;
     this._error = undefined;
     this._waiting = true;
     const mountData = { ...this._data! };
@@ -350,6 +352,7 @@ class ViewMountDialog extends LitElement {
     } catch (err: any) {
       this._error = extractApiErrorMessage(err);
       this._waiting = false;
+      progressButton.actionError();
       if (this._data!.type === "cifs" && !this._showCIFSVersion) {
         this._showCIFSVersion = true;
       }

--- a/src/panels/config/storage/dialog-mount-view.ts
+++ b/src/panels/config/storage/dialog-mount-view.ts
@@ -5,6 +5,7 @@ import { mdiHelpCircle } from "@mdi/js";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-form/ha-form";
 import "../../../components/ha-icon-button";
+import "../../../components/buttons/ha-progress-button";
 import { extractApiErrorMessage } from "../../../data/hassio/common";
 import {
   createSupervisorMount,
@@ -269,8 +270,8 @@ class ViewMountDialog extends LitElement {
             : nothing}
         </div>
 
-        <mwc-button
-          .disabled=${this._waiting}
+        <ha-progress-button
+          .progress=${this._waiting}
           slot="primaryAction"
           @click=${this._connectMount}
         >
@@ -281,7 +282,7 @@ class ViewMountDialog extends LitElement {
             : this.hass.localize(
                 "ui.panel.config.storage.network_mounts.connect"
               )}
-        </mwc-button>
+        </ha-progress-button>
       </ha-dialog>
     `;
   }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Add progress spinner while mount is being connected, as this can take some time.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
