### PR TITLE
Add custom card names to the edit card dialog header

### DIFF
--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -157,8 +157,7 @@ export class HuiDialogEditCard
         // Trim names that end in " Card" so as not to redundantly duplicate it
         if (
           cardName
-            ?.substring(cardName.length - 5, cardName.length)
-            .toLowerCase() === " card"
+            ?.toLowerCase().endsWith(" card")
         ) {
           cardName = cardName.substring(0, cardName.length - 5);
         }

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -155,10 +155,7 @@ export class HuiDialogEditCard
         cardName = getCustomCardEntry(stripCustomPrefix(this._cardConfig.type))
           ?.name;
         // Trim names that end in " Card" so as not to redundantly duplicate it
-        if (
-          cardName
-            ?.toLowerCase().endsWith(" card")
-        ) {
+        if (cardName?.toLowerCase().endsWith(" card")) {
           cardName = cardName.substring(0, cardName.length - 5);
         }
       } else {

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -156,9 +156,8 @@ export class HuiDialogEditCard
           ?.name;
         // Trim names that end in " Card" so as not to redundantly duplicate it
         if (
-          cardName &&
           cardName
-            .substring(cardName.length - 5, cardName.length)
+            ?.substring(cardName.length - 5, cardName.length)
             .toLowerCase() === " card"
         ) {
           cardName = cardName.substring(0, cardName.length - 5);

--- a/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-dialog-edit-card.ts
@@ -31,6 +31,11 @@ import "./hui-card-preview";
 import type { EditCardDialogParams } from "./show-edit-card-dialog";
 import { LovelaceCardConfig } from "../../../../data/lovelace/config/card";
 import { LovelaceViewConfig } from "../../../../data/lovelace/config/view";
+import {
+  getCustomCardEntry,
+  isCustomType,
+  stripCustomPrefix,
+} from "../../../../data/lovelace_custom_cards";
 
 declare global {
   // for fire event
@@ -145,12 +150,28 @@ export class HuiDialogEditCard
 
     let heading: string;
     if (this._cardConfig && this._cardConfig.type) {
+      let cardName: string | undefined;
+      if (isCustomType(this._cardConfig.type)) {
+        cardName = getCustomCardEntry(stripCustomPrefix(this._cardConfig.type))
+          ?.name;
+        // Trim names that end in " Card" so as not to redundantly duplicate it
+        if (
+          cardName &&
+          cardName
+            .substring(cardName.length - 5, cardName.length)
+            .toLowerCase() === " card"
+        ) {
+          cardName = cardName.substring(0, cardName.length - 5);
+        }
+      } else {
+        cardName = this.hass!.localize(
+          `ui.panel.lovelace.editor.card.${this._cardConfig.type}.name`
+        );
+      }
       heading = this.hass!.localize(
         "ui.panel.lovelace.editor.edit_card.typed_header",
         "type",
-        this.hass!.localize(
-          `ui.panel.lovelace.editor.card.${this._cardConfig.type}.name`
-        )
+        cardName
       );
     } else if (!this._cardConfig) {
       heading = this._viewConfig.title


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
If a custom card publishes a name, use that name in the header of the edit card dialog, similar to native cards:

![image](https://github.com/home-assistant/frontend/assets/32912880/f80f2894-6879-4e49-bb87-7e857cfc0faf)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18737
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
