### PR TITLE
Localization bugfixes in config devices/entities/helpers

### DIFF
--- a/src/panels/config/devices/ha-config-devices-dashboard.ts
+++ b/src/panels/config/devices/ha-config-devices-dashboard.ts
@@ -285,145 +285,143 @@ export class HaConfigDeviceDashboard extends LitElement {
     }
   );
 
-  private _columns = memoizeOne((narrow: boolean, showDisabled: boolean) => {
-    type DeviceItem = ReturnType<
-      typeof this._devicesAndFilterDomains
-    >["devicesOutput"][number];
+  private _columns = memoizeOne(
+    (localize: LocalizeFunc, narrow: boolean, showDisabled: boolean) => {
+      type DeviceItem = ReturnType<
+        typeof this._devicesAndFilterDomains
+      >["devicesOutput"][number];
 
-    const columns: DataTableColumnContainer<DeviceItem> = {
-      icon: {
-        title: "",
-        type: "icon",
-        template: (device) =>
-          device.domains.length
-            ? html`<img
-                alt=""
-                crossorigin="anonymous"
-                referrerpolicy="no-referrer"
-                src=${brandsUrl({
-                  domain: device.domains[0],
-                  type: "icon",
-                  darkOptimized: this.hass.themes?.darkMode,
-                })}
-              />`
-            : "",
-      },
-    };
+      const columns: DataTableColumnContainer<DeviceItem> = {
+        icon: {
+          title: "",
+          type: "icon",
+          template: (device) =>
+            device.domains.length
+              ? html`<img
+                  alt=""
+                  crossorigin="anonymous"
+                  referrerpolicy="no-referrer"
+                  src=${brandsUrl({
+                    domain: device.domains[0],
+                    type: "icon",
+                    darkOptimized: this.hass.themes?.darkMode,
+                  })}
+                />`
+              : "",
+        },
+      };
 
-    if (narrow) {
-      columns.name = {
-        title: this.hass.localize("ui.panel.config.devices.data_table.device"),
-        main: true,
+      if (narrow) {
+        columns.name = {
+          title: localize("ui.panel.config.devices.data_table.device"),
+          main: true,
+          sortable: true,
+          filterable: true,
+          direction: "asc",
+          grows: true,
+          template: (device) => html`
+            ${device.name}
+            <div class="secondary">${device.area} | ${device.integration}</div>
+          `,
+        };
+      } else {
+        columns.name = {
+          title: localize("ui.panel.config.devices.data_table.device"),
+          main: true,
+          sortable: true,
+          filterable: true,
+          grows: true,
+          direction: "asc",
+        };
+      }
+
+      columns.manufacturer = {
+        title: localize("ui.panel.config.devices.data_table.manufacturer"),
+        sortable: true,
+        hidden: narrow,
+        filterable: true,
+        width: "15%",
+      };
+      columns.model = {
+        title: localize("ui.panel.config.devices.data_table.model"),
+        sortable: true,
+        hidden: narrow,
+        filterable: true,
+        width: "15%",
+      };
+      columns.area = {
+        title: localize("ui.panel.config.devices.data_table.area"),
+        sortable: true,
+        hidden: narrow,
+        filterable: true,
+        width: "15%",
+      };
+      columns.integration = {
+        title: localize("ui.panel.config.devices.data_table.integration"),
+        sortable: true,
+        hidden: narrow,
+        filterable: true,
+        width: "15%",
+      };
+      columns.battery_entity = {
+        title: localize("ui.panel.config.devices.data_table.battery"),
         sortable: true,
         filterable: true,
-        direction: "asc",
-        grows: true,
-        template: (device) => html`
-          ${device.name}
-          <div class="secondary">${device.area} | ${device.integration}</div>
-        `,
-      };
-    } else {
-      columns.name = {
-        title: this.hass.localize("ui.panel.config.devices.data_table.device"),
-        main: true,
-        sortable: true,
-        filterable: true,
-        grows: true,
-        direction: "asc",
-      };
-    }
-
-    columns.manufacturer = {
-      title: this.hass.localize(
-        "ui.panel.config.devices.data_table.manufacturer"
-      ),
-      sortable: true,
-      hidden: narrow,
-      filterable: true,
-      width: "15%",
-    };
-    columns.model = {
-      title: this.hass.localize("ui.panel.config.devices.data_table.model"),
-      sortable: true,
-      hidden: narrow,
-      filterable: true,
-      width: "15%",
-    };
-    columns.area = {
-      title: this.hass.localize("ui.panel.config.devices.data_table.area"),
-      sortable: true,
-      hidden: narrow,
-      filterable: true,
-      width: "15%",
-    };
-    columns.integration = {
-      title: this.hass.localize(
-        "ui.panel.config.devices.data_table.integration"
-      ),
-      sortable: true,
-      hidden: narrow,
-      filterable: true,
-      width: "15%",
-    };
-    columns.battery_entity = {
-      title: this.hass.localize("ui.panel.config.devices.data_table.battery"),
-      sortable: true,
-      filterable: true,
-      type: "numeric",
-      width: narrow ? "95px" : "15%",
-      maxWidth: "95px",
-      valueColumn: "battery_level",
-      template: (device) => {
-        const batteryEntityPair = device.battery_entity;
-        const battery =
-          batteryEntityPair && batteryEntityPair[0]
-            ? this.hass.states[batteryEntityPair[0]]
+        type: "numeric",
+        width: narrow ? "95px" : "15%",
+        maxWidth: "95px",
+        valueColumn: "battery_level",
+        template: (device) => {
+          const batteryEntityPair = device.battery_entity;
+          const battery =
+            batteryEntityPair && batteryEntityPair[0]
+              ? this.hass.states[batteryEntityPair[0]]
+              : undefined;
+          const batteryDomain = battery
+            ? computeStateDomain(battery)
             : undefined;
-        const batteryDomain = battery ? computeStateDomain(battery) : undefined;
-        const batteryCharging =
-          batteryEntityPair && batteryEntityPair[1]
-            ? this.hass.states[batteryEntityPair[1]]
-            : undefined;
+          const batteryCharging =
+            batteryEntityPair && batteryEntityPair[1]
+              ? this.hass.states[batteryEntityPair[1]]
+              : undefined;
 
-        return battery &&
-          (batteryDomain === "binary_sensor" || !isNaN(battery.state as any))
-          ? html`
-              ${batteryDomain === "sensor"
-                ? this.hass.formatEntityState(battery)
-                : nothing}
-              <ha-battery-icon
-                .hass=${this.hass}
-                .batteryStateObj=${battery}
-                .batteryChargingStateObj=${batteryCharging}
-              ></ha-battery-icon>
-            `
-          : html`—`;
-      },
-    };
-    if (showDisabled) {
-      columns.disabled_by = {
-        title: "",
-        label: this.hass.localize(
-          "ui.panel.config.devices.data_table.disabled_by"
-        ),
-        type: "icon",
-        template: (device) =>
-          device.disabled_by
-            ? html`<div
-                tabindex="0"
-                style="display:inline-block; position: relative;"
-              >
-                <ha-svg-icon .path=${mdiCancel}></ha-svg-icon>
-                <simple-tooltip animation-delay="0" position="left">
-                  ${this.hass.localize("ui.panel.config.devices.disabled")}
-                </simple-tooltip>
-              </div>`
-            : "—",
+          return battery &&
+            (batteryDomain === "binary_sensor" || !isNaN(battery.state as any))
+            ? html`
+                ${batteryDomain === "sensor"
+                  ? this.hass.formatEntityState(battery)
+                  : nothing}
+                <ha-battery-icon
+                  .hass=${this.hass}
+                  .batteryStateObj=${battery}
+                  .batteryChargingStateObj=${batteryCharging}
+                ></ha-battery-icon>
+              `
+            : html`—`;
+        },
       };
+      if (showDisabled) {
+        columns.disabled_by = {
+          title: "",
+          label: localize("ui.panel.config.devices.data_table.disabled_by"),
+          type: "icon",
+          template: (device) =>
+            device.disabled_by
+              ? html`<div
+                  tabindex="0"
+                  style="display:inline-block; position: relative;"
+                >
+                  <ha-svg-icon .path=${mdiCancel}></ha-svg-icon>
+                  <simple-tooltip animation-delay="0" position="left">
+                    ${this.hass.localize("ui.panel.config.devices.disabled")}
+                  </simple-tooltip>
+                </div>`
+              : "—",
+        };
+      }
+      return columns;
     }
-    return columns;
-  });
+  );
 
   public willUpdate(changedProps) {
     if (changedProps.has("_searchParms")) {
@@ -474,7 +472,11 @@ export class HaConfigDeviceDashboard extends LitElement {
           "number",
           this._numHiddenDevices
         )}
-        .columns=${this._columns(this.narrow, this._showDisabled)}
+        .columns=${this._columns(
+          this.hass.localize,
+          this.narrow,
+          this._showDisabled
+        )}
         .data=${devicesOutput}
         .filter=${this._filter}
         @clear-filter=${this._clearFilter}

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -84,6 +84,7 @@ export interface EntityRow extends StateEntity {
   restored: boolean;
   status: string;
   area?: string;
+  localized_platform: string;
 }
 
 @customElement("ha-config-entities")
@@ -176,12 +177,15 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
   );
 
   private _columns = memoize(
-    (narrow, _language, showDisabled): DataTableColumnContainer<EntityRow> => ({
+    (
+      localize: LocalizeFunc,
+      narrow,
+      _language,
+      showDisabled
+    ): DataTableColumnContainer<EntityRow> => ({
       icon: {
         title: "",
-        label: this.hass.localize(
-          "ui.panel.config.entities.picker.headers.state_icon"
-        ),
+        label: localize("ui.panel.config.entities.picker.headers.state_icon"),
         type: "icon",
         template: (entry) => html`
           <ha-state-icon
@@ -193,9 +197,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
       },
       name: {
         main: true,
-        title: this.hass.localize(
-          "ui.panel.config.entities.picker.headers.name"
-        ),
+        title: localize("ui.panel.config.entities.picker.headers.name"),
         sortable: true,
         filterable: true,
         direction: "asc",
@@ -204,47 +206,34 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
           ? (entry) => html`
               ${entry.name}<br />
               <div class="secondary">
-                ${entry.entity_id} |
-                ${this.hass.localize(`component.${entry.platform}.title`) ||
-                entry.platform}
+                ${entry.entity_id} | ${entry.localized_platform}
               </div>
             `
           : undefined,
       },
       entity_id: {
-        title: this.hass.localize(
-          "ui.panel.config.entities.picker.headers.entity_id"
-        ),
+        title: localize("ui.panel.config.entities.picker.headers.entity_id"),
         hidden: narrow,
         sortable: true,
         filterable: true,
         width: "25%",
       },
-      platform: {
-        title: this.hass.localize(
-          "ui.panel.config.entities.picker.headers.integration"
-        ),
+      localized_platform: {
+        title: localize("ui.panel.config.entities.picker.headers.integration"),
         hidden: narrow,
         sortable: true,
         filterable: true,
         width: "20%",
-        template: (entry) =>
-          this.hass.localize(`component.${entry.platform}.title`) ||
-          entry.platform,
       },
       area: {
-        title: this.hass.localize(
-          "ui.panel.config.entities.picker.headers.area"
-        ),
+        title: localize("ui.panel.config.entities.picker.headers.area"),
         sortable: true,
         hidden: narrow,
         filterable: true,
         width: "15%",
       },
       disabled_by: {
-        title: this.hass.localize(
-          "ui.panel.config.entities.picker.headers.disabled_by"
-        ),
+        title: localize("ui.panel.config.entities.picker.headers.disabled_by"),
         sortable: true,
         hidden: narrow || !showDisabled,
         filterable: true,
@@ -257,9 +246,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
               ),
       },
       status: {
-        title: this.hass.localize(
-          "ui.panel.config.entities.picker.headers.status"
-        ),
+        title: localize("ui.panel.config.entities.picker.headers.status"),
         type: "icon",
         sortable: true,
         filterable: true,
@@ -432,6 +419,9 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
           ),
           unavailable,
           restored,
+          localized_platform:
+            this.hass.localize(`component.${entry.platform}.title`) ||
+            entry.platform,
           area: area ? area.name : "—",
           status: restored
             ? this.hass.localize(
@@ -526,6 +516,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
         .route=${this.route}
         .tabs=${configSections.devices}
         .columns=${this._columns(
+          this.hass.localize,
           this.narrow,
           this.hass.language,
           this._showDisabled

--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -305,6 +305,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
 
   private _filteredEntitiesAndDomains = memoize(
     (
+      localize: LocalizeFunc,
       entities: StateEntity[],
       devices: DeviceRegistryEntry[] | undefined,
       areas: AreaRegistryEntry[] | undefined,
@@ -420,22 +421,15 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
           unavailable,
           restored,
           localized_platform:
-            this.hass.localize(`component.${entry.platform}.title`) ||
-            entry.platform,
+            localize(`component.${entry.platform}.title`) || entry.platform,
           area: area ? area.name : "—",
           status: restored
-            ? this.hass.localize(
-                "ui.panel.config.entities.picker.status.restored"
-              )
+            ? localize("ui.panel.config.entities.picker.status.restored")
             : unavailable
-            ? this.hass.localize(
-                "ui.panel.config.entities.picker.status.unavailable"
-              )
+            ? localize("ui.panel.config.entities.picker.status.unavailable")
             : entry.disabled_by
-            ? this.hass.localize(
-                "ui.panel.config.entities.picker.status.disabled"
-              )
-            : this.hass.localize("ui.panel.config.entities.picker.status.ok"),
+            ? localize("ui.panel.config.entities.picker.status.disabled")
+            : localize("ui.panel.config.entities.picker.status.ok"),
         });
       }
 
@@ -488,6 +482,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
 
     const { filteredEntities, filteredDomains } =
       this._filteredEntitiesAndDomains(
+        this.hass.localize,
         this._entities,
         this._devices,
         this._areas,
@@ -958,6 +953,7 @@ export class HaConfigEntities extends SubscribeMixin(LitElement) {
   private _addDevice() {
     const { filteredConfigEntry, filteredDomains } =
       this._filteredEntitiesAndDomains(
+        this.hass.localize,
         this._entities!,
         this._devices,
         this._areas,

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -158,19 +158,11 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
           width: "25%",
         };
       }
-      columns.type = {
+      columns.localized_type = {
         title: localize("ui.panel.config.helpers.picker.headers.type"),
         sortable: true,
         width: "25%",
         filterable: true,
-        template: (helper) =>
-          helper.configEntry
-            ? domainToName(localize, helper.type)
-            : html`
-                ${localize(
-                  `ui.panel.config.helpers.types.${helper.type}` as LocalizeKeys
-                ) || helper.type}
-              `,
       };
       columns.editable = {
         title: "",
@@ -202,6 +194,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
 
   private _getItems = memoizeOne(
     (
+      localize: LocalizeFunc,
       stateItems: HassEntity[],
       entityEntries: Record<string, EntityRegistryEntry>,
       configEntries: Record<string, ConfigEntry>
@@ -248,7 +241,14 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
         entity: undefined,
       }));
 
-      return [...states, ...entries];
+      return [...states, ...entries].map((item) => ({
+        ...item,
+        localized_type: item.configEntry
+          ? domainToName(localize, item.type)
+          : localize(
+              `ui.panel.config.helpers.types.${item.type}` as LocalizeKeys
+            ) || item.type,
+      }));
     }
   );
 
@@ -271,6 +271,7 @@ export class HaConfigHelpers extends SubscribeMixin(LitElement) {
         .tabs=${configSections.devices}
         .columns=${this._columns(this.narrow, this.hass.localize)}
         .data=${this._getItems(
+          this.hass.localize,
           this._stateItems,
           this._entityEntries,
           this._configEntries


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Fix two issues in config data tables:

### 1. 

Occasionally on refresh devices and entities table render without header labels:

![image](https://github.com/home-assistant/frontend/assets/32912880/29ccc2a5-0aff-4652-91ba-4889e1a696d3)

There was a race condition where the columns were being memoized with the initial dummy localization function, and never refreshed when hass.localize updated. This adds the function pointer to the memoize function. 


### 2. 

The integration column in Entities table, and the type column in Helpers table, were applying sort/filter on the backend integration name, but displaying the pretty/translated name, which makes the sort and filter behave unexpectedly. 

For example, you can have helpers which have the type "Combine the state of several entities". If you search for "combine", you will have no results, because the row is actually comparing against `min_max`, which no one would ever guess to type. Also it makes "Combine" sort alphabetically after "M" which is unexpected. Similar problems with `Dropdown`, `Riemann`, `Toggle`, etc. 

This changes the table logic to sort and filter on the displayed text, not the pre-translation value. 



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
