### PR TITLE
Simple automation trigger for Timer events

### DIFF
--- a/src/data/automation.ts
+++ b/src/data/automation.ts
@@ -107,6 +107,15 @@ export interface NumericStateTrigger extends BaseTrigger {
   for?: string | number | ForDict;
 }
 
+export interface TimerTrigger extends BaseTrigger {
+  platform: "event";
+  event_type: string;
+  event_data: {
+    entity_id: string;
+  };
+  metadata: Record<string, never>;
+}
+
 export interface ConversationTrigger extends BaseTrigger {
   platform: "conversation";
   command: string | string[];
@@ -190,6 +199,7 @@ export type Trigger =
   | ZoneTrigger
   | TagTrigger
   | TimeTrigger
+  | TimerTrigger
   | TemplateTrigger
   | EventTrigger
   | DeviceTrigger

--- a/src/data/trigger.ts
+++ b/src/data/trigger.ts
@@ -16,12 +16,21 @@ import {
   mdiShape,
   mdiStateMachine,
   mdiSwapHorizontal,
+  mdiTimerOutline,
   mdiWeatherSunny,
   mdiWebhook,
 } from "@mdi/js";
-
+import {
+  object,
+  optional,
+  string,
+  union,
+  literal,
+  boolean,
+  is,
+} from "superstruct";
 import { mdiHomeAssistant } from "../resources/home-assistant-logo-svg";
-import { AutomationElementGroup } from "./automation";
+import { AutomationElementGroup, Trigger } from "./automation";
 
 export const TRIGGER_ICONS = {
   calendar: mdiCalendar,
@@ -37,6 +46,7 @@ export const TRIGGER_ICONS = {
   tag: mdiNfcVariant,
   template: mdiCodeBraces,
   time: mdiClockOutline,
+  timer: mdiTimerOutline,
   time_pattern: mdiAvTimer,
   webhook: mdiWebhook,
   persistent_notification: mdiMessageAlert,
@@ -59,9 +69,37 @@ export const TRIGGER_GROUPS: AutomationElementGroup = {
       mqtt: {},
       conversation: {},
       tag: {},
+      timer: {},
       template: {},
       webhook: {},
       persistent_notification: {},
     },
   },
 } as const;
+
+const timerEventTypeStruct = union([
+  literal("timer.cancelled"),
+  literal("timer.finished"),
+  literal("timer.started"),
+  literal("timer.restarted"),
+  literal("timer.paused"),
+]);
+
+const timerEventTriggerStruct = object({
+  alias: optional(string()),
+  id: optional(string()),
+  variables: optional(object()),
+  enabled: optional(boolean()),
+  platform: literal("event"),
+  metadata: object(),
+  event_type: optional(timerEventTypeStruct),
+  event_data: object({
+    entity_id: optional(string()),
+  }),
+});
+
+export const getTriggerType = (trigger: Trigger): string => {
+  if (is(trigger, timerEventTriggerStruct)) return "timer";
+
+  return trigger.platform;
+};

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -37,7 +37,7 @@ import { describeTrigger } from "../../../../data/automation_i18n";
 import { validateConfig } from "../../../../data/config";
 import { fullEntitiesContext } from "../../../../data/context";
 import { EntityRegistryEntry } from "../../../../data/entity_registry";
-import { TRIGGER_ICONS } from "../../../../data/trigger";
+import { TRIGGER_ICONS, getTriggerType } from "../../../../data/trigger";
 import {
   showAlertDialog,
   showConfirmationDialog,
@@ -59,6 +59,7 @@ import "./types/ha-automation-trigger-sun";
 import "./types/ha-automation-trigger-tag";
 import "./types/ha-automation-trigger-template";
 import "./types/ha-automation-trigger-time";
+import "./types/ha-automation-trigger-timer";
 import "./types/ha-automation-trigger-time_pattern";
 import "./types/ha-automation-trigger-webhook";
 import "./types/ha-automation-trigger-zone";
@@ -128,9 +129,10 @@ export default class HaAutomationTriggerRow extends LitElement {
   private _triggerUnsub?: Promise<UnsubscribeFunc>;
 
   protected render() {
+    const triggerType = getTriggerType(this.trigger);
+
     const supported =
-      customElements.get(`ha-automation-trigger-${this.trigger.platform}`) !==
-      undefined;
+      customElements.get(`ha-automation-trigger-${triggerType}`) !== undefined;
     const yamlMode = this._yamlMode || !supported;
     const showId = "id" in this.trigger || this._requestShowId;
 
@@ -150,7 +152,7 @@ export default class HaAutomationTriggerRow extends LitElement {
           <h3 slot="header">
             <ha-svg-icon
               class="trigger-icon"
-              .path=${TRIGGER_ICONS[this.trigger.platform]}
+              .path=${TRIGGER_ICONS[triggerType]}
             ></ha-svg-icon>
             ${describeTrigger(this.trigger, this.hass, this._entityReg)}
           </h3>
@@ -351,14 +353,11 @@ export default class HaAutomationTriggerRow extends LitElement {
                     @ui-mode-not-available=${this._handleUiModeNotAvailable}
                     @value-changed=${this._onUiChanged}
                   >
-                    ${dynamicElement(
-                      `ha-automation-trigger-${this.trigger.platform}`,
-                      {
-                        hass: this.hass,
-                        trigger: this.trigger,
-                        disabled: this.disabled,
-                      }
-                    )}
+                    ${dynamicElement(`ha-automation-trigger-${triggerType}`, {
+                      hass: this.hass,
+                      trigger: this.trigger,
+                      disabled: this.disabled,
+                    })}
                   </div>
                 `}
           </div>

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -11,6 +11,7 @@ import "../../../../components/ha-button";
 import "../../../../components/ha-button-menu";
 import "../../../../components/ha-svg-icon";
 import { AutomationClipboard, Trigger } from "../../../../data/automation";
+import { getTriggerType } from "../../../../data/trigger";
 import { sortableStyles } from "../../../../resources/ha-sortable-style";
 import type { SortableInstance } from "../../../../resources/sortable";
 import { HomeAssistant } from "../../../../types";
@@ -131,7 +132,9 @@ export default class HaAutomationTrigger extends LitElement {
     showAddAutomationElementDialog(this, {
       type: "trigger",
       add: this._addTrigger,
-      clipboardItem: this._clipboard?.trigger?.platform,
+      clipboardItem: this._clipboard?.trigger
+        ? getTriggerType(this._clipboard.trigger)
+        : undefined,
     });
   }
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-timer.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-timer.ts
@@ -1,0 +1,123 @@
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../../../../common/dom/fire_event";
+import type { LocalizeFunc } from "../../../../../common/translations/localize";
+import "../../../../../components/ha-form/ha-form";
+import type { SchemaUnion } from "../../../../../components/ha-form/types";
+import type { TimerTrigger } from "../../../../../data/automation";
+import type { HomeAssistant } from "../../../../../types";
+
+const EVENTS = [
+  "cancelled",
+  "finished",
+  "started",
+  "restarted",
+  "paused",
+] as const;
+
+@customElement("ha-automation-trigger-timer")
+export class HaTimerTrigger extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public trigger!: TimerTrigger;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  private _schema = memoizeOne(
+    (localize: LocalizeFunc) =>
+      [
+        {
+          name: "entity_id",
+          required: true,
+          selector: {
+            entity: {
+              filter: {
+                domain: "timer",
+              },
+            },
+          },
+        },
+        {
+          name: "event",
+          type: "select",
+          required: true,
+          options: EVENTS.map(
+            (e) =>
+              [
+                `timer.${e}`,
+                localize(
+                  `ui.panel.config.automation.editor.triggers.type.timer.event_types.${e}`
+                ),
+              ] as const
+          ),
+        },
+      ] as const
+  );
+
+  public static get defaultConfig() {
+    return {
+      platform: "event",
+      event_type: undefined,
+      metadata: {},
+      event_data: {
+        entity_id: undefined,
+      },
+    };
+  }
+
+  public render() {
+    const schema = this._schema(this.hass.localize);
+
+    const data = {
+      entity_id: this.trigger.event_data?.entity_id,
+      event: this.trigger.event_type,
+    };
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${schema}
+        .disabled=${this.disabled}
+        @value-changed=${this._valueChanged}
+        .computeLabel=${this._computeLabelCallback}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const value = ev.detail.value;
+
+    const newTrigger = {
+      platform: "event",
+      metadata: {},
+      event_data: {
+        entity_id: value.entity_id,
+      },
+      event_type: value.event,
+    };
+
+    fireEvent(this, "value-changed", { value: newTrigger });
+  }
+
+  private _computeLabelCallback = (
+    schema: SchemaUnion<ReturnType<typeof this._schema>>
+  ): string => {
+    switch (schema.name) {
+      case "entity_id":
+        return this.hass.localize("ui.components.entity.entity-picker.entity");
+      default:
+        return this.hass.localize(
+          `ui.panel.config.automation.editor.triggers.type.timer.${schema.name}`
+        );
+    }
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-automation-trigger-timer": HaTimerTrigger;
+  }
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2662,6 +2662,21 @@
                     "full": "When the time is equal to {time}"
                   }
                 },
+                "timer": {
+                  "label": "Timer",
+                  "description": {
+                    "picker": "When a timer fires an event.",
+                    "full": "When {entity} is {event}"
+                  },
+                  "event": "[%key:ui::panel::config::automation::editor::triggers::type::homeassistant::event%]",
+                  "event_types": {
+                    "cancelled": "Cancelled",
+                    "finished": "Finished",
+                    "started": "Started",
+                    "restarted": "Restarted",
+                    "paused": "Paused"
+                  }
+                },
                 "time_pattern": {
                   "label": "Time pattern",
                   "hours": "Hours",


### PR DESCRIPTION
## Proposed change

I like using timer helpers for automations, but I think the experience leaves something to be desired. Even as an experienced user I still have to go review the documentation every time I want to use one, to remember how to structure the necessary manual events. I think this could be somewhat difficult for new users as well, given that the manual event trigger describes itself as an "advanced concept". 

As an alternative, I propose a simpler UI "Timer trigger", which just has an entity id picker, and a select to choose a timer event to listen for. I believe this would be much more accessible than having to setup a manual event trigger. 

I debated if this would need to be a "real" trigger in the backend, or if we could just wrap the existing event with a new UI, and not really need any core changes. I decided to try the latter for now, as the former sounded somewhat more difficult, and possibly unnecessary. 

This change does require a one line change in core to allow the validator to accept and ignore the `metadata` field for triggers, similar to how we have done in other areas. I can try an additional PR for that if we think this approach is favorable. 


![image](https://github.com/home-assistant/frontend/assets/32912880/32b4a8f5-92c9-4a32-a3b2-5356d9b2edb8)

![image](https://github.com/home-assistant/frontend/assets/32912880/1f476059-418b-4c8c-bc04-d0722a635a4b)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
