### PR TITLE
Allow description placeholders in all repair flow title options

### DIFF
--- a/src/panels/config/repairs/show-dialog-repair-flow.ts
+++ b/src/panels/config/repairs/show-dialog-repair-flow.ts
@@ -100,7 +100,8 @@ export const showRepairsFlowDialog = (
         return hass.localize(
           `component.${issue.domain}.issues.${
             issue.translation_key || issue.issue_id
-          }.fix_flow.step.${step.step_id}.data.${field.name}`
+          }.fix_flow.step.${step.step_id}.data.${field.name}`,
+          step.description_placeholders
         );
       },
 
@@ -163,7 +164,8 @@ export const showRepairsFlowDialog = (
           hass.localize(
             `component.${issue.domain}.issues.step.${
               issue.translation_key || issue.issue_id
-            }.fix_flow.${step.step_id}.title`
+            }.fix_flow.${step.step_id}.title`,
+            step.description_placeholders
           ) || hass.localize(`component.${issue.domain}.title`)
         );
       },
@@ -191,7 +193,8 @@ export const showRepairsFlowDialog = (
           hass.localize(
             `component.${issue.domain}.issues.${
               issue.translation_key || issue.issue_id
-            }.fix_flow.step.${step.step_id}.title`
+            }.fix_flow.step.${step.step_id}.title`,
+            step.description_placeholders
           ) || hass.localize(`component.${issue.domain}.title`)
         );
       },


### PR DESCRIPTION
## Proposed change
Description placeholders are only working in "normal" repair flows. This adds the placeholders to "menu" and "progress" repairs flows. It also allows description placeholders in field names, since they are allowed in the field helpers.  

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #19551
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
