### PR TITLE
Don't show duplicates in statistics picker

### DIFF
--- a/src/components/entity/ha-statistic-picker.ts
+++ b/src/components/entity/ha-statistic-picker.ts
@@ -129,7 +129,8 @@ export class HaStatisticPicker extends LitElement {
       includeUnitClass?: string | string[],
       includeDeviceClass?: string | string[],
       entitiesOnly?: boolean,
-      excludeStatistics?: string[]
+      excludeStatistics?: string[],
+      value?: string
     ): StatisticItem[] => {
       if (!statisticIds.length) {
         return [
@@ -176,6 +177,7 @@ export class HaStatisticPicker extends LitElement {
       statisticIds.forEach((meta) => {
         if (
           excludeStatistics &&
+          meta.statistic_id !== value &&
           excludeStatistics.includes(meta.statistic_id)
         ) {
           return;
@@ -258,7 +260,8 @@ export class HaStatisticPicker extends LitElement {
           this.includeUnitClass,
           this.includeDeviceClass,
           this.entitiesOnly,
-          this.excludeStatistics
+          this.excludeStatistics,
+          this.value
         );
       } else {
         this.updateComplete.then(() => {
@@ -268,7 +271,8 @@ export class HaStatisticPicker extends LitElement {
             this.includeUnitClass,
             this.includeDeviceClass,
             this.entitiesOnly,
-            this.excludeStatistics
+            this.excludeStatistics,
+            this.value
           );
         });
       }

--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -1,5 +1,6 @@
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import { repeat } from "lit/directives/repeat";
 import { fireEvent } from "../../common/dom/fire_event";
 import type { ValueChangedEvent, HomeAssistant } from "../../types";
 import "./ha-statistic-picker";
@@ -81,7 +82,9 @@ class HaStatisticsPicker extends LitElement {
       : this.statisticTypes;
 
     return html`
-      ${this._currentStatistics.map(
+      ${repeat(
+        this._currentStatistics,
+        (statisticId) => statisticId,
         (statisticId) => html`
           <div>
             <ha-statistic-picker

--- a/src/components/entity/ha-statistics-picker.ts
+++ b/src/components/entity/ha-statistics-picker.ts
@@ -94,6 +94,7 @@ class HaStatisticsPicker extends LitElement {
               .statisticTypes=${includeStatisticTypesCurrent}
               .statisticIds=${this.statisticIds}
               .label=${this.pickedStatisticLabel}
+              .excludeStatistics=${this.value}
               .allowCustomEntity=${this.allowCustomEntity}
               @value-changed=${this._statisticChanged}
             ></ha-statistic-picker>
@@ -110,6 +111,7 @@ class HaStatisticsPicker extends LitElement {
           .statisticTypes=${this.statisticTypes}
           .statisticIds=${this.statisticIds}
           .label=${this.pickStatisticLabel}
+          .excludeStatistics=${this.value}
           .allowCustomEntity=${this.allowCustomEntity}
           @value-changed=${this._addStatistic}
         ></ha-statistic-picker>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The ha-statistics-picker does not allow for statistics to be selected multiple times, it throws them away if you try. 

Yet it still shows already chosen statistics in the dropdown lists, which makes it harder than necessary when you are trying to build a big list of statistics, since you will have to mentally filter out everything you already picked.

This change removes items from the dropdown selection once they have already been selected one time, making it very easy to add all statistics of a type to the picker, you just have to keep repeatedly adding until there are none left that can be added. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
