### PR TITLE
Add valve to translations

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1201,7 +1201,8 @@
               "shutter": "Shutter"
             },
             "switch": {
-              "outlet": "Outlet"
+              "outlet": "Outlet",
+              "valve": "Valve"
             }
           },
           "unavailable": "This entity is unavailable.",


### PR DESCRIPTION
## Proposed change
Fixes issue where `entity-registry-settings-editor` `Show as` dropdown displays `Valve` as `valve`.

### Example of issue
![image](https://github.com/home-assistant/frontend/assets/50791984/da583970-dbb2-4577-8d0e-8abbb8f2c356)

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
Find a `switch` and change it to `Show as` = `valve`.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: caused by #16671
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
