### PR TITLE
Simplify GtHub markdown alerts

### DIFF
--- a/src/components/ha-markdown.ts
+++ b/src/components/ha-markdown.ts
@@ -42,6 +42,10 @@ export class HaMarkdown extends LitElement {
       ha-markdown-element > *:last-child {
         margin-bottom: 0;
       }
+      ha-alert {
+        display: block;
+        margin: 4px 0;
+      }
       a {
         color: var(--primary-color);
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `**Warning**` and `**Note**` blockquote syntax will no longer render a `ha-alert` element.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

GitHub has actually stopped rendering the old syntax, so I don't see a reason why we should continue to support it. This part of the rendering logic was never added to any documentation (only shown in the gallery).

In addition to removing the old style this fixes 2 issues:
- There were problems matching because of spaces and casing of the keywords, a regex was implemented to mitigate that.
- The new `ha-alert` node was added as a child of the block quote node. This is wrong, as it should replace it.
  When I switched to replacing it it was too close if there were several "joined" alerts, so I also added some styling for that.

Hopefully, this will be the last PR about this 🙈 I have tested the changes against some basic structures and [this README file](https://github.com/RobertD502/home-assistant-petkit/blob/main/README.md) which contains a lot of edge cases.


One thing that I did not implement that GitHub does is the alert titles:
<img width="573" alt="image" src="https://github.com/home-assistant/frontend/assets/15093472/bb82aadf-da2a-4bbd-a56d-df59523b3204">

If wanted, I can do that in a follow-up PR. As of today, GitHub does not support custom titles for these so that it would be identical to the image above.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
