### PR TITLE
Fix missing tooltips in energy-usage-graph

### DIFF
--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -662,10 +662,9 @@ export class HuiEnergyUsageGraphCard
       });
     });
 
-    const uniqueKeys = Array.from(new Set(allKeys))
-      .map((key) => Number(key))
-      .sort((a, b) => a - b)
-      .map((key) => key.toString());
+    const uniqueKeys = Array.from(new Set(allKeys)).sort(
+      (a, b) => Number(a) - Number(b)
+    );
 
     Object.entries(combinedData).forEach(([type, sources]) => {
       Object.entries(sources).forEach(([statId, source], idx) => {

--- a/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
+++ b/src/panels/lovelace/cards/energy/hui-energy-usage-graph-card.ts
@@ -662,7 +662,10 @@ export class HuiEnergyUsageGraphCard
       });
     });
 
-    const uniqueKeys = Array.from(new Set(allKeys));
+    const uniqueKeys = Array.from(new Set(allKeys))
+      .map((key) => Number(key))
+      .sort((a, b) => a - b)
+      .map((key) => key.toString());
 
     Object.entries(combinedData).forEach(([type, sources]) => {
       Object.entries(sources).forEach(([statId, source], idx) => {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

In some cases when coalescing the energy-usage-graph datapoints, the combined set keys can be generated in non-ascending time order, if some datasets have holes in their data. 

The graph still renders the dataset correctly, but I notice that the tooltips do not work in this case, and nothing appears when you hover over the out-of-order datapoint. 

By explicitly ensuring all the data is in ascending time order, all tooltips are correctly rendered. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
