### PR TITLE
Add missing Intl polyfills to modern build

### DIFF
--- a/src/resources/intl-polyfill.ts
+++ b/src/resources/intl-polyfill.ts
@@ -1,9 +1,11 @@
-import { shouldPolyfill as shouldPolyfillDateTime } from "@formatjs/intl-datetimeformat/should-polyfill";
-import { shouldPolyfill as shouldPolyfillDisplayName } from "@formatjs/intl-displaynames/should-polyfill";
-import { shouldPolyfill as shouldPolyfillLocale } from "@formatjs/intl-locale/should-polyfill";
-import { shouldPolyfill as shouldPolyfillPluralRules } from "@formatjs/intl-pluralrules/should-polyfill";
-import { shouldPolyfill as shouldPolyfillRelativeTime } from "@formatjs/intl-relativetimeformat/should-polyfill";
+import { shouldPolyfill as shouldPolyfillDateTimeFormat } from "@formatjs/intl-datetimeformat/should-polyfill";
+import { shouldPolyfill as shouldPolyfillDisplayNames } from "@formatjs/intl-displaynames/should-polyfill";
+import { shouldPolyfill as shouldPolyfillGetCanonicalLocales } from "@formatjs/intl-getcanonicallocales/should-polyfill";
 import { shouldPolyfill as shouldPolyfillListFormat } from "@formatjs/intl-listformat/should-polyfill";
+import { shouldPolyfill as shouldPolyfillLocale } from "@formatjs/intl-locale/should-polyfill";
+import { shouldPolyfill as shouldPolyfillNumberFormat } from "@formatjs/intl-numberformat/should-polyfill";
+import { shouldPolyfill as shouldPolyfillPluralRules } from "@formatjs/intl-pluralrules/should-polyfill";
+import { shouldPolyfill as shouldPolyfillRelativeTimeFormat } from "@formatjs/intl-relativetimeformat/should-polyfill";
 import { getLocalLanguage } from "../util/common-translation";
 import {
   polyfillLocaleData,
@@ -13,28 +15,40 @@ import {
 const polyfillIntl = async () => {
   const locale = getLocalLanguage();
   const polyfills: Promise<unknown>[] = [];
-
+  if (shouldPolyfillGetCanonicalLocales()) {
+    await import("@formatjs/intl-getcanonicallocales/polyfill-force");
+  }
   if (shouldPolyfillLocale()) {
     await import("@formatjs/intl-locale/polyfill-force");
   }
-  if (shouldPolyfillPluralRules(locale)) {
-    polyfills.push(import("@formatjs/intl-pluralrules/polyfill-force"));
-  }
-  if (shouldPolyfillRelativeTime(locale)) {
-    polyfills.push(import("@formatjs/intl-relativetimeformat/polyfill-force"));
-  }
-  if (shouldPolyfillDateTime(locale)) {
+  if (shouldPolyfillDateTimeFormat(locale)) {
     polyfills.push(
       import("@formatjs/intl-datetimeformat/polyfill-force").then(() =>
         polyfillTimeZoneData()
       )
     );
   }
-  if (shouldPolyfillDisplayName(locale)) {
+  if (shouldPolyfillDisplayNames(locale)) {
     polyfills.push(import("@formatjs/intl-displaynames/polyfill-force"));
   }
   if (shouldPolyfillListFormat(locale)) {
     polyfills.push(import("@formatjs/intl-listformat/polyfill-force"));
+  }
+  if (shouldPolyfillNumberFormat(locale)) {
+    polyfills.push(import("@formatjs/intl-numberformat/polyfill-force"));
+  }
+  if (shouldPolyfillPluralRules(locale)) {
+    polyfills.push(
+      import("@formatjs/intl-pluralrules/polyfill-force").then(
+        // Locale data for plural rules breaks current JSON conversions as it includes functions,
+        // so only import English to avoid huge bundles
+        // TODo: Setup JS imports instead of JSON fetches
+        () => import("@formatjs/intl-pluralrules/locale-data/en")
+      )
+    );
+  }
+  if (shouldPolyfillRelativeTimeFormat(locale)) {
+    polyfills.push(import("@formatjs/intl-relativetimeformat/polyfill-force"));
   }
   if (polyfills.length === 0) {
     return;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Make the modern module consistent with the legacy one by adding polyfills for `Intl.getCanonicalLocales` and `Intl.NumberFormat`.  Also at least adds English data for `Intl.PluralRules`.  We need to revamp importing the locale data to make this work for all languages.

Next step is to get rid of the static import version for the legacy build...


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
