### PR TITLE
Move cloud login forgot password link into card actions area

### DIFF
--- a/src/panels/config/cloud/login/cloud-login.ts
+++ b/src/panels/config/cloud/login/cloud-login.ts
@@ -144,15 +144,6 @@ export class CloudLogin extends LitElement {
                     "ui.panel.config.cloud.login.password_error_msg"
                   )}
                 ></ha-textfield>
-                <button
-                  class="link pwd-forgot-link"
-                  .disabled=${this._requestInProgress}
-                  @click=${this._handleForgotPassword}
-                >
-                  ${this.hass.localize(
-                    "ui.panel.config.cloud.login.forgot_password"
-                  )}
-                </button>
               </div>
               <div class="card-actions">
                 <ha-progress-button
@@ -163,6 +154,15 @@ export class CloudLogin extends LitElement {
                   )}</ha-progress-button
                 >
               </div>
+              <button
+                class="link pwd-forgot-link"
+                .disabled=${this._requestInProgress}
+                @click=${this._handleForgotPassword}
+              >
+                ${this.hass.localize(
+                  "ui.panel.config.cloud.login.forgot_password"
+                )}
+              </button>
             </ha-card>
 
             <ha-card outlined>

--- a/src/panels/config/cloud/login/cloud-login.ts
+++ b/src/panels/config/cloud/login/cloud-login.ts
@@ -153,16 +153,16 @@ export class CloudLogin extends LitElement {
                     "ui.panel.config.cloud.login.sign_in"
                   )}</ha-progress-button
                 >
+                <button
+                  class="link pwd-forgot-link"
+                  .disabled=${this._requestInProgress}
+                  @click=${this._handleForgotPassword}
+                >
+                  ${this.hass.localize(
+                    "ui.panel.config.cloud.login.forgot_password"
+                  )}
+                </button>
               </div>
-              <button
-                class="link pwd-forgot-link"
-                .disabled=${this._requestInProgress}
-                @click=${this._handleForgotPassword}
-              >
-                ${this.hass.localize(
-                  "ui.panel.config.cloud.login.forgot_password"
-                )}
-              </button>
             </ha-card>
 
             <ha-card outlined>
@@ -310,11 +310,6 @@ export class CloudLogin extends LitElement {
         .login-form {
           display: flex;
           flex-direction: column;
-        }
-        .pwd-forgot-link {
-          color: var(--secondary-text-color) !important;
-          text-align: right !important;
-          align-self: flex-end;
         }
       `,
     ];


### PR DESCRIPTION
## Proposed change
Aligns login forgot password link styling with create resend confirmation styling.

### Example
![Web capture_3-2-2024_15542_homeassistant local](https://github.com/home-assistant/frontend/assets/50791984/81036ad4-f5cd-42e3-adc0-9e339108c862)
![Web capture_3-2-2024_155435_homeassistant local](https://github.com/home-assistant/frontend/assets/50791984/c5ad2fca-6fda-4254-862d-b1025744afd7)

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
