### PR TITLE
Reload entity component icons when missing

### DIFF
--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -72,17 +72,17 @@ type CategoryType = {
   services: ServiceIcons;
 };
 
-export function getHassIcons(
+export async function getHassIcons(
   hass: HomeAssistant,
   category: "entity",
   integration?: string
 ): Promise<IconResources<PlatformIcons>>;
-export function getHassIcons(
+export async function getHassIcons(
   hass: HomeAssistant,
   category: "entity_component",
   integration?: string
 ): Promise<IconResources<ComponentIcons>>;
-export function getHassIcons(
+export async function getHassIcons(
   hass: HomeAssistant,
   category: "services",
   integration?: string

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -8,30 +8,41 @@ import {
   EntityRegistryDisplayEntry,
   EntityRegistryEntry,
 } from "./entity_registry";
+import { isComponentLoaded } from "../common/config/is_component_loaded";
 
-const resources: Record<IconCategory, any> = {
+const resources: {
+  entity: Record<string, Promise<PlatformIcons>>;
+  entity_component: {
+    domains?: string[];
+    resources?: Promise<Record<string, ComponentIcons>>;
+  };
+  services: {
+    all?: Promise<Record<string, ServiceIcons>>;
+    domains: { [domain: string]: ServiceIcons | Promise<ServiceIcons> };
+  };
+} = {
   entity: {},
-  entity_component: undefined,
-  services: {},
+  entity_component: {},
+  services: { domains: {} },
 };
 
-interface IconResources {
-  resources: Record<string, string | Record<string, string>>;
+interface IconResources<
+  T extends ComponentIcons | PlatformIcons | ServiceIcons,
+> {
+  resources: Record<string, T>;
 }
 
 interface PlatformIcons {
-  [domain: string]: {
-    [translation_key: string]: {
-      state: Record<string, string>;
-      state_attributes: Record<
-        string,
-        {
-          state: Record<string, string>;
-          default: string;
-        }
-      >;
-      default: string;
-    };
+  [translation_key: string]: {
+    state: Record<string, string>;
+    state_attributes: Record<
+      string,
+      {
+        state: Record<string, string>;
+        default: string;
+      }
+    >;
+    default: string;
   };
 }
 
@@ -55,12 +66,14 @@ interface ServiceIcons {
 
 export type IconCategory = "entity" | "entity_component" | "services";
 
-export const getHassIcons = async (
+export const getHassIcons = async <
+  T extends ServiceIcons | ComponentIcons | PlatformIcons,
+>(
   hass: HomeAssistant,
   category: IconCategory,
   integration?: string
-): Promise<IconResources> =>
-  hass.callWS<{ resources: Record<string, string> }>({
+) =>
+  hass.callWS<IconResources<T>>({
     type: "frontend/get_icons",
     category,
     integration,
@@ -70,14 +83,17 @@ export const getPlatformIcons = async (
   hass: HomeAssistant,
   integration: string,
   force = false
-): Promise<PlatformIcons> => {
+): Promise<PlatformIcons | undefined> => {
   if (!force && integration in resources.entity) {
     return resources.entity[integration];
   }
-  const result = getHassIcons(hass, "entity", integration);
-  resources.entity[integration] = result.then(
+  if (!isComponentLoaded(hass, integration)) {
+    return undefined;
+  }
+  const result = getHassIcons<PlatformIcons>(hass, "entity", integration).then(
     (res) => res?.resources[integration]
   );
+  resources.entity[integration] = result;
   return resources.entity[integration];
 };
 
@@ -85,50 +101,61 @@ export const getComponentIcons = async (
   hass: HomeAssistant,
   domain: string,
   force = false
-): Promise<ComponentIcons> => {
-  if (!force && resources.entity_component) {
-    const domainRes = await resources.entity_component.then(
-      (res) => res[domain]
-    );
-    if (domainRes) {
-      return domainRes;
-    }
+): Promise<ComponentIcons | undefined> => {
+  if (
+    !force &&
+    resources.entity_component.resources &&
+    resources.entity_component.domains?.includes(domain)
+  ) {
+    return resources.entity_component.resources.then((res) => res[domain]);
   }
-  resources.entity_component = getHassIcons(hass, "entity_component").then(
-    (result) => result.resources
-  );
-  return resources.entity_component.then((res) => res[domain]);
+  if (!isComponentLoaded(hass, domain)) {
+    return undefined;
+  }
+  resources.entity_component.domains = hass.config.components;
+  resources.entity_component.resources = getHassIcons<ComponentIcons>(
+    hass,
+    "entity_component"
+  ).then((result) => result.resources);
+  return resources.entity_component.resources.then((res) => res[domain]);
 };
 
 export const getServiceIcons = async (
   hass: HomeAssistant,
   domain?: string,
   force = false
-): Promise<ServiceIcons> => {
+): Promise<ServiceIcons | Record<string, ServiceIcons> | undefined> => {
   if (!domain) {
     if (!force && resources.services.all) {
       return resources.services.all;
     }
-    resources.services.all = getHassIcons(hass, "services", domain).then(
-      (res) => {
-        resources.services = res.resources;
-        return res?.resources;
-      }
-    );
+    resources.services.all = getHassIcons<ServiceIcons>(
+      hass,
+      "services",
+      domain
+    ).then((res) => {
+      resources.services.domains = res.resources;
+      return res?.resources;
+    });
     return resources.services.all;
   }
-  if (!force && domain && domain in resources.services) {
-    return resources.services[domain];
+  if (!force && domain && domain in resources.services.domains) {
+    return resources.services.domains[domain];
   }
   if (resources.services.all && !force) {
     await resources.services.all;
-    if (domain in resources.services) {
-      return resources.services[domain];
+    if (domain in resources.services.domains) {
+      return resources.services.domains[domain];
     }
   }
-  const result = getHassIcons(hass, "services", domain);
-  resources.services[domain] = result.then((res) => res?.resources[domain]);
-  return resources.services[domain];
+  if (!isComponentLoaded(hass, domain)) {
+    return undefined;
+  }
+  const result = getHassIcons<ServiceIcons>(hass, "services", domain);
+  resources.services.domains[domain] = result.then(
+    (res) => res?.resources[domain]
+  );
+  return resources.services.domains[domain];
 };
 
 export const entityIcon = async (
@@ -243,7 +270,7 @@ export const serviceIcon = async (
   const serviceName = computeObjectId(service);
   const serviceIcons = await getServiceIcons(hass, domain);
   if (serviceIcons) {
-    icon = serviceIcons[serviceName];
+    icon = serviceIcons[serviceName] as string;
   }
   if (!icon) {
     icon = await domainIcon(hass, domain);

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -72,32 +72,16 @@ type CategoryType = {
   services: ServiceIcons;
 };
 
-export async function getHassIcons(
+export const getHassIcons = async <T extends IconCategory>(
   hass: HomeAssistant,
-  category: "entity",
+  category: T,
   integration?: string
-): Promise<IconResources<PlatformIcons>>;
-export async function getHassIcons(
-  hass: HomeAssistant,
-  category: "entity_component",
-  integration?: string
-): Promise<IconResources<ComponentIcons>>;
-export async function getHassIcons(
-  hass: HomeAssistant,
-  category: "services",
-  integration?: string
-): Promise<IconResources<ServiceIcons>>;
-export async function getHassIcons<T extends IconCategory>(
-  hass: HomeAssistant,
-  category: IconCategory,
-  integration?: string
-): Promise<IconResources<CategoryType[T]>> {
-  return hass.callWS<IconResources<CategoryType[T]>>({
+) =>
+  hass.callWS<IconResources<CategoryType[T]>>({
     type: "frontend/get_icons",
     category,
     integration,
   });
-}
 
 export const getPlatformIcons = async (
   hass: HomeAssistant,

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -66,14 +66,18 @@ interface ServiceIcons {
 
 export type IconCategory = "entity" | "entity_component" | "services";
 
-export const getHassIcons = async <
-  T extends ServiceIcons | ComponentIcons | PlatformIcons,
->(
+type CategoryType = {
+  entity: PlatformIcons;
+  entity_component: ComponentIcons;
+  services: ServiceIcons;
+};
+
+export const getHassIcons = async <T extends IconCategory>(
   hass: HomeAssistant,
   category: IconCategory,
   integration?: string
 ) =>
-  hass.callWS<IconResources<T>>({
+  hass.callWS<IconResources<CategoryType[T]>>({
     type: "frontend/get_icons",
     category,
     integration,
@@ -90,7 +94,7 @@ export const getPlatformIcons = async (
   if (!isComponentLoaded(hass, integration)) {
     return undefined;
   }
-  const result = getHassIcons<PlatformIcons>(hass, "entity", integration).then(
+  const result = getHassIcons<"entity">(hass, "entity", integration).then(
     (res) => res?.resources[integration]
   );
   resources.entity[integration] = result;
@@ -113,7 +117,7 @@ export const getComponentIcons = async (
     return undefined;
   }
   resources.entity_component.domains = [...hass.config.components];
-  resources.entity_component.resources = getHassIcons<ComponentIcons>(
+  resources.entity_component.resources = getHassIcons<"entity_component">(
     hass,
     "entity_component"
   ).then((result) => result.resources);
@@ -129,7 +133,7 @@ export const getServiceIcons = async (
     if (!force && resources.services.all) {
       return resources.services.all;
     }
-    resources.services.all = getHassIcons<ServiceIcons>(
+    resources.services.all = getHassIcons<"services">(
       hass,
       "services",
       domain
@@ -151,7 +155,7 @@ export const getServiceIcons = async (
   if (!isComponentLoaded(hass, domain)) {
     return undefined;
   }
-  const result = getHassIcons<ServiceIcons>(hass, "services", domain);
+  const result = getHassIcons<"services">(hass, "services", domain);
   resources.services.domains[domain] = result.then(
     (res) => res?.resources[domain]
   );

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -87,7 +87,12 @@ export const getComponentIcons = async (
   force = false
 ): Promise<ComponentIcons> => {
   if (!force && resources.entity_component) {
-    return resources.entity_component.then((res) => res[domain]);
+    const domainRes = await resources.entity_component.then(
+      (res) => res[domain]
+    );
+    if (domainRes) {
+      return domainRes;
+    }
   }
   resources.entity_component = getHassIcons(hass, "entity_component").then(
     (result) => result.resources

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -112,7 +112,7 @@ export const getComponentIcons = async (
   if (!isComponentLoaded(hass, domain)) {
     return undefined;
   }
-  resources.entity_component.domains = hass.config.components;
+  resources.entity_component.domains = [...hass.config.components];
   resources.entity_component.resources = getHassIcons<ComponentIcons>(
     hass,
     "entity_component"
@@ -139,7 +139,7 @@ export const getServiceIcons = async (
     });
     return resources.services.all;
   }
-  if (!force && domain && domain in resources.services.domains) {
+  if (!force && domain in resources.services.domains) {
     return resources.services.domains[domain];
   }
   if (resources.services.all && !force) {


### PR DESCRIPTION


## Proposed change

If we cached too early, or a domain is added later, we would miss the icons for that domain. If we miss an icon now we refetch all icons.

Fixes https://github.com/home-assistant/frontend/issues/19601


## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
