### PR TITLE
Fix yaml editor lovelace

### DIFF
--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -343,26 +343,25 @@ export class LovelacePanel extends LitElement {
         this._panelState = "yaml-editor";
       },
       setEditMode: (editMode: boolean) => {
+        // If the dashboard is generated (default dashboard)
+        // Propose de to take control of it
+        if (this.lovelace!.mode === "generated" && editMode) {
+          showSaveDialog(this, {
+            lovelace: this.lovelace!,
+            mode: this.panel!.config.mode,
+            narrow: this.narrow!,
+          });
+          return;
+        }
+
         // If we use a strategy for dashboard, we cannot show the edit UI
         // So go straight to the YAML editor
-        if (
-          this.lovelace!.rawConfig &&
-          this.lovelace!.rawConfig !== this.lovelace!.config
-        ) {
+        if (isStrategyDashboard(this.lovelace!.rawConfig) && editMode) {
           this.lovelace!.enableFullEditMode();
           return;
         }
 
-        if (!editMode || this.lovelace!.mode !== "generated") {
-          this._updateLovelace({ editMode });
-          return;
-        }
-
-        showSaveDialog(this, {
-          lovelace: this.lovelace!,
-          mode: this.panel!.config.mode,
-          narrow: this.narrow!,
-        });
+        this._updateLovelace({ editMode });
       },
       saveConfig: async (newConfig: LovelaceRawConfig): Promise<void> => {
         const {

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -344,7 +344,7 @@ export class LovelacePanel extends LitElement {
       },
       setEditMode: (editMode: boolean) => {
         // If the dashboard is generated (default dashboard)
-        // Propose de to take control of it
+        // Propose to take control of it
         if (this.lovelace!.mode === "generated" && editMode) {
           showSaveDialog(this, {
             lovelace: this.lovelace!,

--- a/src/panels/lovelace/hui-root.ts
+++ b/src/panels/lovelace/hui-root.ts
@@ -558,19 +558,26 @@ class HUIRoot extends LitElement {
           view.visible.some((show) => show.user === this.hass!.user?.id))
     );
 
+  private _clearParam(param: string) {
+    window.history.replaceState(
+      null,
+      "",
+      constructUrlCurrentPath(removeSearchParam(param))
+    );
+  }
+
   protected firstUpdated(changedProps: PropertyValues) {
     super.firstUpdated(changedProps);
     // Check for requested edit mode
     const searchParams = extractSearchParamsObject();
-    if (searchParams.edit === "1" && this.hass!.user?.is_admin) {
-      this.lovelace!.setEditMode(true);
+    if (searchParams.edit === "1") {
+      this._clearParam("edit");
+      if (this.hass!.user?.is_admin) {
+        this.lovelace!.setEditMode(true);
+      }
     } else if (searchParams.conversation === "1") {
+      this._clearParam("conversation");
       this._showVoiceCommandDialog();
-      window.history.replaceState(
-        null,
-        "",
-        constructUrlCurrentPath(removeSearchParam("conversation"))
-      );
     }
     window.addEventListener("scroll", this._handleWindowScroll, {
       passive: true,


### PR DESCRIPTION
## Proposed change

Fix 2 issues : 
- It wasn't possible to take control on the default dashboard since https://github.com/home-assistant/frontend/pull/18652
- it wasn't possible to exit the yaml editor for strategy with `edit=1` param.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
