### PR TITLE
Update ZHA reconfigure device dialog to show accurate cluster configuration statuses

### DIFF
--- a/src/data/zha.ts
+++ b/src/data/zha.ts
@@ -73,7 +73,7 @@ export interface ClusterAttributeData {
 export interface AttributeConfigurationStatus {
   id: number;
   name: string;
-  success: boolean | undefined;
+  status: string;
   min: number;
   max: number;
   change: number;

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-reconfigure-device.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-reconfigure-device.ts
@@ -57,6 +57,7 @@ class DialogZHAReconfigureDevice extends LitElement {
     this._stages = undefined;
     this._clusterConfigurationStatuses = undefined;
     this._showDetails = false;
+    this._allSuccessful = true;
     fireEvent(this, "dialog-closed", { dialog: this.localName });
   }
 

--- a/src/panels/config/integrations/integration-panels/zha/dialog-zha-reconfigure-device.ts
+++ b/src/panels/config/integrations/integration-panels/zha/dialog-zha-reconfigure-device.ts
@@ -1,4 +1,5 @@
 import "@material/mwc-button/mwc-button";
+import "@lrnwebcomponents/simple-tooltip/simple-tooltip";
 import { mdiCheckCircle, mdiCloseCircle } from "@mdi/js";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
@@ -278,7 +279,7 @@ class DialogZHAReconfigureDevice extends LitElement {
                                       (attribute) => html`
                                         <span class="grid-item">
                                           ${attribute.name}:
-                                          ${attribute.success
+                                          ${attribute.status === "SUCCESS"
                                             ? html`
                                                 <span class="stage">
                                                   <ha-svg-icon
@@ -289,6 +290,12 @@ class DialogZHAReconfigureDevice extends LitElement {
                                               `
                                             : html`
                                                 <span class="stage">
+                                                  <simple-tooltip
+                                                    animation-delay="0"
+                                                    position="top"
+                                                  >
+                                                    ${attribute.status}
+                                                  </simple-tooltip>
                                                   <ha-svg-icon
                                                     .path=${mdiCloseCircle}
                                                     class="failed"
@@ -361,7 +368,12 @@ class DialogZHAReconfigureDevice extends LitElement {
         Object.keys(attributes).forEach((name) => {
           const attribute = attributes[name];
           clusterConfigurationStatus!.attributes.set(attribute.id, attribute);
-          this._allSuccessful = this._allSuccessful && attribute.success;
+          this._allSuccessful =
+            this._allSuccessful &&
+            !(
+              attribute.status in
+              ["FAILURE", "UNSUPPORTED_ATTRIBUTE", "UNREPORTABLE_ATTRIBUTE"]
+            );
         });
       }
       this.requestUpdate();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This PR updates the ZHA reconfigure device dialog to show the actual statuses for each attribute. 

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/home-assistant/core/pull/108532
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
