### PR TITLE
Handle integration exceptions when automation YAML is malformed

### DIFF
--- a/src/panels/config/automation/ha-automation-editor.ts
+++ b/src/panels/config/automation/ha-automation-editor.ts
@@ -476,21 +476,31 @@ export class HaAutomationEditor extends KeyboardShortcutMixin(LitElement) {
     if (stateObj?.state !== UNAVAILABLE) {
       return;
     }
-    const validation = await validateConfig(this.hass, {
-      trigger: this._config.trigger,
-      condition: this._config.condition,
-      action: this._config.action,
-    });
-    this._validationErrors = (
-      Object.entries(validation) as Entries<typeof validation>
-    ).map(([key, value]) =>
-      value.valid
-        ? ""
-        : html`${this.hass.localize(
-              `ui.panel.config.automation.editor.${key}s.name`
-            )}:
-            ${value.error}<br />`
-    );
+
+    try {
+      const validation = await validateConfig(this.hass, {
+        trigger: this._config.trigger,
+        condition: this._config.condition,
+        action: this._config.action,
+      });
+
+      this._validationErrors = (
+        Object.entries(validation) as Entries<typeof validation>
+      ).map(([key, value]) =>
+        value.valid
+          ? ""
+          : html`${this.hass.localize(
+                `ui.panel.config.automation.editor.${key}s.name`
+              )}:
+              ${value.error}<br />`
+      );
+    } catch (errors: any) {
+      this._validationErrors = errors.message || errors.code;
+      showToast(this, {
+        message: errors.message || errors.code,
+      });
+      throw errors;
+    }
   }
 
   private _normalizeConfig(config: AutomationConfig): AutomationConfig {


### PR DESCRIPTION
## Proposed change
Adds exception handling for when an unexpected condition occured in the checkValidation function.

This can happen when the automation YAML data becomes malformed, such as when a Device Action entity_id no longer exists or is empty.

Previously, just showed `Automation is unavailable` at the top and nothing about the reason why.

I have modelled the exception handler code off the existing exception handling in the file. Now, shows the error message below `Automation is unavailable` and pops a toast - both are consistent with the behaviour for other kinds of automation issues.

![image](https://github.com/home-assistant/frontend/assets/50791984/7af73675-e036-4971-b7c1-c9d1e04205c1)


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml
- id: '1697489596989'
  alias: Garage - EV Schedule
  description: ''
  trigger:
  - platform: time
    at: '21:01:00'
    id: time_start
    alias: Begin Off Peak (TOD)
  - platform: time
    at: 06:59:00
    id: time_stop
    alias: End Off-Peak (TOD)
  - alias: Begin solar (producing more than 1.8 kW)
    platform: numeric_state
    entity_id:
    - sensor.garage_solar_inverter_pv_power
    for:
      hours: 0
      minutes: 5
      seconds: 0
    id: solar_start
    above: 1.8
  - alias: End solar (producing less 1.8 kW)
    platform: numeric_state
    entity_id:
    - sensor.garage_solar_inverter_pv_power
    for:
      hours: 0
      minutes: 5
      seconds: 0
    below: 1.8
    id: solar_stop_fixed
  - alias: End solar (producing less than EV is consuming)
    platform: numeric_state
    entity_id:
    - sensor.garage_solar_inverter_pv_power
    for:
      hours: 0
      minutes: 5
      seconds: 0
    below: sensor.garage_ev_current_power
    id: solar_stop_dynamic
  condition:
  - condition: numeric_state
    entity_id: zone.home
    above: 0
  action:
  - choose:
    - conditions:
      - condition: trigger
        id:
        - solar_start
        - time_start
      sequence:
      - type: turn_on
        device_id: e9eee6046b80aabf468dc51c90a26297
        entity_id: bef7fc95ab5129fefccd82d61e372e3f
        domain: switch
      - type: turn_on
        device_id: c2064b339e22d70212eeef6834224d89
        entity_id: 6b3f33b06e20e763e58c80373223edd3
        domain: switch
    - conditions:
      - condition: trigger
        id:
        - solar_stop_fixed
        - solar_stop_dynamic
      sequence:
      - type: turn_off
        device_id: e9eee6046b80aabf468dc51c90a26297
        entity_id: bef7fc95ab5129fefccd82d61e372e3f
        domain: switch
      - type: turn_off
        device_id: c2064b339e22d70212eeef6834224d89
        entity_id: 6b3f33b06e20e763e58c80373223edd3
        domain: switch
    - conditions:
      - condition: trigger
        id:
        - time_stop
      sequence:
      - type: turn_off
        device_id: e9eee6046b80aabf468dc51c90a26297
        entity_id: bef7fc95ab5129fefccd82d61e372e3f
        domain: switch
      - type: turn_off
        device_id: c2064b339e22d70212eeef6834224d89
        entity_id: 6b3f33b06e20e763e58c80373223edd3
        domain: switch
  mode: parallel
  max: 10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #19694
- This PR is related to issue or discussion: https://community.home-assistant.io/t/message-malformed-integration-not-found-what-have-i-done/178480
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
