### PR TITLE
Add localization to service call exceptions

### DIFF
--- a/src/data/translation.ts
+++ b/src/data/translation.ts
@@ -61,6 +61,7 @@ export type TranslationCategory =
   | "state"
   | "entity"
   | "entity_component"
+  | "exceptions"
   | "config"
   | "config_panel"
   | "options"

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -173,6 +173,9 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     // @ts-ignore
     this._loadHassTranslations(this.hass!.language, "state");
 
+    // @ts-ignore
+    this._loadHassTranslations(this.hass!.language, "exceptions");
+
     document.addEventListener(
       "visibilitychange",
       () => this._checkVisibility(),

--- a/src/layouts/home-assistant.ts
+++ b/src/layouts/home-assistant.ts
@@ -173,9 +173,6 @@ export class HomeAssistantAppEl extends QuickBarMixin(HassElement) {
     // @ts-ignore
     this._loadHassTranslations(this.hass!.language, "state");
 
-    // @ts-ignore
-    this._loadHassTranslations(this.hass!.language, "exceptions");
-
     document.addEventListener(
       "visibilitychange",
       () => this._checkVisibility(),

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -122,6 +122,10 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
             }
             if (notifyOnError) {
               forwardHaptic("failure");
+              const lokalizedErrorMessage = (this as any).hass.localize(
+                `component.${err.translation_domain}.exceptions.${err.translation_key}.message`,
+                err.translation_placeholders
+              );
               const message =
                 (this as any).hass.localize(
                   "ui.notification_toast.service_call_failed",
@@ -129,6 +133,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
                   `${domain}/${service}`
                 ) +
                 ` ${
+                  lokalizedErrorMessage ||
                   err.message ||
                   (err.error?.code === ERR_CONNECTION_LOST
                     ? "connection lost"

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -122,19 +122,19 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
             }
             if (notifyOnError) {
               forwardHaptic("failure");
-              const lokalizedErrorMessage = (this as any).hass.localize(
+              const localizedErrorMessage = (this as any).hass.localize(
                 `component.${err.translation_domain}.exceptions.${err.translation_key}.message`,
                 err.translation_placeholders
               );
               const message =
-                lokalizedErrorMessage ||
+                localizedErrorMessage ||
                 (this as any).hass.localize(
                   "ui.notification_toast.service_call_failed",
                   "service",
                   `${domain}/${service}`
                 ) +
                   ` ${
-                    (lokalizedErrorMessage ? "" : err.message) ||
+                    err.message ||
                     (err.error?.code === ERR_CONNECTION_LOST
                       ? "connection lost"
                       : "unknown error")

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -122,10 +122,16 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
             }
             if (notifyOnError) {
               forwardHaptic("failure");
-              const localizedErrorMessage = (this as any).hass.localize(
-                `component.${err.translation_domain}.exceptions.${err.translation_key}.message`,
-                err.translation_placeholders
+              const lokalize = await this.hass?.loadBackendTranslation(
+                "exceptions",
+                domain
               );
+              const localizedErrorMessage =
+                lokalize &&
+                lokalize(
+                  `component.${err.translation_domain}.exceptions.${err.translation_key}.message`,
+                  err.translation_placeholders
+                );
               const message =
                 localizedErrorMessage ||
                 (this as any).hass.localize(

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -124,7 +124,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
               forwardHaptic("failure");
               const lokalize = await this.hass!.loadBackendTranslation(
                 "exceptions",
-                domain
+                err.translation_domain
               );
               const localizedErrorMessage = lokalize(
                 `component.${err.translation_domain}.exceptions.${err.translation_key}.message`,

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -122,16 +122,14 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
             }
             if (notifyOnError) {
               forwardHaptic("failure");
-              const lokalize = await this.hass?.loadBackendTranslation(
+              const lokalize = await this.hass!.loadBackendTranslation(
                 "exceptions",
                 domain
               );
-              const localizedErrorMessage =
-                lokalize &&
-                lokalize(
-                  `component.${err.translation_domain}.exceptions.${err.translation_key}.message`,
-                  err.translation_placeholders
-                );
+              const localizedErrorMessage = lokalize(
+                `component.${err.translation_domain}.exceptions.${err.translation_key}.message`,
+                err.translation_placeholders
+              );
               const message =
                 localizedErrorMessage ||
                 (this as any).hass.localize(

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -127,18 +127,18 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
                 err.translation_placeholders
               );
               const message =
+                lokalizedErrorMessage ||
                 (this as any).hass.localize(
                   "ui.notification_toast.service_call_failed",
                   "service",
                   `${domain}/${service}`
                 ) +
-                ` ${
-                  lokalizedErrorMessage ||
-                  err.message ||
-                  (err.error?.code === ERR_CONNECTION_LOST
-                    ? "connection lost"
-                    : "unknown error")
-                }`;
+                  ` ${
+                    (lokalizedErrorMessage ? "" : err.message) ||
+                    (err.error?.code === ERR_CONNECTION_LOST
+                      ? "connection lost"
+                      : "unknown error")
+                  }`;
               fireEvent(this as any, "hass-notification", { message });
             }
             throw err;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add localization to service call exceptions

Needs https://github.com/home-assistant/core/pull/102592

Example of localize custom error message when reloading the MQTT YAML config:

![image](https://github.com/home-assistant/frontend/assets/7188918/aec65753-f646-4962-ae2b-201852832478)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
