### PR TITLE
Create helpers from automation editor

### DIFF
--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -19,7 +19,6 @@ import "../ha-svg-icon";
 import "./state-badge";
 import { caseInsensitiveStringCompare } from "../../common/string/compare";
 import { showHelperDetailDialog } from "../../panels/config/helpers/show-dialog-helper-detail";
-import type { HelperDomain } from "../../panels/config/helpers/const";
 
 interface HassEntityWithCachedName extends HassEntity, ScorableTextItem {
   friendly_name: string;
@@ -385,9 +384,9 @@ export class HaEntityPicker extends LitElement {
 
     if (newValue === NEW_ENTITY_ID) {
       showHelperDetailDialog(this, {
-        domain: this.createDomains![0] as HelperDomain,
+        domains: this.createDomains!,
         dialogClosedCallback: (item) => {
-          if (item.entryId) this._setValue(item.entryId);
+          if (item.entityId) this._setValue(item.entityId);
         },
       });
       return;

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -19,14 +19,17 @@ import "../ha-svg-icon";
 import "./state-badge";
 import { caseInsensitiveStringCompare } from "../../common/string/compare";
 import { showHelperDetailDialog } from "../../panels/config/helpers/show-dialog-helper-detail";
+import { domainToName } from "../../data/integration";
+import {
+  isHelperDomain,
+  HelperDomain,
+} from "../../panels/config/helpers/const";
 
 interface HassEntityWithCachedName extends HassEntity, ScorableTextItem {
   friendly_name: string;
 }
 
 export type HaEntityPickerEntityFilterFunc = (entity: HassEntity) => boolean;
-
-const NEW_ENTITY_ID = "__new_entity__";
 
 @customElement("ha-entity-picker")
 export class HaEntityPicker extends LitElement {
@@ -158,20 +161,37 @@ export class HaEntityPicker extends LitElement {
       }
       let entityIds = Object.keys(hass.states);
 
+      const newFriendlyName = hass.localize(
+        "ui.components.entity.entity-picker.create_helper",
+        {
+          domain:
+            createDomains?.length === 1
+              ? isHelperDomain(createDomains[0])
+                ? hass.localize(
+                    `ui.panel.config.helpers.types.${
+                      createDomains[0] as HelperDomain
+                    }`
+                  )
+                : domainToName(hass.localize, createDomains[0])
+              : undefined,
+        }
+      );
+
+      const newEntityId = hass.localize(
+        "ui.components.entity.entity-picker.new_entity"
+      );
+
       const newEntity = {
-        entity_id: NEW_ENTITY_ID,
+        entity_id: newEntityId,
         state: "on",
         last_changed: "",
         last_updated: "",
         context: { id: "", user_id: null, parent_id: null },
-        friendly_name: `Create a new ${
-          createDomains?.length === 1 ? `${createDomains[0]} ` : ""
-        }helper`,
+        friendly_name: newFriendlyName,
         attributes: {
-          friendly_name: "foo",
           icon: "mdi:plus",
         },
-        strings: ["create new"],
+        strings: [newEntityId, newFriendlyName],
       };
 
       if (!entityIds.length) {
@@ -382,7 +402,10 @@ export class HaEntityPicker extends LitElement {
     ev.stopPropagation();
     const newValue = ev.detail.value;
 
-    if (newValue === NEW_ENTITY_ID) {
+    if (
+      newValue ===
+      this.hass.localize("ui.components.entity.entity-picker.new_entity")
+    ) {
       showHelperDetailDialog(this, {
         domains: this.createDomains!,
         dialogClosedCallback: (item) => {

--- a/src/components/entity/ha-entity-picker.ts
+++ b/src/components/entity/ha-entity-picker.ts
@@ -50,7 +50,7 @@ export class HaEntityPicker extends LitElement {
 
   @property() public helper?: string;
 
-  @property() public createDomains?: string[];
+  @property({ type: Array }) public createDomains?: string[];
 
   /**
    * Show entities from specific domains.

--- a/src/components/ha-selector/ha-selector-target.ts
+++ b/src/components/ha-selector/ha-selector-target.ts
@@ -82,6 +82,7 @@ export class HaTargetSelector extends LitElement {
       .deviceFilter=${this._filterDevices}
       .entityFilter=${this._filterEntities}
       .disabled=${this.disabled}
+      .createDomains=${this.selector.target?.create_domains}
     ></ha-target-picker>`;
   }
 

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -33,6 +33,7 @@ import {
   expandFloorTarget,
   expandLabelTarget,
   Selector,
+  TargetSelector,
 } from "../data/selector";
 import { HomeAssistant, ValueChangedEvent } from "../types";
 import { documentationUrl } from "../util/documentation-url";
@@ -364,6 +365,15 @@ export class HaServiceControl extends LitElement {
     return false;
   }
 
+  private _targetSelector = memoizeOne(
+    (targetSelector: TargetSelector | null | undefined, domain?: string) => {
+      const create_domains = isHelperDomain(domain) ? [domain] : undefined;
+      return targetSelector
+        ? { target: { ...targetSelector, create_domains } }
+        : { target: { create_domains } };
+    }
+  );
+
   protected render() {
     const serviceData = this._getServiceInfo(
       this._value?.service,
@@ -401,8 +411,6 @@ export class HaServiceControl extends LitElement {
           `component.${domain}.services.${serviceName}.description`
         )) ||
       serviceData?.description;
-
-    const create_domains = isHelperDomain(domain) ? [domain] : undefined;
 
     return html`${this.hidePicker
       ? nothing
@@ -453,9 +461,10 @@ export class HaServiceControl extends LitElement {
             )}</span
           ><ha-selector
             .hass=${this.hass}
-            .selector=${serviceData.target
-              ? { target: { ...serviceData.target, create_domains } }
-              : { target: { create_domains } }}
+            .selector=${this._targetSelector(
+              serviceData.target as TargetSelector,
+              domain
+            )}
             .disabled=${this.disabled}
             @value-changed=${this._targetChanged}
             .value=${this._value?.target}

--- a/src/components/ha-service-control.ts
+++ b/src/components/ha-service-control.ts
@@ -43,6 +43,7 @@ import "./ha-service-picker";
 import "./ha-settings-row";
 import "./ha-yaml-editor";
 import type { HaYamlEditor } from "./ha-yaml-editor";
+import { isHelperDomain } from "../panels/config/helpers/const";
 
 const attributeFilter = (values: any[], attribute: any) => {
   if (typeof attribute === "object") {
@@ -401,157 +402,153 @@ export class HaServiceControl extends LitElement {
         )) ||
       serviceData?.description;
 
-    return html`
-      ${this.hidePicker
-        ? nothing
-        : html`<ha-service-picker
+    const create_domains = isHelperDomain(domain) ? [domain] : undefined;
+
+    return html`${this.hidePicker
+      ? nothing
+      : html`<ha-service-picker
+          .hass=${this.hass}
+          .value=${this._value?.service}
+          .disabled=${this.disabled}
+          @value-changed=${this._serviceChanged}
+        ></ha-service-picker>`}
+    ${this.hideDescription
+      ? nothing
+      : html`
+          <div class="description">
+            ${description ? html`<p>${description}</p>` : ""}
+            ${this._manifest
+              ? html` <a
+                  href=${this._manifest.is_built_in
+                    ? documentationUrl(
+                        this.hass,
+                        `/integrations/${this._manifest.domain}`
+                      )
+                    : this._manifest.documentation}
+                  title=${this.hass.localize(
+                    "ui.components.service-control.integration_doc"
+                  )}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <ha-icon-button
+                    .path=${mdiHelpCircle}
+                    class="help-icon"
+                  ></ha-icon-button>
+                </a>`
+              : nothing}
+          </div>
+        `}
+    ${serviceData && "target" in serviceData
+      ? html`<ha-settings-row .narrow=${this.narrow}>
+          ${hasOptional
+            ? html`<div slot="prefix" class="checkbox-spacer"></div>`
+            : ""}
+          <span slot="heading"
+            >${this.hass.localize("ui.components.service-control.target")}</span
+          >
+          <span slot="description"
+            >${this.hass.localize(
+              "ui.components.service-control.target_description"
+            )}</span
+          ><ha-selector
             .hass=${this.hass}
-            .value=${this._value?.service}
+            .selector=${serviceData.target
+              ? { target: { ...serviceData.target, create_domains } }
+              : { target: { create_domains } }}
             .disabled=${this.disabled}
-            @value-changed=${this._serviceChanged}
-          ></ha-service-picker>`}
-      ${this.hideDescription
-        ? nothing
-        : html`
-            <div class="description">
-              ${description ? html`<p>${description}</p>` : ""}
-              ${this._manifest
-                ? html` <a
-                    href=${this._manifest.is_built_in
-                      ? documentationUrl(
-                          this.hass,
-                          `/integrations/${this._manifest.domain}`
-                        )
-                      : this._manifest.documentation}
-                    title=${this.hass.localize(
-                      "ui.components.service-control.integration_doc"
-                    )}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <ha-icon-button
-                      .path=${mdiHelpCircle}
-                      class="help-icon"
-                    ></ha-icon-button>
-                  </a>`
-                : nothing}
-            </div>
-          `}
-      ${serviceData && "target" in serviceData
-        ? html`<ha-settings-row .narrow=${this.narrow}>
-            ${hasOptional
-              ? html`<div slot="prefix" class="checkbox-spacer"></div>`
-              : ""}
-            <span slot="heading"
-              >${this.hass.localize(
-                "ui.components.service-control.target"
-              )}</span
-            >
-            <span slot="description"
-              >${this.hass.localize(
-                "ui.components.service-control.target_description"
-              )}</span
-            ><ha-selector
-              .hass=${this.hass}
-              .selector=${serviceData.target
-                ? { target: serviceData.target }
-                : { target: {} }}
-              .disabled=${this.disabled}
-              @value-changed=${this._targetChanged}
-              .value=${this._value?.target}
-            ></ha-selector
-          ></ha-settings-row>`
-        : entityId
-          ? html`<ha-entity-picker
-              .hass=${this.hass}
-              .disabled=${this.disabled}
-              .value=${this._value?.data?.entity_id}
-              .label=${this.hass.localize(
-                `component.${domain}.services.${serviceName}.fields.entity_id.description`
-              ) || entityId.description}
-              @value-changed=${this._entityPicked}
-              allow-custom-entity
-            ></ha-entity-picker>`
-          : ""}
-      ${shouldRenderServiceDataYaml
-        ? html`<ha-yaml-editor
+            @value-changed=${this._targetChanged}
+            .value=${this._value?.target}
+          ></ha-selector
+        ></ha-settings-row>`
+      : entityId
+        ? html`<ha-entity-picker
             .hass=${this.hass}
-            .label=${this.hass.localize("ui.components.service-control.data")}
-            .name=${"data"}
-            .readOnly=${this.disabled}
-            .defaultValue=${this._value?.data}
-            @value-changed=${this._dataChanged}
-          ></ha-yaml-editor>`
-        : filteredFields?.map((dataField) => {
-            const selector = dataField?.selector ?? { text: undefined };
-            const type = Object.keys(selector)[0];
-            const enhancedSelector = [
-              "action",
-              "condition",
-              "trigger",
-            ].includes(type)
-              ? {
-                  [type]: {
-                    ...selector[type],
-                    path: [dataField.key],
-                  },
-                }
-              : selector;
+            .disabled=${this.disabled}
+            .value=${this._value?.data?.entity_id}
+            .label=${this.hass.localize(
+              `component.${domain}.services.${serviceName}.fields.entity_id.description`
+            ) || entityId.description}
+            @value-changed=${this._entityPicked}
+            allow-custom-entity
+          ></ha-entity-picker>`
+        : ""}
+    ${shouldRenderServiceDataYaml
+      ? html`<ha-yaml-editor
+          .hass=${this.hass}
+          .label=${this.hass.localize("ui.components.service-control.data")}
+          .name=${"data"}
+          .readOnly=${this.disabled}
+          .defaultValue=${this._value?.data}
+          @value-changed=${this._dataChanged}
+        ></ha-yaml-editor>`
+      : filteredFields?.map((dataField) => {
+          const selector = dataField?.selector ?? { text: undefined };
+          const type = Object.keys(selector)[0];
+          const enhancedSelector = ["action", "condition", "trigger"].includes(
+            type
+          )
+            ? {
+                [type]: {
+                  ...selector[type],
+                  path: [dataField.key],
+                },
+              }
+            : selector;
 
-            const showOptional = showOptionalToggle(dataField);
+          const showOptional = showOptionalToggle(dataField);
 
-            return dataField.selector &&
-              (!dataField.advanced ||
-                this.showAdvanced ||
-                (this._value?.data &&
-                  this._value.data[dataField.key] !== undefined))
-              ? html`<ha-settings-row .narrow=${this.narrow}>
-                  ${!showOptional
-                    ? hasOptional
-                      ? html`<div slot="prefix" class="checkbox-spacer"></div>`
-                      : ""
-                    : html`<ha-checkbox
-                        .key=${dataField.key}
-                        .checked=${this._checkedKeys.has(dataField.key) ||
-                        (this._value?.data &&
-                          this._value.data[dataField.key] !== undefined)}
-                        .disabled=${this.disabled}
-                        @change=${this._checkboxChanged}
-                        slot="prefix"
-                      ></ha-checkbox>`}
-                  <span slot="heading"
-                    >${this.hass.localize(
-                      `component.${domain}.services.${serviceName}.fields.${dataField.key}.name`
-                    ) ||
-                    dataField.name ||
-                    dataField.key}</span
-                  >
-                  <span slot="description"
-                    >${this.hass.localize(
-                      `component.${domain}.services.${serviceName}.fields.${dataField.key}.description`
-                    ) || dataField?.description}</span
-                  >
-                  <ha-selector
-                    .disabled=${this.disabled ||
-                    (showOptional &&
-                      !this._checkedKeys.has(dataField.key) &&
-                      (!this._value?.data ||
-                        this._value.data[dataField.key] === undefined))}
-                    .hass=${this.hass}
-                    .selector=${enhancedSelector}
-                    .key=${dataField.key}
-                    @value-changed=${this._serviceDataChanged}
-                    .value=${this._value?.data
-                      ? this._value.data[dataField.key]
-                      : undefined}
-                    .placeholder=${dataField.default}
-                    .localizeValue=${this._localizeValueCallback}
-                    @item-moved=${this._itemMoved}
-                  ></ha-selector>
-                </ha-settings-row>`
-              : "";
-          })}
-    `;
+          return dataField.selector &&
+            (!dataField.advanced ||
+              this.showAdvanced ||
+              (this._value?.data &&
+                this._value.data[dataField.key] !== undefined))
+            ? html`<ha-settings-row .narrow=${this.narrow}>
+                ${!showOptional
+                  ? hasOptional
+                    ? html`<div slot="prefix" class="checkbox-spacer"></div>`
+                    : ""
+                  : html`<ha-checkbox
+                      .key=${dataField.key}
+                      .checked=${this._checkedKeys.has(dataField.key) ||
+                      (this._value?.data &&
+                        this._value.data[dataField.key] !== undefined)}
+                      .disabled=${this.disabled}
+                      @change=${this._checkboxChanged}
+                      slot="prefix"
+                    ></ha-checkbox>`}
+                <span slot="heading"
+                  >${this.hass.localize(
+                    `component.${domain}.services.${serviceName}.fields.${dataField.key}.name`
+                  ) ||
+                  dataField.name ||
+                  dataField.key}</span
+                >
+                <span slot="description"
+                  >${this.hass.localize(
+                    `component.${domain}.services.${serviceName}.fields.${dataField.key}.description`
+                  ) || dataField?.description}</span
+                >
+                <ha-selector
+                  .disabled=${this.disabled ||
+                  (showOptional &&
+                    !this._checkedKeys.has(dataField.key) &&
+                    (!this._value?.data ||
+                      this._value.data[dataField.key] === undefined))}
+                  .hass=${this.hass}
+                  .selector=${enhancedSelector}
+                  .key=${dataField.key}
+                  @value-changed=${this._serviceDataChanged}
+                  .value=${this._value?.data
+                    ? this._value.data[dataField.key]
+                    : undefined}
+                  .placeholder=${dataField.default}
+                  .localizeValue=${this._localizeValueCallback}
+                  @item-moved=${this._itemMoved}
+                ></ha-selector>
+              </ha-settings-row>`
+            : "";
+        })} `;
   }
 
   private _localizeValueCallback = (key: string) => {

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -65,7 +65,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   @property() public helper?: string;
 
-  @property() public createDomains?: string[];
+  @property({ type: Array }) public createDomains?: string[];
 
   /**
    * Show only targets with entities from specific domains.

--- a/src/components/ha-target-picker.ts
+++ b/src/components/ha-target-picker.ts
@@ -65,6 +65,8 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
 
   @property() public helper?: string;
 
+  @property() public createDomains?: string[];
+
   /**
    * Show only targets with entities from specific domains.
    * @type {Array}
@@ -468,6 +470,7 @@ export class HaTargetPicker extends SubscribeMixin(LitElement) {
                   .includeDeviceClasses=${this.includeDeviceClasses}
                   .includeDomains=${this.includeDomains}
                   .excludeEntities=${ensureArray(this.value?.entity_id)}
+                  .createDomains=${this.createDomains}
                   @value-changed=${this._targetPicked}
                   @click=${this._preventDefault}
                   allow-custom-entity

--- a/src/data/selector.ts
+++ b/src/data/selector.ts
@@ -401,6 +401,7 @@ export interface TargetSelector {
   target: {
     entity?: EntitySelectorFilter | readonly EntitySelectorFilter[];
     device?: DeviceSelectorFilter | readonly DeviceSelectorFilter[];
+    create_domains?: string[];
   } | null;
 }
 

--- a/src/panels/config/helpers/dialog-helper-detail.ts
+++ b/src/panels/config/helpers/dialog-helper-detail.ts
@@ -159,7 +159,7 @@ export class DialogHelperDetail extends LitElement {
         >
           ${this.hass!.localize("ui.panel.config.helpers.dialog.create")}
         </mwc-button>
-        ${this._params?.domains?.length === 1
+        ${this._params?.domain
           ? nothing
           : html`<mwc-button
               slot="secondaryAction"

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -878,7 +878,7 @@ ${rejected
     }
     if (isHelperDomain(domain)) {
       showHelperDetailDialog(this, {
-        domain,
+        domains: [domain],
       });
       return;
     }

--- a/src/panels/config/helpers/ha-config-helpers.ts
+++ b/src/panels/config/helpers/ha-config-helpers.ts
@@ -878,7 +878,7 @@ ${rejected
     }
     if (isHelperDomain(domain)) {
       showHelperDetailDialog(this, {
-        domains: [domain],
+        domain,
       });
       return;
     }

--- a/src/panels/config/helpers/show-dialog-helper-detail.ts
+++ b/src/panels/config/helpers/show-dialog-helper-detail.ts
@@ -3,8 +3,7 @@ import { fireEvent } from "../../../common/dom/fire_event";
 export const loadHelperDetailDialog = () => import("./dialog-helper-detail");
 
 export interface ShowDialogHelperDetailParams {
-  domains?: string[];
-  // Only used for config entries
+  domain?: string;
   dialogClosedCallback?: (params: {
     flowFinished: boolean;
     entryId?: string;

--- a/src/panels/config/helpers/show-dialog-helper-detail.ts
+++ b/src/panels/config/helpers/show-dialog-helper-detail.ts
@@ -1,13 +1,15 @@
 import { fireEvent } from "../../../common/dom/fire_event";
-import { DataEntryFlowDialogParams } from "../../../dialogs/config-flow/show-dialog-data-entry-flow";
-import { HelperDomain } from "./const";
 
 export const loadHelperDetailDialog = () => import("./dialog-helper-detail");
 
 export interface ShowDialogHelperDetailParams {
-  domain?: HelperDomain;
+  domains?: string[];
   // Only used for config entries
-  dialogClosedCallback?: DataEntryFlowDialogParams["dialogClosedCallback"];
+  dialogClosedCallback?: (params: {
+    flowFinished: boolean;
+    entryId?: string;
+    entityId?: string;
+  }) => void;
 }
 
 export const showHelperDetailDialog = (

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -473,7 +473,7 @@
           "no_entities": "You don't have any entities",
           "no_match": "No matching entities found",
           "show_entities": "Show entities",
-          "new_entity": "New Entity",
+          "new_entity": "Create a new entity",
           "create_helper": "Create a new {domain, select, \n undefined {} \n other {{domain} }\n } helper."
         },
         "entity-attribute-picker": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -472,7 +472,9 @@
           "clear": "Clear",
           "no_entities": "You don't have any entities",
           "no_match": "No matching entities found",
-          "show_entities": "Show entities"
+          "show_entities": "Show entities",
+          "new_entity": "New Entity",
+          "create_helper": "Create a new {domain, select, \n undefined {} \n other {{domain} }\n } helper."
         },
         "entity-attribute-picker": {
           "attribute": "Attribute",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Often when writing an automation, I will discover I need some additional helper as part of the logic flow. Instead of having to leave the automation page, I thought it might be nice if we can have an option to create a new helper right where it is used, requiring less navigating and steps to accomplish the goal. 

I considered a couple different ideas, like maybe adding `Create Helper` option to the quick bar, or adding a small button somewhere on the automation page, but for now I'm proposing a new option in the entity picker, for service calls of the 9 helper domains, as that I think is where they might most typically be wanted, and it nicely pre-fills the target picker when you create it. 

This could possibly be expanded further, for creating more types of helpers in more places, but this felt like a reasonable start. 

![helper-automation](https://github.com/home-assistant/frontend/assets/32912880/ebd187fa-a979-4bf8-ab50-4f70a27d09da)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
