### PR TITLE
Circular progress improvement in update area

### DIFF
--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -111,6 +111,9 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
                     indeterminate
                     slot="graphic"
                     class="absolute"
+                    .ariaLabel=${this.hass.localize(
+                      "ui.panel.config.updates.update_in_progress"
+                    )}
                   ></ha-circular-progress>`
                 : ""}
               <span
@@ -130,6 +133,9 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
                       indeterminate
                       size="small"
                       slot="meta"
+                      .ariaLabel=${this.hass.localize(
+                        "ui.panel.config.updates.update_in_progress"
+                      )}
                     ></ha-circular-progress>`
                   : html`<ha-icon-next slot="meta"></ha-icon-next>`
                 : ""}

--- a/src/panels/config/dashboard/ha-config-updates.ts
+++ b/src/panels/config/dashboard/ha-config-updates.ts
@@ -109,7 +109,6 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
               ${this.narrow && entity.attributes.in_progress
                 ? html`<ha-circular-progress
                     indeterminate
-                    size="small"
                     slot="graphic"
                     class="absolute"
                   ></ha-circular-progress>`
@@ -191,6 +190,8 @@ class HaConfigUpdates extends SubscribeMixin(LitElement) {
         }
         ha-circular-progress.absolute {
           position: absolute;
+          width: 40px;
+          height: 40px;
         }
         state-badge.updating {
           opacity: 0.5;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1676,7 +1676,8 @@
           "show_skipped": "Show skipped updates",
           "join_beta": "[%key:supervisor::system::supervisor::join_beta_action%]",
           "leave_beta": "[%key:supervisor::system::supervisor::leave_beta_action%]",
-          "skipped": "Skipped"
+          "skipped": "Skipped",
+          "update_in_progress": "Update in progress"
         },
         "repairs": {
           "caption": "Repairs",


### PR DESCRIPTION
## Proposed change
Circular progress was displayed incorrectly on the update page after the upgrade to material design 3 component. 

For the update area, the UX has been improved while being there: 
* The circular progress now has an aria-label for accessibility. 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18976
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
