### PR TITLE
Automation traces localization

### DIFF
--- a/src/components/trace/ha-trace-path-details.ts
+++ b/src/components/trace/ha-trace-path-details.ts
@@ -25,7 +25,7 @@ import { traceTabStyles } from "./trace-tab-styles";
 import { HomeAssistant } from "../../types";
 import type { NodeInfo } from "./hat-script-graph";
 
-const trace_path_tabs = [
+const TRACE_PATH_TABS = [
   "step_config",
   "changed_variables",
   "logbook",
@@ -47,8 +47,7 @@ export class HaTracePathDetails extends LitElement {
 
   @property() public trackedNodes!: Record<string, any>;
 
-  @state() private _view: "step_config" | "changed_variables" | "logbook" =
-    "step_config";
+  @state() private _view: (typeof TRACE_PATH_TABS)[number] = "step_config";
 
   protected render(): TemplateResult {
     return html`
@@ -57,7 +56,7 @@ export class HaTracePathDetails extends LitElement {
       </div>
 
       <div class="tabs top">
-        ${trace_path_tabs.map(
+        ${TRACE_PATH_TABS.map(
           (view) => html`
             <button
               .view=${view}

--- a/src/components/trace/ha-trace-path-details.ts
+++ b/src/components/trace/ha-trace-path-details.ts
@@ -1,5 +1,12 @@
 import { dump } from "js-yaml";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  nothing,
+  TemplateResult,
+} from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { formatDateTimeWithSeconds } from "../../common/datetime/format_date_time";
@@ -18,6 +25,12 @@ import { traceTabStyles } from "./trace-tab-styles";
 import { HomeAssistant } from "../../types";
 import type { NodeInfo } from "./hat-script-graph";
 
+const trace_path_tabs = [
+  "step_config",
+  "changed_variables",
+  "logbook",
+] as const;
+
 @customElement("ha-trace-path-details")
 export class HaTracePathDetails extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -34,7 +47,8 @@ export class HaTracePathDetails extends LitElement {
 
   @property() public trackedNodes!: Record<string, any>;
 
-  @state() private _view: "config" | "changed_variables" | "logbook" = "config";
+  @state() private _view: "step_config" | "changed_variables" | "logbook" =
+    "step_config";
 
   protected render(): TemplateResult {
     return html`
@@ -43,23 +57,21 @@ export class HaTracePathDetails extends LitElement {
       </div>
 
       <div class="tabs top">
-        ${[
-          ["config", "Step Config"],
-          ["changed_variables", "Changed Variables"],
-          ["logbook", "Related logbook entries"],
-        ].map(
-          ([view, label]) => html`
+        ${trace_path_tabs.map(
+          (view) => html`
             <button
               .view=${view}
               class=${classMap({ active: this._view === view })}
               @click=${this._showTab}
             >
-              ${label}
+              ${this.hass!.localize(
+                `ui.panel.config.automation.trace.tabs.${view}`
+              )}
             </button>
           `
         )}
       </div>
-      ${this._view === "config"
+      ${this._view === "step_config"
         ? this._renderSelectedConfig()
         : this._view === "changed_variables"
           ? this._renderChangedVars()
@@ -71,7 +83,9 @@ export class HaTracePathDetails extends LitElement {
     const paths = this.trace.trace;
 
     if (!this.selected?.path) {
-      return "Select a node on the left for more information.";
+      return this.hass!.localize(
+        "ui.panel.config.automation.trace.path.choose"
+      );
     }
 
     // HACK: default choice node is not part of paths. We filter them out here by checking parent.
@@ -82,12 +96,16 @@ export class HaTracePathDetails extends LitElement {
       ] as ChooseActionTraceStep[];
 
       if (parentTraceInfo && parentTraceInfo[0]?.result?.choice === "default") {
-        return "The default action was executed because no options matched.";
+        return this.hass!.localize(
+          "ui.panel.config.automation.trace.path.default_action_executed"
+        );
       }
     }
 
     if (!(this.selected.path in paths)) {
-      return "This node was not executed and so no further trace information is available.";
+      return this.hass!.localize(
+        "ui.panel.config.automation.trace.path.no_further_execution"
+      );
     }
 
     const parts: TemplateResult[][] = [];
@@ -115,29 +133,53 @@ export class HaTracePathDetails extends LitElement {
             trace as any;
 
           if (result?.enabled === false) {
-            return html`This node was disabled and skipped during execution so
-            no further trace information is available.`;
+            return html`${this.hass!.localize(
+              "ui.panel.config.automation.trace.path.disabled_node"
+            )}`;
           }
 
           return html`
             ${curPath === this.selected.path
               ? ""
-              : html`<h2>${curPath.substr(this.selected.path.length + 1)}</h2>`}
-            ${data.length === 1 ? "" : html`<h3>Iteration ${idx + 1}</h3>`}
-            Executed:
-            ${formatDateTimeWithSeconds(
-              new Date(timestamp),
-              this.hass.locale,
-              this.hass.config
-            )}<br />
+              : html`<h2>
+                  ${curPath.substring(this.selected.path.length + 1)}
+                </h2>`}
+            ${data.length === 1
+              ? nothing
+              : html`<h3>
+                  ${this.hass!.localize(
+                    "ui.panel.config.automation.trace.path.iteration",
+                    { number: idx + 1 }
+                  )}
+                </h3>`}
+            ${this.hass!.localize(
+              "ui.panel.config.automation.trace.path.executed",
+              {
+                time: formatDateTimeWithSeconds(
+                  new Date(timestamp),
+                  this.hass.locale,
+                  this.hass.config
+                ),
+              }
+            )}
+            <br />
             ${result
-              ? html`Result:
+              ? html`${this.hass!.localize(
+                    "ui.panel.config.automation.trace.path.result"
+                  )}
                   <pre>${dump(result)}</pre>`
               : error
-                ? html`<div class="error">Error: ${error}</div>`
-                : ""}
+                ? html`<div class="error">
+                    ${this.hass!.localize(
+                      "ui.panel.config.automation.trace.path.error",
+                      {
+                        error: error,
+                      }
+                    )}
+                  </div>`
+                : nothing}
             ${Object.keys(rest).length === 0
-              ? ""
+              ? nothing
               : html`<pre>${dump(rest)}</pre>`}
           `;
         })
@@ -149,16 +191,18 @@ export class HaTracePathDetails extends LitElement {
 
   private _renderSelectedConfig() {
     if (!this.selected?.path) {
-      return "";
+      return nothing;
     }
     const config = getDataFromPath(this.trace!.config, this.selected.path);
     return config
       ? html`<ha-code-editor
-          .value=${dump(config).trimRight()}
+          .value=${dump(config).trimEnd()}
           readOnly
           dir="ltr"
         ></ha-code-editor>`
-      : "Unable to find config";
+      : this.hass!.localize(
+          "ui.panel.config.automation.trace.path.unable_to_find_config"
+        );
   }
 
   private _renderChangedVars() {
@@ -169,10 +213,19 @@ export class HaTracePathDetails extends LitElement {
       <div class="padded-box">
         ${data.map(
           (trace, idx) => html`
-            ${idx > 0 ? html`<p>Iteration ${idx + 1}</p>` : ""}
+            ${idx > 0
+              ? html`<p>
+                  ${this.hass!.localize(
+                    "ui.panel.config.automation.trace.path.iteration",
+                    { number: idx + 1 }
+                  )}
+                </p>`
+              : ""}
             ${Object.keys(trace.changed_variables || {}).length === 0
-              ? "No variables changed"
-              : html`<pre>${dump(trace.changed_variables).trimRight()}</pre>`}
+              ? this.hass!.localize(
+                  "ui.panel.config.automation.trace.path.no_variables_changed"
+                )
+              : html`<pre>${dump(trace.changed_variables).trimEnd()}</pre>`}
           `
         )}
       </div>
@@ -186,7 +239,11 @@ export class HaTracePathDetails extends LitElement {
     const index = trackedPaths.indexOf(this.selected.path);
 
     if (index === -1) {
-      return html`<div class="padded-box">Node not tracked.</div>`;
+      return html`<div class="padded-box">
+        ${this.hass!.localize(
+          "ui.panel.config.automation.trace.path.node_not_tracked"
+        )}
+      </div>`;
     }
 
     let entries: LogbookEntry[];
@@ -234,7 +291,9 @@ export class HaTracePathDetails extends LitElement {
           <hat-logbook-note .domain=${this.trace.domain}></hat-logbook-note>
         `
       : html`<div class="padded-box">
-          No Logbook entries found for this step.
+          ${this.hass!.localize(
+            "ui.panel.config.automation.trace.path.no_logbook_entries"
+          )}
         </div>`;
   }
 

--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -48,7 +48,7 @@ import { haStyle } from "../../../resources/styles";
 import { HomeAssistant, Route } from "../../../types";
 import { computeRTL } from "../../../common/util/compute_rtl";
 
-const tabs = ["details", "automation_config", "timeline", "logbook"] as const;
+const TABS = ["details", "automation_config", "timeline", "logbook"] as const;
 
 @customElement("ha-automation-trace")
 export class HaAutomationTrace extends LitElement {
@@ -245,7 +245,7 @@ export class HaAutomationTrace extends LitElement {
 
                     <div class="info">
                       <div class="tabs top">
-                        ${tabs.map(
+                        ${TABS.map(
                           (view) => html`
                             <button
                               tabindex="0"

--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -76,12 +76,7 @@ export class HaAutomationTrace extends LitElement {
 
   @state() private _logbookEntries?: LogbookEntry[];
 
-  @state() private _view:
-    | "details"
-    | "config"
-    | "timeline"
-    | "logbook"
-    | "blueprint" = "details";
+  @state() private _view: (typeof TABS)[number] | "blueprint" = "details";
 
   @query("hat-script-graph") private _graph?: HatScriptGraph;
 
@@ -292,7 +287,7 @@ export class HaAutomationTrace extends LitElement {
                                 .renderedNodes=${renderedNodes!}
                               ></ha-trace-path-details>
                             `
-                          : this._view === "config"
+                          : this._view === "automation_config"
                             ? html`
                                 <ha-trace-config
                                   .hass=${this.hass}

--- a/src/panels/config/automation/ha-automation-trace.ts
+++ b/src/panels/config/automation/ha-automation-trace.ts
@@ -7,7 +7,14 @@ import {
   mdiRayStartArrow,
   mdiRefresh,
 } from "@mdi/js";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  nothing,
+  TemplateResult,
+} from "lit";
 import { customElement, property, query, state } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { repeat } from "lit/directives/repeat";
@@ -40,6 +47,8 @@ import "../../../layouts/hass-subpage";
 import { haStyle } from "../../../resources/styles";
 import { HomeAssistant, Route } from "../../../types";
 import { computeRTL } from "../../../common/util/compute_rtl";
+
+const tabs = ["details", "automation_config", "timeline", "logbook"] as const;
 
 @customElement("ha-automation-trace")
 export class HaAutomationTrace extends LitElement {
@@ -213,9 +222,15 @@ export class HaAutomationTrace extends LitElement {
         </div>
 
         ${this._traces === undefined
-          ? html`<div class="container">Loading…</div>`
+          ? html`<div class="container">
+              ${this.hass!.localize("ui.common.loading")}
+            </div>`
           : this._traces.length === 0
-            ? html`<div class="container">No traces found</div>`
+            ? html`<div class="container">
+                ${this.hass!.localize(
+                  "ui.panel.config.automation.trace.no_traces_found"
+                )}
+              </div>`
             : this._trace === undefined
               ? ""
               : html`
@@ -230,20 +245,17 @@ export class HaAutomationTrace extends LitElement {
 
                     <div class="info">
                       <div class="tabs top">
-                        ${[
-                          ["details", "Step Details"],
-                          ["timeline", "Trace Timeline"],
-                          ["logbook", "Related logbook entries"],
-                          ["config", "Automation Config"],
-                        ].map(
-                          ([view, label]) => html`
+                        ${tabs.map(
+                          (view) => html`
                             <button
                               tabindex="0"
                               .view=${view}
                               class=${classMap({ active: this._view === view })}
                               @click=${this._showTab}
                             >
-                              ${label}
+                              ${this.hass!.localize(
+                                `ui.panel.config.automation.trace.tabs.${view}`
+                              )}
                             </button>
                           `
                         )}
@@ -257,7 +269,9 @@ export class HaAutomationTrace extends LitElement {
                                 })}
                                 @click=${this._showTab}
                               >
-                                Blueprint Config
+                                ${this.hass!.localize(
+                                  `ui.panel.config.automation.trace.tabs.blueprint_config`
+                                )}
                               </button>
                             `
                           : ""}
@@ -265,7 +279,7 @@ export class HaAutomationTrace extends LitElement {
                       ${this._selected === undefined ||
                       this._logbookEntries === undefined ||
                       trackedNodes === undefined
-                        ? ""
+                        ? nothing
                         : this._view === "details"
                           ? html`
                               <ha-trace-path-details

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2955,7 +2955,31 @@
             "download_trace": "Download trace",
             "edit_automation": "Edit automation",
             "older_trace": "Older trace",
-            "newer_trace": "Newer trace"
+            "newer_trace": "Newer trace",
+            "no_traces_found": "No traces found",
+            "tabs": {
+              "details": "Step Details",
+              "timeline": "Trace Timeline",
+              "logbook": "Related logbook entries",
+              "automation_config": "Automation Config",
+              "step_config": "Step Config",
+              "changed_variables": "Changed Variables",
+              "blueprint_config": "Blueprint Config"
+            },
+            "path": {
+              "choose": "Select a node on the left for more information.",
+              "default_action_executed": "The default action was executed because no options matched.",
+              "no_further_execution": "This node was not executed and so no further trace information is available.",
+              "disabled_node": "This node was disabled and skipped during execution so no further trace information is available.",
+              "iteration": "Iteration {number}",
+              "executed": "Executed: {time}",
+              "error": "Error: {error}",
+              "result": "Result:",
+              "node_not_tracked": "Node not tracked.",
+              "no_logbook_entries": "No Logbook entries found for this step.",
+              "no_variables_changed": "No variables changed",
+              "unable_to_find_config": "Unable to find config"
+            }
           }
         },
         "blueprint": {


### PR DESCRIPTION
## Proposed change
Add some localization to automation traces area. 
Some tabs ids have been changed from "config" into either "step_config", "automation_config" or "blueprint_config". 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18360
- This PR is related to issue or discussion: #18362
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
