### PR TITLE
Add Z-Wave controller hard reset device action (certification req)

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -760,7 +760,7 @@ export const fetchZwaveNodeFirmwareUpdateCapabilities = (
 export const hardResetController = (
   hass: HomeAssistant,
   entry_id: string
-): Promise<ZWaveJSNodeFirmwareUpdateCapabilities> =>
+): Promise<string> =>
   hass.callWS({
     type: "zwave_js/hard_reset_controller",
     entry_id,

--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -757,6 +757,15 @@ export const fetchZwaveNodeFirmwareUpdateCapabilities = (
     device_id,
   });
 
+export const hardResetController = (
+  hass: HomeAssistant,
+  entry_id: string
+): Promise<ZWaveJSNodeFirmwareUpdateCapabilities> =>
+  hass.callWS({
+    type: "zwave_js/hard_reset_controller",
+    entry_id,
+  });
+
 export const uploadFirmwareAndBeginUpdate = async (
   hass: HomeAssistant,
   device_id: string,

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-actions.ts
@@ -19,8 +19,9 @@ import { showZWaveJSRebuildNodeRoutesDialog } from "../../../../integrations/int
 import { showZWaveJSNodeStatisticsDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-node-statistics";
 import { showZWaveJSReinterviewNodeDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-reinterview-node";
 import { showZWaveJSRemoveFailedNodeDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-remove-failed-node";
-import { showZWaveJUpdateFirmwareNodeDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-update-firmware-node";
+import { showZWaveJSUpdateFirmwareNodeDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-update-firmware-node";
 import type { DeviceAction } from "../../../ha-config-device-page";
+import { showZWaveJSHardResetControllerDialog } from "../../../../integrations/integration-panels/zwave_js/show-dialog-zwave_js-hard-reset-controller";
 
 export const getZwaveDeviceActions = async (
   el: HTMLElement,
@@ -136,10 +137,24 @@ export const getZwaveDeviceActions = async (
             confirmText: hass.localize("ui.common.yes"),
           }))
         ) {
-          showZWaveJUpdateFirmwareNodeDialog(el, {
+          showZWaveJSUpdateFirmwareNodeDialog(el, {
             device,
           });
         }
+      },
+    });
+  }
+
+  if (nodeStatus.is_controller_node) {
+    actions.push({
+      label: hass.localize(
+        "ui.panel.config.zwave_js.device_info.hard_reset_controller"
+      ),
+      icon: mdiDeleteForever,
+      action: async () => {
+        showZWaveJSHardResetControllerDialog(el, {
+          entryId,
+        });
       },
     });
   }

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -1,0 +1,122 @@
+import { mdiDeleteForever } from "@mdi/js";
+import "@material/mwc-button/mwc-button";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import { createCloseHeading } from "../../../../../components/ha-dialog";
+import "../../../../../components/ha-svg-icon";
+import { hardResetController } from "../../../../../data/zwave_js";
+import { haStyleDialog } from "../../../../../resources/styles";
+import { HomeAssistant } from "../../../../../types";
+import { ZWaveJSHardResetControllerDialogParams } from "./show-dialog-zwave_js-hard-reset-controller";
+import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dialog-box";
+
+@customElement("dialog-zwave_js-hard-reset-controller")
+class DialogZWaveJSHardResetController extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private entry_id?: string;
+
+  @state() private _done = false;
+
+  public showDialog(params: ZWaveJSHardResetControllerDialogParams): void {
+    this.entry_id = params.entryId;
+  }
+
+  public closeDialog(): void {
+    this.entry_id = undefined;
+    this._done = false;
+
+    fireEvent(this, "dialog-closed", { dialog: this.localName });
+  }
+
+  protected render() {
+    if (!this.entry_id) {
+      return nothing;
+    }
+
+    return html` <ha-dialog
+      open
+      @closed=${this.closeDialog}
+      .heading=${createCloseHeading(
+        this.hass,
+        this.hass.localize(
+          `ui.panel.config.zwave_js.hard_reset_controller.title_${
+            this._done ? "done" : "not_done"
+          }`
+        )
+      )}
+    >
+      ${!this._done
+        ? html`<p>
+            ${this.hass.localize(
+              `ui.panel.config.zwave_js.hard_reset_controller.success`
+            )}
+          </p>`
+        : html`<div class="flex-container">
+              <div>
+                <ha-svg-icon
+                  .path=${mdiDeleteForever}
+                  .class="icon"
+                ></ha-svg-icon>
+              </div>
+              <p>
+                ${this.hass.localize(
+                  `ui.panel.config.zwave_js.hard_reset_controller.dialog_body`
+                )}
+              </p>
+            </div>
+            <mwc-button
+              slot="primaryAction"
+              @click=${this._hardResetController}
+            >
+              ${this.hass.localize("ui.common.continue")}
+            </mwc-button>
+            <mwc-button slot="secondaryAction" @click=${this.closeDialog}>
+              ${this.hass.localize("ui.common.cancel")}
+            </mwc-button>`}
+    </ha-dialog>`;
+  }
+
+  private async _hardResetController(): Promise<void> {
+    if (
+      await showConfirmationDialog(this, {
+        text: this.hass.localize(
+          `ui.panel.config.zwave_js.hard_reset_controller.final_warning`
+        ),
+        dismissText: this.hass.localize("ui.common.cancel"),
+        confirmText: this.hass.localize("ui.common.continue"),
+      })
+    ) {
+      await hardResetController(this.hass, this.entry_id!);
+      this._done = true;
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyleDialog,
+      css`
+        .icon {
+          color: var(--label-badge-red);
+        }
+        .flex-container {
+          display: flex;
+          align-items: center;
+          margin-bottom: 5px;
+        }
+
+        ha-svg-icon {
+          width: 68px;
+          height: 48px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "dialog-zwave_js-hard-reset-controller": DialogZWaveJSHardResetController;
+  }
+}

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -15,7 +15,7 @@ import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dial
 class DialogZWaveJSHardResetController extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @state() private entry_id?: string;
+  @state() private _entryId?: string;
 
   @state() private _done = false;
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -35,7 +35,7 @@ class DialogZWaveJSHardResetController extends LitElement {
       return nothing;
     }
 
-    return html` <ha-dialog
+    return html`<ha-dialog
       open
       @closed=${this.closeDialog}
       .heading=${createCloseHeading(
@@ -47,7 +47,7 @@ class DialogZWaveJSHardResetController extends LitElement {
         )
       )}
     >
-      ${!this._done
+      ${this._done
         ? html`<p>
             ${this.hass.localize(
               `ui.panel.config.zwave_js.hard_reset_controller.success`

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -10,6 +10,7 @@ import { haStyleDialog } from "../../../../../resources/styles";
 import { HomeAssistant } from "../../../../../types";
 import { ZWaveJSHardResetControllerDialogParams } from "./show-dialog-zwave_js-hard-reset-controller";
 import { showConfirmationDialog } from "../../../../../dialogs/generic/show-dialog-box";
+import { navigate } from "../../../../../common/navigate";
 
 @customElement("dialog-zwave_js-hard-reset-controller")
 class DialogZWaveJSHardResetController extends LitElement {
@@ -20,21 +21,18 @@ class DialogZWaveJSHardResetController extends LitElement {
   @state() private _done = false;
 
   public showDialog(params: ZWaveJSHardResetControllerDialogParams): void {
-    this.entry_id = params.entryId;
+    this._entryId = params.entryId;
   }
 
   public closeDialog(): void {
-    this.entry_id = undefined;
+    this._entryId = undefined;
+    this._done = false;
 
     fireEvent(this, "dialog-closed", { dialog: this.localName });
-    if (this._done) {
-      this._done = false;
-      history.back();
-    }
   }
 
   protected render() {
-    if (!this.entry_id) {
+    if (!this._entryId) {
       return nothing;
     }
 
@@ -91,8 +89,9 @@ class DialogZWaveJSHardResetController extends LitElement {
         confirmText: this.hass.localize("ui.common.continue"),
       })
     ) {
-      await hardResetController(this.hass, this.entry_id!);
+      await hardResetController(this.hass, this._entryId!);
       this._done = true;
+      navigate(`/config/devices/dashboard?config_entry=${this._entryId}`);
     }
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -67,17 +67,15 @@ class DialogZWaveJSHardResetController extends LitElement {
             .class="icon"
           ></ha-svg-icon>
         </div>
+        <p>
+          ${this.hass.localize(
+            `ui.panel.config.zwave_js.hard_reset_controller.${
+              ResetStatus[this._resetStatus]
+            }`
+          )}
+        </p>
       </div>
-      <p>
-        ${this.hass.localize(
-          `ui.panel.config.zwave_js.hard_reset_controller.${
-            ResetStatus[this._resetStatus]
-          }`
-        )}
-      </p>
-    </div>
-    ${
-      this._resetStatus === ResetStatus.NotStarted
+      ${this._resetStatus === ResetStatus.NotStarted
         ? html`<mwc-button
               slot="primaryAction"
               @click=${this._hardResetController}
@@ -87,8 +85,7 @@ class DialogZWaveJSHardResetController extends LitElement {
             <mwc-button slot="secondaryAction" @click=${this.closeDialog}>
               ${this.hass.localize("ui.common.cancel")}
             </mwc-button>`
-        : nothing
-    }
+        : nothing}
     </ha-dialog>`;
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -22,8 +22,6 @@ class DialogZWaveJSHardResetController extends LitElement {
 
   @state() private _done = false;
 
-  private _devices?: DeviceRegistryEntry[];
-
   private _subscribedDeviceRegistryUpdates?: Promise<UnsubscribeFunc>;
 
   public showDialog(params: ZWaveJSHardResetControllerDialogParams): void {
@@ -105,7 +103,11 @@ class DialogZWaveJSHardResetController extends LitElement {
                 device.config_entries.includes(this._entryId!)
               );
               if (deviceEntries.length === 1) {
-                navigate(`/config/devices/device/${deviceEntries[0].id}`);
+                setTimeout(
+                  () =>
+                    navigate(`/config/devices/device/${deviceEntries[0].id}`),
+                  0
+                );
                 this._unsubscribe();
               }
             }),

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -25,9 +25,12 @@ class DialogZWaveJSHardResetController extends LitElement {
 
   public closeDialog(): void {
     this.entry_id = undefined;
-    this._done = false;
 
     fireEvent(this, "dialog-closed", { dialog: this.localName });
+    if (this._done) {
+      this._done = false;
+      setTimeout(() => history.back(), 0);
+    }
   }
 
   protected render() {

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -97,7 +97,7 @@ class DialogZWaveJSHardResetController extends LitElement {
         ),
         dismissText: this.hass.localize("ui.common.cancel"),
         confirmText: this.hass.localize("ui.common.continue"),
-        destructive: true
+        destructive: true,
       })
     ) {
       this._resetStatus = ResetStatus.InProgress;

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -54,9 +54,9 @@ class DialogZWaveJSHardResetController extends LitElement {
       .heading=${createCloseHeading(
         this.hass,
         this.hass.localize(
-          `ui.panel.config.zwave_js.hard_reset_controller.title_${
-            this._resetStatus === ResetStatus.Done ? "done" : "not_done"
-          }`
+          `ui.panel.config.zwave_js.hard_reset_controller.${
+            ResetStatus[this._resetStatus]
+          }.title`
         )
       )}
     >
@@ -71,7 +71,7 @@ class DialogZWaveJSHardResetController extends LitElement {
           ${this.hass.localize(
             `ui.panel.config.zwave_js.hard_reset_controller.${
               ResetStatus[this._resetStatus]
-            }`
+            }.body`
           )}
         </p>
       </div>
@@ -93,7 +93,7 @@ class DialogZWaveJSHardResetController extends LitElement {
     if (
       await showConfirmationDialog(this, {
         text: this.hass.localize(
-          `ui.panel.config.zwave_js.hard_reset_controller.final_warning`
+          `ui.panel.config.zwave_js.hard_reset_controller.confirmation`
         ),
         dismissText: this.hass.localize("ui.common.cancel"),
         confirmText: this.hass.localize("ui.common.continue"),

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -97,6 +97,7 @@ class DialogZWaveJSHardResetController extends LitElement {
         ),
         dismissText: this.hass.localize("ui.common.cancel"),
         confirmText: this.hass.localize("ui.common.continue"),
+        destructive: true
       })
     ) {
       this._resetStatus = ResetStatus.InProgress;

--- a/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/dialog-zwave_js-hard-reset-controller.ts
@@ -29,7 +29,7 @@ class DialogZWaveJSHardResetController extends LitElement {
     fireEvent(this, "dialog-closed", { dialog: this.localName });
     if (this._done) {
       this._done = false;
-      setTimeout(() => history.back(), 0);
+      history.back();
     }
   }
 

--- a/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-hard-reset-controller.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-hard-reset-controller.ts
@@ -1,0 +1,19 @@
+import { fireEvent } from "../../../../../common/dom/fire_event";
+
+export interface ZWaveJSHardResetControllerDialogParams {
+  entryId: string;
+}
+
+export const loadHardResetControllerDialog = () =>
+  import("./dialog-zwave_js-hard-reset-controller");
+
+export const showZWaveJSHardResetControllerDialog = (
+  element: HTMLElement,
+  hardResetControllerDialogParams: ZWaveJSHardResetControllerDialogParams
+): void => {
+  fireEvent(element, "show-dialog", {
+    dialogTag: "dialog-zwave_js-hard-reset-controller",
+    dialogImport: loadHardResetControllerDialog,
+    dialogParams: hardResetControllerDialogParams,
+  });
+};

--- a/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-update-firmware-node.ts
+++ b/src/panels/config/integrations/integration-panels/zwave_js/show-dialog-zwave_js-update-firmware-node.ts
@@ -8,7 +8,7 @@ export interface ZWaveJSUpdateFirmwareNodeDialogParams {
 export const loadUpdateFirmwareNodeDialog = () =>
   import("./dialog-zwave_js-update-firmware-node");
 
-export const showZWaveJUpdateFirmwareNodeDialog = (
+export const showZWaveJSUpdateFirmwareNodeDialog = (
   element: HTMLElement,
   updateFirmwareNodeDialogParams: ZWaveJSUpdateFirmwareNodeDialogParams
 ): void => {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4005,8 +4005,9 @@
             "node_statistics": "Statistics"
           },
           "hard_reset_controller": {
-            "success": "Your controller has been reset to factory settings and is now restarting. Once it is back online, you will be redirected to the new device page as long as you keep this dialog open.",
-            "dialog_body": "If you decide to move forward, you will reset your controller to factory settings. As a result, the controller will forget all devices it is paired with and all Z-Wave devices for this network will be removed from Home Assistant. If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired. Would you like to continue?",
+            "Done": "Your controller has been reset to factory settings and has been restarted! You can now close this dialog.",
+            "InProgress": "Your controller is being reset and restarted. Wait until the process is complete before closing this dialog",
+            "NotStarted": "If you decide to move forward, you will reset your controller to factory settings. As a result, the controller will forget all devices it is paired with and all Z-Wave devices for this network will be removed from Home Assistant. If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired. Would you like to continue?",
             "title_not_done": "Reset Controller to Factory Settings",
             "title_done": "Controller Reset Complete",
             "final_warning": "This action cannot be undone unless you have an NVM backup from your controller."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4005,7 +4005,7 @@
             "node_statistics": "Statistics"
           },
           "hard_reset_controller": {
-            "success": "Your controller has been reset to factory settings, you can now close this dialog!",
+            "success": "Your controller has been reset to factory settings and is now restarting. Once it is back online, you will be redirected to the new device page as long as you keep this dialog open.",
             "dialog_body": "If you decide to move forward, you will reset your controller to factory settings. As a result, the controller will forget all devices it is paired with and all Z-Wave devices for this network will be removed from Home Assistant. If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired. Would you like to continue?",
             "title_not_done": "Reset Controller to Factory Settings",
             "title_done": "Controller Reset Complete",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4006,7 +4006,7 @@
           },
           "hard_reset_controller": {
             "success": "Your controller has been reset to factory settings, you can now close this dialog!",
-            "dialog_body": "If you decide to move forward, you will reset your controller to factory settings. As a result, the controller will forget all devices it is paired with and all Z-Wave devices will be removed from Home Assistant. If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired. Would you like to continue?",
+            "dialog_body": "If you decide to move forward, you will reset your controller to factory settings. As a result, the controller will forget all devices it is paired with and all Z-Wave devices for this network will be removed from Home Assistant. If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired. Would you like to continue?",
             "title_not_done": "Reset Controller to Factory Settings",
             "title_done": "Controller Reset Complete",
             "final_warning": "This action cannot be undone unless you have an NVM backup from your controller."

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3998,10 +3998,18 @@
             "remove_failed": "Remove failed",
             "update_firmware": "Update",
             "highest_security": "Highest security",
+            "hard_reset_controller": "Factory reset",
             "unknown": "Unknown",
             "zwave_plus": "Z-Wave Plus",
             "zwave_plus_version": "Version {version}",
             "node_statistics": "Statistics"
+          },
+          "hard_reset_controller": {
+            "success": "Your controller has been reset to factory settings, you can now close this dialog!",
+            "dialog_body": "If you decide to move forward, you will reset your controller to factory settings. As a result, the controller will forget all devices it is paired with and all Z-Wave devices will be removed from Home Assistant. If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired. Would you like to continue?",
+            "title_not_done": "Reset Controller to Factory Settings",
+            "title_done": "Controller Reset Complete",
+            "final_warning": "This action cannot be undone unless you have an NVM backup from your controller."
           },
           "node_statistics": {
             "title": "Device statistics",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4005,12 +4005,19 @@
             "node_statistics": "Statistics"
           },
           "hard_reset_controller": {
-            "Done": "Your controller has been reset to factory settings and has been restarted! You can now close this dialog.",
-            "InProgress": "Your controller is being reset and restarted. Wait until the process is complete before closing this dialog",
-            "NotStarted": "If you decide to move forward, you will reset your controller to factory settings. As a result, the controller will forget all devices it is paired with and all Z-Wave devices for this network will be removed from Home Assistant. If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired. Would you like to continue?",
-            "title_not_done": "Reset Controller to Factory Settings",
-            "title_done": "Controller Reset Complete",
-            "final_warning": "This action cannot be undone unless you have an NVM backup from your controller."
+            "NotStarted": {
+              "title": "Reset Controller to Factory Settings",
+              "body": "If you decide to move forward, you will reset your controller to factory settings. As a result, the controller will forget all devices it is paired with and all Z-Wave devices for this network will be removed from Home Assistant. If there are any devices still paired with the controller when it is reset, they will have to go through the exclusion process before they can be re-paired. Would you like to continue?"
+            },
+            "InProgress": {
+              "title": "Resetting Controller",
+              "body": "Your controller is being reset and restarted. Wait until the process is complete before closing this dialog"
+            },
+            "Done": {
+              "title": "Controller Reset Complete",
+              "body": "Your controller has been reset to factory settings and has been restarted! You can now close this dialog."
+            },
+            "confirmation": "This action cannot be undone unless you have an NVM backup from your controller."
           },
           "node_statistics": {
             "title": "Device statistics",


### PR DESCRIPTION
## Proposed change
This PR adds a new device action for the controller to hard reset it which is a Z-Wave certification requirement. We want it to be hard to do to avoid accidental resets which is why there are multiple confirmations. There is an issue that we may need to resolve beforehand where the config entry drops and reloads but need opinions on that. Also is it weird that the device info underneath the dialog goes to `Device / service not found`? CC @MartinHjelmare @marcelveldt @AlCalzone - please review the copy and provide feedback.

Upstream core changes are already merged.

Device action:
![action](https://github.com/home-assistant/frontend/assets/7243222/62ced5b1-045b-4926-9d81-33a3ad6724f5)

First warning:
![first warning](https://github.com/home-assistant/frontend/assets/7243222/63f4ae78-1fd7-4800-a0e7-7dc9f35eeb68)

Second warning:
![second warning](https://github.com/home-assistant/frontend/assets/7243222/001387bb-1733-4fed-9e82-c1590272721c)

In progress:
![In Progress](https://github.com/home-assistant/frontend/assets/7243222/4133d7f3-a4a5-4ec9-8854-146401a48a9f)

Complete:
![Complete](https://github.com/home-assistant/frontend/assets/7243222/4974b08e-b9f0-45d5-bd0e-0ba69b729f8d)

Final device info page when you close the dialog:
![not found](https://github.com/home-assistant/frontend/assets/7243222/421a7fbd-1986-4634-b197-fdff67665601)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR fixes or closes issue: fixes https://github.com/zwave-js/certification-backlog/issues/13
- Link to core pull requests:
  - https://github.com/home-assistant/core/pull/101449
  - https://github.com/home-assistant/core/pull/102280
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29362

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
