### PR TITLE
Ensure websocket_api error messages shows longer

### DIFF
--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -143,7 +143,10 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
                       ? "connection lost"
                       : "unknown error")
                   }`;
-              fireEvent(this as any, "hass-notification", { message });
+              fireEvent(this as any, "hass-notification", {
+                message,
+                duration: 10000,
+              });
             }
             throw err;
           }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Change the default 3 seconds duration to 10 seconds for `websocket_api` error messages.

With https://github.com/home-assistant/core/pull/102410 we do lo loner use persistent notifications when yaml config is reloaded. Insted an error is can be raised to ensure the reload is not effecting the current loaded entities.
The yaml config errors shouw through the UI and support translations but 3 seconds is to short for longer messages.
Suggestion is to increase this to 10 seconds.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
