### PR TITLE
Update hassio-addon-dashboard.ts to fix back button issue

### DIFF
--- a/hassio/src/addon-view/hassio-addon-dashboard.ts
+++ b/hassio/src/addon-view/hassio-addon-dashboard.ts
@@ -250,7 +250,9 @@ class HassioAddonDashboard extends LitElement {
     }
 
     if (path === "uninstall") {
-      window.history.back();
+      if (this.isConnected) {
+        navigate(this._backPath);
+      }
     } else if (path === "install") {
       this.addon = await fetchHassioAddonInfo(this.hass, this.addon!.slug);
     } else {


### PR DESCRIPTION
## Problem
Sometimes an add-on takes a while to uninstall. When this happens, you can click uninstall, then quickly click out with the back button and venture on into another area of HA.

Once the add-on finishes uninstalling, the API response comes in, and suddenly you are thrown out of where you were (could be the main dashboard, another add-on, anywhere really!) and pushed back a page in the browser history. Typically for me this puts me back to the add-on's page (which no longer exists) but it could even be somewhere else in HA. You can imagine this is very frustrating!

## Proposed change
Follow-up to broken PR https://github.com/home-assistant/frontend/pull/19430

In this change, I have added a check that the add-on slug is still in the browsers path name.

If not, we are on another page, so don't need to do anything. This avoids redirecting anyone who is not looking at the add-on anymore.

If we have the slug, I have used window.location.replace so that the now defunct add-on page is removed from the browser history and cannot be clicked back to with the back button. I've also added the existing _backPath, so that we don't just simply hardcode /hassio/dashboard because we may have come from the store, for example.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
1. Uninstall a larger add-on.
2. Immediately hit the back button in HA.
3. Wait for a bit
4. You'll see it throws you to an unexpected page.

## Checklist
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.