### PR TITLE
Default to `ltr` for reading direction

### DIFF
--- a/src/components/ha-button-menu.ts
+++ b/src/components/ha-button-menu.ts
@@ -3,6 +3,7 @@ import "@material/mwc-menu";
 import type { Corner, Menu, MenuCorner } from "@material/mwc-menu";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, query } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 import { FOCUS_TARGET } from "../dialogs/make-dialog-manager";
 import type { HaIconButton } from "./ha-icon-button";
 
@@ -68,7 +69,7 @@ export class HaButtonMenu extends LitElement {
   protected firstUpdated(changedProps): void {
     super.firstUpdated(changedProps);
 
-    if (document.dir === "rtl") {
+    if (mainWindow.document.dir === "rtl") {
       this.updateComplete.then(() => {
         this.querySelectorAll("mwc-list-item").forEach((item) => {
           const style = document.createElement("style");

--- a/src/components/ha-fab.ts
+++ b/src/components/ha-fab.ts
@@ -2,6 +2,7 @@ import { FabBase } from "@material/mwc-fab/mwc-fab-base";
 import { styles } from "@material/mwc-fab/mwc-fab.css";
 import { customElement } from "lit/decorators";
 import { css } from "lit";
+import { mainWindow } from "../common/dom/get_main_window";
 
 @customElement("ha-fab")
 export class HaFab extends FabBase {
@@ -20,7 +21,7 @@ export class HaFab extends FabBase {
       }
     `,
     // safari workaround - must be explicit
-    document.dir === "rtl"
+    mainWindow.document.dir === "rtl"
       ? css`
           :host .mdc-fab--extended .mdc-fab__icon {
             direction: rtl;

--- a/src/components/ha-icon-button-arrow-next.ts
+++ b/src/components/ha-icon-button-arrow-next.ts
@@ -2,6 +2,7 @@ import { mdiArrowLeft, mdiArrowRight } from "@mdi/js";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { HomeAssistant } from "../types";
+import { computeRTLDirection } from "../common/util/compute_rtl";
 import "./ha-icon-button";
 
 @customElement("ha-icon-button-arrow-next")
@@ -13,7 +14,17 @@ export class HaIconButtonArrowNext extends LitElement {
   @property() public label?: string;
 
   @state() private _icon =
-    document.dir === "ltr" ? mdiArrowRight : mdiArrowLeft;
+    document.dir === "rtl" ? mdiArrowLeft : mdiArrowRight;
+
+  public connectedCallback() {
+    super.connectedCallback();
+    if (!document.dir) {
+      const dir = this.hass ? computeRTLDirection(this.hass) : undefined;
+      if (dir === "rtl") {
+        this._icon = mdiArrowLeft;
+      }
+    }
+  }
 
   protected render(): TemplateResult {
     return html`

--- a/src/components/ha-icon-button-arrow-next.ts
+++ b/src/components/ha-icon-button-arrow-next.ts
@@ -1,8 +1,8 @@
 import { mdiArrowLeft, mdiArrowRight } from "@mdi/js";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 import { HomeAssistant } from "../types";
-import { computeRTLDirection } from "../common/util/compute_rtl";
 import "./ha-icon-button";
 
 @customElement("ha-icon-button-arrow-next")
@@ -14,17 +14,7 @@ export class HaIconButtonArrowNext extends LitElement {
   @property() public label?: string;
 
   @state() private _icon =
-    document.dir === "rtl" ? mdiArrowLeft : mdiArrowRight;
-
-  public connectedCallback() {
-    super.connectedCallback();
-    if (!document.dir) {
-      const dir = this.hass ? computeRTLDirection(this.hass) : undefined;
-      if (dir === "rtl") {
-        this._icon = mdiArrowLeft;
-      }
-    }
-  }
+    mainWindow.document.dir === "rtl" ? mdiArrowLeft : mdiArrowRight;
 
   protected render(): TemplateResult {
     return html`

--- a/src/components/ha-icon-button-arrow-prev.ts
+++ b/src/components/ha-icon-button-arrow-prev.ts
@@ -1,8 +1,8 @@
 import { mdiArrowLeft, mdiArrowRight } from "@mdi/js";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 import { HomeAssistant } from "../types";
-import { computeRTLDirection } from "../common/util/compute_rtl";
 import "./ha-icon-button";
 
 @customElement("ha-icon-button-arrow-prev")
@@ -14,17 +14,7 @@ export class HaIconButtonArrowPrev extends LitElement {
   @property() public label?: string;
 
   @state() private _icon =
-    document.dir === "rtl" ? mdiArrowRight : mdiArrowLeft;
-
-  public connectedCallback() {
-    super.connectedCallback();
-    if (!document.dir) {
-      const dir = this.hass ? computeRTLDirection(this.hass) : undefined;
-      if (dir === "rtl") {
-        this._icon = mdiArrowRight;
-      }
-    }
-  }
+    mainWindow.document.dir === "rtl" ? mdiArrowRight : mdiArrowLeft;
 
   protected render(): TemplateResult {
     return html`

--- a/src/components/ha-icon-button-arrow-prev.ts
+++ b/src/components/ha-icon-button-arrow-prev.ts
@@ -2,6 +2,7 @@ import { mdiArrowLeft, mdiArrowRight } from "@mdi/js";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { HomeAssistant } from "../types";
+import { computeRTLDirection } from "../common/util/compute_rtl";
 import "./ha-icon-button";
 
 @customElement("ha-icon-button-arrow-prev")
@@ -13,7 +14,17 @@ export class HaIconButtonArrowPrev extends LitElement {
   @property() public label?: string;
 
   @state() private _icon =
-    document.dir === "ltr" ? mdiArrowLeft : mdiArrowRight;
+    document.dir === "rtl" ? mdiArrowRight : mdiArrowLeft;
+
+  public connectedCallback() {
+    super.connectedCallback();
+    if (!document.dir) {
+      const dir = this.hass ? computeRTLDirection(this.hass) : undefined;
+      if (dir === "rtl") {
+        this._icon = mdiArrowRight;
+      }
+    }
+  }
 
   protected render(): TemplateResult {
     return html`

--- a/src/components/ha-icon-button-next.ts
+++ b/src/components/ha-icon-button-next.ts
@@ -2,6 +2,7 @@ import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { HomeAssistant } from "../types";
+import { computeRTLDirection } from "../common/util/compute_rtl";
 import "./ha-icon-button";
 
 @customElement("ha-icon-button-next")
@@ -13,7 +14,17 @@ export class HaIconButtonNext extends LitElement {
   @property() public label?: string;
 
   @state() private _icon =
-    document.dir === "ltr" ? mdiChevronRight : mdiChevronLeft;
+    document.dir === "rtl" ? mdiChevronLeft : mdiChevronRight;
+
+  public connectedCallback() {
+    super.connectedCallback();
+    if (!document.dir) {
+      const dir = this.hass ? computeRTLDirection(this.hass) : undefined;
+      if (dir === "rtl") {
+        this._icon = mdiChevronLeft;
+      }
+    }
+  }
 
   protected render(): TemplateResult {
     return html`

--- a/src/components/ha-icon-button-next.ts
+++ b/src/components/ha-icon-button-next.ts
@@ -1,8 +1,8 @@
 import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 import { HomeAssistant } from "../types";
-import { computeRTLDirection } from "../common/util/compute_rtl";
 import "./ha-icon-button";
 
 @customElement("ha-icon-button-next")
@@ -14,17 +14,7 @@ export class HaIconButtonNext extends LitElement {
   @property() public label?: string;
 
   @state() private _icon =
-    document.dir === "rtl" ? mdiChevronLeft : mdiChevronRight;
-
-  public connectedCallback() {
-    super.connectedCallback();
-    if (!document.dir) {
-      const dir = this.hass ? computeRTLDirection(this.hass) : undefined;
-      if (dir === "rtl") {
-        this._icon = mdiChevronLeft;
-      }
-    }
-  }
+    mainWindow.document.dir === "rtl" ? mdiChevronLeft : mdiChevronRight;
 
   protected render(): TemplateResult {
     return html`

--- a/src/components/ha-icon-button-prev.ts
+++ b/src/components/ha-icon-button-prev.ts
@@ -1,8 +1,8 @@
 import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 import { HomeAssistant } from "../types";
-import { computeRTLDirection } from "../common/util/compute_rtl";
 import "./ha-icon-button";
 
 @customElement("ha-icon-button-prev")
@@ -14,17 +14,7 @@ export class HaIconButtonPrev extends LitElement {
   @property() public label?: string;
 
   @state() private _icon =
-    document.dir === "rtl" ? mdiChevronRight : mdiChevronLeft;
-
-  public connectedCallback() {
-    super.connectedCallback();
-    if (!document.dir) {
-      const dir = this.hass ? computeRTLDirection(this.hass) : undefined;
-      if (dir === "rtl") {
-        this._icon = mdiChevronRight;
-      }
-    }
-  }
+    mainWindow.document.dir === "rtl" ? mdiChevronRight : mdiChevronLeft;
 
   protected render(): TemplateResult {
     return html`

--- a/src/components/ha-icon-button-prev.ts
+++ b/src/components/ha-icon-button-prev.ts
@@ -2,6 +2,7 @@ import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
 import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { HomeAssistant } from "../types";
+import { computeRTLDirection } from "../common/util/compute_rtl";
 import "./ha-icon-button";
 
 @customElement("ha-icon-button-prev")
@@ -13,7 +14,17 @@ export class HaIconButtonPrev extends LitElement {
   @property() public label?: string;
 
   @state() private _icon =
-    document.dir === "ltr" ? mdiChevronLeft : mdiChevronRight;
+    document.dir === "rtl" ? mdiChevronRight : mdiChevronLeft;
+
+  public connectedCallback() {
+    super.connectedCallback();
+    if (!document.dir) {
+      const dir = this.hass ? computeRTLDirection(this.hass) : undefined;
+      if (dir === "rtl") {
+        this._icon = mdiChevronRight;
+      }
+    }
+  }
 
   protected render(): TemplateResult {
     return html`

--- a/src/components/ha-icon-next.ts
+++ b/src/components/ha-icon-next.ts
@@ -5,7 +5,7 @@ import { HaSvgIcon } from "./ha-svg-icon";
 @customElement("ha-icon-next")
 export class HaIconNext extends HaSvgIcon {
   @property() public override path =
-    document.dir === "ltr" ? mdiChevronRight : mdiChevronLeft;
+    document.dir === "rtl" ? mdiChevronLeft : mdiChevronRight;
 }
 
 declare global {

--- a/src/components/ha-icon-next.ts
+++ b/src/components/ha-icon-next.ts
@@ -1,11 +1,12 @@
 import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
 import { customElement, property } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 import { HaSvgIcon } from "./ha-svg-icon";
 
 @customElement("ha-icon-next")
 export class HaIconNext extends HaSvgIcon {
   @property() public override path =
-    document.dir === "rtl" ? mdiChevronLeft : mdiChevronRight;
+    mainWindow.document.dir === "rtl" ? mdiChevronLeft : mdiChevronRight;
 }
 
 declare global {

--- a/src/components/ha-icon-prev.ts
+++ b/src/components/ha-icon-prev.ts
@@ -1,11 +1,12 @@
 import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
 import { customElement, property } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 import { HaSvgIcon } from "./ha-svg-icon";
 
 @customElement("ha-icon-prev")
 export class HaIconPrev extends HaSvgIcon {
   @property() public override path =
-    document.dir === "rtl" ? mdiChevronRight : mdiChevronLeft;
+    mainWindow.document.dir === "rtl" ? mdiChevronRight : mdiChevronLeft;
 }
 
 declare global {

--- a/src/components/ha-icon-prev.ts
+++ b/src/components/ha-icon-prev.ts
@@ -5,7 +5,7 @@ import { HaSvgIcon } from "./ha-svg-icon";
 @customElement("ha-icon-prev")
 export class HaIconPrev extends HaSvgIcon {
   @property() public override path =
-    document.dir === "ltr" ? mdiChevronLeft : mdiChevronRight;
+    document.dir === "rtl" ? mdiChevronRight : mdiChevronLeft;
 }
 
 declare global {

--- a/src/components/ha-textarea.ts
+++ b/src/components/ha-textarea.ts
@@ -3,6 +3,7 @@ import { styles as textfieldStyles } from "@material/mwc-textfield/mwc-textfield
 import { styles as textareaStyles } from "@material/mwc-textarea/mwc-textarea.css";
 import { css, PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 
 @customElement("ha-textarea")
 export class HaTextArea extends TextAreaBase {
@@ -11,7 +12,7 @@ export class HaTextArea extends TextAreaBase {
   firstUpdated() {
     super.firstUpdated();
 
-    this.setAttribute("dir", document.dir);
+    this.setAttribute("dir", mainWindow.document.dir);
   }
 
   updated(changedProperties: PropertyValues) {

--- a/src/components/ha-textfield.ts
+++ b/src/components/ha-textfield.ts
@@ -2,6 +2,7 @@ import { TextFieldBase } from "@material/mwc-textfield/mwc-textfield-base";
 import { styles } from "@material/mwc-textfield/mwc-textfield.css";
 import { TemplateResult, html, PropertyValues, css } from "lit";
 import { customElement, property, query } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
 
 @customElement("ha-textfield")
 export class HaTextField extends TextFieldBase {
@@ -194,7 +195,7 @@ export class HaTextField extends TextFieldBase {
       }
     `,
     // safari workaround - must be explicit
-    document.dir === "rtl"
+    mainWindow.document.dir === "rtl"
       ? css`
           .mdc-text-field__affix--suffix,
           .mdc-text-field--with-leading-icon,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
- Default to `ltr` for reading direction of icons instead of `rtl`
- Use `mainWindow`s `document.dir` to get correct reading direction even from iFrames

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/pull/18087#issuecomment-1820479727
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
