### PR TITLE
Fix entities sort for hidden/readonly

### DIFF
--- a/src/panels/config/entities/ha-config-entities.ts
+++ b/src/panels/config/entities/ha-config-entities.ts
@@ -74,7 +74,7 @@ export interface EntityRow extends StateEntity {
   entity?: HassEntity;
   unavailable: boolean;
   restored: boolean;
-  status: string;
+  status: string | undefined;
   area?: string;
   localized_platform: string;
 }
@@ -429,7 +429,13 @@ export class HaConfigEntities extends LitElement {
               ? localize("ui.panel.config.entities.picker.status.unavailable")
               : entry.disabled_by
                 ? localize("ui.panel.config.entities.picker.status.disabled")
-                : localize("ui.panel.config.entities.picker.status.ok"),
+                : entry.hidden_by
+                  ? localize("ui.panel.config.entities.picker.status.hidden")
+                  : entry.readonly
+                    ? localize(
+                        "ui.panel.config.entities.picker.status.readonly"
+                      )
+                    : undefined,
         });
       }
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3607,8 +3607,7 @@
               "unavailable": "Unavailable",
               "disabled": "Disabled",
               "readonly": "Read-only",
-              "hidden": "Hidden",
-              "ok": "Ok"
+              "hidden": "Hidden"
             },
             "headers": {
               "state_icon": "State icon",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

Fix sort by status on entities table. Currently "hidden" and "readonly" have status icons, but sorting on status ignores them, so they just kind of float around randomly in the table when trying to sort. 

I added these to sort, but I also want to propose changing the "ok" status to undefined, so that it always sorts to the bottom of the table. Given that "ok" entities don't show an icon or have a label, I consider the status column to really only be sorting the exceptional states, and should ignore the ok entities. 

This is similar to how when we sort by battery, the devices without battery always go to the bottom, regardless of if it is sorted asc or desc.

If I don't do this, then it's somewhat odd as sorting the table shows "disabled" and "hidden" first, then all of the ok entities, and finally "readonly" "restored" and "unavailable" at the end. That seems like not how sort would be expected to behave for status. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
