### PR TITLE
Show +/- volume buttons for media players which support VOLUME_SET

### DIFF
--- a/src/data/media-player.ts
+++ b/src/data/media-player.ts
@@ -90,7 +90,7 @@ export const enum MediaPlayerEntityFeature {
   TURN_ON = 128,
   TURN_OFF = 256,
   PLAY_MEDIA = 512,
-  VOLUME_BUTTONS = 1024,
+  VOLUME_STEP = 1024,
   SELECT_SOURCE = 2048,
   STOP = 4096,
   CLEAR_PLAYLIST = 8192,

--- a/src/dialogs/more-info/controls/more-info-media_player.ts
+++ b/src/dialogs/more-info/controls/more-info-media_player.ts
@@ -81,7 +81,7 @@ class MoreInfoMediaPlayer extends LitElement {
           : ""}
       </div>
       ${(supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_SET) ||
-        supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_BUTTONS)) &&
+        supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_STEP)) &&
       stateActive(stateObj)
         ? html`
             <div class="volume">
@@ -104,8 +104,9 @@ class MoreInfoMediaPlayer extends LitElement {
                 : ""}
               ${supportsFeature(
                 stateObj,
-                MediaPlayerEntityFeature.VOLUME_BUTTONS
-              )
+                MediaPlayerEntityFeature.VOLUME_SET
+              ) ||
+              supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_STEP)
                 ? html`
                     <ha-icon-button
                       action="volume_down"

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -263,7 +263,7 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
                   : !this._veryNarrow &&
                       supportsFeature(
                         stateObj,
-                        MediaPlayerEntityFeature.VOLUME_SET
+                        MediaPlayerEntityFeature.VOLUME_STEP
                       )
                     ? html`
                         <ha-icon-button

--- a/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
+++ b/src/panels/lovelace/entity-rows/hui-media-player-entity-row.ts
@@ -208,10 +208,7 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
                 ></ha-icon-button>
               `
             : !supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_SET) &&
-                !supportsFeature(
-                  stateObj,
-                  MediaPlayerEntityFeature.VOLUME_BUTTONS
-                )
+                !supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_STEP)
               ? buttons
               : ""}
           ${supportsFeature(stateObj, MediaPlayerEntityFeature.TURN_OFF) &&
@@ -226,8 +223,8 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
             : ""}
         </div>
       </hui-generic-entity-row>
-      ${(supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_SET) ||
-        supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_BUTTONS)) &&
+      ${(supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_STEP) ||
+        supportsFeature(stateObj, MediaPlayerEntityFeature.VOLUME_SET)) &&
       stateActive(stateObj)
         ? html`
             <div class="flex">
@@ -266,7 +263,7 @@ class HuiMediaPlayerEntityRow extends LitElement implements LovelaceRow {
                   : !this._veryNarrow &&
                       supportsFeature(
                         stateObj,
-                        MediaPlayerEntityFeature.VOLUME_BUTTONS
+                        MediaPlayerEntityFeature.VOLUME_SET
                       )
                     ? html`
                         <ha-icon-button


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Show +/- volume buttons in media player more info for media players which support VOLUME_SET

Also rename `MediaPlayerEntityFeature.VOLUME_BUTTONS` to `MediaPlayerEntityFeature.VOLUME_STEP` to match core

Rationale:
A media player which supports the `volume_set` service also supports both the `volume_up` and `volume_down` services

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
