### PR TITLE
Use gap instead of margin for vertical and horizontal card

### DIFF
--- a/src/panels/lovelace/cards/hui-horizontal-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-horizontal-stack-card.ts
@@ -28,27 +28,11 @@ export class HuiHorizontalStackCard extends HuiStackCard {
         #root {
           display: flex;
           height: 100%;
-        }
-        #root {
-          --stack-card-side-margin: 4px;
+          gap: var(--horizontal-stack-card-gap, var(--stack-card-gap, 8px));
         }
         #root > * {
           flex: 1 1 0;
-          margin: var(
-            --horizontal-stack-card-margin,
-            var(--stack-card-margin, 0 var(--stack-card-side-margin))
-          );
           min-width: 0;
-        }
-        #root > *:first-child {
-          margin-left: 0;
-          margin-inline-start: 0;
-          margin-inline-end: var(--stack-card-side-margin);
-        }
-        #root > *:last-child {
-          margin-right: 0;
-          margin-inline-end: 0;
-          margin-inline-start: var(--stack-card-side-margin);
         }
       `,
     ];

--- a/src/panels/lovelace/cards/hui-vertical-stack-card.ts
+++ b/src/panels/lovelace/cards/hui-vertical-stack-card.ts
@@ -27,18 +27,7 @@ class HuiVerticalStackCard extends HuiStackCard {
           display: flex;
           flex-direction: column;
           height: 100%;
-        }
-        #root > * {
-          margin: var(
-            --vertical-stack-card-margin,
-            var(--stack-card-margin, 4px 0)
-          );
-        }
-        #root > *:first-child {
-          margin-top: 0;
-        }
-        #root > *:last-child {
-          margin-bottom: 0;
+          gap: var(--vertical-stack-card-gap, var(--stack-card-gap, 8px));
         }
       `,
     ];


### PR DESCRIPTION
## Breaking changes

`horizontal-stack-card-margin` and `vertical-stack-card-margin` are replaced by `horizontal-stack-card-gap` and `vertical-stack-card-gap`.

## Proposed change

https://github.com/home-assistant/frontend/pull/19394 PR broke the previous theme variables. When trying to fix that, I simplified the code to use gap instead of margin with condition on the first and last item.
Here's the new themes variables :
- `horizontal-stack-card-gap` (default value : 8px)
- `vertical-stack-card-gap` (default value : 8px)
- `stack-card-gap` can also be used to theme both card (default value : 8px)

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/frontend/issues/19611
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
