### PR TITLE
Display that entity is disabled in more info

### DIFF
--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -43,12 +43,15 @@ export class MoreInfoInfo extends LitElement {
 
     return html`
       <div class="container" data-domain=${domain}>
-        ${!stateObj ?         
-          html`<ha-alert alert-type="warning">              
-              ${this.entry?.disabled_by ?
-                this.hass.localize("ui.dialogs.entity_registry.editor.entity_disabled") : 
-                this.hass.localize("ui.dialogs.entity_registry.editor.unavailable")
-              }
+        ${!stateObj
+          ? html`<ha-alert alert-type="warning">
+              ${this.entry?.disabled_by
+                ? this.hass.localize(
+                    "ui.dialogs.entity_registry.editor.entity_disabled"
+                  )
+                : this.hass.localize(
+                    "ui.dialogs.entity_registry.editor.unavailable"
+                  )}
             </ha-alert>`
           : nothing}
         ${stateObj?.attributes.restored && entityRegObj

--- a/src/dialogs/more-info/ha-more-info-info.ts
+++ b/src/dialogs/more-info/ha-more-info-info.ts
@@ -43,11 +43,12 @@ export class MoreInfoInfo extends LitElement {
 
     return html`
       <div class="container" data-domain=${domain}>
-        ${!stateObj
-          ? html`<ha-alert alert-type="warning">
-              ${this.hass.localize(
-                "ui.dialogs.entity_registry.editor.unavailable"
-              )}
+        ${!stateObj ?         
+          html`<ha-alert alert-type="warning">              
+              ${this.entry?.disabled_by ?
+                this.hass.localize("ui.dialogs.entity_registry.editor.entity_disabled") : 
+                this.hass.localize("ui.dialogs.entity_registry.editor.unavailable")
+              }
             </ha-alert>`
           : nothing}
         ${stateObj?.attributes.restored && entityRegObj


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Make sure more info dialog directly displays that an entity is disabled

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
