### PR TITLE
Remove flag that sets icon as required when creating a new dashboard

### DIFF
--- a/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
+++ b/src/panels/config/lovelace/dashboards/dialog-lovelace-dashboard-detail.ts
@@ -169,7 +169,7 @@ export class DialogLovelaceDashboardDetail extends LitElement {
         },
         {
           name: "icon",
-          required: true,
+          required: false,
           selector: {
             icon: {},
           },


### PR DESCRIPTION
## Proposed change
Less friction to create a new dashboard. Moreover, an icon isn't actually required in order to create the dashboard anyway.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
Create a new dashboard from the UI.

## Additional information
- This PR fixes or closes issue: fixes #19639 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
