### PR TITLE
Compute climate icons case-insensitively

### DIFF
--- a/src/data/climate.ts
+++ b/src/data/climate.ts
@@ -137,7 +137,7 @@ export const CLIMATE_HVAC_MODE_ICONS: Record<HvacMode, string> = {
 };
 
 export const computeHvacModeIcon = (mode: HvacMode) =>
-  CLIMATE_HVAC_MODE_ICONS[mode];
+  CLIMATE_HVAC_MODE_ICONS[String(mode ?? "").toLocaleLowerCase()];
 
 type ClimateBuiltInPresetMode =
   | "eco"
@@ -162,9 +162,8 @@ export const CLIMATE_PRESET_MODE_ICONS: Record<
 };
 
 export const computePresetModeIcon = (mode: string) =>
-  mode in CLIMATE_PRESET_MODE_ICONS
-    ? CLIMATE_PRESET_MODE_ICONS[mode]
-    : mdiCircleMedium;
+  CLIMATE_PRESET_MODE_ICONS[String(mode ?? "").toLocaleLowerCase()]
+  ?? mdiCircleMedium;
 
 type ClimateBuiltInFanMode =
   | "on"
@@ -190,9 +189,8 @@ export const CLIMATE_FAN_MODE_ICONS: Record<ClimateBuiltInFanMode, string> = {
 };
 
 export const computeFanModeIcon = (mode: string) =>
-  mode in CLIMATE_FAN_MODE_ICONS
-    ? CLIMATE_FAN_MODE_ICONS[mode]
-    : mdiCircleMedium;
+  CLIMATE_FAN_MODE_ICONS[String(mode ?? "").toLocaleLowerCase()]
+  ?? mdiCircleMedium;
 
 type ClimateBuiltInSwingMode =
   | "off"
@@ -211,6 +209,5 @@ export const CLIMATE_SWING_MODE_ICONS: Record<ClimateBuiltInSwingMode, string> =
   };
 
 export const computeSwingModeIcon = (mode: string) =>
-  mode in CLIMATE_SWING_MODE_ICONS
-    ? CLIMATE_SWING_MODE_ICONS[mode]
-    : mdiCircleMedium;
+  CLIMATE_SWING_MODE_ICONS[String(mode ?? "").toLocaleLowerCase()]
+  ?? mdiCircleMedium;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This computes all the icons for climate-based features in a case-insensitive manner. Otherwise, case-sensitive climate presets (like those broadcast by Ecobee) would never get an icon:
![image](https://github.com/home-assistant/frontend/assets/9013284/6ae27b9d-0470-4263-86a6-801939f42c6e)

Although the functions are all typed to accept only strings, the implementation is designed *defensively* in case non-string arguments are passed:

```ts
// This fails if `mode` does not have a .toLocaleLowerCase() method
export const computePresetModeIcon_DANGEROUS = (mode: string) =>
  CLIMATE_PRESET_MODE_ICONS[mode.toLocaleLowerCase()]
  ?? mdiCircleMedium;

// This normalizes `mode` to a string
export const computePresetModeIcon = (mode: string) =>
  CLIMATE_PRESET_MODE_ICONS[String(mode ?? "").toLocaleLowerCase()]
  ?? mdiCircleMedium;
```


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

`lovelace.yaml`:
```yaml
views:
  - title: Climate
    path: climate
    icon: mdi:thermostat
    badges: []
    cards:
      - type: thermostat
        entity: climate.thermostat
        features:
          - type: climate-hvac-modes
            style: icons
            hvac_modes:
              - heat
              - cool
              - 'off'
          - type: climate-preset-modes
            style: icons
            preset_modes:
              - Home
              - Away
              - Sleep
              - Eco
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #19250
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.
  - No tests existed for any of these functions

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
