### PR TITLE
Wrap dict attributes

### DIFF
--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -67,6 +67,7 @@ class HaAttributeValue extends LitElement {
 
   static styles = css`
     pre {
+      margin: 0;
       white-space: pre-wrap;
     }
   `;

--- a/src/components/ha-attribute-value.ts
+++ b/src/components/ha-attribute-value.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { html, LitElement, nothing } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { until } from "lit/directives/until";
 import { HomeAssistant } from "../types";
@@ -64,6 +64,12 @@ class HaAttributeValue extends LitElement {
 
     return this.hass.formatEntityAttributeValue(this.stateObj!, this.attribute);
   }
+
+  static styles = css`
+    pre {
+      white-space: pre-wrap;
+    }
+  `;
 }
 
 declare global {


### PR DESCRIPTION
## Proposed change

This lets the `<pre>` element used for `dict_attr` wrap long text instead of breaking out of its container when viewing sensor attributes, for example, in a more info dialog. Simply wrapping the text will ensure that all of the information is visible, but it could become difficult to read for *very* large blocks of text as seen in https://github.com/home-assistant/frontend/issues/18027.

This also removes the default margins on the `<pre>` element to be consistent with how other attribute values are displayed.

A couple of other ways to fix this could be to use `text-overflow: ellipsis` and either `overflow: hidden` or `overflow-x: auto`, or even offer some kind of "view more" button that pops up a separate, larger dialog with just that text to give it more room to be viewed.

Before:
<img width="604" alt="Screenshot 2023-10-19 at 12 08 22 PM" src="https://github.com/home-assistant/frontend/assets/1522068/67731fe0-8010-4bd6-932c-5b9b9c129df6">


After:
<img width="609" alt="Screenshot 2023-10-19 at 12 40 58 PM" src="https://github.com/home-assistant/frontend/assets/1522068/f300e837-7a9a-4747-b5bd-5c85c3570055">


With `text-overflow: ellipsis` and `overflow-x: auto`:
<img width="609" alt="Screenshot 2023-10-19 at 12 41 26 PM" src="https://github.com/home-assistant/frontend/assets/1522068/0b253389-d482-47ec-b369-19c4fb3c86e7">





## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

This is borrowed from the issue linked below

```yaml
template:
  - sensor:
      - name: test_long_attr
        state: ok
        attributes:
          dict_attr_long: >-
            {% set LONG_VALUE_1 = "Morocco lies close to the Azores–Gibraltar Transform Fault." %}
            {% set LONG_VALUE_2 = "Morocco lies close to the Azores–Gibraltar Transform Fault." %}
            {%- set DICT = {
              'value_1': LONG_VALUE_1,
              'value_2': LONG_VALUE_2
              } -%}
            {{DICT}}
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/17932
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/issues/18027
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.


