### PR TITLE
Add Fields to Script UI

### DIFF
--- a/src/components/ha-selector/ha-selector-date.ts
+++ b/src/components/ha-selector/ha-selector-date.ts
@@ -26,7 +26,7 @@ export class HaDateSelector extends LitElement {
         .label=${this.label}
         .locale=${this.hass.locale}
         .disabled=${this.disabled}
-        .value=${this.value}
+        .value=${typeof this.value === "string" ? this.value : undefined}
         .required=${this.required}
         .helper=${this.helper}
       >

--- a/src/components/ha-selector/ha-selector-datetime.ts
+++ b/src/components/ha-selector/ha-selector-datetime.ts
@@ -30,7 +30,8 @@ export class HaDateTimeSelector extends LitElement {
   @query("ha-time-input") private _timeInput!: HaTimeInput;
 
   protected render() {
-    const values = this.value?.split(" ");
+    const values =
+      typeof this.value === "string" ? this.value.split(" ") : undefined;
 
     return html`
       <div class="input">

--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -70,11 +70,9 @@ export class HaNumberSelector extends LitElement {
           (this.selector.number?.step ?? 1) % 1 !== 0
             ? "decimal"
             : "numeric"}
-          .label=${this.selector.number?.mode !== "box"
-            ? undefined
-            : this.label}
+          .label=${!isBox ? undefined : this.label}
           .placeholder=${this.placeholder}
-          class=${classMap({ single: this.selector.number?.mode === "box" })}
+          class=${classMap({ single: isBox })}
           .min=${this.selector.number?.min}
           .max=${this.selector.number?.max}
           .value=${this._valueStr ?? ""}
@@ -86,7 +84,7 @@ export class HaNumberSelector extends LitElement {
           .suffix=${this.selector.number?.unit_of_measurement}
           type="number"
           autoValidate
-          ?no-spinner=${this.selector.number?.mode !== "box"}
+          ?no-spinner=${!isBox}
           @input=${this._handleInputChange}
         >
         </ha-textfield>

--- a/src/components/ha-selector/ha-selector-number.ts
+++ b/src/components/ha-selector/ha-selector-number.ts
@@ -38,7 +38,10 @@ export class HaNumberSelector extends LitElement {
   }
 
   protected render() {
-    const isBox = this.selector.number?.mode === "box";
+    const isBox =
+      this.selector.number?.mode === "box" ||
+      this.selector.number?.min === undefined ||
+      this.selector.number?.max === undefined;
 
     return html`
       <div class="input">

--- a/src/components/ha-selector/ha-selector-time.ts
+++ b/src/components/ha-selector/ha-selector-time.ts
@@ -23,7 +23,7 @@ export class HaTimeSelector extends LitElement {
   protected render() {
     return html`
       <ha-time-input
-        .value=${this.value}
+        .value=${typeof this.value === "string" ? this.value : undefined}
         .locale=${this.hass.locale}
         .disabled=${this.disabled}
         .required=${this.required}

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -52,8 +52,6 @@ const LOAD_ELEMENTS = {
   ui_color: () => import("./ha-selector-ui-color"),
 };
 
-export const SelectorTypes = Object.keys(LOAD_ELEMENTS);
-
 const LEGACY_UI_SELECTORS = new Set(["ui-action", "ui-color"]);
 
 @customElement("ha-selector")

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -52,6 +52,8 @@ const LOAD_ELEMENTS = {
   ui_color: () => import("./ha-selector-ui-color"),
 };
 
+export const SelectorTypes = Object.keys(LOAD_ELEMENTS);
+
 const LEGACY_UI_SELECTORS = new Set(["ui-action", "ui-color"]);
 
 @customElement("ha-selector")

--- a/src/data/script.ts
+++ b/src/data/script.ts
@@ -93,10 +93,25 @@ export interface ManualScriptConfig {
   icon?: string;
   mode?: (typeof MODES)[number];
   max?: number;
+  fields?: Fields;
 }
 
 export interface BlueprintScriptConfig extends ManualScriptConfig {
   use_blueprint: { path: string; input?: BlueprintInput };
+}
+
+export interface Fields {
+  [key: string]: Field;
+}
+
+export interface Field {
+  name?: string;
+  description?: string;
+  advanced?: boolean;
+  required?: boolean;
+  example?: string;
+  default?: any;
+  selector?: any;
 }
 
 interface BaseAction {

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -8,6 +8,7 @@ import {
   mdiInformationOutline,
   mdiPlay,
   mdiTransitConnection,
+  mdiFormTextbox,
 } from "@mdi/js";
 import {
   css,
@@ -45,9 +46,11 @@ import {
   getScriptEditorInitData,
   getScriptStateConfig,
   isMaxMode,
+  Fields,
   MODES,
   MODES_MAX,
   ScriptConfig,
+  ManualScriptConfig,
   showScriptEditor,
   triggerScript,
 } from "../../../data/script";
@@ -231,6 +234,23 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
             <ha-svg-icon slot="graphic" .path=${mdiPlay}></ha-svg-icon>
           </mwc-list-item>
 
+          ${!useBlueprint && !("fields" in this._config)
+            ? html`
+                <mwc-list-item
+                  graphic="icon"
+                  .disabled=${!this.scriptId}
+                  @click=${this._addFields}
+                >
+                  ${this.hass.localize(
+                    "ui.panel.config.script.editor.add_field"
+                  )}
+                  <ha-svg-icon
+                    slot="graphic"
+                    .path=${mdiFormTextbox}
+                  ></ha-svg-icon>
+                </mwc-list-item>
+              `
+            : nothing}
           ${this.scriptId && this.narrow
             ? html`
                 <a href="/config/script/trace/${this.scriptId}">
@@ -659,6 +679,23 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
       this._setEntityId(newComputedId);
     }
+  }
+
+  private _addFields() {
+    if ("fields" in this._config!) {
+      return;
+    }
+    this._config = {
+      ...this._config,
+      fields: {
+        new_field: {
+          selector: {
+            text: null,
+          },
+        },
+      } as Fields,
+    } as ManualScriptConfig;
+    this._dirty = true;
   }
 
   private _valueChanged(ev: CustomEvent) {

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -240,7 +240,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
             ? html`
                 <mwc-list-item graphic="icon" @click=${this._addFields}>
                   ${this.hass.localize(
-                    "ui.panel.config.script.editor.add_fields"
+                    "ui.panel.config.script.editor.field.add_fields"
                   )}
                   <ha-svg-icon
                     slot="graphic"

--- a/src/panels/config/script/ha-script-editor.ts
+++ b/src/panels/config/script/ha-script-editor.ts
@@ -5,18 +5,18 @@ import {
   mdiContentSave,
   mdiDelete,
   mdiDotsVertical,
+  mdiFormTextbox,
   mdiInformationOutline,
   mdiPlay,
   mdiTransitConnection,
-  mdiFormTextbox,
 } from "@mdi/js";
 import {
-  css,
   CSSResultGroup,
-  html,
   LitElement,
   PropertyValues,
   TemplateResult,
+  css,
+  html,
   nothing,
 } from "lit";
 import { property, query, state } from "lit/decorators";
@@ -39,18 +39,18 @@ import "../../../components/ha-icon-button";
 import "../../../components/ha-svg-icon";
 import "../../../components/ha-yaml-editor";
 import type { HaYamlEditor } from "../../../components/ha-yaml-editor";
+import { validateConfig } from "../../../data/config";
+import { UNAVAILABLE } from "../../../data/entity";
 import { EntityRegistryEntry } from "../../../data/entity_registry";
 import {
+  MODES,
+  MODES_MAX,
+  ScriptConfig,
   deleteScript,
   fetchScriptFileConfig,
   getScriptEditorInitData,
   getScriptStateConfig,
   isMaxMode,
-  Fields,
-  MODES,
-  MODES_MAX,
-  ScriptConfig,
-  ManualScriptConfig,
   showScriptEditor,
   triggerScript,
 } from "../../../data/script";
@@ -63,8 +63,7 @@ import { documentationUrl } from "../../../util/documentation-url";
 import { showToast } from "../../../util/toast";
 import "./blueprint-script-editor";
 import "./manual-script-editor";
-import { UNAVAILABLE } from "../../../data/entity";
-import { validateConfig } from "../../../data/config";
+import type { HaManualScriptEditor } from "./manual-script-editor";
 
 export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -95,7 +94,10 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
   @state() private _readOnly = false;
 
-  @query("ha-yaml-editor", true) private _yamlEditor?: HaYamlEditor;
+  @query("ha-yaml-editor") private _yamlEditor?: HaYamlEditor;
+
+  @query("manual-script-editor")
+  private _manualEditor?: HaManualScriptEditor;
 
   @state() private _validationErrors?: (string | TemplateResult)[];
 
@@ -236,13 +238,9 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
 
           ${!useBlueprint && !("fields" in this._config)
             ? html`
-                <mwc-list-item
-                  graphic="icon"
-                  .disabled=${!this.scriptId}
-                  @click=${this._addFields}
-                >
+                <mwc-list-item graphic="icon" @click=${this._addFields}>
                   ${this.hass.localize(
-                    "ui.panel.config.script.editor.add_field"
+                    "ui.panel.config.script.editor.add_fields"
                   )}
                   <ha-svg-icon
                     slot="graphic"
@@ -685,16 +683,7 @@ export class HaScriptEditor extends KeyboardShortcutMixin(LitElement) {
     if ("fields" in this._config!) {
       return;
     }
-    this._config = {
-      ...this._config,
-      fields: {
-        new_field: {
-          selector: {
-            text: null,
-          },
-        },
-      } as Fields,
-    } as ManualScriptConfig;
+    this._manualEditor?.addFields();
     this._dirty = true;
   }
 

--- a/src/panels/config/script/ha-script-field-row.ts
+++ b/src/panels/config/script/ha-script-field-row.ts
@@ -225,16 +225,24 @@ export default class HaScriptFieldRow extends LitElement {
     if (!nameChanged || keyChanged) {
       return;
     }
-    const slugifyName = this.field.name ? slugify(this.field.name) : "field";
+    const slugifyName = this.field.name
+      ? slugify(this.field.name)
+      : this.hass.localize("ui.panel.config.script.editor.field.field") ||
+        "field";
     const regex = new RegExp(`^${slugifyName}(_\\d)?$`);
     if (regex.test(this.key)) {
-      let key = !value.name ? "field" : slugify(value.name);
+      let key = !value.name
+        ? this.hass.localize("ui.panel.config.script.editor.field.field") ||
+          "field"
+        : slugify(value.name);
       if (this.excludeKeys.includes(key)) {
+        let uniqueKey = key;
         let i = 2;
         do {
-          key = `${key}_${i}`;
+          uniqueKey = `${key}_${i}`;
           i++;
-        } while (this.excludeKeys.includes(key));
+        } while (this.excludeKeys.includes(uniqueKey));
+        key = uniqueKey;
       }
       value.key = key;
     }

--- a/src/panels/config/script/ha-script-field-row.ts
+++ b/src/panels/config/script/ha-script-field-row.ts
@@ -1,0 +1,221 @@
+import { ActionDetail } from "@material/mwc-list/mwc-list-foundation";
+import "@material/mwc-list/mwc-list-item";
+import { mdiDelete, mdiDotsVertical } from "@mdi/js";
+import { CSSResultGroup, LitElement, css, html } from "lit";
+import { customElement, property } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-alert";
+import "../../../components/ha-button-menu";
+import "../../../components/ha-card";
+import "../../../components/ha-expansion-panel";
+import "../../../components/ha-icon-button";
+import { Field } from "../../../data/script";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
+import { haStyle } from "../../../resources/styles";
+import type { HomeAssistant } from "../../../types";
+import type { SchemaUnion } from "../../../components/ha-form/types";
+
+const SCHEMA = [
+  {
+    name: "name",
+    selector: { text: {} },
+  },
+  {
+    name: "description",
+    selector: { text: {} },
+  },
+  {
+    name: "required",
+    selector: { boolean: {} },
+  },
+  {
+    name: "example",
+    selector: { text: {} },
+  },
+  {
+    name: "default",
+    selector: { object: {} },
+  },
+  {
+    name: "selector",
+    selector: { object: {} },
+  },
+] as const;
+
+const preventDefault = (ev) => ev.preventDefault();
+
+@customElement("ha-script-field-row")
+export default class HaScriptFieldRow extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property() public key!: string;
+
+  @property() public field!: Field;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  protected render() {
+    return html`
+      <ha-card outlined>
+        <ha-expansion-panel leftChevron>
+          <h3 slot="header">${this.key}</h3>
+
+          <slot name="icons" slot="icons"></slot>
+          <ha-button-menu
+            slot="icons"
+            @action=${this._handleAction}
+            @click=${preventDefault}
+            fixed
+          >
+            <ha-icon-button
+              slot="trigger"
+              .label=${this.hass.localize("ui.common.menu")}
+              .path=${mdiDotsVertical}
+            ></ha-icon-button>
+            <mwc-list-item
+              class="warning"
+              graphic="icon"
+              .disabled=${this.disabled}
+            >
+              ${this.hass.localize(
+                "ui.panel.config.automation.editor.actions.delete"
+              )}
+              <ha-svg-icon
+                class="warning"
+                slot="graphic"
+                .path=${mdiDelete}
+              ></ha-svg-icon>
+            </mwc-list-item>
+          </ha-button-menu>
+          <div
+            class=${classMap({
+              "card-content": true,
+            })}
+          >
+            <ha-form
+              .schema=${SCHEMA}
+              .data=${this.field}
+              .hass=${this.hass}
+              .disabled=${this.disabled}
+              .computeLabel=${this._computeLabelCallback}
+              @value-changed=${this._valueChanged}
+            ></ha-form>
+          </div>
+        </ha-expansion-panel>
+      </ha-card>
+    `;
+  }
+
+  private async _handleAction(ev: CustomEvent<ActionDetail>) {
+    switch (ev.detail.index) {
+      case 0:
+        this._onDelete();
+        break;
+    }
+  }
+
+  private _onDelete() {
+    showConfirmationDialog(this, {
+      title: this.hass.localize(
+        "ui.panel.config.script.editor.field_delete_confirm_title"
+      ),
+      text: this.hass.localize(
+        "ui.panel.config.script.editor.field_delete_confirm_text"
+      ),
+      dismissText: this.hass.localize("ui.common.cancel"),
+      confirmText: this.hass.localize("ui.common.delete"),
+      destructive: true,
+      confirm: () => {
+        fireEvent(this, "value-changed", { value: null });
+      },
+    });
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const value = { ...ev.detail.value };
+    fireEvent(this, "value-changed", { value });
+  }
+
+  public expand() {
+    this.updateComplete.then(() => {
+      this.shadowRoot!.querySelector("ha-expansion-panel")!.expanded = true;
+    });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<typeof SCHEMA>
+  ): string => {
+    switch (schema.name) {
+      default:
+        return this.hass.localize(
+          `ui.panel.config.script.editor.field.${schema.name}`
+        );
+    }
+  };
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      css`
+        ha-button-menu,
+        ha-icon-button {
+          --mdc-theme-text-primary-on-background: var(--primary-text-color);
+        }
+        .disabled {
+          opacity: 0.5;
+          pointer-events: none;
+        }
+        ha-expansion-panel {
+          --expansion-panel-summary-padding: 0 0 0 8px;
+          --expansion-panel-content-padding: 0;
+        }
+        h3 {
+          margin: 0;
+          font-size: inherit;
+          font-weight: inherit;
+        }
+        .action-icon {
+          display: none;
+        }
+        @media (min-width: 870px) {
+          .action-icon {
+            display: inline-block;
+            color: var(--secondary-text-color);
+            opacity: 0.9;
+            margin-right: 8px;
+          }
+        }
+        .card-content {
+          padding: 16px;
+        }
+        .disabled-bar {
+          background: var(--divider-color, #e0e0e0);
+          text-align: center;
+          border-top-right-radius: var(--ha-card-border-radius);
+          border-top-left-radius: var(--ha-card-border-radius);
+        }
+
+        mwc-list-item[disabled] {
+          --mdc-theme-text-primary-on-background: var(--disabled-text-color);
+        }
+        .warning ul {
+          margin: 4px 0;
+        }
+        .selected_menu_item {
+          color: var(--primary-color);
+        }
+        li[role="separator"] {
+          border-bottom-color: var(--divider-color);
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-script-field-row": HaScriptFieldRow;
+  }
+}

--- a/src/panels/config/script/ha-script-field-row.ts
+++ b/src/panels/config/script/ha-script-field-row.ts
@@ -62,7 +62,7 @@ export default class HaScriptFieldRow extends LitElement {
         },
         {
           name: "default",
-          selector: selector,
+          selector: selector && typeof selector === "object" ? selector : {},
         },
         {
           name: "required",
@@ -268,12 +268,6 @@ export default class HaScriptFieldRow extends LitElement {
     }
     this._errorKey = undefined;
     this._uiError = undefined;
-
-    // If we render the default with an incompatible selector, it risks throwing an exception and not rendering.
-    // Clear the default when changing the selector.
-    if (this.field.selector !== value.selector) {
-      delete value.default;
-    }
 
     fireEvent(this, "value-changed", { value });
   }

--- a/src/panels/config/script/ha-script-fields.ts
+++ b/src/panels/config/script/ha-script-fields.ts
@@ -54,7 +54,9 @@ export default class HaScriptFields extends LitElement {
         outlined
         @click=${this._addField}
         .disabled=${this.disabled}
-        .label=${this.hass.localize("ui.panel.config.script.editor.add_field")}
+        .label=${this.hass.localize(
+          "ui.panel.config.script.editor.field.add_field"
+        )}
       >
         <ha-svg-icon .path=${mdiPlus} slot="icon"></ha-svg-icon>
       </ha-button>
@@ -82,7 +84,11 @@ export default class HaScriptFields extends LitElement {
   }
 
   private _addField() {
-    const key = this._getUniqueKey("field", this.fields || {});
+    const key = this._getUniqueKey(
+      this.hass.localize("ui.panel.config.script.editor.field.field") ||
+        "field",
+      this.fields || {}
+    );
     const fields = {
       ...(this.fields || {}),
       [key]: {

--- a/src/panels/config/script/ha-script-fields.ts
+++ b/src/panels/config/script/ha-script-fields.ts
@@ -80,7 +80,14 @@ export default class HaScriptFields extends LitElement {
 
   private _addField() {
     const key = this._getUniqueKey("new_field", this.fields || {});
-    const fields = { ...(this.fields || {}), [key]: {} };
+    const fields = {
+      ...(this.fields || {}),
+      [key]: {
+        selector: {
+          text: null,
+        },
+      },
+    };
     this._focusLastActionOnChange = true;
     fireEvent(this, "value-changed", { value: fields });
   }

--- a/src/panels/config/script/ha-script-fields.ts
+++ b/src/panels/config/script/ha-script-fields.ts
@@ -16,8 +16,8 @@ import "../../../components/ha-svg-icon";
 import { Fields } from "../../../data/script";
 import { sortableStyles } from "../../../resources/ha-sortable-style";
 import { HomeAssistant } from "../../../types";
-import type HaScriptFieldRow from "./ha-script-field-row";
 import "./ha-script-field-row";
+import type HaScriptFieldRow from "./ha-script-field-row";
 
 @customElement("ha-script-fields")
 export default class HaScriptFields extends LitElement {
@@ -66,20 +66,23 @@ export default class HaScriptFields extends LitElement {
 
     if (changedProps.has("fields") && this._focusLastActionOnChange) {
       this._focusLastActionOnChange = false;
-
-      const row = this.shadowRoot!.querySelector<HaScriptFieldRow>(
-        "ha-script-field-row:last-of-type"
-      )!;
-      row.updateComplete.then(() => {
-        row.expand();
-        row.scrollIntoView();
-        row.focus();
-      });
+      this.focusLastField();
     }
   }
 
+  public focusLastField() {
+    const row = this.shadowRoot!.querySelector<HaScriptFieldRow>(
+      "ha-script-field-row:last-of-type"
+    )!;
+    row.updateComplete.then(() => {
+      row.expand();
+      row.scrollIntoView();
+      row.focus();
+    });
+  }
+
   private _addField() {
-    const key = this._getUniqueKey("new_field", this.fields || {});
+    const key = this._getUniqueKey("field", this.fields || {});
     const fields = {
       ...(this.fields || {}),
       [key]: {

--- a/src/panels/config/script/ha-script-fields.ts
+++ b/src/panels/config/script/ha-script-fields.ts
@@ -1,0 +1,153 @@
+import "@material/mwc-button";
+import { mdiPlus } from "@mdi/js";
+import {
+  CSSResultGroup,
+  LitElement,
+  PropertyValues,
+  css,
+  html,
+  nothing,
+} from "lit";
+import { customElement, property } from "lit/decorators";
+import { fireEvent } from "../../../common/dom/fire_event";
+import "../../../components/ha-button";
+import "../../../components/ha-button-menu";
+import "../../../components/ha-svg-icon";
+import { Fields } from "../../../data/script";
+import { sortableStyles } from "../../../resources/ha-sortable-style";
+import { HomeAssistant } from "../../../types";
+import { slugify } from "../../../common/string/slugify";
+import type HaScriptFieldRow from "./ha-script-field-row";
+import "./ha-script-field-row";
+
+@customElement("ha-script-fields")
+export default class HaScriptFields extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property() public fields!: Fields;
+
+  private _focusLastActionOnChange = false;
+
+  protected render() {
+    return html`
+      ${this.fields
+        ? html`<div class="fields">
+            ${Object.entries(this.fields).map(
+              ([key, field]) => html`
+                <ha-script-field-row
+                  .key=${key}
+                  .field=${field}
+                  .disabled=${this.disabled}
+                  @value-changed=${this._fieldChanged}
+                  .hass=${this.hass}
+                >
+                </ha-script-field-row>
+              `
+            )}
+          </div> `
+        : nothing}
+      <ha-button
+        outlined
+        @click=${this._addField}
+        .disabled=${this.disabled}
+        .label=${this.hass.localize("ui.panel.config.script.editor.add_field")}
+      >
+        <ha-svg-icon .path=${mdiPlus} slot="icon"></ha-svg-icon>
+      </ha-button>
+    `;
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+
+    if (changedProps.has("fields") && this._focusLastActionOnChange) {
+      this._focusLastActionOnChange = false;
+
+      const row = this.shadowRoot!.querySelector<HaScriptFieldRow>(
+        "ha-script-field-row:last-of-type"
+      )!;
+      row.updateComplete.then(() => {
+        row.expand();
+        row.scrollIntoView();
+        row.focus();
+      });
+    }
+  }
+
+  private _addField() {
+    const key = this._getUniqueKey("new_field", this.fields || {});
+    const fields = { ...(this.fields || {}), [key]: {} };
+    this._focusLastActionOnChange = true;
+    fireEvent(this, "value-changed", { value: fields });
+  }
+
+  private _fieldChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const newValue = ev.detail.value;
+    const key = (ev.target as any).key;
+
+    const nameChanged =
+      newValue !== null && this.fields[key].name !== newValue.name;
+    let fields: Fields = {};
+
+    // If the field name is changed, change the key as well, but recreate the entire object
+    // to maintain the same insertion order.
+    if (nameChanged) {
+      const oldFields = { ...this.fields };
+      delete oldFields[key];
+      const newKey = this._getUniqueKey(
+        slugify(newValue.name || "unnamed_field"),
+        oldFields
+      );
+      Object.entries(this.fields).forEach(([k, v]) => {
+        if (k === key) {
+          fields[newKey] = newValue;
+        } else fields[k] = v;
+      });
+    } else {
+      fields = { ...this.fields };
+      if (newValue === null) {
+        delete fields[key];
+      } else {
+        fields[key] = newValue;
+      }
+    }
+    fireEvent(this, "value-changed", { value: fields });
+  }
+
+  private _getUniqueKey(base: string, fields: Fields): string {
+    let key = base;
+    if (base in fields) {
+      let i = 2;
+      do {
+        key = `${base}_${i}`;
+        i++;
+      } while (key in fields);
+    }
+    return key;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      sortableStyles,
+      css`
+        ha-script-field-row {
+          display: block;
+          margin-bottom: 16px;
+          scroll-margin-top: 48px;
+        }
+        ha-svg-icon {
+          height: 20px;
+        }
+      `,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-script-fields": HaScriptFields;
+  }
+}

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -1,6 +1,6 @@
 import "@material/mwc-button/mwc-button";
 import { mdiHelpCircle } from "@mdi/js";
-import { css, CSSResultGroup, html, LitElement } from "lit";
+import { css, CSSResultGroup, html, nothing, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-card";
@@ -34,33 +34,37 @@ export class HaManualScriptEditor extends LitElement {
             </mwc-button>
           </ha-alert>`
         : ""}
+      ${this.config.fields
+        ? html` <div class="header">
+              <h2 id="fields-heading" class="name">
+                ${this.hass.localize("ui.panel.config.script.editor.fields")}
+              </h2>
+              <a
+                href=${documentationUrl(
+                  this.hass,
+                  "/integrations/script/#fields"
+                )}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <ha-icon-button
+                  .path=${mdiHelpCircle}
+                  .label=${this.hass.localize(
+                    "ui.panel.config.script.editor.link_help_fields"
+                  )}
+                ></ha-icon-button>
+              </a>
+            </div>
 
-      <div class="header">
-        <h2 id="fields-heading" class="name">
-          ${this.hass.localize("ui.panel.config.script.editor.fields")}
-        </h2>
-        <a
-          href=${documentationUrl(this.hass, "/integrations/script/#fields")}
-          target="_blank"
-          rel="noreferrer"
-        >
-          <ha-icon-button
-            .path=${mdiHelpCircle}
-            .label=${this.hass.localize(
-              "ui.panel.config.script.editor.link_help_fields"
-            )}
-          ></ha-icon-button>
-        </a>
-      </div>
-
-      <ha-script-fields
-        role="region"
-        aria-labelledby="fields-heading"
-        .fields=${this.config.fields}
-        @value-changed=${this._fieldsChanged}
-        .hass=${this.hass}
-        .disabled=${this.disabled}
-      ></ha-script-fields>
+            <ha-script-fields
+              role="region"
+              aria-labelledby="fields-heading"
+              .fields=${this.config.fields}
+              @value-changed=${this._fieldsChanged}
+              .hass=${this.hass}
+              .disabled=${this.disabled}
+            ></ha-script-fields>`
+        : nothing}
 
       <div class="header">
         <h2 id="sequence-heading" class="name">

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -5,11 +5,12 @@ import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
-import { Action, ScriptConfig } from "../../../data/script";
+import { Action, Fields, ScriptConfig } from "../../../data/script";
 import { haStyle } from "../../../resources/styles";
 import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import "../automation/action/ha-automation-action";
+import "./ha-script-fields";
 
 @customElement("manual-script-editor")
 export class HaManualScriptEditor extends LitElement {
@@ -33,6 +34,34 @@ export class HaManualScriptEditor extends LitElement {
             </mwc-button>
           </ha-alert>`
         : ""}
+
+      <div class="header">
+        <h2 id="fields-heading" class="name">
+          ${this.hass.localize("ui.panel.config.script.editor.fields")}
+        </h2>
+        <a
+          href=${documentationUrl(this.hass, "/integrations/script/#fields")}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <ha-icon-button
+            .path=${mdiHelpCircle}
+            .label=${this.hass.localize(
+              "ui.panel.config.script.editor.link_help_fields"
+            )}
+          ></ha-icon-button>
+        </a>
+      </div>
+
+      <ha-script-fields
+        role="region"
+        aria-labelledby="fields-heading"
+        .fields=${this.config.fields}
+        @value-changed=${this._fieldsChanged}
+        .hass=${this.hass}
+        .disabled=${this.disabled}
+      ></ha-script-fields>
+
       <div class="header">
         <h2 id="sequence-heading" class="name">
           ${this.hass.localize("ui.panel.config.script.editor.sequence")}
@@ -61,6 +90,13 @@ export class HaManualScriptEditor extends LitElement {
         .disabled=${this.disabled}
       ></ha-automation-action>
     `;
+  }
+
+  private _fieldsChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    fireEvent(this, "value-changed", {
+      value: { ...this.config!, fields: ev.detail.value as Fields },
+    });
   }
 
   private _sequenceChanged(ev: CustomEvent): void {

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -36,7 +36,8 @@ export class HaManualScriptEditor extends LitElement {
       value: {
         ...this.config,
         fields: {
-          field: {
+          [this.hass.localize("ui.panel.config.script.editor.field.field") ||
+          "field"]: {
             selector: {
               text: null,
             },
@@ -68,7 +69,9 @@ export class HaManualScriptEditor extends LitElement {
       ${this.config.fields
         ? html`<div class="header">
               <h2 id="fields-heading" class="name">
-                ${this.hass.localize("ui.panel.config.script.editor.fields")}
+                ${this.hass.localize(
+                  "ui.panel.config.script.editor.field.fields"
+                )}
               </h2>
               <a
                 href=${documentationUrl(
@@ -81,7 +84,7 @@ export class HaManualScriptEditor extends LitElement {
                 <ha-icon-button
                   .path=${mdiHelpCircle}
                   .label=${this.hass.localize(
-                    "ui.panel.config.script.editor.link_help_fields"
+                    "ui.panel.config.script.editor.field.link_help_fields"
                   )}
                 ></ha-icon-button>
               </a>

--- a/src/panels/config/script/manual-script-editor.ts
+++ b/src/panels/config/script/manual-script-editor.ts
@@ -1,7 +1,7 @@
 import "@material/mwc-button/mwc-button";
 import { mdiHelpCircle } from "@mdi/js";
-import { css, CSSResultGroup, html, nothing, LitElement } from "lit";
-import { customElement, property } from "lit/decorators";
+import { CSSResultGroup, LitElement, css, html, nothing } from "lit";
+import { customElement, property, query } from "lit/decorators";
 import { fireEvent } from "../../../common/dom/fire_event";
 import "../../../components/ha-card";
 import "../../../components/ha-icon-button";
@@ -11,6 +11,7 @@ import type { HomeAssistant } from "../../../types";
 import { documentationUrl } from "../../../util/documentation-url";
 import "../automation/action/ha-automation-action";
 import "./ha-script-fields";
+import type HaScriptFields from "./ha-script-fields";
 
 @customElement("manual-script-editor")
 export class HaManualScriptEditor extends LitElement {
@@ -24,6 +25,36 @@ export class HaManualScriptEditor extends LitElement {
 
   @property({ attribute: false }) public config!: ScriptConfig;
 
+  @query("ha-script-fields")
+  private _scriptFields?: HaScriptFields;
+
+  private _openFields = false;
+
+  public addFields() {
+    this._openFields = true;
+    fireEvent(this, "value-changed", {
+      value: {
+        ...this.config,
+        fields: {
+          field: {
+            selector: {
+              text: null,
+            },
+          },
+        },
+      },
+    });
+  }
+
+  protected updated(changedProps) {
+    if (this._openFields && changedProps.has("config")) {
+      this._openFields = false;
+      this._scriptFields?.updateComplete.then(
+        () => this._scriptFields?.focusLastField()
+      );
+    }
+  }
+
   protected render() {
     return html`
       ${this.disabled
@@ -35,7 +66,7 @@ export class HaManualScriptEditor extends LitElement {
           </ha-alert>`
         : ""}
       ${this.config.fields
-        ? html` <div class="header">
+        ? html`<div class="header">
               <h2 id="fields-heading" class="name">
                 ${this.hass.localize("ui.panel.config.script.editor.fields")}
               </h2>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3007,8 +3007,6 @@
             "unavailable": "Script is unavailable",
             "migrate": "Migrate",
             "duplicate": "[%key:ui::common::duplicate%]",
-            "fields": "Fields",
-            "link_help_fields": "Learn more about fields.",
             "field": {
               "name": "[%key:ui::common::name%]",
               "key": "Field variable key name",
@@ -3018,10 +3016,13 @@
               "selector": "Selector",
               "yaml_error": "Field yaml has invalid format.",
               "key_not_null": "The field key must not be empty.",
-              "key_not_unique": "The field key must not be the same value as another field."
+              "key_not_unique": "The field key must not be the same value as another field.",
+              "fields": "Fields",
+              "link_help_fields": "Learn more about fields.",
+              "add_fields": "Add fields",
+              "add_field": "Add field",
+              "field": "field"
             },
-            "add_fields": "Add fields",
-            "add_field": "Add field",
             "field_delete_confirm_title": "Delete field?",
             "field_delete_confirm_text": "[%key:ui::panel::config::automation::editor::triggers::delete_confirm_text%]",
             "header": "Script: {name}",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3016,7 +3016,9 @@
               "required": "Required",
               "example": "Example",
               "default": "Default",
-              "selector": "Selector"
+              "selector": "Selector",
+              "key_not_null": "The field key must not be empty.",
+              "key_not_unique": "The field key must not be the same value as another field."
             },
             "add_field": "Add field",
             "field_delete_confirm_title": "Delete field?",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3017,6 +3017,7 @@
               "example": "Example",
               "default": "Default",
               "selector": "Selector",
+              "yaml_error": "Field yaml has invalid format.",
               "key_not_null": "The field key must not be empty.",
               "key_not_unique": "The field key must not be the same value as another field."
             },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -311,7 +311,8 @@
       "successfully_deleted": "Successfully deleted",
       "error_required": "Required",
       "copied": "Copied",
-      "copied_clipboard": "Copied to clipboard"
+      "copied_clipboard": "Copied to clipboard",
+      "name": "Name"
     },
     "components": {
       "selectors": {
@@ -3006,6 +3007,19 @@
             "unavailable": "Script is unavailable",
             "migrate": "Migrate",
             "duplicate": "[%key:ui::common::duplicate%]",
+            "fields": "Fields",
+            "link_help_fields": "Learn more about fields.",
+            "field": {
+              "name": "[%key:ui::common::name%]",
+              "description": "Description",
+              "required": "Required",
+              "example": "Example",
+              "default": "Default",
+              "selector": "Selector"
+            },
+            "add_field": "Add field",
+            "field_delete_confirm_title": "Delete field?",
+            "field_delete_confirm_text": "[%key:ui::panel::config::automation::editor::triggers::delete_confirm_text%]",
             "header": "Script: {name}",
             "default_name": "New Script",
             "modes": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3020,6 +3020,7 @@
               "key_not_null": "The field key must not be empty.",
               "key_not_unique": "The field key must not be the same value as another field."
             },
+            "add_fields": "Add fields",
             "add_field": "Add field",
             "field_delete_confirm_title": "Delete field?",
             "field_delete_confirm_text": "[%key:ui::panel::config::automation::editor::triggers::delete_confirm_text%]",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3014,7 +3014,6 @@
               "key": "Field variable key name",
               "description": "Description",
               "required": "Required",
-              "example": "Example",
               "default": "Default",
               "selector": "Selector",
               "yaml_error": "Field yaml has invalid format.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3011,6 +3011,7 @@
             "link_help_fields": "Learn more about fields.",
             "field": {
               "name": "[%key:ui::common::name%]",
+              "key": "Field variable key name",
               "description": "Description",
               "required": "Required",
               "example": "Example",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add a fields editor to the UI for scripts.

![image](https://github.com/home-assistant/frontend/assets/32912880/4974c636-6b9c-418b-a0d9-bdcd75bbfe02)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://github.com/home-assistant/frontend/discussions/13771
https://community.home-assistant.io/t/wth-are-fields-variables-in-scripts-automations-arent-included-in-the-ui/467210
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
