### PR TITLE
Add alert to zwave_js device info page for custom device config

### DIFF
--- a/src/data/zwave_js.ts
+++ b/src/data/zwave_js.ts
@@ -219,8 +219,9 @@ export interface ZwaveJSNodeMetadata {
   device_database_url: string;
 }
 
-export interface ZwaveJSNodeComments {
+export interface ZwaveJSNodeAlerts {
   comments: ZWaveJSNodeComment[];
+  is_embedded: boolean | null;
 }
 
 export interface ZWaveJSNodeConfigParams {
@@ -601,12 +602,12 @@ export const fetchZwaveNodeMetadata = (
     device_id,
   });
 
-export const fetchZwaveNodeComments = (
+export const fetchZwaveNodeAlerts = (
   hass: HomeAssistant,
   device_id: string
-): Promise<ZwaveJSNodeComments> =>
+): Promise<ZwaveJSNodeAlerts> =>
   hass.callWS({
-    type: "zwave_js/node_comments",
+    type: "zwave_js/node_alerts",
     device_id,
   });
 

--- a/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-alerts.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zwave_js/device-alerts.ts
@@ -1,5 +1,5 @@
 import { DeviceRegistryEntry } from "../../../../../../data/device_registry";
-import { fetchZwaveNodeComments } from "../../../../../../data/zwave_js";
+import { fetchZwaveNodeAlerts } from "../../../../../../data/zwave_js";
 import { HomeAssistant } from "../../../../../../types";
 import { DeviceAlert } from "../../../ha-config-device-page";
 
@@ -7,14 +7,27 @@ export const getZwaveDeviceAlerts = async (
   hass: HomeAssistant,
   device: DeviceRegistryEntry
 ): Promise<DeviceAlert[]> => {
-  const nodeComments = await fetchZwaveNodeComments(hass, device.id);
+  const nodeAlerts = await fetchZwaveNodeAlerts(hass, device.id);
+  const deviceAlerts: DeviceAlert[] = [];
 
-  if (!nodeComments?.comments?.length) {
-    return [];
+  if (nodeAlerts?.is_embedded === false) {
+    deviceAlerts.push({
+      level: "info",
+      text: hass.localize(
+        "ui.panel.config.zwave_js.device_info.custom_device_config"
+      ),
+    });
   }
 
-  return nodeComments.comments.map((comment) => ({
-    level: comment.level,
-    text: comment.text,
-  }));
+  if (!nodeAlerts?.comments?.length) {
+    return deviceAlerts;
+  }
+
+  deviceAlerts.push(
+    ...nodeAlerts.comments.map((comment) => ({
+      level: comment.level,
+      text: comment.text,
+    }))
+  );
+  return deviceAlerts;
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4055,7 +4055,7 @@
             "zwave_plus": "Z-Wave Plus",
             "zwave_plus_version": "Version {version}",
             "node_statistics": "Statistics",
-            "custom_device_config": "This device is using a custom device config file not provided by Z-Wave JS. Remove the custom device config file to use the default device config provided by Z-Wave JS."
+            "custom_device_config": "This device is using a custom device config file not provided by Z-Wave JS. If you want to use the default device config provided by Z-Wave JS, you must remove the custom device config file from the folder that Z-Wave JS is reading from."
           },
           "hard_reset_controller": {
             "NotStarted": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4054,7 +4054,8 @@
             "unknown": "Unknown",
             "zwave_plus": "Z-Wave Plus",
             "zwave_plus_version": "Version {version}",
-            "node_statistics": "Statistics"
+            "node_statistics": "Statistics",
+            "custom_device_config": "This device is using a custom device config file not provided by Z-Wave JS. Remove the custom device config file to use the default device config provided by Z-Wave JS."
           },
           "hard_reset_controller": {
             "NotStarted": {


### PR DESCRIPTION
## Proposed change
Z-Wave JS allows users to provide their own device config files. Because these files have to be stored on the filesystem that `zwave-js-server` is running from in order to use them, it's possible that a user forgets they put it there. With this change we can show an alert on the device info page letting them know that they are using a custom device config file.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to core pull request: https://github.com/home-assistant/core/pull/104115

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
