### PR TITLE
Allow config flow to show error per field

### DIFF
--- a/src/components/ha-alert.ts
+++ b/src/components/ha-alert.ts
@@ -155,6 +155,10 @@ class HaAlert extends LitElement {
     .issue-type.success::after {
       background-color: var(--success-color);
     }
+    :host ::slotted(ul) {
+      margin: 0;
+      padding-inline-start: 24px;
+    }
   `;
 }
 

--- a/src/components/ha-alert.ts
+++ b/src/components/ha-alert.ts
@@ -157,7 +157,7 @@ class HaAlert extends LitElement {
     }
     :host ::slotted(ul) {
       margin: 0;
-      padding-inline-start: 24px;
+      padding-inline-start: 20px;
     }
   `;
 }

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -45,7 +45,10 @@ export class HaForm extends LitElement implements HaFormElement {
 
   @property({ attribute: false }) public schema!: readonly HaFormSchema[];
 
-  @property({ attribute: false }) public error?: Record<string, string>;
+  @property({ attribute: false }) public error?: Record<
+    string,
+    string | string[]
+  >;
 
   @property({ attribute: false }) public warning?: Record<string, string>;
 
@@ -228,7 +231,20 @@ export class HaForm extends LitElement implements HaFormElement {
     return this.computeHelper ? this.computeHelper(schema) : "";
   }
 
-  private _computeError(error, schema: HaFormSchema | readonly HaFormSchema[]) {
+  private _computeError(
+    error: string | string[],
+    schema: HaFormSchema | readonly HaFormSchema[]
+  ): string {
+    if (Array.isArray(error)) {
+      return html`<ul>
+        ${error.map(
+          (err) =>
+            html`<li>
+              ${this.computeError ? this.computeError(err, schema) : err}
+            </li>`
+        )}
+      </ul>`;
+    }
     return this.computeError ? this.computeError(error, schema) : error;
   }
 

--- a/src/components/ha-form/ha-form.ts
+++ b/src/components/ha-form/ha-form.ts
@@ -234,7 +234,7 @@ export class HaForm extends LitElement implements HaFormElement {
   private _computeError(
     error: string | string[],
     schema: HaFormSchema | readonly HaFormSchema[]
-  ): string {
+  ): string | TemplateResult {
     if (Array.isArray(error)) {
       return html`<ul>
         ${error.map(

--- a/src/dialogs/config-flow/step-flow-form.ts
+++ b/src/dialogs/config-flow/step-flow-form.ts
@@ -201,8 +201,19 @@ class StepFlowForm extends LitElement {
         step,
       });
     } catch (err: any) {
-      this._errorMsg =
-        (err && err.body && err.body.message) || "Unknown error occurred";
+      if (err && err.body) {
+        if (err.body.message) {
+          this._errorMsg = err.body.message;
+        }
+        if (err.body.errors) {
+          this.step = { ...this.step, errors: err.body.errors };
+        }
+        if (!err.body.message && !err.body.errors) {
+          this._errorMsg = "Unknown error occurred";
+        }
+      } else {
+        this._errorMsg = "Unknown error occurred";
+      }
     } finally {
       this._loading = false;
     }


### PR DESCRIPTION



## Proposed change

For https://github.com/home-assistant/core/pull/108075?

![image](https://github.com/home-assistant/frontend/assets/5662298/c2435c3e-e62f-4b28-b0bb-a7c789260d24)


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
