### PR TITLE
Update ha-panel-calendar.ts

### DIFF
--- a/src/panels/calendar/ha-panel-calendar.ts
+++ b/src/panels/calendar/ha-panel-calendar.ts
@@ -59,6 +59,12 @@ class PanelCalendar extends LitElement {
   })
   private _deSelectedCalendars: string[] = [];
 
+  @storage({
+    key: "calendarHidePane",
+    state: true,
+  })
+  private _calendarHidePane: boolean = false;
+
   private _start?: Date;
 
   private _end?: Date;
@@ -119,7 +125,7 @@ class PanelCalendar extends LitElement {
         </ha-check-list-item>
       `
     );
-    const showPane = this._showPaneController.value ?? !this.narrow;
+    const showPane = !this._calendarHidePane && (this._showPaneController.value ?? !this.narrow);
     return html`
       <ha-two-pane-top-app-bar-fixed .pane=${showPane} footer>
         <ha-menu-button
@@ -157,6 +163,12 @@ class PanelCalendar extends LitElement {
           : html`<div slot="title">
               ${this.hass.localize("ui.components.calendar.my_calendars")}
             </div>`}
+        <ha-icon-button
+          slot="actionItems"
+          .label=${this.hass!.localize("ui.panel.config")}
+          .path=${mdiPencil}
+          @click=${this._openConfig}
+        ></ha-icon-button>
         <ha-icon-button
           slot="actionItems"
           .path=${mdiRefresh}
@@ -270,6 +282,10 @@ class PanelCalendar extends LitElement {
     );
     this._events = result.events;
     this._handleErrors(result.errors);
+  }
+
+  private async _openConfig(): Promise<void> {
+    // TODO Open dialog to flip switch hide/show pane
   }
 
   private _handleErrors(error_entity_ids: string[]) {


### PR DESCRIPTION
- Adding a config button to Calendar Panel
- Toggle panel to allow for fullscreen view on small screen (larger than 750px which is hardcoded today)
- TODO: Add config dialog and persist 'toggle panel' variable

## Proposed change
I'm using a mounted 7 inch tablet as the family calendar. 1/4 of the screen is used for "My calendars", which is wasted space. The code already allows for hiding the side pane when the size of the screen is 750px or smaller.

The change will allow to force the side pane to be hidden.

## Type of change
-[ ] New feature

## Additional information
- This PR is a start to make hiding calendar pane happen (I don't have dev environment set up and not familiar with the code). I'm sure that if one of the maintainers looked at this they would be able to complete the PR with the remaining gaps in a relatively short amount of time. 

## Checklist
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
