### PR TITLE
Import service responses to devtools/template

### DIFF
--- a/src/panels/developer-tools/service/developer-tools-service.ts
+++ b/src/panels/developer-tools/service/developer-tools-service.ts
@@ -38,7 +38,13 @@ class HaPanelDevService extends LitElement {
 
   @state() private _uiAvailable = true;
 
-  @state() private _response?: Record<string, any>;
+  @storage({
+    key: "panel-dev-service-response-data",
+    state: true,
+    subscribe: false,
+    storage: "sessionStorage",
+  })
+  private _response?: Record<string, any>;
 
   @state() private _error?: string;
 

--- a/src/panels/developer-tools/template/developer-tools-template.ts
+++ b/src/panels/developer-tools/template/developer-tools-template.ts
@@ -471,7 +471,6 @@ class HaPanelDevTemplate extends LitElement {
   private _importServiceResponse() {
     this._template += `{{ ${SERVICE_RESPONSE} }}`;
     this._subscribeTemplate();
-    delete localStorage["panel-dev-template-template"];
   }
 }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5884,7 +5884,8 @@
             "no_listeners": "This template does not listen for any events and will not update automatically.",
             "listeners": "This template listens for the following state changed events:",
             "entity": "Entity",
-            "domain": "Domain"
+            "domain": "Domain",
+            "import_service_response": "Import service response"
           },
           "statistics": {
             "title": "Statistics",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
With many new services returning large complex object structures, it's not a trivial process to test writing a template against their result. This make it easy to test templates like you would write in an automation after a service call.

![import service](https://github.com/home-assistant/frontend/assets/32912880/8df0ddaa-9754-49d2-b03f-4661ada81aad)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
