### PR TITLE
Replace internal material/web usages

### DIFF
--- a/src/components/ha-outlined-button.ts
+++ b/src/components/ha-outlined-button.ts
@@ -5,7 +5,7 @@ import { MdOutlinedButton } from "@material/web/button/outlined-button";
 @customElement("ha-outlined-button")
 export class HaOutlinedButton extends MdOutlinedButton {
   static override styles = [
-    ...MdOutlinedButton.styles,
+    ...super.styles,
     css`
       :host {
         --ha-icon-display: block;

--- a/src/components/ha-outlined-button.ts
+++ b/src/components/ha-outlined-button.ts
@@ -1,14 +1,11 @@
 import { css } from "lit";
 import { customElement } from "lit/decorators";
-import { OutlinedButton } from "@material/web/button/internal/outlined-button";
-import { styles as outlinedStyles } from "@material/web/button/internal/outlined-styles.css";
-import { styles as sharedStyles } from "@material/web/button/internal/shared-styles.css";
+import { MdOutlinedButton } from "@material/web/button/outlined-button";
 
 @customElement("ha-outlined-button")
-export class HaOutlinedButton extends OutlinedButton {
+export class HaOutlinedButton extends MdOutlinedButton {
   static override styles = [
-    sharedStyles,
-    outlinedStyles,
+    ...MdOutlinedButton.styles,
     css`
       :host {
         --ha-icon-display: block;

--- a/src/components/ha-outlined-icon-button.ts
+++ b/src/components/ha-outlined-icon-button.ts
@@ -5,7 +5,7 @@ import { MdOutlinedIconButton } from "@material/web/iconbutton/outlined-icon-but
 @customElement("ha-outlined-icon-button")
 export class HaOutlinedIconButton extends MdOutlinedIconButton {
   static override styles = [
-    ...MdOutlinedIconButton.styles,
+    ...super.styles,
     css`
       :host {
         --ha-icon-display: block;

--- a/src/components/ha-outlined-icon-button.ts
+++ b/src/components/ha-outlined-icon-button.ts
@@ -1,21 +1,11 @@
 import { css } from "lit";
 import { customElement } from "lit/decorators";
-import { IconButton } from "@material/web/iconbutton/internal/icon-button";
-import { styles as outlinedStyles } from "@material/web/iconbutton/internal/outlined-styles.css";
-import { styles as sharedStyles } from "@material/web/iconbutton/internal/shared-styles.css";
+import { MdOutlinedIconButton } from "@material/web/iconbutton/outlined-icon-button";
 
 @customElement("ha-outlined-icon-button")
-export class HaOutlinedIconButton extends IconButton {
-  protected override getRenderClasses() {
-    return {
-      ...super.getRenderClasses(),
-      outlined: true,
-    };
-  }
-
+export class HaOutlinedIconButton extends MdOutlinedIconButton {
   static override styles = [
-    sharedStyles,
-    outlinedStyles,
+    ...MdOutlinedIconButton.styles,
     css`
       :host {
         --ha-icon-display: block;


### PR DESCRIPTION
## Proposed change
This was in the changelog of material/web package during the prereleases: 
"Rename @material/web/<component>/lib to @material/web/<component>/internal. Prefer not using internal files."
There were already some imports at the time, and they were replaced with internal import back then.
I think it can be avoided using the changes in this PR, and allows us to stick closer to their public API.  

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
