### PR TITLE
Add (i) tooltip button for More Info functionality on mobile devices & tooltip z-index fix

### DIFF
--- a/src/components/chart/ha-chart-base.ts
+++ b/src/components/chart/ha-chart-base.ts
@@ -261,6 +261,7 @@ export class HaChartBase extends LitElement {
                       ${this._tooltip.footer.map((item) => html`${item}<br />`)}
                     </div>`
                   : ""}
+                <slot name="tooltip-footer"></slot>
               </div>`
             : ""}
         </div>
@@ -449,9 +450,12 @@ export class HaChartBase extends LitElement {
         color: white;
         border-radius: 4px;
         pointer-events: none;
-        z-index: 1000;
+        z-index: 1;
         width: 200px;
         box-sizing: border-box;
+        -ms-user-select: none;
+        -webkit-user-select: none;
+        -moz-user-select: none;
       }
       :host([rtl]) .chartTooltip {
         direction: rtl;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Some people complained that tapping on a chart to open More Info dialog instantly is not a common or expected behavior on mobile UIs.

Therefore this PR adjusts the functionality by introducing a tooltop-footer slot in the `ha-chart-base` component. This slot is then used by the `state-history-chart-line` and the `state-history-chart-timeline` to conditionally display a clickable (i) info button in the tooltip footer.

The decision to display this tooltip button is based on a type of native touch/mouse event which triggered `onTap` or `onHover` on the chart. For mouse events, the tooltip button is not visible and a click on a chart opens More Info directly (the current state). For non-mouse events, this (i) info button is displayed and can be additionally tapped on to display More Info.

The decision to use a clickable (i) tooltip button instead of just reacting to a tap on the tooltip itself was made because sometimes a tap on a tooltip is a valid action if there is a graph data point under the tooltip which a user wants to select. Therefore it is best to keep this functionality and just add this small clickable (i) instead.

![ha-touch-moreinfo](https://github.com/home-assistant/frontend/assets/966992/e5047f28-cebc-4602-af8d-a7c5eb980921)

Additionally, this PR also decreases the z-index CSS rule of the tooptip div from 1000 to 1 to prevent over-drawing of the sidebar or dialogs with chart tooltips.

I also set `user-select` CSS rule to `none` on the tooltip div to [avoid selecting text](https://github.com/home-assistant/frontend/issues/18784#issuecomment-1853363854) on a tooltip in History panel.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
  - fixes #18344 
  - fixes #18784
  - fixes #18198
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
