### PR TITLE
Use entity registry icon directly

### DIFF
--- a/src/components/ha-state-icon.ts
+++ b/src/components/ha-state-icon.ts
@@ -17,10 +17,12 @@ export class HaStateIcon extends LitElement {
   @property() public icon?: string;
 
   protected render() {
-    if (this.icon || this.stateObj?.attributes.icon) {
-      return html`<ha-icon
-        .icon=${this.icon || this.stateObj?.attributes.icon}
-      ></ha-icon>`;
+    const overrideIcon =
+      this.icon ||
+      (this.stateObj && this.hass?.entities[this.stateObj.entity_id]?.icon) ||
+      this.stateObj?.attributes.icon;
+    if (overrideIcon) {
+      return html`<ha-icon .icon=${overrideIcon}></ha-icon>`;
     }
     if (!this.stateObj) {
       return nothing;

--- a/src/data/entity_registry.ts
+++ b/src/data/entity_registry.ts
@@ -15,6 +15,7 @@ type entityCategory = "config" | "diagnostic";
 export interface EntityRegistryDisplayEntry {
   entity_id: string;
   name?: string;
+  icon?: string;
   device_id?: string;
   area_id?: string;
   hidden?: boolean;
@@ -31,6 +32,7 @@ export interface EntityRegistryDisplayEntryResponse {
     ai?: string;
     ec?: number;
     en?: string;
+    ic?: string;
     pl?: string;
     tk?: string;
     hb?: boolean;

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -75,6 +75,9 @@ export const entityIcon = async (hass: HomeAssistant, state: HassEntity) => {
   let icon: string | undefined;
   const domain = computeStateDomain(state);
   const entity = hass.entities?.[state.entity_id];
+  if (entity?.icon) {
+    return entity.icon;
+  }
   if (entity?.translation_key && entity.platform) {
     const platformIcons = await getPlatformIcons(hass, entity.platform);
     if (platformIcons) {

--- a/src/state/connection-mixin.ts
+++ b/src/state/connection-mixin.ts
@@ -239,6 +239,7 @@ export const connectionMixin = <T extends Constructor<HassBaseEl>>(
                 ? entityReg.entity_categories[entity.ec]
                 : undefined,
             name: entity.en,
+            icon: entity.ic,
             hidden: entity.hb,
             display_precision: entity.dp,
           };


### PR DESCRIPTION



## Proposed change
Use entity registry to check for a icon set, instead of using the icon attribute that would be set by core when the icon is set in the entity registry.

Core could remove the icon attribute in the future now.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
