### PR TITLE
Remove tile pointer/ripple/index when it has no action

### DIFF
--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -387,8 +387,8 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             hasHold: hasAction(this._config!.hold_action),
             hasDoubleClick: hasAction(this._config!.double_tap_action),
           })}
-          role=${this.hasCardAction ? "button" : ""}
-          tabindex=${this.hasCardAction ? "0" : undefined}
+          role=${ifDefined(this.hasCardAction ? "button" : undefined)}
+          tabindex=${ifDefined(this.hasCardAction ? "0" : undefined)}
           aria-labelledby="info"
           @mousedown=${this.handleRippleActivate}
           @mouseup=${this.handleRippleDeactivate}
@@ -405,8 +405,8 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
         <div class="content ${classMap(contentClasses)}">
           <div
             class="icon-container"
-            role=${this.hasIconAction ? "button" : ""}
-            tabindex=${this.hasIconAction ? "0" : undefined}
+            role=${ifDefined(this.hasIconAction ? "button" : undefined)}
+            tabindex=${ifDefined(this.hasIconAction ? "0" : undefined)}
             @action=${this._handleIconAction}
             .actionHandler=${actionHandler()}
           >

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -287,19 +287,38 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
 
   @eventOptions({ passive: true })
   private handleRippleActivate(evt?: Event) {
+    if (!this.hasCardAction) return;
     this._rippleHandlers.startPress(evt);
   }
 
   private handleRippleDeactivate() {
+    if (!this.hasCardAction) return;
     this._rippleHandlers.endPress();
   }
 
   private handleRippleMouseEnter() {
+    if (!this.hasCardAction) return;
     this._rippleHandlers.startHover();
   }
 
   private handleRippleMouseLeave() {
+    if (!this.hasCardAction) return;
     this._rippleHandlers.endHover();
+  }
+
+  get hasCardAction() {
+    return (
+      !this._config?.tap_action ||
+      hasAction(this._config?.tap_action) ||
+      hasAction(this._config?.hold_action) ||
+      hasAction(this._config?.double_tap_action)
+    );
+  }
+
+  get hasIconAction() {
+    return (
+      !this._config?.icon_tap_action || hasAction(this._config?.icon_tap_action)
+    );
   }
 
   protected render() {
@@ -359,15 +378,6 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       : undefined;
     const badge = computeTileBadge(stateObj, this.hass);
 
-    const hasCardAction =
-      !this._config.tap_action ||
-      hasAction(this._config.tap_action) ||
-      hasAction(this._config.hold_action) ||
-      hasAction(this._config.double_tap_action);
-
-    const hasIconAction =
-      !this._config.icon_tap_action || hasAction(this._config.icon_tap_action);
-
     return html`
       <ha-card style=${styleMap(style)} class=${classMap({ active })}>
         <div
@@ -377,18 +387,16 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             hasHold: hasAction(this._config!.hold_action),
             hasDoubleClick: hasAction(this._config!.double_tap_action),
           })}
-          role=${hasCardAction ? "button" : ""}
-          tabindex=${hasCardAction ? "0" : undefined}
+          role=${this.hasCardAction ? "button" : ""}
+          tabindex=${this.hasCardAction ? "0" : undefined}
           aria-labelledby="info"
-          @mousedown=${hasCardAction ? this.handleRippleActivate : undefined}
-          @mouseup=${hasCardAction ? this.handleRippleDeactivate : undefined}
-          @mouseenter=${hasCardAction ? this.handleRippleMouseEnter : undefined}
-          @mouseleave=${hasCardAction ? this.handleRippleMouseLeave : undefined}
-          @touchstart=${hasCardAction ? this.handleRippleActivate : undefined}
-          @touchend=${hasCardAction ? this.handleRippleDeactivate : undefined}
-          @touchcancel=${hasCardAction
-            ? this.handleRippleDeactivate
-            : undefined}
+          @mousedown=${this.handleRippleActivate}
+          @mouseup=${this.handleRippleDeactivate}
+          @mouseenter=${this.handleRippleMouseEnter}
+          @mouseleave=${this.handleRippleMouseLeave}
+          @touchstart=${this.handleRippleActivate}
+          @touchend=${this.handleRippleDeactivate}
+          @touchcancel=${this.handleRippleDeactivate}
         >
           ${this._shouldRenderRipple
             ? html`<mwc-ripple></mwc-ripple>`
@@ -397,8 +405,8 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
         <div class="content ${classMap(contentClasses)}">
           <div
             class="icon-container"
-            role=${hasIconAction ? "button" : ""}
-            tabindex=${hasIconAction ? "0" : undefined}
+            role=${this.hasIconAction ? "button" : ""}
+            tabindex=${this.hasIconAction ? "0" : undefined}
             @action=${this._handleIconAction}
             .actionHandler=${actionHandler()}
           >

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -359,6 +359,15 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
       : undefined;
     const badge = computeTileBadge(stateObj, this.hass);
 
+    const hasCardAction =
+      !this._config.tap_action ||
+      hasAction(this._config.tap_action) ||
+      hasAction(this._config.hold_action) ||
+      hasAction(this._config.double_tap_action);
+
+    const hasIconAction =
+      !this._config.icon_tap_action || hasAction(this._config.icon_tap_action);
+
     return html`
       <ha-card style=${styleMap(style)} class=${classMap({ active })}>
         <div
@@ -368,16 +377,18 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             hasHold: hasAction(this._config!.hold_action),
             hasDoubleClick: hasAction(this._config!.double_tap_action),
           })}
-          role="button"
-          tabindex="0"
+          role=${hasCardAction ? "button" : ""}
+          tabindex=${hasCardAction ? "0" : undefined}
           aria-labelledby="info"
-          @mousedown=${this.handleRippleActivate}
-          @mouseup=${this.handleRippleDeactivate}
-          @mouseenter=${this.handleRippleMouseEnter}
-          @mouseleave=${this.handleRippleMouseLeave}
-          @touchstart=${this.handleRippleActivate}
-          @touchend=${this.handleRippleDeactivate}
-          @touchcancel=${this.handleRippleDeactivate}
+          @mousedown=${hasCardAction ? this.handleRippleActivate : undefined}
+          @mouseup=${hasCardAction ? this.handleRippleDeactivate : undefined}
+          @mouseenter=${hasCardAction ? this.handleRippleMouseEnter : undefined}
+          @mouseleave=${hasCardAction ? this.handleRippleMouseLeave : undefined}
+          @touchstart=${hasCardAction ? this.handleRippleActivate : undefined}
+          @touchend=${hasCardAction ? this.handleRippleDeactivate : undefined}
+          @touchcancel=${hasCardAction
+            ? this.handleRippleDeactivate
+            : undefined}
         >
           ${this._shouldRenderRipple
             ? html`<mwc-ripple></mwc-ripple>`
@@ -386,8 +397,8 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
         <div class="content ${classMap(contentClasses)}">
           <div
             class="icon-container"
-            role="button"
-            tabindex="0"
+            role=${hasIconAction ? "button" : ""}
+            tabindex=${hasIconAction ? "0" : undefined}
             @action=${this._handleIconAction}
             .actionHandler=${actionHandler()}
           >


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

If a tile card (or tile card icon) explicitly defines no action, remove the visual suggestions that is interactive:
 - No mouse hover effects
 - No cursor pointer
 - No ripples on click
 - No tab index


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #18122
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
