### PR TITLE
Restore map filter theme

### DIFF
--- a/src/components/map/ha-map.ts
+++ b/src/components/map/ha-map.ts
@@ -151,8 +151,14 @@ export class HaMap extends ReactiveElement {
     ) {
       return;
     }
-    const darkMode = this.darkMode ?? this.hass.themes?.darkMode;
-    this.shadowRoot!.getElementById("map")!.classList.toggle("dark", darkMode);
+    this._updateMapStyle();
+  }
+
+  private _updateMapStyle(): void {
+    const darkMode = this.darkMode ?? this.hass.themes.darkMode;
+    const map = this.shadowRoot!.getElementById("map");
+    map!.classList.toggle("dark", darkMode);
+    map!.classList.toggle("forced-dark", this.darkMode);
   }
 
   private async _loadMap(): Promise<void> {
@@ -162,9 +168,8 @@ export class HaMap extends ReactiveElement {
       map.id = "map";
       this.shadowRoot!.append(map);
     }
-    const darkMode = this.darkMode ?? this.hass.themes.darkMode;
     [this.leafletMap, this.Leaflet] = await setupLeafletMap(map);
-    this.shadowRoot!.getElementById("map")!.classList.toggle("dark", darkMode);
+    this._updateMapStyle();
     this._loaded = true;
   }
 
@@ -496,7 +501,10 @@ export class HaMap extends ReactiveElement {
       }
       #map.dark {
         background: #090909;
-        --map-filter: invert(0.9) hue-rotate(170deg) grayscale(0.7);
+      }
+      #map.forced-dark {
+        --map-filter: invert(0.9) hue-rotate(170deg) brightness(1.5)
+          contrast(1.2) saturate(0.3);
       }
       #map:active {
         cursor: grabbing;


### PR DESCRIPTION
## Proposed change

It was possible to theme the map before https://github.com/home-assistant/frontend/pull/13297. This PR restore this behavior. It also updates the filter with the one proposed in https://github.com/home-assistant/frontend/pull/13243.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
