### PR TITLE
Add bottom padding to code editor

### DIFF
--- a/src/resources/codemirror.ts
+++ b/src/resources/codemirror.ts
@@ -79,6 +79,7 @@ export const haTheme = EditorView.theme({
   ".cm-content": {
     caretColor: "var(--secondary-text-color)",
     paddingTop: "16px",
+    paddingBottom: "16px",
   },
 
   ".cm-panels": {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Adds bottom padding to the code editor so horizontal scrollbars do not cover up the last line of code when they appear. This is notable on macOS using a trackpad with the "Show scroll bars" setting set to "Automatically based on mouse or trackpad". This matches the top padding for the code editor.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Open the Developer Tools > Template tab on  macOS with the scrollbar setting mentioned above and then use the trackpad to scroll horizontally. A scrollbar will appear and cover the bottom line of code in the editor.

https://github.com/home-assistant/frontend/assets/1522068/3b66a04d-75d4-4c72-87ee-9d100fb3884d


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16929
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/discussions/8739
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
