### PR TITLE
Sort default dashboard area cards by alphabetical order if no order specified

### DIFF
--- a/src/data/area_registry.ts
+++ b/src/data/area_registry.ts
@@ -128,7 +128,7 @@ export const areaCompare =
   (entries?: HomeAssistant["areas"], order?: string[]) =>
   (a: string, b: string) => {
     const indexA = order ? order.indexOf(a) : -1;
-    const indexB = order ? order.indexOf(b) : 1;
+    const indexB = order ? order.indexOf(b) : -1;
     if (indexA === -1 && indexB === -1) {
       const nameA = entries?.[a]?.name ?? a;
       const nameB = entries?.[b]?.name ?? b;

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -526,7 +526,7 @@ export const generateDefaultViewConfig = (
   const areaCards: LovelaceCardConfig[] = [];
 
   const sortedAreas = Object.keys(splittedByAreaDevice.areasWithEntities).sort(
-    areaCompare(areaEntries, areasPrefs?.order ?? [])
+    areaCompare(areaEntries, areasPrefs?.order)
   );
 
   for (const areaId of sortedAreas) {

--- a/src/panels/lovelace/common/generate-lovelace-config.ts
+++ b/src/panels/lovelace/common/generate-lovelace-config.ts
@@ -526,7 +526,7 @@ export const generateDefaultViewConfig = (
   const areaCards: LovelaceCardConfig[] = [];
 
   const sortedAreas = Object.keys(splittedByAreaDevice.areasWithEntities).sort(
-    areaCompare(areaEntries, areasPrefs?.order)
+    areaCompare(areaEntries, areasPrefs?.order ?? [])
   );
 
   for (const areaId of sortedAreas) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

With the new area sorting feature, if user does not specifically open the area picker and save an order, the default cards are sorted in an unintelligible order. 

It is especially strange because if user goes to the picker to fix the broken order, the areas in the picker already appear in alphabetical order the first time. So the only thing to do is change nothing, click save, and then the dashboard sorts in alphabetical order, despite having changed nothing. 

This change sorts areas alphabetically if no order is specified. I believe this was the default behavior before 2023.12. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18958
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
