### PR TITLE
feat: Dynamically adjust gradient percentages based on min/max values

### DIFF
--- a/src/common/color/convert-light-color.ts
+++ b/src/common/color/convert-light-color.ts
@@ -58,10 +58,10 @@ const matchMaxScale = (
   return outputColors.map((value) => Math.round(value * factor));
 };
 
-const mired2kelvin = (miredTemperature: number) =>
+export const mired2kelvin = (miredTemperature: number) =>
   Math.floor(1000000 / miredTemperature);
 
-const kelvin2mired = (kelvintTemperature: number) =>
+export const kelvin2mired = (kelvintTemperature: number) =>
   Math.floor(1000000 / kelvintTemperature);
 
 export const rgbww2rgb = (

--- a/src/components/ha-selector/ha-selector-color-temp.ts
+++ b/src/components/ha-selector/ha-selector-color-temp.ts
@@ -1,12 +1,12 @@
-import { css, html, LitElement } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators";
+import { styleMap } from "lit/directives/style-map";
+import memoizeOne from "memoize-one";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { ColorTempSelector } from "../../data/selector";
 import type { HomeAssistant } from "../../types";
 import "../ha-labeled-slider";
-import { styleMap } from "lit/directives/style-map";
 import { generateColorTemperatureGradient } from "../../dialogs/more-info/components/lights/light-color-temp-picker";
-import memoizeOne from "memoize-one";
 import { mired2kelvin } from "../../common/color/convert-light-color";
 
 @customElement("ha-selector-color_temp")
@@ -31,9 +31,6 @@ export class HaColorTempSelector extends LitElement {
 
 
     const gradient = this._generateTemperatureGradient(min, max);
-    // const firstPercentage = (100 * (153 - min)) / 173.5;
-    // const secondPercentage = (50 * (153 - min + 500 - max)) / 173.5 + 50;
-    // const thirdPercentage = (100 * (500 - max)) / 173.5 + 100;
 
     return html`
       <ha-labeled-slider
@@ -56,7 +53,7 @@ export class HaColorTempSelector extends LitElement {
   }
 
   private _generateTemperatureGradient = memoizeOne(
-    (min: number, max: number) => generateColorTemperatureGradient(mired2kelvin(max), mired2kelvin(min))
+    (min: number, max: number) => generateColorTemperatureGradient(mired2kelvin(min), mired2kelvin(max))
   );
 
   private _valueChanged(ev: CustomEvent) {
@@ -64,17 +61,6 @@ export class HaColorTempSelector extends LitElement {
       value: Number((ev.detail as any).value),
     });
   }
-
-  // static styles = css`
-  //   ha-labeled-slider {
-  //     --ha-slider-background: linear-gradient(
-  //       to var(--float-end),
-  //       rgb(255, 160, 0) var(--first-percentage),
-  //       white var(--second-percentage),
-  //       rgb(166, 209, 255) var(--third-percentage)
-  //     );
-  //   }
-  // `;
 }
 
 declare global {

--- a/src/components/ha-selector/ha-selector-color-temp.ts
+++ b/src/components/ha-selector/ha-selector-color-temp.ts
@@ -20,15 +20,27 @@ export class HaColorTempSelector extends LitElement {
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
   @property({ type: Boolean }) public required = true;
-
+  
   protected render() {
+    const min = this.selector.color_temp?.min_mireds ?? 153;
+    const max = this.selector.color_temp?.max_mireds ?? 500;
+
+    const firstPercentage = 100 * (153 - min) / 173.5;
+    const secondPercentage = 50 * (153 - min + 500 - max) / 173.5 + 50;
+    const thirdPercentage = 100 * (500 - max) / 173.5 + 100;
+
     return html`
       <ha-labeled-slider
+        style="
+          --first-percentage: ${firstPercentage}%;
+          --second-percentage: ${secondPercentage}%;
+          --third-percentage: ${thirdPercentage}%;
+        "
         labeled
         icon="hass:thermometer"
         .caption=${this.label || ""}
-        .min=${this.selector.color_temp?.min_mireds ?? 153}
-        .max=${this.selector.color_temp?.max_mireds ?? 500}
+        .min=${min}
+        .max=${max}
         .value=${this.value}
         .disabled=${this.disabled}
         .helper=${this.helper}
@@ -48,9 +60,9 @@ export class HaColorTempSelector extends LitElement {
     ha-labeled-slider {
       --ha-slider-background: linear-gradient(
         to var(--float-end),
-        rgb(255, 160, 0) 0%,
-        white 50%,
-        rgb(166, 209, 255) 100%
+        rgb(255, 160, 0) var(--first-percentage),
+        white var(--second-percentage),
+        rgb(166, 209, 255) var(--third-percentage)
       );
     }
   `;

--- a/src/components/ha-selector/ha-selector-color-temp.ts
+++ b/src/components/ha-selector/ha-selector-color-temp.ts
@@ -4,6 +4,10 @@ import { fireEvent } from "../../common/dom/fire_event";
 import type { ColorTempSelector } from "../../data/selector";
 import type { HomeAssistant } from "../../types";
 import "../ha-labeled-slider";
+import { styleMap } from "lit/directives/style-map";
+import { generateColorTemperatureGradient } from "../../dialogs/more-info/components/lights/light-color-temp-picker";
+import memoizeOne from "memoize-one";
+import { mired2kelvin } from "../../common/color/convert-light-color";
 
 @customElement("ha-selector-color_temp")
 export class HaColorTempSelector extends LitElement {
@@ -20,22 +24,23 @@ export class HaColorTempSelector extends LitElement {
   @property({ type: Boolean, reflect: true }) public disabled = false;
 
   @property({ type: Boolean }) public required = true;
-  
+
   protected render() {
     const min = this.selector.color_temp?.min_mireds ?? 153;
     const max = this.selector.color_temp?.max_mireds ?? 500;
 
-    const firstPercentage = 100 * (153 - min) / 173.5;
-    const secondPercentage = 50 * (153 - min + 500 - max) / 173.5 + 50;
-    const thirdPercentage = 100 * (500 - max) / 173.5 + 100;
+
+    const gradient = this._generateTemperatureGradient(min, max);
+    // const firstPercentage = (100 * (153 - min)) / 173.5;
+    // const secondPercentage = (50 * (153 - min + 500 - max)) / 173.5 + 50;
+    // const thirdPercentage = (100 * (500 - max)) / 173.5 + 100;
 
     return html`
       <ha-labeled-slider
-        style="
-          --first-percentage: ${firstPercentage}%;
-          --second-percentage: ${secondPercentage}%;
-          --third-percentage: ${thirdPercentage}%;
-        "
+        style=${styleMap({
+          "--ha-slider-background": `linear-gradient( to var(--float-end), ${gradient})`,
+        })}
+  
         labeled
         icon="hass:thermometer"
         .caption=${this.label || ""}
@@ -50,22 +55,26 @@ export class HaColorTempSelector extends LitElement {
     `;
   }
 
+  private _generateTemperatureGradient = memoizeOne(
+    (min: number, max: number) => generateColorTemperatureGradient(mired2kelvin(max), mired2kelvin(min))
+  );
+
   private _valueChanged(ev: CustomEvent) {
     fireEvent(this, "value-changed", {
       value: Number((ev.detail as any).value),
     });
   }
 
-  static styles = css`
-    ha-labeled-slider {
-      --ha-slider-background: linear-gradient(
-        to var(--float-end),
-        rgb(255, 160, 0) var(--first-percentage),
-        white var(--second-percentage),
-        rgb(166, 209, 255) var(--third-percentage)
-      );
-    }
-  `;
+  // static styles = css`
+  //   ha-labeled-slider {
+  //     --ha-slider-background: linear-gradient(
+  //       to var(--float-end),
+  //       rgb(255, 160, 0) var(--first-percentage),
+  //       white var(--second-percentage),
+  //       rgb(166, 209, 255) var(--third-percentage)
+  //     );
+  //   }
+  // `;
 }
 
 declare global {

--- a/src/components/ha-selector/ha-selector-color-temp.ts
+++ b/src/components/ha-selector/ha-selector-color-temp.ts
@@ -29,7 +29,6 @@ export class HaColorTempSelector extends LitElement {
     const min = this.selector.color_temp?.min_mireds ?? 153;
     const max = this.selector.color_temp?.max_mireds ?? 500;
 
-
     const gradient = this._generateTemperatureGradient(min, max);
 
     return html`
@@ -37,7 +36,6 @@ export class HaColorTempSelector extends LitElement {
         style=${styleMap({
           "--ha-slider-background": `linear-gradient( to var(--float-end), ${gradient})`,
         })}
-  
         labeled
         icon="hass:thermometer"
         .caption=${this.label || ""}
@@ -53,7 +51,8 @@ export class HaColorTempSelector extends LitElement {
   }
 
   private _generateTemperatureGradient = memoizeOne(
-    (min: number, max: number) => generateColorTemperatureGradient(mired2kelvin(min), mired2kelvin(max))
+    (min: number, max: number) =>
+      generateColorTemperatureGradient(mired2kelvin(min), mired2kelvin(max))
   );
 
   private _valueChanged(ev: CustomEvent) {


### PR DESCRIPTION
Updated the CSS gradient for the  element to have its color stops adjust dynamically based on the  and  values of the color temperature selector.
This provides a more accurate visual representation of the selected range.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
The documentation ([link](https://www.home-assistant.io/docs/blueprint/selectors/#color-temperature-selector)):

![selector-color-temp](https://github.com/home-assistant/frontend/assets/13403863/256d0077-80f4-4614-b723-ae4d4d850264)

The `dev` branch:

![image](https://github.com/home-assistant/frontend/assets/13403863/998d0db3-f25c-4cf0-8201-1f1ea2c01c1f)


Proposed in this pull request:
![image](https://github.com/home-assistant/frontend/assets/13403863/62d76d3b-e798-4342-81de-cd0d566415c7)

[Blueprint used to create the images](https://gist.github.com/schelv/e57b3da2f9446ebbca1228c95fc18fa6)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
