### PR TITLE
Improve state and name display on state-card-display

### DIFF
--- a/src/components/entity/state-info.ts
+++ b/src/components/entity/state-info.ts
@@ -99,6 +99,10 @@ class StateInfo extends LitElement {
         align-items: center;
       }
 
+      state-badge {
+        flex: none;
+      }
+
       .info {
         margin-left: 8px;
         display: flex;

--- a/src/state-summary/state-card-display.ts
+++ b/src/state-summary/state-card-display.ts
@@ -70,19 +70,21 @@ export class StateCardDisplay extends LitElement {
       haStyle,
       css`
         state-info {
-          flex: 0 0 fit-content;
-          min-width: 0;
+          flex: 0 1 fit-content;
+          min-width: 120px;
         }
         .state {
           color: var(--primary-text-color);
           margin-inline-start: 16px;
           margin-inline-end: initial;
           text-align: var(--float-end, right);
+          min-width: 50px;
           flex: 0 1 fit-content;
           word-break: break-word;
           display: flex;
           align-items: center;
           direction: ltr;
+          justify-content: flex-end;
         }
         .state.has-unit_of_measurement {
           white-space: nowrap;


### PR DESCRIPTION
## Proposed change

https://github.com/home-assistant/frontend/pull/17649 PR introduced multiline support. This PR improves the display by setting `min-width` to name and state to avoid multiline text for small state like version number.

**Short name, long state**

![CleanShot 2023-10-13 at 10 20 58](https://github.com/home-assistant/frontend/assets/5878303/fdf8a49b-b4d1-4eb9-9469-e71dd2c1c485)

**Short name, short state**

![CleanShot 2023-10-13 at 10 20 42](https://github.com/home-assistant/frontend/assets/5878303/6a556355-7ad3-4018-8331-74c9cd224235)

**Long name, short state**

![CleanShot 2023-10-13 at 10 20 28](https://github.com/home-assistant/frontend/assets/5878303/2b271570-2f5e-47c7-8ade-d1b303a6599d)

**Long name, long state**

![CleanShot 2023-10-13 at 10 20 17](https://github.com/home-assistant/frontend/assets/5878303/1f5c4e2f-4d0e-462e-bcef-7a6be4b10387)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
