### PR TITLE
Confirmation dialog for todo clear checked items

### DIFF
--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -22,6 +22,7 @@ import memoizeOne from "memoize-one";
 import type { SortableEvent } from "sortablejs";
 import { applyThemesOnElement } from "../../../common/dom/apply_themes_on_element";
 import { supportsFeature } from "../../../common/entity/supports-feature";
+import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import "../../../components/ha-card";
 import "../../../components/ha-checkbox";
 import "../../../components/ha-icon-button";
@@ -439,7 +440,21 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
     }
     const checkedItems = this._getCheckedItems(this._items);
     const uids = checkedItems.map((item: TodoItem) => item.uid);
-    deleteItems(this.hass!, this._entityId!, uids);
+    showConfirmationDialog(this, {
+      title: this.hass.localize(
+        "ui.panel.lovelace.cards.todo-list.delete_confirm_title"
+      ),
+      text: this.hass.localize(
+        "ui.panel.lovelace.cards.todo-list.delete_confirm_text",
+        { number: uids.length }
+      ),
+      dismissText: this.hass.localize("ui.common.cancel"),
+      confirmText: this.hass.localize("ui.common.delete"),
+      destructive: true,
+      confirm: () => {
+        deleteItems(this.hass!, this._entityId!, uids);
+      },
+    });
   }
 
   private get _newItem(): HaTextField {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4589,7 +4589,9 @@
             "add_item": "Add item",
             "reorder_items": "Reorder items",
             "drag_and_drop": "Drag and drop",
-            "delete_item": "Delete item"
+            "delete_item": "Delete item",
+            "delete_confirm_title": "Clear checked items?",
+            "delete_confirm_text": "{number} {number, plural,\n  one {item}\n  other {items}\n} will be permanently deleted from the to-do list."
           },
           "picture-elements": {
             "hold": "Hold:",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Todo list has a button to clear completed items on the card, but it uses a somewhat non-standard icon (or at least I am not familiar with it), and it is potentially very destructive to click, as it can delete multiple items instantly and there's no way to recover them.

I propose a confirmation dialog to this action, as I feel it is warranted here, to guard against accidental misclicks or someone misunderstanding what the button does (see linked discussion for an example).

![image](https://github.com/home-assistant/frontend/assets/32912880/0ebad593-8f6e-420d-8641-988e28edc06a)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/frontend/discussions/18556
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
