### PR TITLE
media-player: Show volume slider in more cases

### DIFF
--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -125,9 +125,13 @@ class MoreInfoMediaPlayer extends LitElement {
                     ></ha-icon-button>
                   `
                 : ""}
-              ${supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_SET)
+              ${stateObj.attributes.volume_level != null
                 ? html`
                     <ha-slider
+                      ?disabled=${!supportsFeature(
+                        stateObj,
+                        MediaPlayerEntityFeature.VOLUME_SET
+                      )}
                       labeled
                       id="input"
                       .dir=${computeRTLDirection(this.hass!)}

--- a/src/panels/media-browser/ha-bar-media-player.ts
+++ b/src/panels/media-browser/ha-bar-media-player.ts
@@ -298,9 +298,7 @@ export class BarMediaPlayer extends SubscribeMixin(LitElement) {
     return html`
     <div class="choose-player ${isBrowser ? "browser" : ""}">
       ${
-        !this.narrow &&
-        stateObj &&
-        supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_SET)
+        !this.narrow && stateObj && stateObj.attributes.volume_level != null
           ? html`
               <ha-button-menu y="0" x="76">
                 <ha-icon-button
@@ -308,6 +306,10 @@ export class BarMediaPlayer extends SubscribeMixin(LitElement) {
                   .path=${mdiVolumeHigh}
                 ></ha-icon-button>
                 <ha-slider
+                  ?disabled=${!supportsFeature(
+                    stateObj,
+                    MediaPlayerEntityFeature.VOLUME_SET
+                  )}
                   labeled
                   min="0"
                   max="100"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Show a disabled volume slider in cases where the device's volume is reported but can't be "set". This is useful for displaying the volume level even if it can't be changed. I'm working on such functionality for the `hdmi_cec` integration, and it appears to be the case for some other integrations like `epson` and `androidtv_remote`.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
hdmi_cec:
  host: <some-address>
  platform: media_player
  devices:
    AVR: 1.0.0.0
```
Here's my hdmi_cec snippet. Obviously not really applicable to anyone else, but maybe you get the gist?

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io

Old look:
<img width="604" alt="image" src="https://github.com/home-assistant/frontend/assets/474937/a33fd3ce-20ba-4e46-8751-020021fe22a7">

New look:
<img width="605" alt="image" src="https://github.com/home-assistant/frontend/assets/474937/ae842752-06e2-4ab4-ba77-102ff4749b1a">

