### PR TITLE
Fix refresh in developer state tools

### DIFF
--- a/src/panels/developer-tools/state/developer-tools-state.ts
+++ b/src/panels/developer-tools/state/developer-tools-state.ts
@@ -167,7 +167,7 @@ class HaPanelDevState extends LitElement {
                 )}</mwc-button
               >
               <ha-icon-button
-                @click=${this._entityIdChanged}
+                @click=${this._updateEntity}
                 .label=${this.hass.localize("ui.common.refresh")}
                 .path=${mdiRefresh}
               ></ha-icon-button>
@@ -355,6 +355,10 @@ class HaPanelDevState extends LitElement {
       this._stateAttributes = {};
       return;
     }
+    this._updateEntity();
+  }
+
+  private _updateEntity() {
     const entityState = this.hass.states[this._entityId];
     if (!entityState) {
       return;

--- a/src/panels/developer-tools/state/developer-tools-state.ts
+++ b/src/panels/developer-tools/state/developer-tools-state.ts
@@ -349,16 +349,16 @@ class HaPanelDevState extends LitElement {
 
   private _entityIdChanged(ev: CustomEvent) {
     this._entityId = ev.detail.value;
+    this._updateEntity();
+  }
+
+  private _updateEntity() {
     if (!this._entityId) {
       this._entity = undefined;
       this._state = "";
       this._stateAttributes = {};
       return;
     }
-    this._updateEntity();
-  }
-
-  private _updateEntity() {
     const entityState = this.hass.states[this._entityId];
     if (!entityState) {
       return;


### PR DESCRIPTION
## Proposed change
My last bug fix on this page broke the state refresh. See #18530

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18530
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
