### PR TITLE
Update dashboard resources title to reflect translations

### DIFF
--- a/src/panels/config/lovelace/ha-config-lovelace.ts
+++ b/src/panels/config/lovelace/ha-config-lovelace.ts
@@ -12,6 +12,9 @@ export const lovelaceTabs = [
     translationKey: "ui.panel.config.lovelace.dashboards.caption",
     iconPath: mdiViewDashboard,
   },
+];
+
+export const lovelaceResourcesTabs = [
   {
     path: "/config/lovelace/resources",
     translationKey: "ui.panel.config.lovelace.resources.caption",

--- a/src/panels/config/lovelace/ha-config-lovelace.ts
+++ b/src/panels/config/lovelace/ha-config-lovelace.ts
@@ -8,9 +8,13 @@ import { HomeAssistant } from "../../../types";
 
 export const lovelaceTabs = [
   {
-    component: "lovelace",
     path: "/config/lovelace/dashboards",
     translationKey: "ui.panel.config.lovelace.dashboards.caption",
+    iconPath: mdiViewDashboard,
+  },
+  {
+    path: "/config/lovelace/resources",
+    translationKey: "ui.panel.config.lovelace.resources.caption",
     iconPath: mdiViewDashboard,
   },
 ];

--- a/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
+++ b/src/panels/config/lovelace/resources/ha-config-lovelace-resources.ts
@@ -34,7 +34,7 @@ import "../../../../layouts/hass-tabs-subpage-data-table";
 import { haStyle } from "../../../../resources/styles";
 import { HomeAssistant, Route } from "../../../../types";
 import { loadLovelaceResources } from "../../../lovelace/common/load-resources";
-import { lovelaceTabs } from "../ha-config-lovelace";
+import { lovelaceResourcesTabs } from "../ha-config-lovelace";
 import { showResourceDetailDialog } from "./show-dialog-lovelace-resource-detail";
 
 @customElement("ha-config-lovelace-resources")
@@ -117,7 +117,7 @@ export class HaConfigLovelaceRescources extends LitElement {
         .hass=${this.hass}
         .narrow=${this.narrow}
         .route=${this.route}
-        .tabs=${lovelaceTabs}
+        .tabs=${lovelaceResourcesTabs}
         .columns=${this._columns(this.hass.language)}
         .data=${this._resources}
         .noDataText=${this.hass.localize(


### PR DESCRIPTION
## Proposed change
/config/lovelace/resources is not using the translation ("Resources"), instead it is using the default for /config/lovelace/dashboards ("Dashboards").

### Example of issue
![Web capture_3-2-2024_15359_homeassistant local](https://github.com/home-assistant/frontend/assets/50791984/86447e41-613b-475a-8dae-a7765587a1cc)
![Web capture_3-2-2024_15353_homeassistant local](https://github.com/home-assistant/frontend/assets/50791984/6cdcd497-7407-417c-bd87-b93969e9dd79)

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
Browse to /config/lovelace/dashboards and observe it is not using `ui.panel.config.lovelace.resources.caption`

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
