### PR TITLE
Added hold and double tap actions for tile card

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -42,6 +42,7 @@ import { HomeAssistant } from "../../../types";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { findEntities } from "../common/find-entities";
 import { handleAction } from "../common/handle-action";
+import { hasAction } from "../common/has-action";
 import "../components/hui-timestamp-display";
 import "../tile-features/hui-tile-features";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
@@ -362,7 +363,10 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
           <div
             class="background"
             @action=${this._handleAction}
-            .actionHandler=${actionHandler()}
+            .actionHandler=${actionHandler({
+              hasHold: hasAction(this._config!.hold_action),
+              hasDoubleClick: hasAction(this._config!.double_tap_action),
+            })}
             role="button"
             tabindex="0"
             aria-labelledby="info"

--- a/src/panels/lovelace/cards/types.ts
+++ b/src/panels/lovelace/cards/types.ts
@@ -534,6 +534,8 @@ export interface TileCardConfig extends LovelaceCardConfig {
   show_entity_picture?: string;
   vertical?: boolean;
   tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_action?: ActionConfig;
   icon_tap_action?: ActionConfig;
   features?: LovelaceTileFeatureConfig[];
 }

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -101,6 +101,8 @@ const cardConfigStruct = assign(
     show_entity_picture: optional(boolean()),
     vertical: optional(boolean()),
     tap_action: optional(actionConfigStruct),
+    hold_action: optional(actionConfigStruct),
+    double_tap_action: optional(actionConfigStruct),
     icon_tap_action: optional(actionConfigStruct),
     features: optional(array(any())),
   })
@@ -228,6 +230,18 @@ export class HuiTileCardEditor
                 ui_action: {
                   default_action: "more-info",
                 },
+              },
+            },
+            {
+              name: "hold_action",
+              selector: {
+                ui_action: {},
+              },
+            },
+            {
+              name: "double_tap_action",
+              selector: {
+                ui_action: {},
               },
             },
             {

--- a/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-tile-card-editor.ts
@@ -101,8 +101,6 @@ const cardConfigStruct = assign(
     show_entity_picture: optional(boolean()),
     vertical: optional(boolean()),
     tap_action: optional(actionConfigStruct),
-    hold_action: optional(actionConfigStruct),
-    double_tap_action: optional(actionConfigStruct),
     icon_tap_action: optional(actionConfigStruct),
     features: optional(array(any())),
   })
@@ -230,18 +228,6 @@ export class HuiTileCardEditor
                 ui_action: {
                   default_action: "more-info",
                 },
-              },
-            },
-            {
-              name: "hold_action",
-              selector: {
-                ui_action: {},
-              },
-            },
-            {
-              name: "double_tap_action",
-              selector: {
-                ui_action: {},
               },
             },
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Added hold and double tap actions for the Tile card
My personal use case is that I want both the tap and icon_tap actions to be toggle for a light but that leaves me without a quick access to more-info dialog, this solves that.
Based on the linked feature request it seems that I'm not the only one with similar problem.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: tile
tap_action:
  action: toggle
hold_action:
  action: more-info
double_tap_action:
  action: more-info
icon_tap_action:
  action: toggle
entity: light.kitchen
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://community.home-assistant.io/t/hold-action-for-tile-card/481666
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29481

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
