### PR TITLE
Fix RelativeCI format issues

### DIFF
--- a/.github/workflows/relative-ci.yaml
+++ b/.github/workflows/relative-ci.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Send bundle stats and build information to RelativeCI
         uses: relative-ci/agent-action@v2.1.8
         with:
-          key: ${{ secrets[format('RELATIVE_CI_KEY_{1}_{2}', matrix.bundle, matrix.build)] }}
+          key: ${{ secrets[format('RELATIVE_CI_KEY_{0}_{1}', matrix.bundle, matrix.build)] }}
           token: ${{ github.token }}
-          slug: ${{ format('{1}-{2}', matrix.bundle, matrix.build) }}
-          artifactName: ${{ format('{1}-bundle-stats', matrix.bundle) }}
-          artifactWebpackStatsFile: ${{ format('{1}-{2}.json', matrix.bundle, matrix.build) }}
+          slug: ${{ format('{0}-{1}', matrix.bundle, matrix.build) }}
+          artifactName: ${{ format('{0}-bundle-stats', matrix.bundle) }}
+          artifactWebpackStatsFile: ${{ format('{0}-{1}.json', matrix.bundle, matrix.build) }}


### PR DESCRIPTION
## Proposed change
Fixes: The template is not valid. 
.github/workflows/relative-ci.yaml (Line: 24, Col: 16): The following format string references more arguments than were supplied: RELATIVE_CI_KEY_{1}_{2},
.github/workflows/relative-ci.yaml (Line: 26, Col: 17): The following format string references more arguments than were supplied: {1}-{2},
.github/workflows/relative-ci.yaml (Line: 27, Col: 25): The following format string references more arguments than were supplied: {1}-bundle-stats,
.github/workflows/relative-ci.yaml (Line: 28, Col: 37): The following format string references more arguments than were supplied: {1}-{2}.json

Expressions link: https://docs.github.com/en/actions/learn-github-actions/expressions#format

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
