### PR TITLE
Update statistics chart to respect entity display precision, fix precision bug in history chart

### DIFF
--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -141,16 +141,10 @@ export class StateHistoryChartLine extends LitElement {
                 `${context.dataset.label}: ${formatNumber(
                   context.parsed.y,
                   this.hass.locale,
-                  this.data[context.datasetIndex]?.entity_id
-                    ? getNumberFormatOptions(
-                        this.hass.states[
-                          this.data[context.datasetIndex].entity_id
-                        ],
-                        this.hass.entities[
-                          this.data[context.datasetIndex].entity_id
-                        ]
-                      )
-                    : undefined
+                  getNumberFormatOptions(
+                    this.hass.states[this._entityIds[context.datasetIndex]],
+                    this.hass.entities[this._entityIds[context.datasetIndex]]
+                  )
                 )} ${this.unit}`,
             },
           },

--- a/src/components/chart/state-history-chart-line.ts
+++ b/src/components/chart/state-history-chart-line.ts
@@ -142,7 +142,7 @@ export class StateHistoryChartLine extends LitElement {
                   context.parsed.y,
                   this.hass.locale,
                   getNumberFormatOptions(
-                    this.hass.states[this._entityIds[context.datasetIndex]],
+                    undefined,
                     this.hass.entities[this._entityIds[context.datasetIndex]]
                   )
                 )} ${this.unit}`,

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -194,7 +194,7 @@ export class StatisticsChart extends LitElement {
                 context.parsed.y,
                 this.hass.locale,
                 getNumberFormatOptions(
-                  this.hass.states[this._statisticIds[context.datasetIndex]],
+                  undefined,
                   this.hass.entities[this._statisticIds[context.datasetIndex]]
                 )
               )} ${

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -19,6 +19,7 @@ import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import {
   formatNumber,
   numberFormatToLocale,
+  getNumberFormatOptions,
 } from "../../common/number/format_number";
 import {
   getDisplayUnit,
@@ -73,6 +74,8 @@ export class StatisticsChart extends LitElement {
   @property({ type: Boolean }) public isLoadingData = false;
 
   @state() private _chartData: ChartData = { datasets: [] };
+
+  @state() private _statisticIds: string[] = [];
 
   @state() private _chartOptions?: ChartOptions;
 
@@ -189,7 +192,11 @@ export class StatisticsChart extends LitElement {
             label: (context) =>
               `${context.dataset.label}: ${formatNumber(
                 context.parsed.y,
-                this.hass.locale
+                this.hass.locale,
+                getNumberFormatOptions(
+                  this.hass.states[this._statisticIds[context.datasetIndex]],
+                  this.hass.entities[this._statisticIds[context.datasetIndex]]
+                )
               )} ${
                 // @ts-ignore
                 context.dataset.unit || ""
@@ -248,6 +255,7 @@ export class StatisticsChart extends LitElement {
     let colorIndex = 0;
     const statisticsData = Object.entries(this.statisticsData);
     const totalDataSets: ChartDataset<"line">[] = [];
+    const statisticIds: string[] = [];
     let endTime: Date;
 
     if (statisticsData.length === 0) {
@@ -384,8 +392,10 @@ export class StatisticsChart extends LitElement {
             data: [],
             // @ts-ignore
             unit: meta?.unit_of_measurement,
+            statistic_id,
             band,
           });
+          statisticIds.push(statistic_id);
         }
       });
 
@@ -427,6 +437,7 @@ export class StatisticsChart extends LitElement {
     this._chartData = {
       datasets: totalDataSets,
     };
+    this._statisticIds = statisticIds;
   }
 
   static get styles(): CSSResultGroup {

--- a/src/components/chart/statistics-chart.ts
+++ b/src/components/chart/statistics-chart.ts
@@ -392,7 +392,6 @@ export class StatisticsChart extends LitElement {
             data: [],
             // @ts-ignore
             unit: meta?.unit_of_measurement,
-            statistic_id,
             band,
           });
           statisticIds.push(statistic_id);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Allow statistics chart graph tooltip to get a display precision from an entity's settings. Previously seems hardcoded to two decimal places. 

Also fixes a bug in history-graph use of display precision where the wrong dataset index is used when an entity has multiple datasets (like a climate entity). 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18287
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
