### PR TITLE
Add a Grid/List toggle for Media Browser

### DIFF
--- a/src/components/media-player/dialog-media-player-browse.ts
+++ b/src/components/media-player/dialog-media-player-browse.ts
@@ -1,11 +1,20 @@
-import { mdiArrowLeft, mdiClose } from "@mdi/js";
-import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
+import { ActionDetail } from "@material/mwc-list";
+import {
+  mdiAlphaABoxOutline,
+  mdiArrowLeft,
+  mdiClose,
+  mdiDotsVertical,
+  mdiGrid,
+  mdiListBoxOutline,
+} from "@mdi/js";
+import { CSSResultGroup, LitElement, css, html, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators";
-import { fireEvent, HASSDomEvent } from "../../common/dom/fire_event";
+import { HASSDomEvent, fireEvent } from "../../common/dom/fire_event";
 import type {
   MediaPickedEvent,
   MediaPlayerBrowseAction,
   MediaPlayerItem,
+  MediaPlayerLayoutType,
 } from "../../data/media-player";
 import { haStyleDialog } from "../../resources/styles";
 import type { HomeAssistant } from "../../types";
@@ -18,6 +27,7 @@ import type {
   MediaPlayerItemId,
 } from "./ha-media-player-browse";
 import { MediaPlayerBrowseDialogParams } from "./show-media-browser-dialog";
+import { stopPropagation } from "../../common/dom/stop_propagation";
 
 @customElement("dialog-media-player-browse")
 class DialogMediaPlayerBrowse extends LitElement {
@@ -28,6 +38,8 @@ class DialogMediaPlayerBrowse extends LitElement {
   @state() private _navigateIds?: MediaPlayerItemId[];
 
   @state() private _params?: MediaPlayerBrowseDialogParams;
+
+  @state() _preferredLayout: MediaPlayerLayoutType = "auto";
 
   @query("ha-media-player-browse") private _browser!: HaMediaPlayerBrowse;
 
@@ -45,6 +57,7 @@ class DialogMediaPlayerBrowse extends LitElement {
     this._params = undefined;
     this._navigateIds = undefined;
     this._currentItem = undefined;
+    this._preferredLayout = "auto";
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 
@@ -84,13 +97,54 @@ class DialogMediaPlayerBrowse extends LitElement {
                 )
               : this._currentItem.title}
           </span>
-
           <ha-media-manage-button
             slot="actionItems"
             .hass=${this.hass}
             .currentItem=${this._currentItem}
             @media-refresh=${this._refreshMedia}
           ></ha-media-manage-button>
+          <ha-button-menu
+            slot="actionItems"
+            @action=${this._handleMenuAction}
+            @closed=${stopPropagation}
+            fixed
+          >
+            <ha-icon-button
+              slot="trigger"
+              .label=${this.hass.localize("ui.common.menu")}
+              .path=${mdiDotsVertical}
+            ></ha-icon-button>
+            <mwc-list-item graphic="icon">
+              ${this.hass.localize("ui.components.media-browser.auto")}
+              <ha-svg-icon
+                class=${this._preferredLayout === "auto"
+                  ? "selected_menu_item"
+                  : ""}
+                slot="graphic"
+                .path=${mdiAlphaABoxOutline}
+              ></ha-svg-icon>
+            </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              ${this.hass.localize("ui.components.media-browser.grid")}
+              <ha-svg-icon
+                class=${this._preferredLayout === "grid"
+                  ? "selected_menu_item"
+                  : ""}
+                slot="graphic"
+                .path=${mdiGrid}
+              ></ha-svg-icon>
+            </mwc-list-item>
+            <mwc-list-item graphic="icon">
+              ${this.hass.localize("ui.components.media-browser.list")}
+              <ha-svg-icon
+                slot="graphic"
+                class=${this._preferredLayout === "list"
+                  ? "selected_menu_item"
+                  : ""}
+                .path=${mdiListBoxOutline}
+              ></ha-svg-icon>
+            </mwc-list-item>
+          </ha-button-menu>
           <ha-icon-button
             .label=${this.hass.localize("ui.dialogs.generic.close")}
             .path=${mdiClose}
@@ -104,12 +158,27 @@ class DialogMediaPlayerBrowse extends LitElement {
           .entityId=${this._params.entityId}
           .navigateIds=${this._navigateIds}
           .action=${this._action}
+          .preferredLayout=${this._preferredLayout}
           @close-dialog=${this.closeDialog}
           @media-picked=${this._mediaPicked}
           @media-browsed=${this._mediaBrowsed}
         ></ha-media-player-browse>
       </ha-dialog>
     `;
+  }
+
+  private async _handleMenuAction(ev: CustomEvent<ActionDetail>) {
+    switch (ev.detail.index) {
+      case 0:
+        this._preferredLayout = "auto";
+        break;
+      case 1:
+        this._preferredLayout = "grid";
+        break;
+      case 2:
+        this._preferredLayout = "list";
+        break;
+    }
   }
 
   private _goBack() {

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -448,76 +448,41 @@ export class HaMediaPlayerBrowse extends LitElement {
                     </div>
                   `
                 : isTTSMediaSource(currentItem.media_content_id)
-                ? html`
-                    <ha-browse-media-tts
-                      .item=${currentItem}
-                      .hass=${this.hass}
-                      .action=${this.action}
-                      @tts-picked=${this._ttsPicked}
-                    ></ha-browse-media-tts>
-                  `
-                : !children.length && !currentItem.not_shown
-                ? html`
-                    <div class="container no-items">
-                      ${currentItem.media_content_id ===
-                      "media-source://media_source/local/."
-                        ? html`
-                            <div class="highlight-add-button">
-                              <span>
-                                <ha-svg-icon
-                                  .path=${mdiArrowUpRight}
-                                ></ha-svg-icon>
-                              </span>
-                              <span>
-                                ${this.hass.localize(
-                                  "ui.components.media-browser.file_management.highlight_button"
-                                )}
-                              </span>
-                            </div>
-                          `
-                        : this.hass.localize(
-                            "ui.components.media-browser.no_items"
-                          )}
-                    </div>
-                  `
-                : this.preferredLayout === "grid" ||
-                  (this.preferredLayout === "auto" &&
-                    childrenMediaClass.layout === "grid")
-                ? html`
-                    <lit-virtualizer
-                      scroller
-                      .layout=${grid({
-                        itemSize: {
-                          width: "175px",
-                          height:
-                            childrenMediaClass.thumbnail_ratio === "portrait"
-                              ? "312px"
-                              : "225px",
-                        },
-                        gap: "16px",
-                        flex: { preserve: "aspect-ratio" },
-                        justify: "space-evenly",
-                        direction: "vertical",
-                      })}
-                      .items=${children}
-                      .renderItem=${this._renderGridItem}
-                      class="children ${classMap({
-                        portrait:
-                          childrenMediaClass.thumbnail_ratio === "portrait",
-                        not_shown: !!currentItem.not_shown,
-                      })}"
-                    ></lit-virtualizer>
-                    ${currentItem.not_shown
-                      ? html`
-                          <div class="grid not-shown">
-                            <div class="title">
-                              ${this.hass.localize(
-                                "ui.components.media-browser.not_shown",
-                                { count: currentItem.not_shown }
+                  ? html`
+                      <ha-browse-media-tts
+                        .item=${currentItem}
+                        .hass=${this.hass}
+                        .action=${this.action}
+                        @tts-picked=${this._ttsPicked}
+                      ></ha-browse-media-tts>
+                    `
+                  : !children.length && !currentItem.not_shown
+                    ? html`
+                        <div class="container no-items">
+                          ${currentItem.media_content_id ===
+                          "media-source://media_source/local/."
+                            ? html`
+                                <div class="highlight-add-button">
+                                  <span>
+                                    <ha-svg-icon
+                                      .path=${mdiArrowUpRight}
+                                    ></ha-svg-icon>
+                                  </span>
+                                  <span>
+                                    ${this.hass.localize(
+                                      "ui.components.media-browser.file_management.highlight_button"
+                                    )}
+                                  </span>
+                                </div>
+                              `
+                            : this.hass.localize(
+                                "ui.components.media-browser.no_items"
                               )}
                         </div>
                       `
-                    : childrenMediaClass.layout === "grid"
+                    : this.preferredLayout === "grid" ||
+                        (this.preferredLayout === "auto" &&
+                          childrenMediaClass.layout === "grid")
                       ? html`
                           <lit-virtualizer
                             scroller
@@ -951,7 +916,6 @@ export class HaMediaPlayerBrowse extends LitElement {
           overflow-y: auto;
           box-sizing: border-box;
           height: 100%;
-          position: relative;
         }
 
         /* HEADER */

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -609,11 +609,12 @@ export class HaMediaPlayerBrowse extends LitElement {
             ${child.thumbnail
               ? html`
                   <div
-                    class="${["app", "directory"].includes(child.media_class)
-                      ? "centered-image"
-                      : ""} ${isBrandUrl(child.thumbnail)
-                      ? "brand-image"
-                      : ""} image"
+                    class="${classMap({
+                      "centered-image": ["app", "directory"].includes(
+                        child.media_class
+                      ),
+                      "brand-image": isBrandUrl(child.thumbnail),
+                    })} image"
                     style="background-image: ${until(backgroundImage, "")}"
                   ></div>
                 `
@@ -674,26 +675,37 @@ export class HaMediaPlayerBrowse extends LitElement {
         .graphic=${mediaClass.show_list_images ? "medium" : "avatar"}
         dir=${computeRTLDirection(this.hass)}
       >
-        <div
-          class=${classMap({
-            graphic: true,
-            thumbnail: mediaClass.show_list_images === true,
-          })}
-          style="background-image: ${until(backgroundImage, "")}"
-          slot="graphic"
-        >
-          <ha-icon-button
-            class="play ${classMap({
-              show: !mediaClass.show_list_images || !child.thumbnail,
-            })}"
-            .item=${child}
-            .label=${this.hass.localize(
-              `ui.components.media-browser.${this.action}-media`
-            )}
-            .path=${this.action === "play" ? mdiPlay : mdiPlus}
-            @click=${this._actionClicked}
-          ></ha-icon-button>
-        </div>
+        ${backgroundImage === "none" && !child.can_play
+          ? html`<ha-svg-icon
+              .path=${MediaClassBrowserSettings[
+                child.media_class === "directory"
+                  ? child.children_media_class || child.media_class
+                  : child.media_class
+              ].icon}
+              slot="graphic"
+            ></ha-svg-icon>`
+          : html`<div
+              class=${classMap({
+                graphic: true,
+                thumbnail: mediaClass.show_list_images === true,
+              })}
+              style="background-image: ${until(backgroundImage, "")}"
+              slot="graphic"
+            >
+              ${child.can_play
+                ? html`<ha-icon-button
+                    class="play ${classMap({
+                      show: !mediaClass.show_list_images || !child.thumbnail,
+                    })}"
+                    .item=${child}
+                    .label=${this.hass.localize(
+                      `ui.components.media-browser.${this.action}-media`
+                    )}
+                    .path=${this.action === "play" ? mdiPlay : mdiPlus}
+                    @click=${this._actionClicked}
+                  ></ha-icon-button>`
+                : nothing}
+            </div>`}
         <span class="title">${child.title}</span>
       </mwc-list-item>
     `;
@@ -953,7 +965,7 @@ export class HaMediaPlayerBrowse extends LitElement {
           top: 0;
           right: 0;
           left: 0;
-          z-index: 5;
+          z-index: 3;
           padding: 16px;
         }
         .header_button {
@@ -1194,6 +1206,8 @@ export class HaMediaPlayerBrowse extends LitElement {
 
         mwc-list-item .graphic {
           background-size: contain;
+          background-repeat: no-repeat;
+          background-position: center;
           border-radius: 2px;
           display: flex;
           align-content: center;

--- a/src/components/media-player/ha-media-player-browse.ts
+++ b/src/components/media-player/ha-media-player-browse.ts
@@ -35,6 +35,7 @@ import {
   MediaClassBrowserSettings,
   MediaPickedEvent,
   MediaPlayerBrowseAction,
+  MediaPlayerLayoutType,
 } from "../../data/media-player";
 import { browseLocalMediaPlayer } from "../../data/media_source";
 import { isTTSMediaSource } from "../../data/tts";
@@ -86,6 +87,8 @@ export class HaMediaPlayerBrowse extends LitElement {
   @property() public entityId!: string;
 
   @property() public action: MediaPlayerBrowseAction = "play";
+
+  @property() public preferredLayout: MediaPlayerLayoutType = "auto";
 
   @property({ type: Boolean }) public dialog = false;
 
@@ -445,35 +448,72 @@ export class HaMediaPlayerBrowse extends LitElement {
                     </div>
                   `
                 : isTTSMediaSource(currentItem.media_content_id)
-                  ? html`
-                      <ha-browse-media-tts
-                        .item=${currentItem}
-                        .hass=${this.hass}
-                        .action=${this.action}
-                        @tts-picked=${this._ttsPicked}
-                      ></ha-browse-media-tts>
-                    `
-                  : !children.length && !currentItem.not_shown
-                    ? html`
-                        <div class="container no-items">
-                          ${currentItem.media_content_id ===
-                          "media-source://media_source/local/."
-                            ? html`
-                                <div class="highlight-add-button">
-                                  <span>
-                                    <ha-svg-icon
-                                      .path=${mdiArrowUpRight}
-                                    ></ha-svg-icon>
-                                  </span>
-                                  <span>
-                                    ${this.hass.localize(
-                                      "ui.components.media-browser.file_management.highlight_button"
-                                    )}
-                                  </span>
-                                </div>
-                              `
-                            : this.hass.localize(
-                                "ui.components.media-browser.no_items"
+                ? html`
+                    <ha-browse-media-tts
+                      .item=${currentItem}
+                      .hass=${this.hass}
+                      .action=${this.action}
+                      @tts-picked=${this._ttsPicked}
+                    ></ha-browse-media-tts>
+                  `
+                : !children.length && !currentItem.not_shown
+                ? html`
+                    <div class="container no-items">
+                      ${currentItem.media_content_id ===
+                      "media-source://media_source/local/."
+                        ? html`
+                            <div class="highlight-add-button">
+                              <span>
+                                <ha-svg-icon
+                                  .path=${mdiArrowUpRight}
+                                ></ha-svg-icon>
+                              </span>
+                              <span>
+                                ${this.hass.localize(
+                                  "ui.components.media-browser.file_management.highlight_button"
+                                )}
+                              </span>
+                            </div>
+                          `
+                        : this.hass.localize(
+                            "ui.components.media-browser.no_items"
+                          )}
+                    </div>
+                  `
+                : this.preferredLayout === "grid" ||
+                  (this.preferredLayout === "auto" &&
+                    childrenMediaClass.layout === "grid")
+                ? html`
+                    <lit-virtualizer
+                      scroller
+                      .layout=${grid({
+                        itemSize: {
+                          width: "175px",
+                          height:
+                            childrenMediaClass.thumbnail_ratio === "portrait"
+                              ? "312px"
+                              : "225px",
+                        },
+                        gap: "16px",
+                        flex: { preserve: "aspect-ratio" },
+                        justify: "space-evenly",
+                        direction: "vertical",
+                      })}
+                      .items=${children}
+                      .renderItem=${this._renderGridItem}
+                      class="children ${classMap({
+                        portrait:
+                          childrenMediaClass.thumbnail_ratio === "portrait",
+                        not_shown: !!currentItem.not_shown,
+                      })}"
+                    ></lit-virtualizer>
+                    ${currentItem.not_shown
+                      ? html`
+                          <div class="grid not-shown">
+                            <div class="title">
+                              ${this.hass.localize(
+                                "ui.components.media-browser.not_shown",
+                                { count: currentItem.not_shown }
                               )}
                         </div>
                       `

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -119,12 +119,13 @@ export const MediaClassBrowserSettings: {
   [type: string]: MediaClassBrowserSetting;
 } = {
   album: { icon: mdiAlbum, layout: "grid" },
-  app: { icon: mdiApplication, layout: "grid" },
+  app: { icon: mdiApplication, layout: "grid", show_list_images: true },
   artist: { icon: mdiAccountMusic, layout: "grid", show_list_images: true },
   channel: {
     icon: mdiTelevisionClassic,
     thumbnail_ratio: "portrait",
     layout: "grid",
+    show_list_images: true,
   },
   composer: {
     icon: mdiAccountMusicOutline,
@@ -141,6 +142,7 @@ export const MediaClassBrowserSettings: {
     icon: mdiTelevisionClassic,
     layout: "grid",
     thumbnail_ratio: "portrait",
+    show_list_images: true,
   },
   game: {
     icon: mdiGamepadVariant,
@@ -148,15 +150,21 @@ export const MediaClassBrowserSettings: {
     thumbnail_ratio: "portrait",
   },
   genre: { icon: mdiDramaMasks, layout: "grid", show_list_images: true },
-  image: { icon: mdiImage, layout: "grid" },
-  movie: { icon: mdiMovie, thumbnail_ratio: "portrait", layout: "grid" },
-  music: { icon: mdiMusic },
+  image: { icon: mdiImage, layout: "grid", show_list_images: true },
+  movie: {
+    icon: mdiMovie,
+    thumbnail_ratio: "portrait",
+    layout: "grid",
+    show_list_images: true,
+  },
+  music: { icon: mdiMusic, show_list_images: true },
   playlist: { icon: mdiPlaylistMusic, layout: "grid", show_list_images: true },
   podcast: { icon: mdiPodcast, layout: "grid" },
   season: {
     icon: mdiTelevisionClassic,
     layout: "grid",
     thumbnail_ratio: "portrait",
+    show_list_images: true,
   },
   track: { icon: mdiFileMusic },
   tv_show: {
@@ -165,7 +173,7 @@ export const MediaClassBrowserSettings: {
     thumbnail_ratio: "portrait",
   },
   url: { icon: mdiWeb },
-  video: { icon: mdiVideo, layout: "grid" },
+  video: { icon: mdiVideo, layout: "grid", show_list_images: true },
 };
 
 export interface MediaPickedEvent {

--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -106,6 +106,8 @@ export type MediaPlayerBrowseAction = "pick" | "play";
 
 export const BROWSER_PLAYER = "browser";
 
+export type MediaPlayerLayoutType = "grid" | "list" | "auto";
+
 export type MediaClassBrowserSetting = {
   icon: string;
   thumbnail_ratio?: string;

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -1,4 +1,10 @@
-import { mdiArrowLeft } from "@mdi/js";
+import {
+  mdiGrid,
+  mdiListBoxOutline,
+  mdiArrowLeft,
+  mdiDotsVertical,
+} from "@mdi/js";
+import { ActionDetail } from "@material/mwc-list";
 import "@material/mwc-button";
 import {
   css,
@@ -26,6 +32,7 @@ import {
   MediaPickedEvent,
   MediaPlayerItem,
   mediaPlayerPlayMedia,
+  MediaPlayerLayoutType,
 } from "../../data/media-player";
 import {
   ResolvedMediaSource,
@@ -63,6 +70,8 @@ class PanelMediaBrowser extends LitElement {
   @property() public route!: Route;
 
   @state() _currentItem?: MediaPlayerItem;
+
+  @state() _preferredLayout: MediaPlayerLayoutType = "auto";
 
   private _navigateIds: MediaPlayerItemId[] = [
     {
@@ -107,6 +116,33 @@ class PanelMediaBrowser extends LitElement {
               )
             : this._currentItem.title}
         </div>
+        <ha-button-menu slot="actionItems" @action=${this._handleMenuAction}>
+          <ha-icon-button
+            slot="trigger"
+            .label=${this.hass.localize("ui.common.menu")}
+            .path=${mdiDotsVertical}
+          ></ha-icon-button>
+          <mwc-list-item graphic="icon">
+            ${this.hass.localize("ui.components.media-browser.grid")}
+            <ha-svg-icon
+              class=${this._preferredLayout === "grid"
+                ? "selected_menu_item"
+                : ""}
+              slot="graphic"
+              .path=${mdiGrid}
+            ></ha-svg-icon>
+          </mwc-list-item>
+          <mwc-list-item graphic="icon">
+            ${this.hass.localize("ui.components.media-browser.list")}
+            <ha-svg-icon
+              slot="graphic"
+              class=${this._preferredLayout === "list"
+                ? "selected_menu_item"
+                : ""}
+              .path=${mdiListBoxOutline}
+            ></ha-svg-icon>
+          </mwc-list-item>
+        </ha-button-menu>
         <ha-media-manage-button
           slot="actionItems"
           .hass=${this.hass}
@@ -117,6 +153,7 @@ class PanelMediaBrowser extends LitElement {
           .hass=${this.hass}
           .entityId=${this._entityId}
           .navigateIds=${this._navigateIds}
+          .preferredLayout=${this._preferredLayout}
           @media-picked=${this._mediaPicked}
           @media-browsed=${this._mediaBrowsed}
         ></ha-media-player-browse>
@@ -128,6 +165,19 @@ class PanelMediaBrowser extends LitElement {
         @player-picked=${this._playerPicked}
       ></ha-bar-media-player>
     `;
+  }
+
+  private async _handleMenuAction(ev: CustomEvent<ActionDetail>) {
+    switch (ev.detail.index) {
+      case 0:
+        this._preferredLayout =
+          this._preferredLayout === "grid" ? "auto" : "grid";
+        break;
+      case 1:
+        this._preferredLayout =
+          this._preferredLayout === "list" ? "auto" : "list";
+        break;
+    }
   }
 
   public willUpdate(changedProps: PropertyValues): void {
@@ -287,6 +337,9 @@ class PanelMediaBrowser extends LitElement {
 
         :host([narrow]) ha-media-player-browse {
           height: calc(100vh - (57px + var(--header-height)));
+        }
+        .selected_menu_item {
+          color: var(--primary-color);
         }
 
         ha-bar-media-player {

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -117,6 +117,12 @@ class PanelMediaBrowser extends LitElement {
               )
             : this._currentItem.title}
         </div>
+        <ha-media-manage-button
+          slot="actionItems"
+          .hass=${this.hass}
+          .currentItem=${this._currentItem}
+          @media-refresh=${this._refreshMedia}
+        ></ha-media-manage-button>
         <ha-button-menu slot="actionItems" @action=${this._handleMenuAction}>
           <ha-icon-button
             slot="trigger"
@@ -154,12 +160,6 @@ class PanelMediaBrowser extends LitElement {
             ></ha-svg-icon>
           </mwc-list-item>
         </ha-button-menu>
-        <ha-media-manage-button
-          slot="actionItems"
-          .hass=${this.hass}
-          .currentItem=${this._currentItem}
-          @media-refresh=${this._refreshMedia}
-        ></ha-media-manage-button>
         <ha-media-player-browse
           .hass=${this.hass}
           .entityId=${this._entityId}

--- a/src/panels/media-browser/ha-panel-media-browser.ts
+++ b/src/panels/media-browser/ha-panel-media-browser.ts
@@ -2,6 +2,7 @@ import {
   mdiGrid,
   mdiListBoxOutline,
   mdiArrowLeft,
+  mdiAlphaABoxOutline,
   mdiDotsVertical,
 } from "@mdi/js";
 import { ActionDetail } from "@material/mwc-list";
@@ -123,6 +124,16 @@ class PanelMediaBrowser extends LitElement {
             .path=${mdiDotsVertical}
           ></ha-icon-button>
           <mwc-list-item graphic="icon">
+            ${this.hass.localize("ui.components.media-browser.auto")}
+            <ha-svg-icon
+              class=${this._preferredLayout === "auto"
+                ? "selected_menu_item"
+                : ""}
+              slot="graphic"
+              .path=${mdiAlphaABoxOutline}
+            ></ha-svg-icon>
+          </mwc-list-item>
+          <mwc-list-item graphic="icon">
             ${this.hass.localize("ui.components.media-browser.grid")}
             <ha-svg-icon
               class=${this._preferredLayout === "grid"
@@ -170,12 +181,13 @@ class PanelMediaBrowser extends LitElement {
   private async _handleMenuAction(ev: CustomEvent<ActionDetail>) {
     switch (ev.detail.index) {
       case 0:
-        this._preferredLayout =
-          this._preferredLayout === "grid" ? "auto" : "grid";
+        this._preferredLayout = "auto";
         break;
       case 1:
-        this._preferredLayout =
-          this._preferredLayout === "list" ? "auto" : "list";
+        this._preferredLayout = "grid";
+        break;
+      case 2:
+        this._preferredLayout = "list";
         break;
     }
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -704,6 +704,7 @@
           "video": "Video"
         },
         "media_player_unavailable": "The selected media player is unavailable.",
+        "auto": "Auto",
         "grid": "Grid",
         "list": "List"
       },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -703,7 +703,9 @@
           "url": "URL",
           "video": "Video"
         },
-        "media_player_unavailable": "The selected media player is unavailable."
+        "media_player_unavailable": "The selected media player is unavailable.",
+        "grid": "Grid",
+        "list": "List"
       },
       "calendar": {
         "label": "Calendar",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Add a grid/list toggle for media browser in the top right corner overflow menu. When neither item is selected, the choice will be automatic (current behavior). Choosing one of the options sets the browser to force render in grid/list mode. Choosing it a second time reverts back to automatic behavior. 

![image](https://github.com/home-assistant/frontend/assets/32912880/416527e2-0932-41e3-ad58-ad54948f676a)

![image](https://github.com/home-assistant/frontend/assets/32912880/ba13888a-a9c8-4711-ba3b-676a47da5c55)



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/issues/18225
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
