### PR TITLE
Fix text alignment on mobile devices for zha-add-devices-page.ts

### DIFF
--- a/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
+++ b/src/panels/config/integrations/integration-panels/zha/zha-add-devices-page.ts
@@ -218,6 +218,7 @@ class ZHAAddDevicesPage extends LitElement {
           display: flex;
           flex-direction: column;
           align-items: center;
+          text-align: center;
         }
         .content {
           display: flex;


### PR DESCRIPTION
## Proposed change
discovery_text ("Make sure your devices are in pairing mode. Check the instructions of your device on how to do this.") is showing left aligned on mobile, which is inconsistent with the discovered_text ("Devices will show up here once discovered.") underneath.

### Before
Tablet shows okay.

![Tablet](https://github.com/home-assistant/frontend/assets/50791984/9a7eb9f9-5e0f-47ce-95a4-21746a3ba6b6)

But Mobile Phone's don't center the top line of text.

![Mobile Before](https://github.com/home-assistant/frontend/assets/50791984/ad57239e-ee4e-44cf-bc8a-9cb1cb1a841a)

## After
Mobile Phone text is centered, same as on Tablets.

![Mobile After](https://github.com/home-assistant/frontend/assets/50791984/cf99c456-17db-4ca0-8b1f-b7d7af35b9b4)

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
Search for a device with ZHA on mobile (i.e. iOS).

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.