### PR TITLE
Use entity component translations for update entity

### DIFF
--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -203,6 +203,7 @@ export const DOMAINS_WITH_CARD = [
   "select",
   "timer",
   "text",
+  "update",
   "vacuum",
   "water_heater",
 ];

--- a/src/common/entity/compute_state_display.ts
+++ b/src/common/entity/compute_state_display.ts
@@ -2,10 +2,6 @@ import { HassConfig, HassEntity } from "home-assistant-js-websocket";
 import { UNAVAILABLE, UNKNOWN } from "../../data/entity";
 import { EntityRegistryDisplayEntry } from "../../data/entity_registry";
 import { FrontendLocaleData, TimeZone } from "../../data/translation";
-import {
-  UPDATE_SUPPORT_PROGRESS,
-  updateIsInstallingFromAttributes,
-} from "../../data/update";
 import { HomeAssistant } from "../../types";
 import {
   UNIT_TO_MILLISECOND_CONVERT,
@@ -19,10 +15,9 @@ import {
   getNumberFormatOptions,
   isNumericFromAttributes,
 } from "../number/format_number";
+import { blankBeforeUnit } from "../translations/blank_before_unit";
 import { LocalizeFunc } from "../translations/localize";
 import { computeDomain } from "./compute_domain";
-import { supportsFeatureFromAttributes } from "./supports-feature";
-import { blankBeforeUnit } from "../translations/blank_before_unit";
 
 export const computeStateDisplaySingleEntity = (
   localize: LocalizeFunc,
@@ -206,27 +201,6 @@ export const computeStateDisplayFromEntityAttributes = (
     } catch (_err) {
       return state;
     }
-  }
-
-  if (domain === "update") {
-    // When updating, and entity does not support % show "Installing"
-    // When updating, and entity does support % show "Installing (xx%)"
-    // When update available, show the version
-    // When the latest version is skipped, show the latest version
-    // When update is not available, show "Up-to-date"
-    // When update is not available and there is no latest_version show "Unavailable"
-    return state === "on"
-      ? updateIsInstallingFromAttributes(attributes)
-        ? supportsFeatureFromAttributes(attributes, UPDATE_SUPPORT_PROGRESS) &&
-          typeof attributes.in_progress === "number"
-          ? localize("ui.card.update.installing_with_progress", {
-              progress: attributes.in_progress,
-            })
-          : localize("ui.card.update.installing")
-        : attributes.latest_version
-      : attributes.skipped_version === attributes.latest_version
-        ? attributes.latest_version ?? localize("state.default.unavailable")
-        : localize("ui.card.update.up_to_date");
   }
 
   return (

--- a/src/data/update.ts
+++ b/src/data/update.ts
@@ -7,10 +7,7 @@ import type {
 import { BINARY_STATE_ON } from "../common/const";
 import { computeDomain } from "../common/entity/compute_domain";
 import { computeStateDomain } from "../common/entity/compute_state_domain";
-import {
-  supportsFeature,
-  supportsFeatureFromAttributes,
-} from "../common/entity/supports-feature";
+import { supportsFeature } from "../common/entity/supports-feature";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
 import { showAlertDialog } from "../dialogs/generic/show-dialog-box";
 import { HomeAssistant } from "../types";
@@ -38,13 +35,8 @@ export interface UpdateEntity extends HassEntityBase {
 }
 
 export const updateUsesProgress = (entity: UpdateEntity): boolean =>
-  updateUsesProgressFromAttributes(entity.attributes);
-
-export const updateUsesProgressFromAttributes = (attributes: {
-  [key: string]: any;
-}): boolean =>
-  supportsFeatureFromAttributes(attributes, UPDATE_SUPPORT_PROGRESS) &&
-  typeof attributes.in_progress === "number";
+  supportsFeature(entity, UPDATE_SUPPORT_PROGRESS) &&
+  typeof entity.attributes.in_progress === "number";
 
 export const updateCanInstall = (
   entity: UpdateEntity,
@@ -56,11 +48,6 @@ export const updateCanInstall = (
 
 export const updateIsInstalling = (entity: UpdateEntity): boolean =>
   updateUsesProgress(entity) || !!entity.attributes.in_progress;
-
-export const updateIsInstallingFromAttributes = (attributes: {
-  [key: string]: any;
-}): boolean =>
-  updateUsesProgressFromAttributes(attributes) || !!attributes.in_progress;
 
 export const updateReleaseNotes = (hass: HomeAssistant, entityId: string) =>
   hass.callWS<string | null>({
@@ -161,4 +148,48 @@ export const checkForEntityUpdates = async (
       message: hass.localize("ui.panel.config.updates.no_new_updates"),
     });
   }
+};
+
+// When updating, and entity does not support % show "Installing"
+// When updating, and entity does support % show "Installing (xx%)"
+// When update available, show the version
+// When the latest version is skipped, show the latest version
+// When update is not available, show "Up-to-date"
+// When update is not available and there is no latest_version show "Unavailable"
+export const computeUpdateStateDisplay = (
+  stateObj: UpdateEntity,
+  hass: HomeAssistant
+): string => {
+  const state = stateObj.state;
+  const attributes = stateObj.attributes;
+
+  if (state === "off") {
+    const isSkipped =
+      attributes.latest_version &&
+      attributes.skipped_version === attributes.latest_version;
+    if (isSkipped) {
+      return attributes.latest_version!;
+    }
+    return hass.formatEntityState(stateObj);
+  }
+
+  if (state === "on") {
+    if (updateIsInstalling(stateObj)) {
+      const supportsProgress =
+        supportsFeature(stateObj, UPDATE_SUPPORT_PROGRESS) &&
+        typeof typeof attributes.in_progress === "number";
+      if (supportsProgress) {
+        return hass.localize("ui.card.update.installing_with_progress", {
+          progress: attributes.in_progress,
+        });
+      }
+      return hass.localize("ui.card.update.installing");
+    }
+
+    if (attributes.latest_version) {
+      return attributes.latest_version;
+    }
+  }
+
+  return hass.formatEntityState(stateObj);
 };

--- a/src/dialogs/more-info/controls/more-info-update.ts
+++ b/src/dialogs/more-info/controls/more-info-update.ts
@@ -63,8 +63,9 @@ class MoreInfoUpdate extends LitElement {
         : ""}
       <div class="row">
         <div class="key">
-          ${this.hass.localize(
-            "ui.dialogs.more_info_control.update.installed_version"
+          ${this.hass.formatEntityAttributeName(
+            this.stateObj,
+            "installed_version"
           )}
         </div>
         <div class="value">
@@ -74,8 +75,9 @@ class MoreInfoUpdate extends LitElement {
       </div>
       <div class="row">
         <div class="key">
-          ${this.hass.localize(
-            "ui.dialogs.more_info_control.update.latest_version"
+          ${this.hass.formatEntityAttributeName(
+            this.stateObj,
+            "latest_version"
           )}
         </div>
         <div class="value">

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -47,6 +47,7 @@ import "../tile-features/hui-tile-features";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import { computeTileBadge } from "./tile/badges/tile-badge";
 import type { ThermostatCardConfig, TileCardConfig } from "./types";
+import { UpdateEntity, computeUpdateStateDisplay } from "../../../data/update";
 
 const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
 
@@ -258,6 +259,13 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
         "state",
         "current_temperature",
       ]);
+    }
+
+    if (domain === "update") {
+      return html`${computeUpdateStateDisplay(
+        stateObj as UpdateEntity,
+        this.hass!
+      )}`;
     }
 
     return this._renderStateContent(stateObj, "state");

--- a/src/panels/lovelace/create-element/create-row-element.ts
+++ b/src/panels/lovelace/create-element/create-row-element.ts
@@ -48,6 +48,7 @@ const LAZY_LOAD_TYPES = {
   "text-entity": () => import("../entity-rows/hui-text-entity-row"),
   "time-entity": () => import("../entity-rows/hui-time-entity-row"),
   "timer-entity": () => import("../entity-rows/hui-timer-entity-row"),
+  "update-entity": () => import("../entity-rows/hui-update-entity-row"),
   conditional: () => import("../special-rows/hui-conditional-row"),
   "weather-entity": () => import("../entity-rows/hui-weather-entity-row"),
   divider: () => import("../special-rows/hui-divider-row"),
@@ -73,6 +74,7 @@ const DOMAIN_TO_ELEMENT_TYPE = {
   humidifier: "humidifier",
   input_boolean: "toggle",
   input_button: "input-button",
+  input_datetime: "input-datetime",
   input_number: "input-number",
   input_select: "input-select",
   input_text: "input-text",
@@ -90,11 +92,11 @@ const DOMAIN_TO_ELEMENT_TYPE = {
   text: "text",
   time: "time",
   timer: "timer",
+  update: "update",
   vacuum: "toggle",
   // Temporary. Once climate is rewritten,
   // water heater should get its own row.
   water_heater: "climate",
-  input_datetime: "input-datetime",
   weather: "weather",
 };
 

--- a/src/panels/lovelace/entity-rows/hui-update-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-update-entity-row.ts
@@ -1,0 +1,75 @@
+import {
+  CSSResultGroup,
+  LitElement,
+  PropertyValues,
+  css,
+  html,
+  nothing,
+} from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { UpdateEntity, computeUpdateStateDisplay } from "../../../data/update";
+import { HomeAssistant } from "../../../types";
+import { EntitiesCardEntityConfig } from "../cards/types";
+import { hasConfigOrEntityChanged } from "../common/has-changed";
+import "../components/hui-generic-entity-row";
+import { createEntityNotFoundWarning } from "../components/hui-warning";
+import { LovelaceRow } from "./types";
+
+@customElement("hui-update-entity-row")
+class HuiUpdateEntityRow extends LitElement implements LovelaceRow {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _config?: EntitiesCardEntityConfig;
+
+  public setConfig(config: EntitiesCardEntityConfig): void {
+    if (!config) {
+      throw new Error("Invalid configuration");
+    }
+    this._config = config;
+  }
+
+  protected shouldUpdate(changedProps: PropertyValues): boolean {
+    return hasConfigOrEntityChanged(this, changedProps);
+  }
+
+  protected render() {
+    if (!this._config || !this.hass) {
+      return nothing;
+    }
+
+    const stateObj = this.hass.states[this._config.entity] as
+      | UpdateEntity
+      | undefined;
+
+    if (!stateObj) {
+      return html`
+        <hui-warning>
+          ${createEntityNotFoundWarning(this.hass, this._config.entity)}
+        </hui-warning>
+      `;
+    }
+
+    return html`
+      <hui-generic-entity-row .hass=${this.hass} .config=${this._config}>
+        ${computeUpdateStateDisplay(stateObj, this.hass)}
+      </hui-generic-entity-row>
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      div {
+        text-align: right;
+      }
+      .pointer {
+        cursor: pointer;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-update-entity-row": HuiUpdateEntityRow;
+  }
+}

--- a/src/state-summary/state-card-content.js
+++ b/src/state-summary/state-card-content.js
@@ -24,6 +24,7 @@ import "./state-card-select";
 import "./state-card-text";
 import "./state-card-timer";
 import "./state-card-toggle";
+import "./state-card-update";
 import "./state-card-vacuum";
 import "./state-card-water_heater";
 

--- a/src/state-summary/state-card-update.ts
+++ b/src/state-summary/state-card-update.ts
@@ -1,0 +1,56 @@
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators";
+import "../components/entity/state-info";
+import { computeUpdateStateDisplay, UpdateEntity } from "../data/update";
+import { haStyle } from "../resources/styles";
+import type { HomeAssistant } from "../types";
+
+@customElement("state-card-update")
+export class StateCardUpdate extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public stateObj!: UpdateEntity;
+
+  @property({ type: Boolean }) public inDialog = false;
+
+  protected render(): TemplateResult {
+    return html`
+      <div class="horizontal justified layout">
+        <state-info
+          .hass=${this.hass}
+          .stateObj=${this.stateObj}
+          .inDialog=${this.inDialog}
+        >
+        </state-info>
+        <div class="state">
+          ${computeUpdateStateDisplay(this.stateObj, this.hass)}
+        </div>
+      </div>
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      haStyle,
+      css`
+        state-info {
+          flex: 0 1 fit-content;
+          min-width: 120px;
+        }
+        .state {
+          color: var(--primary-text-color);
+          margin-inline-start: 16px;
+          margin-inline-end: initial;
+          text-align: var(--float-end, right);
+          min-width: 50px;
+          flex: 0 1 fit-content;
+          word-break: break-word;
+          display: flex;
+          align-items: center;
+          direction: ltr;
+          justify-content: flex-end;
+        }
+      `,
+    ];
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -936,8 +936,6 @@
           "setting": "Setting"
         },
         "update": {
-          "installed_version": "Installed version",
-          "latest_version": "Latest version",
           "release_announcement": "Read release announcement",
           "skip": "Skip",
           "clear_skipped": "Clear skipped",


### PR DESCRIPTION
## Proposed change

Previously, all the state display logic for `update` entities was done with the state translation function.
One of the issue was that `on` state was using the latest version number in the automation editor as state translation.

![CleanShot 2023-11-10 at 15 25 49](https://github.com/home-assistant/frontend/assets/5878303/a7da9755-d60e-40e1-821d-2408618be4c9)

This PR move the display logic into card components (e.g. tile, entity row, state content) so state translation can work in the automation editor.

After the fix, automation editor uses translations and card uses special display.

![CleanShot 2023-11-10 at 15 40 36](https://github.com/home-assistant/frontend/assets/5878303/1ae4e5ae-d643-4a53-be6e-d0aed73c1efd)
![CleanShot 2023-11-10 at 15 40 04](https://github.com/home-assistant/frontend/assets/5878303/12cf3ced-e18b-4ede-8b58-f5f7ba871415)

Needs https://github.com/home-assistant/core/pull/103752

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
