### PR TITLE
Fix trace graph for non-safari & safari

### DIFF
--- a/src/components/trace/hat-graph-node.ts
+++ b/src/components/trace/hat-graph-node.ts
@@ -8,6 +8,7 @@ import {
 } from "lit";
 import { customElement, property } from "lit/decorators";
 import { NODE_SIZE, SPACING } from "./hat-graph-const";
+import { isSafari } from "../../util/is_safari";
 
 /**
  * @attribute active
@@ -42,6 +43,7 @@ export class HatGraphNode extends LitElement {
     const width = SPACING + NODE_SIZE;
     return html`
       <svg
+        class=${isSafari ? "safari" : ""}
         width="${width}px"
         height="${height}px"
         viewBox="-${Math.ceil(width / 2)} -${this.graphStart
@@ -124,6 +126,10 @@ export class HatGraphNode extends LitElement {
       }
       :host([notEnabled]:hover) circle {
         --stroke-clr: var(--disabled-hover-clr);
+      }
+      svg:not(.safari) {
+        width: 100%;
+        height: 100%;
       }
       circle,
       path.connector {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Originally trace graph was working properly for chrome browsers, but not for safari browser. 

In #19036 @avdbrink pushed a change to fix the safari browser. This allegedly worked for safari, but it regressed the trace graph for chrome, which now had some broken alignment issues confirmed to be from this change. (see #19304)

I'm not knowledgeable enough about trace graph alignment to know if this fix was correct or not, but presumably we could restrict the proposed fix from that PR to only safari, so that it can be satisfactory for both browsers.

I can't validate this for safari browsers, but I am assuming that the preexisting `isSafari` utility function is working correctly.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [?] The code change is tested and works locally. (partially)
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
