### PR TITLE
Fix temperature cards not syncing

### DIFF
--- a/src/panels/lovelace/cards/hui-thermostat-card.ts
+++ b/src/panels/lovelace/cards/hui-thermostat-card.ts
@@ -91,6 +91,8 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
 
   @state() private resyncSetpoint = false;
 
+  @state() private _error?: string;
+
   public getCardSize(): number {
     return 7;
   }
@@ -487,9 +489,11 @@ export class HuiThermostatCard extends LitElement implements LovelaceCard {
     }
 
     data.entity_id = this._config!.entity;
-
-    await this.hass!.callService("climate", service, data);
-
+    try {
+      await this.hass!.callService("climate", service, data);
+    } catch (err: any) {
+      this._error = err.message;
+    }
     // After updating temperature, wait 2s and check if the values
     // from call service are reflected in the entity. If not, resync
     // the slider to the entity values.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Ensure the thermostat tile card, the thermostat card, and the thermostat dialog card keep their original values when an exception is thrown.

Demo:

https://github.com/home-assistant/frontend/assets/37427166/1236031f-f1da-460a-8b13-ce9bd5e5c47e


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: thermostat
entity: climate.nest_thermostat
```
```yaml
type: tile
entity: climate.nest_thermostat
tap_action:
  action: call-service
  service: ''
vertical: false
features:
  - type: climate-hvac-modes
    hvac_modes:
      - 'off'
      - heat
      - cool
      - heat_cool
  - type: target-temperature
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18455
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
