### PR TITLE
Fixes alarm dialog inputmode for code input

### DIFF
--- a/src/dialogs/enter-code/dialog-enter-code.ts
+++ b/src/dialogs/enter-code/dialog-enter-code.ts
@@ -100,7 +100,7 @@ export class DialogEnterCode
             .label=${this.hass.localize("ui.dialogs.enter_code.input_label")}
             type="password"
             pattern=${ifDefined(this._dialogParams.codePattern)}
-            input-mode="text"
+            inputmode="text"
           ></ha-textfield>
           <ha-button slot="secondaryAction" dialogAction="cancel">
             ${this._dialogParams.cancelText ??
@@ -130,7 +130,7 @@ export class DialogEnterCode
             id="code"
             .label=${this.hass.localize("ui.dialogs.enter_code.input_label")}
             type="password"
-            input-mode="numeric"
+            inputmode="numeric"
           ></ha-textfield>
           <div class="keypad">
             ${BUTTONS.map((value) =>


### PR DESCRIPTION
## Proposed change

This change ensures that the `inputmode` is set on the input field for the code entry dialog (for example to arm/disarm an alarm). Currently this is not set because of a hyphen in the attribute.

The `inputmode` is helpful particularly on mobile keyboards that change how they are displayed. For an alarm code that is all numbers, this PR will ensure that on supported devices a numeric keyboard (only digits) is shown instead of the full QWERTY keyboard.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Add an alarm entity with a number code to arm/disarm. Open the alarm dialog on a mobile device, then change the alarm arming status. This will display the code entry dialog. Click/tap on the input field and you should now see a numeric keyboard instead of the full qwerty keyboard on the mobile device.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/12953
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.


