### PR TITLE
Add missing device classes for entity-registry-settings-editor

### DIFF
--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -118,7 +118,7 @@ const OVERRIDE_DEVICE_CLASSES = {
       "carbon_monoxide",
       "moisture",
     ], // Alarm
-    ["connectivity"],
+    ["connectivity", "update"], // Other
   ],
 };
 

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -118,7 +118,8 @@ const OVERRIDE_DEVICE_CLASSES = {
       "carbon_monoxide",
       "moisture",
     ], // Alarm
-    ["connectivity", "update"], // Other
+    ["connectivity"], // Connectivity
+    ["update"], // Update
   ],
 };
 

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -118,6 +118,7 @@ const OVERRIDE_DEVICE_CLASSES = {
       "carbon_monoxide",
       "moisture",
     ], // Alarm
+    ["connectivity"],
   ],
 };
 


### PR DESCRIPTION
## Proposed change

Currently the "Show as" dropdown for binary sensors does not have "Connectivity" or "Update" as an option. I noticed this when I created a `group` binary sensor for multiple `ping` sensors. This PR adds the `connectivity` and `update` device classes to the dropdown. Both of these `binary_sensor` device classes are listed in the `/src/common/entity/get_states.ts` and translations files, but were missing from the dropdown.

After change:
<img width="633" alt="Screenshot 2024-01-02 at 10 06 39 AM" src="https://github.com/home-assistant/frontend/assets/1522068/7b40b8b0-695c-45af-a0b6-26be811b3233">


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

Edit the settings of any binary sensor, in the Show as dropdown there is no option for Connectivity or Update before this PR. After this PR those options are available.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
