### PR TITLE
Add test button to conditional card

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4810,6 +4810,11 @@
           "condition-editor": {
             "explanation": "The card will be shown when ALL conditions below are fulfilled.",
             "add": "Add condition",
+            "test": "[%key:ui::panel::config::automation::editor::conditions::test%]",
+            "testing_pass": "[%key:ui::panel::config::automation::editor::conditions::testing_pass%]",
+            "testing_error": "[%key:ui::panel::config::automation::editor::conditions::testing_error%]",
+            "invalid_config_title": "Invalid configuration",
+            "invalid_config_text": "The condition can not be tested because the configuration is not valid.",
             "condition": {
               "numeric_state": {
                 "label": "Entity numeric state",


### PR DESCRIPTION
## Proposed change

Add test button to conditional card.

The UX is the same as automation condition tests.
 
![CleanShot 2023-10-25 at 19 41 44](https://github.com/home-assistant/frontend/assets/5878303/ac6d2a16-bbc0-49a2-94f9-f79cdc3e372f)


![CleanShot 2023-10-25 at 19 41 47](https://github.com/home-assistant/frontend/assets/5878303/addc9e2b-7d30-4b2d-841e-7ff771fa7868)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
