### PR TITLE
Improve template trigger/condition descriptions

### DIFF
--- a/src/data/automation_i18n.ts
+++ b/src/data/automation_i18n.ts
@@ -1090,6 +1090,12 @@ const tryDescribeCondition = (
     }`;
   }
 
+  if (condition.condition === "template") {
+    return hass.localize(
+      `${conditionsTranslationBaseKey}.template.description.full`
+    );
+  }
+
   if (condition.condition === "trigger" && condition.id != null) {
     return hass.localize(
       `${conditionsTranslationBaseKey}.trigger.description.full`,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2532,7 +2532,7 @@
                   "value_template": "Value template",
                   "for": "For",
                   "description": {
-                    "full": "When a template triggers{hasDuration, select, \n true { for {duration}} \n other {}\n }"
+                    "full": "When a template changes from false to true{hasDuration, select, \n true { for {duration}} \n other {}\n }"
                   }
                 },
                 "time": {
@@ -2662,7 +2662,10 @@
                 },
                 "template": {
                   "label": "[%key:ui::panel::config::automation::editor::triggers::type::template::label%]",
-                  "value_template": "[%key:ui::panel::config::automation::editor::triggers::type::template::value_template%]"
+                  "value_template": "[%key:ui::panel::config::automation::editor::triggers::type::template::value_template%]",
+                  "description": {
+                    "full": "Test if template renders a value equal to true"
+                  }
                 },
                 "time": {
                   "type_value": "[%key:ui::panel::config::automation::editor::triggers::type::time::type_value%]",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Two minor improvements to description rendering in expansion panel header for templates in automations:

1. The current description for template trigger is "When a template triggers". I think this can be improved, as this is somewhat of a circular definition and is not immediately clear what it means. (_When does this trigger execute? When it triggers._).
I propose the more exact description "When a template changes from false to true". I think this will be an improvement as there is sometimes some confusion around this trigger, with some users expecting it to trigger everytime the template evaluates to true. 

2. Condition template currently has no description, and just displays "Template". This looks odd when juxtaposed with the other conditions, most/all of which use an imperitive sentence to describe the condition, such as "Test if... or "Confirm that....".
I have added the sentence "Test if template renders a value equal to true", which matches how this condition is described in the official documentation.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
