### PR TITLE
Add restart in safe mode in restart dialog

### DIFF
--- a/src/dialogs/restart/dialog-restart.ts
+++ b/src/dialogs/restart/dialog-restart.ts
@@ -1,6 +1,12 @@
 import "@material/mwc-list/mwc-list";
-import { mdiAutoFix, mdiPower, mdiPowerCycle, mdiRefresh } from "@mdi/js";
-import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
+import {
+  mdiAutoFix,
+  mdiLifebuoy,
+  mdiPower,
+  mdiPowerCycle,
+  mdiRefresh,
+} from "@mdi/js";
+import { CSSResultGroup, LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { isComponentLoaded } from "../../common/config/is_component_loaded";
 import { fireEvent } from "../../common/dom/fire_event";
@@ -14,8 +20,8 @@ import {
   ignoreSupervisorError,
 } from "../../data/hassio/common";
 import {
-  fetchHassioHostInfo,
   HassioHostInfo,
+  fetchHassioHostInfo,
   rebootHost,
   shutdownHost,
 } from "../../data/hassio/host";
@@ -146,14 +152,14 @@ class DialogRestart extends LitElement {
                 </ha-list-item>
               </mwc-list>
 
-              ${showRebootShutdown
-                ? html`
-                    <ha-expansion-panel
-                      .header=${this.hass.localize(
-                        "ui.dialogs.restart.advanced_options"
-                      )}
-                    >
-                      <mwc-list>
+              <ha-expansion-panel
+                .header=${this.hass.localize(
+                  "ui.dialogs.restart.advanced_options"
+                )}
+              >
+                <mwc-list>
+                  ${showRebootShutdown
+                    ? html`
                         <ha-list-item
                           graphic="avatar"
                           twoline
@@ -196,10 +202,34 @@ class DialogRestart extends LitElement {
                             )}
                           </span>
                         </ha-list-item>
-                      </mwc-list>
-                    </ha-expansion-panel>
-                  `
-                : nothing}
+                      `
+                    : nothing}
+                  <ha-list-item
+                    graphic="avatar"
+                    twoline
+                    multiline-secondary
+                    hasMeta
+                    @request-selected=${this._restartSafeMode}
+                  >
+                    <div
+                      slot="graphic"
+                      class="icon-background restart-safe-mode"
+                    >
+                      <ha-svg-icon .path=${mdiLifebuoy}></ha-svg-icon>
+                    </div>
+                    <span>
+                      ${this.hass.localize(
+                        "ui.dialogs.restart.restart-safe-mode.title"
+                      )}
+                    </span>
+                    <span slot="secondary">
+                      ${this.hass.localize(
+                        "ui.dialogs.restart.restart-safe-mode.description"
+                      )}
+                    </span>
+                  </ha-list-item>
+                </mwc-list>
+              </ha-expansion-panel>
             `}
       </ha-dialog>
     `;
@@ -257,6 +287,47 @@ class DialogRestart extends LitElement {
     } catch (err: any) {
       showAlertDialog(this, {
         title: this.hass.localize("ui.dialogs.restart.restart.failed"),
+        text: err.message,
+      });
+    }
+  }
+
+  private async _restartSafeMode(ev) {
+    if (!shouldHandleRequestSelectedEvent(ev)) {
+      return;
+    }
+    this._showRestartSafeModeDialog();
+  }
+
+  private async _showRestartSafeModeDialog() {
+    const confirmed = await showConfirmationDialog(this, {
+      title: this.hass.localize(
+        "ui.dialogs.restart.restart-safe-mode.confirm_title"
+      ),
+      text: this.hass.localize(
+        "ui.dialogs.restart.restart-safe-mode.confirm_description"
+      ),
+      confirmText: this.hass.localize(
+        "ui.dialogs.restart.restart-safe-mode.confirm_action"
+      ),
+      destructive: true,
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
+    this.closeDialog();
+
+    try {
+      await this.hass.callService("homeassistant", "restart", {
+        safe_mode: true,
+      });
+    } catch (err: any) {
+      showAlertDialog(this, {
+        title: this.hass.localize(
+          "ui.dialogs.restart.restart-safe-mode.failed"
+        ),
         text: err.message,
       });
     }
@@ -380,6 +451,10 @@ class DialogRestart extends LitElement {
         }
         .shutdown {
           background-color: #0b1d29;
+          color: #fff;
+        }
+        .restart-safe-mode {
+          background-color: #e48629;
           color: #fff;
         }
         .divider {

--- a/src/dialogs/restart/dialog-restart.ts
+++ b/src/dialogs/restart/dialog-restart.ts
@@ -60,19 +60,6 @@ class DialogRestart extends LitElement {
         this._loadingHostInfo = false;
       }
     }
-
-    const showReload = this.hass.userData?.showAdvanced;
-    const showSafeMode = this.hass.userData?.showAdvanced;
-    const showRebootShutdown = !!this._hostInfo;
-
-    // Present restart core dialog if no host actions and not advanced mode as it's the only option
-    if (!showReload && !showSafeMode && !showRebootShutdown) {
-      this._open = false;
-      this._showRestartDialog().then(() => this.closeDialog());
-      return;
-    }
-
-    await this.updateComplete;
   }
 
   public closeDialog(): void {
@@ -87,7 +74,6 @@ class DialogRestart extends LitElement {
     }
 
     const showReload = this.hass.userData?.showAdvanced;
-    const showSafeMode = this.hass.userData?.showAdvanced;
     const showRebootShutdown = !!this._hostInfo;
 
     return html`
@@ -153,99 +139,84 @@ class DialogRestart extends LitElement {
                   </span>
                 </ha-list-item>
               </mwc-list>
-
-              ${showRebootShutdown || showSafeMode
-                ? html`<ha-expansion-panel
-                    .header=${this.hass.localize(
-                      "ui.dialogs.restart.advanced_options"
-                    )}
+              <ha-expansion-panel
+                .header=${this.hass.localize(
+                  "ui.dialogs.restart.advanced_options"
+                )}
+              >
+                <mwc-list>
+                  ${showRebootShutdown
+                    ? html`
+                        <ha-list-item
+                          graphic="avatar"
+                          twoline
+                          multiline-secondary
+                          hasMeta
+                          @request-selected=${this._hostReboot}
+                        >
+                          <div slot="graphic" class="icon-background reboot">
+                            <ha-svg-icon .path=${mdiPowerCycle}></ha-svg-icon>
+                          </div>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.dialogs.restart.reboot.title"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
+                              "ui.dialogs.restart.reboot.description"
+                            )}
+                          </span>
+                        </ha-list-item>
+                        <ha-list-item
+                          graphic="avatar"
+                          twoline
+                          multiline-secondary
+                          hasMeta
+                          @request-selected=${this._hostShutdown}
+                        >
+                          <div slot="graphic" class="icon-background shutdown">
+                            <ha-svg-icon .path=${mdiPower}></ha-svg-icon>
+                          </div>
+                          <span>
+                            ${this.hass.localize(
+                              "ui.dialogs.restart.shutdown.title"
+                            )}
+                          </span>
+                          <span slot="secondary">
+                            ${this.hass.localize(
+                              "ui.dialogs.restart.shutdown.description"
+                            )}
+                          </span>
+                        </ha-list-item>
+                      `
+                    : nothing}
+                  <ha-list-item
+                    graphic="avatar"
+                    twoline
+                    multiline-secondary
+                    hasMeta
+                    @request-selected=${this._restartSafeMode}
                   >
-                    <mwc-list>
-                      ${showRebootShutdown
-                        ? html`
-                            <ha-list-item
-                              graphic="avatar"
-                              twoline
-                              multiline-secondary
-                              hasMeta
-                              @request-selected=${this._hostReboot}
-                            >
-                              <div
-                                slot="graphic"
-                                class="icon-background reboot"
-                              >
-                                <ha-svg-icon
-                                  .path=${mdiPowerCycle}
-                                ></ha-svg-icon>
-                              </div>
-                              <span>
-                                ${this.hass.localize(
-                                  "ui.dialogs.restart.reboot.title"
-                                )}
-                              </span>
-                              <span slot="secondary">
-                                ${this.hass.localize(
-                                  "ui.dialogs.restart.reboot.description"
-                                )}
-                              </span>
-                            </ha-list-item>
-                            <ha-list-item
-                              graphic="avatar"
-                              twoline
-                              multiline-secondary
-                              hasMeta
-                              @request-selected=${this._hostShutdown}
-                            >
-                              <div
-                                slot="graphic"
-                                class="icon-background shutdown"
-                              >
-                                <ha-svg-icon .path=${mdiPower}></ha-svg-icon>
-                              </div>
-                              <span>
-                                ${this.hass.localize(
-                                  "ui.dialogs.restart.shutdown.title"
-                                )}
-                              </span>
-                              <span slot="secondary">
-                                ${this.hass.localize(
-                                  "ui.dialogs.restart.shutdown.description"
-                                )}
-                              </span>
-                            </ha-list-item>
-                          `
-                        : nothing}
-                      ${showSafeMode
-                        ? html`
-                            <ha-list-item
-                              graphic="avatar"
-                              twoline
-                              multiline-secondary
-                              hasMeta
-                              @request-selected=${this._restartSafeMode}
-                            >
-                              <div
-                                slot="graphic"
-                                class="icon-background restart-safe-mode"
-                              >
-                                <ha-svg-icon .path=${mdiLifebuoy}></ha-svg-icon>
-                              </div>
-                              <span>
-                                ${this.hass.localize(
-                                  "ui.dialogs.restart.restart-safe-mode.title"
-                                )}
-                              </span>
-                              <span slot="secondary">
-                                ${this.hass.localize(
-                                  "ui.dialogs.restart.restart-safe-mode.description"
-                                )}
-                              </span>
-                            </ha-list-item>
-                          `
-                        : nothing}
-                    </mwc-list>
-                  </ha-expansion-panel>`
-                : nothing}
+                    <div
+                      slot="graphic"
+                      class="icon-background restart-safe-mode"
+                    >
+                      <ha-svg-icon .path=${mdiLifebuoy}></ha-svg-icon>
+                    </div>
+                    <span>
+                      ${this.hass.localize(
+                        "ui.dialogs.restart.restart-safe-mode.title"
+                      )}
+                    </span>
+                    <span slot="secondary">
+                      ${this.hass.localize(
+                        "ui.dialogs.restart.restart-safe-mode.description"
+                      )}
+                    </span>
+                  </ha-list-item>
+                </mwc-list>
+              </ha-expansion-panel>
             `}
       </ha-dialog>
     `;

--- a/src/dialogs/restart/dialog-restart.ts
+++ b/src/dialogs/restart/dialog-restart.ts
@@ -62,10 +62,11 @@ class DialogRestart extends LitElement {
     }
 
     const showReload = this.hass.userData?.showAdvanced;
+    const showSafeMode = this.hass.userData?.showAdvanced;
     const showRebootShutdown = !!this._hostInfo;
 
     // Present restart core dialog if no host actions and not advanced mode as it's the only option
-    if (!showReload && !showRebootShutdown) {
+    if (!showReload && !showSafeMode && !showRebootShutdown) {
       this._open = false;
       this._showRestartDialog().then(() => this.closeDialog());
       return;
@@ -86,6 +87,7 @@ class DialogRestart extends LitElement {
     }
 
     const showReload = this.hass.userData?.showAdvanced;
+    const showSafeMode = this.hass.userData?.showAdvanced;
     const showRebootShutdown = !!this._hostInfo;
 
     return html`
@@ -152,84 +154,98 @@ class DialogRestart extends LitElement {
                 </ha-list-item>
               </mwc-list>
 
-              <ha-expansion-panel
-                .header=${this.hass.localize(
-                  "ui.dialogs.restart.advanced_options"
-                )}
-              >
-                <mwc-list>
-                  ${showRebootShutdown
-                    ? html`
-                        <ha-list-item
-                          graphic="avatar"
-                          twoline
-                          multiline-secondary
-                          hasMeta
-                          @request-selected=${this._hostReboot}
-                        >
-                          <div slot="graphic" class="icon-background reboot">
-                            <ha-svg-icon .path=${mdiPowerCycle}></ha-svg-icon>
-                          </div>
-                          <span>
-                            ${this.hass.localize(
-                              "ui.dialogs.restart.reboot.title"
-                            )}
-                          </span>
-                          <span slot="secondary">
-                            ${this.hass.localize(
-                              "ui.dialogs.restart.reboot.description"
-                            )}
-                          </span>
-                        </ha-list-item>
-                        <ha-list-item
-                          graphic="avatar"
-                          twoline
-                          multiline-secondary
-                          hasMeta
-                          @request-selected=${this._hostShutdown}
-                        >
-                          <div slot="graphic" class="icon-background shutdown">
-                            <ha-svg-icon .path=${mdiPower}></ha-svg-icon>
-                          </div>
-                          <span>
-                            ${this.hass.localize(
-                              "ui.dialogs.restart.shutdown.title"
-                            )}
-                          </span>
-                          <span slot="secondary">
-                            ${this.hass.localize(
-                              "ui.dialogs.restart.shutdown.description"
-                            )}
-                          </span>
-                        </ha-list-item>
-                      `
-                    : nothing}
-                  <ha-list-item
-                    graphic="avatar"
-                    twoline
-                    multiline-secondary
-                    hasMeta
-                    @request-selected=${this._restartSafeMode}
+              ${showRebootShutdown || showSafeMode
+                ? html`<ha-expansion-panel
+                    .header=${this.hass.localize(
+                      "ui.dialogs.restart.advanced_options"
+                    )}
                   >
-                    <div
-                      slot="graphic"
-                      class="icon-background restart-safe-mode"
-                    >
-                      <ha-svg-icon .path=${mdiLifebuoy}></ha-svg-icon>
-                    </div>
-                    <span>
-                      ${this.hass.localize(
-                        "ui.dialogs.restart.restart-safe-mode.title"
-                      )}
-                    </span>
-                    <span slot="secondary">
-                      ${this.hass.localize(
-                        "ui.dialogs.restart.restart-safe-mode.description"
-                      )}
-                    </span>
-                  </ha-list-item>
-                </mwc-list>
-              </ha-expansion-panel>
+                    <mwc-list>
+                      ${showRebootShutdown
+                        ? html`
+                            <ha-list-item
+                              graphic="avatar"
+                              twoline
+                              multiline-secondary
+                              hasMeta
+                              @request-selected=${this._hostReboot}
+                            >
+                              <div
+                                slot="graphic"
+                                class="icon-background reboot"
+                              >
+                                <ha-svg-icon
+                                  .path=${mdiPowerCycle}
+                                ></ha-svg-icon>
+                              </div>
+                              <span>
+                                ${this.hass.localize(
+                                  "ui.dialogs.restart.reboot.title"
+                                )}
+                              </span>
+                              <span slot="secondary">
+                                ${this.hass.localize(
+                                  "ui.dialogs.restart.reboot.description"
+                                )}
+                              </span>
+                            </ha-list-item>
+                            <ha-list-item
+                              graphic="avatar"
+                              twoline
+                              multiline-secondary
+                              hasMeta
+                              @request-selected=${this._hostShutdown}
+                            >
+                              <div
+                                slot="graphic"
+                                class="icon-background shutdown"
+                              >
+                                <ha-svg-icon .path=${mdiPower}></ha-svg-icon>
+                              </div>
+                              <span>
+                                ${this.hass.localize(
+                                  "ui.dialogs.restart.shutdown.title"
+                                )}
+                              </span>
+                              <span slot="secondary">
+                                ${this.hass.localize(
+                                  "ui.dialogs.restart.shutdown.description"
+                                )}
+                              </span>
+                            </ha-list-item>
+                          `
+                        : nothing}
+                      ${showSafeMode
+                        ? html`
+                            <ha-list-item
+                              graphic="avatar"
+                              twoline
+                              multiline-secondary
+                              hasMeta
+                              @request-selected=${this._restartSafeMode}
+                            >
+                              <div
+                                slot="graphic"
+                                class="icon-background restart-safe-mode"
+                              >
+                                <ha-svg-icon .path=${mdiLifebuoy}></ha-svg-icon>
+                              </div>
+                              <span>
+                                ${this.hass.localize(
+                                  "ui.dialogs.restart.restart-safe-mode.title"
+                                )}
+                              </span>
+                              <span slot="secondary">
+                                ${this.hass.localize(
+                                  "ui.dialogs.restart.restart-safe-mode.description"
+                                )}
+                              </span>
+                            </ha-list-item>
+                          `
+                        : nothing}
+                    </mwc-list>
+                  </ha-expansion-panel>`
+                : nothing}
             `}
       </ha-dialog>
     `;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1232,6 +1232,14 @@
           "confirm_action": "Shut down",
           "shutting_down": "Shutting down system",
           "failed": "Failed to shut down system"
+        },
+        "restart-safe-mode": {
+          "title": "Restart Home Assistant in safe mode",
+          "description": "Restart Home Assistant without loading any custom integrations and modules.",
+          "confirm_title": "Restart Home Assistant in safe mode?",
+          "confirm_description": "This will restart Home Assistant without loading any custom integrations and modules.",
+          "confirm_action": "Restart",
+          "failed": "Failed to restart Home Assistant"
         }
       },
       "aliases": {


### PR DESCRIPTION
## Proposed change

Allow user to restart Home Assistant in safe mode.

![CleanShot 2023-10-24 at 09 56 23](https://github.com/home-assistant/frontend/assets/5878303/a57a7b35-d4a1-4e7c-b439-305a247a2629)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/core/pull/102606
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
