### PR TITLE
Fix incompatible object/array property types (1 of 3)

### DIFF
--- a/gallery/src/components/demo-card.ts
+++ b/gallery/src/components/demo-card.ts
@@ -13,7 +13,7 @@ export interface DemoCardConfig {
 class DemoCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public config!: DemoCardConfig;
+  @property({ attribute: false }) public config!: DemoCardConfig;
 
   @property({ type: Boolean }) public showConfig = false;
 

--- a/src/components/device/ha-device-automation-picker.ts
+++ b/src/components/device/ha-device-automation-picker.ts
@@ -25,7 +25,7 @@ export abstract class HaDeviceAutomationPicker<
 
   @property() public deviceId?: string;
 
-  @property() public value?: T;
+  @property({ type: Object }) public value?: T;
 
   @state() private _automations: T[] = [];
 

--- a/src/components/ha-file-upload.ts
+++ b/src/components/ha-file-upload.ts
@@ -31,11 +31,11 @@ export class HaFileUpload extends LitElement {
 
   @property() public supports?: string;
 
-  @property() public value?: File | File[] | FileList | string;
+  @property({ type: Object }) public value?: File | File[] | FileList | string;
 
   @property({ type: Boolean }) public multiple = false;
 
-  @property({ type: Boolean, reflect: true }) public disabled: boolean = false;
+  @property({ type: Boolean, reflect: true }) public disabled = false;
 
   @property({ type: Boolean }) public uploading = false;
 

--- a/src/components/ha-selector/ha-selector-action.ts
+++ b/src/components/ha-selector/ha-selector-action.ts
@@ -11,7 +11,7 @@ export class HaActionSelector extends LitElement {
 
   @property({ attribute: false }) public selector!: ActionSelector;
 
-  @property() public value?: Action;
+  @property({ attribute: false }) public value?: Action;
 
   @property() public label?: string;
 

--- a/src/components/ha-selector/ha-selector-condition.ts
+++ b/src/components/ha-selector/ha-selector-condition.ts
@@ -11,7 +11,7 @@ export class HaConditionSelector extends LitElement {
 
   @property({ attribute: false }) public selector!: ConditionSelector;
 
-  @property() public value?: Condition;
+  @property({ attribute: false }) public value?: Condition;
 
   @property() public label?: string;
 

--- a/src/components/ha-selector/ha-selector-location.ts
+++ b/src/components/ha-selector/ha-selector-location.ts
@@ -16,7 +16,7 @@ export class HaLocationSelector extends LitElement {
 
   @property({ attribute: false }) public selector!: LocationSelector;
 
-  @property() public value?: LocationSelectorValue;
+  @property({ type: Object }) public value?: LocationSelectorValue;
 
   @property() public label?: string;
 

--- a/src/components/ha-selector/ha-selector-target.ts
+++ b/src/components/ha-selector/ha-selector-target.ts
@@ -32,7 +32,7 @@ export class HaTargetSelector extends LitElement {
 
   @property({ attribute: false }) public selector!: TargetSelector;
 
-  @property() public value?: HassServiceTarget;
+  @property({ type: Object }) public value?: HassServiceTarget;
 
   @property() public label?: string;
 

--- a/src/components/ha-selector/ha-selector-trigger.ts
+++ b/src/components/ha-selector/ha-selector-trigger.ts
@@ -11,7 +11,7 @@ export class HaTriggerSelector extends LitElement {
 
   @property({ attribute: false }) public selector!: TriggerSelector;
 
-  @property() public value?: Trigger;
+  @property({ attribute: false }) public value?: Trigger;
 
   @property() public label?: string;
 

--- a/src/components/ha-selector/ha-selector-ui-action.ts
+++ b/src/components/ha-selector/ha-selector-ui-action.ts
@@ -12,7 +12,7 @@ export class HaSelectorUiAction extends LitElement {
 
   @property({ attribute: false }) public selector!: UiActionSelector;
 
-  @property() public value?: ActionConfig;
+  @property({ attribute: false }) public value?: ActionConfig;
 
   @property() public label?: string;
 

--- a/src/panels/config/automation/action/ha-automation-action-row.ts
+++ b/src/panels/config/automation/action/ha-automation-action-row.ts
@@ -125,7 +125,7 @@ const preventDefault = (ev) => ev.preventDefault();
 export default class HaAutomationActionRow extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public action!: Action;
+  @property({ attribute: false }) public action!: Action;
 
   @property({ type: Boolean }) public narrow = false;
 
@@ -133,7 +133,7 @@ export default class HaAutomationActionRow extends LitElement {
 
   @property({ type: Boolean }) public hideMenu = false;
 
-  @property() public path?: ItemPath;
+  @property({ type: Array }) public path?: ItemPath;
 
   @storage({
     key: "automationClipboard",

--- a/src/panels/config/automation/action/ha-automation-action.ts
+++ b/src/panels/config/automation/action/ha-automation-action.ts
@@ -33,9 +33,9 @@ export default class HaAutomationAction extends LitElement {
 
   @property({ type: Boolean }) public disabled = false;
 
-  @property() public path?: ItemPath;
+  @property({ type: Array }) public path?: ItemPath;
 
-  @property() public actions!: Action[];
+  @property({ attribute: false }) public actions!: Action[];
 
   @state()
   @consume({ context: reorderModeContext, subscribe: true })

--- a/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
+++ b/src/panels/config/automation/action/types/ha-automation-action-repeat.ts
@@ -29,7 +29,7 @@ export class HaRepeatAction extends LitElement implements ActionElement {
 
   @property({ attribute: false }) public action!: RepeatAction;
 
-  @property() public path?: ItemPath;
+  @property({ type: Array }) public path?: ItemPath;
 
   public static get defaultConfig() {
     return { repeat: { count: 2, sequence: [] } };

--- a/src/panels/config/automation/blueprint-automation-editor.ts
+++ b/src/panels/config/automation/blueprint-automation-editor.ts
@@ -30,9 +30,9 @@ export class HaBlueprintAutomationEditor extends ReorderModeMixin(LitElement) {
 
   @property({ type: Boolean }) public disabled = false;
 
-  @property({ reflect: true, type: Boolean }) public narrow = false;
+  @property({ type: Boolean, reflect: true }) public narrow = false;
 
-  @property() public config!: BlueprintAutomationConfig;
+  @property({ attribute: false }) public config!: BlueprintAutomationConfig;
 
   @property({ attribute: false }) public stateObj?: HassEntity;
 

--- a/src/panels/config/automation/condition/ha-automation-condition-editor.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-editor.ts
@@ -30,7 +30,7 @@ export default class HaAutomationConditionEditor extends LitElement {
 
   @property({ type: Boolean }) public yamlMode = false;
 
-  @property() public path?: ItemPath;
+  @property({ type: Array }) public path?: ItemPath;
 
   private _processedCondition = memoizeOne((condition) =>
     expandConditionWithShorthand(condition)

--- a/src/panels/config/automation/condition/ha-automation-condition-row.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition-row.ts
@@ -81,13 +81,13 @@ export const handleChangeEvent = (
 export default class HaAutomationConditionRow extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public condition!: Condition;
+  @property({ attribute: false }) public condition!: Condition;
 
   @property({ type: Boolean }) public hideMenu = false;
 
   @property({ type: Boolean }) public disabled = false;
 
-  @property() public path?: ItemPath;
+  @property({ type: Array }) public path?: ItemPath;
 
   @storage({
     key: "automationClipboard",

--- a/src/panels/config/automation/condition/ha-automation-condition.ts
+++ b/src/panels/config/automation/condition/ha-automation-condition.ts
@@ -38,11 +38,11 @@ import type HaAutomationConditionRow from "./ha-automation-condition-row";
 export default class HaAutomationCondition extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public conditions!: Condition[];
+  @property({ attribute: false }) public conditions!: Condition[];
 
   @property({ type: Boolean }) public disabled = false;
 
-  @property() public path?: ItemPath;
+  @property({ type: Array }) public path?: ItemPath;
 
   @state()
   @consume({ context: reorderModeContext, subscribe: true })

--- a/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger-row.ts
@@ -112,7 +112,7 @@ export default class HaAutomationTriggerRow extends LitElement {
 
   @property({ type: Boolean }) public disabled = false;
 
-  @property() public path?: ItemPath;
+  @property({ type: Array }) public path?: ItemPath;
 
   @state() private _warnings?: string[];
 

--- a/src/panels/config/automation/trigger/ha-automation-trigger.ts
+++ b/src/panels/config/automation/trigger/ha-automation-trigger.ts
@@ -28,11 +28,11 @@ import type HaAutomationTriggerRow from "./ha-automation-trigger-row";
 export default class HaAutomationTrigger extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public triggers!: Trigger[];
+  @property({ attribute: false }) public triggers!: Trigger[];
 
   @property({ type: Boolean }) public disabled = false;
 
-  @property() public path?: ItemPath;
+  @property({ type: Array }) public path?: ItemPath;
 
   @state()
   @consume({ context: reorderModeContext, subscribe: true })

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-event.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-event.ts
@@ -15,7 +15,7 @@ import {
 export class HaEventTrigger extends LitElement implements TriggerElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: EventTrigger;
+  @property({ attribute: false }) public trigger!: EventTrigger;
 
   @property({ type: Boolean }) public disabled = false;
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-persistent_notification.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-persistent_notification.ts
@@ -23,7 +23,8 @@ export class HaPersistentNotificationTrigger
 {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: PersistentNotificationTrigger;
+  @property({ attribute: false })
+  public trigger!: PersistentNotificationTrigger;
 
   @property({ type: Boolean }) public disabled = false;
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-tag.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-tag.ts
@@ -13,7 +13,7 @@ import { TriggerElement } from "../ha-automation-trigger-row";
 export class HaTagTrigger extends LitElement implements TriggerElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: TagTrigger;
+  @property({ attribute: false }) public trigger!: TagTrigger;
 
   @property({ type: Boolean }) public disabled = false;
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-webhook.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-webhook.ts
@@ -27,7 +27,7 @@ const DEFAULT_WEBHOOK_ID = "";
 export class HaWebhookTrigger extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: WebhookTrigger;
+  @property({ attribute: false }) public trigger!: WebhookTrigger;
 
   @property({ type: Boolean }) public disabled = false;
 

--- a/src/panels/config/automation/trigger/types/ha-automation-trigger-zone.ts
+++ b/src/panels/config/automation/trigger/types/ha-automation-trigger-zone.ts
@@ -19,7 +19,7 @@ const includeDomains = ["zone"];
 export class HaZoneTrigger extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public trigger!: ZoneTrigger;
+  @property({ attribute: false }) public trigger!: ZoneTrigger;
 
   @property({ type: Boolean }) public disabled = false;
 

--- a/src/panels/config/cloud/account/cloud-remote-pref.ts
+++ b/src/panels/config/cloud/account/cloud-remote-pref.ts
@@ -22,7 +22,7 @@ import { showCloudCertificateDialog } from "../dialog-cloud-certificate/show-dia
 export class CloudRemotePref extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public cloudStatus?: CloudStatusLoggedIn;
+  @property({ attribute: false }) public cloudStatus?: CloudStatusLoggedIn;
 
   protected render() {
     if (!this.cloudStatus) {

--- a/src/panels/config/cloud/account/cloud-tts-pref.ts
+++ b/src/panels/config/cloud/account/cloud-tts-pref.ts
@@ -24,7 +24,7 @@ import { showTryTtsDialog } from "./show-dialog-cloud-tts-try";
 export class CloudTTSPref extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public cloudStatus?: CloudStatusLoggedIn;
+  @property({ attribute: false }) public cloudStatus?: CloudStatusLoggedIn;
 
   @state() private savingPreferences = false;
 

--- a/src/panels/config/cloud/ha-config-cloud.ts
+++ b/src/panels/config/cloud/ha-config-cloud.ts
@@ -22,7 +22,7 @@ class HaConfigCloud extends HassRouterPage {
 
   @property({ attribute: false }) public route!: Route;
 
-  @property() public cloudStatus!: CloudStatus;
+  @property({ attribute: false }) public cloudStatus!: CloudStatus;
 
   protected routerOptions: RouterOptions = {
     defaultPage: "login",

--- a/src/panels/config/dashboard/ha-config-dashboard.ts
+++ b/src/panels/config/dashboard/ha-config-dashboard.ts
@@ -118,7 +118,7 @@ class HaConfigDashboard extends SubscribeMixin(LitElement) {
 
   @property({ type: Boolean }) public isWide = false;
 
-  @property() public cloudStatus?: CloudStatus;
+  @property({ attribute: false }) public cloudStatus?: CloudStatus;
 
   @property({ type: Boolean }) public showAdvanced = false;
 

--- a/src/panels/config/devices/device-detail/ha-device-info-card.ts
+++ b/src/panels/config/devices/device-detail/ha-device-info-card.ts
@@ -13,7 +13,7 @@ import { HomeAssistant } from "../../../../types";
 export class HaDeviceCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public device!: DeviceRegistryEntry;
+  @property({ attribute: false }) public device!: DeviceRegistryEntry;
 
   @property({ type: Boolean }) public narrow = false;
 

--- a/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-info-zha.ts
+++ b/src/panels/config/devices/device-detail/integration-elements/zha/ha-device-info-zha.ts
@@ -18,7 +18,7 @@ import { formatAsPaddedHex } from "../../../../integrations/integration-panels/z
 export class HaDeviceInfoZha extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public device!: DeviceRegistryEntry;
+  @property({ attribute: false }) public device!: DeviceRegistryEntry;
 
   @state() private _zhaDevice?: ZHADevice;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-attributes.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-attributes.ts
@@ -33,9 +33,9 @@ import { ItemSelectedEvent, SetAttributeServiceData } from "./types";
 export class ZHAClusterAttributes extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @property() public device?: ZHADevice;
+  @property({ attribute: false }) public device?: ZHADevice;
 
-  @property() public selectedCluster?: Cluster;
+  @property({ type: Object }) public selectedCluster?: Cluster;
 
   @state() private _attributes: Attribute[] | undefined;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-cluster-commands.ts
@@ -30,9 +30,9 @@ export class ZHAClusterCommands extends LitElement {
 
   @property({ type: Boolean }) public isWide = false;
 
-  @property() public device?: ZHADevice;
+  @property({ attribute: false }) public device?: ZHADevice;
 
-  @property() public selectedCluster?: Cluster;
+  @property({ type: Object }) public selectedCluster?: Cluster;
 
   @state() private _commands: Command[] | undefined;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-binding.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-binding.ts
@@ -21,7 +21,7 @@ import { ItemSelectedEvent } from "./types";
 export class ZHADeviceBindingControl extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @property() public device?: ZHADevice;
+  @property({ attribute: false }) public device?: ZHADevice;
 
   @state() private _bindTargetIndex = -1;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-card.ts
@@ -29,7 +29,7 @@ import { getIeeeTail } from "./functions";
 class ZHADeviceCard extends SubscribeMixin(LitElement) {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public device?: ZHADevice;
+  @property({ attribute: false }) public device?: ZHADevice;
 
   @property({ type: Boolean }) public narrow = false;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-neighbors.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-neighbors.ts
@@ -26,7 +26,7 @@ class ZHADeviceNeighbors extends LitElement {
 
   @property({ type: Boolean }) public narrow = false;
 
-  @property() public device: ZHADevice | undefined;
+  @property({ attribute: false }) public device?: ZHADevice;
 
   @state() private _devices: Map<string, ZHADevice> | undefined;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-pairing-status-card.ts
@@ -18,7 +18,7 @@ import "./zha-device-card";
 class ZHADevicePairingStatusCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public device?: ZHADevice;
+  @property({ attribute: false }) public device?: ZHADevice;
 
   @property({ type: Boolean }) public narrow = false;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-device-signature.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-device-signature.ts
@@ -8,7 +8,7 @@ import { HomeAssistant } from "../../../../../types";
 class ZHADeviceZigbeeInfo extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public device: ZHADevice | undefined;
+  @property({ attribute: false }) public device?: ZHADevice;
 
   @state() private _signature: any;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-group-binding.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-group-binding.ts
@@ -31,7 +31,7 @@ import "@material/mwc-list/mwc-list-item";
 export class ZHAGroupBindingControl extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @property() public device?: ZHADevice;
+  @property({ attribute: false }) public device?: ZHADevice;
 
   @state() private _bindTargetIndex = -1;
 

--- a/src/panels/config/integrations/integration-panels/zha/zha-manage-clusters.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-manage-clusters.ts
@@ -42,7 +42,7 @@ export class ZHAManageClusters extends LitElement {
 
   @property({ type: Boolean }) public isWide = false;
 
-  @property() public device?: ZHADevice;
+  @property({ attribute: false }) public device?: ZHADevice;
 
   @state() private _selectedClusterIndex = -1;
 

--- a/src/panels/config/voice-assistants/assist-pref.ts
+++ b/src/panels/config/voice-assistants/assist-pref.ts
@@ -1,7 +1,7 @@
 import "@material/mwc-list/mwc-list";
 import { mdiHelpCircle, mdiPlus, mdiStar } from "@mdi/js";
-import { css, CSSResultGroup, html, LitElement, PropertyValues } from "lit";
-import { property, state } from "lit/decorators";
+import { CSSResultGroup, LitElement, PropertyValues, css, html } from "lit";
+import { customElement, property, state } from "lit/decorators";
 import memoizeOne from "memoize-one";
 import { formatLanguageCode } from "../../../common/language/format_language";
 import "../../../components/ha-alert";
@@ -26,9 +26,10 @@ import { ExposeEntitySettings } from "../../../data/expose";
 import { showConfirmationDialog } from "../../../dialogs/generic/show-dialog-box";
 import type { HomeAssistant } from "../../../types";
 import { brandsUrl } from "../../../util/brands-url";
-import { showVoiceAssistantPipelineDetailDialog } from "./show-dialog-voice-assistant-pipeline-detail";
 import { documentationUrl } from "../../../util/documentation-url";
+import { showVoiceAssistantPipelineDetailDialog } from "./show-dialog-voice-assistant-pipeline-detail";
 
+@customElement("assist-pref")
 export class AssistPref extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
@@ -37,13 +38,13 @@ export class AssistPref extends LitElement {
     ExposeEntitySettings
   >;
 
+  @property({ attribute: false }) public cloudStatus?: CloudStatus;
+
   @state() private _pipelines: AssistPipeline[] = [];
 
   @state() private _preferred: string | null = null;
 
   @state() private _devices: AssistDevice[] = [];
-
-  @property() public cloudStatus?: CloudStatus;
 
   protected firstUpdated(changedProps: PropertyValues) {
     super.firstUpdated(changedProps);
@@ -277,5 +278,3 @@ declare global {
     "assist-pref": AssistPref;
   }
 }
-
-customElements.define("assist-pref", AssistPref);

--- a/src/panels/config/voice-assistants/cloud-alexa-pref.ts
+++ b/src/panels/config/voice-assistants/cloud-alexa-pref.ts
@@ -27,7 +27,7 @@ export class CloudAlexaPref extends LitElement {
     ExposeEntitySettings
   >;
 
-  @property() public cloudStatus?: CloudStatusLoggedIn;
+  @property({ attribute: false }) public cloudStatus?: CloudStatusLoggedIn;
 
   @state() private _exposeNew?: boolean;
 

--- a/src/panels/lovelace/components/hui-action-editor.ts
+++ b/src/panels/lovelace/components/hui-action-editor.ts
@@ -72,13 +72,13 @@ const ASSIST_SCHEMA = [
 
 @customElement("hui-action-editor")
 export class HuiActionEditor extends LitElement {
-  @property() public config?: ActionConfig;
+  @property({ attribute: false }) public config?: ActionConfig;
 
   @property() public label?: string;
 
-  @property() public actions?: UiAction[];
+  @property({ attribute: false }) public actions?: UiAction[];
 
-  @property() public defaultAction?: UiAction;
+  @property({ attribute: false }) public defaultAction?: UiAction;
 
   @property() public tooltipText?: string;
 

--- a/src/panels/lovelace/components/hui-card-options.ts
+++ b/src/panels/lovelace/components/hui-card-options.ts
@@ -54,7 +54,7 @@ export class HuiCardOptions extends LitElement {
 
   @property({ attribute: false }) public lovelace?: Lovelace;
 
-  @property() public path?: [number, number];
+  @property({ type: Array }) public path?: [number, number];
 
   @queryAssignedNodes() private _assignedNodes?: NodeListOf<LovelaceCard>;
 

--- a/src/panels/lovelace/components/hui-generic-entity-row.ts
+++ b/src/panels/lovelace/components/hui-generic-entity-row.ts
@@ -28,7 +28,7 @@ import { createEntityNotFoundWarning } from "./hui-warning";
 export class HuiGenericEntityRow extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @property() public config?: EntitiesCardEntityConfig;
+  @property({ attribute: false }) public config?: EntitiesCardEntityConfig;
 
   @property() public secondaryText?: string;
 

--- a/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
+++ b/src/panels/lovelace/editor/card-editor/hui-card-preview.ts
@@ -10,7 +10,7 @@ import { LovelaceCard } from "../../types";
 export class HuiCardPreview extends ReactiveElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
-  @property() public config?: LovelaceCardConfig;
+  @property({ attribute: false }) public config?: LovelaceCardConfig;
 
   private _element?: LovelaceCard;
 

--- a/src/panels/lovelace/editor/lovelace-editor/hui-lovelace-editor.ts
+++ b/src/panels/lovelace/editor/lovelace-editor/hui-lovelace-editor.ts
@@ -18,7 +18,7 @@ declare global {
 export class HuiLovelaceEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
-  @property() public config?: LovelaceConfig;
+  @property({ attribute: false }) public config?: LovelaceConfig;
 
   get _title(): string {
     if (!this.config) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Resolve about a third of the ~150 remaining warnings for incompatible property types, which are all objects or arrays since numbers and booleans were fixed in #19349 and #19337, respectively.

As a general rule of thumb, I'm turning off the attributes for safety unless the shape is very simple (e.g. `string[]`, [number, number]`, etc.).  (Presumably this would also be a performance gain since Lit wouldn't monitor their attributes too 🤷🏻‍♂️ ).

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
