### PR TITLE
Add support for new GitHub alerts

### DIFF
--- a/gallery/src/pages/lovelace/markdown-card.ts
+++ b/gallery/src/pages/lovelace/markdown-card.ts
@@ -65,15 +65,20 @@ const CONFIGS = [
     >> ...by using additional greater-than signs right next to each other...
     > > > ...or with spaces between arrows.
 
-    > **Warning** Hey there
-    > This is a warning with a title
+    > [!NOTE]
+    > This is a GitHub note alert
 
-    > **Note**
-    > This is a note
+    > [!TIP]
+    > This is a GitHub tip alert
 
-    > **Note**
-    > This is a multiline note
-    > Lorem ipsum...
+    > [!IMPORTANT]
+    > This is a GitHub important alert
+
+    > [!WARNING]
+    > This is a GitHub warning alert
+
+    > [!CAUTION]
+    > This is a GitHub caution alert
 
     ## Lists
 

--- a/src/components/ha-markdown-element.ts
+++ b/src/components/ha-markdown-element.ts
@@ -3,7 +3,14 @@ import { customElement, property } from "lit/decorators";
 import { fireEvent } from "../common/dom/fire_event";
 import { renderMarkdown } from "../resources/render-markdown";
 
-const _blockQuoteToAlert = { Note: "info", Warning: "warning" };
+const _legacyGitHubBlockQuoteToAlert = { Note: "info", Warning: "warning" };
+const _gitHubBlockQuoteToAlert = {
+  "[!NOTE]": "info",
+  "[!TIP]": "success",
+  "[!IMPORTANT]": "info",
+  "[!WARNING]": "warning",
+  "[!CAUTION]": "error",
+};
 
 @customElement("ha-markdown-element")
 class HaMarkdownElement extends ReactiveElement {
@@ -71,18 +78,25 @@ class HaMarkdownElement extends ReactiveElement {
         // Map GitHub blockquote elements to our ha-alert element
         const firstElementChild = node.firstElementChild;
         const quoteTitleElement = firstElementChild?.firstElementChild;
-        const quoteType =
+        const blockQuoteType =
+          firstElementChild?.firstChild?.textContent &&
+          _gitHubBlockQuoteToAlert[firstElementChild.firstChild.textContent];
+        const legacyBlockQuoteType =
+          !blockQuoteType &&
           quoteTitleElement?.textContent &&
-          _blockQuoteToAlert[quoteTitleElement.textContent];
+          _legacyGitHubBlockQuoteToAlert[quoteTitleElement.textContent];
 
-        // GitHub is strict on how these are defined, we need to make sure we know what we have before starting to replace it
-        if (quoteTitleElement?.nodeName === "STRONG" && quoteType) {
+        if (
+          blockQuoteType ||
+          (quoteTitleElement?.nodeName === "STRONG" && legacyBlockQuoteType)
+        ) {
           const alertNote = document.createElement("ha-alert");
-          alertNote.alertType = quoteType;
-          alertNote.title =
-            (firstElementChild!.childNodes[1].nodeName === "#text" &&
-              firstElementChild!.childNodes[1].textContent?.trimStart()) ||
-            "";
+          alertNote.alertType = blockQuoteType || legacyBlockQuoteType;
+          alertNote.title = blockQuoteType
+            ? ""
+            : (firstElementChild!.childNodes[1].nodeName === "#text" &&
+                firstElementChild!.childNodes[1].textContent?.trimStart()) ||
+              "";
 
           const childNodes = Array.from(firstElementChild!.childNodes);
           for (const child of childNodes.slice(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

A month ago, GitHub changed how the alert syntax is defined https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/.

This PR adds support for that new syntax.
The old (now legacy) format is kept to not cause any breaking change, but removed from the gallery to limit future usage.

<img width="529" alt="2024-01-19_16-22-05" src="https://github.com/home-assistant/frontend/assets/15093472/18690596-5dc0-45ea-a6ed-a87debdfee76">



## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [😂] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
