### PR TITLE
Fix thermostat and humidifier card rendering when off

### DIFF
--- a/src/state-control/climate/ha-state-control-climate-temperature.ts
+++ b/src/state-control/climate/ha-state-control-climate-temperature.ts
@@ -177,11 +177,20 @@ export class HaStateControlClimateTemperature extends LitElement {
 
     const action = this.stateObj.attributes.hvac_action;
 
+    const isTemperatureDisplayed =
+      (this.stateObj.attributes.current_temperature != null &&
+        this.showCurrentAsPrimary) ||
+      ((this._supportsTargetTemperature ||
+        this._supportsTargetTemperatureRange) &&
+        !this.showCurrentAsPrimary);
+
     return html`
       <p class="label">
-        ${action
+        ${action && action !== "off"
           ? this.hass.formatEntityAttributeValue(this.stateObj, "hvac_action")
-          : this.hass.formatEntityState(this.stateObj)}
+          : isTemperatureDisplayed
+            ? this.hass.formatEntityState(this.stateObj)
+            : nothing}
       </p>
     `;
   }
@@ -315,6 +324,14 @@ export class HaStateControlClimateTemperature extends LitElement {
       `;
     }
 
+    if (this.stateObj.state !== UNAVAILABLE) {
+      return html`
+        <p class="primary-state">
+          ${this.hass.formatEntityState(this.stateObj)}
+        </p>
+      `;
+    }
+
     return nothing;
   }
 
@@ -371,6 +388,14 @@ export class HaStateControlClimateTemperature extends LitElement {
     }
 
     return html`<p class="label"></p>`;
+  }
+
+  private _renderInfo() {
+    return html`
+      <div class="info">
+        ${this._renderLabel()}${this._renderPrimary()}${this._renderSecondary()}
+      </div>
+    `;
   }
 
   get _supportsTargetTemperature() {
@@ -447,10 +472,7 @@ export class HaStateControlClimateTemperature extends LitElement {
             @value-changing=${this._valueChanging}
           >
           </ha-control-circular-slider>
-          <div class="info">
-            ${this._renderLabel()}${this._renderPrimary()}${this._renderSecondary()}
-          </div>
-          ${this._renderTemperatureButtons("value")}
+          ${this._renderInfo()} ${this._renderTemperatureButtons("value")}
         </div>
       `;
     }
@@ -484,9 +506,7 @@ export class HaStateControlClimateTemperature extends LitElement {
             @high-changing=${this._valueChanging}
           >
           </ha-control-circular-slider>
-          <div class="info">
-            ${this._renderLabel()}${this._renderPrimary()}${this._renderSecondary()}
-          </div>
+          ${this._renderInfo()}
           ${this._renderTemperatureButtons(this._selectTargetTemperature, true)}
         </div>
       `;
@@ -510,9 +530,7 @@ export class HaStateControlClimateTemperature extends LitElement {
           .disabled=${!active}
         >
         </ha-control-circular-slider>
-        <div class="info">
-          ${this._renderLabel()} ${this._renderSecondary()}
-        </div>
+        ${this._renderInfo()}
       </div>
     `;
   }

--- a/src/state-control/climate/ha-state-control-climate-temperature.ts
+++ b/src/state-control/climate/ha-state-control-climate-temperature.ts
@@ -517,6 +517,7 @@ export class HaStateControlClimateTemperature extends LitElement {
         class="container${containerSizeClass}"
         style=${styleMap({
           "--state-color": stateColor,
+          "--action-color": actionColor,
         })}
       >
         <ha-control-circular-slider

--- a/src/state-control/humidifier/ha-state-control-humidifier-humidity.ts
+++ b/src/state-control/humidifier/ha-state-control-humidifier-humidity.ts
@@ -105,11 +105,18 @@ export class HaStateControlHumidifierHumidity extends LitElement {
 
     const action = this.stateObj.attributes.action;
 
+    const isHumidityDisplayed =
+      (this.stateObj.attributes.current_humidity != null &&
+        this.showCurrentAsPrimary) ||
+      (this._targetHumidity != null && !this.showCurrentAsPrimary);
+
     return html`
       <p class="label">
-        ${action
+        ${action && action !== "off"
           ? this.hass.formatEntityAttributeValue(this.stateObj, "action")
-          : this.hass.formatEntityState(this.stateObj)}
+          : isHumidityDisplayed
+            ? this.hass.formatEntityState(this.stateObj)
+            : nothing}
       </p>
     `;
   }
@@ -142,6 +149,14 @@ export class HaStateControlHumidifierHumidity extends LitElement {
 
     if (this._targetHumidity != null && !this.showCurrentAsPrimary) {
       return this._renderTarget(this._targetHumidity!, "big");
+    }
+
+    if (this.stateObj.state !== UNAVAILABLE) {
+      return html`
+        <p class="primary-state">
+          ${this.hass.formatEntityState(this.stateObj)}
+        </p>
+      `;
     }
 
     return nothing;
@@ -225,6 +240,12 @@ export class HaStateControlHumidifierHumidity extends LitElement {
     `;
   }
 
+  private _renderInfo() {
+    return html` <div class="info">
+      ${this._renderLabel()}${this._renderPrimary()}${this._renderSecondary()}
+    </div>`;
+  }
+
   protected render() {
     const stateColor = stateColorCss(this.stateObj);
     const active = stateActive(this.stateObj);
@@ -272,10 +293,7 @@ export class HaStateControlHumidifierHumidity extends LitElement {
             @value-changing=${this._valueChanging}
           >
           </ha-control-circular-slider>
-          <div class="info">
-            ${this._renderLabel()}${this._renderPrimary()}${this._renderSecondary()}
-          </div>
-          ${this._renderButtons()}
+          ${this._renderInfo()} ${this._renderButtons()}
         </div>
       `;
     }
@@ -296,9 +314,7 @@ export class HaStateControlHumidifierHumidity extends LitElement {
           disabled
         >
         </ha-control-circular-slider>
-        <div class="info">
-          ${this._renderLabel()} ${this._renderSecondary()}
-        </div>
+        ${this._renderInfo()}
       </div>
     `;
   }

--- a/src/state-control/humidifier/ha-state-control-humidifier-humidity.ts
+++ b/src/state-control/humidifier/ha-state-control-humidifier-humidity.ts
@@ -241,9 +241,11 @@ export class HaStateControlHumidifierHumidity extends LitElement {
   }
 
   private _renderInfo() {
-    return html` <div class="info">
-      ${this._renderLabel()}${this._renderPrimary()}${this._renderSecondary()}
-    </div>`;
+    return html`
+      <div class="info">
+        ${this._renderLabel()}${this._renderPrimary()}${this._renderSecondary()}
+      </div>
+    `;
   }
 
   protected render() {
@@ -302,6 +304,7 @@ export class HaStateControlHumidifierHumidity extends LitElement {
       <div
         class="container${containerSizeClass}"
         style=${styleMap({
+          "--state-color": stateColor,
           "--action-color": actionColor,
         })}
       >

--- a/src/state-control/state-control-circular-slider-style.ts
+++ b/src/state-control/state-control-circular-slider-style.ts
@@ -54,7 +54,6 @@ export const stateControlCircularSliderStyle = css`
   .label.disabled {
     color: var(--secondary-text-color);
   }
-
   .buttons {
     position: absolute;
     bottom: 10px;
@@ -67,6 +66,9 @@ export const stateControlCircularSliderStyle = css`
     align-items: center;
     justify-content: center;
   }
+  .primary-state {
+    font-size: 36px;
+  }
 
   .buttons ha-outlined-icon-button {
     --md-outlined-icon-button-container-width: 48px;
@@ -76,6 +78,9 @@ export const stateControlCircularSliderStyle = css`
 
   .container.md ha-big-number {
     font-size: 44px;
+  }
+  .container.md .state {
+    font-size: 30px;
   }
   .container.md .info {
     margin-top: 12px;
@@ -90,6 +95,9 @@ export const stateControlCircularSliderStyle = css`
 
   .container.sm ha-big-number {
     font-size: 32px;
+  }
+  .container.sm .state {
+    font-size: 26px;
   }
   .container.sm .info {
     margin-top: 12px;
@@ -106,6 +114,9 @@ export const stateControlCircularSliderStyle = css`
 
   .container.xs ha-big-number {
     font-size: 32px;
+  }
+  .container.xs .state {
+    font-size: 16px;
   }
   .container.xs .info {
     margin-top: 12px;


### PR DESCRIPTION
## Proposed change

This PR fixes 2 issues with thermostat card and humidifier card.

Always display temperature (current or target), even if the state if off.

![CleanShot 2024-01-04 at 15 04 11](https://github.com/home-assistant/frontend/assets/5878303/04209f2d-4da1-4dca-85b7-110c87f8653f)

If no temperature is available, display the state at the center instead of label to have bigger text.

![CleanShot 2024-01-04 at 15 07 02](https://github.com/home-assistant/frontend/assets/5878303/3b3fec89-9bd5-40a3-a0d6-87b59550800e)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #19271
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
