### PR TITLE
Add translation to integration setup failures

### DIFF
--- a/gallery/src/pages/misc/integration-card.ts
+++ b/gallery/src/pages/misc/integration-card.ts
@@ -36,6 +36,8 @@ const createConfigEntry = (
   pref_disable_new_entities: false,
   pref_disable_polling: false,
   reason: null,
+  reason_translation_key: null,
+  reason_translation_placeholders: null,
   ...override,
 });
 

--- a/gallery/src/pages/misc/integration-card.ts
+++ b/gallery/src/pages/misc/integration-card.ts
@@ -36,8 +36,8 @@ const createConfigEntry = (
   pref_disable_new_entities: false,
   pref_disable_polling: false,
   reason: null,
-  reason_translation_key: null,
-  reason_translation_placeholders: null,
+  error_reason_translation_key: null,
+  error_reason_translation_placeholders: null,
   ...override,
 });
 

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -23,8 +23,8 @@ export interface ConfigEntry {
   pref_disable_polling: boolean;
   disabled_by: "user" | null;
   reason: string | null;
-  reason_translation_key: string | null;
-  reason_translation_placeholders: Record<string, string> | null;
+  error_reason_translation_key: string | null;
+  error_reason_translation_placeholders: Record<string, string> | null;
 }
 
 export type ConfigEntryMutableParams = Partial<

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -23,6 +23,10 @@ export interface ConfigEntry {
   pref_disable_polling: boolean;
   disabled_by: "user" | null;
   reason: string | null;
+  reason_translation: Map<
+    string,
+    string | null | Record<string, string>
+  > | null;
 }
 
 export type ConfigEntryMutableParams = Partial<

--- a/src/data/config_entries.ts
+++ b/src/data/config_entries.ts
@@ -23,10 +23,8 @@ export interface ConfigEntry {
   pref_disable_polling: boolean;
   disabled_by: "user" | null;
   reason: string | null;
-  reason_translation: Map<
-    string,
-    string | null | Record<string, string>
-  > | null;
+  reason_translation_key: string | null;
+  reason_translation_placeholders: Record<string, string> | null;
 }
 
 export type ConfigEntryMutableParams = Partial<

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -556,16 +556,11 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           `component.${item.domain}.config.error.${item.reason}`
         );
         let stateTextReason: string | null = null;
-        if (item.reason_translation) {
+        if (item.reason_translation_key) {
           this.hass.loadBackendTranslation("exceptions", item.domain);
-          const placeHolders: Record<string, string> | undefined =
-            item.reason_translation.get("translation_placeholders") ??
-            undefined;
           stateTextReason = this.hass.localize(
-            `component.${item.domain}.exceptions.${item.reason_translation.get(
-              "translation_key"
-            )}.message`,
-            placeHolders
+            `component.${item.domain}.exceptions.${item.reason_translation_key}.message`,
+            item.reason_translation_placeholders ?? undefined
           );
         } else {
           stateTextReason = item.reason;

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -104,7 +104,6 @@ import { documentationUrl } from "../../../util/documentation-url";
 import { fileDownload } from "../../../util/file_download";
 import { DataEntryFlowProgressExtended } from "./ha-config-integrations";
 import { showAddIntegrationDialog } from "./show-add-integration-dialog";
-import { string } from "superstruct";
 
 @customElement("ha-config-integration-page")
 class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
@@ -565,7 +564,7 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         } else {
           stateTextReason = item.reason;
         }
-        stateTextExtra = html`${stateTextError || stateTextReason}`;
+        stateTextExtra = html`${stateTextReason || stateTextError}`;
       } else {
         stateTextExtra = html`
           <br />

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -556,13 +556,13 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
           .then((localize) =>
             localize(`component.${item.domain}.config.error.${item.reason}`)
           );
-        if (item.reason_translation_key) {
+        if (item.error_reason_translation_key) {
           const lokalisePromExc = this.hass
             .loadBackendTranslation("exceptions", item.domain)
             .then((localize) =>
               localize(
-                `component.${item.domain}.exceptions.${item.reason_translation_key}.message`,
-                item.reason_translation_placeholders ?? undefined
+                `component.${item.domain}.exceptions.${item.error_reason_translation_key}.message`,
+                item.error_reason_translation_placeholders ?? undefined
               )
             );
           stateTextExtra = html`${until(lokalisePromExc)}`;

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -561,10 +561,10 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
             `component.${item.domain}.exceptions.${item.reason_translation_key}.message`,
             item.reason_translation_placeholders ?? undefined
           );
-        } else {
-          stateTextReason = item.reason;
         }
-        stateTextExtra = html`${stateTextReason || stateTextError}`;
+        stateTextExtra = html`${stateTextReason ||
+        stateTextError ||
+        item.reason}`;
       } else {
         stateTextExtra = html`
           <br />

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -104,6 +104,7 @@ import { documentationUrl } from "../../../util/documentation-url";
 import { fileDownload } from "../../../util/file_download";
 import { DataEntryFlowProgressExtended } from "./ha-config-integrations";
 import { showAddIntegrationDialog } from "./show-add-integration-dialog";
+import { string } from "superstruct";
 
 @customElement("ha-config-integration-page")
 class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
@@ -551,9 +552,25 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
       ];
       if (item.reason) {
         this.hass.loadBackendTranslation("config", item.domain);
-        stateTextExtra = html`${this.hass.localize(
+        const stateTextError = this.hass.localize(
           `component.${item.domain}.config.error.${item.reason}`
-        ) || item.reason}`;
+        );
+        let stateTextReason: string | null = null;
+        if (item.reason_translation) {
+          this.hass.loadBackendTranslation("exceptions", item.domain);
+          const placeHolders: Record<string, string> | undefined =
+            item.reason_translation.get("translation_placeholders") ??
+            undefined;
+          stateTextReason = this.hass.localize(
+            `component.${item.domain}.exceptions.${item.reason_translation.get(
+              "translation_key"
+            )}.message`,
+            placeHolders
+          );
+        } else {
+          stateTextReason = item.reason;
+        }
+        stateTextExtra = html`${stateTextError || stateTextReason}`;
       } else {
         stateTextExtra = html`
           <br />

--- a/src/panels/config/integrations/ha-config-integration-page.ts
+++ b/src/panels/config/integrations/ha-config-integration-page.ts
@@ -551,11 +551,6 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
         `ui.panel.config.integrations.config_entry.state.${item.state}`,
       ];
       if (item.reason) {
-        const lokalisePromError = this.hass
-          .loadBackendTranslation("config", item.domain)
-          .then((localize) =>
-            localize(`component.${item.domain}.config.error.${item.reason}`)
-          );
         if (item.error_reason_translation_key) {
           const lokalisePromExc = this.hass
             .loadBackendTranslation("exceptions", item.domain)
@@ -567,6 +562,11 @@ class HaConfigIntegrationPage extends SubscribeMixin(LitElement) {
             );
           stateTextExtra = html`${until(lokalisePromExc)}`;
         } else {
+          const lokalisePromError = this.hass
+            .loadBackendTranslation("config", item.domain)
+            .then((localize) =>
+              localize(`component.${item.domain}.config.error.${item.reason}`)
+            );
           stateTextExtra = html`${until(lokalisePromError, item.reason)}`;
         }
       } else {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Add possibility for translations for Config Entry setup errors
Core PR: https://github.com/home-assistant/core/pull/106305

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
