### PR TITLE
Use trigger and condition type translation labels

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -661,9 +661,14 @@ const tryDescribeTrigger = (
     }`;
   }
 
-  return `${
-    trigger.platform ? trigger.platform.replace(/_/g, " ") : "Unknown"
-  } trigger`;
+  if (typeof trigger.platform) {
+    return hass.localize(
+      `ui.panel.config.automation.editor.triggers.type.${trigger.platform}.label`
+    );
+  }
+  return hass.localize(
+    `ui.panel.config.automation.editor.triggers.unknown_trigger`
+  );
 };
 
 export const describeCondition = (
@@ -1100,7 +1105,12 @@ const tryDescribeCondition = (
     return `When triggered by ${condition.id}`;
   }
 
-  return `${
-    condition.condition ? condition.condition.replace(/_/g, " ") : "Unknown"
-  } condition`;
+  if (condition.condition) {
+    return hass.localize(
+      `ui.panel.config.automation.editor.conditions.type.${condition.condition}.label`
+    );
+  }
+  return hass.localize(
+    `ui.panel.config.automation.editor.conditions.unknown_condition`
+  );
 };

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -660,8 +660,8 @@ const tryDescribeTrigger = (
 
   return (
     hass.localize(
-        `ui.panel.config.automation.editor.triggers.type.${trigger.platform}.label`
-      ) ||
+      `ui.panel.config.automation.editor.triggers.type.${trigger.platform}.label`
+    ) ||
     hass.localize(`ui.panel.config.automation.editor.triggers.unknown_trigger`)
   );
 };
@@ -1094,11 +1094,10 @@ const tryDescribeCondition = (
     return `When triggered by ${condition.id}`;
   }
 
-
   return (
     hass.localize(
-        `ui.panel.config.automation.editor.conditions.type.${condition.condition}.label`
-      ) ||
+      `ui.panel.config.automation.editor.conditions.type.${condition.condition}.label`
+    ) ||
     hass.localize(
       `ui.panel.config.automation.editor.conditions.unknown_condition`
     )

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -661,13 +661,15 @@ const tryDescribeTrigger = (
     }`;
   }
 
-  if (typeof trigger.platform) {
-    return hass.localize(
-      `ui.panel.config.automation.editor.triggers.type.${trigger.platform}.label`
-    );
-  }
-  return hass.localize(
-    `ui.panel.config.automation.editor.triggers.unknown_trigger`
+  const triggerType = trigger.platform
+    ? hass.localize(
+        `ui.panel.config.automation.editor.triggers.type.${trigger.platform}.label`
+      )
+    : "";
+
+  return (
+    triggerType ||
+    hass.localize(`ui.panel.config.automation.editor.triggers.unknown_trigger`)
   );
 };
 
@@ -1105,12 +1107,16 @@ const tryDescribeCondition = (
     return `When triggered by ${condition.id}`;
   }
 
-  if (condition.condition) {
-    return hass.localize(
-      `ui.panel.config.automation.editor.conditions.type.${condition.condition}.label`
-    );
-  }
-  return hass.localize(
-    `ui.panel.config.automation.editor.conditions.unknown_condition`
+  const conditionType = condition.condition
+    ? hass.localize(
+        `ui.panel.config.automation.editor.conditions.type.${condition.condition}.label`
+      )
+    : "";
+
+  return (
+    conditionType ||
+    hass.localize(
+      `ui.panel.config.automation.editor.conditions.unknown_condition`
+    )
   );
 };

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -642,10 +642,7 @@ const tryDescribeTrigger = (
   }
 
   // Device Trigger
-  if (trigger.platform === "device") {
-    if (!trigger.device_id) {
-      return "Device trigger";
-    }
+  if (trigger.platform === "device" && trigger.device_id) {
     const config = trigger as DeviceTrigger;
     const localized = localizeDeviceAutomationTrigger(
       hass,
@@ -1081,10 +1078,7 @@ const tryDescribeCondition = (
     );
   }
 
-  if (condition.condition === "device") {
-    if (!condition.device_id) {
-      return "Device condition";
-    }
+  if (condition.condition === "device" && condition.device_id) {
     const config = condition as DeviceCondition;
     const localized = localizeDeviceAutomationCondition(
       hass,
@@ -1100,10 +1094,7 @@ const tryDescribeCondition = (
     }`;
   }
 
-  if (condition.condition === "trigger") {
-    if (!condition.id) {
-      return "Trigger condition";
-    }
+  if (condition.condition === "trigger" && condition.id) {
     return `When triggered by ${condition.id}`;
   }
 

--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -658,14 +658,10 @@ const tryDescribeTrigger = (
     }`;
   }
 
-  const triggerType = trigger.platform
-    ? hass.localize(
-        `ui.panel.config.automation.editor.triggers.type.${trigger.platform}.label`
-      )
-    : "";
-
   return (
-    triggerType ||
+    hass.localize(
+        `ui.panel.config.automation.editor.triggers.type.${trigger.platform}.label`
+      ) ||
     hass.localize(`ui.panel.config.automation.editor.triggers.unknown_trigger`)
   );
 };
@@ -1098,14 +1094,11 @@ const tryDescribeCondition = (
     return `When triggered by ${condition.id}`;
   }
 
-  const conditionType = condition.condition
-    ? hass.localize(
-        `ui.panel.config.automation.editor.conditions.type.${condition.condition}.label`
-      )
-    : "";
 
   return (
-    conditionType ||
+    hass.localize(
+        `ui.panel.config.automation.editor.conditions.type.${condition.condition}.label`
+      ) ||
     hass.localize(
       `ui.panel.config.automation.editor.conditions.unknown_condition`
     )

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2385,6 +2385,7 @@
               "delete_confirm_text": "It will be permanently deleted.",
               "unsupported_platform": "No visual editor support for platform: {platform}",
               "type_select": "Trigger type",
+              "unknown_trigger": "[%key:ui::panel::config::devices::automation::triggers::unknown_trigger%]",
               "type": {
                 "calendar": {
                   "label": "Calendar",
@@ -2580,6 +2581,7 @@
               "delete_confirm_text": "[%key:ui::panel::config::automation::editor::triggers::delete_confirm_text%]",
               "unsupported_condition": "No visual editor support for condition: {condition}",
               "type_select": "Condition type",
+              "unknown_condition": "[%key:ui::panel::config::devices::automation::conditions::unknown_condition%]",
               "type": {
                 "and": {
                   "label": "And",


### PR DESCRIPTION
## Proposed change
Use existing translation labels to display the trigger or condition type. 
To not add a few more labels, I've removed the redundant "trigger" or "condition" mentioned after the type. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18359 fixes  #18353 fixes #18351 fixes #18350 fixes #18349 fixes #18347
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
