### PR TITLE
Remove tabs from top of Application Credentials page

### DIFF
--- a/src/panels/config/application_credentials/ha-config-application-credentials.ts
+++ b/src/panels/config/application_credentials/ha-config-application-credentials.ts
@@ -100,7 +100,7 @@ export class HaConfigApplicationCredentials extends LitElement {
         .narrow=${this.narrow}
         .route=${this.route}
         backPath="/config"
-        .tabs=${configSections.devices}
+        .tabs=${configSections.application_credentials}
         .columns=${this._columns(this.narrow, this.hass.localize)}
         .data=${this._applicationCredentials}
         hasFab

--- a/src/panels/config/ha-panel-config.ts
+++ b/src/panels/config/ha-panel-config.ts
@@ -213,6 +213,15 @@ export const configSections: { [name: string]: PageNavigation[] } = {
       iconColor: "#616161",
     },
   ],
+  application_credentials: [
+    {
+      component: "application_credentials",
+      path: "/config/application_credentials",
+      translationKey: "ui.panel.config.application_credentials.caption",
+      iconPath: mdiDevices,
+      iconColor: "#2D338F",
+    },
+  ],
   voice_assistants: [
     {
       path: "/config/voice-assistants",


### PR DESCRIPTION
## Proposed change
Application Credentials is a sub-page accessed from the higher level pages under Devices.

When we are on Application Credentials today, it's not clear as no title is shown and we can confusingly click back and forth between the device pages but then cannot get back.

This change removes the tabs across the top in favour of the back button.

![image](https://github.com/home-assistant/frontend/assets/50791984/a4ff7bd0-6683-4b48-bc64-aaa4bda5f91c)

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
