### PR TITLE
Add a picture uploader to picture-card-editor

### DIFF
--- a/src/components/ha-picture-upload.ts
+++ b/src/components/ha-picture-upload.ts
@@ -2,7 +2,13 @@ import { mdiImagePlus } from "@mdi/js";
 import { LitElement, TemplateResult, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
-import { createImage, generateImageThumbnailUrl } from "../data/image_upload";
+import { haStyle } from "../resources/styles";
+import {
+  createImage,
+  deleteImage,
+  generateImageThumbnailUrl,
+  getIdFromUrl,
+} from "../data/image_upload";
 import { showAlertDialog } from "../dialogs/generic/show-dialog-box";
 import {
   CropOptions,
@@ -62,13 +68,21 @@ export class HaPictureUpload extends LitElement {
           alt=${this.currentImageAltText ||
           this.hass.localize("ui.components.picture-upload.current_image_alt")}
         />
-        <ha-button
-          @click=${this._handleChangeClick}
-          .label=${this.hass.localize(
-            "ui.components.picture-upload.change_picture"
-          )}
-        >
-        </ha-button>
+        <div>
+          <ha-button
+            @click=${this._handleChangeClick}
+            .label=${this.hass.localize(
+              "ui.components.picture-upload.change_picture"
+            )}
+          >
+          </ha-button>
+          <ha-button
+            class="warning"
+            @click=${this._handleDelete}
+            .label=${this.hass.localize("ui.common.delete")}
+          >
+          </ha-button>
+        </div>
       </div>
     </div>`;
   }
@@ -76,6 +90,15 @@ export class HaPictureUpload extends LitElement {
   private _handleChangeClick() {
     this.value = null;
     fireEvent(this, "change");
+  }
+
+  private async _handleDelete() {
+    const id = getIdFromUrl(this.value!);
+    if (id) {
+      await deleteImage(this.hass, id);
+      this.value = null;
+      fireEvent(this, "change");
+    }
   }
 
   private async _handleFilePicked(ev) {
@@ -140,32 +163,35 @@ export class HaPictureUpload extends LitElement {
   }
 
   static get styles() {
-    return css`
-      :host {
-        display: block;
-        height: 240px;
-      }
-      ha-file-upload {
-        height: 100%;
-      }
-      .center-vertical {
-        display: flex;
-        align-items: center;
-        height: 100%;
-      }
-      .value {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-      }
-      img {
-        max-width: 100%;
-        max-height: 200px;
-        margin-bottom: 4px;
-        border-radius: var(--file-upload-image-border-radius);
-      }
-    `;
+    return [
+      haStyle,
+      css`
+        :host {
+          display: block;
+          height: 240px;
+        }
+        ha-file-upload {
+          height: 100%;
+        }
+        .center-vertical {
+          display: flex;
+          align-items: center;
+          height: 100%;
+        }
+        .value {
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+        img {
+          max-width: 100%;
+          max-height: 200px;
+          margin-bottom: 4px;
+          border-radius: var(--file-upload-image-border-radius);
+        }
+      `,
+    ];
   }
 }
 

--- a/src/components/ha-picture-upload.ts
+++ b/src/components/ha-picture-upload.ts
@@ -1,5 +1,5 @@
 import { mdiImagePlus } from "@mdi/js";
-import { LitElement, TemplateResult, css, html } from "lit";
+import { LitElement, TemplateResult, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import { haStyle } from "../resources/styles";
@@ -34,6 +34,8 @@ export class HaPictureUpload extends LitElement {
   @property() public currentImageAltText?: string;
 
   @property({ type: Boolean }) public crop = false;
+
+  @property({ type: Boolean }) public canDelete = false;
 
   @property({ attribute: false }) public cropOptions?: CropOptions;
 
@@ -76,12 +78,14 @@ export class HaPictureUpload extends LitElement {
             )}
           >
           </ha-button>
-          <ha-button
-            class="warning"
-            @click=${this._handleDelete}
-            .label=${this.hass.localize("ui.common.delete")}
-          >
-          </ha-button>
+          ${this.canDelete
+            ? html`<ha-button
+                class="warning"
+                @click=${this._handleDelete}
+                .label=${this.hass.localize("ui.common.delete")}
+              >
+              </ha-button>`
+            : nothing}
         </div>
       </div>
     </div>`;

--- a/src/components/ha-picture-upload.ts
+++ b/src/components/ha-picture-upload.ts
@@ -1,14 +1,9 @@
 import { mdiImagePlus } from "@mdi/js";
-import { LitElement, TemplateResult, css, html, nothing } from "lit";
+import { LitElement, TemplateResult, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import { haStyle } from "../resources/styles";
-import {
-  createImage,
-  deleteImage,
-  generateImageThumbnailUrl,
-  getIdFromUrl,
-} from "../data/image_upload";
+import { createImage, generateImageThumbnailUrl } from "../data/image_upload";
 import { showAlertDialog } from "../dialogs/generic/show-dialog-box";
 import {
   CropOptions,
@@ -34,8 +29,6 @@ export class HaPictureUpload extends LitElement {
   @property() public currentImageAltText?: string;
 
   @property({ type: Boolean }) public crop = false;
-
-  @property({ type: Boolean }) public canDelete = false;
 
   @property({ attribute: false }) public cropOptions?: CropOptions;
 
@@ -78,14 +71,6 @@ export class HaPictureUpload extends LitElement {
             )}
           >
           </ha-button>
-          ${this.canDelete
-            ? html`<ha-button
-                class="warning"
-                @click=${this._handleDelete}
-                .label=${this.hass.localize("ui.common.delete")}
-              >
-              </ha-button>`
-            : nothing}
         </div>
       </div>
     </div>`;
@@ -94,15 +79,6 @@ export class HaPictureUpload extends LitElement {
   private _handleChangeClick() {
     this.value = null;
     fireEvent(this, "change");
-  }
-
-  private async _handleDelete() {
-    const id = getIdFromUrl(this.value!);
-    if (id) {
-      await deleteImage(this.hass, id);
-      this.value = null;
-      fireEvent(this, "change");
-    }
   }
 
   private async _handleFilePicked(ev) {

--- a/src/components/ha-selector/ha-selector-image.ts
+++ b/src/components/ha-selector/ha-selector-image.ts
@@ -49,7 +49,11 @@ export class HaImageSelector extends LitElement {
         <ha-icon-button
           @click=${this._handleUploadToggle}
           .path=${this.showUpload ? mdiUploadOff : mdiUpload}
-          .label=${this.hass.localize(`ui.common.upload`) || "Upload"}
+          .label=${this.hass.localize(
+            this.showUpload
+              ? "ui.components.selectors.image.upload_off"
+              : "ui.components.selectors.image.upload_on"
+          )}
         >
         </ha-icon-button>
       </div>

--- a/src/components/ha-selector/ha-selector-image.ts
+++ b/src/components/ha-selector/ha-selector-image.ts
@@ -83,7 +83,6 @@ export class HaImageSelector extends LitElement {
             `
           : html`
               <ha-picture-upload
-                canDelete
                 .hass=${this.hass}
                 .value=${this.value?.startsWith(URL_PREFIX) ? this.value : null}
                 @change=${this._pictureChanged}

--- a/src/components/ha-selector/ha-selector-image.ts
+++ b/src/components/ha-selector/ha-selector-image.ts
@@ -1,0 +1,113 @@
+import { mdiUpload, mdiUploadOff } from "@mdi/js";
+import { css, CSSResultGroup, html, nothing, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { fireEvent } from "../../common/dom/fire_event";
+import { ImageSelector } from "../../data/selector";
+import { HomeAssistant } from "../../types";
+import "../ha-icon-button";
+import "../ha-textarea";
+import "../ha-textfield";
+import "../ha-picture-upload";
+import type { HaPictureUpload } from "../ha-picture-upload";
+
+@customElement("ha-selector-image")
+export class HaImageSelector extends LitElement {
+  @property() public hass!: HomeAssistant;
+
+  @property() public value?: any;
+
+  @property() public name?: string;
+
+  @property() public label?: string;
+
+  @property() public placeholder?: string;
+
+  @property() public helper?: string;
+
+  @property() public selector!: ImageSelector;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = true;
+
+  @state() private showUpload = false;
+
+  protected render() {
+    return html`
+      <div class="row">
+        <ha-textfield
+          .name=${this.name}
+          .value=${this.value || ""}
+          .placeholder=${this.placeholder || ""}
+          .helper=${this.helper}
+          helperPersistent
+          .disabled=${this.disabled}
+          @input=${this._handleChange}
+          .label=${this.label || ""}
+          .required=${this.required}
+        ></ha-textfield>
+        <ha-icon-button
+          @click=${this._handleUploadToggle}
+          .path=${this.showUpload ? mdiUploadOff : mdiUpload}
+          .label=${this.hass.localize(`ui.common.upload`) || "Upload"}
+        >
+        </ha-icon-button>
+      </div>
+      ${this.showUpload
+        ? html`
+            <ha-picture-upload
+              .hass=${this.hass}
+              .value=${this.value?.startsWith("/api/") ? this.value : null}
+              @change=${this._pictureChanged}
+            ></ha-picture-upload>
+          `
+        : nothing}
+    `;
+  }
+
+  private _handleUploadToggle() {
+    this.showUpload = !this.showUpload;
+  }
+
+  private _pictureChanged(ev) {
+    const value = (ev.target as HaPictureUpload).value;
+    if (value) {
+      fireEvent(this, "value-changed", { value });
+    }
+  }
+
+  private _handleChange(ev) {
+    let value = ev.target.value;
+    if (this.value === value) {
+      return;
+    }
+    if (value === "" && !this.required) {
+      value = undefined;
+    }
+
+    fireEvent(this, "value-changed", { value });
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      :host {
+        display: block;
+        position: relative;
+      }
+      div {
+        display: flex;
+        align-items: center;
+      }
+      ha-textarea,
+      ha-textfield {
+        width: 100%;
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-selector-image": HaImageSelector;
+  }
+}

--- a/src/components/ha-selector/ha-selector-image.ts
+++ b/src/components/ha-selector/ha-selector-image.ts
@@ -13,7 +13,7 @@ import { URL_PREFIX } from "../../data/image_upload";
 
 @customElement("ha-selector-image")
 export class HaImageSelector extends LitElement {
-  @property() public hass!: HomeAssistant;
+  @property({ attribute: false }) public hass!: HomeAssistant;
 
   @property() public value?: any;
 
@@ -25,7 +25,7 @@ export class HaImageSelector extends LitElement {
 
   @property() public helper?: string;
 
-  @property() public selector!: ImageSelector;
+  @property({ attribute: false }) public selector!: ImageSelector;
 
   @property({ type: Boolean }) public disabled = false;
 

--- a/src/components/ha-selector/ha-selector.ts
+++ b/src/components/ha-selector/ha-selector.ts
@@ -32,6 +32,7 @@ const LOAD_ELEMENTS = {
   file: () => import("./ha-selector-file"),
   floor: () => import("./ha-selector-floor"),
   label: () => import("./ha-selector-label"),
+  image: () => import("./ha-selector-image"),
   language: () => import("./ha-selector-language"),
   navigation: () => import("./ha-selector-navigation"),
   number: () => import("./ha-selector-number"),

--- a/src/data/image_upload.ts
+++ b/src/data/image_upload.ts
@@ -8,7 +8,7 @@ interface Image {
   id: string;
 }
 
-const URL_PREFIX = "/api/image/serve/";
+export const URL_PREFIX = "/api/image/serve/";
 
 export interface ImageMutableParams {
   name: string;

--- a/src/data/image_upload.ts
+++ b/src/data/image_upload.ts
@@ -8,9 +8,23 @@ interface Image {
   id: string;
 }
 
+const URL_PREFIX = "/api/image/serve/";
+
 export interface ImageMutableParams {
   name: string;
 }
+
+export const getIdFromUrl = (url: string): string | undefined => {
+  let id;
+  if (url.startsWith(URL_PREFIX)) {
+    id = url.substring(URL_PREFIX.length);
+    const idx = id.indexOf("/");
+    if (idx >= 0) {
+      id = id.substring(0, idx);
+    }
+  }
+  return id;
+};
 
 export const generateImageThumbnailUrl = (
   mediaId: string,
@@ -61,5 +75,5 @@ export const updateImage = (
 export const deleteImage = (hass: HomeAssistant, id: string) =>
   hass.callWS({
     type: "image/delete",
-    media_id: id,
+    image_id: id,
   });

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -40,6 +40,7 @@ export type Selector =
   | FileSelector
   | IconSelector
   | LabelSelector
+  | ImageSelector
   | LanguageSelector
   | LocationSelector
   | MediaSelector
@@ -260,6 +261,11 @@ export interface LabelSelector {
   label: {
     multiple?: boolean;
   };
+}
+
+export interface ImageSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  image: {} | null;
 }
 
 export interface LanguageSelector {

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -257,15 +257,15 @@ export interface IconSelector {
   } | null;
 }
 
+export interface ImageSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  image: {} | null;
+}
+
 export interface LabelSelector {
   label: {
     multiple?: boolean;
   };
-}
-
-export interface ImageSelector {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  image: {} | null;
 }
 
 export interface LanguageSelector {

--- a/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
@@ -4,12 +4,14 @@ import { assert, assign, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { SchemaUnion } from "../../../../components/ha-form/types";
 import "../../../../components/ha-theme-picker";
-import { HomeAssistant } from "../../../../types";
+import { HomeAssistant, ValueChangedEvent } from "../../../../types";
 import { PictureCardConfig } from "../../cards/types";
 import "../../components/hui-action-editor";
 import { LovelaceCardEditor } from "../../types";
 import { actionConfigStruct } from "../structs/action-struct";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
+import "../../../../components/ha-picture-upload";
+import type { HaPictureUpload } from "../../../../components/ha-picture-upload";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -58,6 +60,15 @@ export class HuiPictureCardEditor
     }
 
     return html`
+      <ha-picture-upload
+        .hass=${this.hass}
+        .value=${this._config?.image?.startsWith("/api/")
+          ? this._config.image
+          : null}
+        crop
+        @change=${this._pictureChanged}
+      ></ha-picture-upload>
+
       <ha-form
         .hass=${this.hass}
         .data=${this._config}
@@ -70,6 +81,15 @@ export class HuiPictureCardEditor
 
   private _valueChanged(ev: CustomEvent): void {
     fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+
+  private _pictureChanged(ev: ValueChangedEvent<string | null>) {
+    const picture = (ev.target as HaPictureUpload).value;
+    if (picture) {
+      fireEvent(this, "config-changed", {
+        config: { ...this._config!, image: picture },
+      });
+    }
   }
 
   private _computeLabelCallback = (schema: SchemaUnion<typeof SCHEMA>) => {

--- a/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-card-editor.ts
@@ -4,14 +4,12 @@ import { assert, assign, object, optional, string } from "superstruct";
 import { fireEvent } from "../../../../common/dom/fire_event";
 import { SchemaUnion } from "../../../../components/ha-form/types";
 import "../../../../components/ha-theme-picker";
-import { HomeAssistant, ValueChangedEvent } from "../../../../types";
+import { HomeAssistant } from "../../../../types";
 import { PictureCardConfig } from "../../cards/types";
 import "../../components/hui-action-editor";
 import { LovelaceCardEditor } from "../../types";
 import { actionConfigStruct } from "../structs/action-struct";
 import { baseLovelaceCardConfig } from "../structs/base-card-struct";
-import "../../../../components/ha-picture-upload";
-import type { HaPictureUpload } from "../../../../components/ha-picture-upload";
 
 const cardConfigStruct = assign(
   baseLovelaceCardConfig,
@@ -26,7 +24,7 @@ const cardConfigStruct = assign(
 );
 
 const SCHEMA = [
-  { name: "image", selector: { text: {} } },
+  { name: "image", selector: { image: {} } },
   { name: "image_entity", selector: { entity: { domain: "image" } } },
   { name: "alt_text", selector: { text: {} } },
   { name: "theme", selector: { theme: {} } },
@@ -60,15 +58,6 @@ export class HuiPictureCardEditor
     }
 
     return html`
-      <ha-picture-upload
-        .hass=${this.hass}
-        .value=${this._config?.image?.startsWith("/api/")
-          ? this._config.image
-          : null}
-        crop
-        @change=${this._pictureChanged}
-      ></ha-picture-upload>
-
       <ha-form
         .hass=${this.hass}
         .data=${this._config}
@@ -81,15 +70,6 @@ export class HuiPictureCardEditor
 
   private _valueChanged(ev: CustomEvent): void {
     fireEvent(this, "config-changed", { config: ev.detail.value });
-  }
-
-  private _pictureChanged(ev: ValueChangedEvent<string | null>) {
-    const picture = (ev.target as HaPictureUpload).value;
-    if (picture) {
-      fireEvent(this, "config-changed", {
-        config: { ...this._config!, image: picture },
-      });
-    }
   }
 
   private _computeLabelCallback = (schema: SchemaUnion<typeof SCHEMA>) => {

--- a/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-entity-card-editor.ts
@@ -32,7 +32,7 @@ const cardConfigStruct = assign(
 const SCHEMA = [
   { name: "entity", required: true, selector: { entity: {} } },
   { name: "name", selector: { text: {} } },
-  { name: "image", selector: { text: {} } },
+  { name: "image", selector: { image: {} } },
   { name: "camera_image", selector: { entity: { domain: "camera" } } },
   {
     name: "",

--- a/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
+++ b/src/panels/lovelace/editor/config-elements/hui-picture-glance-card-editor.ts
@@ -35,7 +35,7 @@ const cardConfigStruct = assign(
 
 const SCHEMA = [
   { name: "title", selector: { text: {} } },
-  { name: "image", selector: { text: {} } },
+  { name: "image", selector: { image: {} } },
   { name: "image_entity", selector: { entity: { domain: "image" } } },
   { name: "camera_image", selector: { entity: { domain: "camera" } } },
   {

--- a/src/resources/styles.ts
+++ b/src/resources/styles.ts
@@ -82,6 +82,7 @@ export const haStyle = css`
     color: var(--error-color);
   }
 
+  ha-button.warning,
   mwc-button.warning {
     --mdc-theme-primary: var(--error-color);
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -377,6 +377,11 @@
           "upload_failed": "Upload failed",
           "unknown_file": "Unknown file"
         },
+        "image": {
+          "select_image": "Select image",
+          "upload": "Upload picture",
+          "url": "Local path or web URL"
+        },
         "location": {
           "latitude": "[%key:ui::panel::config::zone::detail::latitude%]",
           "longitude": "[%key:ui::panel::config::zone::detail::longitude%]",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -413,8 +413,9 @@
           }
         },
         "image": {
-          "upload_on": "Show Upload Form",
-          "upload_off": "Hide Upload Form"
+          "select_image": "Select image",
+          "upload": "Upload picture",
+          "url": "Local path or web URL"
         },
         "text": {
           "show_password": "Show password",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -412,6 +412,10 @@
             "manual": "Manual Entry"
           }
         },
+        "image": {
+          "upload_on": "Show Upload Form",
+          "upload_off": "Hide Upload Form"
+        },
         "text": {
           "show_password": "Show password",
           "hide_password": "Hide password"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Add a picture-upload form to the picture-card editor. I think this makes working with images much more accessible, otherwise it can be a source of a lot of confusion how to add pictures to the server and figure out the path. 

Maybe this should be wrapped up in some kind of image-selector element that can be reused? 

That would allow for either entering an external URL, uploading, or maybe opening a file picker and allowing to select from the list of current uploaded images either in /image/ or /www/?

![image-picker](https://github.com/home-assistant/frontend/assets/32912880/18035436-fa62-4bb8-b54f-4262b9b98830)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
https://github.com/home-assistant/frontend/discussions/18669
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an image selector component allowing users to upload or specify an image via URL.
  - Added new image-related options in various card editors for enhanced customization.

- **Style**
  - Updated button styles to better display warning buttons with a distinct color.

- **Translations**
  - Added new English translations for image selection, upload, and URL input options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->