### PR TITLE
Subscribe to the issue registry as early as possible

### DIFF
--- a/src/entrypoints/core.ts
+++ b/src/entrypoints/core.ts
@@ -21,6 +21,7 @@ import {
 } from "../data/lovelace";
 import { subscribePanels } from "../data/ws-panels";
 import { subscribeThemes } from "../data/ws-themes";
+import { subscribeRepairsIssueRegistry } from "../data/repairs";
 import { subscribeUser } from "../data/ws-user";
 import type { ExternalAuth } from "../external_app/external_auth";
 import "../resources/array.flat.polyfill";
@@ -121,6 +122,7 @@ window.hassConnection.then(({ conn }) => {
   subscribeThemes(conn, noop);
   subscribeUser(conn, noop);
   subscribeFrontendUserData(conn, "core", noop);
+  subscribeRepairsIssueRegistry(conn, noop);
 
   if (location.pathname === "/" || location.pathname.startsWith("/lovelace/")) {
     const llWindow = window as WindowWithLovelaceProm;


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
We always subscribe here so we should do it as soon as possible to reduce reconnect latency

There are still a few other things we fetch nearly every time that are not accounted for (these are harder to prefetch):
- `getRecorderInfo`
- `getEnergyPreferences`
- `subscribeLovelaceUpdates`
- `title` translations
- `subscribeNotifications`

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
