### PR TITLE
Add device class "screen" for Cover

### DIFF
--- a/gallery/src/pages/misc/entity-state.ts
+++ b/gallery/src/pages/misc/entity-state.ts
@@ -162,6 +162,7 @@ const ENTITIES: HassEntity[] = [
   createEntity("cover.door", "open", "door"),
   createEntity("cover.garage", "open", "garage"),
   createEntity("cover.gate", "open", "gate"),
+  createEntity("cover.screen", "open", "screen"),
   createEntity("cover.shade", "open", "shade"),
   createEntity("cover.shutter", "open", "shutter"),
   createEntity("cover.window", "open", "window"),

--- a/src/common/entity/cover_icon.ts
+++ b/src/common/entity/cover_icon.ts
@@ -26,6 +26,8 @@ import {
   mdiArrowSplitVertical,
   mdiCurtains,
   mdiCurtainsClosed,
+  mdiProjectorScreenVariantOffOutline,
+  mdiProjectorScreenVariantOutline,
 } from "@mdi/js";
 import { HassEntity } from "home-assistant-js-websocket";
 
@@ -113,6 +115,17 @@ export const coverIcon = (state?: string, stateObj?: HassEntity): string => {
         default:
           return mdiWindowOpen;
       }
+    case "screen":
+      switch (state) {
+        case "opening":
+          return mdiArrowDownBox;
+        case "closing":
+          return mdiArrowUpBox;
+        case "closed":
+          return mdiProjectorScreenVariantOffOutline;
+        default:
+          return mdiProjectorScreenVariantOutline;
+      }
   }
 
   switch (state) {
@@ -134,6 +147,8 @@ export const computeOpenIcon = (stateObj: HassEntity): string => {
     case "gate":
     case "curtain":
       return mdiArrowExpandHorizontal;
+    case "screen":
+      return mdiArrowDown;
     default:
       return mdiArrowUp;
   }
@@ -146,6 +161,8 @@ export const computeCloseIcon = (stateObj: HassEntity): string => {
     case "gate":
     case "curtain":
       return mdiArrowCollapseHorizontal;
+    case "screen":
+      return mdiArrowUp;
     default:
       return mdiArrowDown;
   }

--- a/src/common/entity/get_states.ts
+++ b/src/common/entity/get_states.ts
@@ -132,6 +132,7 @@ const FIXED_DOMAIN_ATTRIBUTE_STATES = {
       "door",
       "garage",
       "gate",
+      "screen",
       "shade",
       "shutter",
       "window",

--- a/src/data/cover.ts
+++ b/src/data/cover.ts
@@ -20,6 +20,9 @@ export const enum CoverEntityFeature {
 
 export function isFullyOpen(stateObj: CoverEntity) {
   if (stateObj.attributes.current_position !== undefined) {
+    if (stateObj.attributes.device_class === "screen") {
+      return stateObj.attributes.current_position === 0;
+    }
     return stateObj.attributes.current_position === 100;
   }
   return stateObj.state === "open";
@@ -27,6 +30,9 @@ export function isFullyOpen(stateObj: CoverEntity) {
 
 export function isFullyClosed(stateObj: CoverEntity) {
   if (stateObj.attributes.current_position !== undefined) {
+    if (stateObj.attributes.device_class === "screen") {
+      return stateObj.attributes.current_position === 100;
+    }
     return stateObj.attributes.current_position === 0;
   }
   return stateObj.state === "closed";

--- a/src/panels/config/entities/entity-registry-settings-editor.ts
+++ b/src/panels/config/entities/entity-registry-settings-editor.ts
@@ -97,6 +97,7 @@ const OVERRIDE_DEVICE_CLASSES = {
       "door",
       "garage",
       "gate",
+      "screen",
       "shade",
       "shutter",
       "window",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1190,6 +1190,7 @@
               "blind": "Blind",
               "curtain": "Curtain",
               "damper": "Damper",
+              "screen": "Screen",
               "shutter": "Shutter"
             },
             "switch": {
@@ -2498,7 +2499,9 @@
                   "label": "Time and location",
                   "description": "When someone enters or leaves a zone, or at a specific time."
                 },
-                "other": { "label": "Other triggers" }
+                "other": {
+                  "label": "Other triggers"
+                }
               },
               "type": {
                 "calendar": {
@@ -2734,7 +2737,9 @@
                   "label": "Time and location",
                   "description": "If someone is in a zone or if the current time is before or after a specified time."
                 },
-                "other": { "label": "Other conditions" },
+                "other": {
+                  "label": "Other conditions"
+                },
                 "building_blocks": {
                   "label": "Building blocks",
                   "description": "Build more complex conditions."
@@ -2898,8 +2903,12 @@
               "type_select": "Action type",
               "continue_on_error": "Continue on error",
               "groups": {
-                "helpers": { "label": "Helpers" },
-                "other": { "label": "Other actions" },
+                "helpers": {
+                  "label": "Helpers"
+                },
+                "other": {
+                  "label": "Other actions"
+                },
                 "building_blocks": {
                   "label": "Building blocks",
                   "description": "Build more complex sequences of actions."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This change adds a new Cover device class called "screen" that represents an in-ceiling or on-ceiling projector screen.
A projector screen has different icons than the other cover device classes and different semantics for being "open" and "closed".  
This change allows an integration to indicate that it supports projector screens to the front end.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to back end pull request: https://github.com/home-assistant/core/pull/107400
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30681

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
