### PR TITLE
Change the type of input fields for password to support Safari auto fill

### DIFF
--- a/src/panels/config/users/dialog-add-user.ts
+++ b/src/panels/config/users/dialog-add-user.ts
@@ -26,6 +26,7 @@ import { ValueChangedEvent, HomeAssistant } from "../../../types";
 import { haStyleDialog } from "../../../resources/styles";
 import { AddUserDialogParams } from "./show-dialog-add-user";
 import "../../../components/ha-textfield";
+import "../../../auth/ha-auth-textfield";
 import type { HaTextField } from "../../../components/ha-textfield";
 
 @customElement("dialog-add-user")
@@ -128,19 +129,20 @@ export class DialogAddUser extends LitElement {
             dialogInitialFocus
           ></ha-textfield>
 
-          <ha-textfield
+          <ha-auth-textfield
             .label=${this.hass.localize(
               "ui.panel.config.users.add_user.password"
             )}
+            style="display: block"
             type="password"
             name="password"
             .value=${this._password}
             required
             @input=${this._handleValueChanged}
             .validationMessage=${this.hass.localize("ui.common.error_required")}
-          ></ha-textfield>
+          ></ha-auth-textfield>
 
-          <ha-textfield
+          <ha-auth-textfield
             label=${this.hass.localize(
               "ui.panel.config.users.add_user.password_confirm"
             )}
@@ -148,6 +150,7 @@ export class DialogAddUser extends LitElement {
             .value=${this._passwordConfirm}
             @input=${this._handleValueChanged}
             required
+            style="display: block"
             type="password"
             .invalid=${this._password !== "" &&
             this._passwordConfirm !== "" &&
@@ -155,7 +158,7 @@ export class DialogAddUser extends LitElement {
             .validationMessage=${this.hass.localize(
               "ui.panel.config.users.add_user.password_not_match"
             )}
-          ></ha-textfield>
+          ></ha-auth-textfield>
           <div class="row">
             <ha-formfield
               .label=${this.hass.localize(


### PR DESCRIPTION
## Proposed change 
As described in issue #18942 the Safari Autofill doesn't seem to trigger a change of the input password field(s). This results in the Create button on the Add-user dialog not becoming enabled because the form password fields are not propagated to the form.
With this PR I changed the type of fields for the password entry in the user-add dialog from ha-textfield to ha-auth-textfield. This type was already present for the authentication mechanism and makes the autofill of Safari being reccognized.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
No specific configuration needed
```yaml

```

## Additional information
- This PR fixes or closes issue: fixes #18942 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

[docs-repository]: https://github.com/home-assistant/home-assistant.io
