### PR TITLE
Update hassio-addon-dashboard.ts to fix back button issue

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -42,7 +42,7 @@ jobs:
           LOKALISE_TOKEN: ${{ secrets.LOKALISE_TOKEN }}
 
       - name: Bump version
-        run: script/version_bump.cjs nightly
+        run: script/version_bump.js nightly
 
       - name: Build nightly Python wheels
         run: |

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "element-internals-polyfill": "1.3.10",
     "fuse.js": "7.0.0",
     "google-timezones-json": "1.2.0",
-    "hls.js": "1.5.0",
+    "hls.js": "1.5.1",
     "home-assistant-js-websocket": "9.1.0",
     "idb-keyval": "6.2.1",
     "intl-messageformat": "10.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9461,10 +9461,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hls.js@npm:1.5.0":
-  version: 1.5.0
-  resolution: "hls.js@npm:1.5.0"
-  checksum: ba63871fba052a2e6f7bd744333a1ff18edd61535b51cd5a6b3f0331527333ce1954c3a4d5e95bcb20c1fc8c7c87a75ca338f008ac213486f7ca4a9e08982f92
+"hls.js@npm:1.5.1":
+  version: 1.5.1
+  resolution: "hls.js@npm:1.5.1"
+  checksum: 1e2452892ec62a370fecf5c8d643154fdb7f49c41693a9b757c3d9f62a1383402f1d4be78456a764956533621676a67bc584fec7b7c1ed50c1415951b125b02b
   languageName: node
   linkType: hard
 
@@ -9618,7 +9618,7 @@ __metadata:
     gulp-merge-json: "npm:2.1.2"
     gulp-rename: "npm:2.0.0"
     gulp-zopfli-green: "npm:6.0.1"
-    hls.js: "npm:1.5.0"
+    hls.js: "npm:1.5.1"
     home-assistant-js-websocket: "npm:9.1.0"
     html-minifier-terser: "npm:7.2.0"
     husky: "npm:8.0.3"


### PR DESCRIPTION
## Problem
Sometimes an add-on takes a while to uninstall. When this happens, you can click uninstall, then quickly click out with the back button and venture on into another area of HA.

Once the add-on finishes uninstalling, the API response comes in, and suddenly you are thrown out of where you were (could be the main dashboard, another add-on, anywhere really!) and pushed back a page in the browser history. Typically for me this puts me back to the add-on's page (which no longer exists) but it could even be somewhere else in HA. You can imagine this is very frustrating!

## Proposed change
In this change, I have added a check that the add-on slug is still in the browsers path name.

If not, we are on another page, so don't need to do anything. This avoids redirecting anyone who is not looking at the add-on anymore.

If we have the slug, I have used window.location.replace so that the now defunct add-on page is removed from the browser history and cannot be clicked back to with the back button. I've also added the existing _backPath, so that we don't just simply hardcode /hassio/dashboard because we may have come from the store, for example.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
1. Uninstall a larger add-on.
2. Immediately hit the back button in HA.
3. Wait for a bit
4. You'll see it throws you to an unexpected page.

## Checklist
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.