### PR TITLE
Add minimal UI for climate and water entity without target

### DIFF
--- a/src/components/ha-control-circular-slider.ts
+++ b/src/components/ha-control-circular-slider.ts
@@ -66,6 +66,9 @@ export class HaControlCircularSlider extends LitElement {
   @property({ type: Boolean, reflect: true })
   public disabled = false;
 
+  @property({ type: Boolean, reflect: true })
+  public readonly = false;
+
   @property({ type: Boolean })
   public dual?: boolean;
 
@@ -258,7 +261,7 @@ export class HaControlCircularSlider extends LitElement {
         e.srcEvent.preventDefault();
       });
       this._mc.on("panstart", (e) => {
-        if (this.disabled) return;
+        if (this.disabled || this.readonly) return;
         const percentage = this._getPercentageFromEvent(e);
         const raw = this._percentageToValue(percentage);
         this._activeSlider = this._findActiveSlider(raw);
@@ -266,11 +269,11 @@ export class HaControlCircularSlider extends LitElement {
         this.shadowRoot?.getElementById("#slider")?.focus();
       });
       this._mc.on("pancancel", () => {
-        if (this.disabled) return;
+        if (this.disabled || this.readonly) return;
         this._activeSlider = undefined;
       });
       this._mc.on("panmove", (e) => {
-        if (this.disabled) return;
+        if (this.disabled || this.readonly) return;
         const percentage = this._getPercentageFromEvent(e);
         const raw = this._percentageToValue(percentage);
         const bounded = this._boundedValue(raw);
@@ -281,7 +284,7 @@ export class HaControlCircularSlider extends LitElement {
         }
       });
       this._mc.on("panend", (e) => {
-        if (this.disabled) return;
+        if (this.disabled || this.readonly) return;
         const percentage = this._getPercentageFromEvent(e);
         const raw = this._percentageToValue(percentage);
         const bounded = this._boundedValue(raw);
@@ -296,7 +299,7 @@ export class HaControlCircularSlider extends LitElement {
         this._activeSlider = undefined;
       });
       this._mc.on("singletap", (e) => {
-        if (this.disabled) return;
+        if (this.disabled || this.readonly) return;
         const percentage = this._getPercentageFromEvent(e);
         const raw = this._percentageToValue(percentage);
         this._activeSlider = this._findActiveSlider(raw);
@@ -436,11 +439,15 @@ export class HaControlCircularSlider extends LitElement {
         ? current <= target
         : false;
 
-    const activeArc = showActive
-      ? mode === "end"
-        ? this._strokeDashArc(target, current)
-        : this._strokeDashArc(current, target)
-      : this._strokeCircleDashArc(target);
+    const showTarget = value != null;
+
+    const activeArc = showTarget
+      ? showActive
+        ? mode === "end"
+          ? this._strokeDashArc(target, current)
+          : this._strokeDashArc(current, target)
+        : this._strokeCircleDashArc(target)
+      : undefined;
 
     const coloredArc =
       mode === "full"
@@ -449,7 +456,9 @@ export class HaControlCircularSlider extends LitElement {
         ? this._strokeDashArc(target, limit)
         : this._strokeDashArc(limit, target);
 
-    const targetCircle = this._strokeCircleDashArc(target);
+    const targetCircle = showTarget
+      ? this._strokeCircleDashArc(target)
+      : undefined;
 
     const currentCircle =
       this.current != null &&
@@ -473,26 +482,33 @@ export class HaControlCircularSlider extends LitElement {
           stroke-dasharray=${coloredArc[0]}
           stroke-dashoffset=${coloredArc[1]}
         />
-        <path
-          .id=${id}
-          d=${path}
-          class="arc arc-active ${classMap({ [id]: true })}"
-          stroke-dasharray=${activeArc[0]}
-          stroke-dashoffset=${activeArc[1]}
-          role="slider"
-          tabindex="0"
-          aria-valuemin=${this.min}
-          aria-valuemax=${this.max}
-          aria-valuenow=${
-            this._localValue != null
-              ? this._steppedValue(this._localValue)
-              : undefined
-          }
-          aria-disabled=${this.disabled}
-          aria-label=${ifDefined(this.lowLabel ?? this.label)}
-          @keydown=${this._handleKeyDown}
-          @keyup=${this._handleKeyUp}
-        />
+        ${
+          activeArc
+            ? svg`
+              <path
+                .id=${id}
+                d=${path}
+                class="arc arc-active ${classMap({ [id]: true })}"
+                stroke-dasharray=${activeArc[0]}
+                stroke-dashoffset=${activeArc[1]}
+                role="slider"
+                tabindex="0"
+                aria-valuemin=${this.min}
+                aria-valuemax=${this.max}
+                aria-valuenow=${
+                  this._localValue != null
+                    ? this._steppedValue(this._localValue)
+                    : undefined
+                }
+                aria-disabled=${this.disabled}
+                aria-readonly=${this.readonly}
+                aria-label=${ifDefined(this.lowLabel ?? this.label)}
+                @keydown=${this._handleKeyDown}
+                @keyup=${this._handleKeyUp}
+              />
+            `
+            : nothing
+        }
         ${
           currentCircle
             ? svg`
@@ -505,18 +521,24 @@ export class HaControlCircularSlider extends LitElement {
           `
             : nothing
         }
-        <path
-          class="target-border ${classMap({ [id]: true })}"
-          d=${path}
-          stroke-dasharray=${targetCircle[0]}
-          stroke-dashoffset=${targetCircle[1]}
-        />
-        <path
-          class="target"
-          d=${path}
-          stroke-dasharray=${targetCircle[0]}
-          stroke-dashoffset=${targetCircle[1]}
-        />
+        ${
+          targetCircle
+            ? svg`
+              <path
+                class="target-border ${classMap({ [id]: true })}"
+                d=${path}
+                stroke-dasharray=${targetCircle[0]}
+                stroke-dashoffset=${targetCircle[1]}
+              />
+              <path
+                class="target"
+                d=${path}
+                stroke-dasharray=${targetCircle[0]}
+                stroke-dashoffset=${targetCircle[1]}
+              />
+          `
+            : nothing
+        }
       </g>
     `;
   }
@@ -568,7 +590,7 @@ export class HaControlCircularSlider extends LitElement {
                   />
                 `
               : nothing}
-            ${lowValue != null
+            ${lowValue != null || this.mode === "full"
               ? this.renderArc(
                   this.dual ? "low" : "value",
                   lowValue,
@@ -615,7 +637,8 @@ export class HaControlCircularSlider extends LitElement {
       #display {
         pointer-events: none;
       }
-      :host([disabled]) #interaction {
+      :host([disabled]) #interaction,
+      :host([readonly]) #interaction {
         cursor: initial;
       }
 

--- a/src/dialogs/more-info/components/climate/ha-more-info-climate-temperature.ts
+++ b/src/dialogs/more-info/components/climate/ha-more-info-climate-temperature.ts
@@ -159,6 +159,21 @@ export class HaMoreInfoClimateTemperature extends LitElement {
       `;
     }
 
+    if (
+      !supportsFeature(
+        this.stateObj,
+        ClimateEntityFeature.TARGET_TEMPERATURE
+      ) &&
+      !supportsFeature(
+        this.stateObj,
+        ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+      )
+    ) {
+      return html`
+        <p class="label">${this.hass.formatEntityState(this.stateObj)}</p>
+      `;
+    }
+
     const action = this.stateObj.attributes.hvac_action;
 
     const actionLabel = this.hass.formatEntityAttributeValue(
@@ -383,15 +398,17 @@ export class HaMoreInfoClimateTemperature extends LitElement {
       <div
         class="container"
         style=${styleMap({
-          "--action-color": actionColor,
+          "--state-color": stateColor,
         })}
       >
         <ha-control-circular-slider
+          mode="full"
           .current=${this.stateObj.attributes.current_temperature}
           .min=${this._min}
           .max=${this._max}
           .step=${this._step}
-          disabled
+          readonly
+          .disabled=${!active}
         >
         </ha-control-circular-slider>
         <div class="info">

--- a/src/dialogs/more-info/components/water_heater/ha-more-info-water_heater-temperature.ts
+++ b/src/dialogs/more-info/components/water_heater/ha-more-info-water_heater-temperature.ts
@@ -99,6 +99,17 @@ export class HaMoreInfoWaterHeaterTemperature extends LitElement {
       `;
     }
 
+    if (
+      !supportsFeature(
+        this.stateObj,
+        WaterHeaterEntityFeature.TARGET_TEMPERATURE
+      )
+    ) {
+      return html`
+        <p class="label">${this.hass.formatEntityState(this.stateObj)}</p>
+      `;
+    }
+
     return html`
       <p class="label">
         ${this.hass.localize(
@@ -202,13 +213,20 @@ export class HaMoreInfoWaterHeaterTemperature extends LitElement {
     }
 
     return html`
-      <div class="container">
+      <div
+        class="container"
+        style=${styleMap({
+          "--state-color": stateColor,
+        })}
+      >
         <ha-control-circular-slider
+          mode="full"
           .current=${this.stateObj.attributes.current_temperature}
           .min=${this._min}
           .max=${this._max}
           .step=${this._step}
-          disabled
+          readonly
+          .disabled=${!active}
         >
         </ha-control-circular-slider>
         <div class="info">


### PR DESCRIPTION
## Proposed change

Some climate or water heater can not support target temperature (e.g. evohome, hive, nibe_heatpump, qubino wire pilot (custom integration)). This PR adds minimal UI for those entities to reflect at least the hvac mode or operation mode.

### Before
![CleanShot 2023-11-15 at 17 53 04](https://github.com/home-assistant/frontend/assets/5878303/41d69882-0a04-4996-b0ed-3c258382e299)

### After
![CleanShot 2023-11-15 at 17 51 59](https://github.com/home-assistant/frontend/assets/5878303/c719d6e5-6ba8-46fb-bdf0-4836f906a905)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
