### PR TITLE
Add support for re-auth flows in repairs

### DIFF
--- a/src/data/repairs.ts
+++ b/src/data/repairs.ts
@@ -32,6 +32,13 @@ export const fetchRepairsIssues = (conn: Connection) =>
     type: "repairs/list_issues",
   });
 
+export const fetchRepairsIssueData = (conn: Connection, domain, issue_id) =>
+  conn.sendMessagePromise<{ issue_data: { string: any } }>({
+    type: "repairs/get_issue_data",
+    domain,
+    issue_id,
+  });
+
 export const ignoreRepairsIssue = async (
   hass: HomeAssistant,
   issue: RepairsIssue,

--- a/src/panels/config/repairs/ha-config-repairs.ts
+++ b/src/panels/config/repairs/ha-config-repairs.ts
@@ -8,11 +8,15 @@ import "../../../components/ha-card";
 import "../../../components/ha-list-item";
 import "../../../components/ha-svg-icon";
 import { domainToName } from "../../../data/integration";
-import type { RepairsIssue } from "../../../data/repairs";
+import {
+  fetchRepairsIssueData,
+  type RepairsIssue,
+} from "../../../data/repairs";
 import type { HomeAssistant } from "../../../types";
 import { brandsUrl } from "../../../util/brands-url";
 import { showRepairsFlowDialog } from "./show-dialog-repair-flow";
 import { showRepairsIssueDialog } from "./show-repair-issue-dialog";
+import { showConfigFlowDialog } from "../../../dialogs/config-flow/show-dialog-config-flow";
 
 @customElement("ha-config-repairs")
 class HaConfigRepairs extends LitElement {
@@ -107,10 +111,24 @@ class HaConfigRepairs extends LitElement {
     `;
   }
 
-  private _openShowMoreDialog(ev): void {
+  private async _openShowMoreDialog(ev): Promise<void> {
     const issue = ev.currentTarget.issue as RepairsIssue;
     if (issue.is_fixable) {
       showRepairsFlowDialog(this, issue);
+    } else if (
+      issue.domain === "homeassistant" &&
+      issue.translation_key === "config_entry_reauth"
+    ) {
+      const data = await fetchRepairsIssueData(
+        this.hass.connection,
+        issue.domain,
+        issue.issue_id
+      );
+      if ("flow_id" in data.issue_data) {
+        showConfigFlowDialog(this, {
+          continueFlowId: data.issue_data.flow_id as string,
+        });
+      }
     } else {
       showRepairsIssueDialog(this, {
         issue,


### PR DESCRIPTION



## Proposed change
Allows a repair flow to continue a config flow
For https://github.com/home-assistant/core/pull/109105


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
