### PR TITLE
Use fixed colors for qr codes

### DIFF
--- a/src/components/ha-qr-code.ts
+++ b/src/components/ha-qr-code.ts
@@ -74,8 +74,7 @@ export class HaQrCode extends LitElement {
         margin: this.margin,
         maskPattern: this.maskPattern,
         color: {
-          light: computedStyles.getPropertyValue("--card-background-color"),
-          dark: computedStyles.getPropertyValue("--primary-text-color"),
+          light: #ffffffff,
         },
       }).catch((err) => {
         this._error = err.message;

--- a/src/components/ha-qr-code.ts
+++ b/src/components/ha-qr-code.ts
@@ -74,7 +74,7 @@ export class HaQrCode extends LitElement {
         margin: this.margin,
         maskPattern: this.maskPattern,
         color: {
-          light: #ffffffff,
+          light: "#ffffffff",
         },
       }).catch((err) => {
         this._error = err.message;

--- a/src/components/ha-qr-code.ts
+++ b/src/components/ha-qr-code.ts
@@ -64,7 +64,6 @@ export class HaQrCode extends LitElement {
         changedProperties.has("errorCorrectionLevel") ||
         changedProperties.has("centerImage"))
     ) {
-      const computedStyles = getComputedStyle(this);
 
       QRCode.toCanvas(canvas, this.data, {
         errorCorrectionLevel:

--- a/src/components/ha-qr-code.ts
+++ b/src/components/ha-qr-code.ts
@@ -64,7 +64,6 @@ export class HaQrCode extends LitElement {
         changedProperties.has("errorCorrectionLevel") ||
         changedProperties.has("centerImage"))
     ) {
-
       QRCode.toCanvas(canvas, this.data, {
         errorCorrectionLevel:
           this.errorCorrectionLevel || (this.centerImage ? "Q" : "M"),
@@ -73,7 +72,7 @@ export class HaQrCode extends LitElement {
         margin: this.margin,
         maskPattern: this.maskPattern,
         color: {
-          light: "#ffffffff",
+          light: "#fff",
         },
       }).catch((err) => {
         this._error = err.message;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Use a fixed black and white color qr code instead of the user theme.

Fixes #19722, hopefully.

The qrcode canvas requires colors to be specified as rgba hex codes (ex `#000000ff`, `#ffffffff` for black and white), but the css specification used for themes allows for a lot of other things like `magenta`, `rgb(255, 0, 0)`, `rgba(1, 2, 3, 4)` etc.

A black-on-white qr code is likely more reliable anyway.

This problem was introduced in #19155
Documentation reference: https://www.npmjs.com/package/qrcode#colordark

# I HAVE NOT TESTED THIS. PLEASE DO BEFORE MERGING

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR.
-->

```yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
