### PR TITLE
Localize date-range-picker

### DIFF
--- a/src/common/datetime/localize_date.ts
+++ b/src/common/datetime/localize_date.ts
@@ -1,46 +1,30 @@
 import memoizeOne from "memoize-one";
 
-// Sunday = 0
-const localizeWeekday = (
-  language: string,
-  day_of_week: number,
-  short: boolean
-): string => {
-  const date = new Date(Date.UTC(1970, 0, 1 + 3 + day_of_week));
-  return new Intl.DateTimeFormat(language, {
-    weekday: short ? "short" : "long",
-    timeZone: "UTC",
-  }).format(date);
-};
-
 export const localizeWeekdays = memoizeOne(
   (language: string, short: boolean): string[] => {
     const days: string[] = [];
+    const format = new Intl.DateTimeFormat(language, {
+      weekday: short ? "short" : "long",
+      timeZone: "UTC",
+    });
     for (let i = 0; i < 7; i++) {
-      days.push(localizeWeekday(language, i, short));
+      const date = new Date(Date.UTC(1970, 0, 1 + 3 + i));
+      days.push(format.format(date));
     }
     return days;
   }
 );
 
-// January = 0
-const localizeMonth = (
-  language: string,
-  month: number,
-  short: boolean
-): string => {
-  const date = new Date(Date.UTC(1970, 0 + month, 1));
-  return new Intl.DateTimeFormat(language, {
-    month: short ? "short" : "long",
-    timeZone: "UTC",
-  }).format(date);
-};
-
 export const localizeMonths = memoizeOne(
   (language: string, short: boolean): string[] => {
     const months: string[] = [];
+    const format = new Intl.DateTimeFormat(language, {
+      month: short ? "short" : "long",
+      timeZone: "UTC",
+    });
     for (let i = 0; i < 12; i++) {
-      months.push(localizeMonth(language, i, short));
+      const date = new Date(Date.UTC(1970, 0 + i, 1));
+      months.push(format.format(date));
     }
     return months;
   }

--- a/src/common/datetime/localize_date.ts
+++ b/src/common/datetime/localize_date.ts
@@ -1,0 +1,47 @@
+import memoizeOne from "memoize-one";
+
+// Sunday = 0
+const localizeWeekday = (
+  language: string,
+  day_of_week: number,
+  short: boolean
+): string => {
+  const date = new Date(Date.UTC(1970, 0, 1 + 3 + day_of_week));
+  return new Intl.DateTimeFormat(language, {
+    weekday: short ? "short" : "long",
+    timeZone: "UTC",
+  }).format(date);
+};
+
+export const localizeWeekdays = memoizeOne(
+  (language: string, short: boolean): string[] => {
+    const days: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      days.push(localizeWeekday(language, i, short));
+    }
+    return days;
+  }
+);
+
+// January = 0
+const localizeMonth = (
+  language: string,
+  month: number,
+  short: boolean
+): string => {
+  const date = new Date(Date.UTC(1970, 0 + month, 1));
+  return new Intl.DateTimeFormat(language, {
+    month: short ? "short" : "long",
+    timeZone: "UTC",
+  }).format(date);
+};
+
+export const localizeMonths = memoizeOne(
+  (language: string, short: boolean): string[] => {
+    const months: string[] = [];
+    for (let i = 0; i < 12; i++) {
+      months.push(localizeMonth(language, i, short));
+    }
+    return months;
+  }
+);

--- a/src/components/date-range-picker.ts
+++ b/src/components/date-range-picker.ts
@@ -5,6 +5,10 @@ import DateRangePicker from "vue2-daterange-picker";
 // @ts-ignore
 import dateRangePickerStyles from "vue2-daterange-picker/dist/vue2-daterange-picker.css";
 import { fireEvent } from "../common/dom/fire_event";
+import {
+  localizeWeekdays,
+  localizeMonths,
+} from "../common/datetime/localize_date";
 
 // Set the current date to the left picker instead of the right picker because the right is hidden
 const CustomDateRangePicker = Vue.extend({
@@ -63,33 +67,9 @@ const Component = Vue.extend({
       type: Boolean,
       default: false,
     },
-    weekdaySu: {
+    language: {
       type: String,
-      default: "Su",
-    },
-    weekdayMo: {
-      type: String,
-      default: "Mo",
-    },
-    weekdayTu: {
-      type: String,
-      default: "Tu",
-    },
-    weekdayWe: {
-      type: String,
-      default: "We",
-    },
-    weekdayTh: {
-      type: String,
-      default: "Th",
-    },
-    weekdayFr: {
-      type: String,
-      default: "Fr",
-    },
-    weekdaySa: {
-      type: String,
-      default: "Sa",
+      default: "en",
     },
   },
   render(createElement) {
@@ -105,15 +85,8 @@ const Component = Vue.extend({
         ranges: this.ranges ? {} : false,
         "locale-data": {
           firstDay: this.firstDay,
-          daysOfWeek: [
-            this.weekdaySu,
-            this.weekdayMo,
-            this.weekdayTu,
-            this.weekdayWe,
-            this.weekdayTh,
-            this.weekdayFr,
-            this.weekdaySa,
-          ],
+          daysOfWeek: localizeWeekdays(this.language, true),
+          monthNames: localizeMonths(this.language, false),
         },
       },
       model: {
@@ -199,7 +172,7 @@ class DateRangePickerElement extends WrappedElement {
             color: var(--secondary-text-color);
             border-radius: 0;
             outline: none;
-            width: 32px;
+            min-width: 32px;
             height: 32px;
           }
           .daterangepicker td.off,
@@ -275,6 +248,9 @@ class DateRangePickerElement extends WrappedElement {
           }
           .daterangepicker .drp-calendar.left {
             padding: 8px;
+            width: unset;
+            max-width: unset;
+            min-width: 270px;
           }
           .daterangepicker.show-calendar .ranges {
             margin-top: 0;

--- a/src/components/date-range-picker.ts
+++ b/src/components/date-range-picker.ts
@@ -63,6 +63,34 @@ const Component = Vue.extend({
       type: Boolean,
       default: false,
     },
+    weekdaySu: {
+      type: String,
+      default: "Su",
+    },
+    weekdayMo: {
+      type: String,
+      default: "Mo",
+    },
+    weekdayTu: {
+      type: String,
+      default: "Tu",
+    },
+    weekdayWe: {
+      type: String,
+      default: "We",
+    },
+    weekdayTh: {
+      type: String,
+      default: "Th",
+    },
+    weekdayFr: {
+      type: String,
+      default: "Fr",
+    },
+    weekdaySa: {
+      type: String,
+      default: "Sa",
+    },
   },
   render(createElement) {
     // @ts-expect-error
@@ -77,6 +105,15 @@ const Component = Vue.extend({
         ranges: this.ranges ? {} : false,
         "locale-data": {
           firstDay: this.firstDay,
+          daysOfWeek: [
+            this.weekdaySu,
+            this.weekdayMo,
+            this.weekdayTu,
+            this.weekdayWe,
+            this.weekdayTh,
+            this.weekdayFr,
+            this.weekdaySa,
+          ],
         },
       },
       model: {

--- a/src/components/ha-date-range-picker.ts
+++ b/src/components/ha-date-range-picker.ts
@@ -42,6 +42,8 @@ export interface DateRangePickerRanges {
   [key: string]: [Date, Date];
 }
 
+const DAYS = ["su", "mo", "tu", "we", "th", "fr", "sa"] as const;
+
 @customElement("ha-date-range-picker")
 export class HaDateRangePicker extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -76,12 +78,23 @@ export class HaDateRangePicker extends LitElement {
     | "center"
     | "inline";
 
+  @state() private _weekdays?: string[];
+
   protected willUpdate(changedProps: PropertyValues) {
     if (
       (!this.hasUpdated && this.ranges === undefined) ||
       (changedProps.has("hass") &&
         this.hass?.localize !== changedProps.get("hass")?.localize)
     ) {
+      this._weekdays = DAYS.map((day) =>
+        this.hass.localize(
+          `ui.components.date-range-picker.weekdays_short.${day}`
+        )
+      );
+
+      // temporary for development so I can view other languages
+      // this._weekdays = DAYS.map((day) => this.hass.localize(`ui.components.calendar.event.repeat.weekly.weekday.${day}`));
+
       const today = new Date();
       const weekStartsOn = firstWeekdayIndex(this.hass.locale);
       const weekStart = calcDate(
@@ -253,6 +266,13 @@ export class HaDateRangePicker extends LitElement {
         opening-direction=${this.openingDirection ||
         this._calcedOpeningDirection}
         first-day=${firstWeekdayIndex(this.hass.locale)}
+        weekday-su=${this._weekdays?.[0]}
+        weekday-mo=${this._weekdays?.[1]}
+        weekday-tu=${this._weekdays?.[2]}
+        weekday-we=${this._weekdays?.[3]}
+        weekday-th=${this._weekdays?.[4]}
+        weekday-fr=${this._weekdays?.[5]}
+        weekday-sa=${this._weekdays?.[6]}
       >
         <div slot="input" class="date-range-inputs" @click=${this._handleClick}>
           ${!this.minimal

--- a/src/components/ha-date-range-picker.ts
+++ b/src/components/ha-date-range-picker.ts
@@ -42,8 +42,6 @@ export interface DateRangePickerRanges {
   [key: string]: [Date, Date];
 }
 
-const DAYS = ["su", "mo", "tu", "we", "th", "fr", "sa"] as const;
-
 @customElement("ha-date-range-picker")
 export class HaDateRangePicker extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -78,23 +76,12 @@ export class HaDateRangePicker extends LitElement {
     | "center"
     | "inline";
 
-  @state() private _weekdays?: string[];
-
   protected willUpdate(changedProps: PropertyValues) {
     if (
       (!this.hasUpdated && this.ranges === undefined) ||
       (changedProps.has("hass") &&
         this.hass?.localize !== changedProps.get("hass")?.localize)
     ) {
-      this._weekdays = DAYS.map((day) =>
-        this.hass.localize(
-          `ui.components.date-range-picker.weekdays_short.${day}`
-        )
-      );
-
-      // temporary for development so I can view other languages
-      // this._weekdays = DAYS.map((day) => this.hass.localize(`ui.components.calendar.event.repeat.weekly.weekday.${day}`));
-
       const today = new Date();
       const weekStartsOn = firstWeekdayIndex(this.hass.locale);
       const weekStart = calcDate(
@@ -266,13 +253,7 @@ export class HaDateRangePicker extends LitElement {
         opening-direction=${this.openingDirection ||
         this._calcedOpeningDirection}
         first-day=${firstWeekdayIndex(this.hass.locale)}
-        weekday-su=${this._weekdays?.[0]}
-        weekday-mo=${this._weekdays?.[1]}
-        weekday-tu=${this._weekdays?.[2]}
-        weekday-we=${this._weekdays?.[3]}
-        weekday-th=${this._weekdays?.[4]}
-        weekday-fr=${this._weekdays?.[5]}
-        weekday-sa=${this._weekdays?.[6]}
+        language=${this.hass.locale.language}
       >
         <div slot="input" class="date-range-inputs" @click=${this._handleClick}>
           ${!this.minimal

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -604,6 +604,15 @@
         "end_date": "End date",
         "select": "Select",
         "select_date_range": "Select time period",
+        "weekdays_short": {
+          "su": "[%key:ui::components::calendar::event::repeat::weekly::weekday::su%]",
+          "mo": "[%key:ui::components::calendar::event::repeat::weekly::weekday::mo%]",
+          "tu": "[%key:ui::components::calendar::event::repeat::weekly::weekday::tu%]",
+          "we": "[%key:ui::components::calendar::event::repeat::weekly::weekday::we%]",
+          "th": "[%key:ui::components::calendar::event::repeat::weekly::weekday::th%]",
+          "fr": "[%key:ui::components::calendar::event::repeat::weekly::weekday::fr%]",
+          "sa": "[%key:ui::components::calendar::event::repeat::weekly::weekday::sa%]"
+        },
         "ranges": {
           "today": "Today",
           "yesterday": "Yesterday",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -604,15 +604,6 @@
         "end_date": "End date",
         "select": "Select",
         "select_date_range": "Select time period",
-        "weekdays_short": {
-          "su": "[%key:ui::components::calendar::event::repeat::weekly::weekday::su%]",
-          "mo": "[%key:ui::components::calendar::event::repeat::weekly::weekday::mo%]",
-          "tu": "[%key:ui::components::calendar::event::repeat::weekly::weekday::tu%]",
-          "we": "[%key:ui::components::calendar::event::repeat::weekly::weekday::we%]",
-          "th": "[%key:ui::components::calendar::event::repeat::weekly::weekday::th%]",
-          "fr": "[%key:ui::components::calendar::event::repeat::weekly::weekday::fr%]",
-          "sa": "[%key:ui::components::calendar::event::repeat::weekly::weekday::sa%]"
-        },
         "ranges": {
           "today": "Today",
           "yesterday": "Yesterday",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Localizing the weekdays in date range picker. I think we still need to do the months as well, but wanted to get a review of this before moving to that. 

![image](https://github.com/home-assistant/frontend/assets/32912880/794707b1-1c87-48bb-9082-12ac609c20c8)


~Looking at what's currently on lokalize, this seems like it would work good for every language except Malayalam, which currently has pretty long strings for abbreviated weeekday, and get some overflow issues.~

~I'm not sure if there's anything I can do there except just push it out and wait for someone to come update it to be shorter?~

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18919
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
