### PR TITLE
Add per domain style for tile card image

### DIFF
--- a/src/components/tile/ha-tile-image.ts
+++ b/src/components/tile/ha-tile-image.ts
@@ -1,16 +1,19 @@
-import { CSSResultGroup, html, css, LitElement, nothing } from "lit";
+import { CSSResultGroup, LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 
+export type TileImageStyle = "square" | "rounded-square" | "circle";
 @customElement("ha-tile-image")
 export class HaTileImage extends LitElement {
   @property() public imageUrl?: string;
 
   @property() public imageAlt?: string;
 
+  @property() public imageStyle: TileImageStyle = "circle";
+
   protected render() {
     return html`
-      <div class="image">
+      <div class="image ${this.imageStyle}">
         ${this.imageUrl
           ? html`<img alt=${ifDefined(this.imageAlt)} src=${this.imageUrl} />`
           : nothing}
@@ -30,6 +33,12 @@ export class HaTileImage extends LitElement {
         align-items: center;
         justify-content: center;
         overflow: hidden;
+      }
+      .image.rounded-square {
+        border-radius: 8%;
+      }
+      .image.square {
+        border-radius: 0;
       }
       .image img {
         width: 100%;

--- a/src/panels/lovelace/cards/hui-tile-card.ts
+++ b/src/panels/lovelace/cards/hui-tile-card.ts
@@ -33,22 +33,23 @@ import "../../../components/ha-card";
 import "../../../components/tile/ha-tile-badge";
 import "../../../components/tile/ha-tile-icon";
 import "../../../components/tile/ha-tile-image";
+import type { TileImageStyle } from "../../../components/tile/ha-tile-image";
 import "../../../components/tile/ha-tile-info";
 import { cameraUrlWithWidthHeight } from "../../../data/camera";
 import { isUnavailableState } from "../../../data/entity";
 import type { ActionHandlerEvent } from "../../../data/lovelace/action_handler";
 import { SENSOR_DEVICE_CLASS_TIMESTAMP } from "../../../data/sensor";
+import { UpdateEntity, computeUpdateStateDisplay } from "../../../data/update";
 import { HomeAssistant } from "../../../types";
+import "../card-features/hui-card-features";
 import { actionHandler } from "../common/directives/action-handler-directive";
 import { findEntities } from "../common/find-entities";
 import { handleAction } from "../common/handle-action";
 import { hasAction } from "../common/has-action";
 import "../components/hui-timestamp-display";
-import "../card-features/hui-card-features";
 import type { LovelaceCard, LovelaceCardEditor } from "../types";
 import { computeTileBadge } from "./tile/badges/tile-badge";
 import type { ThermostatCardConfig, TileCardConfig } from "./types";
-import { UpdateEntity, computeUpdateStateDisplay } from "../../../data/update";
 
 const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
 
@@ -59,6 +60,11 @@ export const getEntityDefaultTileIconAction = (entityId: string) => {
     ["button", "input_button", "scene"].includes(domain);
 
   return supportsIconAction ? "toggle" : "more-info";
+};
+
+const DOMAIN_IMAGE_STYLE: Record<string, TileImageStyle> = {
+  update: "square",
+  media_player: "rounded-square",
 };
 
 @customElement("hui-tile-card")
@@ -413,6 +419,7 @@ export class HuiTileCard extends LitElement implements LovelaceCard {
             ${imageUrl
               ? html`
                   <ha-tile-image
+                    .imageStyle=${DOMAIN_IMAGE_STYLE[domain] || "circle"}
                     class="icon"
                     .imageUrl=${imageUrl}
                   ></ha-tile-image>


### PR DESCRIPTION
## Proposed change

Update tile card image to match entities card style. 
I think we should merge `tile-icon`/`tile-image` component with state `badge-state` but there are still some difference 
- brightness is not used in `tile-card`, only in `badge-state`.
- `badge-state` doesn't have background
- `tile-icon` have a fix to not display white icon if the light color is white

![CleanShot 2024-01-16 at 10 32 10](https://github.com/home-assistant/frontend/assets/5878303/1dea2d68-f523-4098-9c4d-7952c978a2b3)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
