### PR TITLE
Polyfill ElementInternals for material-web components. Fix #18600

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "date-fns-tz": "2.0.0",
     "deep-clone-simple": "1.1.1",
     "deep-freeze": "0.0.1",
+    "element-internals-polyfill": "1.3.9",
     "fuse.js": "7.0.0",
     "google-timezones-json": "1.2.0",
     "hls.js": "1.4.12",

--- a/src/components/chips/ha-assist-chip.ts
+++ b/src/components/chips/ha-assist-chip.ts
@@ -1,3 +1,4 @@
+import "element-internals-polyfill";
 import { MdAssistChip } from "@material/web/chips/assist-chip";
 import { css, html } from "lit";
 import { customElement, property } from "lit/decorators";

--- a/src/components/chips/ha-chip-set.ts
+++ b/src/components/chips/ha-chip-set.ts
@@ -1,3 +1,4 @@
+import "element-internals-polyfill";
 import { MdChipSet } from "@material/web/chips/chip-set";
 import { customElement } from "lit/decorators";
 

--- a/src/components/chips/ha-filter-chip.ts
+++ b/src/components/chips/ha-filter-chip.ts
@@ -1,3 +1,4 @@
+import "element-internals-polyfill";
 import { MdFilterChip } from "@material/web/chips/filter-chip";
 import { css, html } from "lit";
 import { customElement, property } from "lit/decorators";

--- a/src/components/chips/ha-input-chip.ts
+++ b/src/components/chips/ha-input-chip.ts
@@ -1,3 +1,4 @@
+import "element-internals-polyfill";
 import { MdInputChip } from "@material/web/chips/input-chip";
 import { css } from "lit";
 import { customElement } from "lit/decorators";

--- a/src/components/ha-outlined-button.ts
+++ b/src/components/ha-outlined-button.ts
@@ -1,5 +1,6 @@
 import { css } from "lit";
 import { customElement } from "lit/decorators";
+import "element-internals-polyfill";
 import { MdOutlinedButton } from "@material/web/button/outlined-button";
 
 @customElement("ha-outlined-button")

--- a/src/components/ha-outlined-icon-button.ts
+++ b/src/components/ha-outlined-icon-button.ts
@@ -1,5 +1,6 @@
 import { css } from "lit";
 import { customElement } from "lit/decorators";
+import "element-internals-polyfill";
 import { MdOutlinedIconButton } from "@material/web/iconbutton/outlined-icon-button";
 
 @customElement("ha-outlined-icon-button")

--- a/src/components/ha-slider.ts
+++ b/src/components/ha-slider.ts
@@ -1,6 +1,7 @@
 import { customElement } from "lit/decorators";
 import { MdSlider } from "@material/web/slider/slider";
 import { CSSResult, css } from "lit";
+import "element-internals-polyfill";
 
 @customElement("ha-slider")
 export class HaSlider extends MdSlider {

--- a/src/components/ha-slider.ts
+++ b/src/components/ha-slider.ts
@@ -1,7 +1,7 @@
 import { customElement } from "lit/decorators";
+import "element-internals-polyfill";
 import { MdSlider } from "@material/web/slider/slider";
 import { CSSResult, css } from "lit";
-import "element-internals-polyfill";
 
 @customElement("ha-slider")
 export class HaSlider extends MdSlider {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7621,6 +7621,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"element-internals-polyfill@npm:1.3.9":
+  version: 1.3.9
+  resolution: "element-internals-polyfill@npm:1.3.9"
+  checksum: bd9b63e68ca3462ed7623758398d5b8016736438b02be4527e456711bb91afe93af60028ddb928e12f0f1975c958c7b439d4b31a1ec41f4737969cd0202bcced
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^10.2.1":
   version: 10.3.0
   resolution: "emoji-regex@npm:10.3.0"
@@ -9720,6 +9727,7 @@ __metadata:
     deep-clone-simple: "npm:1.1.1"
     deep-freeze: "npm:0.0.1"
     del: "npm:7.1.0"
+    element-internals-polyfill: "npm:1.3.9"
     eslint: "npm:8.53.0"
     eslint-config-airbnb-base: "npm:15.0.0"
     eslint-config-airbnb-typescript: "npm:17.1.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add elementInternals polyfil to improve compatibility with older safari versions (particularly mobile).

~~I put this on ha-slider because that's where I have found the problem, but it may be necessary at other places too since many material-web components seem to rely on `attachInternals`.
I tried `/src/resources/compatibility.ts`, but that caused issues with scoped-custom-elements-registry for some reason.~~

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
