### PR TITLE
Improve warning messages in conditional card

### DIFF
--- a/src/common/structs/handle-errors.ts
+++ b/src/common/structs/handle-errors.ts
@@ -13,45 +13,33 @@ export const handleStructError = (
   for (const failure of err.failures()) {
     if (failure.value === undefined) {
       errors.push(
-        hass.localize(
-          "ui.errors.config.key_missing",
-          "key",
-          failure.path.join(".")
-        )
+        hass.localize("ui.errors.config.key_missing", {
+          key: failure.path.join("."),
+        })
       );
     } else if (failure.type === "never") {
       warnings.push(
-        hass.localize(
-          "ui.errors.config.key_not_expected",
-          "key",
-          failure.path.join(".")
-        )
+        hass.localize("ui.errors.config.key_not_expected", {
+          key: failure.path.join("."),
+        })
       );
     } else if (failure.type === "union") {
       continue;
     } else if (failure.type === "enums") {
       warnings.push(
-        hass.localize(
-          "ui.errors.config.key_wrong_type",
-          "key",
-          failure.path.join("."),
-          "type_correct",
-          failure.message.replace("Expected ", "").split(", ")[0],
-          "type_wrong",
-          JSON.stringify(failure.value)
-        )
+        hass.localize("ui.errors.config.key_wrong_type", {
+          key: failure.path.join("."),
+          type_correct: failure.message.replace("Expected ", "").split(", ")[0],
+          type_wrong: JSON.stringify(failure.value),
+        })
       );
     } else {
       warnings.push(
-        hass.localize(
-          "ui.errors.config.key_wrong_type",
-          "key",
-          failure.path.join("."),
-          "type_correct",
-          failure.refinement || failure.type,
-          "type_wrong",
-          JSON.stringify(failure.value)
-        )
+        hass.localize("ui.errors.config.key_wrong_type", {
+          key: failure.path.join("."),
+          type_correct: failure.refinement || failure.type,
+          type_wrong: JSON.stringify(failure.value),
+        })
       );
     }
   }

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -1,7 +1,7 @@
 import { Statistic, StatisticType } from "../../../data/recorder";
 import { ActionConfig, LovelaceCardConfig } from "../../../data/lovelace";
 import { FullCalendarView, TranslationDict } from "../../../types";
-import { Condition } from "../common/validate-condition";
+import { Condition, LegacyCondition } from "../common/validate-condition";
 import { HuiImage } from "../components/hui-image";
 import { LovelaceElementConfig } from "../elements/types";
 import {
@@ -37,7 +37,7 @@ export interface CalendarCardConfig extends LovelaceCardConfig {
 
 export interface ConditionalCardConfig extends LovelaceCardConfig {
   card: LovelaceCardConfig;
-  conditions: Condition[];
+  conditions: (Condition | LegacyCondition)[];
 }
 
 export interface EmptyStateCardConfig extends LovelaceCardConfig {

--- a/src/panels/lovelace/common/validate-condition.ts
+++ b/src/panels/lovelace/common/validate-condition.ts
@@ -21,7 +21,10 @@ export type ScreenCondition = {
   media_query?: string;
 };
 
-function checkStateCondition(condition: StateCondition, hass: HomeAssistant) {
+function checkStateCondition(
+  condition: StateCondition | LegacyCondition,
+  hass: HomeAssistant
+) {
   const state =
     condition.entity && hass.states[condition.entity]
       ? hass.states[condition.entity].state
@@ -42,19 +45,20 @@ function checkScreenCondition(
 }
 
 export function checkConditionsMet(
-  conditions: Condition[],
+  conditions: (Condition | LegacyCondition)[],
   hass: HomeAssistant
 ): boolean {
   return conditions.every((c) => {
-    if (c.condition === "screen") {
-      return checkScreenCondition(c, hass);
+    if ("condition" in c) {
+      if (c.condition === "screen") {
+        return checkScreenCondition(c, hass);
+      }
     }
-
     return checkStateCondition(c, hass);
   });
 }
 
-function valideStateCondition(condition: StateCondition) {
+function valideStateCondition(condition: StateCondition | LegacyCondition) {
   return (
     condition.entity != null &&
     (condition.state != null || condition.state_not != null)
@@ -65,10 +69,14 @@ function validateScreenCondition(condition: ScreenCondition) {
   return condition.media_query != null;
 }
 
-export function validateConditionalConfig(conditions: Condition[]): boolean {
+export function validateConditionalConfig(
+  conditions: (Condition | LegacyCondition)[]
+): boolean {
   return conditions.every((c) => {
-    if (c.condition === "screen") {
-      return validateScreenCondition(c);
+    if ("condition" in c) {
+      if (c.condition === "screen") {
+        return validateScreenCondition(c);
+      }
     }
     return valideStateCondition(c);
   });

--- a/src/panels/lovelace/components/hui-conditional-base.ts
+++ b/src/panels/lovelace/components/hui-conditional-base.ts
@@ -78,7 +78,7 @@ export class HuiConditionalBase extends ReactiveElement {
     }
 
     const conditions = this._config.conditions.filter(
-      (c) => c.condition === "screen"
+      (c) => "condition" in c && c.condition === "screen"
     ) as ScreenCondition[];
 
     const mediaQueries = conditions

--- a/src/panels/lovelace/editor/conditions/ha-card-condition-editor.ts
+++ b/src/panels/lovelace/editor/conditions/ha-card-condition-editor.ts
@@ -40,7 +40,7 @@ export default class HaCardConditionEditor extends LitElement {
 
   protected willUpdate(changedProperties: PropertyValues): void {
     if (changedProperties.has("condition")) {
-      const validator = this._editor && this._editor.validateUIConfig;
+      const validator = this._editor?.validateUIConfig;
       if (validator) {
         try {
           validator(this.condition, this.hass);

--- a/src/panels/lovelace/editor/conditions/types.ts
+++ b/src/panels/lovelace/editor/conditions/types.ts
@@ -1,6 +1,7 @@
+import { HomeAssistant } from "../../../../types";
 import { Condition } from "../../common/validate-condition";
 
 export interface LovelaceConditionEditorConstructor {
   defaultConfig?: Condition;
-  validateUIConfig?: (condition: Condition) => boolean;
+  validateUIConfig?: (condition: Condition, hass: HomeAssistant) => void;
 }

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-screen.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-screen.ts
@@ -103,10 +103,17 @@ export class HaCardConditionScreen extends LitElement {
     return { condition: "screen", media_query: "" };
   }
 
-  protected static validateUIConfig(condition: ScreenCondition) {
-    return (
-      !condition.media_query || mediaQueryReverseMap.get(condition.media_query)
-    );
+  protected static validateUIConfig(
+    condition: ScreenCondition,
+    hass: HomeAssistant
+  ) {
+    const valid =
+      !condition.media_query || mediaQueryReverseMap.has(condition.media_query);
+    if (!valid) {
+      throw new Error(
+        hass.localize("ui.errors.config.media_query_not_supported")
+      );
+    }
   }
 
   private _schema = memoizeOne(

--- a/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
+++ b/src/panels/lovelace/editor/conditions/types/ha-card-condition-state.ts
@@ -12,7 +12,7 @@ import { StateCondition } from "../../../common/validate-condition";
 
 const stateConditionStruct = object({
   condition: literal("state"),
-  entity: string(),
+  entity: optional(string()),
   state: optional(string()),
   state_not: optional(string()),
 });
@@ -34,6 +34,10 @@ export class HaCardConditionState extends LitElement {
 
   public static get defaultConfig(): StateCondition {
     return { condition: "state", entity: "", state: "" };
+  }
+
+  protected static validateUIConfig(condition: StateCondition) {
+    return assert(condition, stateConditionStruct);
   }
 
   protected willUpdate(changedProperties: PropertyValues): void {

--- a/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-conditional-card-editor.ts
@@ -163,21 +163,27 @@ export class HuiConditionalCardEditor
           `
         : html`
             <div class="conditions">
-              ${this.hass!.localize(
-                "ui.panel.lovelace.editor.card.conditional.condition_explanation"
-              )}
-              ${this._config.conditions.map(
-                (cond, idx) => html`
+              <ha-alert alert-type="info">
+                ${this.hass!.localize(
+                  "ui.panel.lovelace.editor.card.conditional.condition_explanation"
+                )}
+              </ha-alert>
+              ${this._config.conditions.map((cond, idx) => {
+                const condition: Condition = {
+                  condition: "state",
+                  ...cond,
+                };
+                return html`
                   <div class="condition">
                     <ha-card-condition-editor
                       .index=${idx}
                       @value-changed=${this._conditionChanged}
                       .hass=${this.hass}
-                      .condition=${cond}
+                      .condition=${condition}
                     ></ha-card-condition-editor>
                   </div>
-                `
-              )}
+                `;
+              })}
               <div>
                 <ha-button-menu
                   @action=${this._addCondition}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1488,7 +1488,8 @@
         "key_missing": "Required key ''{key}'' is missing.",
         "key_not_expected": "Key ''{key}'' is not expected or not supported by the visual editor.",
         "key_wrong_type": "The provided value for ''{key}'' is not supported by the visual editor. We support ({type_correct}) but received ({type_wrong}).",
-        "no_template_editor_support": "Templates not supported in visual editor"
+        "no_template_editor_support": "Templates not supported in visual editor",
+        "media_query_not_supported": "This media query is not supported by the visual editor."
       },
       "supervisor": {
         "title": "Could not load the Supervisor panel!",


### PR DESCRIPTION
## Proposed change

Improve warning messages in conditional card when the UI is not supported.

![CleanShot 2023-10-18 at 12 08 29](https://github.com/home-assistant/frontend/assets/5878303/b5dfc5b4-912a-4cc2-8349-c67125d890df)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
