### PR TITLE
Fix onboarding state exception following restore

### DIFF
--- a/src/data/onboarding.ts
+++ b/src/data/onboarding.ts
@@ -84,5 +84,9 @@ export const fetchInstallationType = async (): Promise<InstallationType> => {
     throw Error("unauthorized");
   }
 
+  if (response.status === 404) {
+    throw Error("not_found");
+  }
+
   return response.json();
 };

--- a/src/onboarding/ha-onboarding.ts
+++ b/src/onboarding/ha-onboarding.ts
@@ -286,7 +286,7 @@ class HaOnboarding extends litLocalizeLiteMixin(HassElement) {
     try {
       const response = await (window.stepsPromise || fetchOnboardingOverview());
 
-      if (response.status === 404) {
+      if (response.status === 401 || response.status === 404) {
         // We don't load the component when onboarding is done
         document.location.assign("/");
         return;

--- a/src/onboarding/onboarding-restore-backup.ts
+++ b/src/onboarding/onboarding-restore-backup.ts
@@ -62,7 +62,10 @@ class OnboardingRestoreBackup extends LitElement {
       try {
         await fetchInstallationType();
       } catch (err: any) {
-        if ((err as Error).message === "unauthorized") {
+        if (
+          (err as Error).message === "unauthorized" ||
+          (err as Error).message === "not_found"
+        ) {
           window.location.replace("/");
         }
       }


### PR DESCRIPTION
## Proposed change
Fixes #19388 by handling expected 401 Unauthorised & 404 Not Found API responses where one, or the other, is otherwise not handled during the onboarding process following a sucessful restore.

Anecdotally this would go some way towards explaining why some users believe (errornousely, through no fault of their own) that updates are taking hours, when in fact they find hours later that a simple page reload was all that is required.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: https://github.com/home-assistant/frontend/issues/19388
- This PR is related to issue or discussion:
- - https://github.com/home-assistant/core/issues/92282#issuecomment-1560703223
- - https://github.com/home-assistant/frontend/issues/19388
- - https://github.com/home-assistant/supervisor/issues/4287#issuecomment-1856569101
- - https://community.home-assistant.io/t/how-long-should-a-restore-from-backup-take/566770/45
- - https://community.home-assistant.io/t/how-long-should-a-restore-from-backup-take/566770/48
- - https://community.home-assistant.io/t/how-long-should-a-restore-from-backup-take/566770/49

## Checklist
- [ ] The code change is tested and works locally - **sorry, I don't have a way to test this locally and am doing my best guess here**
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works - **sorry, I don't know how to do this but welcome any assistance**