### PR TITLE
Inject polyfills where used

### DIFF
--- a/build-scripts/babel-plugins/custom-polyfill-plugin.js
+++ b/build-scripts/babel-plugins/custom-polyfill-plugin.js
@@ -1,0 +1,56 @@
+import defineProvider from "@babel/helper-define-polyfill-provider";
+
+// List of polyfill keys with supported browser targets for the functionality
+const PolyfillSupport = {
+  fetch: {
+    android: 42,
+    chrome: 42,
+    edge: 14,
+    firefox: 39,
+    ios: 10.3,
+    opera: 29,
+    opera_mobile: 29,
+    safari: 10.1,
+    samsung: 4.0,
+  },
+  proxy: {
+    android: 49,
+    chrome: 49,
+    edge: 12,
+    firefox: 18,
+    ios: 10.0,
+    opera: 36,
+    opera_mobile: 36,
+    safari: 10.0,
+    samsung: 5.0,
+  },
+};
+
+// Map of global variables and/or instance and static properties to the
+// corresponding polyfill key and actual module to import
+const polyfillMap = {
+  global: {
+    Proxy: { key: "proxy", module: "proxy-polyfill" },
+    fetch: { key: "fetch", module: "unfetch/polyfill" },
+  },
+  instance: {},
+  static: {},
+};
+
+// Create plugin using the same factory as for CoreJS
+export default defineProvider(
+  ({ createMetaResolver, debug, shouldInjectPolyfill }) => {
+    const resolvePolyfill = createMetaResolver(polyfillMap);
+    return {
+      name: "HA Custom",
+      polyfills: PolyfillSupport,
+      usageGlobal(meta, utils) {
+        const polyfill = resolvePolyfill(meta);
+        if (polyfill && shouldInjectPolyfill(polyfill.desc.key)) {
+          debug(polyfill.desc.key);
+          utils.injectGlobalImport(polyfill.desc.module);
+        }
+      },
+    };
+  }
+);

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -31,8 +31,6 @@ module.exports.emptyPackages = ({ latestBuild, isHassioBuild }) =>
       require.resolve(
         path.resolve(paths.polymer_dir, "src/resources/compatibility.ts")
       ),
-    // This polyfill is loaded in workers to support ES5, filter it out.
-    latestBuild && require.resolve("proxy-polyfill/src/index.js"),
     // Icons in supervisor conflict with icons in HA so we don't load.
     isHassioBuild &&
       require.resolve(
@@ -109,6 +107,13 @@ module.exports.babelOptions = ({ latestBuild, isProdBuild, isTestBuild }) => ({
         modules: ["@mdi/js"],
         ignoreModuleNotFound: true,
       },
+    ],
+    [
+      path.resolve(
+        paths.polymer_dir,
+        "build-scripts/babel-plugins/custom-polyfill-plugin.js"
+      ),
+      { method: "usage-global" },
     ],
     // Minify template literals for production
     isProdBuild && [

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -91,8 +91,8 @@ module.exports.babelOptions = ({ latestBuild, isProdBuild, isTestBuild }) => ({
     [
       "@babel/preset-env",
       {
-        useBuiltIns: latestBuild ? false : "entry",
-        corejs: latestBuild ? false : { version: "3.33", proposals: true },
+        useBuiltIns: latestBuild ? false : "usage",
+        corejs: latestBuild ? false : "3.33",
         bugfixes: true,
         shippedProposals: true,
       },

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.3",
+    "@babel/helper-define-polyfill-provider": "0.4.3",
     "@babel/plugin-proposal-decorators": "7.23.3",
     "@babel/plugin-transform-runtime": "7.23.3",
     "@babel/preset-env": "7.23.3",

--- a/src/components/data-table/sort-filter-worker.ts
+++ b/src/components/data-table/sort-filter-worker.ts
@@ -1,6 +1,4 @@
-// To use comlink under ES5
 import { expose } from "comlink";
-import "proxy-polyfill";
 import { stringCompare } from "../../common/string/compare";
 import type {
   ClonedDataTableColumnData,

--- a/src/entrypoints/app.ts
+++ b/src/entrypoints/app.ts
@@ -1,3 +1,5 @@
+// Compat needs to be first import
+import "../resources/compatibility";
 import "@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min";
 import "../layouts/home-assistant";
 

--- a/src/entrypoints/core.ts
+++ b/src/entrypoints/core.ts
@@ -1,5 +1,3 @@
-// Compat needs to be first import
-import "../resources/compatibility";
 import {
   Auth,
   Connection,

--- a/src/html/_js_base.html.template
+++ b/src/html/_js_base.html.template
@@ -2,7 +2,6 @@
   function _ls(src, notCustom) {
     var script = document.createElement("script");
     if (notCustom) {
-      script.async = false;
       script.crossOrigin = "use-credentials";
     }
     script.src = src;

--- a/src/html/index.html.template
+++ b/src/html/index.html.template
@@ -77,14 +77,11 @@
     <script>
         if (!window.latestJS) {
           window.customPanelJS = "<%= es5CustomPanelJS %>";
-
           <% if (useRollup) { %>
             _ls("/static/js/s.min.js").onload = function() {
-              // Although core and app can load in any order, we need to
-              // force loading core first because it contains polyfills
-              return System.import("<%= es5EntryJS[0] %>").then(function() {
-                System.import("<%= es5EntryJS[1] %>");
-              });
+              <% for (const entry of es5EntryJS) { %>
+                System.import("<%= entry %>");
+              <% } %>
             }
           <% } else { %>
             <% for (const entry of es5EntryJS) { %>

--- a/src/resources/compatibility.ts
+++ b/src/resources/compatibility.ts
@@ -1,5 +1,4 @@
 // Caution before editing - For latest builds, this module is replaced with emptiness and thus not imported (see build-scripts/bundle.js)
-import "core-js";
 import "lit/polyfill-support";
 
 // To use comlink under ES5

--- a/src/resources/compatibility.ts
+++ b/src/resources/compatibility.ts
@@ -1,10 +1,6 @@
 // Caution before editing - For latest builds, this module is replaced with emptiness and thus not imported (see build-scripts/bundle.js)
 import "lit/polyfill-support";
 
-// To use comlink under ES5
-import "proxy-polyfill";
-import "unfetch/polyfill";
-
 import ResizeObserver from "resize-observer-polyfill";
 
 if (!window.ResizeObserver) {

--- a/src/resources/markdown-worker.ts
+++ b/src/resources/markdown-worker.ts
@@ -1,5 +1,3 @@
-// To use comlink under ES5
-import "proxy-polyfill";
 import { expose } from "comlink";
 import { marked, MarkedOptions } from "marked";
 import { filterXSS, getDefaultWhiteList, IWhiteList } from "xss";

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,7 +160,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-define-polyfill-provider@npm:^0.4.3":
+"@babel/helper-define-polyfill-provider@npm:0.4.3, @babel/helper-define-polyfill-provider@npm:^0.4.3":
   version: 0.4.3
   resolution: "@babel/helper-define-polyfill-provider@npm:0.4.3"
   dependencies:
@@ -9556,6 +9556,7 @@ __metadata:
   resolution: "home-assistant-frontend@workspace:."
   dependencies:
     "@babel/core": "npm:7.23.3"
+    "@babel/helper-define-polyfill-provider": "npm:0.4.3"
     "@babel/plugin-proposal-decorators": "npm:7.23.3"
     "@babel/plugin-transform-runtime": "npm:7.23.3"
     "@babel/preset-env": "npm:7.23.3"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Use Babel to inject polyfill imports where needed instead of in the entrypoints.  For CoreJS, this just means changing the `preset-env` setting.  For other polyfills, I wrote a simple Babel plugin using the same helper package, and implemented it for `fetch` and `Proxy`.  Others can follow.

This results in:
- significantly smaller entrypoints since many are deferred and each only gets the polyfills they need
- ability to load `core` and `app` in parallel
- ability to move remainder of `compatibility` to `app` instead of `core`

Essentially, it trades some duplication for those benefits, but that duplication is minimal.  The almost 1% bundle increase reported by CI is a bit deceiving though because:
1. Half of that increase actually comes from polyfilling the service worker and web workers, which are currently not getting any.  So technically this also fixes that bug.
2. Using `usage` in `preset-env` permits turning off *all* proposals, which we certainly don't need, especially for the legacy build (e.g. it's currently polyfilling all the proposed changes to async iterators).  The `shippedProposals` flag covers those that are mature enough to be showing up in browsers.

Probably the biggest downside here is a much much bigger development build since optimizations haven't removed all the duplicates.  If that somehow becomes an issue, I could look into selectively flipping on some of them.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
