### PR TITLE
Fix double load of lovelace resources

### DIFF
--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -229,7 +229,7 @@ export class LovelacePanel extends LitElement {
     }
     if (!resourcesLoaded) {
       resourcesLoaded = true;
-      (llWindow.llConfProm || fetchResources(this.hass!.connection)).then(
+      (llWindow.llResProm || fetchResources(this.hass!.connection)).then(
         (resources) =>
           loadLovelaceResources(resources, this.hass!.auth.data.hassUrl)
       );


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
fixes #18331

We load these early in `src/entrypoints/core.ts` to prevent delaying the UI load, but it seems like we never actually used them and instead load them again which adds another round trip which can delay the UI from loading by another 100ms or so when on mobile.

Maybe I'm missing something here.. but this seems like the right fix.  I'm not sure if they need to be thrown away once used like config is, but it didn't seem to need that in testing.

`llResProm` is never accessed anywhere else AFAICT

Side note: We may want to prefetch some more data as well since these all seemed to be called every time anyways in case any of these are also blocking loads?
- `subscribeRepairsIssueRegistry`
- `getRecorderInfo`
- `getEnergyPreferences`
- `subscribeLovelaceUpdates`
- `title` translations
- `subscribeNotifications`

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18331
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
