### PR TITLE
Load registries in core, wait them to be loaded before generating das…

### DIFF
--- a/src/data/area_registry.ts
+++ b/src/data/area_registry.ts
@@ -53,7 +53,7 @@ export const deleteAreaRegistryEntry = (hass: HomeAssistant, areaId: string) =>
     area_id: areaId,
   });
 
-const fetchAreaRegistry = (conn: Connection) =>
+export const fetchAreaRegistry = (conn: Connection) =>
   conn
     .sendMessagePromise({
       type: "config/area_registry/list",
@@ -64,7 +64,7 @@ const fetchAreaRegistry = (conn: Connection) =>
       )
     );
 
-const subscribeAreaRegistryUpdates = (
+export const subscribeAreaRegistryUpdates = (
   conn: Connection,
   store: Store<AreaRegistryEntry[]>
 ) =>

--- a/src/data/area_registry.ts
+++ b/src/data/area_registry.ts
@@ -1,10 +1,9 @@
-import { Connection, createCollection } from "home-assistant-js-websocket";
-import { Store } from "home-assistant-js-websocket/dist/store";
 import { stringCompare } from "../common/string/compare";
-import { debounce } from "../common/util/debounce";
 import { HomeAssistant } from "../types";
 import { DeviceRegistryEntry } from "./device_registry";
 import { EntityRegistryEntry } from "./entity_registry";
+
+export { subscribeAreaRegistry } from "./ws-area_registry";
 
 export interface AreaRegistryEntry {
   area_id: string;
@@ -52,45 +51,6 @@ export const deleteAreaRegistryEntry = (hass: HomeAssistant, areaId: string) =>
     type: "config/area_registry/delete",
     area_id: areaId,
   });
-
-export const fetchAreaRegistry = (conn: Connection) =>
-  conn
-    .sendMessagePromise({
-      type: "config/area_registry/list",
-    })
-    .then((areas) =>
-      (areas as AreaRegistryEntry[]).sort((ent1, ent2) =>
-        stringCompare(ent1.name, ent2.name)
-      )
-    );
-
-export const subscribeAreaRegistryUpdates = (
-  conn: Connection,
-  store: Store<AreaRegistryEntry[]>
-) =>
-  conn.subscribeEvents(
-    debounce(
-      () =>
-        fetchAreaRegistry(conn).then((areas: AreaRegistryEntry[]) =>
-          store.setState(areas, true)
-        ),
-      500,
-      true
-    ),
-    "area_registry_updated"
-  );
-
-export const subscribeAreaRegistry = (
-  conn: Connection,
-  onChange: (areas: AreaRegistryEntry[]) => void
-) =>
-  createCollection<AreaRegistryEntry[]>(
-    "_areaRegistry",
-    fetchAreaRegistry,
-    subscribeAreaRegistryUpdates,
-    conn,
-    onChange
-  );
 
 export const getAreaEntityLookup = (
   entities: EntityRegistryEntry[]

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -1,14 +1,16 @@
-import { Connection, createCollection } from "home-assistant-js-websocket";
-import type { Store } from "home-assistant-js-websocket/dist/store";
 import { computeStateName } from "../common/entity/compute_state_name";
 import { caseInsensitiveStringCompare } from "../common/string/compare";
-import { debounce } from "../common/util/debounce";
 import type { HomeAssistant } from "../types";
 import type {
   EntityRegistryDisplayEntry,
   EntityRegistryEntry,
 } from "./entity_registry";
 import type { EntitySources } from "./entity_sources";
+
+export {
+  fetchDeviceRegistry,
+  subscribeDeviceRegistry,
+} from "./ws-device_registry";
 
 export interface DeviceRegistryEntry {
   id: string;
@@ -95,39 +97,6 @@ export const removeConfigEntryFromDevice = (
     device_id: deviceId,
     config_entry_id: configEntryId,
   });
-
-export const fetchDeviceRegistry = (conn: Connection) =>
-  conn.sendMessagePromise<DeviceRegistryEntry[]>({
-    type: "config/device_registry/list",
-  });
-
-export const subscribeDeviceRegistryUpdates = (
-  conn: Connection,
-  store: Store<DeviceRegistryEntry[]>
-) =>
-  conn.subscribeEvents(
-    debounce(
-      () =>
-        fetchDeviceRegistry(conn).then((devices) =>
-          store.setState(devices, true)
-        ),
-      500,
-      true
-    ),
-    "device_registry_updated"
-  );
-
-export const subscribeDeviceRegistry = (
-  conn: Connection,
-  onChange: (devices: DeviceRegistryEntry[]) => void
-) =>
-  createCollection<DeviceRegistryEntry[]>(
-    "_dr",
-    fetchDeviceRegistry,
-    subscribeDeviceRegistryUpdates,
-    conn,
-    onChange
-  );
 
 export const sortDeviceRegistryByName = (
   entries: DeviceRegistryEntry[],

--- a/src/data/device_registry.ts
+++ b/src/data/device_registry.ts
@@ -101,7 +101,7 @@ export const fetchDeviceRegistry = (conn: Connection) =>
     type: "config/device_registry/list",
   });
 
-const subscribeDeviceRegistryUpdates = (
+export const subscribeDeviceRegistryUpdates = (
   conn: Connection,
   store: Store<DeviceRegistryEntry[]>
 ) =>

--- a/src/data/entity_registry.ts
+++ b/src/data/entity_registry.ts
@@ -130,11 +130,11 @@ export interface EntityRegistryEntryUpdateParams {
   aliases?: string[];
 }
 
-const batteryPriorities = ["sensor", "binary_sensor"];
 export const findBatteryEntity = <T extends { entity_id: string }>(
   hass: HomeAssistant,
   entities: T[]
 ): T | undefined => {
+  const batteryPriorities = ["sensor", "binary_sensor"];
   const batteryEntities = entities
     .filter(
       (entity) =>
@@ -227,7 +227,7 @@ export const fetchEntityRegistryDisplay = (conn: Connection) =>
     type: "config/entity_registry/list_for_display",
   });
 
-const subscribeEntityRegistryUpdates = (
+export const subscribeEntityRegistryUpdates = (
   conn: Connection,
   store: Store<EntityRegistryEntry[]>
 ) =>
@@ -255,7 +255,7 @@ export const subscribeEntityRegistry = (
     onChange
   );
 
-const subscribeEntityRegistryDisplayUpdates = (
+export const subscribeEntityRegistryDisplayUpdates = (
   conn: Connection,
   store: Store<EntityRegistryDisplayEntryResponse>
 ) =>

--- a/src/data/entity_registry.ts
+++ b/src/data/entity_registry.ts
@@ -8,6 +8,8 @@ import { HomeAssistant } from "../types";
 import { LightColor } from "./light";
 import { computeDomain } from "../common/entity/compute_domain";
 
+export { subscribeEntityRegistryDisplay } from "./ws-entity_registry_display";
+
 type entityCategory = "config" | "diagnostic";
 
 export interface EntityRegistryDisplayEntry {
@@ -22,7 +24,7 @@ export interface EntityRegistryDisplayEntry {
   display_precision?: number;
 }
 
-interface EntityRegistryDisplayEntryResponse {
+export interface EntityRegistryDisplayEntryResponse {
   entities: {
     ei: string;
     di?: string;
@@ -130,11 +132,11 @@ export interface EntityRegistryEntryUpdateParams {
   aliases?: string[];
 }
 
+const batteryPriorities = ["sensor", "binary_sensor"];
 export const findBatteryEntity = <T extends { entity_id: string }>(
   hass: HomeAssistant,
   entities: T[]
 ): T | undefined => {
-  const batteryPriorities = ["sensor", "binary_sensor"];
   const batteryEntities = entities
     .filter(
       (entity) =>
@@ -227,7 +229,7 @@ export const fetchEntityRegistryDisplay = (conn: Connection) =>
     type: "config/entity_registry/list_for_display",
   });
 
-export const subscribeEntityRegistryUpdates = (
+const subscribeEntityRegistryUpdates = (
   conn: Connection,
   store: Store<EntityRegistryEntry[]>
 ) =>
@@ -251,34 +253,6 @@ export const subscribeEntityRegistry = (
     "_entityRegistry",
     fetchEntityRegistry,
     subscribeEntityRegistryUpdates,
-    conn,
-    onChange
-  );
-
-export const subscribeEntityRegistryDisplayUpdates = (
-  conn: Connection,
-  store: Store<EntityRegistryDisplayEntryResponse>
-) =>
-  conn.subscribeEvents(
-    debounce(
-      () =>
-        fetchEntityRegistryDisplay(conn).then((entities) =>
-          store.setState(entities, true)
-        ),
-      500,
-      true
-    ),
-    "entity_registry_updated"
-  );
-
-export const subscribeEntityRegistryDisplay = (
-  conn: Connection,
-  onChange: (entities: EntityRegistryDisplayEntryResponse) => void
-) =>
-  createCollection<EntityRegistryDisplayEntryResponse>(
-    "_entityRegistryDisplay",
-    fetchEntityRegistryDisplay,
-    subscribeEntityRegistryDisplayUpdates,
     conn,
     onChange
   );

--- a/src/data/ws-area_registry.ts
+++ b/src/data/ws-area_registry.ts
@@ -1,0 +1,44 @@
+import { Connection, createCollection } from "home-assistant-js-websocket";
+import { Store } from "home-assistant-js-websocket/dist/store";
+import { stringCompare } from "../common/string/compare";
+import { AreaRegistryEntry } from "./area_registry";
+import { debounce } from "../common/util/debounce";
+
+const fetchAreaRegistry = (conn: Connection) =>
+  conn
+    .sendMessagePromise({
+      type: "config/area_registry/list",
+    })
+    .then((areas) =>
+      (areas as AreaRegistryEntry[]).sort((ent1, ent2) =>
+        stringCompare(ent1.name, ent2.name)
+      )
+    );
+
+const subscribeAreaRegistryUpdates = (
+  conn: Connection,
+  store: Store<AreaRegistryEntry[]>
+) =>
+  conn.subscribeEvents(
+    debounce(
+      () =>
+        fetchAreaRegistry(conn).then((areas: AreaRegistryEntry[]) =>
+          store.setState(areas, true)
+        ),
+      500,
+      true
+    ),
+    "area_registry_updated"
+  );
+
+export const subscribeAreaRegistry = (
+  conn: Connection,
+  onChange: (areas: AreaRegistryEntry[]) => void
+) =>
+  createCollection<AreaRegistryEntry[]>(
+    "_areaRegistry",
+    fetchAreaRegistry,
+    subscribeAreaRegistryUpdates,
+    conn,
+    onChange
+  );

--- a/src/data/ws-device_registry.ts
+++ b/src/data/ws-device_registry.ts
@@ -1,0 +1,37 @@
+import { Connection, createCollection } from "home-assistant-js-websocket";
+import { Store } from "home-assistant-js-websocket/dist/store";
+import { DeviceRegistryEntry } from "./device_registry";
+import { debounce } from "../common/util/debounce";
+
+export const fetchDeviceRegistry = (conn: Connection) =>
+  conn.sendMessagePromise<DeviceRegistryEntry[]>({
+    type: "config/device_registry/list",
+  });
+
+const subscribeDeviceRegistryUpdates = (
+  conn: Connection,
+  store: Store<DeviceRegistryEntry[]>
+) =>
+  conn.subscribeEvents(
+    debounce(
+      () =>
+        fetchDeviceRegistry(conn).then((devices) =>
+          store.setState(devices, true)
+        ),
+      500,
+      true
+    ),
+    "device_registry_updated"
+  );
+
+export const subscribeDeviceRegistry = (
+  conn: Connection,
+  onChange: (devices: DeviceRegistryEntry[]) => void
+) =>
+  createCollection<DeviceRegistryEntry[]>(
+    "_dr",
+    fetchDeviceRegistry,
+    subscribeDeviceRegistryUpdates,
+    conn,
+    onChange
+  );

--- a/src/data/ws-entity_registry_display.ts
+++ b/src/data/ws-entity_registry_display.ts
@@ -1,0 +1,35 @@
+import { Connection, createCollection } from "home-assistant-js-websocket";
+import { Store } from "home-assistant-js-websocket/dist/store";
+import {
+  EntityRegistryDisplayEntryResponse,
+  fetchEntityRegistryDisplay,
+} from "./entity_registry";
+import { debounce } from "../common/util/debounce";
+
+const subscribeEntityRegistryDisplayUpdates = (
+  conn: Connection,
+  store: Store<EntityRegistryDisplayEntryResponse>
+) =>
+  conn.subscribeEvents(
+    debounce(
+      () =>
+        fetchEntityRegistryDisplay(conn).then((entities) =>
+          store.setState(entities, true)
+        ),
+      500,
+      true
+    ),
+    "entity_registry_updated"
+  );
+
+export const subscribeEntityRegistryDisplay = (
+  conn: Connection,
+  onChange: (entities: EntityRegistryDisplayEntryResponse) => void
+) =>
+  createCollection<EntityRegistryDisplayEntryResponse>(
+    "_entityRegistryDisplay",
+    fetchEntityRegistryDisplay,
+    subscribeEntityRegistryDisplayUpdates,
+    conn,
+    onChange
+  );

--- a/src/entrypoints/core.ts
+++ b/src/entrypoints/core.ts
@@ -9,21 +9,24 @@ import {
   subscribeServices,
 } from "home-assistant-js-websocket";
 import { loadTokens, saveTokens } from "../common/auth/token_storage";
+import { subscribeAreaRegistry } from "../data/area_registry";
 import { hassUrl } from "../data/auth";
+import { subscribeDeviceRegistry } from "../data/device_registry";
+import { subscribeEntityRegistryDisplay } from "../data/entity_registry";
 import { isExternal } from "../data/external";
-import { getRecorderInfo } from "../data/recorder";
 import { subscribeFrontendUserData } from "../data/frontend";
 import { fetchConfig } from "../data/lovelace/config/types";
 import { fetchResources } from "../data/lovelace/resource";
+import { MAIN_WINDOW_NAME } from "../data/main_window";
+import { WindowWithPreloads } from "../data/preloads";
+import { getRecorderInfo } from "../data/recorder";
+import { subscribeRepairsIssueRegistry } from "../data/repairs";
 import { subscribePanels } from "../data/ws-panels";
 import { subscribeThemes } from "../data/ws-themes";
-import { subscribeRepairsIssueRegistry } from "../data/repairs";
 import { subscribeUser } from "../data/ws-user";
 import type { ExternalAuth } from "../external_app/external_auth";
 import "../resources/array.flat.polyfill";
 import "../resources/safari-14-attachshadow-patch";
-import { MAIN_WINDOW_NAME } from "../data/main_window";
-import { WindowWithPreloads } from "../data/preloads";
 
 window.name = MAIN_WINDOW_NAME;
 (window as any).frontendVersion = __VERSION__;
@@ -113,6 +116,9 @@ window.hassConnection.then(({ conn }) => {
     // do nothing
   };
   subscribeEntities(conn, noop);
+  subscribeEntityRegistryDisplay(conn, noop);
+  subscribeDeviceRegistry(conn, noop);
+  subscribeAreaRegistry(conn, noop);
   subscribeConfig(conn, noop);
   subscribeServices(conn, noop);
   subscribePanels(conn, noop);

--- a/src/entrypoints/core.ts
+++ b/src/entrypoints/core.ts
@@ -9,10 +9,7 @@ import {
   subscribeServices,
 } from "home-assistant-js-websocket";
 import { loadTokens, saveTokens } from "../common/auth/token_storage";
-import { subscribeAreaRegistry } from "../data/area_registry";
 import { hassUrl } from "../data/auth";
-import { subscribeDeviceRegistry } from "../data/device_registry";
-import { subscribeEntityRegistryDisplay } from "../data/entity_registry";
 import { isExternal } from "../data/external";
 import { subscribeFrontendUserData } from "../data/frontend";
 import { fetchConfig } from "../data/lovelace/config/types";
@@ -21,6 +18,9 @@ import { MAIN_WINDOW_NAME } from "../data/main_window";
 import { WindowWithPreloads } from "../data/preloads";
 import { getRecorderInfo } from "../data/recorder";
 import { subscribeRepairsIssueRegistry } from "../data/repairs";
+import { subscribeAreaRegistry } from "../data/ws-area_registry";
+import { subscribeDeviceRegistry } from "../data/ws-device_registry";
+import { subscribeEntityRegistryDisplay } from "../data/ws-entity_registry_display";
 import { subscribePanels } from "../data/ws-panels";
 import { subscribeThemes } from "../data/ws-themes";
 import { subscribeUser } from "../data/ws-user";

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -161,10 +161,15 @@ export class LovelacePanel extends LitElement {
     `;
   }
 
-  protected firstUpdated(changedProps) {
-    super.firstUpdated(changedProps);
+  protected willUpdate(changedProps: PropertyValues) {
+    super.willUpdate(changedProps);
+    if (!this.lovelace && this._panelState !== "error") {
+      this._fetchConfig(false);
+    }
+  }
 
-    this._fetchConfig(false);
+  protected firstUpdated(changedProps: PropertyValues): void {
+    super.firstUpdated(changedProps);
     if (!this._unsubUpdates) {
       this._subscribeUpdates();
     }
@@ -267,6 +272,10 @@ export class LovelacePanel extends LitElement {
 
       // If strategy defined, apply it here.
       if (isStrategyDashboard(rawConf)) {
+        if (!this.hass?.entities || !this.hass.devices || !this.hass.areas) {
+          // We need these to generate a dashboard, wait for them
+          return;
+        }
         conf = await generateLovelaceDashboardStrategy(
           rawConf.strategy,
           this.hass!
@@ -280,6 +289,10 @@ export class LovelacePanel extends LitElement {
         console.log(err);
         this._panelState = "error";
         this._errorMsg = err.message;
+        return;
+      }
+      if (!this.hass?.entities || !this.hass.devices || !this.hass.areas) {
+        // We need these to generate a dashboard, wait for them
         return;
       }
       conf = await generateLovelaceDashboardStrategy(

--- a/src/panels/lovelace/ha-panel-lovelace.ts
+++ b/src/panels/lovelace/ha-panel-lovelace.ts
@@ -1,7 +1,7 @@
 import "@material/mwc-button";
 import deepFreeze from "deep-freeze";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import { constructUrlCurrentPath } from "../../common/url/construct-url";
 import {


### PR DESCRIPTION
…hboard


## Proposed change
Start loading entity, device and area registry sooner, and guard for them when generating a dashboard.


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
