### PR TITLE
Chart updates to improve stability, possible fix for infinite loop

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -140,7 +140,7 @@ export class HaChartBase extends LitElement {
         if (this._paddingUpdateCount > 300) {
           this._paddingUpdateLock = true;
           // eslint-disable-next-line
-          console.warn(
+          console.error(
             "Detected excessive chart padding updates, possibly an infinite loop. Disabling axis padding."
           );
         } else {

--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -12,6 +12,7 @@ import { styleMap } from "lit/directives/style-map";
 import { clamp } from "../../common/number/clamp";
 import { computeRTL } from "../../common/util/compute_rtl";
 import { HomeAssistant } from "../../types";
+import { debounce } from "../../common/util/debounce";
 
 export const MIN_TIME_BETWEEN_UPDATES = 60 * 5 * 1000;
 
@@ -51,6 +52,12 @@ export class HaChartBase extends LitElement {
   @state() private _tooltip?: Tooltip;
 
   @state() private _hiddenDatasets: Set<number> = new Set();
+
+  private _paddingUpdateCount = 0;
+
+  private _paddingUpdateLock = false;
+
+  private _paddingYAxisInternal = 0;
 
   public disconnectedCallback() {
     super.disconnectedCallback();
@@ -104,8 +111,43 @@ export class HaChartBase extends LitElement {
     });
   }
 
+  public shouldUpdate(changedProps: PropertyValues): boolean {
+    if (
+      this._paddingUpdateLock &&
+      changedProps.size === 1 &&
+      changedProps.has("paddingYAxis")
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  private _debouncedClearUpdates = debounce(
+    () => {
+      this._paddingUpdateCount = 0;
+    },
+    2000,
+    false
+  );
+
   public willUpdate(changedProps: PropertyValues): void {
     super.willUpdate(changedProps);
+
+    if (!this._paddingUpdateLock) {
+      this._paddingYAxisInternal = this.paddingYAxis;
+      if (changedProps.size === 1 && changedProps.has("paddingYAxis")) {
+        this._paddingUpdateCount++;
+        if (this._paddingUpdateCount > 300) {
+          this._paddingUpdateLock = true;
+          // eslint-disable-next-line
+          console.warn(
+            "Detected excessive chart padding updates, possibly an infinite loop. Disabling axis padding."
+          );
+        } else {
+          this._debouncedClearUpdates();
+        }
+      }
+    }
 
     if (!this.hasUpdated || !this.chart) {
       return;
@@ -171,10 +213,10 @@ export class HaChartBase extends LitElement {
               this.height ?? this._chartHeight ?? this.clientWidth / 2
             }px`,
             "padding-left": `${
-              computeRTL(this.hass) ? 0 : this.paddingYAxis
+              computeRTL(this.hass) ? 0 : this._paddingYAxisInternal
             }px`,
             "padding-right": `${
-              computeRTL(this.hass) ? this.paddingYAxis : 0
+              computeRTL(this.hass) ? this._paddingYAxisInternal : 0
             }px`,
           })}
         >
@@ -324,7 +366,7 @@ export class HaChartBase extends LitElement {
         clamp(
           context.tooltip.caretX,
           100,
-          this.clientWidth - 100 - this.paddingYAxis
+          this.clientWidth - 100 - this._paddingYAxisInternal
         ) -
         100 +
         "px",

--- a/src/components/chart/state-history-charts.ts
+++ b/src/components/chart/state-history-charts.ts
@@ -73,9 +73,9 @@ export class StateHistoryCharts extends LitElement {
 
   @property({ type: Boolean }) public isLoadingData = false;
 
-  @state() private _computedStartTime!: Date;
+  private _computedStartTime!: Date;
 
-  @state() private _computedEndTime!: Date;
+  private _computedEndTime!: Date;
 
   @state() private _maxYWidth = 0;
 
@@ -114,31 +114,6 @@ export class StateHistoryCharts extends LitElement {
         ${this.hass.localize("ui.components.history_charts.no_history_found")}
       </div>`;
     }
-
-    const now = new Date();
-
-    this._computedEndTime =
-      this.upToNow || !this.endTime || this.endTime > now ? now : this.endTime;
-
-    if (this.startTime) {
-      this._computedStartTime = this.startTime;
-    } else if (this.hoursToShow) {
-      this._computedStartTime = new Date(
-        new Date().getTime() - 60 * 60 * this.hoursToShow * 1000
-      );
-    } else {
-      this._computedStartTime = new Date(
-        this.historyData.timeline.reduce(
-          (minTime, stateInfo) =>
-            Math.min(
-              minTime,
-              new Date(stateInfo.data[0].last_changed).getTime()
-            ),
-          new Date().getTime()
-        )
-      );
-    }
-
     const combinedItems = this.historyData.timeline.length
       ? (this.virtualize
           ? chunkData(this.historyData.timeline, CANVAS_TIMELINE_ROWS_CHUNK)
@@ -220,9 +195,44 @@ export class StateHistoryCharts extends LitElement {
     return true;
   }
 
-  protected willUpdate() {
+  protected willUpdate(changedProps: PropertyValues) {
     if (!this.hasUpdated) {
       loadVirtualizer();
+    }
+    if (
+      [...changedProps.keys()].some(
+        (prop) =>
+          !(
+            ["_maxYWidth", "_childYWidths", "_chartCount"] as PropertyKey[]
+          ).includes(prop)
+      )
+    ) {
+      // Don't recompute times when we just want to update layout
+      const now = new Date();
+
+      this._computedEndTime =
+        this.upToNow || !this.endTime || this.endTime > now
+          ? now
+          : this.endTime;
+
+      if (this.startTime) {
+        this._computedStartTime = this.startTime;
+      } else if (this.hoursToShow) {
+        this._computedStartTime = new Date(
+          new Date().getTime() - 60 * 60 * this.hoursToShow * 1000
+        );
+      } else {
+        this._computedStartTime = new Date(
+          this.historyData.timeline.reduce(
+            (minTime, stateInfo) =>
+              Math.min(
+                minTime,
+                new Date(stateInfo.data[0].last_changed).getTime()
+              ),
+            new Date().getTime()
+          )
+        );
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Two updates to history charts to attempt to improve rendering stability:

First is an update to not recompute start/end time in the `render` function of state-history-charts, as render is called after a child chart fires a y axis width change. That event should trigger a re-render of the children with different axis padding value, but it should not functionally change the data in the chart. I think this continual re-updating of time ranges and therefore data on each re-render can sometimes contribute to infinite render loops.

Second change is an escape hatch in the chart base that tries to detect if it caught in an infinite loop of rerendering layout padding changes (as has happened a few times in the past, when chart.js gets into an oscillation where it keeps flipping back and forth between two different axis width values on each render), and if it does, shows a warning and stops trying to maintain axis alignment to break the infinite loop, I think this could potentially prevent a hard browser hang. These cases are often difficult to predict and difficult to reproduce, sometimes depending on the time of day due to how chart.js lays out the tick labels. After making the first change above I am not currently able to trigger this case in my dev instance, but it may be helpful to speculatively prevent future issues, versus letting browser hang occur and trying to debug afterward. 

I have a pathological test view with dozens of charts of varying options in various grid sizes, and without these changes I am occasionally (but not always) able to trigger a hard lockup in the browser when aggressively resizing the window. After making these changes I am not able to trigger a hang, so they seem to be helping. 


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
